### PR TITLE
docs: improve contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,17 +20,9 @@
    make install
    ```
 
-1. Install the stdlib of scripts/nodes:
+1. Install the Griptape Nodes Engine:
 
-   ```shell
-   ./install.sh
-   ```
-
-   If you have Griptape Nodes API key, pass it as an argument to the install script:
-
-   ```shell
-   ./install.sh <API_KEY>
-   ```
+   Visit [https://nodes.griptape.ai/](https://nodes.griptape.ai/), and follow the instructions to install the Engine locally.
 
 1. Configure the Engine to use the nodes library in this repo.
 
@@ -38,9 +30,9 @@
    https://github.com/griptape-ai/griptape-nodes/blob/24d1fdab898e1617793eeb55b7a5a87c161502ef/install.sh?plain=1#L63-L64
    https://github.com/griptape-ai/griptape-nodes/blob/24d1fdab898e1617793eeb55b7a5a87c161502ef/src/griptape_nodes/retained_mode/managers/settings.py?plain=1#L52-L54
 
-   When developing locally, we want to configure the Engine to use the nodes library in this repo:
+   When developing locally, you must configure the Engine to use the nodes library in this repo:
 
-   1. Create a file `griptape_nodes_config.json` in the root of your project.
+   1. Create a file `griptape_nodes_config.json` in the root of the cloned repo.
    1. Add the following content to the file:
       ```json
       {
@@ -60,9 +52,10 @@
    make run
    ```
 
-   To start the engine using SSE (Server Sent Events) to the remote Griptape Nodes API:
-   `GT_CLOUD_API_KEY=<your_key> make run`
-
+   To point your engine at a different instance of the API, set the `GRIPTAPE_NODES_API_BASE_URL` environment variable before running:
+   ```shell
+   GRIPTAPE_NODES_API_BASE_URL=http://localhost:8001 make run
+   ```
 1. Navigate to the URL provided in the terminal.
 
 # Make Commands

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ## Getting Started
 
-Review the [CONTRIBUTING.md](CONTRIBUTING.md) file for how to get started with the project.
+For getting started with using Griptape Nodes, please visit [griptapenodes.com](https://www.griptapenodes.com/).
+
+## Contributing
+
+If you would like to contribute to the Griptape Nodes Engine, please review the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 ### Request Structure
 


### PR DESCRIPTION
Closes #11 -- an `.example.env` should not be needed with these up to date instructions.