### PR TITLE
chore: update gitignore to ignore default workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ cython_debug/
 .pypircpersonal_node_library/
 griptape_nodes_user_config.json
 griptape_nodes_config.json
+GriptapeNodes/
 
 # MacOS
 .DS_Store


### PR DESCRIPTION
Closes #207 based on https://github.com/griptape-ai/griptape-nodes/issues/207#issuecomment-2784451123