### PR TITLE
fix: use correct class names in griptape nodes library

### DIFF
--- a/nodes/griptape_nodes_library.json
+++ b/nodes/griptape_nodes_library.json
@@ -252,7 +252,7 @@
       }
     },
     {
-      "class_name": "FileManagerToolNode",
+      "class_name": "PromptSummaryTool",
       "file_path": "griptape_nodes_library/tools/prompt_summary_tool.py",
       "metadata": {
         "category": "Tools",
@@ -369,7 +369,7 @@
       }
     },
     {
-      "class_name": "LoadImageNode",
+      "class_name": "LoadTextNode",
       "file_path": "griptape_nodes_library/load_text.py",
       "metadata": {
         "category": "Utility",
@@ -414,7 +414,7 @@
       }
     },
     {
-      "class_name": "SimpleAgentNode",
+      "class_name": "StartFlowNode",
       "file_path": "griptape_nodes_library/start_flow.py",
       "metadata": {
         "category": "Utility",


### PR DESCRIPTION
Fixes:
```
Attempted to register Node class 'FileManagerToolNode' from Library 'Griptape Nodes Library', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times.
Attempted to register Node class 'LoadImageNode' from Library 'Griptape Nodes Library', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times.
Attempted to register Node class 'SimpleAgentNode' from Library 'Griptape Nodes Library', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times.
```