### PR TITLE
Prevents Engine shutdown on library or node error

### DIFF
--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1401,7 +1401,7 @@ class NodeManager:
         try:
             parent_flow = GriptapeNodes().FlowManager().get_flow_by_name(parent_flow_name)
         except KeyError as err:
-            details= f"Attempted to delete a Node '{request.node_name}'. Error: {err}"
+            details = f"Attempted to delete a Node '{request.node_name}'. Error: {err}"
             GriptapeNodes.get_logger().error(details)
 
             result = DeleteNodeResult_Failure()
@@ -1899,7 +1899,8 @@ class NodeManager:
         result = AlterParameterDetailsResult_Success()
         return result
 
-    def on_get_parameter_value_request(self, request: GetParameterValueRequest) -> ResultPayload:
+    # For C901 (too complex): Need to give customers explicit reasons for failure on each case.
+    def on_get_parameter_value_request(self, request: GetParameterValueRequest) -> ResultPayload:  # noqa: C901
         # Does this node exist?
         obj_mgr = GriptapeNodes().get_instance().ObjectManager()
 
@@ -2559,7 +2560,7 @@ class ScriptManager:
                     try:
                         handle_parameter_creation_saving(file, node, flow_name)
                     except Exception as e:
-                        details=f"Failed to save scene because failed to save parameter creation for node '{node.name}'. Error: {e}"
+                        details = f"Failed to save scene because failed to save parameter creation for node '{node.name}'. Error: {e}"
                         GriptapeNodes.get_logger().error(details)
                         return SaveSceneResult_Failure()
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -16,7 +16,7 @@ from xdg_base_dirs import xdg_data_home
 from griptape_nodes.exe_types.core_types import Parameter, ParameterControlType, ParameterMode
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import NodeBase, NodeResolutionState
-from griptape_nodes.exe_types.type_validator import TypeValidator
+from griptape_nodes.exe_types.type_validator import TypeValidationError, TypeValidator
 from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.node_library.script_registry import ScriptRegistry
 from griptape_nodes.retained_mode.events.app_events import (
@@ -1912,10 +1912,15 @@ class NodeManager:
         data_value_type = type(data_value)
         data_value_type_str = None
         for allowed_type_str in parameter.allowed_types:
-            allowed_type = TypeValidator.convert_to_type(allowed_type_str)
-            if allowed_type == data_value_type:
-                data_value_type_str = allowed_type_str
-                break
+            try:
+                allowed_type = TypeValidator.convert_to_type(allowed_type_str)
+                if allowed_type == data_value_type:
+                    data_value_type_str = allowed_type_str
+                    break
+            except TypeValidationError as e:
+                details = f"Failed to Get Parameter Value. {e}"
+                GriptapeNodes.get_logger().error(details)
+                return GetParameterValueResult_Failure()
 
         # TODO(griptape): Handle for dict type
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1356,7 +1356,8 @@ class NodeManager:
                 specific_library_name=request.specific_library_name,
                 metadata=request.metadata,
             )
-        except KeyError as err:
+        # modifying to exception to try to catch all possible issues with node creation.
+        except Exception as err:
             details = f"Could not create Node '{final_node_name}' of type '{request.node_type}': {err}"
             GriptapeNodes.get_logger().error(details)
 


### PR DESCRIPTION
Closes #25 and #15 . 
- Updated node creation to check types to catch errors before `GetAllNodeInfoRequest`. 
- Updated `GetParameterValueRequest` with a try-catch. All exceptions raised should be logged, and not shut down the engine. 
- Noticed that `get_flow_by_name` threw a `KeyError` instead of returning `None`, so I updated code to make sure to account for that.
- Try-catches the json.loads for libraries so it just doesn't load that library instead of shutting down engine