### PR TITLE
fix: solve install script issues

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -15,40 +15,10 @@ if ($API_KEY) {
 
     # Check if the file already exists
     if (Test-Path $ConfigFile) {
-        Write-Host "A config file already exists at '$ConfigFile'."
-        $response = Read-Host "Do you want to override it with the new API key? (y/n)"
-        switch -Wildcard ($response.ToLower()) {
-            'y' { 
-                '{
-  "griptape": {
-    "api_keys": {
-      "Nodes": {
-        "GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"
-      }
-    }
-  }
-}' | Out-File $ConfigFile
-                Write-Host "API key updated in $ConfigFile"
-            }
-            'yes' { 
-                '{
-  "griptape": {
-    "api_keys": {
-      "Nodes": {
-        "GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"
-      }
-    }
-  }
-}' | Out-File $ConfigFile
-                Write-Host "API key updated in $ConfigFile"
-            }
-            default {
-                Write-Host "Skipping config file update."
-            }
-        }
-    } else {
+        Write-Host "A config file already exists at '$ConfigFile', overwriting..."
+    } 
         # Write the API key to the config file
-        '{
+'{
   "griptape": {
     "api_keys": {
       "Nodes": {
@@ -57,8 +27,7 @@ if ($API_KEY) {
     }
   }
 }' | Out-File $ConfigFile
-        Write-Host "API key saved to $ConfigFile"
-    }
+    Write-Host "API key saved to $ConfigFile"
 } else {
     Write-Host "No API key provided. Skipping config file creation."
 }

--- a/install.ps1
+++ b/install.ps1
@@ -19,11 +19,27 @@ if ($API_KEY) {
         $response = Read-Host "Do you want to override it with the new API key? (y/n)"
         switch -Wildcard ($response.ToLower()) {
             'y' { 
-                '{"env": {"GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"}}' | Out-File $ConfigFile
+                '{
+  "griptape": {
+    "api_keys": {
+      "Nodes": {
+        "GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"
+      }
+    }
+  }
+}' | Out-File $ConfigFile
                 Write-Host "API key updated in $ConfigFile"
             }
             'yes' { 
-                '{"env": {"GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"}}' | Out-File $ConfigFile
+                '{
+  "griptape": {
+    "api_keys": {
+      "Nodes": {
+        "GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"
+      }
+    }
+  }
+}' | Out-File $ConfigFile
                 Write-Host "API key updated in $ConfigFile"
             }
             default {
@@ -32,13 +48,17 @@ if ($API_KEY) {
         }
     } else {
         # Write the API key to the config file
-        '{"env": {"GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"}}' | Out-File $ConfigFile
+        '{
+  "griptape": {
+    "api_keys": {
+      "Nodes": {
+        "GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"
+      }
+    }
+  }
+}' | Out-File $ConfigFile
         Write-Host "API key saved to $ConfigFile"
     }
-
-    # This matches the final overwrite in the original script:
-    '{"env": {"GRIPTAPE_NODES_API_KEY": "' + $API_KEY + '"}}' | Out-File $ConfigFile
-    Write-Host "API key saved to $ConfigFile"
 } else {
     Write-Host "No API key provided. Skipping config file creation."
 }
@@ -61,7 +81,6 @@ if (-not $Env:XDG_DATA_HOME) {
 Write-Host "`nInstalling Griptape Nodes Library...`n"
 $RepoName = "griptape-nodes"
 $TmpDir = New-TemporaryFile
-# Convert the temporary file to an actual directory path
 Remove-Item $TmpDir
 New-Item -ItemType Directory -Path $TmpDir | Out-Null
 

--- a/install.sh
+++ b/install.sh
@@ -14,23 +14,36 @@ if [ -n "$API_KEY" ]; then
         printf "Do you want to override it with the new API key? (y/n) "
         read -r RESPONSE
         case "$RESPONSE" in
-            [yY][eE][sS]|[yY])
-                echo "{\"env\": {\"GRIPTAPE_NODES_API_KEY\": \"$API_KEY\"}}" > "$CONFIG_FILE"
-                echo "API key updated in $CONFIG_FILE"
-                ;;
-            *)
-                echo "Skipping config file update."
-                ;;
+        [yY][eE][sS] | [yY])
+
+            echo '{
+  "griptape": {
+    "api_keys": {
+      "Nodes": {
+        "GRIPTAPE_NODES_API_KEY": "'"$API_KEY"'"
+      }
+    }
+  }
+}' >"$CONFIG_FILE"
+            echo "API key updated in $CONFIG_FILE"
+            ;;
+        *)
+            echo "Skipping config file update."
+            ;;
         esac
     else
         # Write the API key to the config file
-        echo "{\"env\": {\"GRIPTAPE_NODES_API_KEY\": \"$API_KEY\"}}" > "$CONFIG_FILE"
+        echo '{
+  "griptape": {
+    "api_keys": {
+      "Nodes": {
+        "GRIPTAPE_NODES_API_KEY": "'"$API_KEY"'"
+      }
+    }
+  }
+}' >"$CONFIG_FILE"
         echo "API key saved to $CONFIG_FILE"
     fi
-
-    # Write the API key to the config file
-    echo "{\"env\": {\"GRIPTAPE_NODES_API_KEY\": \"$API_KEY\"}}" > "$CONFIG_FILE"
-    echo "API key saved to $CONFIG_FILE"
 else
     echo "No API key provided. Skipping config file creation."
 fi
@@ -44,7 +57,6 @@ echo ""
 echo "Installing Griptape Nodes Engine..."
 echo ""
 uv tool install --force --python python3.13 --from git+https://github.com/griptape-ai/griptape-nodes.git@latest griptape_nodes
-
 
 # Install Griptape Nodes Library + Scripts
 : "${XDG_DATA_HOME:="$HOME/.local/share"}"
@@ -63,7 +75,7 @@ mkdir -p "$XDG_DATA_HOME/griptape_nodes"
 cp -R $REPO_NAME/nodes/ "$XDG_DATA_HOME/griptape_nodes/nodes"
 cp -R $REPO_NAME/scripts/ "$XDG_DATA_HOME/griptape_nodes/scripts"
 
-cd - > /dev/null
+cd - >/dev/null
 rm -rf "$TMP_DIR"
 
 echo ""
@@ -71,4 +83,3 @@ echo "Installation complete!"
 echo ""
 echo "Run 'griptape-nodes' (or just 'gtn') to start the engine."
 echo ""
-

--- a/install.sh
+++ b/install.sh
@@ -10,40 +10,19 @@ if [ -n "$API_KEY" ]; then
 
     # Check if the file already exists
     if [ -e "$CONFIG_FILE" ]; then
-        echo "A config file already exists at '$CONFIG_FILE'."
-        printf "Do you want to override it with the new API key? (y/n) "
-        read -r RESPONSE
-        case "$RESPONSE" in
-        [yY][eE][sS] | [yY])
-
-            echo '{
-  "griptape": {
-    "api_keys": {
-      "Nodes": {
-        "GRIPTAPE_NODES_API_KEY": "'"$API_KEY"'"
-      }
-    }
-  }
-}' >"$CONFIG_FILE"
-            echo "API key updated in $CONFIG_FILE"
-            ;;
-        *)
-            echo "Skipping config file update."
-            ;;
-        esac
-    else
-        # Write the API key to the config file
-        echo '{
-  "griptape": {
-    "api_keys": {
-      "Nodes": {
-        "GRIPTAPE_NODES_API_KEY": "'"$API_KEY"'"
-      }
-    }
-  }
-}' >"$CONFIG_FILE"
-        echo "API key saved to $CONFIG_FILE"
+        echo "A config file already exists at '$CONFIG_FILE', overwriting..."
     fi
+    # Write the API key to the config file
+    echo '{
+  "griptape": {
+    "api_keys": {
+      "Nodes": {
+        "GRIPTAPE_NODES_API_KEY": "'"$API_KEY"'"
+      }
+    }
+  }
+}' >"$CONFIG_FILE"
+    echo "API key saved to $CONFIG_FILE"
 else
     echo "No API key provided. Skipping config file creation."
 fi


### PR DESCRIPTION
- Fix install script config format
- Remove confirmation of overwriting config file. It doesn't work with bash piping and isn't a big deal if they overwrite.