### PR TITLE
Rerouter Node Logic

### DIFF
--- a/nodes/griptape_nodes_library.json
+++ b/nodes/griptape_nodes_library.json
@@ -384,6 +384,15 @@
       }
     },
     {
+      "class_name": "gnReroute",
+      "file_path": "griptape_nodes_library/utils/reroute.py",
+      "metadata": {
+        "category": "Utility",
+        "description": "Passes data through, for visual organization",
+        "display_name": "Reroute"
+      }
+    },
+    {
       "class_name": "gnMergeTextsNode",
       "file_path": "griptape_nodes_library/merge_texts.py",
       "metadata": {
@@ -457,4 +466,3 @@
     }
   ]
 }
-

--- a/nodes/griptape_nodes_library/utils/reroute.py
+++ b/nodes/griptape_nodes_library/utils/reroute.py
@@ -1,0 +1,140 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode, NodeBase
+
+
+class gnReroute(DataNode):
+    # Track the incoming and outgoing connections to choose our allowed types.
+    # I'd use sets for faster removal but I don't know if I want to hash Parameter objects
+    incoming_connection_params: list[Parameter]
+    outgoing_connection_params: list[Parameter]
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        self.incoming_connection_params = []
+        self.outgoing_connection_params = []
+
+        passthru = Parameter(
+            name="passThru",
+            allowed_types=["Any"],
+            default_value=None,
+            tooltip="",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT},
+        )
+        self.add_parameter(passthru)
+
+    @staticmethod
+    def intersection_of_allowed_types(*allowed_type_lists) -> list[str]:  # noqa: C901
+        """Intersects allowed types lists.
+        Find intersection of N lists with special rules:
+        1. Preserve order where possible
+        2. "Any" is a wildcard that matches any string.
+        Args:
+            *allowed_type_lists: Variable number of string lists
+        Returns:
+            List containing the intersection with preserved order
+        One day we will handle things like dict[Any, List[Tuple[Str, Any]]]
+        ...but today is not that day.
+        """
+        if len(allowed_type_lists) == 0:
+            return ["Any"]
+
+        if len(allowed_type_lists) == 1:
+            return allowed_type_lists[0].copy()
+
+        # Check which lists contain "Any"
+        has_any = [("Any" in lst) for lst in allowed_type_lists]
+
+        # Initialize result with first list's items
+        all_items = set()
+        for lst in allowed_type_lists:
+            all_items.update(lst)
+
+        result = []
+
+        # If all lists have "Any", include it in the result
+        if all(has_any):
+            result.append("Any")
+
+        # Process each list in order
+        for list_index, current_list in enumerate(allowed_type_lists):
+            for item in current_list:
+                if item == "Any":
+                    # Skip "Any" as it's already handled
+                    continue
+
+                # Check if item should be in result
+                should_include = True
+
+                for other_index, other_list in enumerate(allowed_type_lists):
+                    if other_index == list_index:
+                        continue
+
+                    # Item should be included if it's in the other list
+                    # OR if the other list contains "Any"
+                    if item not in other_list and not has_any[other_index]:
+                        should_include = False
+                        break
+
+                if should_include and item not in result:
+                    result.append(item)
+
+        return result
+
+    def update_allowed_types_based_on_connection_status(self, parameter: Parameter) -> None:
+        # Our allowed types is the intersection of all of our current connections.
+        all_allowed_types = []
+        for incoming_connection_param in self.incoming_connection_params:
+            allowed_types = incoming_connection_param.allowed_types
+            all_allowed_types.append(allowed_types)
+        for outgoing_connection_param in self.outgoing_connection_params:
+            allowed_types = outgoing_connection_param.allowed_types
+            all_allowed_types.append(allowed_types)
+
+        intersection = gnReroute.intersection_of_allowed_types(*all_allowed_types)
+        parameter.allowed_types = intersection
+
+    def handle_incoming_connection(
+        self,
+        source_node: NodeBase,  # noqa: ARG002
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Callback after a Connection has been established TO this Node."""
+        self.incoming_connection_params.append(source_parameter)
+        self.update_allowed_types_based_on_connection_status(parameter=target_parameter)
+
+    def handle_outgoing_connection(
+        self,
+        source_parameter: Parameter,
+        target_node: NodeBase,  # noqa: ARG002
+        target_parameter: Parameter,
+    ) -> None:
+        """Callback after a Connection has been established OUT of this Node."""
+        self.outgoing_connection_params.append(target_parameter)
+        self.update_allowed_types_based_on_connection_status(parameter=source_parameter)
+
+    def handle_incoming_connection_removed(
+        self,
+        source_node: NodeBase,  # noqa: ARG002
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Callback after a Connection TO this Node was REMOVED."""
+        self.incoming_connection_params.remove(source_parameter)
+        self.update_allowed_types_based_on_connection_status(parameter=target_parameter)
+
+    def handle_outgoing_connection_removed(
+        self,
+        source_parameter: Parameter,
+        target_node: NodeBase,  # noqa: ARG002
+        target_parameter: Parameter,
+    ) -> None:
+        """Callback after a Connection OUT of this Node was REMOVED."""
+        self.outgoing_connection_params.remove(target_parameter)
+        self.update_allowed_types_based_on_connection_status(parameter=source_parameter)
+
+    def process(self) -> None:
+        self.parameter_output_values["passThru"] = self.parameter_values["passThru"]

--- a/nodes/griptape_nodes_library/utils/reroute.py
+++ b/nodes/griptape_nodes_library/utils/reroute.py
@@ -28,9 +28,11 @@ class gnReroute(DataNode):
     @staticmethod
     def intersection_of_allowed_types(*allowed_type_lists) -> list[str]:  # noqa: C901
         """Intersects allowed types lists.
+
         Find intersection of N lists with special rules:
         1. Preserve order where possible
         2. "Any" is a wildcard that matches any string.
+
         Args:
             *allowed_type_lists: Variable number of string lists
         Returns:

--- a/src/griptape_nodes/exe_types/connections.py
+++ b/src/griptape_nodes/exe_types/connections.py
@@ -41,8 +41,8 @@ class Connections:
             errormsg = f"Input Connection not allowed on Parameter '{target_parameter.name}'."
             raise ValueError(errormsg)
         # Handle multiple inputs on parameters and multiple outputs on controls
-        if self.connection_allowed(source_node, source_parameter, True) and self.connection_allowed(
-            target_node, target_parameter, False
+        if self.connection_allowed(source_node, source_parameter,source=True) and self.connection_allowed(
+            target_node, target_parameter, source=False
         ):
             connection = Connection(source_node, source_parameter, target_node, target_parameter)
             # New index management.
@@ -61,8 +61,11 @@ class Connections:
         msg = "Connection not allowed because of multiple connections on the same parameter input or control output parameter"
         raise ValueError(msg)
 
-    def connection_allowed(self, node: NodeBase, parameter: Parameter, source: bool) -> bool:  # noqa: FBT001
+    def connection_allowed(self, node: NodeBase, parameter: Parameter, *, source: bool) -> bool:
         # True if allowed, false if not
+        # Here are the rules:
+        # A Control Parameter can have multiple connections as an input, but only one output.
+        # A Data Parameter can have one connection as input, but multiple outputs.
         if source and ParameterControlType.__name__ in parameter.allowed_types:
             connections = self.outgoing_index
             connections_from_node = connections.get(node.name, {})

--- a/src/griptape_nodes/exe_types/connections.py
+++ b/src/griptape_nodes/exe_types/connections.py
@@ -41,7 +41,7 @@ class Connections:
             errormsg = f"Input Connection not allowed on Parameter '{target_parameter.name}'."
             raise ValueError(errormsg)
         # Handle multiple inputs on parameters and multiple outputs on controls
-        if self.connection_allowed(source_node, source_parameter,source=True) and self.connection_allowed(
+        if self.connection_allowed(source_node, source_parameter, source=True) and self.connection_allowed(
             target_node, target_parameter, source=False
         ):
             connection = Connection(source_node, source_parameter, target_node, target_parameter)

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -150,8 +150,12 @@ class Parameter:
         # Original code continues here...
         # Can't just do a string compare as we'll whiff on things like "list" not matching "List"
         test_type = TypeValidator.convert_to_type(type_as_str)
+        if test_type is Any:
+            return True
         for allowed_type_str in self.allowed_types:
             allowed_type = TypeValidator.convert_to_type(allowed_type_str)
+            if allowed_type is Any:
+                return True
             if allowed_type == test_type:
                 return True
         return False

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -95,6 +95,24 @@ class NodeBase(ABC):
         """Callback after a Connection has been established OUT of this Node."""
         return
 
+    def handle_incoming_connection_removed(
+        self,
+        source_node: Self,  # noqa: ARG002
+        source_parameter: Parameter,  # noqa: ARG002
+        target_parameter: Parameter,  # noqa: ARG002
+    ) -> None:
+        """Callback after a Connection TO this Node was REMOVED."""
+        return
+
+    def handle_outgoing_connection_removed(
+        self,
+        source_parameter: Parameter,  # noqa: ARG002
+        target_node: Self,  # noqa: ARG002
+        target_parameter: Parameter,  # noqa: ARG002
+    ) -> None:
+        """Callback after a Connection OUT of this Node was REMOVED."""
+        return
+
     def on_griptape_event(self, event: BaseEvent) -> None:  # noqa: ARG002
         """Callback for when a Griptape Event comes destined for this Node."""
         return

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -995,6 +995,29 @@ class FlowManager:
             result = DeleteConnectionResult_Failure()
             return result
 
+        # TEMP HACK: SWAP BACK Data connections appear to reverse Source and Target. TODO(griptape): Let's reconcile this. SWAP BACK
+        if ParameterControlType.__name__ not in source_param.allowed_types:
+            temp_node = source_node
+            temp_param = source_param
+            source_node = target_node
+            source_param = target_param
+            target_node = temp_node
+            target_param = temp_param
+
+        # Let the source make any internal handling decisions now that the Connection has been REMOVED.
+        source_node.handle_outgoing_connection_removed(
+            source_parameter=source_param,
+            target_node=target_node,
+            target_parameter=target_param,
+        )
+
+        # And target.
+        target_node.handle_incoming_connection_removed(
+            source_node=source_node,
+            source_parameter=source_param,
+            target_parameter=target_param,
+        )
+
         details = f'Connection "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}" deleted.'
         print(details)  # TODO(griptape): Move to Log
 
@@ -2407,6 +2430,7 @@ def handle_parameter_creation_saving(file: TextIO, node: NodeBase, flow_name: st
             diff = manage_alter_details(parameter, type(node))
             if diff:
                 diff["node_name"] = node.name
+                diff["parameter_name"] = parameter.name
                 creation_request = AlterParameterDetailsRequest.create(**diff)
                 code_string = f"GriptapeNodes().handle_request({creation_request})"
                 file.write(code_string + "\n")


### PR DESCRIPTION
- migrating PR from EE. 
- The re-router object should take the input and re-route out to the outputs.
- [old PR ](https://github.com/griptape-ai/griptape-vsl-execution-engine/pull/239)