### PR TITLE
Add retries on websocket connect and failures

### DIFF
--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-logger = GriptapeNodes.get_instance().LogManager().get_logger()
+logger = GriptapeNodes.get_instance().LogManager().get_logger(event_handler=False)
 
 
 def run_with_context(func: Callable) -> Callable:
@@ -175,12 +175,6 @@ def sse_listener() -> None:
 
             with httpx.stream("get", endpoint, auth=auth, timeout=None) as response:  # noqa: S113 We intentionally want to never timeout
                 response.raise_for_status()
-                if not init:
-                    # Broadcast this to anybody who wants a callback on "hey, the app's ready to roll"
-                    payload = app_events.AppInitializationComplete()
-                    app_event = AppEvent(payload=payload)
-                    event_queue.put(app_event)
-                    init = True
 
                 for line in response.iter_lines():
                     if not line.strip():
@@ -194,12 +188,24 @@ def sse_listener() -> None:
                                 nodes_app_url,
                                 nodes_app_url,
                             )
+                            if not init:
+                                # Broadcast this to anybody who wants a callback on "hey, the app's ready to roll"
+                                payload = app_events.AppInitializationComplete()
+                                app_event = AppEvent(payload=payload)
+                                event_queue.put(app_event)
+                                init = True
 
                         else:
-                            process_event(json.loads(data))
+                            try:
+                                process_event(json.loads(data))
+                            except Exception:
+                                logger.exception("Error processing event, skipping.")
+                    else:
+                        logger.warning("Unexpected line received: %s, skipping.", line)
         except Exception:
-            logger.exception("Error while listening to SSE")
-            sleep(5)
+            logger.warning("Error while listening for events. Retrying in 2 seconds.")
+            sleep(2)
+            init = False
 
 
 def run_sse_mode() -> None:

--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -200,8 +200,7 @@ def sse_listener() -> None:
                                 process_event(json.loads(data))
                             except Exception:
                                 logger.exception("Error processing event, skipping.")
-                    else:
-                        logger.warning("Unexpected line received: %s, skipping.", line)
+
         except Exception:
             logger.warning("Error while listening for events. Retrying in 2 seconds.")
             sleep(2)

--- a/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
+++ b/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
@@ -1,11 +1,16 @@
 import json
 import os
+from threading import Lock
+from time import sleep
 from urllib.parse import urljoin
 
 from attrs import Factory, define, field
+from websockets.exceptions import WebSocketException
 from websockets.sync.client import ClientConnection, connect
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+logger = GriptapeNodes.get_instance().LogManager().get_logger(event_handler=False)
 
 
 @define(kw_only=True)
@@ -14,28 +19,48 @@ class NodesApiSocketManager:
 
     socket: ClientConnection = field(
         default=Factory(
-            lambda: connect(
-                urljoin(
-                    os.getenv("GRIPTAPE_NODES_API_BASE_URL", "wss://api.nodes.griptape.ai")
-                    .replace("http", "ws")
-                    .replace("https", "wss"),
-                    "/api/editors/ws",  # TODO(matt): this is the destination path for events. reevaluate if we do bi-directional communication
-                ),
-                additional_headers={
-                    "Authorization": f"Bearer {
-                        GriptapeNodes.get_instance().ConfigManager().get_config_value('env.Griptape.GT_CLOUD_API_KEY')
-                    }"
-                },
-            ),
+            lambda self: self._connect(),
+            takes_self=True,
         ),
     )
+    lock: Lock = field(factory=Lock)
 
     def emit(self, *args, **kwargs) -> None:  # noqa: ARG002 # drop-in replacement workaround
         body = {"type": args[0], "payload": json.loads(args[1])}
-        self.socket.send(json.dumps(body))
+        sent = False
+        while not sent:
+            try:
+                self.socket.send(json.dumps(body))
+                sent = True
+            except WebSocketException:
+                logger.warning("Error sending event to Nodes API, attempting to reconnect.")
+                self.socket = self._connect()
 
     def run(self, *args, **kwargs) -> None:
         pass
 
     def start_background_task(self, *args, **kwargs) -> None:
         pass
+
+    def _connect(self) -> ClientConnection:
+        while True:
+            try:
+                return connect(
+                    urljoin(
+                        os.getenv("GRIPTAPE_NODES_API_BASE_URL", "wss://api.nodes.griptape.ai")
+                        .replace("http", "ws")
+                        .replace("https", "wss"),
+                        "/api/editors/ws",  # TODO(matt): this is the destination path for events. reevaluate if we do bi-directional communication
+                    ),
+                    additional_headers={
+                        "Authorization": f"Bearer {
+                            GriptapeNodes.get_instance()
+                            .ConfigManager()
+                            .get_config_value('env.Griptape.GT_CLOUD_API_KEY')
+                        }"
+                    },
+                    ping_timeout=None,
+                )
+            except ConnectionError:
+                logger.warning("Nodes API is not available, waiting 5 seconds before retrying")
+                sleep(5)

--- a/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
+++ b/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
@@ -45,6 +45,11 @@ class NodesApiSocketManager:
     def _connect(self) -> ClientConnection:
         while True:
             try:
+                api_key = GriptapeNodes.get_instance().ConfigManager().get_config_value("env.Griptape.GT_CLOUD_API_KEY")
+                if api_key is None:
+                    msg = "env.Griptape.GT_CLOUD_API_KEY is not set, please add this value to your griptape_nodes_config.json file."
+                    raise ValueError(msg) from None
+
                 return connect(
                     urljoin(
                         os.getenv("GRIPTAPE_NODES_API_BASE_URL", "wss://api.nodes.griptape.ai")
@@ -52,13 +57,7 @@ class NodesApiSocketManager:
                         .replace("https", "wss"),
                         "/api/editors/ws",  # TODO(matt): this is the destination path for events. reevaluate if we do bi-directional communication
                     ),
-                    additional_headers={
-                        "Authorization": f"Bearer {
-                            GriptapeNodes.get_instance()
-                            .ConfigManager()
-                            .get_config_value('env.Griptape.GT_CLOUD_API_KEY')
-                        }"
-                    },
+                    additional_headers={"Authorization": f"Bearer {api_key}"},
                     ping_timeout=None,
                 )
             except ConnectionError:

--- a/src/griptape_nodes/retained_mode/managers/log_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/log_manager.py
@@ -25,6 +25,12 @@ class LogManager:
             root_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True))
             root_logger.addHandler(EventLogHandler())
 
-    def get_logger(self) -> logging.Logger:
-        logger = logging.getLogger()
+        local_logger = logging.getLogger("griptape_nodes_engine")
+        local_logger.setLevel(logging.INFO)
+
+        if not local_logger.hasHandlers():
+            local_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True))
+
+    def get_logger(self, *, event_handler: bool = True) -> logging.Logger:
+        logger = logging.getLogger() if event_handler else logging.getLogger("griptape_nodes_engine")
         return logger


### PR DESCRIPTION
also need to selectively remove the event handler for the logger otherwise it recursively fails to send events every time anything is logged.

closes #121 