### PR TITLE
Removed Temporary Hack for Connection Deletion

### DIFF
--- a/src/griptape_nodes/exe_types/connections.py
+++ b/src/griptape_nodes/exe_types/connections.py
@@ -103,25 +103,29 @@ class Connections:
             return connection.source_node, connection.source_parameter
         return None
 
-    def remove_connection(self, source_node: str, source_parameter: str, target_node:str, target_parameter:str) -> bool:
-            # Remove from outgoing
-            try:
-                # use copy to prevent modifying the list while it's iterating
-                outgoing_parameter_connections = self.outgoing_index[source_node][source_parameter].copy()
-            except Exception as e:
-                print(f"Cannot remove connection that does not exist: {e}")
-                return False
-            for connection_id in outgoing_parameter_connections:
-                if connection_id not in self.connections:
-                    print("Cannot remove connection does not exist")
-                    return False
-                connection = self.connections[connection_id]
-                test_target_node = connection.target_node.name
-                test_target_parameter = connection.target_parameter.name
-                if test_target_node == target_node and test_target_parameter == target_parameter:
-                    self._remove_connection(connection_id, source_node, source_parameter, test_target_node, test_target_parameter)
-                    return True
+    def remove_connection(
+        self, source_node: str, source_parameter: str, target_node: str, target_parameter: str
+    ) -> bool:
+        # Remove from outgoing
+        try:
+            # use copy to prevent modifying the list while it's iterating
+            outgoing_parameter_connections = self.outgoing_index[source_node][source_parameter].copy()
+        except Exception as e:
+            print(f"Cannot remove connection that does not exist: {e}")
             return False
+        for connection_id in outgoing_parameter_connections:
+            if connection_id not in self.connections:
+                print("Cannot remove connection does not exist")
+                return False
+            connection = self.connections[connection_id]
+            test_target_node = connection.target_node.name
+            test_target_parameter = connection.target_parameter.name
+            if test_target_node == target_node and test_target_parameter == target_parameter:
+                self._remove_connection(
+                    connection_id, source_node, source_parameter, test_target_node, test_target_parameter
+                )
+                return True
+        return False
 
     def _remove_connection(
         self, connection_id: int, source_node: str, source_param: str, target_node: str, target_param: str

--- a/src/griptape_nodes/exe_types/connections.py
+++ b/src/griptape_nodes/exe_types/connections.py
@@ -103,12 +103,11 @@ class Connections:
             return connection.source_node, connection.source_parameter
         return None
 
-    def remove_connection(self, node: NodeBase, parameter: Parameter) -> bool:
-        if ParameterControlType.__name__ in parameter.allowed_types:
+    def remove_connection(self, source_node: str, source_parameter: str, target_node:str, target_parameter:str) -> bool:
             # Remove from outgoing
             try:
                 # use copy to prevent modifying the list while it's iterating
-                outgoing_parameter_connections = self.outgoing_index[node.name][parameter.name].copy()
+                outgoing_parameter_connections = self.outgoing_index[source_node][source_parameter].copy()
             except Exception as e:
                 print(f"Cannot remove connection that does not exist: {e}")
                 return False
@@ -117,23 +116,12 @@ class Connections:
                     print("Cannot remove connection does not exist")
                     return False
                 connection = self.connections[connection_id]
-                target_node = connection.target_node.name
-                target_parameter = connection.target_parameter.name
-                self._remove_connection(connection_id, node.name, parameter.name, target_node, target_parameter)
-        else:
-            # Remove from outgoing
-            try:
-                incoming_parameter_connections = self.incoming_index[node.name][parameter.name].copy()
-            except Exception:
-                return False
-            for connection_id in incoming_parameter_connections:
-                if connection_id not in self.connections:
-                    return False
-                connection = self.connections[connection_id]
-                source_node = connection.source_node.name
-                source_parameter = connection.source_parameter.name
-                self._remove_connection(connection_id, source_node, source_parameter, node.name, parameter.name)
-        return True
+                test_target_node = connection.target_node.name
+                test_target_parameter = connection.target_parameter.name
+                if test_target_node == target_node and test_target_parameter == target_parameter:
+                    self._remove_connection(connection_id, source_node, source_parameter, test_target_node, test_target_parameter)
+                    return True
+            return False
 
     def _remove_connection(
         self, connection_id: int, source_node: str, source_param: str, target_node: str, target_param: str

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -50,10 +50,10 @@ class ControlFlow:
         source_node: NodeBase,
         source_parameter: Parameter,
         target_node: NodeBase,
-        target_parameter: Parameter,  # noqa: ARG002
+        target_parameter: Parameter
     ) -> bool:
         if source_node.name in self.nodes and target_node.name in self.nodes:
-            return self.connections.remove_connection(source_node, source_parameter)
+            return self.connections.remove_connection(source_node.name, source_parameter.name,target_node.name,target_parameter.name)
         return False
 
     def has_connection(
@@ -64,11 +64,12 @@ class ControlFlow:
         target_parameter: Parameter,
     ) -> bool:
         if source_node.name in self.nodes and target_node.name in self.nodes:
-            connected_node_tuple = self.connections.get_connected_node(source_node, source_parameter)
+            connected_node_tuple = self.get_connected_output_parameters(node=source_node, param=source_parameter)
             if connected_node_tuple is not None:
-                connected_node, connected_param = connected_node_tuple
-                if connected_node is target_node and connected_param is target_parameter:
-                    return True
+                for connected_node_values in connected_node_tuple:
+                    connected_node, connected_param = connected_node_values
+                    if connected_node is target_node and connected_param is target_parameter:
+                        return True
         return False
 
     def start_flow(self, start_node: NodeBase | None = None, debug_mode: bool = False) -> None:  # noqa: FBT001, FBT002

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -46,14 +46,12 @@ class ControlFlow:
         return False
 
     def remove_connection(
-        self,
-        source_node: NodeBase,
-        source_parameter: Parameter,
-        target_node: NodeBase,
-        target_parameter: Parameter
+        self, source_node: NodeBase, source_parameter: Parameter, target_node: NodeBase, target_parameter: Parameter
     ) -> bool:
         if source_node.name in self.nodes and target_node.name in self.nodes:
-            return self.connections.remove_connection(source_node.name, source_parameter.name,target_node.name,target_parameter.name)
+            return self.connections.remove_connection(
+                source_node.name, source_parameter.name, target_node.name, target_parameter.name
+            )
         return False
 
     def has_connection(

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -970,15 +970,6 @@ class FlowManager:
             result = DeleteConnectionResult_Failure()
             return result
 
-        # TEMP HACK: Data connections appear to reverse Source and Target. TODO(griptape): Let's reconcile this.
-        if ParameterControlType.__name__ not in source_param.allowed_types:
-            temp_node = source_node
-            temp_param = source_param
-            source_node = target_node
-            source_param = target_param
-            target_node = temp_node
-            target_param = temp_param
-
         # Vet that a Connection actually exists between them already.
         if not source_flow.has_connection(
             source_node=source_node,
@@ -1004,15 +995,6 @@ class FlowManager:
 
             result = DeleteConnectionResult_Failure()
             return result
-
-        # TEMP HACK: SWAP BACK Data connections appear to reverse Source and Target. TODO(griptape): Let's reconcile this. SWAP BACK
-        if ParameterControlType.__name__ not in source_param.allowed_types:
-            temp_node = source_node
-            temp_param = source_param
-            source_node = target_node
-            source_param = target_param
-            target_node = temp_node
-            target_param = temp_param
 
         # Let the source make any internal handling decisions now that the Connection has been REMOVED.
         source_node.handle_outgoing_connection_removed(

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -898,7 +898,7 @@ class FlowManager:
 
         return result
 
-    def on_delete_connection_request(self, request: DeleteConnectionRequest) -> ResultPayload:  # noqa: PLR0911, PLR0915, C901 TODO(griptape): resolve
+    def on_delete_connection_request(self, request: DeleteConnectionRequest) -> ResultPayload:  # noqa: PLR0911, PLR0915 TODO(griptape): resolve
         # Vet the two nodes first.
         source_node = None
         try:


### PR DESCRIPTION
- We had some old code that dated back to when we were representing connections differently. I removed that code, and refactored a bug that I then caught in connections where deleting a connection was deleting all connections from that parameter, not just the one connection that needed to be deleted. (This wasn't an issue with the old hack, but needed to be modified on removal of that). 