### PR TITLE
Removing app events from resolution

### DIFF
--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -8,8 +8,7 @@ from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.exe_types.type_validator import TypeValidator
 from griptape_nodes.machines.fsm import FSM, State
-from griptape_nodes.retained_mode.events.app_events import AppExecutionEvent
-from griptape_nodes.retained_mode.events.base_events import AppEvent, ExecutionEvent, ExecutionGriptapeNodeEvent
+from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent
 from griptape_nodes.retained_mode.events.execution_events import (
     CurrentDataNodeEvent,
     NodeFinishProcessEvent,
@@ -150,11 +149,12 @@ class ExecuteNodeState(State):
                 if modified_parameters:
                     for modified_parameter_name in modified_parameters:
                         # TODO(kate): Move to a different type of event
+                        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
                         modified_request = GetParameterDetailsRequest(
                             parameter_name=modified_parameter_name, node_name=current_node.name
                         )
-                        app_event = AppEvent(payload=AppExecutionEvent(modified_request))
-                        EventBus.publish_event(app_event)  # pyright: ignore[reportArgumentType]
+                        GriptapeNodes.handle_request(modified_request)
             if parameter.name in current_node.parameter_values:
                 parameter_value = current_node.get_parameter_value(parameter.name)
                 data_type = parameter.type

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -35,12 +35,6 @@ class AppInitializationComplete(AppPayload):
 
 @dataclass
 @PayloadRegistry.register
-class AppExecutionEvent(AppPayload):
-    request: RequestPayload
-
-
-@dataclass
-@PayloadRegistry.register
 class GetEngineVersionRequest(RequestPayload):
     pass
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -23,7 +23,6 @@ from griptape_nodes.exe_types.type_validator import TypeValidator
 from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.node_library.script_registry import LibraryNameAndVersion, ScriptMetadata, ScriptRegistry
 from griptape_nodes.retained_mode.events.app_events import (
-    AppExecutionEvent,
     AppInitializationComplete,
     AppStartSessionRequest,
     AppStartSessionResultFailure,
@@ -586,8 +585,6 @@ class FlowManager:
         event_manager.assign_manager_to_request_type(
             ValidateFlowDependenciesRequest, self.on_validate_flow_dependencies_request
         )
-        # events that happen after a flow is ran
-        event_manager.add_listener_to_app_event(AppExecutionEvent, self.on_app_execution_event)
 
         self._name_to_parent_name = {}
 
@@ -1303,11 +1300,6 @@ class FlowManager:
         details = f"Unresolved flow with name {flow_name}"
         GriptapeNodes.get_logger().debug(details)
         return UnresolveFlowResultSuccess()
-
-    def on_app_execution_event(self, event: AppExecutionEvent) -> None:
-        # Handle all events from the execution engine
-        # TODO(kate): Should this somehow be modified to be specific events for the gui?
-        GriptapeNodes.handle_request(event.request)
 
     def on_validate_flow_dependencies_request(self, request: ValidateFlowDependenciesRequest) -> ResultPayload:
         flow_name = request.flow_name


### PR DESCRIPTION
- Using lazy import removes the need to send the app event back and forth. 
- Closes #18 .along with #176 