### PR TITLE
Task/update node and param callbacks

### DIFF
--- a/nodes/griptape_nodes_library/utils/reroute.py
+++ b/nodes/griptape_nodes_library/utils/reroute.py
@@ -98,7 +98,7 @@ class gnReroute(DataNode):
         intersection = gnReroute.intersection_of_allowed_types(*all_allowed_types)
         parameter.allowed_types = intersection
 
-    def handle_incoming_connection(
+    def after_incoming_connection(
         self,
         source_node: NodeBase,  # noqa: ARG002
         source_parameter: Parameter,
@@ -108,7 +108,7 @@ class gnReroute(DataNode):
         self.incoming_connection_params.append(source_parameter)
         self.update_allowed_types_based_on_connection_status(parameter=target_parameter)
 
-    def handle_outgoing_connection(
+    def after_outgoing_connection(
         self,
         source_parameter: Parameter,
         target_node: NodeBase,  # noqa: ARG002
@@ -118,7 +118,7 @@ class gnReroute(DataNode):
         self.outgoing_connection_params.append(target_parameter)
         self.update_allowed_types_based_on_connection_status(parameter=source_parameter)
 
-    def handle_incoming_connection_removed(
+    def after_incoming_connection_removed(
         self,
         source_node: NodeBase,  # noqa: ARG002
         source_parameter: Parameter,
@@ -128,7 +128,7 @@ class gnReroute(DataNode):
         self.incoming_connection_params.remove(source_parameter)
         self.update_allowed_types_based_on_connection_status(parameter=target_parameter)
 
-    def handle_outgoing_connection_removed(
+    def after_outgoing_connection_removed(
         self,
         source_parameter: Parameter,
         target_node: NodeBase,  # noqa: ARG002

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -219,6 +219,9 @@ class NodeBase(ABC):
         the value assignment. Similarly, validator callbacks may reject the value and
         raise an Exception.
 
+        Exceptions should be handled by the caller; this may result in canceling
+        a running Flow or forcing an upstream object to alter its assumptions.
+
         Changing a Parameter may trigger other Parameters within the Node
         to be changed. If other Parameters are changed, the engine needs a list of which
         ones have changed to cascade unresolved state.
@@ -237,13 +240,15 @@ class NodeBase(ABC):
             err = f"Attempted to set value for Parameter '{param_name}' but no such Parameter could be found."
             raise KeyError(err)
         # Perform any conversions to the value based on how the Parameter is configured.
-        # THESE MAY RAISE EXCEPTIONS
+        # THESE MAY RAISE EXCEPTIONS. These can cause a running Flow to be canceled, or
+        # cause a calling object to alter its assumptions/behavior.
         final_value = value
         for converter in parameter.converters:
             final_value = converter(final_value)
 
         # Validate the values next, based on how the Parameter is configured.
-        # THESE MAY RAISE EXCEPTIONS.
+        # THESE MAY RAISE EXCEPTIONS. These can cause a running Flow to be canceled, or
+        # cause a calling object to alter its assumptions/behavior.
         for validator in parameter.validators:
             validator(parameter, final_value)
 

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -77,7 +77,7 @@ class NodeBase(ABC):
     ) -> bool:
         return True
 
-    def handle_incoming_connection(
+    def after_incoming_connection(
         self,
         source_node: Self,  # noqa: ARG002
         source_parameter: Parameter,  # noqa: ARG002
@@ -86,7 +86,7 @@ class NodeBase(ABC):
         """Callback after a Connection has been established TO this Node."""
         return
 
-    def handle_outgoing_connection(
+    def after_outgoing_connection(
         self,
         source_parameter: Parameter,  # noqa: ARG002
         target_node: Self,  # noqa: ARG002
@@ -95,7 +95,7 @@ class NodeBase(ABC):
         """Callback after a Connection has been established OUT of this Node."""
         return
 
-    def handle_incoming_connection_removed(
+    def after_incoming_connection_removed(
         self,
         source_node: Self,  # noqa: ARG002
         source_parameter: Parameter,  # noqa: ARG002
@@ -104,7 +104,7 @@ class NodeBase(ABC):
         """Callback after a Connection TO this Node was REMOVED."""
         return
 
-    def handle_outgoing_connection_removed(
+    def after_outgoing_connection_removed(
         self,
         source_parameter: Parameter,  # noqa: ARG002
         target_node: Self,  # noqa: ARG002

--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -121,7 +121,7 @@ class EvaluateParameterState(State):
 
 class ExecuteNodeState(State):
     @staticmethod
-    def on_enter(context: ResolutionContext) -> type[State] | None:  # noqa: C901, PLR0912, PLR0915
+    def on_enter(context: ResolutionContext) -> type[State] | None:  # noqa: C901, PLR0912
         current_node = context.focus_stack[-1]
         connections = context.flow.connections
         # Get the parameters that have input values
@@ -185,27 +185,16 @@ class ExecuteNodeState(State):
                 else:
                     data_type = type(parameter_value).__name__
 
-                # Run through all converters
                 try:
-                    for converter in parameter.converters:
-                        parameter_value = converter(parameter_value)
+                    current_node.set_parameter_value(parameter.name, parameter_value)
                 except Exception as e:
-                    msg = f"Canceling flow run. Node '{current_node.name}' failed to convert {parameter.name}: {e}"
+                    msg = (
+                        f"Canceling flow run. Node '{current_node.name}' failed to set value for {parameter.name}: {e}"
+                    )
                     current_node.state = NodeResolutionState.UNRESOLVED
                     context.flow.cancel_flow_run()
                     raise RuntimeError(msg) from e
 
-                # Run through all validators
-                try:
-                    for validator in parameter.validators:
-                        validator(parameter, parameter_value)
-                except Exception as e:
-                    msg = f"Canceling flow run. Node '{current_node.name}' failed to validate {parameter.name}: {e}"
-                    current_node.state = NodeResolutionState.UNRESOLVED
-                    context.flow.cancel_flow_run()
-                    raise RuntimeError(msg) from e
-
-                current_node.set_parameter_value(parameter.name, parameter_value)
                 EventBus.publish_event(
                     ExecutionGriptapeNodeEvent(
                         wrapped_event=ExecutionEvent(

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -872,14 +872,14 @@ class FlowManager:
             return CreateConnectionResult_Failure()
 
         # Let the source make any internal handling decisions now that the Connection has been made.
-        source_node.handle_outgoing_connection(
+        source_node.after_outgoing_connection(
             source_parameter=source_param,
             target_node=target_node,
             target_parameter=target_param,
         )
 
         # And target.
-        target_node.handle_incoming_connection(
+        target_node.after_incoming_connection(
             source_node=source_node,
             source_parameter=source_param,
             target_parameter=target_param,
@@ -1013,14 +1013,14 @@ class FlowManager:
             return result
 
         # Let the source make any internal handling decisions now that the Connection has been REMOVED.
-        source_node.handle_outgoing_connection_removed(
+        source_node.after_outgoing_connection_removed(
             source_parameter=source_param,
             target_node=target_node,
             target_parameter=target_param,
         )
 
         # And target.
-        target_node.handle_incoming_connection_removed(
+        target_node.after_incoming_connection_removed(
             source_node=source_node,
             source_parameter=source_param,
             target_parameter=target_param,


### PR DESCRIPTION
Beefed up the set_parameter_value function to do the following:
1. Perform conversion and validation BEFORE assignment (may throw). Yanked this out of the node_resolution.
2. Offer custom NODE logic before assignment of a Parameter value. This is the `before_value_set`, which a node may elect to override. Kate had a similar callback in place, but this allows the NODE (not the Param) to catch it and override default behavior. This is useful for, say, a bool Parameter being checked to change a bunch of other Parameters. Needs to return a set of modified Parameters so the engine knows who dirty and who not so dirty.
3. Similar behavior for a NODE-level override for logic AFTER the value has been set. If this modifies things, give us back the set please.

Also updated the other callbacks to match what we discussed today.