### PR TITLE
Remove Ruff Rules N999 and RUF012

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ ignore = [
   "SIM108", # Intentional
   "SIM110", # Intentional
   "D105",   # Intentional
-  "N999",   # TODO(griptape): discuss with team
   "N802",   # TODO(griptape): discuss with team
   "TRY002", # TODO(griptape): discuss with team
   "RUF012", # TODO(griptape): discuss with team

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ ignore = [
   "D105",   # Intentional
   "N802",   # TODO(griptape): discuss with team
   "TRY002", # TODO(griptape): discuss with team
-  "RUF012", # TODO(griptape): discuss with team
   "FBT003", # Intentional
   "RET504", # Intentional
 ]

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -32,7 +32,7 @@ class ParameterTypeBuiltin(Enum):
 
 
 class ParameterType:
-    _builtin_aliases = {
+    _builtin_aliases: ClassVar[dict] = {
         "str": ParameterTypeBuiltin.STR,
         "string": ParameterTypeBuiltin.STR,
         "bool": ParameterTypeBuiltin.BOOL,

--- a/src/griptape_nodes/exe_types/data_types.py
+++ b/src/griptape_nodes/exe_types/data_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -139,7 +139,7 @@ class EnumPropertyArray(PropertyArray[Enum]):
     """Base class for property arrays of Enum values."""
 
     # List of enum types for each component
-    enum_types: list[type[Enum] | None] = []
+    enum_types: ClassVar[list[type[Enum] | None]] = []
 
     def _process_enum_value(self, value, index) -> str | float | int:
         """Convert string to enum value if needed, using the enum type at the specified index."""
@@ -249,7 +249,7 @@ class Str4(PropertyArray[str]):
 class Enum2(EnumPropertyArray):
     """A 2D property array for Enum values."""
 
-    enum_types = [None, None]  # Placeholder, to be set by subclassing
+    enum_types: ClassVar[list] = [None, None]  # Placeholder, to be set by subclassing
 
     def __init__(self, x=None, y=None) -> None:
         # Set defaults based on enum types
@@ -269,7 +269,7 @@ class Enum2(EnumPropertyArray):
 class Enum3(EnumPropertyArray):
     """A 3D property array for Enum values."""
 
-    enum_types = [None, None, None]
+    enum_types: ClassVar[list] = [None, None, None]
 
     def __init__(self, x=None, y=None, z=None) -> None:
         # Set defaults based on enum types
@@ -294,7 +294,7 @@ class Enum3(EnumPropertyArray):
 class Enum4(EnumPropertyArray):
     """A 4D property array for Enum values."""
 
-    enum_types = [None, None, None, None]
+    enum_types: ClassVar[list] = [None, None, None, None]
 
     def __init__(self, x=None, y=None, z=None, w=None) -> None:
         # Set defaults based on enum types

--- a/src/griptape_nodes/node_library/script_registry.py
+++ b/src/griptape_nodes/node_library/script_registry.py
@@ -27,8 +27,12 @@ class ScriptRegistry(SingletonMixin):
     class _RegistryKey:
         """Private class for script construction."""
 
-    _scripts: dict[str, Script] = {}
+    _scripts: dict[str, Script]
     _registry_key: _RegistryKey = _RegistryKey()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._scripts = {}
 
     # Create a new script with everything we'd need
     @classmethod

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -93,7 +93,7 @@ class BaseEvent(BaseModel, ABC):
     # Custom JSON encoder for the payload
     class Config:
         arbitrary_types_allowed = True
-        json_encoders = {
+        json_encoders: ClassVar[dict] = {
             # Use to_dict() methods for Griptape objects
             BaseArtifact: lambda obj: obj.to_dict(),
             BaseTool: lambda obj: obj.to_dict(),

--- a/src/griptape_nodes/retained_mode/events/payload_registry.py
+++ b/src/griptape_nodes/retained_mode/events/payload_registry.py
@@ -10,7 +10,11 @@ T = TypeVar("T", bound=Payload, default=Payload)
 class PayloadRegistry(SingletonMixin):
     """Registry for payload types."""
 
-    _registry: dict[str, type[Payload]] = {}
+    _registry: dict[str, type[Payload]]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._registry = {}
 
     @classmethod
     def register(cls, payload_class: type[T]) -> type[T]:

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -230,7 +230,7 @@ logger = logging.getLogger("griptape_nodes")
 
 
 class SingletonMeta(type):
-    _instances = {}
+    _instances: ClassVar[dict] = {}
 
     def __call__(cls, *args, **kwargs) -> Any:
         if cls not in cls._instances:

--- a/src/griptape_nodes/traits/minmax.py
+++ b/src/griptape_nodes/traits/minmax.py
@@ -11,7 +11,7 @@ class MinMax(Trait):
     max: Any = 30
     element_id: str = field(default_factory=lambda: "MinMaxTrait")
 
-    _allowed_modes = {ParameterMode.PROPERTY}
+    _allowed_modes: set = field(default_factory=lambda: {ParameterMode.PROPERTY})
 
     def __init__(self, min_val: float, max_val: float) -> None:
         super().__init__()

--- a/src/griptape_nodes/traits/slider.py
+++ b/src/griptape_nodes/traits/slider.py
@@ -11,7 +11,7 @@ class Slider(Trait):
     max: Any = 100
     element_id: str = field(default_factory=lambda: "Slider")
 
-    _allowed_modes = {ParameterMode.PROPERTY}
+    _allowed_modes: set = field(default_factory=lambda: {ParameterMode.PROPERTY})
 
     def __init__(self, min_val: float, max_val: float) -> None:
         super().__init__()

--- a/src/griptape_nodes/traits/trait_registry.py
+++ b/src/griptape_nodes/traits/trait_registry.py
@@ -12,7 +12,11 @@ if TYPE_CHECKING:
 class TraitRegistry(SingletonMixin):
     # I'm going to create a dictionary that stores all of the created traits we have so far?
     # Traits will be associated with certain key words
-    key_to_trait: dict[str, list[Trait.__class__]] = {}
+    key_to_trait: dict[str, list[Trait.__class__]]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.key_to_trait = {}
 
     @classmethod
     def create_traits(cls, key_word: str) -> list[Trait] | None:


### PR DESCRIPTION
- [N999](https://docs.astral.sh/ruff/rules/invalid-module-name/)
- [RUF012](https://docs.astral.sh/ruff/rules/mutable-class-default/)

@SavagePencil for RUF012, can you please make sure these are actually intended to be `ClassVar`s?