### PR TITLE
Fix/catch param exceptions

### DIFF
--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1103,6 +1103,11 @@ class FlowManager:
         except Exception as e:
             details = f"Failed to kick off flow with name {flow_name}. Exception occurred: {e} "
             GriptapeNodes.get_logger().error(details)
+
+            # Cancel the flow run.
+            cancel_request = CancelFlowRequest(flow_name=flow_name)
+            GriptapeNodes.handle_request(cancel_request)
+
             return StartFlowResult_Failure(validation_exceptions=[])
 
         details = f"Successfully kicked off flow with name {flow_name}"

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -2060,7 +2060,13 @@ class NodeManager:
             return SetParameterValueResult_Failure()
 
         # Values are actually stored on the NODE.
-        modified_parameters = node.set_parameter_value(request.parameter_name, object_created)
+        try:
+            modified_parameters = node.set_parameter_value(request.parameter_name, object_created)
+        except Exception as err:
+            details = f'set_value for "{request.node_name}.{request.parameter_name}" failed. Exception: {err}'
+            GriptapeNodes.get_logger().error(details)
+            return SetParameterValueResult_Failure()
+
         if modified_parameters:
             for modified_parameter_name in modified_parameters:
                 modified_request = GetParameterDetailsRequest(modified_parameter_name, node.name)


### PR DESCRIPTION
1. Catch exceptions when a user attempts to set_parameter_value directly
2. If exception occurs during running flow, cancel it.