### PR TITLE
Feature/embedded scene metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "httpx>=0.28.0,<1.0.0",
   "cohere>=5.14.0",
   "websockets>=15.0.1,<16.0.0",
+  "tomlkit>=0.13.2",
 ]
 
 [dependency-groups]
@@ -73,7 +74,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "D104"]
 "nodes/tests/*" = ["S101", "D104"]
-"scripts/*" = ["ERA001"]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "D104"]
 "nodes/tests/*" = ["S101", "D104"]
+"scripts/*" = ["ERA001"]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/scripts/coloring_book.py
+++ b/scripts/coloring_book.py
@@ -1,4 +1,8 @@
-# /// griptape-nodes-scene-metadata
+# /// script
+# dependencies = [
+#    "griptape",
+#    "langchain",
+# ]
 # {
 #   "name": "coloring book",
 #   "schema_version": "0.1.0",

--- a/scripts/coloring_book.py
+++ b/scripts/coloring_book.py
@@ -2,7 +2,6 @@
 # {
 #   "name": "coloring book",
 #   "schema_version": "0.1.0",
-#   "file_path": "coloring_book.py",
 #   "engine_version_created_with": "0.3.2",
 #   "node_libraries_referenced": [
 #     [

--- a/scripts/coloring_book.py
+++ b/scripts/coloring_book.py
@@ -1,21 +1,18 @@
 # /// script
-# dependencies = [
-#    "griptape",
-#    "langchain",
-# ]
-# {
-#   "name": "coloring book",
-#   "schema_version": "0.1.0",
-#   "engine_version_created_with": "0.3.2",
-#   "node_libraries_referenced": [
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "coloring book"
+# schema_version = "0.1.0"
+# engine_version_created_with = "0.3.2"
+# node_libraries_referenced = [
 #     [
 #       "Griptape Nodes Library",
 #       "0.1.0"
 #     ]
-#   ],
-#   "description": null,
-#   "image": null
-# }
+#   ]
+#
 # ///
+
 
 print("coloring_book!")

--- a/scripts/coloring_book.py
+++ b/scripts/coloring_book.py
@@ -1,1 +1,18 @@
+# /// griptape-nodes-scene-metadata
+# {
+#   "name": "coloring book",
+#   "schema_version": "0.1.0",
+#   "file_path": "coloring_book.py",
+#   "engine_version_created_with": "0.3.2",
+#   "node_libraries_referenced": [
+#     [
+#       "Griptape Nodes Library",
+#       "0.1.0"
+#     ]
+#   ],
+#   "description": null,
+#   "image": null
+# }
+# ///
+
 print("coloring_book!")

--- a/scripts/prompt_an_image.py
+++ b/scripts/prompt_an_image.py
@@ -1,17 +1,17 @@
 print("prompt an image!")
 
-# /// griptape-nodes-scene-metadata
-# {
-#   "name": "prompt an image!",
-#   "schema_version": "0.1.0",
-#   "engine_version_created_with": "0.3.2",
-#   "node_libraries_referenced": [
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "prompt an image"
+# schema_version = "0.1.0"
+# engine_version_created_with = "0.3.2"
+# node_libraries_referenced = [
 #     [
 #       "Griptape Nodes Library",
 #       "0.1.0"
 #     ]
-#   ],
-#   "description": null,
-#   "image": null
-# }
+#   ]
+#
 # ///

--- a/scripts/prompt_an_image.py
+++ b/scripts/prompt_an_image.py
@@ -4,7 +4,6 @@ print("prompt an image!")
 # {
 #   "name": "prompt an image!",
 #   "schema_version": "0.1.0",
-#   "file_path": "prompt_an_image.py",
 #   "engine_version_created_with": "0.3.2",
 #   "node_libraries_referenced": [
 #     [

--- a/scripts/prompt_an_image.py
+++ b/scripts/prompt_an_image.py
@@ -1,1 +1,18 @@
-print("render_logs!")
+print("prompt an image!")
+
+# /// griptape-nodes-scene-metadata
+# {
+#   "name": "prompt an image!",
+#   "schema_version": "0.1.0",
+#   "file_path": "prompt_an_image.py",
+#   "engine_version_created_with": "0.3.2",
+#   "node_libraries_referenced": [
+#     [
+#       "Griptape Nodes Library",
+#       "0.1.0"
+#     ]
+#   ],
+#   "description": null,
+#   "image": null
+# }
+# ///

--- a/scripts/render_logs.py
+++ b/scripts/render_logs.py
@@ -1,17 +1,17 @@
 print("render logs!")
 
-# /// griptape-nodes-scene-metadata
-# {
-#   "name": "render logs!",
-#   "schema_version": "0.1.0",
-#   "engine_version_created_with": "0.3.2",
-#   "node_libraries_referenced": [
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "render log debugger"
+# schema_version = "0.1.0"
+# engine_version_created_with = "0.3.2"
+# node_libraries_referenced = [
 #     [
 #       "Griptape Nodes Library",
 #       "0.1.0"
 #     ]
-#   ],
-#   "description": null,
-#   "image": null
-# }
+#   ]
+#
 # ///

--- a/scripts/render_logs.py
+++ b/scripts/render_logs.py
@@ -1,1 +1,18 @@
-print("coloring_book!")
+print("render logs!")
+
+# /// griptape-nodes-scene-metadata
+# {
+#   "name": "render logs!",
+#   "schema_version": "0.1.0",
+#   "file_path": "render_logs.py",
+#   "engine_version_created_with": "0.3.2",
+#   "node_libraries_referenced": [
+#     [
+#       "Griptape Nodes Library",
+#       "0.1.0"
+#     ]
+#   ],
+#   "description": null,
+#   "image": null
+# }
+# ///

--- a/scripts/render_logs.py
+++ b/scripts/render_logs.py
@@ -4,7 +4,6 @@ print("render logs!")
 # {
 #   "name": "render logs!",
 #   "schema_version": "0.1.0",
-#   "file_path": "render_logs.py",
 #   "engine_version_created_with": "0.3.2",
 #   "node_libraries_referenced": [
 #     [

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -252,11 +252,11 @@ class ParameterGroup(BaseNodeElement):
 class Parameter(BaseNodeElement):
     name: str  # must be unique from other parameters in Node
     allowed_types: list[str]
-    tooltip: str  # Default tooltip
+    tooltip: str | list[dict]  # Default tooltip, can be string or list of dicts
     default_value: Any = None
-    tooltip_as_input: str | None = None
-    tooltip_as_property: str | None = None
-    tooltip_as_output: str | None = None
+    tooltip_as_input: str | list[dict] | None = None
+    tooltip_as_property: str | list[dict] | None = None
+    tooltip_as_output: str | list[dict] | None = None
     settable: bool = True
     user_defined: bool = False
     allowed_modes: set = field(
@@ -354,7 +354,7 @@ class ControlParameter(Parameter, ABC):
 @dataclass(kw_only=True)
 class ControlParameterInput(ControlParameter):
     name: str = "exec_in"
-    tooltip: str = "Connection from previous node in the execution chain"
+    tooltip: str | list[dict] = "Connection from previous node in the execution chain"
     allowed_modes: set = field(
         default_factory=lambda: {
             ParameterMode.INPUT,
@@ -365,7 +365,7 @@ class ControlParameterInput(ControlParameter):
 @dataclass
 class ControlParameterOutput(ControlParameter):
     name: str = "exec_out"
-    tooltip: str = "Connection to the next node in the execution chain"
+    tooltip: str | list[dict] = "Connection to the next node in the execution chain"
     allowed_modes: set = field(
         default_factory=lambda: {
             ParameterMode.OUTPUT,

--- a/src/griptape_nodes/node_library/script_registry.py
+++ b/src/griptape_nodes/node_library/script_registry.py
@@ -22,7 +22,6 @@ class ScriptMetadata(BaseModel):
     node_libraries_referenced: list[LibraryNameAndVersion]
     description: str | None = None
     image: str | None = None
-    internal: bool = False
 
 
 class ScriptRegistry(SingletonMixin):

--- a/src/griptape_nodes/node_library/script_registry.py
+++ b/src/griptape_nodes/node_library/script_registry.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import NamedTuple
+from typing import ClassVar, NamedTuple
 
 from griptape.mixins.singleton_mixin import SingletonMixin
+from pydantic import BaseModel
 
 
 class LibraryNameAndVersion(NamedTuple):
     library_name: str
     library_version: str
+
+
+class ScriptMetadata(BaseModel):
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.1.0"
+
+    name: str
+    schema_version: str
+    file_path: str
+    engine_version_created_with: str
+    node_libraries_referenced: list[LibraryNameAndVersion]
+    description: str | None = None
+    image: str | None = None
+    internal: bool = False
 
 
 class ScriptRegistry(SingletonMixin):
@@ -20,30 +34,13 @@ class ScriptRegistry(SingletonMixin):
 
     # Create a new script with everything we'd need
     @classmethod
-    def generate_new_script(  # noqa: PLR0913
-        cls,
-        name: str,
-        relative_file_path: str,
-        engine_version_created_with: str,
-        node_libraries_referenced: list[LibraryNameAndVersion],
-        description: str | None = None,
-        image: str | None = None,
-    ) -> Script:
+    def generate_new_script(cls, metadata: ScriptMetadata) -> Script:
         instance = cls()
-        if name in instance._scripts:
-            # TODO(griptape): Should we rename scripts here?
-            msg = f"Script with name {name} already registered."
+        if metadata.name in instance._scripts:
+            msg = f"Script with name {metadata.name} already registered."
             raise KeyError(msg)
-        script = Script(
-            name=name,
-            relative_file_path=relative_file_path,
-            registry_key=instance._registry_key,
-            description=description,
-            image=image,
-            engine_version_created_with=engine_version_created_with,
-            node_libraries_referenced=node_libraries_referenced,
-        )
-        instance._scripts[name] = script
+        script = Script(registry_key=instance._registry_key, metadata=metadata)
+        instance._scripts[metadata.name] = script
         return script
 
     @classmethod
@@ -80,45 +77,28 @@ class ScriptRegistry(SingletonMixin):
 class Script:
     """A script card to be ran."""
 
-    name: str
-    relative_file_path: str
-    engine_version_created_with: str
-    node_libraries_referenced: list[LibraryNameAndVersion]
-    description: str | None
-    image: str | None  # TODO(griptape): Make work with real images
+    metadata: ScriptMetadata
 
-    def __init__(  # noqa: PLR0913
-        self,
-        name: str,
-        relative_file_path: str,
-        engine_version_created_with: str,
-        node_libraries_referenced: list[LibraryNameAndVersion],
-        registry_key: ScriptRegistry._RegistryKey,
-        description: str | None = None,
-        image: str | None = None,
-    ) -> None:
+    def __init__(self, registry_key: ScriptRegistry._RegistryKey, metadata: ScriptMetadata) -> None:
         if not isinstance(registry_key, ScriptRegistry._RegistryKey):
             msg = "Scripts can only be created through ScriptRegistry"
             raise TypeError(msg)
 
+        self.metadata = metadata
+
         # Get the absolute file path.
-        complete_path = ScriptRegistry.get_complete_file_path(relative_file_path=relative_file_path)
+        complete_path = ScriptRegistry.get_complete_file_path(relative_file_path=metadata.file_path)
         if not Path(complete_path).is_file():
             msg = f"File path '{complete_path}' does not exist."
             raise ValueError(msg)
-        self.name = name
-        self.relative_file_path = relative_file_path
-        self.description = description
-        self.image = image
-        self.engine_version_created_with = engine_version_created_with
-        self.node_libraries_referenced = node_libraries_referenced
 
     def get_script_metadata(self) -> dict:
+        # TODO(griptape): either convert the Pydantic schema to a dict or use it directly.
         return {
-            "name": self.name,
-            "file_path": self.relative_file_path,
-            "description": self.description,
-            "image": self.image,
-            "engine_version_created_with": self.engine_version_created_with,
-            "node_libraries_referenced": self.node_libraries_referenced,
+            "name": self.metadata.name,
+            "file_path": self.metadata.file_path,
+            "description": self.metadata.description,
+            "image": self.metadata.image,
+            "engine_version_created_with": self.metadata.engine_version_created_with,
+            "node_libraries_referenced": self.metadata.node_libraries_referenced,
         }

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -19,10 +19,10 @@ class AddParameterToNodeRequest(RequestPayload):
     node_name: str
     allowed_types: list[str]
     default_value: Any | None
-    tooltip: str
-    tooltip_as_input: str | None = None
-    tooltip_as_property: str | None = None
-    tooltip_as_output: str | None = None
+    tooltip: str | list[dict]
+    tooltip_as_input: str | list[dict] | None = None
+    tooltip_as_property: str | list[dict] | None = None
+    tooltip_as_output: str | list[dict] | None = None
     ui_options: ParameterUIOptions | None = None
     mode_allowed_input: bool = Field(default=True)
     mode_allowed_property: bool = Field(default=True)
@@ -108,10 +108,10 @@ class GetParameterDetailsResultSuccess(ResultPayloadSuccess):
     element_id: str
     allowed_types: list[str]
     default_value: Any | None
-    tooltip: str
-    tooltip_as_input: str | None
-    tooltip_as_property: str | None
-    tooltip_as_output: str | None
+    tooltip: str | list[dict]
+    tooltip_as_input: str | list[dict] | None
+    tooltip_as_property: str | list[dict] | None
+    tooltip_as_output: str | list[dict] | None
     mode_allowed_input: bool
     mode_allowed_property: bool
     mode_allowed_output: bool
@@ -132,10 +132,10 @@ class AlterParameterDetailsRequest(RequestPayload):
     node_name: str
     allowed_types: list[str] | None = None
     default_value: Any | None = None
-    tooltip: str | None = None
-    tooltip_as_input: str | None = None
-    tooltip_as_property: str | None = None
-    tooltip_as_output: str | None = None
+    tooltip: str | list[dict] | None = None
+    tooltip_as_input: str | list[dict] | None = None
+    tooltip_as_property: str | list[dict] | None = None
+    tooltip_as_output: str | list[dict] | None = None
     mode_allowed_input: bool | None = None
     mode_allowed_property: bool | None = None
     mode_allowed_output: bool | None = None

--- a/src/griptape_nodes/retained_mode/events/script_events.py
+++ b/src/griptape_nodes/retained_mode/events/script_events.py
@@ -133,3 +133,21 @@ class SaveSceneResultSuccess(ResultPayloadSuccess):
 @PayloadRegistry.register
 class SaveSceneResultFailure(ResultPayloadFailure):
     pass
+
+
+@dataclass
+@PayloadRegistry.register
+class LoadScriptMetadata(RequestPayload):
+    file_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class LoadScriptMetadataResultSuccess(ResultPayloadSuccess):
+    metadata: ScriptMetadata
+
+
+@dataclass
+@PayloadRegistry.register
+class LoadScriptMetadataResultFailure(ResultPayloadFailure):
+    pass

--- a/src/griptape_nodes/retained_mode/events/script_events.py
+++ b/src/griptape_nodes/retained_mode/events/script_events.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from griptape_nodes.node_library.script_registry import LibraryNameAndVersion
+from griptape_nodes.node_library.script_registry import ScriptMetadata
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -66,12 +66,7 @@ class RunScriptFromRegistryResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class RegisterScriptRequest(RequestPayload):
-    script_name: str
-    file_path: str
-    engine_version_created_with: str
-    node_libraries_referenced: list[LibraryNameAndVersion]
-    description: str | None = None
-    image: str | None = None
+    metadata: ScriptMetadata
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/script_events.py
+++ b/src/griptape_nodes/retained_mode/events/script_events.py
@@ -67,6 +67,7 @@ class RunScriptFromRegistryResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class RegisterScriptRequest(RequestPayload):
     metadata: ScriptMetadata
+    file_name: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -21,7 +21,7 @@ from griptape_nodes.retained_mode.events.config_events import (
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
 
-from .settings import Settings
+from .settings import ScriptSettingsDetail, Settings
 
 
 class ConfigManager:
@@ -78,13 +78,14 @@ class ConfigManager:
         """
         self.set_config_value("workspace_directory", str(Path(path).resolve()))
 
-    def save_user_script_json(self, script: dict) -> None:
-        # find the filepath for our default json file
-        existing_scripts = self.get_config_value("app_events.on_app_initialization_complete.scripts_to_register")
+    def save_user_script_json(self, script_file_name: str) -> None:
+        script_details = ScriptSettingsDetail(file_name=script_file_name, is_griptape_provided=False)
+        config_loc = "app_events.on_app_initialization_complete.scripts_to_register"
+        existing_scripts = self.get_config_value(config_loc)
         if not existing_scripts:
             existing_scripts = []
-        existing_scripts.append(script)
-        self.set_config_value("app_events.on_app_initialization_complete.scripts_to_register", existing_scripts)
+        existing_scripts.append(script_details.__dict__)
+        self.set_config_value(config_loc, existing_scripts)
 
     def delete_user_script(self, script: dict) -> None:
         default_scripts = self.get_config_value("app_events.on_app_initialization_complete.scripts_to_register")

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -1,4 +1,4 @@
-import importlib.metadata
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -11,8 +11,6 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 from xdg_base_dirs import xdg_config_dirs, xdg_config_home, xdg_data_home
-
-from griptape_nodes.node_library.script_registry import LibraryNameAndVersion, ScriptMetadata
 
 
 def _find_config_files(filename: str, extension: str) -> list[Path]:
@@ -40,36 +38,23 @@ def _find_config_files(filename: str, extension: str) -> list[Path]:
     return config_files
 
 
+@dataclass
+class ScriptSettingsDetail:
+    """Griptape-provided scripts are pathed differently and display in the GUI in a different section."""
+
+    file_name: str
+    is_griptape_provided: bool
+
+
 class AppInitializationComplete(BaseModel):
     libraries_to_register: list[str] = Field(
         default_factory=lambda: [str(xdg_data_home() / "griptape_nodes/nodes/griptape_nodes_library.json")]
     )
-    scripts_to_register: list[ScriptMetadata] = Field(
+    scripts_to_register: list[ScriptSettingsDetail] = Field(
         default_factory=lambda: [
-            ScriptMetadata(
-                name="Prompt an image",
-                schema_version=ScriptMetadata.LATEST_SCHEMA_VERSION,
-                file_path="griptape_nodes/scripts/prompt_an_image.py",
-                internal=True,
-                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
-            ),
-            ScriptMetadata(
-                name="Coloring Book",
-                schema_version=ScriptMetadata.LATEST_SCHEMA_VERSION,
-                file_path="griptape_nodes/scripts/coloring_book.py",
-                internal=True,
-                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
-            ),
-            ScriptMetadata(
-                name="Render logs",
-                schema_version=ScriptMetadata.LATEST_SCHEMA_VERSION,
-                file_path="griptape_nodes/scripts/render_logs.py",
-                internal=True,
-                engine_version_created_with=importlib.metadata.version("griptape_nodes"),
-                node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
-            ),
+            ScriptSettingsDetail(file_name="griptape_nodes/scripts/prompt_an_image.py", is_griptape_provided=True),
+            ScriptSettingsDetail(file_name="griptape_nodes/scripts/coloring_book.py", is_griptape_provided=True),
+            ScriptSettingsDetail(file_name="griptape_nodes/scripts/render_logs.py", is_griptape_provided=True),
         ]
     )
 

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -12,7 +12,7 @@ from pydantic_settings import (
 )
 from xdg_base_dirs import xdg_config_dirs, xdg_config_home, xdg_data_home
 
-from griptape_nodes.node_library.script_registry import LibraryNameAndVersion
+from griptape_nodes.node_library.script_registry import LibraryNameAndVersion, ScriptMetadata
 
 
 def _find_config_files(filename: str, extension: str) -> list[Path]:
@@ -40,39 +40,32 @@ def _find_config_files(filename: str, extension: str) -> list[Path]:
     return config_files
 
 
-class Script(BaseModel):
-    name: str
-    relative_file_path: str
-    engine_version_created_with: str
-    node_libraries_referenced: list[LibraryNameAndVersion]
-    description: str | None = None
-    image: str | None = None
-    internal: bool = False
-
-
 class AppInitializationComplete(BaseModel):
     libraries_to_register: list[str] = Field(
         default_factory=lambda: [str(xdg_data_home() / "griptape_nodes/nodes/griptape_nodes_library.json")]
     )
-    scripts_to_register: list[Script] = Field(
+    scripts_to_register: list[ScriptMetadata] = Field(
         default_factory=lambda: [
-            Script(
+            ScriptMetadata(
                 name="Prompt an image",
-                relative_file_path="griptape_nodes/scripts/prompt_an_image.py",
+                schema_version=ScriptMetadata.LATEST_SCHEMA_VERSION,
+                file_path="griptape_nodes/scripts/prompt_an_image.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
                 node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
             ),
-            Script(
+            ScriptMetadata(
                 name="Coloring Book",
-                relative_file_path="griptape_nodes/scripts/coloring_book.py",
+                schema_version=ScriptMetadata.LATEST_SCHEMA_VERSION,
+                file_path="griptape_nodes/scripts/coloring_book.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
                 node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],
             ),
-            Script(
+            ScriptMetadata(
                 name="Render logs",
-                relative_file_path="griptape_nodes/scripts/render_logs.py",
+                schema_version=ScriptMetadata.LATEST_SCHEMA_VERSION,
+                file_path="griptape_nodes/scripts/render_logs.py",
                 internal=True,
                 engine_version_created_with=importlib.metadata.version("griptape_nodes"),
                 node_libraries_referenced=[LibraryNameAndVersion("Griptape Nodes Library", "0.1.0")],

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -227,11 +227,11 @@ class RetainedMode:
         parameter_name: str,
         allowed_types: list[str],
         default_value: Any | None,
-        tooltip: str,
+        tooltip: str | list[dict],
         edit: bool = False,  # noqa: FBT001, FBT002
-        tooltip_as_input: str | None = None,
-        tooltip_as_property: str | None = None,
-        tooltip_as_output: str | None = None,
+        tooltip_as_input: str | list[dict] | None = None,
+        tooltip_as_property: str | list[dict] | None = None,
+        tooltip_as_output: str | list[dict] | None = None,
         ui_options: ParameterUIOptions | None = None,
         mode_allowed_input: bool = True,  # noqa: FBT001, FBT002
         mode_allowed_property: bool = True,  # noqa: FBT001, FBT002

--- a/uv.lock
+++ b/uv.lock
@@ -259,6 +259,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "tomlkit" },
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
@@ -288,6 +289,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "websockets", specifier = ">=15.0.1,<16.0.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
@@ -1069,6 +1071,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/aa/8ae85f69a9f6012c6f8011c6f4aa1c96154c816e9eea2e1b758601157833/tokenizers-0.21.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e5a69c1a4496b81a5ee5d2c1f3f7fbdf95e90a0196101b0ee89ed9956b8a168f", size = 9384380 },
     { url = "https://files.pythonhosted.org/packages/e8/5b/a5d98c89f747455e8b7a9504910c865d5e51da55e825a7ae641fb5ff0a58/tokenizers-0.21.1-cp39-abi3-win32.whl", hash = "sha256:1039a3a5734944e09de1d48761ade94e00d0fa760c0e0551151d4dd851ba63e3", size = 2239506 },
     { url = "https://files.pythonhosted.org/packages/e6/b6/072a8e053ae600dcc2ac0da81a23548e3b523301a442a6ca900e92ac35be/tokenizers-0.21.1-cp39-abi3-win_amd64.whl", hash = "sha256:0f0dcbcc9f6e13e675a66d7a5f2f225a736745ce484c1a4e07476a89ccdad382", size = 2435481 },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79", size = 192885 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde", size = 37955 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #141
Closes #142 

It creates a script schema, and saves that as metadata WITHIN a Python file. This puts all the tasty bits (name, description, link to images, etc.) into the file and out of the config.

NOTE: this DOES require the user to kill their config.json. We need to make that more fault tolerant and to drop back to defaults if the current schema changes. That's a @collindutter issue we will discuss tomorrow.