### PR TITLE
Fix connection deletion error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,11 @@
    ```
 
    To point your engine at a different instance of the API, set the `GRIPTAPE_NODES_API_BASE_URL` environment variable before running:
+
    ```shell
    GRIPTAPE_NODES_API_BASE_URL=http://localhost:8001 make run
    ```
+
 1. Navigate to the URL provided in the terminal.
 
 # Make Commands

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -537,7 +537,7 @@ class ObjectManager:
         return has_it
 
     def attempt_get_object_by_name(self, name: str) -> Any | None:
-        return self._name_to_objects.get(name)
+        return self._name_to_objects.get(name, None)
 
     def attempt_get_object_by_name_as_type(self, name: str, cast_type: type[T]) -> T | None:
         obj = self.attempt_get_object_by_name(name)
@@ -772,7 +772,7 @@ class FlowManager:
         source_node = None
         try:
             source_node = GriptapeNodes.NodeManager().get_node_by_name(request.source_node_name)
-        except KeyError as err:
+        except ValueError as err:
             details = f'Connection failed: "{request.source_node_name}" does not exist. Error: {err}.'
             GriptapeNodes.get_logger().error(details)
 
@@ -782,7 +782,7 @@ class FlowManager:
         target_node = None
         try:
             target_node = GriptapeNodes.NodeManager().get_node_by_name(request.target_node_name)
-        except KeyError as err:
+        except ValueError as err:
             details = f'Connection failed: "{request.target_node_name}" does not exist. Error: {err}.'
             GriptapeNodes.get_logger().error(details)
             result = CreateConnectionResultFailure()
@@ -952,7 +952,7 @@ class FlowManager:
         source_node = None
         try:
             source_node = GriptapeNodes.NodeManager().get_node_by_name(request.source_node_name)
-        except KeyError as err:
+        except ValueError as err:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Error: {err}'
             GriptapeNodes.get_logger().error(details)
 
@@ -962,7 +962,7 @@ class FlowManager:
         target_node = None
         try:
             target_node = GriptapeNodes.NodeManager().get_node_by_name(request.target_node_name)
-        except KeyError as err:
+        except ValueError as err:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Error: {err}'
             GriptapeNodes.get_logger().error(details)
 
@@ -2268,7 +2268,7 @@ class NodeManager:
         # Vet the node
         try:
             node = GriptapeNodes.NodeManager().get_node_by_name(request.node_name)
-        except KeyError as err:
+        except ValueError as err:
             details = f"Attempted to get compatible parameters for node '{request.node_name}', but that node does not exist. Error: {err}."
             GriptapeNodes.get_logger().error(details)
             return GetCompatibleParametersResultFailure()
@@ -2320,7 +2320,7 @@ class NodeManager:
                 # Get node by name
                 try:
                     test_node = GriptapeNodes.NodeManager().get_node_by_name(test_node_name)
-                except KeyError as err:
+                except ValueError as err:
                     details = f"Attempted to get compatible parameters for node '{request.node_name}', and sought to test against {test_node_name}, but that node does not exist. Error: {err}."
                     GriptapeNodes.get_logger().error(details)
                     return GetCompatibleParametersResultFailure()
@@ -2388,7 +2388,7 @@ class NodeManager:
             return ResolveNodeResultFailure(validation_exceptions=[])
         try:
             node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
-        except KeyError:
+        except ValueError:
             details = f'Resolve failure. "{node_name}" does not exist.'
             GriptapeNodes.get_logger().error(details)
 


### PR DESCRIPTION
Quick one. We were catching the wrong type of error when a node couldn't be found, so it was crashing the machine instead of returning a failure result. 

The other issue: on occasion (not every time! but randomly sometimes) the connection deletion requests get out of order. They are sent in the right order from the GUI, but something happens, maybe on the api layer, where the last DeleteConnection request comes AFTER the DeleteNodeRequest. 

I think that the GUI should just only make 1 call: DeleteNodeRequest, because that handles all connection deletion anyways. Then this won't happen. Thoughts? @aodhanroche @SavagePencil 