### PR TITLE
feat: add secrets manager for storing secrets in .env file

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -5,6 +5,7 @@ Param(
 # --- Set up paths and variables ---
 $ConfigDir = Join-Path $Env:APPDATA "griptape_nodes"
 $ConfigFile = Join-Path $ConfigDir "griptape_nodes_config.json"
+$EnvFile = Join-Path $ConfigDir ".env"
 
 # --- Write/update the config file if API key is provided ---
 if ($API_KEY) {
@@ -21,10 +22,13 @@ if ($API_KEY) {
 '{
   "env": {
       "Griptape": {
-        "GT_CLOUD_API_KEY": "' + $API_KEY + '"
+        "GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"
       }
   }
 }' | Out-File $ConfigFile
+
+'GT_CLOUD_API_KEY="' + $API_KEY + '"' | Out-File $EnvFile
+
     Write-Host "API key saved to $ConfigFile"
 } else {
     Write-Host "No API key provided. Skipping config file creation."

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CONFIG_FILE="$HOME/.config/griptape_nodes/griptape_nodes_config.json"
+ENV_FILE="$HOME/.config/griptape_nodes/.env"
 API_KEY="$1"
 
 # If an API key was passed, attempt to write it to the config file
@@ -16,10 +17,12 @@ if [ -n "$API_KEY" ]; then
   echo '{
   "env": {
     "Griptape": {
-        "GT_CLOUD_API_KEY": "'"$API_KEY"'"
+        "GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"
     }
   }
 }' >"$CONFIG_FILE"
+
+  echo 'GT_CLOUD_API_KEY="'"$API_KEY"'"' >"$ENV_FILE"
   echo "API key saved to $CONFIG_FILE"
 else
   echo "No API key provided. Skipping config file creation."

--- a/nodes/griptape_nodes_library/agent.py
+++ b/nodes/griptape_nodes_library/agent.py
@@ -9,8 +9,6 @@ from griptape_nodes.exe_types.core_types import (
     ParameterUIOptions,
 )
 from griptape_nodes.exe_types.node_types import ControlNode
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes_library.utils.env_utils import getenv
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
 DEFAULT_MODEL = "gpt-4o"
@@ -21,8 +19,6 @@ SERVICE = "Griptape"
 class RunAgentNode(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-
-        self.config = GriptapeNodes.ConfigManager()
 
         self.category = "Agent"
         self.description = "Create an agent and run it."
@@ -92,7 +88,7 @@ class RunAgentNode(ControlNode):
     def validate_node(self) -> list[Exception] | None:
         # Items here are openai api key
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))
@@ -101,7 +97,7 @@ class RunAgentNode(ControlNode):
 
     def process(self) -> None:
         # Get api key
-        api_key = self.config.get_config_value(f"env.{SERVICE}.{API_KEY_ENV_VAR}")
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
 
         # Get input values
         params = self.parameter_values

--- a/nodes/griptape_nodes_library/create_image.py
+++ b/nodes/griptape_nodes_library/create_image.py
@@ -4,8 +4,7 @@ from griptape.tasks import PromptImageGenerationTask
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import ControlNode
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
-from griptape_nodes_library.utils.env_utils import getenv
+from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -18,8 +17,6 @@ DEFAULT_STYLE = "natural"
 class CreateImageNode(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-
-        self.config = GriptapeNodes.ConfigManager()
 
         self.category = "Agent"
         self.description = "Generate an image"
@@ -84,7 +81,7 @@ class CreateImageNode(ControlNode):
     def validate_node(self) -> list[Exception] | None:
         # TODO(kate): Figure out how to wrap this so it's easily repeatable
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         # No need for the api key. These exceptions caught on other nodes.
         if self.parameter_values.get("agent", None) and self.parameter_values.get("driver", None):
             return None
@@ -98,7 +95,7 @@ class CreateImageNode(ControlNode):
         # Get the parameters from the node
         params = self.parameter_values
 
-        workspace_path = self.config.workspace_path
+        workspace_path = self.config_manager.workspace_path
         images_dir = workspace_path / "Images/"
 
         agent = params.get("agent", Agent(tasks=[]))
@@ -114,7 +111,7 @@ class CreateImageNode(ControlNode):
         else:
             driver = GriptapeCloudImageGenerationDriver(
                 model=params.get("model", DEFAULT_MODEL),
-                api_key=getenv(service=SERVICE, value=API_KEY_ENV_VAR),
+                api_key=self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR),
             )
         kwargs["image_generation_driver"] = driver
 

--- a/nodes/griptape_nodes_library/drivers/anthropic_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/anthropic_prompt_driver.py
@@ -3,7 +3,6 @@ from griptape.drivers.prompt.anthropic import AnthropicPromptDriver
 
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes_library.drivers.base_prompt_driver import BasePromptDriverNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 DEFAULT_MODEL = "claude-3-5-sonnet-latest"
 API_KEY_ENV_VAR = "ANTHROPIC_API_KEY"
@@ -28,7 +27,7 @@ class AnthropicPromptDriverNode(BasePromptDriverNode):
 
         # Initialize kwargs with required parameters
         kwargs = {}
-        kwargs["api_key"] = getenv(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
         kwargs["model"] = self.valid_or_fallback("model", DEFAULT_MODEL)
 
         # Handle optional parameters
@@ -64,7 +63,7 @@ class AnthropicPromptDriverNode(BasePromptDriverNode):
 
     def validate_node(self) -> list[Exception] | None:
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/drivers/audio_transcription_drivers.py
+++ b/nodes/griptape_nodes_library/drivers/audio_transcription_drivers.py
@@ -3,7 +3,6 @@ from griptape.drivers.audio_transcription.openai import OpenAiAudioTranscription
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes_library.drivers.base_driver import BaseDriverNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 
 class BaseAudioTranscriptionDriverNode(BaseDriverNode):
@@ -35,7 +34,7 @@ class OpenAiAudioTranscriptionDriverNode(BaseAudioTranscriptionDriverNode):
         # Items here are openai api key
         exceptions = []
         key = "OPENAI_API_KEY"
-        api_key = getenv("OpenAI", key)
+        api_key = self.get_config_value("OpenAI", key)
         if not api_key:
             msg = f"{key} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/drivers/azure_openai_chat_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/azure_openai_chat_prompt_driver.py
@@ -34,8 +34,8 @@ class AzureOpenAiChatPromptDriverNode(BasePromptDriverNode):
     def process(self) -> None:
         # Initialize kwargs with required parameters
         kwargs = {}
-        kwargs["api_key"] = self.getenv(service=SERVICE, value=API_KEY_ENV_VAR)
-        kwargs["azure_endpoint"] = self.getenv(service=SERVICE, value=DEFAULT_AZURE_ENDPOINT_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["azure_endpoint"] = self.get_config_value(service=SERVICE, value=DEFAULT_AZURE_ENDPOINT_ENV_VAR)
 
         kwargs["model"] = self.valid_or_fallback("model", DEFAULT_MODEL)
         # HACKATTACK:

--- a/nodes/griptape_nodes_library/drivers/azure_openai_image_driver.py
+++ b/nodes/griptape_nodes_library/drivers/azure_openai_image_driver.py
@@ -95,8 +95,8 @@ class AzureOpenAiImageDriverNode(BaseImageDriverNode):
         # Initialize kwargs with required parameters
         kwargs = {
             "model": model,
-            "api_key": self.getenv(service=SERVICE, value=API_KEY_ENV_VAR),
-            "azure_endpoint": self.getenv(service=SERVICE, value=AZURE_ENDPOINT_ENV_VAR),
+            "api_key": self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR),
+            "azure_endpoint": self.get_config_value(service=SERVICE, value=AZURE_ENDPOINT_ENV_VAR),
             "azure_deployment": deployment_name,
             "image_size": size,
         }

--- a/nodes/griptape_nodes_library/drivers/base_driver.py
+++ b/nodes/griptape_nodes_library/drivers/base_driver.py
@@ -2,13 +2,11 @@ from griptape.drivers.prompt.dummy import DummyPromptDriver
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 class BaseDriverNode(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self.config = GriptapeNodes.ConfigManager()
 
         self.add_parameter(
             Parameter(
@@ -19,10 +17,6 @@ class BaseDriverNode(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
-
-    def getenv(self, service: str, value: str) -> str:
-        api_key = self.config.get_config_value(f"env.{service}.{value}")
-        return api_key
 
     def params_to_sparse_dict(self, params, kwargs, param_name, target_name=None, transform=None) -> dict:
         """Add a parameter to kwargs if it exists in params, with optional transformation.

--- a/nodes/griptape_nodes_library/drivers/base_image_driver.py
+++ b/nodes/griptape_nodes_library/drivers/base_image_driver.py
@@ -2,7 +2,6 @@ from griptape.drivers.image_generation.griptape_cloud import GriptapeCloudImageG
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes_library.drivers.base_driver import BaseDriverNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
@@ -47,7 +46,7 @@ class BaseImageDriverNode(BaseDriverNode):
 
         # Initialize kwargs with required parameters
         kwargs = {}
-        kwargs["api_key"] = self.getenv(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
 
         kwargs["model"] = params.get("model", DEFAULT_MODEL)
         kwargs["quality"] = params.get("quality", DEFAULT_QUALITY)
@@ -62,7 +61,7 @@ class BaseImageDriverNode(BaseDriverNode):
     def validate_node(self) -> list[Exception] | None:
         # Items here are openai api key
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/drivers/cohere_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/cohere_prompt_driver.py
@@ -2,7 +2,6 @@ import cohere
 from griptape.drivers.prompt.cohere import CoherePromptDriver
 
 from griptape_nodes_library.drivers.base_prompt_driver import BasePromptDriverNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 DEFAULT_MODEL = "command-r-plus"
 API_KEY_ENV_VAR = "COHERE_API_KEY"
@@ -24,7 +23,7 @@ class CoherePromptDriverNode(BasePromptDriverNode):
 
         # Initialize kwargs with required parameters
         kwargs = {}
-        kwargs["api_key"] = self.getenv(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
         kwargs["model"] = params.get("model", DEFAULT_MODEL)
 
         # Handle optional parameters
@@ -50,7 +49,7 @@ class CoherePromptDriverNode(BasePromptDriverNode):
     def validate_node(self) -> list[Exception] | None:
         # Items here are openai api key
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/drivers/griptape_cloud_image_driver.py
+++ b/nodes/griptape_nodes_library/drivers/griptape_cloud_image_driver.py
@@ -46,7 +46,7 @@ class GriptapeCloudImageDriverNode(BaseImageDriverNode):
             )
         )
 
-        kwargs["api_key"] = self.getenv(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
 
     def adjust_size_based_on_model(self, model, size) -> str:
         """Adjust the image size based on the selected model's capabilities.
@@ -77,7 +77,7 @@ class GriptapeCloudImageDriverNode(BaseImageDriverNode):
         # Initialize kwargs with required parameters
         kwargs = {
             "model": model,
-            "api_key": self.getenv(service=SERVICE, value=API_KEY_ENV_VAR),
+            "api_key": self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR),
             "image_size": size,
         }
 
@@ -85,7 +85,7 @@ class GriptapeCloudImageDriverNode(BaseImageDriverNode):
 
     def validate_node(self) -> list[Exception] | None:
         exceptions = []
-        api_key = self.getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/drivers/griptape_cloud_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/griptape_cloud_prompt_driver.py
@@ -1,7 +1,6 @@
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
 
 from griptape_nodes_library.drivers.base_prompt_driver import BasePromptDriverNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 DEFAULT_MODEL = "gpt-4o"
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -24,7 +23,7 @@ class GriptapeCloudPromptDriverNode(BasePromptDriverNode):
 
         # Initialize kwargs with required parameters
         kwargs = {}
-        kwargs["api_key"] = self.getenv(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
         kwargs["model"] = params.get("model", DEFAULT_MODEL)
 
         # Handle optional parameters
@@ -66,7 +65,7 @@ class GriptapeCloudPromptDriverNode(BasePromptDriverNode):
     def validate_node(self) -> list[Exception] | None:
         # Items here are openai api key
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/drivers/ollama_embedding_driver.py
+++ b/nodes/griptape_nodes_library/drivers/ollama_embedding_driver.py
@@ -56,7 +56,7 @@ class OllamaEmbeddingDriverNode(BaseEmbeddingDriverNode):
         # Set up the host URL by combining base_url and port
         base_url = params.get("base_url", DEFAULT_BASE_URL)
         if not base_url or base_url == "":
-            base_url = self.getenv(service=SERVICE, value=OLLAMA_BASE_URL_ENV_VAR)
+            base_url = self.get_config_value(service=SERVICE, value=OLLAMA_BASE_URL_ENV_VAR)
 
         port = params.get("port", DEFAULT_PORT)
         if base_url and port:

--- a/nodes/griptape_nodes_library/drivers/openai_chat_prompt_driver.py
+++ b/nodes/griptape_nodes_library/drivers/openai_chat_prompt_driver.py
@@ -30,7 +30,7 @@ class OpenAiChatPromptDriverNode(BasePromptDriverNode):
         # Get the parameters from the node
         params = self.parameter_values
         kwargs = {}
-        kwargs["api_key"] = self.getenv(service=SERVICE, value=API_KEY_ENV_VAR)
+        kwargs["api_key"] = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
         kwargs["model"] = params.get("model", DEFAULT_MODEL)
         response_format = params.get("response_format", None)
         seed = params.get("seed", None)

--- a/nodes/griptape_nodes_library/simple_agent.py
+++ b/nodes/griptape_nodes_library/simple_agent.py
@@ -4,7 +4,6 @@ from griptape.utils import Stream
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterUIOptions
 from griptape_nodes.exe_types.node_types import ControlNode
-from griptape_nodes_library.utils.env_utils import getenv
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
 DEFAULT_MODEL = "gpt-4o"
@@ -59,7 +58,7 @@ class SimpleAgentNode(ControlNode):
     def validate_node(self) -> list[Exception] | None:
         # Items here are openai api key
         exceptions = []
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))
@@ -72,7 +71,9 @@ class SimpleAgentNode(ControlNode):
 
         agent = params.get("agent", None)
         if not agent:
-            agent = Agent(prompt_driver=GriptapeCloudPromptDriver(api_key=getenv(SERVICE, API_KEY_ENV_VAR)))
+            agent = Agent(
+                prompt_driver=GriptapeCloudPromptDriver(api_key=self.get_config_value(SERVICE, API_KEY_ENV_VAR))
+            )
 
         prompt = params.get("prompt", None)
         if prompt:

--- a/nodes/griptape_nodes_library/tools/audio_transcription_tool.py
+++ b/nodes/griptape_nodes_library/tools/audio_transcription_tool.py
@@ -3,7 +3,6 @@ from griptape.drivers.audio_transcription.openai import OpenAiAudioTranscription
 from griptape.tools.audio_transcription.tool import AudioTranscriptionTool
 
 from griptape_nodes_library.tools.tools import BaseToolNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 API_KEY_ENV_VAR = "OPENAI_API_KEY"
 SERVICE = "OpenAI"
@@ -29,7 +28,7 @@ class AudioTranscriptionToolNode(BaseToolNode):
         exceptions = []
         if self.parameter_values.get("driver", None):
             return exceptions
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/tools/extraction_tool.py
+++ b/nodes/griptape_nodes_library/tools/extraction_tool.py
@@ -4,7 +4,6 @@ from griptape.rules import Rule
 from griptape.tools import ExtractionTool
 
 from griptape_nodes_library.tools.base_tool import BaseToolNode
-from griptape_nodes_library.utils.env_utils import getenv
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
@@ -42,7 +41,7 @@ class ExtractionToolNode(BaseToolNode):
         exceptions = []
         if self.parameter_values.get("prompt_driver", None):
             return exceptions
-        api_key = getenv(SERVICE, API_KEY_ENV_VAR)
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))

--- a/nodes/griptape_nodes_library/utils/env_utils.py
+++ b/nodes/griptape_nodes_library/utils/env_utils.py
@@ -1,6 +1,0 @@
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-
-def getenv(service: str, value: str) -> str:
-    api_key = GriptapeNodes.get_instance()._config_manager.get_config_value(f"env.{service}.{value}")
-    return api_key

--- a/nodes/tests/unit/drivers/test_griptape_cloud_image_generation_driver.py
+++ b/nodes/tests/unit/drivers/test_griptape_cloud_image_generation_driver.py
@@ -85,7 +85,7 @@ class TestGriptapeCloudImageGenerationNode:
 
         assert isinstance(driver, GriptapeCloudImageGenerationDriver)
         assert driver.model == "dall-e-3"
-        assert driver.api_key == griptape_cloud_image_generation_node.getenv(
+        assert driver.api_key == griptape_cloud_image_generation_node.get_config_value(
             service="Griptape", value="GT_CLOUD_API_KEY"
         )
         assert driver.image_size == "1024x1024"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape_nodes"
-version = "0.5.3"
+version = "0.5.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import httpx
+from dotenv import get_key
 from griptape.events import (
     BaseEvent,
     EventBus,
@@ -20,6 +21,7 @@ from griptape.events import (
 from rich.align import Align
 from rich.console import Console
 from rich.panel import Panel
+from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.api.queue_manager import event_queue
 from griptape_nodes.api.routes.api import process_event
@@ -163,13 +165,11 @@ def sse_listener() -> None:
             nodes_app_url = os.getenv("GRIPTAPE_NODES_APP_URL", "https://nodes.griptape.ai")
 
             def auth(request: httpx.Request) -> httpx.Request:
-                service = "Griptape"
-                value = "GT_CLOUD_API_KEY"
-                api_token = GriptapeNodes.get_instance().ConfigManager().get_config_value(f"env.{service}.{value}")
+                api_key = get_key(xdg_config_home() / "griptape_nodes" / ".env", "GT_CLOUD_API_KEY")
                 request.headers.update(
                     {
                         "Accept": "text/event-stream",
-                        "Authorization": f"Bearer {api_token}",
+                        "Authorization": f"Bearer {api_key}",
                     }
                 )
                 return request

--- a/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
+++ b/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
@@ -5,8 +5,10 @@ from time import sleep
 from urllib.parse import urljoin
 
 from attrs import Factory, define, field
+from dotenv import get_key
 from websockets.exceptions import WebSocketException
 from websockets.sync.client import ClientConnection, connect
+from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -60,9 +62,9 @@ class NodesApiSocketManager:
     def _connect(self) -> ClientConnection:
         while True:
             try:
-                api_key = GriptapeNodes.get_instance().ConfigManager().get_config_value("env.Griptape.GT_CLOUD_API_KEY")
+                api_key = get_key(xdg_config_home() / "griptape_nodes" / ".env", "GT_CLOUD_API_KEY")
                 if api_key is None:
-                    msg = "env.Griptape.GT_CLOUD_API_KEY is not set, please add this value to your griptape_nodes_config.json file."
+                    msg = "GT_CLOUD_API_KEY is not set, please re-run the install script."
                     raise ValueError(msg) from None
 
                 return connect(

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -48,6 +48,8 @@ class BaseNode(ABC):
         metadata: dict[Any, Any] | None = None,
         state: NodeResolutionState = NodeResolutionState.UNRESOLVED,
     ) -> None:
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
         self.name = name
         self.state = state
         if metadata is None:
@@ -57,6 +59,7 @@ class BaseNode(ABC):
         self.parameter_values = {}
         self.parameter_output_values = {}
         self.root_ui_element = BaseNodeElement()
+        self.config_manager = GriptapeNodes.ConfigManager()
 
     def make_node_unresolved(self) -> None:
         self.state = NodeResolutionState.UNRESOLVED
@@ -349,6 +352,12 @@ class BaseNode(ABC):
     # if not implemented, it will return no issues.
     def validate_node(self) -> list[Exception] | None:
         return None
+
+    def get_config_value(self, service: str, value: str) -> str:
+        return self.config_manager.get_config_value(f"nodes.{service}.{value}")
+
+    def set_config_value(self, service: str, value: str, new_value: str) -> None:
+        self.config_manager.set_config_value(f"nodes.{service}.{value}", new_value)
 
 
 class ControlNode(BaseNode):

--- a/src/griptape_nodes/retained_mode/events/secrets_events.py
+++ b/src/griptape_nodes/retained_mode/events/secrets_events.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+from typing import Any
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+@dataclass
+@PayloadRegistry.register
+class GetSecretValueRequest(RequestPayload):
+    key: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GetSecretValueResultSuccess(ResultPayloadSuccess):
+    value: Any
+
+
+@dataclass
+@PayloadRegistry.register
+class GetSecretValueResultFailure(ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class SetSecretValueRequest(RequestPayload):
+    key: str
+    value: Any
+
+
+@dataclass
+@PayloadRegistry.register
+class SetSecretValueResultSuccess(ResultPayloadSuccess):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class SetSecretValueResultFailure(ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class GetAllSecretValuesRequest(RequestPayload):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class GetAllSecretValuesResultSuccess(ResultPayloadSuccess):
+    values: dict[str, Any]
+
+
+@dataclass
+@PayloadRegistry.register
+class GetAllSecretValuesResultFailure(ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class DeleteSecretValueRequest(RequestPayload):
+    key: str
+
+
+@dataclass
+@PayloadRegistry.register
+class DeleteSecretValueResultSuccess(ResultPayloadSuccess):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class DeleteSecretValueResultFailure(ResultPayloadFailure):
+    pass

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -217,8 +217,8 @@ from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.log_manager import LogManager
 from griptape_nodes.retained_mode.managers.operation_manager import OperationDepthManager
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
-from griptape_nodes.retained_mode.managers.settings import ScriptSettingsDetail
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
+from griptape_nodes.retained_mode.managers.settings import ScriptSettingsDetail
 
 load_dotenv()
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 import io
 import json
@@ -216,6 +218,7 @@ from griptape_nodes.retained_mode.managers.log_manager import LogManager
 from griptape_nodes.retained_mode.managers.operation_manager import OperationDepthManager
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
 from griptape_nodes.retained_mode.managers.settings import ScriptSettingsDetail
+from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
 load_dotenv()
 
@@ -239,6 +242,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._event_manager = EventManager()
             self._os_manager = OSManager(self._event_manager)
             self._config_manager = ConfigManager(self._event_manager)
+            self._secrets_manager = SecretsManager(self._event_manager, self._config_manager)
             self._object_manager = ObjectManager(self._event_manager)
             self._node_manager = NodeManager(self._event_manager)
             self._flow_manager = FlowManager(self._event_manager)
@@ -256,7 +260,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
             )
 
     @classmethod
-    def get_instance(cls) -> "GriptapeNodes":
+    def get_instance(cls) -> GriptapeNodes:
         """Helper method to get the singleton instance."""
         return cls()
 
@@ -289,35 +293,39 @@ class GriptapeNodes(metaclass=SingletonMeta):
         return GriptapeNodes.get_instance()._event_manager
 
     @classmethod
-    def LibraryManager(cls) -> "LibraryManager":
+    def LibraryManager(cls) -> LibraryManager:
         return GriptapeNodes.get_instance()._library_manager
 
     @classmethod
-    def ObjectManager(cls) -> "ObjectManager":
+    def ObjectManager(cls) -> ObjectManager:
         return GriptapeNodes.get_instance()._object_manager
 
     @classmethod
-    def FlowManager(cls) -> "FlowManager":
+    def FlowManager(cls) -> FlowManager:
         return GriptapeNodes.get_instance()._flow_manager
 
     @classmethod
-    def NodeManager(cls) -> "NodeManager":
+    def NodeManager(cls) -> NodeManager:
         return GriptapeNodes.get_instance()._node_manager
 
     @classmethod
-    def ScriptManager(cls) -> "ScriptManager":
+    def ScriptManager(cls) -> ScriptManager:
         return GriptapeNodes.get_instance()._script_manager
 
     @classmethod
-    def ArbitraryCodeExecManager(cls) -> "ArbitraryCodeExecManager":
+    def ArbitraryCodeExecManager(cls) -> ArbitraryCodeExecManager:
         return GriptapeNodes.get_instance()._arbitrary_code_exec_manager
 
     @classmethod
-    def ConfigManager(cls) -> "ConfigManager":
+    def ConfigManager(cls) -> ConfigManager:
         return GriptapeNodes.get_instance()._config_manager
 
     @classmethod
-    def OperationDepthManager(cls) -> "OperationDepthManager":
+    def SecretsManager(cls) -> SecretsManager:
+        return GriptapeNodes.get_instance()._secrets_manager
+
+    @classmethod
+    def OperationDepthManager(cls) -> OperationDepthManager:
         return GriptapeNodes.get_instance()._operation_depth_manager
 
     @classmethod

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 from typing import Any
 
@@ -118,8 +117,15 @@ class ConfigManager:
         """
         value = get_dot_value(self.user_config, key)
 
+        if value is None:
+            msg = f"Config key '{key}' not found in config file."
+            raise ValueError(msg)
+
         if isinstance(value, str) and value.startswith("$"):
-            value = os.getenv(value[1:], value)
+            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+            value = GriptapeNodes.SecretsManager().get_secret(value[1:], value)
+
         return value
 
     def set_config_value(self, key: str, value: Any) -> None:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -34,10 +34,12 @@ class SecretsManager:
         )
 
     def on_handle_get_secret_request(self, request: GetSecretValueRequest) -> ResultPayload:
-        secret_name = request.key
-        secret_value = self.get_secret(secret_name)
+        secret_key = request.key
+        secret_value = self.get_secret(secret_key)
 
         if secret_value is None:
+            details = f"Secret {secret_key} not found: '{secret_key}'"
+            print(details)  # TODO(griptape): Move to Log
             return GetSecretValueResultFailure()
 
         return GetSecretValueResultSuccess(value=secret_value)
@@ -59,9 +61,13 @@ class SecretsManager:
         secret_name = request.key
 
         if not self.env_var_path.exists():
+            details = f"Secret file does not exist: '{self.env_var_path}'"
+            print(details)  # TODO(griptape): Move to Log
             return DeleteSecretValueResultFailure()
 
         if not get_key(self.env_var_path, secret_name):
+            details = f"Secret {secret_name} not found: '{secret_name}'"
+            print(details)  # TODO(griptape): Move to Log
             return DeleteSecretValueResultFailure()
 
         unset_key(self.env_var_path, secret_name)

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -1,0 +1,77 @@
+from os import getenv
+
+from dotenv import dotenv_values, get_key, set_key, unset_key
+
+from griptape_nodes.retained_mode.events.base_events import ResultPayload
+from griptape_nodes.retained_mode.events.secrets_events import (
+    DeleteSecretValueRequest,
+    DeleteSecretValueResultFailure,
+    DeleteSecretValueResultSuccess,
+    GetAllSecretValuesRequest,
+    GetAllSecretValuesResultSuccess,
+    GetSecretValueRequest,
+    GetSecretValueResultFailure,
+    GetSecretValueResultSuccess,
+    SetSecretValueRequest,
+    SetSecretValueResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+
+class SecretsManager:
+    def __init__(self, event_manager: EventManager, config_manager: ConfigManager) -> None:
+        self.env_var_path = config_manager.workspace_path / ".env"
+
+        # Register all our listeners.
+        event_manager.assign_manager_to_request_type(GetSecretValueRequest, self.on_handle_get_secret_request)
+        event_manager.assign_manager_to_request_type(SetSecretValueRequest, self.on_handle_set_secret_request)
+        event_manager.assign_manager_to_request_type(
+            GetAllSecretValuesRequest, self.on_handle_get_all_secret_values_request
+        )
+        event_manager.assign_manager_to_request_type(
+            DeleteSecretValueRequest, self.on_handle_delete_secret_value_request
+        )
+
+    def on_handle_get_secret_request(self, request: GetSecretValueRequest) -> ResultPayload:
+        secret_name = request.key
+        secret_value = self.get_secret(secret_name)
+
+        if secret_value is None:
+            return GetSecretValueResultFailure()
+
+        return GetSecretValueResultSuccess(value=secret_value)
+
+    def on_handle_set_secret_request(self, request: SetSecretValueRequest) -> ResultPayload:
+        secret_name = request.key
+        secret_value = request.value
+
+        self.set_secret(secret_name, secret_value)
+
+        return SetSecretValueResultSuccess()
+
+    def on_handle_get_all_secret_values_request(self, request: GetAllSecretValuesRequest) -> ResultPayload:  # noqa: ARG002
+        secret_values = dotenv_values(self.env_var_path)
+
+        return GetAllSecretValuesResultSuccess(values=secret_values)
+
+    def on_handle_delete_secret_value_request(self, request: DeleteSecretValueRequest) -> ResultPayload:
+        secret_name = request.key
+
+        if not self.env_var_path.exists():
+            return DeleteSecretValueResultFailure()
+
+        if not get_key(self.env_var_path, secret_name):
+            return DeleteSecretValueResultFailure()
+
+        unset_key(self.env_var_path, secret_name)
+
+        return DeleteSecretValueResultSuccess()
+
+    def get_secret(self, secret_name: str, default: str | None = None) -> str | None:
+        return get_key(self.env_var_path, secret_name) or getenv(secret_name) or default
+
+    def set_secret(self, secret_name: str, secret_value: str) -> None:
+        if not self.env_var_path.exists():
+            self.env_var_path.touch()
+        set_key(self.env_var_path, secret_name, secret_value)

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -90,6 +90,11 @@ class AppEvents(BaseModel):
 class Settings(BaseSettings):
     workspace_directory: str = Field(default=str(Path().home() / "GriptapeNodes"))
     app_events: AppEvents = Field(default_factory=AppEvents)
+    env: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "Griptape": {"GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"},
+        }
+    )
     nodes: dict[str, Any] = Field(
         default_factory=lambda: {
             "Griptape": {"GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"},

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -90,7 +90,7 @@ class AppEvents(BaseModel):
 class Settings(BaseSettings):
     workspace_directory: str = Field(default=str(Path().home() / "GriptapeNodes"))
     app_events: AppEvents = Field(default_factory=AppEvents)
-    env: dict[str, Any] = Field(
+    nodes: dict[str, Any] = Field(
         default_factory=lambda: {
             "Griptape": {"GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"},
             "OpenAI": {"OPENAI_API_KEY": "$OPENAI_API_KEY"},

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -90,11 +90,6 @@ class AppEvents(BaseModel):
 class Settings(BaseSettings):
     workspace_directory: str = Field(default=str(Path().home() / "GriptapeNodes"))
     app_events: AppEvents = Field(default_factory=AppEvents)
-    env: dict[str, Any] = Field(
-        default_factory=lambda: {
-            "Griptape": {"GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"},
-        }
-    )
     nodes: dict[str, Any] = Field(
         default_factory=lambda: {
             "Griptape": {"GT_CLOUD_API_KEY": "$GT_CLOUD_API_KEY"},

--- a/tests/integration/retained_mode/events/test_config_events.py
+++ b/tests/integration/retained_mode/events/test_config_events.py
@@ -1,0 +1,20 @@
+from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigValueRequest,
+    GetConfigValueResultSuccess,
+    SetConfigValueRequest,
+)
+from griptape_nodes.retained_mode.events.secrets_events import (
+    SetSecretValueRequest,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class TestConfigEvents:
+    def test_get_config_value(self) -> None:
+        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="secret foo"))
+        GriptapeNodes.handle_request(SetConfigValueRequest(category_and_key="nodes.foo.bar", value="$SECRET_KEY"))
+        result = GriptapeNodes.handle_request(GetConfigValueRequest(category_and_key="nodes.foo.bar"))
+
+        assert isinstance(result, GetConfigValueResultSuccess)
+
+        assert result.value == "secret foo"

--- a/tests/integration/retained_mode/events/test_secret_events.py
+++ b/tests/integration/retained_mode/events/test_secret_events.py
@@ -1,0 +1,38 @@
+from griptape_nodes.retained_mode.events.secrets_events import (
+    DeleteSecretValueRequest,
+    GetAllSecretValuesRequest,
+    GetAllSecretValuesResultSuccess,
+    GetSecretValueRequest,
+    GetSecretValueResultFailure,
+    GetSecretValueResultSuccess,
+    SetSecretValueRequest,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class TestSecretEvents:
+    def test_get_set_delete_secret_value_request(self) -> None:
+        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="foo"))
+        result = GriptapeNodes.handle_request(GetSecretValueRequest(key="SECRET_KEY"))
+
+        assert isinstance(result, GetSecretValueResultSuccess)
+
+        assert result.value == "foo"
+
+        GriptapeNodes.handle_request(DeleteSecretValueRequest(key="SECRET_KEY"))
+
+        result = GriptapeNodes.handle_request(GetSecretValueRequest(key="SECRET_KEY"))
+
+        assert isinstance(result, GetSecretValueResultFailure)
+
+    def test_get_all_secret_values_request(self) -> None:
+        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY_1", value="foo"))
+        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY_2", value="foo"))
+        result = GriptapeNodes.handle_request(GetAllSecretValuesRequest())
+
+        assert isinstance(result, GetAllSecretValuesResultSuccess)
+
+        assert result.values == {
+            "SECRET_KEY_1": "foo",
+            "SECRET_KEY_2": "foo",
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ loaders-image = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "cohere" },


### PR DESCRIPTION
This PR introduces a `SecretsManager` which is responsible for reading/writing to a secrets location. Today the only supported location is a `.env` in the user's workspace directory, but this could be easily expanded to proper secret manager services.

The intended workflow is that the user would configure their secrets either via the UI or directly with the `.env` file. And then reference those secrets in their config with the `$MY_SECRET` syntax.

Closes #65 