### PR TITLE
feat: add init workflow

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -114,8 +114,8 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
         Once the key is created, copy and paste its value here to proceed."""
         console.print(Panel(explainer, expand=False))
 
-    current_key = api_key
     default_key = api_key or DotEnv(ENV_FILE, verbose=False).get("GT_CLOUD_API_KEY")
+    current_key = api_key
     while current_key is None:
         current_key = Prompt.ask(
             "Griptape API Key",
@@ -126,6 +126,7 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
     set_key(ENV_FILE, "GT_CLOUD_API_KEY", current_key)
     config_manager.set_config_value("nodes.Griptape.GT_CLOUD_API_KEY", "$GT_CLOUD_API_KEY")
     secrets_manager.set_secret("GT_CLOUD_API_KEY", current_key)
+    console.print(f"[bold green]API Key set to: {current_key}[/bold green]")
 
 
 def _prompt_for_workspace() -> None:
@@ -235,6 +236,7 @@ def _process_args(args: argparse.Namespace) -> None:
 
     if args.command == "init":
         _run_init(api_key=args.api_key)
+        console.print("Initialization complete! You can now run the engine with 'griptape-nodes' (or just 'gtn').")
     elif args.command == "engine":
         if is_first_init:
             # Default init flow if it's truly the first time

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -133,7 +133,7 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
 def _prompt_for_workspace() -> None:
     """Prompts the user for their workspace directory and stores it in config directory."""
     explainer = """[bold cyan]Workspace Directory[/bold cyan]
-    Select the workspace directory. This is the location where Griptape Nodes will store flows, config, and secrets.
+    Select the workspace directory. This is the location where Griptape Nodes will store your saved workflows, configuration data, and secrets.
     You may enter a custom directory or press Return to accept the default workspace directory"""
     console.print(Panel(explainer, expand=False))
 

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -115,6 +115,7 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
         console.print(Panel(explainer, expand=False))
 
     default_key = api_key or DotEnv(ENV_FILE, verbose=False).get("GT_CLOUD_API_KEY")
+    # If api_key is provided via --api-key, we don't want to prompt for it
     current_key = api_key
     while current_key is None:
         current_key = Prompt.ask(

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -6,7 +6,6 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 import httpx
 from dotenv import load_dotenv, set_key
@@ -24,6 +23,7 @@ CONFIG_DIR = xdg_config_home() / "griptape_nodes"
 ENV_FILE = CONFIG_DIR / ".env"
 CONFIG_FILE = CONFIG_DIR / "griptape_nodes_config.json"
 REPO_NAME = "griptape-ai/griptape-nodes"
+NODES_APP_URL = "https://nodes.griptape.ai"
 
 console = Console()
 config_manager = ConfigManager()
@@ -126,14 +126,20 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
 
 def _prompt_for_workspace() -> None:
     """Prompts the user for their workspace directory and stores it in config directory."""
-    workspace_directory = config_manager.get_config_value("workspace_directory")
+    default_workspace_directory = config_manager.get_config_value("workspace_directory")
 
-    workspace_directory = Prompt.ask(
-        "Please enter your workspace directory",
-        default=workspace_directory,
-        show_default=True,
-    )
-    config_manager.workspace_path = str(Path(workspace_directory).expanduser().resolve())
+    valid_workspace = False
+    while not valid_workspace:
+        try:
+            workspace_directory = Prompt.ask(
+                "Please enter your workspace directory",
+                default=default_workspace_directory,
+                show_default=True,
+            )
+            config_manager.workspace_path = str(Path(workspace_directory).expanduser().resolve())
+            valid_workspace = True
+        except OSError as e:
+            console.print(f"[bold red]Invalid workspace directory: {e}[/bold red]")
     console.print(f"[bold green]Workspace directory set to: {config_manager.workspace_path}[/bold green]")
 
 

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -106,16 +106,16 @@ def _init_system_config() -> bool:
 
 def _prompt_for_api_key(api_key: str | None = None) -> None:
     """Prompts the user for their GT_CLOUD_API_KEY unless it's provided."""
+    if api_key is None:
+        explainer = f"""[bold cyan]Griptape API Key[/bold cyan]
+        A Griptape API Key is needed to proceed.
+        This key allows the Griptape Nodes engine to communicate with the Griptape Nodes Editor.
+        In order to get a key, visit [link={NODES_APP_URL}]{NODES_APP_URL}[/link] in your browser and click the button "Generate API Key".
+        Once the key is created, copy and paste its value here to proceed."""
+        console.print(Panel(explainer, expand=False))
+
+    current_key = api_key
     default_key = api_key or DotEnv(ENV_FILE, verbose=False).get("GT_CLOUD_API_KEY")
-
-    explainer = f"""[bold cyan]Griptape API Key[/bold cyan]
-    A Griptape API Key is needed to proceed.
-    This key allows the Griptape Nodes engine to communicate with the Griptape Nodes Editor.
-    In order to get a key, visit [link={NODES_APP_URL}]{NODES_APP_URL}[/link] in your browser and click the button "Generate API Key".
-    Once the key is created, copy and paste its value here to proceed."""
-    console.print(Panel(explainer, expand=False))
-
-    current_key = None
     while current_key is None:
         current_key = Prompt.ask(
             "Griptape API Key",
@@ -130,8 +130,6 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
 
 def _prompt_for_workspace() -> None:
     """Prompts the user for their workspace directory and stores it in config directory."""
-    default_workspace_directory = config_manager.get_config_value("workspace_directory")
-
     explainer = """[bold cyan]Workspace Directory[/bold cyan]
     Select the workspace directory. This is the location where Griptape Nodes will store flows, config, and secrets.
     You may enter a custom directory or press Return to accept the default workspace directory
@@ -139,6 +137,7 @@ def _prompt_for_workspace() -> None:
     console.print(Panel(explainer, expand=False))
 
     valid_workspace = False
+    default_workspace_directory = config_manager.get_config_value("workspace_directory")
     while not valid_workspace:
         try:
             workspace_directory = Prompt.ask(

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -110,14 +110,14 @@ def _init_system_config() -> bool:
 def _prompt_for_api_key(api_key: str | None = None) -> None:
     """Prompts the user for their GT_CLOUD_API_KEY unless it's provided."""
     default_key = api_key or DotEnv(ENV_FILE, verbose=False).get("GT_CLOUD_API_KEY")
-    current_key = Prompt.ask(
-        "Please enter your Griptape Nodes API key",
-        default=default_key,
-        show_default=True,
-    )
-    if current_key is None:
-        console.print("[bold red]API key cannot be empty![/bold red]")
-        sys.exit(1)
+
+    current_key = None
+    while current_key is None:
+        current_key = Prompt.ask(
+            "Please enter your Griptape Nodes API key",
+            default=default_key,
+            show_default=True,
+        )
 
     set_key(ENV_FILE, "GT_CLOUD_API_KEY", current_key)
     config_manager.set_config_value("nodes.Griptape.GT_CLOUD_API_KEY", "$GT_CLOUD_API_KEY")

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -8,7 +8,8 @@ import sys
 from pathlib import Path
 
 import httpx
-from dotenv import get_key, load_dotenv, set_key
+from dotenv import load_dotenv, set_key
+from dotenv.main import DotEnv
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 from xdg_base_dirs import xdg_config_home
@@ -30,18 +31,25 @@ secrets_manager = SecretsManager(config_manager)
 
 def main() -> None:
     load_dotenv(ENV_FILE)
-    _init_config()
-    _init_api_key()
+
+    is_first_init = _init_config()
+    if is_first_init:
+        _run_init()
 
     # Hack to make paths "just work". # noqa: FIX004
     # Without this, packages like `nodes` don't properly import.
     # Long term solution could be to make `nodes` a proper src-layout package
     # but current engine relies on importing files rather than packages.
-
     sys.path.append(str(Path.cwd()))
 
     args = _get_args()
     _process_args(args)
+
+
+def _run_init() -> None:
+    """Runs through the engine init steps with the user."""
+    _prompt_for_workspace()
+    _prompt_for_api_key()
 
 
 def _get_args() -> argparse.Namespace:
@@ -52,7 +60,7 @@ def _get_args() -> argparse.Namespace:
         "command",
         help="Command to run",
         nargs="?",
-        choices=["engine", "config", "update", "version"],
+        choices=["init", "engine", "config", "update", "version"],
         default="engine",
     )
 
@@ -67,11 +75,18 @@ def _get_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _init_config() -> None:
-    """Initializes the config directory if it doesn't exist."""
+def _init_config() -> bool:
+    """Initializes the config directory if it doesn't exist.
+
+    Returns:
+        bool: True if the config directory was created, False otherwise.
+
+    """
     config_dir = xdg_config_home() / "griptape_nodes"
+    is_first_init = False
     if not config_dir.exists():
         config_dir.mkdir(parents=True, exist_ok=True)
+        is_first_init = True
 
     files_to_create = [
         (ENV_FILE, ""),
@@ -84,21 +99,36 @@ def _init_config() -> None:
             with Path.open(file_path, "w") as file:
                 file.write(file_name[1])
 
+    return is_first_init
 
-def _init_api_key() -> None:
+
+def _prompt_for_api_key() -> None:
     """Prompts the user for their GT_CLOUD_API_KEY and stores it in config directory."""
-    api_key = get_key(ENV_FILE, "GT_CLOUD_API_KEY")
+    api_key = None
+    while not api_key:
+        api_key = Prompt.ask(
+            "Please enter your Griptape Nodes API key",
+            # dotenv.get_key doesn't support disabling verbose mode
+            default=DotEnv(ENV_FILE, verbose=False).get("GT_CLOUD_API_KEY"),
+            show_default=True,
+        )
+    set_key(ENV_FILE, "GT_CLOUD_API_KEY", api_key)
+    config_manager.set_config_value("nodes.Griptape.GT_CLOUD_API_KEY", "$GT_CLOUD_API_KEY")
+    secrets_manager.set_secret("GT_CLOUD_API_KEY", api_key)
 
-    if not api_key:
-        while not api_key:
-            api_key = Prompt.ask(
-                "Please enter your API key to continue",
-                default=None,
-                show_default=False,
-            )
-        set_key(ENV_FILE, "GT_CLOUD_API_KEY", api_key)
-        config_manager.set_config_value("nodes.Griptape.GT_CLOUD_API_KEY", "$GT_CLOUD_API_KEY")
-        secrets_manager.set_secret("GT_CLOUD_API_KEY", api_key)
+
+def _prompt_for_workspace() -> None:
+    """Prompts the user for their workspace directory and stores it in config directory."""
+    workspace_directory = config_manager.get_config_value("workspace_directory")
+
+    workspace_directory = Prompt.ask(
+        "Please enter your workspace directory",
+        default=workspace_directory,
+        show_default=True,
+    )
+    config_manager.workspace_path = str(Path(workspace_directory).resolve())
+
+    console.print(f"[bold green]Workspace directory set to: {config_manager.workspace_path}[/bold green]")
 
 
 def _get_latest_version(repo: str) -> str:
@@ -181,24 +211,22 @@ def _list_user_configs() -> list[Path]:
 
 
 def _process_args(args: argparse.Namespace) -> None:
-    if args.command == "engine":
+    if args.command == "init":
+        _run_init()
+    elif args.command == "engine":
         _auto_update()
         api_main()
-
     elif args.command == "config":
         if args.config_subcommand == "list":
             for config in _list_user_configs():
                 console.print(f"[bold green]{config}[/bold green]")
         else:
             sys.stdout.write(json.dumps(_get_user_config(), indent=2))
-
     elif args.command == "update":
         _install_latest_release()
-
     elif args.command == "version":
         version = _get_current_version()
         console.print(f"[bold green]{version}[/bold green]")
-
     else:
         msg = f"Unknown command: {args.command}"
         raise ValueError(msg)

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -48,10 +48,6 @@ def _run_init(api_key: str | None = None) -> None:
     _prompt_for_workspace()
     _prompt_for_api_key(api_key)
 
-    console.print(
-        "[bold green]Initialization complete! You can now run the engine with 'griptape-nodes' (or just 'gtn').[/bold green]"
-    )
-
 
 def _get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="griptape-nodes", description="Griptape Nodes Engine.")

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -11,6 +11,7 @@ import httpx
 from dotenv import load_dotenv, set_key
 from dotenv.main import DotEnv
 from rich.console import Console
+from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 from xdg_base_dirs import xdg_config_home
 
@@ -107,10 +108,17 @@ def _prompt_for_api_key(api_key: str | None = None) -> None:
     """Prompts the user for their GT_CLOUD_API_KEY unless it's provided."""
     default_key = api_key or DotEnv(ENV_FILE, verbose=False).get("GT_CLOUD_API_KEY")
 
+    explainer = f"""[bold cyan]Griptape API Key[/bold cyan]
+    A Griptape API Key is needed to proceed.
+    This key allows the Griptape Nodes engine to communicate with the Griptape Nodes Editor.
+    In order to get a key, visit [link={NODES_APP_URL}]{NODES_APP_URL}[/link] in your browser and click the button "Generate API Key".
+    Once the key is created, copy and paste its value here to proceed."""
+    console.print(Panel(explainer, expand=False))
+
     current_key = None
     while current_key is None:
         current_key = Prompt.ask(
-            "Please enter your Griptape Nodes API key",
+            "Griptape API Key",
             default=default_key,
             show_default=True,
         )
@@ -124,11 +132,17 @@ def _prompt_for_workspace() -> None:
     """Prompts the user for their workspace directory and stores it in config directory."""
     default_workspace_directory = config_manager.get_config_value("workspace_directory")
 
+    explainer = """[bold cyan]Workspace Directory[/bold cyan]
+    Select the workspace directory. This is the location where Griptape Nodes will store flows, config, and secrets.
+    You may enter a custom directory or press Return to accept the default workspace directory
+    """
+    console.print(Panel(explainer, expand=False))
+
     valid_workspace = False
     while not valid_workspace:
         try:
             workspace_directory = Prompt.ask(
-                "Please enter your Griptape Nodes Engine workspace directory",
+                "Workspace Directory",
                 default=default_workspace_directory,
                 show_default=True,
             )

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -132,8 +132,7 @@ def _prompt_for_workspace() -> None:
     """Prompts the user for their workspace directory and stores it in config directory."""
     explainer = """[bold cyan]Workspace Directory[/bold cyan]
     Select the workspace directory. This is the location where Griptape Nodes will store flows, config, and secrets.
-    You may enter a custom directory or press Return to accept the default workspace directory
-    """
+    You may enter a custom directory or press Return to accept the default workspace directory"""
     console.print(Panel(explainer, expand=False))
 
     valid_workspace = False

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -132,7 +132,7 @@ def _prompt_for_workspace() -> None:
     while not valid_workspace:
         try:
             workspace_directory = Prompt.ask(
-                "Please enter your workspace directory",
+                "Please enter your Griptape Nodes Engine workspace directory",
                 default=default_workspace_directory,
                 show_default=True,
             )

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -133,7 +133,7 @@ def _prompt_for_workspace() -> None:
         default=workspace_directory,
         show_default=True,
     )
-    config_manager.workspace_path = str(Path(workspace_directory).resolve())
+    config_manager.workspace_path = str(Path(workspace_directory).expanduser().resolve())
     console.print(f"[bold green]Workspace directory set to: {config_manager.workspace_path}[/bold green]")
 
 

--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -23,6 +23,7 @@ from rich.console import Console
 from rich.panel import Panel
 from xdg_base_dirs import xdg_config_home
 
+from griptape_nodes import NODES_APP_URL
 from griptape_nodes.api.queue_manager import event_queue
 from griptape_nodes.api.routes.api import process_event
 from griptape_nodes.api.routes.nodes_api_socket_manager import NodesApiSocketManager
@@ -162,7 +163,7 @@ def sse_listener() -> None:
             endpoint = urljoin(
                 os.getenv("GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes.griptape.ai"), "/api/engines/stream"
             )
-            nodes_app_url = os.getenv("GRIPTAPE_NODES_APP_URL", "https://nodes.griptape.ai")
+            nodes_app_url = os.getenv("GRIPTAPE_NODES_APP_URL", NODES_APP_URL)
 
             def auth(request: httpx.Request) -> httpx.Request:
                 api_key = get_key(xdg_config_home() / "griptape_nodes" / ".env", "GT_CLOUD_API_KEY")

--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -23,7 +23,6 @@ from rich.console import Console
 from rich.panel import Panel
 from xdg_base_dirs import xdg_config_home
 
-from griptape_nodes import NODES_APP_URL
 from griptape_nodes.api.queue_manager import event_queue
 from griptape_nodes.api.routes.api import process_event
 from griptape_nodes.api.routes.nodes_api_socket_manager import NodesApiSocketManager
@@ -163,7 +162,7 @@ def sse_listener() -> None:
             endpoint = urljoin(
                 os.getenv("GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes.griptape.ai"), "/api/engines/stream"
             )
-            nodes_app_url = os.getenv("GRIPTAPE_NODES_APP_URL", NODES_APP_URL)
+            nodes_app_url = os.getenv("GRIPTAPE_NODES_APP_URL", "https://nodes.griptape.ai")
 
             def auth(request: httpx.Request) -> httpx.Request:
                 api_key = get_key(xdg_config_home() / "griptape_nodes" / ".env", "GT_CLOUD_API_KEY")

--- a/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
+++ b/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
@@ -64,7 +64,7 @@ class NodesApiSocketManager:
             try:
                 api_key = get_key(xdg_config_home() / "griptape_nodes" / ".env", "GT_CLOUD_API_KEY")
                 if api_key is None:
-                    msg = "GT_CLOUD_API_KEY is not set, please re-run the install script."
+                    msg = "GT_CLOUD_API_KEY is not set, please run `griptape-nodes init` to set it up."
                     raise ValueError(msg) from None
 
                 return connect(

--- a/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
+++ b/src/griptape_nodes/api/routes/nodes_api_socket_manager.py
@@ -64,7 +64,7 @@ class NodesApiSocketManager:
             try:
                 api_key = get_key(xdg_config_home() / "griptape_nodes" / ".env", "GT_CLOUD_API_KEY")
                 if api_key is None:
-                    msg = "GT_CLOUD_API_KEY is not set, please run `griptape-nodes init` to set it up."
+                    msg = "GT_CLOUD_API_KEY is not set, please visit https://nodes.griptape.ai to get a key, and then run `griptape-nodes init` to set it up."
                     raise ValueError(msg) from None
 
                 return connect(

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -84,7 +84,7 @@ class AppEvents(BaseModel):
 
 
 class Settings(BaseSettings):
-    workspace_directory: str = Field(default=str(Path().home() / "GriptapeNodes"))
+    workspace_directory: str = Field(default=str(Path().cwd() / "GriptapeNodes"))
     app_events: AppEvents = Field(default_factory=AppEvents)
     nodes: dict[str, Any] = Field(
         default_factory=lambda: {


### PR DESCRIPTION
- Add `gtn init` command to prompt the user through setting workspace and api key.
- Run this command if the user doesn't have a `~/.config/griptape_nodes` directory (should only be on install).
- Default `workspace_directory` to `cwd / GriptapeNodes` rather than `home / GriptapeNodes`.