### PR TITLE
Preventing important Node Metadata from getting overwritten

### DIFF
--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1553,8 +1553,9 @@ class NodeManager:
 
             result = SetNodeMetadataResult_Failure()
             return result
-
-        node.metadata = request.metadata
+        # We can't completely overwrite metadata.
+        for key, value in request.metadata.items():
+            node.metadata[key] = value
         details = f"Successfully set metadata for a Node '{request.node_name}'."
         GriptapeNodes.get_logger().info(details)
 


### PR DESCRIPTION
- library was getting overwritten by Changing node metadata when the node was getting moved around on the screen. slightly modified how we save metadata to prevent stuff like this from happening (the user can now only partially modify metadata instead of having to save and use it all)