### PR TITLE
adding engine ver and libraries to script info for dependency management

### DIFF
--- a/src/griptape_nodes/node_library/script_registry.py
+++ b/src/griptape_nodes/node_library/script_registry.py
@@ -14,10 +14,12 @@ class ScriptRegistry(SingletonMixin):
 
     # Create a new script with everything we'd need
     @classmethod
-    def generate_new_script(
+    def generate_new_script(  # noqa: PLR0913
         cls,
         name: str,
         relative_file_path: str,
+        engine_version_created_with: str,
+        node_libraries_referenced: list[str],
         description: str | None = None,
         image: str | None = None,
     ) -> Script:
@@ -26,7 +28,15 @@ class ScriptRegistry(SingletonMixin):
             # TODO(griptape): Should we rename scripts here?
             msg = f"Script with name {name} already registered."
             raise KeyError(msg)
-        script = Script(name, relative_file_path, instance._registry_key, description, image)
+        script = Script(
+            name=name,
+            relative_file_path=relative_file_path,
+            registry_key=instance._registry_key,
+            description=description,
+            image=image,
+            engine_version_created_with=engine_version_created_with,
+            node_libraries_referenced=node_libraries_referenced,
+        )
         instance._scripts[name] = script
         return script
 
@@ -66,13 +76,17 @@ class Script:
 
     name: str
     relative_file_path: str
+    engine_version_created_with: str
+    node_libraries_referenced: list[str]
     description: str | None
     image: str | None  # TODO(griptape): Make work with real images
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         name: str,
         relative_file_path: str,
+        engine_version_created_with: str,
+        node_libraries_referenced: list[str],
         registry_key: ScriptRegistry._RegistryKey,
         description: str | None = None,
         image: str | None = None,
@@ -90,6 +104,8 @@ class Script:
         self.relative_file_path = relative_file_path
         self.description = description
         self.image = image
+        self.engine_version_created_with = engine_version_created_with
+        self.node_libraries_referenced = node_libraries_referenced
 
     def get_script_metadata(self) -> dict:
         return {
@@ -97,4 +113,6 @@ class Script:
             "file_path": self.relative_file_path,
             "description": self.description,
             "image": self.image,
+            "engine_version_created_with": self.engine_version_created_with,
+            "node_libraries_referenced": self.node_libraries_referenced,
         }

--- a/src/griptape_nodes/retained_mode/events/script_events.py
+++ b/src/griptape_nodes/retained_mode/events/script_events.py
@@ -67,6 +67,8 @@ class RunScriptFromRegistryResult_Failure(ResultPayload_Failure):
 class RegisterScriptRequest(RequestPayload):
     script_name: str
     file_path: str
+    engine_version_created_with: str
+    node_libraries_referenced: list[str]
     description: str | None = None
     image: str | None = None
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -2266,10 +2266,12 @@ class ScriptManager:
     def on_register_script_request(self, request: RegisterScriptRequest) -> ResultPayload:
         try:
             script = ScriptRegistry.generate_new_script(
-                request.script_name,
-                request.file_path,
-                request.description,
-                request.image,
+                name=request.script_name,
+                relative_file_path=request.file_path,
+                engine_version_created_with=request.engine_version_created_with,
+                node_libraries_referenced=request.node_libraries_referenced,
+                description=request.description,
+                image=request.image,
             )
         except Exception as e:
             print(f"Failed to register script with name {request.script_name}. Error: {e}")
@@ -2318,6 +2320,8 @@ class ScriptManager:
         relative_file_path = f"{file_name}.py"
         file_path = config_manager.workspace_path.joinpath(relative_file_path)
         created_flows = []
+        node_libraries_used = set()
+
         try:
             with file_path.open("w") as file:
                 file.write("from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes\n")
@@ -2336,11 +2340,34 @@ class ScriptManager:
                     file.write(code_string + "\n")
                     # Save the parameters
                     handle_parameter_creation_saving(file, node, flow_name)
+
+                    # See if this node uses a library we need to know about.
+                    library_used = node.metadata["library"]
+                    node_libraries_used.add(library_used)
                 # Now all nodes AND parameters have been created
                 file.write(connection_request_scripts)
         except Exception as e:
-            print(f"Failed to save scene, exception: {e}")
+            details = f"Failed to save scene, exception: {e}"
+            print(details)  # TODO(griptape): Move to Log
             return SaveSceneResult_Failure()
+
+        # Get the engine version.
+        engine_version_request = GetEngineVersion_Request()
+        engine_version_result = GriptapeNodes.handle_request(request=engine_version_request)
+        if not engine_version_result.succeeded():
+            details = f"Attempted to save scene '{relative_file_path}', but failed getting the engine version."
+            print(details)  # TODO(griptape): Move to Log
+            return SaveSceneResult_Failure()
+        try:
+            engine_version_success = cast("GetEngineVersionResult_Success", engine_version_result)
+            engine_version = (
+                f"{engine_version_success.major}.{engine_version_success.minor}.{engine_version_success.patch}"
+            )
+        except Exception as err:
+            details = f"Attempted to save scene '{relative_file_path}', but failed getting the engine version: {err}"
+            print(details)  # TODO(griptape): Move to Log
+            return SaveSceneResult_Failure()
+
         # save the created scene to a personal json file
         if file_name not in ScriptRegistry.list_scripts():
             script = {
@@ -2348,6 +2375,8 @@ class ScriptManager:
                 "relative_file_path": relative_file_path,
                 "image": None,
                 "description": None,
+                "engine_version_created_with": engine_version,
+                "node_libraries_referenced": list(node_libraries_used),
             }
             config_manager.save_user_script_json(script)
             ScriptRegistry.generate_new_script(**script)
@@ -2882,6 +2911,8 @@ class LibraryManager:
                         file_path=str(file_path),
                         description=script["description"],
                         image=script["image"],
+                        engine_version_created_with=script["engine_version_created_with"],
+                        node_libraries_referenced=script["node_libraries_referenced"],
                     )
                     GriptapeNodes().handle_request(script_register_request)
                 else:
@@ -2892,6 +2923,8 @@ class LibraryManager:
                         file_path=str(full_path),
                         description=script["description"],
                         image=script["image"],
+                        engine_version_created_with=script["engine_version_created_with"],
+                        node_libraries_referenced=script["node_libraries_referenced"],
                     )
                     GriptapeNodes().handle_request(script_register_request)
 

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +41,8 @@ def _find_config_files(filename: str, extension: str) -> list[Path]:
 class Script(BaseModel):
     name: str
     relative_file_path: str
+    engine_version_created_with: str
+    node_libraries_referenced: list[str]
     description: str | None = None
     image: str | None = None
     internal: bool = False
@@ -55,21 +58,29 @@ class AppInitializationComplete(BaseModel):
                 name="Prompt an image",
                 relative_file_path="scripts/prompt_an_image.py",
                 internal=True,
+                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
+                node_libraries_referenced=["Griptape Nodes Library"],
             ),
             Script(
                 name="Coloring Book",
                 relative_file_path="scripts/coloring_book.py",
                 internal=True,
+                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
+                node_libraries_referenced=["Griptape Nodes Library"],
             ),
             Script(
                 name="Render logs",
                 relative_file_path="scripts/render_logs.py",
                 internal=True,
+                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
+                node_libraries_referenced=["Griptape Nodes Library"],
             ),
             Script(
                 name="Comfyui flow batch",
                 relative_file_path="scripts/comfyui_flow_batch.py",
                 internal=True,
+                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
+                node_libraries_referenced=["Griptape Nodes Library"],
             ),
         ]
     )


### PR DESCRIPTION
We need provenance for which a script was created. This includes the engine version (in case a breaking change comes in that we cannot overcome) and which libraries were used to build the scene. We add this additional data now alongside the existing script metadata.

Closes #13 