### PR TITLE
Task/make logger easy when node authoring.

### DIFF
--- a/nodes/griptape_nodes_library/create_image.py
+++ b/nodes/griptape_nodes_library/create_image.py
@@ -4,7 +4,7 @@ from griptape.tasks import PromptImageGenerationTask
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import ControlNode
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes_library.utils.env_utils import getenv
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
@@ -122,16 +122,18 @@ class CreateImageNode(ControlNode):
         out_file = params.get("output_file", None)
         if out_file:
             kwargs["output_file"] = out_file
-            details = rf"\Generating '{out_file}'"
-            print(details)
+            details = f"Image saved to {out_file}"
+            logger().info(details)
         else:
             out_dir = params.get("output_dir", None)
             if out_dir:
                 kwargs["output_dir"] = out_dir
-                print(f'\nLook for image in "{out_dir}"')
+                out_dir_msg = f'\nLook for image in "{out_dir}"'
+                logger().info(out_dir_msg)
             else:
                 kwargs["output_dir"] = images_dir
-                print(f'\nLook for image in "{images_dir}"')
+                images_dir_msg = f'\nLook for image in "{images_dir}"'
+                logger().info(images_dir_msg)
 
         # Add the actual image gen *task
         agent.add_task(PromptImageGenerationTask(**kwargs))

--- a/nodes/griptape_nodes_library/create_image.py
+++ b/nodes/griptape_nodes_library/create_image.py
@@ -122,7 +122,8 @@ class CreateImageNode(ControlNode):
         out_file = params.get("output_file", None)
         if out_file:
             kwargs["output_file"] = out_file
-            print(rf'\Generating "{out_file}"')
+            details = rf"\Generating '{out_file}'"
+            print(details)
         else:
             out_dir = params.get("output_dir", None)
             if out_dir:

--- a/nodes/griptape_nodes_library/create_image.py
+++ b/nodes/griptape_nodes_library/create_image.py
@@ -123,17 +123,17 @@ class CreateImageNode(ControlNode):
         if out_file:
             kwargs["output_file"] = out_file
             details = f"Image saved to {out_file}"
-            logger().info(details)
+            logger.info(details)
         else:
             out_dir = params.get("output_dir", None)
             if out_dir:
                 kwargs["output_dir"] = out_dir
                 out_dir_msg = f'\nLook for image in "{out_dir}"'
-                logger().info(out_dir_msg)
+                logger.info(out_dir_msg)
             else:
                 kwargs["output_dir"] = images_dir
                 images_dir_msg = f'\nLook for image in "{images_dir}"'
-                logger().info(images_dir_msg)
+                logger.info(images_dir_msg)
 
         # Add the actual image gen *task
         agent.add_task(PromptImageGenerationTask(**kwargs))

--- a/nodes/griptape_nodes_library/drivers/anthropic_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/anthropic_prompt_driver.py
@@ -1,7 +1,7 @@
 import anthropic
 from griptape.drivers.prompt.anthropic import AnthropicPromptDriver
-from rich import print
 
+from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes_library.drivers.base_prompt_driver import BasePromptDriverNode
 from griptape_nodes_library.utils.env_utils import getenv
 
@@ -56,9 +56,9 @@ class AnthropicPromptDriverNode(BasePromptDriverNode):
         if max_tokens is not None and max_tokens > 0:
             kwargs["max_tokens"] = max_tokens
 
-        print("\n\nANTHROPIC PROMPT DRIVER:")
-        print(kwargs)
-        print("\n\n")
+        # Debug output
+        debug_msg = "\n\nANTHROPIC PROMPT DRIVER:\n" + str(kwargs) + "\n\n"
+        logger().debug(debug_msg)
 
         self.parameter_output_values["driver"] = AnthropicPromptDriver(**kwargs)
 

--- a/nodes/griptape_nodes_library/drivers/anthropic_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/anthropic_prompt_driver.py
@@ -58,7 +58,7 @@ class AnthropicPromptDriverNode(BasePromptDriverNode):
 
         # Debug output
         debug_msg = "\n\nANTHROPIC PROMPT DRIVER:\n" + str(kwargs) + "\n\n"
-        logger().debug(debug_msg)
+        logger.debug(debug_msg)
 
         self.parameter_output_values["driver"] = AnthropicPromptDriver(**kwargs)
 

--- a/nodes/griptape_nodes_library/load_image.py
+++ b/nodes/griptape_nodes_library/load_image.py
@@ -24,5 +24,5 @@ class LoadImageNode(DataNode):
     def process(self) -> None:
         # TODO(griptape): Implement image loading logic
         debug_msg = "We need to do something with this image node.."
-        logger().debug(debug_msg)
+        logger.debug(debug_msg)
         self.parameter_output_values["image"] = self.parameter_values["image"]

--- a/nodes/griptape_nodes_library/load_image.py
+++ b/nodes/griptape_nodes_library/load_image.py
@@ -1,5 +1,6 @@
 from griptape_nodes.exe_types.core_types import Parameter, ParameterUIOptions
 from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.retained_mode.griptape_nodes import logger
 
 
 class LoadImageNode(DataNode):
@@ -21,5 +22,7 @@ class LoadImageNode(DataNode):
         # Add input parameter for model selection
 
     def process(self) -> None:
-        print("We need to do something with this image node..")
+        # TODO(griptape): Implement image loading logic
+        debug_msg = "We need to do something with this image node.."
+        logger().debug(debug_msg)
         self.parameter_output_values["image"] = self.parameter_values["image"]

--- a/nodes/griptape_nodes_library/save_text.py
+++ b/nodes/griptape_nodes_library/save_text.py
@@ -45,7 +45,7 @@ class SaveTextNode(ControlNode):
             with Path(full_output_file).open("w") as f:
                 f.write(text)
             success_msg = f"Saved file: {full_output_file}"
-            logger().info(success_msg)
+            logger.info(success_msg)
 
             # Set output values
             self.parameter_output_values["output_path"] = full_output_file

--- a/nodes/griptape_nodes_library/save_text.py
+++ b/nodes/griptape_nodes_library/save_text.py
@@ -6,6 +6,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterMode,
 )
 from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.retained_mode.griptape_nodes import logger
 
 
 class SaveTextNode(ControlNode):
@@ -43,7 +44,8 @@ class SaveTextNode(ControlNode):
         try:
             with Path(full_output_file).open("w") as f:
                 f.write(text)
-            print(f"Saved file: {full_output_file}")
+            success_msg = f"Saved file: {full_output_file}"
+            logger().info(success_msg)
 
             # Set output values
             self.parameter_output_values["output_path"] = full_output_file

--- a/nodes/griptape_nodes_library/utilities.py
+++ b/nodes/griptape_nodes_library/utilities.py
@@ -14,6 +14,8 @@ import torch
 from jinja2 import Template
 from PIL import Image, ImageOps, ImageSequence
 
+from griptape_nodes.retained_mode.griptape_nodes import logger
+
 
 def to_pascal_case(string) -> str:
     # First, replace any non-word character with a space
@@ -64,7 +66,8 @@ def get_models(engine, base_url, port) -> list[str]:
         else:  # lmstudio
             models = [model["id"] for model in response.json().get("data", [])]
     except Exception as e:
-        print(f"Failed to fetch models from {engine.capitalize()}: {e}")
+        error_msg = f"Failed to fetch models from {engine.capitalize()}: {e}"
+        logger().error(error_msg)
         return []
     else:
         return models
@@ -137,7 +140,8 @@ def convert_tensor_batch_to_base_64(image_batch) -> list[str] | None:
             base64_image = base64.b64encode(buffer.getvalue()).decode("utf-8")
             base64_images.append(base64_image)
 
-        print(f"Converted {len(base64_images)} images to base64")
+        success_msg = f"Converted {len(base64_images)} images to base64"
+        logger().info(success_msg)
         return base64_images
     return None
 

--- a/nodes/griptape_nodes_library/utilities.py
+++ b/nodes/griptape_nodes_library/utilities.py
@@ -67,7 +67,7 @@ def get_models(engine, base_url, port) -> list[str]:
             models = [model["id"] for model in response.json().get("data", [])]
     except Exception as e:
         error_msg = f"Failed to fetch models from {engine.capitalize()}: {e}"
-        logger().error(error_msg)
+        logger.error(error_msg)
         return []
     else:
         return models
@@ -141,7 +141,7 @@ def convert_tensor_batch_to_base_64(image_batch) -> list[str] | None:
             base64_images.append(base64_image)
 
         success_msg = f"Converted {len(base64_images)} images to base64"
-        logger().info(success_msg)
+        logger.info(success_msg)
         return base64_images
     return None
 

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -171,7 +171,7 @@ class BaseNode(ABC):
                 return True
         return False
 
-    # TODO(james): Do i need to flag control/ not control parameters?
+    # Adds a Parameter to the Node. Control and Data Parameters are all treated equally.
     def add_parameter(self, param: Parameter) -> None:
         if self.does_name_exist(param.name):
             msg = "Cannot have duplicate names on parameters."

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -171,8 +171,8 @@ class BaseNode(ABC):
                 return True
         return False
 
-    # Adds a Parameter to the Node. Control and Data Parameters are all treated equally.
     def add_parameter(self, param: Parameter) -> None:
+        """Adds a Parameter to the Node. Control and Data Parameters are all treated equally."""
         if self.does_name_exist(param.name):
             msg = "Cannot have duplicate names on parameters."
             raise ValueError(msg)

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -226,6 +226,16 @@ class SingletonMeta(type):
         return cls._instances[cls]
 
 
+# This is a convenience function for node authors to just write "logger().info()" instead of having to write GriptapeNodes.get_logger().
+def logger() -> logging.Logger:
+    """Get the GriptapeNodes logger instance.
+
+    Returns:
+        logging.Logger: The configured logger instance
+    """
+    return GriptapeNodes.get_logger()
+
+
 class GriptapeNodes(metaclass=SingletonMeta):
     def __init__(self) -> None:
         # Initialize only if our managers haven't been created yet

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -226,16 +226,6 @@ class SingletonMeta(type):
         return cls._instances[cls]
 
 
-# This is a convenience function for node authors to just write "logger().info()" instead of having to write GriptapeNodes.get_logger().
-def logger() -> logging.Logger:
-    """Get the GriptapeNodes logger instance.
-
-    Returns:
-        logging.Logger: The configured logger instance
-    """
-    return GriptapeNodes.get_logger()
-
-
 class GriptapeNodes(metaclass=SingletonMeta):
     def __init__(self) -> None:
         # Initialize only if our managers haven't been created yet
@@ -3298,3 +3288,11 @@ class LibraryManager:
                         node_libraries_referenced=script["node_libraries_referenced"],
                     )
                     GriptapeNodes().handle_request(script_register_request)
+
+
+def __getattr__(name) -> logging.Logger:
+    """Convenience function so that node authors only need to write 'logger.info()'."""
+    if name == "logger":
+        return GriptapeNodes.get_logger()
+    msg = f"module '{__name__}' has no attribute '{name}'"
+    raise AttributeError(msg)


### PR DESCRIPTION
Per customer feedback, they wanted a shorthand for `GriptapeNodes.get_logger()`. I would have put this up in `node_types.py` but didn't want to deal with importing all of retained mode, so instead I made a helper function up in `GriptapeNodes` (which individual nodes will use) called `logger`.

I updated all instances of `print()` to use `logger()` in the existing node code.