### PR TITLE
Update nodes API URL to pull from environment

### DIFF
--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -6,6 +6,7 @@ import os
 import threading
 from time import sleep
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
 
 import httpx
 from flask import Flask
@@ -18,7 +19,6 @@ from griptape.events import (
     FinishStructureRunEvent,
     TextChunkEvent,
 )
-from urllib.parse import urljoin
 
 from griptape_nodes.api.queue_manager import event_queue
 from griptape_nodes.api.routes.api import api_blueprint, process_event

--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -18,6 +18,7 @@ from griptape.events import (
     FinishStructureRunEvent,
     TextChunkEvent,
 )
+from urllib.parse import urljoin
 
 from griptape_nodes.api.queue_manager import event_queue
 from griptape_nodes.api.routes.api import api_blueprint, process_event
@@ -155,8 +156,9 @@ def setup_event_listeners() -> None:
 def sse_listener() -> None:
     while True:
         try:
-            # TODO(griptape): make environment driven
-            endpoint = "https://api.nodes.griptape.ai/api/engines/stream"
+            endpoint = urljoin(
+                os.getenv("GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes.griptape.ai"), "/api/editors/request"
+            )
 
             def auth(request: httpx.Request) -> httpx.Request:
                 service = "Nodes"
@@ -185,7 +187,7 @@ def sse_listener() -> None:
                             logger.info("Engine is ready to receive events")
                         else:
                             process_event(json.loads(data))
-        except (httpx.HTTPStatusError, httpx.RemoteProtocolError):
+        except Exception:
             logger.exception("Error while listening to SSE")
             sleep(5)
 

--- a/src/griptape_nodes/api/routes/nodes_api_fake_socket.py
+++ b/src/griptape_nodes/api/routes/nodes_api_fake_socket.py
@@ -1,8 +1,8 @@
 import json
 import os
+from urllib.parse import urljoin
 
 import httpx
-from urllib.parse import urljoin
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 

--- a/src/griptape_nodes/api/routes/nodes_api_fake_socket.py
+++ b/src/griptape_nodes/api/routes/nodes_api_fake_socket.py
@@ -1,6 +1,8 @@
 import json
+import os
 
 import httpx
+from urllib.parse import urljoin
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -16,7 +18,7 @@ class NodesApiFakeSocket:
         )
         body = {"type": args[0], "payload": json.loads(args[1])}
         response = httpx.post(
-            "https://api.nodes.griptape.ai/api/editors/request",
+            urljoin(os.getenv("GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes.griptape.ai"), "/api/editors/request"),
             json=body,
             headers={"Authorization": f"Bearer {api_token}"},
             timeout=120,


### PR DESCRIPTION
`GRIPTAPE_NODES_API_BASE_URL` can be set in the `.env` for local development