### PR TITLE
fix: API token env variable

### DIFF
--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -161,7 +161,7 @@ def sse_listener() -> None:
 
             def auth(request: httpx.Request) -> httpx.Request:
                 service = "Nodes"
-                value = "NODES_API_KEY"
+                value = "NODES_API_TOKEN"
                 api_token = GriptapeNodes.get_instance().ConfigManager().get_config_value(f"env.{service}.{value}")
                 request.headers.update({"Accept": "text/event-stream", "Authorization": f"Bearer {api_token}"})
                 return request

--- a/src/griptape_nodes/api/routes/nodes_api_fake_socket.py
+++ b/src/griptape_nodes/api/routes/nodes_api_fake_socket.py
@@ -10,7 +10,7 @@ class NodesApiFakeSocket:
 
     def emit(self, *args, **kwargs) -> None:  # noqa: ARG002 # drop-in replacement workaround
         service = "Nodes"
-        value = "NODES_API_KEY"
+        value = "NODES_API_TOKEN"
         api_token = (
             GriptapeNodes.get_instance().ConfigManager().get_config_value(f"griptape.api_keys.{service}.{value}")
         )


### PR DESCRIPTION
Update env variable for the API token to match the README