### PR TITLE
fix: log ConfigManager's loaded logs in app, not constructor

### DIFF
--- a/src/griptape_nodes/api/app.py
+++ b/src/griptape_nodes/api/app.py
@@ -52,6 +52,15 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
+config_files = GriptapeNodes.ConfigManager().config_files
+if len(config_files) == 0:
+    logger.info("No configuration files were found. Will run using default values.")
+else:
+    logger.info("Configuration files were found at the following locations and merged in this order:")
+    for config_file in config_files:
+        logger.info("\t%s", config_file)
+
+
 def run_with_context(func: Callable) -> Callable:
     ctx = contextvars.copy_context()
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -58,13 +58,6 @@ class ConfigManager:
             event_manager.assign_manager_to_request_type(GetConfigValueRequest, self.on_handle_get_config_value_request)
             event_manager.assign_manager_to_request_type(SetConfigValueRequest, self.on_handle_set_config_value_request)
 
-            if len(self.config_files) == 0:
-                logger.info("No configuration files were found. Will run using default values.")
-            else:
-                logger.info("Configuration files were found at the following locations and merged in this order:")
-                for config_file in self.config_files:
-                    logger.info("\t%s", config_file)
-
     @property
     def workspace_path(self) -> Path:
         """Get the base file path from the configuration.


### PR DESCRIPTION
This happens because we initialize an GriptapeNodes instance for each thread (main thread, background event queue).
Fixes https://github.com/griptape-ai/griptape-nodes/issues/246