### PR TITLE
Use Loggers Over Prints and Add Setting For Log Level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ ignore = [
   "RUF012", # TODO(griptape): discuss with team
   "FBT003", # Intentional
   "RET504", # Intentional
-  "T201",   # TODO(griptape): replace prints with logs before removing
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/coloring_book.py
+++ b/scripts/coloring_book.py
@@ -13,6 +13,3 @@
 #   ]
 #
 # ///
-
-
-print("coloring_book!")

--- a/scripts/prompt_an_image.py
+++ b/scripts/prompt_an_image.py
@@ -1,5 +1,3 @@
-print("prompt an image!")
-
 # /// script
 # dependencies = []
 #

--- a/scripts/render_logs.py
+++ b/scripts/render_logs.py
@@ -1,5 +1,3 @@
-print("render logs!")
-
 # /// script
 # dependencies = []
 #

--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextvars
 import json
+import logging
 import os
 import sys
 import threading
@@ -45,14 +46,10 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from logging import Logger
 
 
 console = Console()
-
-
-def get_logger() -> Logger:
-    return GriptapeNodes.get_instance().LogManager().get_logger(event_handler=False)
+logger = logging.getLogger(__name__)
 
 
 def run_with_context(func: Callable) -> Callable:
@@ -134,7 +131,7 @@ def check_event_queue() -> None:
         elif isinstance(event, AppEvent):
             process_app_event(event)
         else:
-            get_logger().warning("Unknown event type encountered: '%s'.", type(event))
+            logger.warning("Unknown event type encountered: '%s'.", type(event))
 
         event_queue.task_done()
 
@@ -236,10 +233,10 @@ def sse_listener() -> None:
                             try:
                                 process_sse(json.loads(data))
                             except Exception:
-                                get_logger().exception("Error processing event, skipping.")
+                                logger.exception("Error processing event, skipping.")
 
         except Exception:
-            get_logger().exception("Error while listening for events. Retrying in 2 seconds.")
+            logger.exception("Error while listening for events. Retrying in 2 seconds.")
             sleep(2)
             init = False
 
@@ -252,7 +249,7 @@ def process_sse(event: dict) -> None:
         else:
             process_event(event)
     except Exception:
-        get_logger().warning("Error processing event, skipping.")
+        logger.warning("Error processing event, skipping.")
 
 
 def run_sse_mode() -> None:

--- a/src/griptape_nodes/exe_types/connections.py
+++ b/src/griptape_nodes/exe_types/connections.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 
 from griptape.events import EventBus
@@ -11,6 +12,8 @@ from griptape_nodes.retained_mode.events.base_events import (
 from griptape_nodes.retained_mode.events.execution_events import (
     NodeUnresolvedEvent,
 )
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 
 @dataclass
@@ -110,12 +113,12 @@ class Connections:
         try:
             # use copy to prevent modifying the list while it's iterating
             outgoing_parameter_connections = self.outgoing_index[source_node][source_parameter].copy()
-        except Exception as e:
-            print(f"Cannot remove connection that does not exist: {e}")
+        except Exception:
+            logger.exception("Cannot remove connection that does not exist")
             return False
         for connection_id in outgoing_parameter_connections:
             if connection_id not in self.connections:
-                print("Cannot remove connection does not exist")
+                logger.error("Cannot remove connection does not exist")
                 return False
             connection = self.connections[connection_id]
             test_target_node = connection.target_node.name

--- a/src/griptape_nodes/exe_types/connections.py
+++ b/src/griptape_nodes/exe_types/connections.py
@@ -13,7 +13,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     NodeUnresolvedEvent,
 )
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 @dataclass

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
 
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 # The flow will own all of the nodes and the connections

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from queue import Queue
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,9 @@ from griptape_nodes.machines.control_flow import CompleteState, ControlFlowMachi
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
     from griptape_nodes.exe_types.node_types import BaseNode
+
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 
 # The flow will own all of the nodes and the connections
@@ -76,7 +80,7 @@ class ControlFlow:
             errormsg = "Flow already has been started. Cannot start flow when it has already been started."
             raise Exception(errormsg)
         if start_node:
-            print(f"start with {start_node.name}")
+            logger.info("start with %s", start_node.name)
             self.control_flow_machine.start_flow(start_node, debug_mode)
         elif not self.flow_queue.empty():
             start_node = self.flow_queue.get()

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
     from griptape_nodes.exe_types.flow import ControlFlow
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 # This is the control flow context. Owns the Resolution Machine

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -1,6 +1,7 @@
 # Control flow machine
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from griptape.events import EventBus
@@ -19,6 +20,8 @@ from griptape_nodes.retained_mode.events.execution_events import (
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
     from griptape_nodes.exe_types.flow import ControlFlow
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 
 # This is the control flow context. Owns the Resolution Machine
@@ -51,8 +54,7 @@ class ResolveNodeState(State):
                 wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name=context.current_node.name))
             )
         )
-        # Print statement for retained mode
-        print(f"Resolving {context.current_node.name}")
+        logger.info("Resolving %s", context.current_node.name)
         if not context.paused:
             # Call the update. Otherwise wait
             return ResolveNodeState
@@ -123,7 +125,7 @@ class CompleteState(State):
                 )
             )
         )
-        print("Flow is complete.")
+        logger.info("Flow is complete.")
         return None
 
     @staticmethod

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -7,7 +7,7 @@ from griptape.mixins.singleton_mixin import SingletonMixin
 
 from griptape_nodes.exe_types.node_types import BaseNode
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 class LibraryNodeIdentifier(NamedTuple):

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, NamedTuple, Self, cast
 
 from griptape.mixins.singleton_mixin import SingletonMixin
 
 from griptape_nodes.exe_types.node_types import BaseNode
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 
 class LibraryNodeIdentifier(NamedTuple):
@@ -73,15 +76,19 @@ class LibraryRegistry(SingletonMixin):
             collision_set = instance._collision_node_names_to_library_names[node_class_name]
             # Make sure we're not re-adding the same node/library combo.
             if library.name in collision_set:
-                print(
-                    f"Attempted to register Node class '{node_class_name}' from Library '{library.name}', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times."
-                )  # TODO(griptape): Move to Log
+                logger.info(
+                    "Attempted to register Node class '%s' from Library '%s', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times.",
+                    node_class_name,
+                    library.name,
+                )
                 return
 
             # Append it to the set.
-            print(
-                f"When registering Node class '{node_class_name}', Nodes with the same class name were already registered from the following Libraries: {collision_set}. In order to create this type of node, you will need to specify the Library name in addition to the Node class name so that it can be disambiguated."
-            )  # TODO(griptape): Move to Log
+            logger.info(
+                "When registering Node class '%s', Nodes with the same class name were already registered from the following Libraries: %s, you will need to specify the Library name in addition to the Node class name so that it can be disambiguated.",
+                node_class_name,
+                collision_set,
+            )
             collision_set.add(library.name)
             return
 
@@ -90,14 +97,19 @@ class LibraryRegistry(SingletonMixin):
             collision_library_name = instance._node_aliases[node_class_name]
             # Make sure we're not trying to register the same node/library combo.
             if library.name == collision_library_name:
-                print(
-                    f"Attempted to register Node class '{node_class_name}' from Library '{library.name}', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times."
-                )  # TODO(griptape): Move to Log
+                logger.info(
+                    "Attempted to register Node class '%s' from Library '%s', but a Node with that name from that Library was already registered. Check to ensure you aren't re-adding the same libraries multiple times.",
+                    node_class_name,
+                    library.name,
+                )
                 return
             # OK, legit collision. Move from the aliases table to the collision table.
-            print(
-                f"WARNING: Attempted to register a Node class '{node_class_name}' from Library '{library.name}', but a Node of that class name already existed from Library '{collision_library_name}'. In order to create these types of node, you will need to specify the Library name in addition to the Node class name so that it can be disambiguated."
-            )  # TODO(griptape): Move to Log
+            logger.warning(
+                "Attempted to register a Node class '%s' from Library '%s', but a Node of that class name already existed from Library '%s'. In order to create these types of node, you will need to specify the Library name in addition to the Node class name so that it can be disambiguated.",
+                node_class_name,
+                library.name,
+                collision_library_name,
+            )
 
             collision_set = set()
             collision_set.add(collision_library_name)

--- a/src/griptape_nodes/retained_mode/events/generate_request_payload_schemas.py
+++ b/src/griptape_nodes/retained_mode/events/generate_request_payload_schemas.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -6,6 +7,8 @@ from pydantic import BaseModel
 
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 payload_type_to_schema: dict[str, dict[str, Any]] = {}
 
@@ -17,11 +20,11 @@ for payload_class_name, payload_class in payload_dict.items():
         class BaseModelPayload(payload_class, BaseModel):
             """BaseModel wrapper to generate JSON schema for the payload."""
 
-        print(f"Generating schema for {payload_class_name}...")
+        logger.info("Generating schema for %s...", payload_class_name)
         schema = BaseModelPayload.model_json_schema()
         payload_type_to_schema[payload_class_name] = schema
     else:
-        print(f"Skipping {payload_class_name} as it is not a RequestPayload.")
+        logger.info("Skipping %s as it is not a RequestPayload.", payload_class_name)
 
 with Path("request_payload_schemas.json").open("w+") as file:
     file.write(json.dumps(list(payload_type_to_schema.values()), indent=2))

--- a/src/griptape_nodes/retained_mode/events/generate_request_payload_schemas.py
+++ b/src/griptape_nodes/retained_mode/events/generate_request_payload_schemas.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 payload_type_to_schema: dict[str, dict[str, Any]] = {}
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -226,6 +226,9 @@ load_dotenv()
 T = TypeVar("T")
 
 
+logger = logging.getLogger("griptape_nodes_engine")
+
+
 class SingletonMeta(type):
     _instances = {}
 
@@ -284,10 +287,6 @@ class GriptapeNodes(metaclass=SingletonMeta):
     @classmethod
     def LogManager(cls) -> LogManager:
         return GriptapeNodes.get_instance()._log_manager
-
-    @classmethod
-    def get_logger(cls) -> logging.Logger:
-        return GriptapeNodes.LogManager().get_logger()
 
     @classmethod
     def EventManager(cls) -> EventManager:
@@ -363,23 +362,23 @@ class GriptapeNodes(metaclass=SingletonMeta):
                 major, minor, patch = map(int, match.groups())
                 return GetEngineVersionResultSuccess(major=major, minor=minor, patch=patch)
             details = f"Attempted to get engine version. Failed because version string '{engine_version_str}' wasn't in expected major.minor.patch format."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetEngineVersionResultFailure()
         except Exception as err:
             details = f"Attempted to get engine version. Failed due to '{err}'."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetEngineVersionResultFailure()
 
     def handle_session_start_request(self, request: AppStartSessionRequest) -> ResultPayload:
         # Do we already have one?
         if BaseEvent._session_id is not None:
             details = f"Attempted to start a session with ID '{request.session_id}' but this engine instance already had a session ID `{BaseEvent._session_id}' in place. Replacing it."
-            GriptapeNodes.get_logger().info(details)
+            logger.info(details)
 
         BaseEvent._session_id = request.session_id
 
         details = f"Session '{request.session_id}' started at {datetime.now(tz=UTC)}."
-        GriptapeNodes.get_logger().info(details)
+        logger.info(details)
 
         # TODO(griptape): Do we want to broadcast that a session started?
 
@@ -403,7 +402,7 @@ class ObjectManager:
         source_obj = self.attempt_get_object_by_name(request.object_name)
         if source_obj is None:
             details = f"Attempted to rename object '{request.object_name}', but no object of that name could be found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return RenameObjectResultFailure(next_available_name=None)
 
         # Is there a collision?
@@ -421,7 +420,7 @@ class ObjectManager:
                 # Not allowed to use it :(
                 # Fail it but be nice and offer the next name that WOULD HAVE been available.
                 details = f"Attempted to rename object '{request.object_name}' to '{request.requested_name}'. Failed because another object of that name exists. Next available name would have been '{next_name}'."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return RenameObjectResultFailure(next_available_name=next_name)
             # We'll use the next available name.
             final_name = next_name
@@ -434,7 +433,7 @@ class ObjectManager:
                 GriptapeNodes.NodeManager().handle_node_rename(old_name=request.object_name, new_name=final_name)
             case _:
                 details = f"Attempted to rename an object named '{request.object_name}', but that object wasn't of a type supported for rename."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return RenameObjectResultFailure(next_available_name=None)
 
         # Update the object table.
@@ -446,7 +445,7 @@ class ObjectManager:
         if final_name != request.requested_name:
             details += " WARNING: Originally requested the name '{request.requested_name}', but that was taken."
             log_level = logging.WARNING
-        GriptapeNodes.get_logger().log(level=log_level, msg=details)
+        logger.log(level=log_level, msg=details)
         return RenameObjectResultSuccess(final_name=final_name)
 
     def get_filtered_subset(
@@ -610,13 +609,13 @@ class FlowManager:
             # We're trying to create the canvas. Ensure that parent does NOT already exist.
             if self.does_canvas_exist():
                 details = "Attempted to create a Flow as the Canvas (top-level Flow with no parents), but the Canvas already exists."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 result = CreateFlowResultFailure()
                 return result
         # That parent exists, right?
         elif parent is None:
             details = f"Attempted to create a Flow with a parent '{request.parent_flow_name}', but no parent with that name could be found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateFlowResultFailure()
 
@@ -635,7 +634,7 @@ class FlowManager:
             details = f"{details} WARNING: Had to rename from original Flow requested '{request.flow_name}' as an object with this name already existed."
             log_level = logging.WARNING
 
-        GriptapeNodes.get_logger().log(level=log_level, msg=details)
+        logger.log(level=log_level, msg=details)
         result = CreateFlowResultSuccess(flow_name=final_flow_name)
         return result
 
@@ -645,7 +644,7 @@ class FlowManager:
         flow = obj_mgr.attempt_get_object_by_name_as_type(request.flow_name, ControlFlow)
         if flow is None:
             details = f"Attempted to delete Flow '{request.flow_name}', but no Flow with that name could be found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = DeleteFlowResultFailure()
             return result
 
@@ -654,7 +653,7 @@ class FlowManager:
         list_nodes_result = GriptapeNodes().handle_request(list_nodes_request)
         if isinstance(list_nodes_result, ListNodesInFlowResultFailure):
             details = f"Attempted to delete Flow '{request.flow_name}', but failed while attempting to get the list of Nodes owned by this Flow."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = DeleteFlowResultFailure()
             return result
         node_names = list_nodes_result.node_names
@@ -663,7 +662,7 @@ class FlowManager:
             delete_node_result = GriptapeNodes().handle_request(delete_node_request)
             if isinstance(delete_node_result, DeleteNodeResultFailure):
                 details = f"Attempted to delete Flow '{request.flow_name}', but failed while attempting to delete child Node '{node_name}'."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 result = DeleteFlowResultFailure()
                 return result
 
@@ -672,7 +671,7 @@ class FlowManager:
         list_flows_result = GriptapeNodes().handle_request(list_flows_request)
         if isinstance(list_flows_result, ListFlowsInFlowResultFailure):
             details = f"Attempted to delete Flow '{request.flow_name}', but failed while attempting to get the list of Flows owned by this Flow."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = DeleteFlowResultFailure()
             return result
         flow_names = list_flows_result.flow_names
@@ -682,7 +681,7 @@ class FlowManager:
             delete_flow_result = GriptapeNodes().handle_request(delete_flow_request)
             if isinstance(delete_flow_result, DeleteFlowResultFailure):
                 details = f"Attempted to delete Flow '{request.flow_name}', but failed while attempting to delete child Flow '{flow_name}'."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 result = DeleteFlowResultFailure()
                 return result
 
@@ -692,7 +691,7 @@ class FlowManager:
         del self._name_to_parent_name[request.flow_name]
 
         details = f"Successfully deleted Flow '{request.flow_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         result = DeleteFlowResultSuccess()
         return result
 
@@ -701,14 +700,14 @@ class FlowManager:
         flow = obj_mgr.attempt_get_object_by_name_as_type(request.flow_name, ControlFlow)
         if flow is None:
             details = f"Attempted to get Flow '{request.flow_name}', but no Flow with that name could be found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = GetIsFlowRunningResultFailure()
             return result
         try:
             is_running = flow.check_for_existing_running_flow()
         except Exception:
             details = f"Error while trying to get status of '{request.flow_name}'."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             result = GetIsFlowRunningResultFailure()
             return result
         return GetIsFlowRunningResultSuccess(is_running=is_running)
@@ -721,13 +720,13 @@ class FlowManager:
             details = (
                 f"Attempted to list Nodes in Flow '{request.flow_name}', but no Flow with that name could be found."
             )
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = ListNodesInFlowResultFailure()
             return result
 
         ret_list = list(flow.nodes.keys())
         details = f"Successfully got the list of Nodes within Flow '{request.flow_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = ListNodesInFlowResultSuccess(node_names=ret_list)
         return result
@@ -739,7 +738,7 @@ class FlowManager:
             flow = obj_mgr.attempt_get_object_by_name_as_type(request.parent_flow_name, ControlFlow)
             if flow is None:
                 details = f"Attempted to list Flows that are children of Flow '{request.parent_flow_name}', but no Flow with that name could be found."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 result = ListFlowsInFlowResultFailure()
                 return result
 
@@ -750,7 +749,7 @@ class FlowManager:
                 ret_list.append(flow_name)
 
         details = f"Successfully got the list of Flows that are direct children of Flow '{request.parent_flow_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = ListFlowsInFlowResultSuccess(flow_names=ret_list)
         return result
@@ -785,7 +784,7 @@ class FlowManager:
             source_node = GriptapeNodes.NodeManager().get_node_by_name(request.source_node_name)
         except ValueError as err:
             details = f'Connection failed: "{request.source_node_name}" does not exist. Error: {err}.'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -795,7 +794,7 @@ class FlowManager:
             target_node = GriptapeNodes.NodeManager().get_node_by_name(request.target_node_name)
         except ValueError as err:
             details = f'Connection failed: "{request.target_node_name}" does not exist. Error: {err}.'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             result = CreateConnectionResultFailure()
             return result
 
@@ -808,7 +807,7 @@ class FlowManager:
             source_flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name=source_flow_name)
         except KeyError as err:
             details = f'Connection "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}" failed: {err}.'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -819,7 +818,7 @@ class FlowManager:
             GriptapeNodes.FlowManager().get_flow_by_name(flow_name=target_flow_name)
         except KeyError as err:
             details = f'Connection "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}" failed: {err}.'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -827,7 +826,7 @@ class FlowManager:
         # CURRENT RESTRICTION: Now vet the parents are in the same Flow (yes this sucks)
         if target_flow_name != source_flow_name:
             details = f'Connection "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}" failed: Different flows.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -836,7 +835,7 @@ class FlowManager:
         source_param = source_node.get_parameter_by_name(request.source_parameter_name)
         if source_param is None:
             details = f'Connection failed: "{request.source_node_name}.{request.source_parameter_name}" not found'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -845,7 +844,7 @@ class FlowManager:
         if target_param is None:
             # TODO(griptape): We may make this a special type of failure, or attempt to handle it gracefully.
             details = f'Connection failed: "{request.target_node_name}.{request.target_parameter_name}" not found'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -853,14 +852,14 @@ class FlowManager:
         source_modes_allowed = source_param.allowed_modes
         if ParameterMode.OUTPUT not in source_modes_allowed:
             details = f'Connection failed: "{request.source_node_name}.{request.source_parameter_name}" is not an allowed OUTPUT'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = CreateConnectionResultFailure()
             return result
 
         target_modes_allowed = target_param.allowed_modes
         if ParameterMode.INPUT not in target_modes_allowed:
             details = f'Connection failed: "{request.target_node_name}.{request.target_parameter_name}" is not an allowed INPUT'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -868,7 +867,7 @@ class FlowManager:
         # Validate that the data type from the source is allowed by the target.
         if not target_param.is_incoming_type_allowed(source_param.output_type):
             details = f'Connection failed on type mismatch "{request.source_node_name}.{request.source_parameter_name}" type({source_param.output_type}) to "{request.target_node_name}.{request.target_parameter_name}" types({target_param.input_types}) '
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -880,7 +879,7 @@ class FlowManager:
             target_parameter=target_param,
         ):
             details = f'Connection failed : "{request.source_node_name}.{request.source_parameter_name}" rejected the connection '
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -891,7 +890,7 @@ class FlowManager:
             target_parameter=target_param,
         ):
             details = f'Connection failed : "{request.target_node_name}.{request.target_parameter_name}" rejected the connection '
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateConnectionResultFailure()
             return result
@@ -905,7 +904,7 @@ class FlowManager:
             )
         except ValueError as e:
             details = f'Connection failed : "{e}"'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return CreateConnectionResultFailure()
 
         # Let the source make any internal handling decisions now that the Connection has been made.
@@ -923,7 +922,7 @@ class FlowManager:
         )
 
         details = f'Connected "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}"'
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         # Now update the parameter values if it exists.
         # check if it's been resolved/has a value in parameter_output_values
@@ -959,7 +958,7 @@ class FlowManager:
             source_node = GriptapeNodes.NodeManager().get_node_by_name(request.source_node_name)
         except ValueError as err:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Error: {err}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -969,7 +968,7 @@ class FlowManager:
             target_node = GriptapeNodes.NodeManager().get_node_by_name(request.target_node_name)
         except ValueError as err:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Error: {err}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -983,7 +982,7 @@ class FlowManager:
             source_flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name=source_flow_name)
         except KeyError as err:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Error: {err}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -994,7 +993,7 @@ class FlowManager:
             GriptapeNodes.FlowManager().get_flow_by_name(flow_name=target_flow_name)
         except KeyError as err:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Error: {err}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -1002,7 +1001,7 @@ class FlowManager:
         # CURRENT RESTRICTION: Now vet the parents are in the same Flow (yes this sucks)
         if target_flow_name != source_flow_name:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". They are in different Flows (TEMPORARY RESTRICTION).'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -1011,7 +1010,7 @@ class FlowManager:
         source_param = source_node.get_parameter_by_name(request.source_parameter_name)
         if source_param is None:
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" Not found.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -1019,7 +1018,7 @@ class FlowManager:
         target_param = target_node.get_parameter_by_name(request.target_parameter_name)
         if target_param is None:
             details = f'Connection not deleted "{request.target_node_name}.{request.target_parameter_name}" Not found.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -1032,7 +1031,7 @@ class FlowManager:
             target_parameter=target_param,
         ):
             details = f'Connection does not exist: "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}"'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -1045,7 +1044,7 @@ class FlowManager:
             target_parameter=target_param,
         ):
             details = f'Connection not deleted "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}". Unknown failure.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteConnectionResultFailure()
             return result
@@ -1065,7 +1064,7 @@ class FlowManager:
         )
 
         details = f'Connection "{request.source_node_name}.{request.source_parameter_name}" to "{request.target_node_name}.{request.target_parameter_name}" deleted.'
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = DeleteConnectionResultSuccess()
         return result
@@ -1076,7 +1075,7 @@ class FlowManager:
         debug_mode = request.debug_mode
         if not flow_name:
             details = "Must provide flow name to start a flow."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             return StartFlowResultFailure(validation_exceptions=[])
         # get the flow by ID
@@ -1084,7 +1083,7 @@ class FlowManager:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Cannot start flow. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return StartFlowResultFailure(validation_exceptions=[])
         # A node has been provided to either start or to run up to.
         if request.flow_node_name:
@@ -1094,14 +1093,14 @@ class FlowManager:
             )
             if not flow_node:
                 details = f"Provided node with name {flow_node_name} does not exist"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return StartFlowResultFailure(validation_exceptions=[])
             # lets get the first control node in the flow!
             start_node = flow.get_start_node_from_node(flow_node)
             # if the start is not the node provided, set a breakpoint at the stop (we're running up until there)
             if not start_node:
                 details = f"Start node for node with name {flow_node_name} does not exist"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return StartFlowResultFailure(validation_exceptions=[])
             if start_node != flow_node:
                 flow_node.stop_flow = True
@@ -1117,7 +1116,7 @@ class FlowManager:
         try:
             if not result.succeeded():
                 details = f"Couldn't start flow with name {flow_name}. Flow Validation Failed"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return StartFlowResultFailure(validation_exceptions=[])
             result = cast("ValidateFlowDependenciesResultSuccess", result)
 
@@ -1126,18 +1125,18 @@ class FlowManager:
                 if len(result.exceptions) > 0:
                     for exception in result.exceptions:
                         details = f"{details}\n\t{exception}"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return StartFlowResultFailure(validation_exceptions=result.exceptions)
         except Exception:
             details = f"Couldn't start flow with name {flow_name}. Flow Validation Failed"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return StartFlowResultFailure(validation_exceptions=[])
         # By now, it has been validated with no exceptions.
         try:
             flow.start_flow(start_node, debug_mode)
         except Exception as e:
             details = f"Failed to kick off flow with name {flow_name}. Exception occurred: {e} "
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             # Cancel the flow run.
             cancel_request = CancelFlowRequest(flow_name=flow_name)
@@ -1146,7 +1145,7 @@ class FlowManager:
             return StartFlowResultFailure(validation_exceptions=[])
 
         details = f"Successfully kicked off flow with name {flow_name}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         return StartFlowResultSuccess()
 
@@ -1154,47 +1153,47 @@ class FlowManager:
         flow_name = event.flow_name
         if not flow_name:
             details = "Could not get flow state. No flow name was provided."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetFlowStateResultFailure()
         try:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Could not get flow state. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetFlowStateResultFailure()
         try:
             control_node, resolving_node = flow.flow_state()
         except Exception as e:
             details = f"Failed to get flow state of flow with name {flow_name}. Exception occurred: {e} "
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetFlowStateResultFailure()
         details = f"Successfully got flow state for flow with name {flow_name}."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         return GetFlowStateResultSuccess(control_node=control_node, resolving_node=resolving_node)
 
     def on_cancel_flow_request(self, request: CancelFlowRequest) -> ResultPayload:
         flow_name = request.flow_name
         if not flow_name:
             details = "Could not cancel flow execution. No flow name was provided."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             return CancelFlowResultFailure()
         try:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Could not cancel flow execution. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return CancelFlowResultFailure()
         try:
             flow.cancel_flow_run()
         except Exception as e:
             details = f"Could not cancel flow execution. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return CancelFlowResultFailure()
         details = f"Successfully cancelled flow execution with name {flow_name}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         return CancelFlowResultSuccess()
 
@@ -1202,28 +1201,28 @@ class FlowManager:
         flow_name = request.flow_name
         if not flow_name:
             details = "Could not step flow. No flow name was provided."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             return SingleNodeStepResultFailure(validation_exceptions=[])
         try:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Could not step flow. No flow with name {flow_name} exists. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return SingleNodeStepResultFailure(validation_exceptions=[])
         try:
             flow.single_node_step()
         except Exception as e:
             details = f"Could not step flow. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             cancel_request = CancelFlowRequest(flow_name=flow_name)
             GriptapeNodes.handle_request(cancel_request)
             return SingleNodeStepResultFailure(validation_exceptions=[])
 
         # All completed happily
         details = f"Successfully stepped flow with name {flow_name}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         return SingleNodeStepResultSuccess()
 
@@ -1231,26 +1230,26 @@ class FlowManager:
         flow_name = request.flow_name
         if not flow_name:
             details = "Could not single step flow. No flow name was provided."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             return SingleExecutionStepResultFailure()
         try:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Could not single step flow. Error: {err}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return SingleExecutionStepResultFailure()
         try:
             flow.single_execution_step()
         except Exception as e:
             details = f"Could not step flow. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             cancel_request = CancelFlowRequest(flow_name=flow_name)
             GriptapeNodes.handle_request(cancel_request)
             return SingleNodeStepResultFailure(validation_exceptions=[])
         details = f"Successfully granularly stepped flow with name {flow_name}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         return SingleExecutionStepResultSuccess()
 
@@ -1258,48 +1257,48 @@ class FlowManager:
         flow_name = request.flow_name
         if not flow_name:
             details = "Failed to continue execution step because no flow name was provided"
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             return ContinueExecutionStepResultFailure()
         try:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Failed to continue execution step. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return ContinueExecutionStepResultFailure()
         try:
             flow.continue_executing()
         except Exception as e:
             details = f"Failed to continue execution step. An exception occurred: {e}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             cancel_request = CancelFlowRequest(flow_name=flow_name)
             GriptapeNodes.handle_request(cancel_request)
             return ContinueExecutionStepResultFailure()
         details = f"Successfully continued flow with name {flow_name}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         return ContinueExecutionStepResultSuccess()
 
     def on_unresolve_flow_request(self, request: UnresolveFlowRequest) -> ResultPayload:
         flow_name = request.flow_name
         if not flow_name:
             details = "Failed to unresolve flow because no flow name was provided"
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return UnresolveFlowResultFailure()
         try:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Failed to unresolve flow. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return UnresolveFlowResultFailure()
         try:
             flow.unresolve_whole_flow()
         except Exception as e:
             details = f"Failed to unresolve flow. An exception occurred: {e}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return UnresolveFlowResultFailure()
         details = f"Unresolved flow with name {flow_name}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         return UnresolveFlowResultSuccess()
 
     def on_validate_flow_dependencies_request(self, request: ValidateFlowDependenciesRequest) -> ResultPayload:
@@ -1309,7 +1308,7 @@ class FlowManager:
             flow = self.get_flow_by_name(flow_name)
         except KeyError as err:
             details = f"Failed to validate flow. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return ValidateFlowDependenciesResultFailure()
         if request.flow_node_name:
             flow_node_name = request.flow_node_name
@@ -1318,7 +1317,7 @@ class FlowManager:
             )
             if not flow_node:
                 details = f"Provided node with name {flow_node_name} does not exist"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return ValidateFlowDependenciesResultFailure()
             # Gets all nodes in that connected group to be ran
             nodes = flow.get_all_connected_nodes(flow_node)
@@ -1390,7 +1389,7 @@ class NodeManager:
         parent_flow_name = request.override_parent_flow_name
         if parent_flow_name is None:
             details = f"Could not create Node of type '{request.node_type}'. No value for parent flow was supplied. This will one day come from the Current Context but we are poor and broken people. Please try your call again later."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = CreateNodeResultFailure()
             return result
@@ -1400,7 +1399,7 @@ class NodeManager:
             flow = flow_mgr.get_flow_by_name(parent_flow_name)
         except KeyError as err:
             details = f"Could not create Node of type '{request.node_type}'. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = CreateNodeResultFailure()
             return result
@@ -1427,7 +1426,7 @@ class NodeManager:
 
             traceback.print_exc()
             details = f"Could not create Node '{final_node_name}' of type '{request.node_type}': {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = CreateNodeResultFailure()
             return result
@@ -1446,7 +1445,7 @@ class NodeManager:
             log_level = logging.WARNING
             details = f"{details} WARNING: Had to rename from original node name requested '{request.node_name}' as an object with this name already existed."
 
-        GriptapeNodes.get_logger().log(level=log_level, msg=details)
+        logger.log(level=log_level, msg=details)
 
         result = CreateNodeResultSuccess(
             node_name=node.name,
@@ -1460,7 +1459,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to delete a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteNodeResultFailure()
             return result
@@ -1470,7 +1469,7 @@ class NodeManager:
             parent_flow = GriptapeNodes().FlowManager().get_flow_by_name(parent_flow_name)
         except KeyError as err:
             details = f"Attempted to delete a Node '{request.node_name}'. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = DeleteNodeResultFailure()
             return result
@@ -1480,7 +1479,7 @@ class NodeManager:
         list_connections_result = GriptapeNodes().handle_request(request=list_node_connections_request)
         if isinstance(list_connections_result, ResultPayloadFailure):
             details = f"Attempted to delete a Node '{request.node_name}'. Failed because it could not gather Connections to the Node."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = DeleteNodeResultFailure()
             return result
@@ -1497,7 +1496,7 @@ class NodeManager:
                 details = (
                     f"Attempted to delete a Node '{request.node_name}'. Failed when attempting to delete Connection."
                 )
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
 
                 result = DeleteNodeResultFailure()
                 return result
@@ -1515,7 +1514,7 @@ class NodeManager:
                 details = (
                     f"Attempted to delete a Node '{request.node_name}'. Failed when attempting to delete Connection."
                 )
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
 
                 result = DeleteNodeResultFailure()
                 return result
@@ -1528,7 +1527,7 @@ class NodeManager:
         del self._name_to_parent_flow_name[request.node_name]
 
         details = f"Successfully deleted Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = DeleteNodeResultSuccess()
         return result
@@ -1540,14 +1539,14 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(event.node_name, BaseNode)
         if node is None:
             details = f"Attempted to get resolution state for a Node '{event.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = GetNodeResolutionStateResultFailure()
             return result
 
         node_state = node.state
 
         details = f"Successfully got resolution state for Node '{event.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = GetNodeResolutionStateResultSuccess(
             state=node_state.name,
@@ -1561,14 +1560,14 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to get metadata for a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetNodeMetadataResultFailure()
             return result
 
         metadata = node.metadata
         details = f"Successfully retrieved metadata for a Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = GetNodeMetadataResultSuccess(
             metadata=metadata,
@@ -1582,7 +1581,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to set metadata for a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = SetNodeMetadataResultFailure()
             return result
@@ -1590,7 +1589,7 @@ class NodeManager:
         for key, value in request.metadata.items():
             node.metadata[key] = value
         details = f"Successfully set metadata for a Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = SetNodeMetadataResultSuccess()
         return result
@@ -1602,7 +1601,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to list Connections for a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = ListConnectionsForNodeResultFailure()
             return result
@@ -1612,7 +1611,7 @@ class NodeManager:
             parent_flow = GriptapeNodes().FlowManager().get_flow_by_name(parent_flow_name)
         except KeyError as err:
             details = f"Attempted to list Connections for a Node '{request.node_name}'. Error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = ListConnectionsForNodeResultFailure()
             return result
@@ -1649,7 +1648,7 @@ class NodeManager:
             ]
 
         details = f"Successfully listed all Connections to and from Node '{node.name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = ListConnectionsForNodeResultSuccess(
             incoming_connections=incoming_connections_list,
@@ -1664,7 +1663,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to list Parameters for a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = ListParametersOnNodeResultFailure()
             return result
@@ -1672,7 +1671,7 @@ class NodeManager:
         ret_list = [param.name for param in node.parameters]
 
         details = f"Successfully listed Parameters for Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = ListParametersOnNodeResultSuccess(
             parameter_names=ret_list,
@@ -1686,7 +1685,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to add Parameter '{request.parameter_name}' to a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = AddParameterToNodeResultFailure()
             return result
@@ -1694,7 +1693,7 @@ class NodeManager:
         # Does the Node already have a parameter by this name?
         if node.get_parameter_by_name(request.parameter_name) is not None:
             details = f"Attempted to add Parameter '{request.parameter_name}' to Node '{request.node_name}'. Failed because it already had a Parameter with that name on it. Parameter names must be unique within the Node."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = AddParameterToNodeResultFailure()
             return result
@@ -1723,7 +1722,7 @@ class NodeManager:
 
         if has_control_type and has_non_control_types:
             details = f"Attempted to add Parameter '{request.parameter_name}' to Node '{request.node_name}'. Failed because it had 'ParameterControlType' AND at least one other non-control type. If a Parameter is intended for control, it must only accept that type."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = AddParameterToNodeResultFailure()
             return result
@@ -1755,11 +1754,11 @@ class NodeManager:
             node.add_parameter(new_param)
         except Exception as e:
             details = f"Couldn't add parameter with name {request.parameter_name} to node. Error: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return AddParameterToNodeResultFailure()
 
         details = f"Successfully added Parameter '{request.parameter_name}' to Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = AddParameterToNodeResultSuccess()
         return result
@@ -1771,7 +1770,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = RemoveParameterFromNodeResultFailure()
             return result
@@ -1780,7 +1779,7 @@ class NodeManager:
         parameter = node.get_parameter_by_name(request.parameter_name)
         if parameter is None:
             details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because it didn't have a Parameter with that name on it."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = RemoveParameterFromNodeResultFailure()
             return result
@@ -1788,7 +1787,7 @@ class NodeManager:
         # No tricky stuff, users!
         if parameter.user_defined is False:
             details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because the Parameter was not user-defined (i.e., critical to the Node implementation). Only user-defined Parameters can be removed from a Node."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = RemoveParameterFromNodeResultFailure()
             return result
@@ -1798,7 +1797,7 @@ class NodeManager:
         list_connections_result = GriptapeNodes().handle_request(request=list_node_connections_request)
         if isinstance(list_connections_result, ListConnectionsForNodeResultFailure):
             details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because we were unable to get a list of Connections for the Parameter's Node."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = RemoveParameterFromNodeResultFailure()
             return result
@@ -1817,7 +1816,7 @@ class NodeManager:
                 delete_result = GriptapeNodes.handle_request(delete_request)
                 if isinstance(delete_result, DeleteConnectionResultFailure):
                     details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because we were unable to delete a Connection for that Parameter."
-                    GriptapeNodes.get_logger().error(details)
+                    logger.error(details)
 
                     result = RemoveParameterFromNodeResultFailure()
 
@@ -1833,7 +1832,7 @@ class NodeManager:
                 delete_result = GriptapeNodes.handle_request(delete_request)
                 if isinstance(delete_result, DeleteConnectionResultFailure):
                     details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because we were unable to delete a Connection for that Parameter."
-                    GriptapeNodes.get_logger().error(details)
+                    logger.error(details)
 
                     result = RemoveParameterFromNodeResultFailure()
 
@@ -1841,7 +1840,7 @@ class NodeManager:
         node.remove_parameter(parameter)
 
         details = f"Successfully removed Parameter '{request.parameter_name}' from Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = RemoveParameterFromNodeResultSuccess()
         return result
@@ -1853,7 +1852,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetParameterDetailsResultFailure()
             return result
@@ -1862,7 +1861,7 @@ class NodeManager:
         parameter = node.get_parameter_by_name(request.parameter_name)
         if parameter is None:
             details = f"Attempted to get details for Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because it didn't have a Parameter with that name on it."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetParameterDetailsResultFailure()
             return result
@@ -1874,7 +1873,7 @@ class NodeManager:
         allows_output = ParameterMode.OUTPUT in modes_allowed
 
         details = f"Successfully got details for Parameter '{request.parameter_name}' from Node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = GetParameterDetailsResultSuccess(
             element_id=parameter.element_id,
@@ -1901,7 +1900,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = AlterParameterDetailsResultFailure()
             return result
@@ -1910,7 +1909,7 @@ class NodeManager:
         parameter = node.get_parameter_by_name(request.parameter_name)
         if parameter is None:
             details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because it didn't have a Parameter with that name on it."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = AlterParameterDetailsResultFailure()
             return result
@@ -1919,7 +1918,7 @@ class NodeManager:
         if parameter.user_defined is False and request.request_id:
             # TODO(griptape): there may be SOME properties on a non-user-defined Parameter that can be changed
             details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{request.node_name}'. Failed because the Parameter was not user-defined (i.e., critical to the Node implementation). Only user-defined Parameters can be removed from a Node."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = AlterParameterDetailsResultFailure()
             return result
@@ -1967,7 +1966,7 @@ class NodeManager:
         details = (
             f"Successfully altered details for Parameter '{request.parameter_name}' from Node '{request.node_name}'."
         )
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = AlterParameterDetailsResultSuccess()
         return result
@@ -1984,14 +1983,14 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f'"{request.node_name}" not found'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetParameterValueResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(param_name)
         if parameter is None:
             details = f'"{request.node_name}.{param_name}" not found'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetParameterValueResultFailure()
 
         # Values are actually stored on the NODE, so let's ask them.
@@ -2007,7 +2006,7 @@ class NodeManager:
 
         # Cool.
         details = f"{request.node_name}.{request.parameter_name} = {data_value}"
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = GetParameterValueResultSuccess(
             input_types=parameter.input_types,
@@ -2029,14 +2028,14 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f'"{request.node_name}" not found'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return SetParameterValueResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(param_name)
         if parameter is None:
             details = f'"{request.node_name}.{param_name}" not found'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = SetParameterValueResultFailure()
             return result
@@ -2044,7 +2043,7 @@ class NodeManager:
         # Validate that parameters can be set at all
         if not parameter.settable:
             details = f'"{request.node_name}.{request.parameter_name}" is not settable'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             result = SetParameterValueResultFailure()
             return result
 
@@ -2054,7 +2053,7 @@ class NodeManager:
         # Is this value kosher for the types allowed?
         if not parameter.is_incoming_type_allowed(object_type):
             details = f'set_value for "{request.node_name}.{request.parameter_name}" failed.  type "{object_created.__class__.__name__}" not in allowed types:{parameter.input_types}'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = SetParameterValueResultFailure()
             return result
@@ -2063,18 +2062,18 @@ class NodeManager:
             parent_flow_name = self.get_node_parent_flow_by_name(node.name)
         except KeyError:
             details = f'set_value for "{request.node_name}.{request.parameter_name}" failed. Parent flow does not exist. Could not unresolve future nodes.'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return SetParameterValueResultFailure()
         parent_flow = obj_mgr.attempt_get_object_by_name_as_type(parent_flow_name, ControlFlow)
         if not parent_flow:
             details = f'set_value for "{request.node_name}.{request.parameter_name}" failed. Parent flow does not exist. Could not unresolve future nodes.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return SetParameterValueResultFailure()
         try:
             parent_flow.connections.unresolve_future_nodes(node)
         except Exception as e:
             details = f'set_value for "{request.node_name}.{request.parameter_name}" failed. Exception: {e}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return SetParameterValueResultFailure()
 
         # Values are actually stored on the NODE.
@@ -2083,7 +2082,7 @@ class NodeManager:
             finalized_value = node.get_parameter_value(request.parameter_name)
         except Exception as err:
             details = f'set_value for "{request.node_name}.{request.parameter_name}" failed. Exception: {err}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return SetParameterValueResultFailure()
 
         if modified_parameters:
@@ -2110,7 +2109,7 @@ class NodeManager:
 
         # Cool.
         details = f"Successfully set value on Node '{request.node_name}' Parameter '{request.parameter_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = SetParameterValueResultSuccess(finalized_value=finalized_value, data_type=parameter.type)
         return result
@@ -2127,7 +2126,7 @@ class NodeManager:
         node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             details = f"Attempted to get all info for Node named '{request.node_name}', but no such Node was found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetAllNodeInfoResultFailure()
             return result
@@ -2138,7 +2137,7 @@ class NodeManager:
             details = (
                 f"Attempted to get all info for Node named '{request.node_name}', but failed getting the metadata."
             )
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetAllNodeInfoResultFailure()
             return result
@@ -2149,7 +2148,7 @@ class NodeManager:
         )
         if not get_resolution_state_result.succeeded():
             details = f"Attempted to get all info for Node named '{request.node_name}', but failed getting the resolution state."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetAllNodeInfoResultFailure()
             return result
@@ -2160,7 +2159,7 @@ class NodeManager:
         )
         if not list_connections_result.succeeded():
             details = f"Attempted to get all info for Node named '{request.node_name}', but failed listing all connections for it."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetAllNodeInfoResultFailure()
             return result
@@ -2169,7 +2168,7 @@ class NodeManager:
         list_parameters_result = GriptapeNodes.NodeManager().on_list_parameters_on_node_request(list_parameters_request)
         if not list_parameters_result.succeeded():
             details = f"Attempted to get all info for Node named '{request.node_name}', but failed listing all Parameters on it."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             result = GetAllNodeInfoResultFailure()
             return result
@@ -2182,7 +2181,7 @@ class NodeManager:
             list_parameters_success = cast("ListParametersOnNodeResultSuccess", list_parameters_result)
         except Exception as err:
             details = f"Attempted to get all info for Node named '{request.node_name}'. Failed due to error: {err}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = GetAllNodeInfoResultFailure()
             return result
@@ -2201,7 +2200,7 @@ class NodeManager:
 
             if not get_parameter_details_result.succeeded():
                 details = f"Attempted to get all info for Node named '{request.node_name}', but failed getting details for Parameter '{param_name}'."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
 
                 result = GetAllNodeInfoResultFailure()
                 return result
@@ -2216,7 +2215,7 @@ class NodeManager:
 
             if not get_parameter_value_result.succeeded():
                 details = f"Attempted to get all info for Node named '{request.node_name}', but failed getting value for Parameter '{param_name}'."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
 
                 result = GetAllNodeInfoResultFailure()
                 return result
@@ -2227,7 +2226,7 @@ class NodeManager:
                 get_parameter_value_success = cast("GetParameterValueResultSuccess", get_parameter_value_result)
             except Exception as err:
                 details = f"Attempted to get all info for Node named '{request.node_name}'. Failed due to error: {err}."
-                GriptapeNodes.get_logger().error(details)
+                logger.exception(details)
 
                 result = GetAllNodeInfoResultFailure()
                 return result
@@ -2238,7 +2237,7 @@ class NodeManager:
             )
 
         details = f"Successfully got all node info for node '{request.node_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         result = GetAllNodeInfoResultSuccess(
             metadata=get_metadata_success.metadata,
             node_resolution_state=get_resolution_state_success.state,
@@ -2254,14 +2253,14 @@ class NodeManager:
             node = GriptapeNodes.NodeManager().get_node_by_name(request.node_name)
         except ValueError as err:
             details = f"Attempted to get compatible parameters for node '{request.node_name}', but that node does not exist. Error: {err}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetCompatibleParametersResultFailure()
 
         # Vet the parameter.
         request_param = node.get_parameter_by_name(request.parameter_name)
         if request_param is None:
             details = f"Attempted to get compatible parameters for '{request.node_name}.{request.parameter_name}', but that no Parameter with that name could not be found."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetCompatibleParametersResultFailure()
 
         # Figure out the mode we're going for, and if this parameter supports the mode.
@@ -2269,7 +2268,7 @@ class NodeManager:
         # Does this parameter support that?
         if request_mode not in request_param.allowed_modes:
             details = f"Attempted to get compatible parameters for '{request.node_name}.{request.parameter_name}' as '{request_mode}', but the Parameter didn't support that type of input/output."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetCompatibleParametersResultFailure()
 
         # Get the parent flows.
@@ -2277,7 +2276,7 @@ class NodeManager:
             flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(request.node_name)
         except KeyError as err:
             details = f"Attempted to get compatible parameters for '{request.node_name}.{request.parameter_name}', but the node's parent flow could not be found: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetCompatibleParametersResultFailure()
 
         # Iterate through all nodes in this Flow (yes, this restriction still sucks)
@@ -2287,14 +2286,14 @@ class NodeManager:
         )
         if not list_nodes_in_flow_result.succeeded():
             details = f"Attempted to get compatible parameters for '{request.node_name}.{request.parameter_name}'. Failed due to inability to list nodes in parent flow '{flow_name}'."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetCompatibleParametersResultFailure()
 
         try:
             list_nodes_in_flow_success = cast("ListNodesInFlowResultSuccess", list_nodes_in_flow_result)
         except Exception as err:
             details = f"Attempted to get compatible parameters for '{request.node_name}.{request.parameter_name}'. Failed due to {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetCompatibleParametersResultFailure()
 
         # Walk through all nodes that are NOT us to find compatible Parameters.
@@ -2306,7 +2305,7 @@ class NodeManager:
                     test_node = GriptapeNodes.NodeManager().get_node_by_name(test_node_name)
                 except ValueError as err:
                     details = f"Attempted to get compatible parameters for node '{request.node_name}', and sought to test against {test_node_name}, but that node does not exist. Error: {err}."
-                    GriptapeNodes.get_logger().error(details)
+                    logger.exception(details)
                     return GetCompatibleParametersResultFailure()
 
                 # Get Parameters from Node
@@ -2343,7 +2342,7 @@ class NodeManager:
                                 valid_parameters_by_node[test_node_name] = compatible_list
 
         details = f"Successfully got compatible parameters for '{request.node_name}.{request.parameter_name}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         return GetCompatibleParametersResultSuccess(valid_parameters_by_node=valid_parameters_by_node)
 
     def get_node_by_name(self, name: str) -> BaseNode:
@@ -2368,14 +2367,14 @@ class NodeManager:
 
         if not node_name:
             details = "No Node name was provided. Failed to resolve node."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
             return ResolveNodeResultFailure(validation_exceptions=[])
         try:
             node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
         except ValueError:
             details = f'Resolve failure. "{node_name}" does not exist.'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return ResolveNodeResultFailure(validation_exceptions=[])
         # try to get the flow parent of this node
@@ -2383,7 +2382,7 @@ class NodeManager:
             flow_name = self._name_to_parent_flow_name[node_name]
         except KeyError:
             details = f'Failed to fetch parent flow for "{node_name}"'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return ResolveNodeResultFailure(validation_exceptions=[])
         try:
@@ -2391,26 +2390,26 @@ class NodeManager:
             flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         except KeyError:
             details = f'Failed to fetch parent flow for "{node_name}"'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             return ResolveNodeResultFailure(validation_exceptions=[])
 
         if flow is None:
             details = f'Failed to fetch parent flow for "{node_name}"'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return ResolveNodeResultFailure(validation_exceptions=[])
         try:
             flow.connections.unresolve_future_nodes(node)
         except Exception:
             details = f'Failed to mark future nodes dirty. Unable to kick off flow from "{node_name}"'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return ResolveNodeResultFailure(validation_exceptions=[])
         # Validate here.
         result = self.on_validate_node_dependencies_request(ValidateNodeDependenciesRequest(node_name=node_name))
         try:
             if not result.succeeded():
                 details = f"Failed to resolve node '{node_name}'. Flow Validation Failed"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return StartFlowResultFailure(validation_exceptions=[])
             result = cast("ValidateNodeDependenciesResultSuccess", result)
 
@@ -2419,22 +2418,22 @@ class NodeManager:
                 if len(result.exceptions) > 0:
                     for exception in result.exceptions:
                         details = f"{details}\n\t{exception}"
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return StartFlowResultFailure(validation_exceptions=result.exceptions)
         except Exception as e:
             details = f"Failed to resolve node '{node_name}'. Flow Validation Failed. Error: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return StartFlowResultFailure(validation_exceptions=[])
         try:
             flow.resolve_singular_node(node, debug_mode)
         except Exception as e:
             details = f'Failed to resolve "{node_name}".  Error: {e}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             cancel_request = CancelFlowRequest(flow_name=flow_name)
             GriptapeNodes.handle_request(cancel_request)
             return ResolveNodeResultFailure(validation_exceptions=[])
         details = f'Starting to resolve "{node_name}" in "{flow_name}"'
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         return ResolveNodeResultSuccess()
 
     def on_validate_node_dependencies_request(self, request: ValidateNodeDependenciesRequest) -> ResultPayload:
@@ -2443,18 +2442,18 @@ class NodeManager:
         node = obj_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if not node:
             details = f'Failed to validate node dependencies. Node with "{node_name}" does not exist.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return ValidateNodeDependenciesResultFailure()
         try:
             flow_name = self.get_node_parent_flow_by_name(node_name)
         except Exception as e:
             details = f'Failed to validate node dependencies. Node with "{node_name}" has no parent flow. Error: {e}'
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return ValidateNodeDependenciesResultFailure()
         flow = GriptapeNodes.get_instance()._object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if not flow:
             details = f'Failed to validate node dependencies. Flow with "{flow_name}" does not exist.'
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return ValidateNodeDependenciesResultFailure()
         # Gets all dependent nodes
         nodes = flow.get_node_dependencies(node)
@@ -2530,7 +2529,7 @@ class ScriptManager:
         complete_file_path = ScriptRegistry.get_complete_file_path(relative_file_path=relative_file_path)
         if not Path(complete_file_path).is_file():
             details = f"Failed to find file. Path '{complete_file_path}' doesn't exist."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return RunScriptFromScratchResultFailure()
 
         try:
@@ -2538,16 +2537,16 @@ class ScriptManager:
             GriptapeNodes.clear_data()
         except Exception as e:
             details = f"Failed to clear the existing context when trying to run '{complete_file_path}'. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return RunScriptFromScratchResultFailure()
 
         # Run the file, goddamn it
         success, details = self.run_script(relative_file_path=relative_file_path)
         if success:
-            GriptapeNodes.get_logger().debug(details)
+            logger.debug(details)
             return RunScriptFromScratchResultSuccess()
 
-        GriptapeNodes.get_logger().error(details)
+        logger.error(details)
         return RunScriptFromScratchResultFailure()
 
     def on_run_script_with_current_state_request(self, request: RunScriptWithCurrentStateRequest) -> ResultPayload:
@@ -2555,22 +2554,22 @@ class ScriptManager:
         complete_file_path = ScriptRegistry.get_complete_file_path(relative_file_path=relative_file_path)
         if not Path(complete_file_path).is_file():
             details = f"Failed to find file. Path '{complete_file_path}' doesn't exist."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return RunScriptWithCurrentStateResultFailure()
         success, details = self.run_script(relative_file_path=relative_file_path)
 
         if success:
-            GriptapeNodes.get_logger().debug(details)
+            logger.debug(details)
             return RunScriptWithCurrentStateResultSuccess()
-        GriptapeNodes.get_logger().error(details)
+        logger.error(details)
         return RunScriptWithCurrentStateResultFailure()
 
     def on_run_script_from_registry_request(self, request: RunScriptFromRegistryRequest) -> ResultPayload:
         # get script from registry
         try:
             script = ScriptRegistry.get_script_by_name(request.script_name)
-        except KeyError as e:
-            GriptapeNodes.get_logger().error(e)
+        except KeyError:
+            logger.exception("Failed to get script from registry.")
             return RunScriptFromRegistryResultFailure()
         # get file_path from script
         relative_file_path = script.file_path
@@ -2578,10 +2577,10 @@ class ScriptManager:
         success, details = self.run_script(relative_file_path=relative_file_path)
 
         if success:
-            GriptapeNodes.get_logger().debug(details)
+            logger.debug(details)
             return RunScriptFromRegistryResultSuccess()
 
-        GriptapeNodes.get_logger().error(details)
+        logger.error(details)
         return RunScriptFromRegistryResultFailure()
 
     def on_register_script_request(self, request: RegisterScriptRequest) -> ResultPayload:
@@ -2589,7 +2588,7 @@ class ScriptManager:
             script = ScriptRegistry.generate_new_script(metadata=request.metadata, file_path=request.file_name)
         except Exception as e:
             details = f"Failed to register script with name '{request.metadata.name}'. Error: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return RegisterScriptResultFailure()
         return RegisterScriptResultSuccess(script_name=script.metadata.name)
 
@@ -2598,7 +2597,7 @@ class ScriptManager:
             scripts = ScriptRegistry.list_scripts()
         except Exception:
             details = "Failed to list all scripts."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return ListAllScriptsResultFailure()
         return ListAllScriptsResultSuccess(scripts=scripts)
 
@@ -2607,14 +2606,14 @@ class ScriptManager:
             script = ScriptRegistry.delete_script_by_name(request.name)
         except Exception as e:
             details = f"Failed to remove script from registry with name '{request.name}'. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return DeleteScriptResultFailure()
         config_manager = GriptapeNodes.get_instance()._config_manager
         try:
             config_manager.delete_user_script(script.__dict__)
         except Exception as e:
             details = f"Failed to remove script from user config with name '{request.name}'. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return DeleteScriptResultFailure()
         # delete the actual file
         full_path = config_manager.workspace_path.joinpath(script.file_path)
@@ -2622,7 +2621,7 @@ class ScriptManager:
             full_path.unlink()
         except Exception as e:
             details = f"Failed to delete script file with path '{script.file_path}'. Exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return DeleteScriptResultFailure()
         return DeleteScriptResultSuccess()
 
@@ -2631,13 +2630,13 @@ class ScriptManager:
 
         if isinstance(save_scene_request, SaveSceneResultFailure):
             details = f"Attempted to rename script '{request.script_name}' to '{request.requested_name}'. Failed while attempting to save."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return RenameScriptResultFailure()
 
         delete_script_result = GriptapeNodes.handle_request(DeleteScriptRequest(name=request.script_name))
         if isinstance(delete_script_result, DeleteScriptResultFailure):
             details = f"Attempted to rename script '{request.script_name}' to '{request.requested_name}'. Failed while attempting to remove the original file name from the registry."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return RenameScriptResultFailure()
 
         return RenameScriptResultSuccess()
@@ -2647,7 +2646,7 @@ class ScriptManager:
         complete_file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(request.file_name)
         if not Path(complete_file_path).is_file():
             details = f"Attempted to load script metadata for a file at '{complete_file_path}. Failed because no file could be found at that path."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return LoadScriptMetadataResultFailure()
 
         # Open 'er up.
@@ -2660,7 +2659,7 @@ class ScriptManager:
         matches = list(filter(lambda m: m.group("type") == block_name, re.finditer(regex, script_content)))
         if len(matches) != 1:
             details = f"Attempted to load script metadata for a file at '{complete_file_path}'. Failed as it had {len(matches)} sections titled '{block_name}', and we expect exactly 1 such section."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return LoadScriptMetadataResultFailure()
 
         # Now attempt to parse out the metadata section, stripped of comment prefixes.
@@ -2673,14 +2672,14 @@ class ScriptManager:
             toml_doc = tomlkit.parse(metadata_content_toml)
         except Exception as err:
             details = f"Attempted to load script metadata for a file at '{complete_file_path}'. Failed because the metadata was not valid TOML: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return LoadScriptMetadataResultFailure()
 
         try:
             griptape_nodes_tool_section = toml_doc["tool"]["griptape-nodes"]  # type: ignore (this is the only way I could find to get tomlkit to do the dotted notation correctly)
         except Exception as err:
             details = f"Attempted to load script metadata for a file at '{complete_file_path}'. Failed because the '[tools.griptape-nodes]' section could not be found: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return LoadScriptMetadataResultFailure()
 
         try:
@@ -2689,7 +2688,7 @@ class ScriptManager:
         except Exception as err:
             # No, it is haram.
             details = f"Attempted to load script metadata for a file at '{complete_file_path}'. Failed because the metadata did not match the requisite schema with error: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return LoadScriptMetadataResultFailure()
 
         return LoadScriptMetadataResultSuccess(metadata=script_metadata)
@@ -2717,7 +2716,7 @@ class ScriptManager:
         engine_version_result = GriptapeNodes.handle_request(request=engine_version_request)
         if not engine_version_result.succeeded():
             details = f"Attempted to save scene '{relative_file_path}', but failed getting the engine version."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return SaveSceneResultFailure()
         try:
             engine_version_success = cast("GetEngineVersionResultSuccess", engine_version_result)
@@ -2726,7 +2725,7 @@ class ScriptManager:
             )
         except Exception as err:
             details = f"Attempted to save scene '{relative_file_path}', but failed getting the engine version: {err}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return SaveSceneResultFailure()
 
         try:
@@ -2751,7 +2750,7 @@ class ScriptManager:
                         handle_parameter_creation_saving(file, node, flow_name)
                     except Exception as e:
                         details = f"Failed to save scene because failed to save parameter creation for node '{node.name}'. Error: {e}"
-                        GriptapeNodes.get_logger().error(details)
+                        logger.exception(details)
                         return SaveSceneResultFailure()
 
                     # See if this node uses a library we need to know about.
@@ -2763,14 +2762,14 @@ class ScriptManager:
                     )
                     if not library_metadata_result.succeeded():
                         details = f"Attempted to save scene '{relative_file_path}', but failed to get library metadata for library '{library_used}'."
-                        GriptapeNodes.get_logger().error(details)
+                        logger.error(details)
                         return SaveSceneResultFailure()
                     try:
                         library_metadata_success = cast("GetLibraryMetadataResultSuccess", library_metadata_result)
                         library_version = library_metadata_success.metadata["library_version"]
                     except Exception as err:
                         details = f"Attempted to save scene '{relative_file_path}', but failed to get library version from metadata for library '{library_used}': {err}."
-                        GriptapeNodes.get_logger().error(details)
+                        logger.exception(details)
                         return SaveSceneResultFailure()
                     library_and_version = LibraryNameAndVersion(
                         library_name=library_used, library_version=library_version
@@ -2800,7 +2799,7 @@ class ScriptManager:
                     toml_doc["tool"]["griptape-nodes"] = griptape_tool_table  # type: ignore (this is the only way I could find to get tomlkit to do the dotted notation correctly)
                 except Exception as err:
                     details = f"Attempted to save scene '{relative_file_path}', but failed to get metadata into TOML format: {err}."
-                    GriptapeNodes.get_logger().error(details)
+                    logger.exception(details)
                     return SaveSceneResultFailure()
 
                 # Format the metadata block with comment markers for each line
@@ -2818,7 +2817,7 @@ class ScriptManager:
                 file.write(metadata_block)
         except Exception as e:
             details = f"Failed to save scene, exception: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return SaveSceneResultFailure()
 
         # save the created scene to a personal json file
@@ -2991,7 +2990,7 @@ class LibraryManager:
         event_copy = snapshot_list.copy()
 
         details = "Successfully retrieved the list of registered libraries."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = ListRegisteredLibrariesResultSuccess(
             libraries=event_copy,
@@ -3004,7 +3003,7 @@ class LibraryManager:
             library = LibraryRegistry.get_library(name=request.library)
         except KeyError:
             details = f"Attempted to list node types in a Library named '{request.library}'. Failed because no Library with that name was registered."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = ListNodeTypesInLibraryResultFailure()
             return result
@@ -3014,7 +3013,7 @@ class LibraryManager:
         event_copy = snapshot_list.copy()
 
         details = f"Successfully retrieved the list of node types in the Library named '{request.library}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = ListNodeTypesInLibraryResultSuccess(
             node_types=event_copy,
@@ -3027,7 +3026,7 @@ class LibraryManager:
             library = LibraryRegistry.get_library(name=request.library)
         except KeyError:
             details = f"Attempted to get metadata for Library '{request.library}'. Failed because no Library with that name was registered."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = GetLibraryMetadataResultFailure()
             return result
@@ -3035,7 +3034,7 @@ class LibraryManager:
         # Get the metadata off of it.
         metadata = library.get_metadata()
         details = f"Successfully retrieved metadata for Library '{request.library}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = GetLibraryMetadataResultSuccess(metadata=metadata)
         return result
@@ -3046,7 +3045,7 @@ class LibraryManager:
             library = LibraryRegistry.get_library(name=request.library)
         except KeyError:
             details = f"Attempted to get node metadata for a node type '{request.node_type}' in a Library named '{request.library}'. Failed because no Library with that name was registered."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = GetNodeMetadataFromLibraryResultFailure()
             return result
@@ -3056,13 +3055,13 @@ class LibraryManager:
             metadata = library.get_node_metadata(node_type=request.node_type)
         except KeyError:
             details = f"Attempted to get node metadata for a node type '{request.node_type}' in a Library named '{request.library}'. Failed because no node type of that name could be found in the Library."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
 
             result = GetNodeMetadataFromLibraryResultFailure()
             return result
 
         details = f"Successfully retrieved node metadata for a node type '{request.node_type}' in a Library named '{request.library}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
 
         result = GetNodeMetadataFromLibraryResultSuccess(
             metadata=metadata,
@@ -3075,7 +3074,7 @@ class LibraryManager:
             library = LibraryRegistry.get_library(name=request.library)
         except KeyError:
             details = f"Attempted to get categories in a Library named '{request.library}'. Failed because no Library with that name was registered."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             result = ListCategoriesInLibraryResultFailure()
             return result
 
@@ -3092,7 +3091,7 @@ class LibraryManager:
         # Check if the file exists
         if not json_path.exists():
             details = f"Attempted to load Library JSON file. Failed because no file could be found at the specified path: {json_path}"
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return RegisterLibraryFromFileResultFailure()
 
         # Load the JSON
@@ -3101,7 +3100,7 @@ class LibraryManager:
                 library_data = json.load(f)
         except json.JSONDecodeError:
             details = f"Attempted to load Library JSON file. Failed because the file at path {json_path} was improperly formatted."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return RegisterLibraryFromFileResultFailure()
         # Extract library information
         try:
@@ -3110,7 +3109,7 @@ class LibraryManager:
             nodes_metadata = library_data.get("nodes", [])
         except KeyError as e:
             details = f"Attempted to load Library JSON file from '{file_path}'. Failed because it was missing required field in library metadata: {e}"
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return RegisterLibraryFromFileResultFailure()
 
         categories = library_data.get("categories", None)
@@ -3131,7 +3130,7 @@ class LibraryManager:
         except KeyError as err:
             # Library already exists
             details = f"Attempted to load Library JSON file from '{file_path}'. Failed because a Library '{library_name}' already exists. Error: {err}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return RegisterLibraryFromFileResultFailure()
 
         # Update library metadata
@@ -3157,12 +3156,12 @@ class LibraryManager:
 
             except (KeyError, ImportError, AttributeError) as e:
                 details = f"Attempted to load Library JSON file from '{file_path}'. Failed due to an error loading node {node_meta.get('class_name', 'unknown')}: {e}"
-                GriptapeNodes.get_logger().error(details)
+                logger.exception(details)
                 return RegisterLibraryFromFileResultFailure()
 
         # Success!
         details = f"Successfully loaded Library '{library_name}' from JSON file at {file_path}"
-        GriptapeNodes.get_logger().info(details)
+        logger.info(details)
         return RegisterLibraryFromFileResultSuccess(library_name=library_name)
 
     def get_all_info_for_all_libraries_request(self, request: GetAllInfoForAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
@@ -3171,7 +3170,7 @@ class LibraryManager:
 
         if not list_libraries_result.succeeded():
             details = "Attempted to get all info for all libraries, but listing the registered libraries failed."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetAllInfoForAllLibrariesResultFailure()
 
         try:
@@ -3186,7 +3185,7 @@ class LibraryManager:
 
                 if not library_all_info_result.succeeded():
                     details = f"Attempted to get all info for all libraries, but failed when getting all info for library named '{library_name}'."
-                    GriptapeNodes.get_logger().error(details)
+                    logger.error(details)
                     return GetAllInfoForAllLibrariesResultFailure()
 
                 library_all_info_success = cast("GetAllInfoForLibraryResultSuccess", library_all_info_result)
@@ -3194,12 +3193,12 @@ class LibraryManager:
                 library_name_to_all_info[library_name] = library_all_info_success
         except Exception as err:
             details = f"Attempted to get all info for all libraries. Encountered error {err}."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetAllInfoForAllLibrariesResultFailure()
 
         # We're home free now
         details = "Successfully retrieved all info for all libraries."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         result = GetAllInfoForAllLibrariesResultSuccess(library_name_to_library_info=library_name_to_all_info)
         return result
 
@@ -3209,7 +3208,7 @@ class LibraryManager:
             LibraryRegistry.get_library(name=request.library)
         except KeyError:
             details = f"Attempted to get all library info for a Library named '{request.library}'. Failed because no Library with that name was registered."
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             result = GetAllInfoForLibraryResultFailure()
             return result
 
@@ -3218,7 +3217,7 @@ class LibraryManager:
 
         if not library_metadata_result.succeeded():
             details = f"Attempted to get all library info for a Library named '{request.library}'. Failed attempting to get the library's metadata."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetAllInfoForLibraryResultFailure()
 
         list_categories_request = ListCategoriesInLibraryRequest(library=request.library)
@@ -3226,7 +3225,7 @@ class LibraryManager:
 
         if not list_categories_result.succeeded():
             details = f"Attempted to get all library info for a Library named '{request.library}'. Failed attempting to get the list of categories in the library."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetAllInfoForLibraryResultFailure()
 
         node_type_list_request = ListNodeTypesInLibraryRequest(library=request.library)
@@ -3234,7 +3233,7 @@ class LibraryManager:
 
         if not node_type_list_result.succeeded():
             details = f"Attempted to get all library info for a Library named '{request.library}'. Failed attempting to get the list of node types in the library."
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
             return GetAllInfoForLibraryResultFailure()
 
         # Cast everyone to their success counterparts.
@@ -3246,7 +3245,7 @@ class LibraryManager:
             details = (
                 f"Attempted to get all library info for a Library named '{request.library}'. Encountered error: {err}."
             )
-            GriptapeNodes.get_logger().error(details)
+            logger.exception(details)
             return GetAllInfoForLibraryResultFailure()
 
         # Now build the map of node types to metadata.
@@ -3257,21 +3256,21 @@ class LibraryManager:
 
             if not node_metadata_result.succeeded():
                 details = f"Attempted to get all library info for a Library named '{request.library}'. Failed attempting to get the metadata for a node type called '{node_type_name}'."
-                GriptapeNodes.get_logger().error(details)
+                logger.error(details)
                 return GetAllInfoForLibraryResultFailure()
 
             try:
                 node_metadata_result_success = cast("GetNodeMetadataFromLibraryResultSuccess", node_metadata_result)
             except Exception as err:
                 details = f"Attempted to get all library info for a Library named '{request.library}'. Encountered error: {err}."
-                GriptapeNodes.get_logger().error(details)
+                logger.exception(details)
                 return GetAllInfoForLibraryResultFailure()
 
             # Put it into the map.
             node_type_name_to_node_metadata_details[node_type_name] = node_metadata_result_success
 
         details = f"Successfully got all library info for a Library named '{request.library}'."
-        GriptapeNodes.get_logger().debug(details)
+        logger.debug(details)
         result = GetAllInfoForLibraryResultSuccess(
             library_metadata_details=library_metadata_result_success,
             category_details=list_categories_result_success,
@@ -3365,7 +3364,7 @@ class LibraryManager:
                 except Exception as err:
                     err_str = f"Error attempting to get info about script to register '{script_to_register}': {err}. SKIPPING IT."
                     failed_registrations.append(script_to_register)
-                    GriptapeNodes.get_logger().error(err_str)
+                    logger.exception(err_str)
                     continue
 
                 # Adjust path depending on if it's a Griptape-provided script or a user one.
@@ -3389,7 +3388,7 @@ class LibraryManager:
                 except Exception as err:
                     err_str = f"Error attempting to get info about script to register '{final_file_path}': {err}. SKIPPING IT."
                     failed_registrations.append(final_file_path)
-                    GriptapeNodes.get_logger().error(err_str)
+                    logger.exception(err_str)
                     continue
 
                 script_metadata = successful_metadata_result.metadata
@@ -3410,22 +3409,22 @@ class LibraryManager:
                     failed_registrations.append(details)
 
         if len(successful_registrations) == 0 and len(failed_registrations) == 0:
-            GriptapeNodes.get_logger().info("No scripts were registered.")
+            logger.info("No scripts were registered.")
         if len(successful_registrations) > 0:
             details = "Scripts successfully registered:"
             for successful_registration in successful_registrations:
                 details = f"{details}\n\t{successful_registration}"
-            GriptapeNodes.get_logger().info(details)
+            logger.info(details)
         if len(failed_registrations) > 0:
             details = "Scripts that FAILED to register:"
             for failed_registration in failed_registrations:
                 details = f"{details}\n\t{failed_registration}"
-            GriptapeNodes.get_logger().error(details)
+            logger.error(details)
 
 
 def __getattr__(name) -> logging.Logger:
     """Convenience function so that node authors only need to write 'logger.debug()'."""
     if name == "logger":
-        return GriptapeNodes.get_logger()
+        return logger
     msg = f"module '{__name__}' has no attribute '{name}'"
     raise AttributeError(msg)

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -226,7 +226,7 @@ load_dotenv()
 T = TypeVar("T")
 
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 class SingletonMeta(type):

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,8 @@ from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
 
 from .settings import ScriptSettingsDetail, Settings, _find_config_files
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 
 class ConfigManager:
@@ -56,15 +59,11 @@ class ConfigManager:
             event_manager.assign_manager_to_request_type(SetConfigValueRequest, self.on_handle_set_config_value_request)
 
             if len(self.config_files) == 0:
-                print(
-                    "No configuration files were found. Will run using default values."
-                )  # TODO(griptape): Move to Log
+                logger.info("No configuration files were found. Will run using default values.")
             else:
-                print(
-                    "Configuration files were found at the following locations and merged in this order:"
-                )  # TODO(griptape): Move to Log
+                logger.info("Configuration files were found at the following locations and merged in this order:")
                 for config_file in self.config_files:
-                    print(f"\t{config_file}")
+                    logger.info("\t%s", config_file)
 
     @property
     def workspace_path(self) -> Path:
@@ -178,30 +177,30 @@ class ConfigManager:
             # Return the whole shebang. Start with the defaults and then layer on the user config.
             contents = self.user_config
             details = "Successfully returned the entire config dictionary."
-            print(details)  # TODO(griptape): Move to Log
+            logger.info(details)
             return GetConfigCategoryResultSuccess(contents=contents)
 
         # See if we got something valid.
         find_results = self.get_config_value(request.category)
         if find_results is None:
             details = f"Attempted to get config details for category '{request.category}'. Failed because no such category could be found."
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return GetConfigCategoryResultFailure()
 
         if not isinstance(find_results, dict):
             details = f"Attempted to get config details for category '{request.category}'. Failed because this was was not a dictionary."
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return GetConfigCategoryResultFailure()
 
         details = f"Successfully returned the config dictionary for section '{request.category}'."
-        print(details)  # TODO(griptape): Move to Log
+        logger.info(details)
         return GetConfigCategoryResultSuccess(contents=find_results)
 
     def on_handle_set_config_category_request(self, request: SetConfigCategoryRequest) -> ResultPayload:
         # Validate the value is a dict
         if not isinstance(request.contents, dict):
             details = f"Attempted to set config details for category '{request.category}'. Failed because the contents provided were not a dictionary."
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return SetConfigCategoryResultFailure()
 
         if request.category is None or request.category == "":
@@ -209,40 +208,40 @@ class ConfigManager:
             self.user_config = request.contents
             self._write_user_config()
             details = "Successfully assigned the entire config dictionary."
-            print(details)  # TODO(griptape): Move to Log
+            logger.info(details)
             return SetConfigCategoryResultSuccess()
 
         self.set_config_value(key=request.category, value=request.contents)
         details = f"Successfully assigned the config dictionary for section '{request.category}'."
-        print(details)  # TODO(griptape): Move to Log
+        logger.info(details)
         return SetConfigCategoryResultSuccess()
 
     def on_handle_get_config_value_request(self, request: GetConfigValueRequest) -> ResultPayload:
         if request.category_and_key == "":
             details = "Attempted to get config value but no category or key was specified."
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return GetConfigValueResultFailure()
 
         # See if we got something valid.
         find_results = self.get_config_value(request.category_and_key)
         if find_results is None:
             details = f"Attempted to get config value for category.key '{request.category_and_key}'. Failed because no such category.key could be found."
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return GetConfigValueResultFailure()
 
         details = f"Successfully returned the config value for section '{request.category_and_key}'."
-        print(details)  # TODO(griptape): Move to Log
+        logger.info(details)
         return GetConfigValueResultSuccess(value=find_results)
 
     def on_handle_set_config_value_request(self, request: SetConfigValueRequest) -> ResultPayload:
         if request.category_and_key == "":
             details = "Attempted to set config value but no category or key was specified."
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return SetConfigValueResultFailure()
 
         self.set_config_value(key=request.category_and_key, value=request.value)
         details = f"Successfully assigned the config value for category.key '{request.category_and_key}'."
-        print(details)  # TODO(griptape): Move to Log
+        logger.info(details)
         return SetConfigValueResultSuccess()
 
     def _write_user_config(self) -> None:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -23,7 +23,7 @@ from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_
 
 from .settings import ScriptSettingsDetail, Settings, _find_config_files
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 class ConfigManager:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -169,6 +169,12 @@ class ConfigManager:
             value: The value to associate with the key.
         """
         delta = set_dot_value({}, key, value)
+        if key == "log_level":
+            try:
+                logger.setLevel(value.upper())
+            except ValueError:
+                logger.exception("Invalid log level %s. Defaulting to INFO.", value)
+                logger.setLevel(logging.INFO)
         self.user_config = merge_dicts(self.user_config, delta)
         self._write_user_config()
 

--- a/src/griptape_nodes/retained_mode/managers/log_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/log_manager.py
@@ -17,20 +17,12 @@ class EventLogHandler(logging.Handler):
 
 
 class LogManager:
+    LOGGER_NAME = "griptape_nodes_engine"
+
     def __init__(self) -> None:
-        root_logger = logging.getLogger()
-        root_logger.setLevel(logging.INFO)
+        logger = logging.getLogger(LogManager.LOGGER_NAME)
+        logger.setLevel(logging.INFO)
 
-        if not root_logger.hasHandlers():
-            root_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True))
-            root_logger.addHandler(EventLogHandler())
-
-        local_logger = logging.getLogger("griptape_nodes_engine")
-        local_logger.setLevel(logging.INFO)
-
-        if not local_logger.hasHandlers():
-            local_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True))
-
-    def get_logger(self, *, event_handler: bool = True) -> logging.Logger:
-        logger = logging.getLogger() if event_handler else logging.getLogger("griptape_nodes_engine")
-        return logger
+        if not logger.hasHandlers():
+            logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
+            logger.addHandler(EventLogHandler())

--- a/src/griptape_nodes/retained_mode/managers/log_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/log_manager.py
@@ -17,7 +17,7 @@ class EventLogHandler(logging.Handler):
 
 
 class LogManager:
-    LOGGER_NAME = "griptape_nodes_engine"
+    LOGGER_NAME = "griptape_nodes"
 
     def __init__(self) -> None:
         logger = logging.getLogger(LogManager.LOGGER_NAME)

--- a/src/griptape_nodes/retained_mode/managers/log_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/log_manager.py
@@ -26,3 +26,5 @@ class LogManager:
         if not logger.hasHandlers():
             logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
             logger.addHandler(EventLogHandler())
+
+        self.logger = logger

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -12,7 +12,7 @@ from griptape_nodes.retained_mode.events.os_events import (
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 class OSManager:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -20,7 +20,7 @@ from griptape_nodes.retained_mode.events.secrets_events import (
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
-logger = logging.getLogger("griptape_nodes_engine")
+logger = logging.getLogger("griptape_nodes")
 
 
 class SecretsManager:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -1,3 +1,4 @@
+import logging
 from os import getenv
 from pathlib import Path
 
@@ -18,6 +19,8 @@ from griptape_nodes.retained_mode.events.secrets_events import (
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+logger = logging.getLogger("griptape_nodes_engine")
 
 
 class SecretsManager:
@@ -45,7 +48,7 @@ class SecretsManager:
 
         if secret_value is None:
             details = f"Secret {secret_key} not found: '{secret_key}'"
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return GetSecretValueResultFailure()
 
         return GetSecretValueResultSuccess(value=secret_value)
@@ -68,12 +71,12 @@ class SecretsManager:
 
         if not self.env_var_path.exists():
             details = f"Secret file does not exist: '{self.env_var_path}'"
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return DeleteSecretValueResultFailure()
 
         if not get_key(self.env_var_path, secret_name):
             details = f"Secret {secret_name} not found in {self.env_var_path}"
-            print(details)  # TODO(griptape): Move to Log
+            logger.error(details)
             return DeleteSecretValueResultFailure()
 
         unset_key(self.env_var_path, secret_name)
@@ -81,19 +84,15 @@ class SecretsManager:
         return DeleteSecretValueResultSuccess()
 
     def get_secret(self, secret_name: str, default: str | None = None) -> str | None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         value = get_key(self.env_var_path, secret_name)
         if value is None:
-            GriptapeNodes.get_logger().warning(
+            logger.warning(
                 "Secret %s not found in %s, looking in environment variables", secret_name, self.env_var_path
             )
             # Check if the secret is set in the environment variables
             value = getenv(secret_name)
         if value is None:
-            GriptapeNodes.get_logger().warning(
-                "Secret %s not found in environment variables, using default value %s", secret_name, default
-            )
+            logger.warning("Secret %s not found in environment variables, using default value %s", secret_name, default)
             # Check if the secret is set in the config manager
             value = default
         return value

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -121,6 +121,7 @@ class Settings(BaseSettings):
             "Serper": {"SERPER_API_KEY": "$SERPER_API_KEY"},
         }
     )
+    log_level: str = Field(default="INFO")
 
     class Config:
         json_file = _find_config_files("griptape_nodes_config", "json")

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
@@ -58,6 +59,8 @@ from griptape_nodes.retained_mode.events.parameter_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 MIN_NODES = 2
+
+logger = logging.getLogger("griptpae_nodes_engine")
 
 
 def node_param_split(node_and_param: str) -> tuple[str, str]:
@@ -177,7 +180,7 @@ class RetainedMode:
         if hasattr(result, "node_name"):
             return result.node_name
         # You could return the result object for debugging
-        print(f"Failed to create node: {result}")
+        logger.error("Failed to create node: %s", result)
         return result
 
     @classmethod
@@ -325,7 +328,7 @@ class RetainedMode:
                 final_param_name = base_param_name
             except Exception as e:
                 details = f"Invalid list index format in parameter name: '{param_name}'. Error: {e}."
-                GriptapeNodes.get_logger().error(details)
+                logger.exception(details)
                 # TODO(griptape): what to do here?
         return (final_param_name, index)
 
@@ -456,13 +459,13 @@ class RetainedMode:
                     idx = int(idx_or_key)
                 except ValueError:
                     error_msg = f"Failed on key/index '{idx_or_key}' because it wasn't an int as expected."
-                    print(error_msg)
+                    logger.exception(error_msg)
                     return GetParameterValueResultFailure()
 
                 # Handle negative indices
                 if idx < 0:
                     error_msg = f"Failed on key/index '{idx_or_key}' because it was less than zero."
-                    print(error_msg)
+                    logger.error(error_msg)
                     return GetParameterValueResultFailure()
 
                 # Extend the list if needed
@@ -477,7 +480,7 @@ class RetainedMode:
                     curr = curr[idx]
             else:
                 error_msg = f"Failed on key/index '{idx_or_key}' because it was a type that was not expected."
-                print(error_msg)
+                logger.error(error_msg)
                 return GetParameterValueResultFailure()
 
         # Update the container
@@ -513,17 +516,30 @@ class RetainedMode:
                 if isinstance(curr_pos_value, list):
                     # Index better be an int.
                     if not isinstance(idx_or_key, int):
-                        print(f'get_value failed for "{node}.{param}" on key/index "{idx_or_key}" only ints allowed.')
+                        logger.error(
+                            "get_value failed for %s.%s on key/index %s only ints allowed.",
+                            node,
+                            param,
+                            idx_or_key,
+                        )
                         return GetParameterValueResultFailure()
                     # Is the index in range?
                     if (idx_or_key < 0) or (idx_or_key >= len(curr_pos_value)):
-                        print(
-                            f'get_value failed for "{node}.{param}" for key/index "{idx_or_key}" being out of range. Object had {len(curr_pos_value)} elements.'
+                        logger.error(
+                            "get_value failed for %s.%s on key/index %s out of range.",
+                            node,
+                            param,
+                            idx_or_key,
                         )
                         return GetParameterValueResultFailure()
                     curr_pos_value = curr_pos_value[idx_or_key]
                 else:
-                    print(f'get_value failed for "{node}.{param}" on key/index "{idx_or_key}". Type Error.')
+                    logger.error(
+                        "get_value failed for %s.%s on key/index %s because it was a type that was not expected.",
+                        node,
+                        param,
+                        idx_or_key,
+                    )
                     return GetParameterValueResultFailure()
             # All done
             return curr_pos_value
@@ -561,8 +577,7 @@ class RetainedMode:
                 value=value,
             )
             result = GriptapeNodes().handle_request(request)
-            print("\n")
-            print(f"D:{result=}")
+            logger.info("\nD:%s", f"{result=}")
         else:
             # We have indices. Get the value of the container first, then attempt to move all the way up to the end.
             request = GetParameterValueRequest(
@@ -572,7 +587,12 @@ class RetainedMode:
             result = GriptapeNodes().handle_request(request)
 
             if not result.succeeded():
-                print(f'set_value failed for "{node}.{param}", failed to get value for container "{base_param_name}".')
+                logger.error(
+                    'set_value failed for "%s.%s", failed to get value for container "%s".',
+                    node,
+                    param,
+                    base_param_name,
+                )
                 return result
 
             base_container = result.value
@@ -585,12 +605,20 @@ class RetainedMode:
                     try:
                         idx_or_key_as_int = int(idx_or_key)
                     except ValueError:
-                        print(f'set_value for "{node}.{param}", failed on key/index "{idx_or_key}". Requires an int.')
+                        logger.exception(
+                            'set_value for "%s.%s", failed on key/index "%s". Requires an int.',
+                            node,
+                            param,
+                            idx_or_key,
+                        )
                         return GetParameterValueResultFailure()
                     # Is the index in range?
                     if idx_or_key_as_int < 0:
-                        print(
-                            f'set_value for "{node}.{param}", failed on key/index "{idx_or_key}" because it was less than zero.'
+                        logger.error(
+                            'set_value for "%s.%s", failed on key/index "%s" because it was less than zero.',
+                            node,
+                            param,
+                            idx_or_key,
                         )
                         return GetParameterValueResultFailure()
                     # Extend the list if needed to accommodate the index.
@@ -612,7 +640,12 @@ class RetainedMode:
                     # Advance.
                     curr_pos_value = curr_pos_value[idx_or_key_as_int]
                 else:
-                    print(f'set_value on "{node}.{param}" failed on key/index "{idx_or_key}": bad type')
+                    logger.error(
+                        'set_value on "%s.%s" failed on key/index "%s" because it was a type that was not expected.',
+                        node,
+                        param,
+                        idx_or_key,
+                    )
                     return GetParameterValueResultFailure()
             # All done
         return result


### PR DESCRIPTION
Adds the ability to change the log level via a new settings field, `log_level`. Also refactors usages of `print` and `LogManager.get_logger` to use native logging mechanism, `logging.getLogger`. This was required to avoid circular dependency issues.

Open questions:
1. [This rule](https://docs.astral.sh/ruff/rules/error-instead-of-exception/) encourages us to use `logger.exception` over `logger.error` inside of exceptions so that the traceback is shown. While I generally agree with this rule, even with [rich_tracebacks](https://rich.readthedocs.io/en/stable/logging.html#handle-exceptions), this can be kind of scary looking to users.
![image](https://github.com/user-attachments/assets/27b8fff9-2a99-4782-a392-7039a0d0121e)
What do we think? Do we want to ignore this rule in all scenarios where we properly handle the exception?

2. Loggers under the `api` package have been configured with module level loggers (`logging.getLogger(__name__)`). All other loggers have been configured with (`logging.getLogger("griptape_nodes_engine")`). Do we want to change this in any way?

Closes #217 