### PR TITLE
Include library version when saving scene so that we can catch it later if there is an update needed.

### DIFF
--- a/nodes/griptape_nodes_library.json
+++ b/nodes/griptape_nodes_library.json
@@ -1,5 +1,6 @@
 {
   "name": "Griptape Nodes Library",
+  "library_schema_version": "0.1.0",
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Default nodes for Griptape Nodes.",

--- a/nodes/griptape_nodes_library.json
+++ b/nodes/griptape_nodes_library.json
@@ -3,7 +3,8 @@
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Default nodes for Griptape Nodes.",
-    "version": "1.0.0",
+    "library_version": "0.1.0",
+    "engine_version_created_with": "0.1.0",
     "tags": [
       "Griptape",
       "AI"

--- a/nodes/griptape_nodes_library.json
+++ b/nodes/griptape_nodes_library.json
@@ -5,7 +5,7 @@
     "author": "Griptape, Inc.",
     "description": "Default nodes for Griptape Nodes.",
     "library_version": "0.1.0",
-    "engine_version_created_with": "0.1.0",
+    "engine_version": "0.1.0",
     "tags": [
       "Griptape",
       "AI"

--- a/src/griptape_nodes/node_library/script_registry.py
+++ b/src/griptape_nodes/node_library/script_registry.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import NamedTuple
 
 from griptape.mixins.singleton_mixin import SingletonMixin
+
+
+class LibraryAndLibVersion(NamedTuple):
+    library_name: str
+    library_version: str
 
 
 class ScriptRegistry(SingletonMixin):
@@ -19,7 +25,7 @@ class ScriptRegistry(SingletonMixin):
         name: str,
         relative_file_path: str,
         engine_version_created_with: str,
-        node_libraries_referenced: list[str],
+        node_libraries_referenced: list[LibraryAndLibVersion],
         description: str | None = None,
         image: str | None = None,
     ) -> Script:
@@ -77,7 +83,7 @@ class Script:
     name: str
     relative_file_path: str
     engine_version_created_with: str
-    node_libraries_referenced: list[str]
+    node_libraries_referenced: list[LibraryAndLibVersion]
     description: str | None
     image: str | None  # TODO(griptape): Make work with real images
 
@@ -86,7 +92,7 @@ class Script:
         name: str,
         relative_file_path: str,
         engine_version_created_with: str,
-        node_libraries_referenced: list[str],
+        node_libraries_referenced: list[LibraryAndLibVersion],
         registry_key: ScriptRegistry._RegistryKey,
         description: str | None = None,
         image: str | None = None,

--- a/src/griptape_nodes/node_library/script_registry.py
+++ b/src/griptape_nodes/node_library/script_registry.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 from griptape.mixins.singleton_mixin import SingletonMixin
 
 
-class LibraryAndLibVersion(NamedTuple):
+class LibraryNameAndVersion(NamedTuple):
     library_name: str
     library_version: str
 
@@ -25,7 +25,7 @@ class ScriptRegistry(SingletonMixin):
         name: str,
         relative_file_path: str,
         engine_version_created_with: str,
-        node_libraries_referenced: list[LibraryAndLibVersion],
+        node_libraries_referenced: list[LibraryNameAndVersion],
         description: str | None = None,
         image: str | None = None,
     ) -> Script:
@@ -83,7 +83,7 @@ class Script:
     name: str
     relative_file_path: str
     engine_version_created_with: str
-    node_libraries_referenced: list[LibraryAndLibVersion]
+    node_libraries_referenced: list[LibraryNameAndVersion]
     description: str | None
     image: str | None  # TODO(griptape): Make work with real images
 
@@ -92,7 +92,7 @@ class Script:
         name: str,
         relative_file_path: str,
         engine_version_created_with: str,
-        node_libraries_referenced: list[LibraryAndLibVersion],
+        node_libraries_referenced: list[LibraryNameAndVersion],
         registry_key: ScriptRegistry._RegistryKey,
         description: str | None = None,
         image: str | None = None,

--- a/src/griptape_nodes/retained_mode/events/script_events.py
+++ b/src/griptape_nodes/retained_mode/events/script_events.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from griptape_nodes.node_library.script_registry import LibraryAndLibVersion
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload_Failure,
@@ -68,7 +69,7 @@ class RegisterScriptRequest(RequestPayload):
     script_name: str
     file_path: str
     engine_version_created_with: str
-    node_libraries_referenced: list[str]
+    node_libraries_referenced: list[LibraryAndLibVersion]
     description: str | None = None
     image: str | None = None
 

--- a/src/griptape_nodes/retained_mode/events/script_events.py
+++ b/src/griptape_nodes/retained_mode/events/script_events.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from griptape_nodes.node_library.script_registry import LibraryAndLibVersion
+from griptape_nodes.node_library.script_registry import LibraryNameAndVersion
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload_Failure,
@@ -69,7 +69,7 @@ class RegisterScriptRequest(RequestPayload):
     script_name: str
     file_path: str
     engine_version_created_with: str
-    node_libraries_referenced: list[LibraryAndLibVersion]
+    node_libraries_referenced: list[LibraryNameAndVersion]
     description: str | None = None
     image: str | None = None
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -18,7 +18,7 @@ from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import NodeBase, NodeResolutionState
 from griptape_nodes.exe_types.type_validator import TypeValidationError, TypeValidator
 from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.node_library.script_registry import LibraryAndLibVersion, ScriptRegistry
+from griptape_nodes.node_library.script_registry import LibraryNameAndVersion, ScriptRegistry
 from griptape_nodes.retained_mode.events.app_events import (
     AppExecutionEvent,
     AppInitializationComplete,
@@ -2586,7 +2586,7 @@ class ScriptManager:
                         details = f"Attempted to save scene '{relative_file_path}', but failed to get library version from metadata for library '{library_used}': {err}."
                         GriptapeNodes.get_logger().error(details)
                         return SaveSceneResult_Failure()
-                    library_and_version = LibraryAndLibVersion(
+                    library_and_version = LibraryNameAndVersion(
                         library_name=library_used, library_version=library_version
                     )
                     node_libraries_used.add(library_and_version)

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -12,6 +12,8 @@ from pydantic_settings import (
 )
 from xdg_base_dirs import xdg_config_dirs, xdg_config_home, xdg_data_home
 
+from griptape_nodes.node_library.script_registry import LibraryAndLibVersion
+
 
 def _find_config_files(filename: str, extension: str) -> list[Path]:
     home = Path.home()
@@ -42,7 +44,7 @@ class Script(BaseModel):
     name: str
     relative_file_path: str
     engine_version_created_with: str
-    node_libraries_referenced: list[str]
+    node_libraries_referenced: list[LibraryAndLibVersion]
     description: str | None = None
     image: str | None = None
     internal: bool = False
@@ -59,28 +61,28 @@ class AppInitializationComplete(BaseModel):
                 relative_file_path="griptape_nodes/scripts/prompt_an_image.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=["Griptape Nodes Library"],
+                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
             ),
             Script(
                 name="Coloring Book",
                 relative_file_path="griptape_nodes/scripts/coloring_book.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=["Griptape Nodes Library"],
+                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
             ),
             Script(
                 name="Render logs",
                 relative_file_path="griptape_nodes/scripts/render_logs.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=["Griptape Nodes Library"],
+                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
             ),
             Script(
                 name="Comfyui flow branch",
                 relative_file_path="griptape_nodes/scripts/comfyui_flow_branch.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=["Griptape Nodes Library"],
+                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
             ),
         ]
     )

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -12,7 +12,7 @@ from pydantic_settings import (
 )
 from xdg_base_dirs import xdg_config_dirs, xdg_config_home, xdg_data_home
 
-from griptape_nodes.node_library.script_registry import LibraryAndLibVersion
+from griptape_nodes.node_library.script_registry import LibraryNameAndVersion
 
 
 def _find_config_files(filename: str, extension: str) -> list[Path]:
@@ -44,7 +44,7 @@ class Script(BaseModel):
     name: str
     relative_file_path: str
     engine_version_created_with: str
-    node_libraries_referenced: list[LibraryAndLibVersion]
+    node_libraries_referenced: list[LibraryNameAndVersion]
     description: str | None = None
     image: str | None = None
     internal: bool = False
@@ -61,28 +61,28 @@ class AppInitializationComplete(BaseModel):
                 relative_file_path="griptape_nodes/scripts/prompt_an_image.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
+                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
             ),
             Script(
                 name="Coloring Book",
                 relative_file_path="griptape_nodes/scripts/coloring_book.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
+                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
             ),
             Script(
                 name="Render logs",
                 relative_file_path="griptape_nodes/scripts/render_logs.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
+                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
             ),
             Script(
                 name="Comfyui flow branch",
                 relative_file_path="griptape_nodes/scripts/comfyui_flow_branch.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryAndLibVersion("Griptape Nodes Library", "0.1.0")],
+                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
             ),
         ]
     )


### PR DESCRIPTION
Scene saving now records the version of a library (now a field in the library metadata) so that we can catch regressions, attempt migrations, or at least alert users if a change has occurred. Doing this as preparation for the example node library template repo.