### PR TITLE
fix: correctly add control parameters

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -358,8 +358,8 @@ class ControlNode(BaseNode):
         control_parameter_in = ControlParameterInput()
         control_parameter_out = ControlParameterOutput()
 
-        self.parameters.append(control_parameter_in)
-        self.parameters.append(control_parameter_out)
+        self.add_parameter(control_parameter_in)
+        self.add_parameter(control_parameter_out)
 
     def get_next_control_output(self) -> Parameter | None:
         for param in self.parameters:


### PR DESCRIPTION
Working again:
![image](https://github.com/user-attachments/assets/34d1c45a-4cbd-44bd-a3df-701068fad386)
