### PR TITLE
Add Validation to Start Flow and Resolve Node on request

### DIFF
--- a/nodes/griptape_nodes_library/start_flow.py
+++ b/nodes/griptape_nodes_library/start_flow.py
@@ -1,10 +1,10 @@
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import ControlParameter_Output
-from griptape_nodes.exe_types.node_types import NodeBase
+from griptape_nodes.exe_types.node_types import StartNode
 
 
-class gnStartFlow(NodeBase):
+class gnStartFlow(StartNode):
     def __init__(
         self,
         name: str,

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -380,11 +380,10 @@ class ControlFlow:
                         queue.put(next_node)
         return list(processed.keys())
 
-    def get_node_dependencies(self, node:NodeBase) -> list[NodeBase]:
+    def get_node_dependencies(self, node: NodeBase) -> list[NodeBase]:
         node_list = [node]
         node_queue = Queue()
         node_queue.put(node)
-        input_connections = self.get_connected_input_from_node(node)
         while not node_queue.empty():
             curr_node = node_queue.get()
             input_connections = self.get_connected_input_from_node(curr_node)

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -224,7 +224,7 @@ class ControlFlow:
                     connections.append((connection.source_node, connection.source_parameter))
         return connections
 
-    def get_connected_output_from_node(self, node: NodeBase) -> list[tuple[NodeBase, Parameter]] | None:
+    def get_connected_output_from_node(self, node: NodeBase) -> list[tuple[NodeBase, Parameter]]:
         connections = []
         if node.name in self.connections.outgoing_index:
             connection_ids = [
@@ -233,9 +233,9 @@ class ControlFlow:
             for connection_id in connection_ids:
                 connection = self.connections.connections[connection_id]
                 connections.append((connection.target_node, connection.target_parameter))
-        return connections if connections else None
+        return connections
 
-    def get_connected_input_from_node(self, node: NodeBase) -> list[tuple[NodeBase, Parameter]] | None:
+    def get_connected_input_from_node(self, node: NodeBase) -> list[tuple[NodeBase, Parameter]]:
         connections = []
         if node.name in self.connections.incoming_index:
             connection_ids = [
@@ -244,7 +244,7 @@ class ControlFlow:
             for connection_id in connection_ids:
                 connection = self.connections.connections[connection_id]
                 connections.append((connection.source_node, connection.source_parameter))
-        return connections if connections else None
+        return connections
 
     def get_start_node_queue(self) -> Queue | None:  # noqa: C901, PLR0912
         # check all nodes in flow

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -381,6 +381,17 @@ class ControlFlow:
         return list(processed.keys())
 
     def get_node_dependencies(self, node: NodeBase) -> list[NodeBase]:
+        """Get all upstream nodes that the given node depends on.
+
+        This method performs a breadth-first search starting from the given node and working backwards through its non-control input connections to identify all nodes that must run before this node can be resolved.
+        It ignores control connections, since we're only focusing on node dependencies.
+
+        Args:
+            node (NodeBase): The node to find dependencies for
+
+        Returns:
+            list[NodeBase]: A list of all nodes that the given node depends on, including the node itself (as the first element)
+        """
         node_list = [node]
         node_queue = Queue()
         node_queue.put(node)

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -28,7 +28,7 @@ class ResolveNodeResult_Success(ResultPayload_Success):
 @dataclass
 @PayloadRegistry.register
 class ResolveNodeResult_Failure(ResultPayload_Failure):
-    pass
+    validation_exceptions: list[Exception] | None = None
 
 
 @dataclass
@@ -48,7 +48,7 @@ class StartFlowResult_Success(ResultPayload_Success):
 @dataclass
 @PayloadRegistry.register
 class StartFlowResult_Failure(ResultPayload_Failure):
-    pass
+    validation_exceptions: list[Exception] | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -28,7 +28,7 @@ class ResolveNodeResult_Success(ResultPayload_Success):
 @dataclass
 @PayloadRegistry.register
 class ResolveNodeResult_Failure(ResultPayload_Failure):
-    validation_exceptions: list[Exception] | None = None
+    validation_exceptions: list[Exception]
 
 
 @dataclass
@@ -48,7 +48,7 @@ class StartFlowResult_Success(ResultPayload_Success):
 @dataclass
 @PayloadRegistry.register
 class StartFlowResult_Failure(ResultPayload_Failure):
-    validation_exceptions: list[Exception] | None = None
+    validation_exceptions: list[Exception]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/validation_events.py
+++ b/src/griptape_nodes/retained_mode/events/validation_events.py
@@ -17,7 +17,7 @@ class ValidateFlowDependenciesRequest(RequestPayload):
 @PayloadRegistry.register
 class ValidateFlowDependenciesResult_Success(ResultPayload_Success):
     validation_succeeded: bool
-    exceptions: list[Exception] | None = None
+    exceptions: list[Exception]
 
 
 # if it doesn't have a dependency we want
@@ -38,7 +38,7 @@ class ValidateNodeDependenciesRequest(RequestPayload):
 @PayloadRegistry.register
 class ValidateNodeDependenciesResult_Success(ResultPayload_Success):
     validation_succeeded: bool
-    exceptions: list[Exception] | None = None
+    exceptions: list[Exception]
 
 
 # if it doesn't have a dependency we want

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -2372,8 +2372,6 @@ class NodeManager:
             details = f'Failed to validate node dependencies. Node with "{node_name}" does not exist.'
             GriptapeNodes.get_logger().error(details)
             return ValidateNodeDependenciesResult_Failure()
-        # TODO (kate): I think I need to get all of the dependencies here.
-        # unfortunately - i think i need to get flow here.
         try:
             flow_name = self.get_node_parent_flow_by_name(node_name)
         except Exception:

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1158,20 +1158,20 @@ class FlowManager:
             details = "Could not step flow. No flow name was provided."
             GriptapeNodes.get_logger().error(details)
 
-            return SingleNodeStepResult_Failure()
+            return SingleNodeStepResult_Failure(validation_exceptions=[])
         flow = self.get_flow_by_name(flow_name)
         if not flow:
             details = f"Could not step flow. No flow with name {flow_name} exists."
             GriptapeNodes.get_logger().error(details)
 
-            return SingleNodeStepResult_Failure()
+            return SingleNodeStepResult_Failure(validation_exceptions=[])
         try:
             flow.single_node_step()
         except Exception as e:
             details = f"Could not step flow. Exception: {e}"
             GriptapeNodes.get_logger().error(details)
 
-            return SingleNodeStepResult_Failure()
+            return SingleNodeStepResult_Failure(validation_exceptions=[])
 
         # All completed happily
         details = f"Successfully stepped flow with name {flow_name}"
@@ -1198,7 +1198,7 @@ class FlowManager:
             details = f"Could not step flow. Exception: {e}"
             GriptapeNodes.get_logger().error(details)
 
-            return SingleNodeStepResult_Failure()
+            return SingleNodeStepResult_Failure(validation_exceptions=[])
         details = f"Successfully granularly stepped flow with name {flow_name}"
         GriptapeNodes.get_logger().info(details)
 


### PR DESCRIPTION
- Received a request from @aodhanroche to package validation into `StartFlowRequest` and `ResolveNodeRequest`. 
- Validation is now called by both of these requests, and if validation fails, the exceptions are returned. 
### New Structure of return: 
```
class StartFlowResult_Failure(ResultPayload_Failure):
    validation_exceptions: list[Exception] | None = None

class ResolveNodeResult_Failure(ResultPayload_Failure):
    validation_exceptions: list[Exception] | None = None
```

Now the list of exceptions is returned in the event on a failure (If validation is WHY it failed). 

closes #55 