### PR TITLE
style: add mdformat plugins for mkdocs, format repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,22 +6,22 @@ We welcome contributions to the Griptape Nodes project! Whether it's bug fixes, 
 
 1. **Clone the Repository:**
 
-   ```shell
-   git clone https://github.com/griptape-ai/griptape-nodes.git
-   cd griptape-nodes
-   ```
+    ```shell
+    git clone https://github.com/griptape-ai/griptape-nodes.git
+    cd griptape-nodes
+    ```
 
 1. **Install `uv`:**
-   If you don't have `uv` installed, follow the official instructions: [Astral's uv Installation Guide](https://docs.astral.sh/uv/getting-started/installation/).
+    If you don't have `uv` installed, follow the official instructions: [Astral's uv Installation Guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 1. **Install Dependencies:**
-   Use `uv` to create a virtual environment and install all required dependencies, including base, development, testing, and documentation tools:
+    Use `uv` to create a virtual environment and install all required dependencies, including base, development, testing, and documentation tools:
 
-   ```shell
-   uv sync -p --all-extras
-   ```
+    ```shell
+    uv sync -p --all-extras
+    ```
 
-   This command reads the `pyproject.toml` file and installs everything needed for development within a `.venv` directory.
+    This command reads the `pyproject.toml` file and installs everything needed for development within a `.venv` directory.
 
 ## Running the Engine Locally for Development
 
@@ -30,39 +30,39 @@ When developing, you typically want to run the engine using your local source co
 **Key Development Commands:**
 
 - **Run the Engine:** Use `uv run` to execute the engine script (`gtn` or `griptape-nodes`) within the virtual environment managed by `uv`.
-  ```shell
-  uv run gtn
-  # or
-  uv run griptape-nodes engine
-  ```
+    ```shell
+    uv run gtn
+    # or
+    uv run griptape-nodes engine
+    ```
 - **Run Initialization:** To trigger the initial setup prompts (API Key, Workspace Directory) using the local code:
-  ```shell
-  uv run gtn init
-  ```
+    ```shell
+    uv run gtn init
+    ```
 - **Run Tests:**
-  ```shell
-  uv run pytest
-  # or use the Makefile shortcut
-  make test/unit
-  ```
+    ```shell
+    uv run pytest
+    # or use the Makefile shortcut
+    make test/unit
+    ```
 - **Check Code (Linting & Formatting):**
-  ```shell
-  uv run ruff check . && uv run ruff format . --check && uv run pyright
-  # or use the Makefile shortcut
-  make check
-  ```
+    ```shell
+    uv run ruff check . && uv run ruff format . --check && uv run pyright
+    # or use the Makefile shortcut
+    make check
+    ```
 - **Format Code:**
-  ```shell
-  uv run ruff format .
-  # or use the Makefile shortcut
-  make format
-  ```
+    ```shell
+    uv run ruff format .
+    # or use the Makefile shortcut
+    make format
+    ```
 - **Fix Code Automatically (Format + Lint):**
-  ```shell
-  uv run ruff check . --fix && uv run ruff format .
-  # or use the Makefile shortcut
-  make fix
-  ```
+    ```shell
+    uv run ruff check . --fix && uv run ruff format .
+    # or use the Makefile shortcut
+    make fix
+    ```
 
 **Connecting to a Different API Backend:**
 
@@ -82,21 +82,21 @@ Griptape Nodes uses a configuration loading system. For full details, see the [C
 
 1. **Using the Local Nodes Library:** By default, a regularly installed engine looks for node definitions (the `griptape_nodes_library.json`) in a system data directory. For development, you **must** tell the engine (run via `uv run gtn`) to use the library file directly from your cloned repository (`./nodes/griptape_nodes_library.json`).
 
-   - **How to Override:** Create a configuration file in a location that has higher priority than the default system paths. The simplest location is the **root of your cloned `griptape-nodes` repository**.
-   - Create a file named `griptape_nodes_config.json` in the project root.
-   - Add the following content:
-     ```json
-     {
-       "app_events": {
-         "on_app_initialization_complete": {
-           "libraries_to_register": [
-             "nodes/griptape_nodes_library.json"
-           ]
-         }
-       }
-     }
-     ```
-   - **Why this works:** When you run `uv run gtn` from the project root, the engine's configuration loader finds this `griptape_nodes_config.json` first (due to the "Current Directory & Parents" search path) and uses its `libraries_to_register` setting, overriding the default path.
+    - **How to Override:** Create a configuration file in a location that has higher priority than the default system paths. The simplest location is the **root of your cloned `griptape-nodes` repository**.
+    - Create a file named `griptape_nodes_config.json` in the project root.
+    - Add the following content:
+        ```json
+        {
+          "app_events": {
+            "on_app_initialization_complete": {
+              "libraries_to_register": [
+                "nodes/griptape_nodes_library.json"
+              ]
+            }
+          }
+        }
+        ```
+    - **Why this works:** When you run `uv run gtn` from the project root, the engine's configuration loader finds this `griptape_nodes_config.json` first (due to the "Current Directory & Parents" search path) and uses its `libraries_to_register` setting, overriding the default path.
 
 ## Contributing to Documentation
 
@@ -108,11 +108,11 @@ The documentation website ([docs.griptapenodes.com](https://docs.griptapenodes.c
 
 1. **Serving Locally:** To preview your changes live, run the MkDocs development server:
 
-   ```shell
-   uv run mkdocs serve
-   ```
+    ```shell
+    uv run mkdocs serve
+    ```
 
-   This will start a local webserver (usually at `http://127.0.0.1:8000/`). The site will automatically reload when you save changes to the documentation files or `mkdocs.yml`.
+    This will start a local webserver (usually at `http://127.0.0.1:8000/`). The site will automatically reload when you save changes to the documentation files or `mkdocs.yml`.
 
 1. **Making Changes:** Edit the Markdown files in the `/docs` directory. Add new pages by creating new `.md` files and updating the `nav` section in `mkdocs.yml`.
 
@@ -133,18 +133,18 @@ The documentation website ([docs.griptapenodes.com](https://docs.griptapenodes.c
 ## Making a Release (Maintainers)
 
 1. Check out the `main` branch locally:
-   ```shell
-   git checkout main
-   git pull origin main
-   ```
+    ```shell
+    git checkout main
+    git pull origin main
+    ```
 1. Set the new release version (this creates Git tags):
-   ```shell
-   # Example for version 0.8.0
-   make version/set v=0.8.0
-   ```
+    ```shell
+    # Example for version 0.8.0
+    make version/set v=0.8.0
+    ```
 1. Publish the release (pushes tags to trigger GitHub Actions workflow):
-   ```shell
-   make version/publish
-   ```
+    ```shell
+    make version/publish
+    ```
 
 Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ Follow these steps to get the Griptape Nodes engine running on your system:
 
 1. **Install Command:** Once logged in, you'll find a setup screen. Copy the installation command provided in the "New Installation" section. It will look similar to this (use the **exact** command provided on the website):
 
-   ```bash
-   curl -LsSf https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/install.sh | bash
-   ```
+    ```bash
+    curl -LsSf https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/install.sh | bash
+    ```
 
 1. **Run Installer:** Open a terminal on your machine (local or cloud environment) and paste/run the command. The installer uses `uv` for fast installation; if `uv` isn't present, the script will typically handle installing it.
 
 1. **Initial Configuration (Automatic on First Run):**
 
-   - The first time you run the engine command (`griptape-nodes` or `gtn`), it will guide you through the initial setup:
-   - **Workspace Directory:** You'll be prompted to choose a directory where Griptape Nodes will store configurations, project files, secrets (`.env`), and generated assets. You can accept the default (`<current_directory>/GriptapeNodes`) or specify a custom path.
-   - **Griptape Cloud API Key:** Return to the [Griptape Nodes setup page](https://griptapenodes.com) in your browser, click "Generate API Key", copy the key, and paste it when prompted in the terminal.
+    - The first time you run the engine command (`griptape-nodes` or `gtn`), it will guide you through the initial setup:
+    - **Workspace Directory:** You'll be prompted to choose a directory where Griptape Nodes will store configurations, project files, secrets (`.env`), and generated assets. You can accept the default (`<current_directory>/GriptapeNodes`) or specify a custom path.
+    - **Griptape Cloud API Key:** Return to the [Griptape Nodes setup page](https://griptapenodes.com) in your browser, click "Generate API Key", copy the key, and paste it when prompted in the terminal.
 
 1. **Start the Engine:** After configuration, start the engine by running:
 
-   ```bash
-   griptape-nodes
-   ```
+    ```bash
+    griptape-nodes
+    ```
 
-   *(or the shorter alias `gtn`)*
+    *(or the shorter alias `gtn`)*
 
 1. **Connect IDE:** Refresh the Griptape Nodes IDE page in your browser. It should now connect to your running engine.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,39 +9,39 @@ When running Griptape Nodes engine on your own machine, you are provided with ut
 Griptape Nodes employs a specific search order to load settings from environment variables and configuration files. Understanding this process is key to managing your setup.
 
 1. **Environment Variables (`.env`)**
-   Environment variables are used to securely store sensitive secrets like API keys. Griptape Nodes automatically loads env files, making these secrets available to the application.
+    Environment variables are used to securely store sensitive secrets like API keys. Griptape Nodes automatically loads env files, making these secrets available to the application.
 
-   - The primary `.env` file is loaded from the system-wide user configuration directory: `xdg_config_home() / "griptape_nodes" / ".env"` (commonly `~/.config/griptape_nodes/.env`).
-   - This file is intended for secrets like `GT_CLOUD_API_KEY`, `OPENAI_API_KEY`.
+    - The primary `.env` file is loaded from the system-wide user configuration directory: `xdg_config_home() / "griptape_nodes" / ".env"` (commonly `~/.config/griptape_nodes/.env`).
+    - This file is intended for secrets like `GT_CLOUD_API_KEY`, `OPENAI_API_KEY`.
 
-> You shouldn't interact with these files directly. Griptape Nodes manages your environment variables through its Settings dialog.
+    > You shouldn't interact with these files directly. Griptape Nodes manages your environment variables through its Settings dialog.
 
-2. **Configuration Files (`griptape_nodes_config.[json|yaml|toml]`)**
-   Configuration files hold information important for Griptape Nodes operation, such as where to locate Node Libraries, as well as user preferences to customize the Griptape Nodes experience.
+1. **Configuration Files (`griptape_nodes_config.[json|yaml|toml]`)**
+    Configuration files hold information important for Griptape Nodes operation, such as where to locate Node Libraries, as well as user preferences to customize the Griptape Nodes experience.
 
-   - If no configuration files are found, Griptape Nodes will issue a warning and attempt to run using built-in default values.
-   - The application searches for configuration files named `griptape_nodes_config` with `.json`, `.yaml`, or `.toml` extensions.
-   - It searches in multiple locations in a specific order. **All** valid configuration files found across these locations are loaded and their settings are **merged**.
-   - **Search Order (Lower numbers are checked first, but higher numbers override):**
-     1. **System-wide Shared:** Paths in `XDG_CONFIG_DIRS` (e.g., `/etc/xdg/griptape_nodes/`). Settings here have the *lowest* priority.
-     1. **System-wide User:** Path in `XDG_CONFIG_HOME` (e.g., `~/.config/griptape_nodes/`). Settings here override System-wide Shared.
-     1. **Implicit CWD Subdirectory:** `current_working_directory / "GriptapeNodes" /` (relative to where `gtn` is run). Settings here override System User.
-     1. **Current Directory & Parents:** The current working directory (`cwd`) and its parent directories up to the user's home directory (`~`). Settings found closer to `cwd` have *higher* priority and override settings from parent directories and all locations above.
-   - **Override Priority:** Because settings are merged, if the same setting exists in multiple files, the value from the file found *later* in the search order (i.e., closer to the current directory) takes precedence. For example, a setting in `./griptape_nodes_config.json` will override the same setting in `~/.config/griptape_nodes/griptape_nodes_config.json`.
-   - **File Type Priority:** If multiple file types (e.g., `.json` and `.yaml`) exist in the *same directory*, they are all loaded, but the priority for merging within that *single* directory is: `.json` > `.yaml` > `.toml`.
+    - If no configuration files are found, Griptape Nodes will issue a warning and attempt to run using built-in default values.
+    - The application searches for configuration files named `griptape_nodes_config` with `.json`, `.yaml`, or `.toml` extensions.
+    - It searches in multiple locations in a specific order. **All** valid configuration files found across these locations are loaded and their settings are **merged**.
+    - **Search Order (Lower numbers are checked first, but higher numbers override):**
+        1. **System-wide Shared:** Paths in `XDG_CONFIG_DIRS` (e.g., `/etc/xdg/griptape_nodes/`). Settings here have the *lowest* priority.
+        1. **System-wide User:** Path in `XDG_CONFIG_HOME` (e.g., `~/.config/griptape_nodes/`). Settings here override System-wide Shared.
+        1. **Implicit CWD Subdirectory:** `current_working_directory / "GriptapeNodes" /` (relative to where `gtn` is run). Settings here override System User.
+        1. **Current Directory & Parents:** The current working directory (`cwd`) and its parent directories up to the user's home directory (`~`). Settings found closer to `cwd` have *higher* priority and override settings from parent directories and all locations above.
+    - **Override Priority:** Because settings are merged, if the same setting exists in multiple files, the value from the file found *later* in the search order (i.e., closer to the current directory) takes precedence. For example, a setting in `./griptape_nodes_config.json` will override the same setting in `~/.config/griptape_nodes/griptape_nodes_config.json`.
+    - **File Type Priority:** If multiple file types (e.g., `.json` and `.yaml`) exist in the *same directory*, they are all loaded, but the priority for merging within that *single* directory is: `.json` > `.yaml` > `.toml`.
 
 1. **Defaults and Merging**
-   Griptape Nodes comes with built-in default settings for various options, including the default workspace directory. These defaults are used unless overridden by settings loaded from discovered configuration files.
+    Griptape Nodes comes with built-in default settings for various options, including the default workspace directory. These defaults are used unless overridden by settings loaded from discovered configuration files.
 
-   - Settings loaded from the first found configuration file override the built-in default values.
-   - If no configuration file is found in any of the search paths, the application uses only the built-in defaults.
-   - One key default is `workspace_directory`, which defaults to `<current_working_directory>/GriptapeNodes` if not specified in a loaded configuration file.
+    - Settings loaded from the first found configuration file override the built-in default values.
+    - If no configuration file is found in any of the search paths, the application uses only the built-in defaults.
+    - One key default is `workspace_directory`, which defaults to `<current_working_directory>/GriptapeNodes` if not specified in a loaded configuration file.
 
 1. **Runtime Management (`ConfigManager`)**
-   After initial settings are loaded, the `ConfigManager` handles runtime operations using the final resolved configuration, particularly the workspace directory. It's responsible for saving user-specific changes, like registered workflows, back to a configuration file within the workspace.
+    After initial settings are loaded, the `ConfigManager` handles runtime operations using the final resolved configuration, particularly the workspace directory. It's responsible for saving user-specific changes, like registered workflows, back to a configuration file within the workspace.
 
-   - Once settings are loaded, the `ConfigManager` uses the final resolved `workspace_directory`.
-   - Modifications made at runtime (e.g., registering custom workflows) are typically saved by the `ConfigManager` into a `griptape_nodes_config.json` file located within this resolved `workspace_directory`.
+    - Once settings are loaded, the `ConfigManager` uses the final resolved `workspace_directory`.
+    - Modifications made at runtime (e.g., registering custom workflows) are typically saved by the `ConfigManager` into a `griptape_nodes_config.json` file located within this resolved `workspace_directory`.
 
 ## Loading Examples
 
@@ -57,22 +57,22 @@ Here are a few scenarios to illustrate how configuration files are located and l
 
 - **File Structure:**
 
-  ```
-  /home/user/
-      my_project/          <-- CWD when running 'gtn'
-          GriptapeNodes/   <-- Default Workspace (may contain runtime saved config)
-          my_flow.graph.json
-      .config/
-          griptape_nodes/
-              .env                     # Loaded for environment variables
-              griptape_nodes_config.json # Contains workspace_directory = /home/user/my_project/GriptapeNodes
-  ```
+    ```
+    /home/user/
+        my_project/          <-- CWD when running 'gtn'
+            GriptapeNodes/   <-- Default Workspace (may contain runtime saved config)
+            my_flow.graph.json
+        .config/
+            griptape_nodes/
+                .env                     # Loaded for environment variables
+                griptape_nodes_config.json # Contains workspace_directory = /home/user/my_project/GriptapeNodes
+    ```
 
 - **Loading Process:**
 
-  1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
-  1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!).
-  1. **Result:** The application loads settings from `~/.config/griptape_nodes/griptape_nodes_config.json`. The `workspace_directory` is set to `/home/user/my_project/GriptapeNodes`. Subsequent runtime changes managed by `ConfigManager` will be saved to `/home/user/my_project/GriptapeNodes/griptape_nodes_config.json`.
+    1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
+    1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!).
+    1. **Result:** The application loads settings from `~/.config/griptape_nodes/griptape_nodes_config.json`. The `workspace_directory` is set to `/home/user/my_project/GriptapeNodes`. Subsequent runtime changes managed by `ConfigManager` will be saved to `/home/user/my_project/GriptapeNodes/griptape_nodes_config.json`.
 
 **Scenario 2: Custom Workspace**
 
@@ -86,24 +86,24 @@ Here are a few scenarios to illustrate how configuration files are located and l
 
 - **File Structure:**
 
-  ```
-  /home/user/
-      some_dir/            <-- CWD when running 'gtn'
-      .config/
-          griptape_nodes/
-              .env                     # Loaded for environment variables
-              griptape_nodes_config.json # Contains workspace_directory = /data/gtn_work
-  /data/
-      gtn_work/            <-- Custom Workspace
-          griptape_nodes_config.yaml # Manually created / runtime saved config
-          project_flows/
-  ```
+    ```
+    /home/user/
+        some_dir/            <-- CWD when running 'gtn'
+        .config/
+            griptape_nodes/
+                .env                     # Loaded for environment variables
+                griptape_nodes_config.json # Contains workspace_directory = /data/gtn_work
+    /data/
+        gtn_work/            <-- Custom Workspace
+            griptape_nodes_config.yaml # Manually created / runtime saved config
+            project_flows/
+    ```
 
 - **Loading Process:**
 
-  1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
-  1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!).
-  1. **Result:** The application *initially* loads settings from `~/.config/griptape_nodes/griptape_nodes_config.json`. The `workspace_directory` is set to `/data/gtn_work`. Even though `/data/gtn_work/griptape_nodes_config.yaml` exists, it's not checked during initial load because a higher priority file was found. Runtime changes will be saved back to `/data/gtn_work/griptape_nodes_config.json` (overwriting/merging with the YAML potentially, depending on `ConfigManager`'s save logic).
+    1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
+    1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!).
+    1. **Result:** The application *initially* loads settings from `~/.config/griptape_nodes/griptape_nodes_config.json`. The `workspace_directory` is set to `/data/gtn_work`. Even though `/data/gtn_work/griptape_nodes_config.yaml` exists, it's not checked during initial load because a higher priority file was found. Runtime changes will be saved back to `/data/gtn_work/griptape_nodes_config.json` (overwriting/merging with the YAML potentially, depending on `ConfigManager`'s save logic).
 
 **Scenario 3: Config in Current Directory (No System Config)**
 
@@ -115,21 +115,21 @@ Here are a few scenarios to illustrate how configuration files are located and l
 
 - **File Structure:**
 
-  ```
-  /home/user/
-      my_project/          <-- CWD when running 'gtn'
-          griptape_nodes_config.toml # User-created config
-          GriptapeNodes/   <-- Potential default workspace location
-          my_flow.graph.json
-  ```
+    ```
+    /home/user/
+        my_project/          <-- CWD when running 'gtn'
+            griptape_nodes_config.toml # User-created config
+            GriptapeNodes/   <-- Potential default workspace location
+            my_flow.graph.json
+    ```
 
 - **Loading Process:**
 
-  1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
-  1. Checks `~/.config/griptape_nodes/` (Assume not found).
-  1. Checks `/home/user/my_project/GriptapeNodes/` (Assume not found).
-  1. Checks `/home/user/my_project/griptape_nodes_config.toml` (Found!).
-  1. **Result:** The application loads settings from `/home/user/my_project/griptape_nodes_config.toml`. If this file specifies a `workspace_directory`, that path is used. If not, the default (`<cwd>/GriptapeNodes` = `/home/user/my_project/GriptapeNodes`) is used.
+    1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
+    1. Checks `~/.config/griptape_nodes/` (Assume not found).
+    1. Checks `/home/user/my_project/GriptapeNodes/` (Assume not found).
+    1. Checks `/home/user/my_project/griptape_nodes_config.toml` (Found!).
+    1. **Result:** The application loads settings from `/home/user/my_project/griptape_nodes_config.toml`. If this file specifies a `workspace_directory`, that path is used. If not, the default (`<cwd>/GriptapeNodes` = `/home/user/my_project/GriptapeNodes`) is used.
 
 ## Workspace Directory
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
-# Getting Started with Griptape\*\*\*[nodes]\*\*\*
+# Getting Started with Griptape **_Nodes_**
 
-An important bit of overview before we begin: Griptape\*\*\*[nodes]\*\*\* is actually two things that work together: An Engine, and a UI. The Engine will install and run on your computer, while the UI is served from the web, and you'll interact with your Engine through a web browser.
+An important bit of overview before we begin: Griptape **_Nodes_** is actually two things that work together: An Engine, and a UI. The Engine will install and run on your computer, while the UI is served from the web, and you'll interact with your Engine through a web browser.
 
 > - If you'd rather not install the Engine locally, it is also easy to run it in a hosted environment. The instructions that follow will work the same for either approach.
 
@@ -34,7 +34,7 @@ Copy the installation command from the **New Installation** section (it's the bi
 > Remember, you can install this on your local machine *or* a cloud-based workstation.
 
 <!--
-> * Griptape***[nodes]*** uses **uv**. **uv** is a Python package installer and environment manager.  If you already have it, great!  If not, this process will install it for you.  This is just info - nothing is required on your part either way.
+> * Griptape **_Nodes_** uses *uv*. *uv* is a Python package installer and environment manager.  If you already have it, great!  If not, this process will install it for you.  This is just info - nothing is required on your part either way.
 -->
 
 ![Installation Page](assets/img/getting_started/getting_started-installation_page.png)
@@ -55,7 +55,7 @@ You'll see this message when installation has completed:
 
 ## 3. Configuration
 
-**First**, you'll be prompted to set your *workspace directory*. Your workspace directory is where the Griptape\*\*\*[nodes]\*\*\* engine will save \[configuration settings\](reference/glossary.md#Configuration Settings), \[project files\](reference/glossary.md#Project Files), and \[generated assets\](reference/glossary.md#Generated Assets). It will also contain a [.env](reference/glossary.md#.env) for your project \[secret keys\](reference/glossary.md#Secret Keys).
+**First**, you'll be prompted to set your *workspace directory*. Your workspace directory is where the Griptape **_Nodes_** engine will save \[configuration settings\](reference/glossary.md#Configuration Settings), \[project files\](reference/glossary.md#Project Files), and \[generated assets\](reference/glossary.md#Generated Assets). It will also contain a [.env](reference/glossary.md#.env) for your project \[secret keys\](reference/glossary.md#Secret Keys).
 
 ```
 ╭───────────────────────────────────────────────────────────────────╮
@@ -94,6 +94,6 @@ Griptape API Key (YOUR-KEY-HERE):
 
 ## 4. Start Your Engine
 
-You're ready to proceed. Run either `griptape-nodes` or `gtn` and refresh your browser. You should be taken to an Untitled flow in Griptape\*\*\*[nodes]\*\*\*!.
+You're ready to proceed. Run either `griptape-nodes` or `gtn` and refresh your browser. You should be taken to an Untitled flow in Griptape **_Nodes_**!.
 
-![A Blank Griptape[nodes] editor](assets/img/getting_started/getting_started-blank_editor.png)
+![A Blank Griptape_nodes_ editor](assets/img/getting_started/getting_started-blank_editor.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
-# Griptape\*\*\*[nodes]\*\*\* Documentation
+# Griptape **_Nodes_** Documentation
 
-Welcome to the official Griptape\*\*\*[nodes]\*\*\* Documentation!
-Here, you'll find everything you need to know on how interact with the GUI which will let you open, construct, and save flows. You'll learn about our [custom scripting interface](reference/retained_mode.md), and even build your own [nodes](nodes/overview.md).
+Welcome to the official Griptape **_Nodes_** Documentation!
+Here, you'll find everything you need to know on how interact with the GUI which will let you open, construct, and save flows. You'll learn about our [custom scripting interface](reference/retained_mode.md), and even build your own _nodes_(nodes/overview.md).
 
 The documentation is structured to provide step-by-step guidance on using the Griptape GUI. It explains the processes involved in constructing
 flows, utilizing the custom scripting interface, and creating custom nodes. Users can learn how to navigate the interface, understand node
@@ -15,5 +15,5 @@ By exploring this documentation, users can learn:
 - How to build and integrate custom nodes into the Griptape framework.
 - The functionalities and applications of various nodes available within Griptape.
 
-Overall, the Griptape\*\*\*[nodes]\*\*\* Documentation is an essential resource for anyone looking to leverage the full potential of the Griptape framework
+Overall, the Griptape **_Nodes_** Documentation is an essential resource for anyone looking to leverage the full potential of the Griptape framework
 in their projects.

--- a/docs/nodes/dict/merge_key_value_pair.md
+++ b/docs/nodes/dict/merge_key_value_pair.md
@@ -14,10 +14,10 @@ Use this node when you need to combine multiple sets of key-value pairs into a s
 
 1. Add the `MergeKeyValuePair` node to your workflow.
 1. Connect four input parameters to the node:
-   - `key_value_pair_1`
-   - `key_value_pair_2`
-   - `key_value_pair_3`
-   - `key_value_pair_4`
+    - `key_value_pair_1`
+    - `key_value_pair_2`
+    - `key_value_pair_3`
+    - `key_value_pair_4`
 
 These inputs should be dictionaries containing key-value pairs.
 

--- a/docs/nodes/drivers/griptape_cloud_image_driver.md
+++ b/docs/nodes/drivers/griptape_cloud_image_driver.md
@@ -44,7 +44,7 @@ Imagine you want to create images using Griptape Cloud:
 - You need a valid Griptape API key set up in your environment as `GT_CLOUD_API_KEY`
 - Currently, only DALL-E 3 is supported through this driver
 - The node will automatically adjust image sizes based on model capabilities:
-  - DALL-E 3 only supports 1024x1024, 1024x1792, and 1792x1024
+- DALL-E 3 only supports 1024x1024, 1024x1792, and 1792x1024
 
 ## Common Issues
 

--- a/docs/nodes/overview.md
+++ b/docs/nodes/overview.md
@@ -1,6 +1,6 @@
-# Griptape\*\*\*[Nodes]\*\*\*... **Nodes**
+# Griptape **[Nodes]**... **Nodes**
 
-This documentation provides a comprehensive overview of the various nodes available within Griptape\*\*\*[nodes]\*\*\*. It focuses on individual nodes, their specific capabilities, and how they can interact with each other, explaining:
+This documentation provides a comprehensive overview of the various nodes available within Griptape **_Nodes_**. It focuses on individual nodes, their specific capabilities, and how they can interact with each other, explaining:
 
 - Core functionality and purpose
 - Configuration options and parameters

--- a/docs/nodes/rules/create_ruleset.md
+++ b/docs/nodes/rules/create_ruleset.md
@@ -16,8 +16,7 @@ Use this node when you want to:
 
 1. Add the CreateRuleset to your workspace
 1. Set the "name" parameter to define the name for your ruleset (optional, defaults to "Behavior")
-1. Set the "rules" parameter to define the list of rules for your ruleset (optional, defaults to an
-   empty string, comma separated)
+1. Set the "rules" parameter to define the list of rules for your ruleset (optional, defaults to an empty string, comma separated)
 1. Connect it to your flow (specifically into nodes that have a Ruleset parameter)
 
 ### Parameters
@@ -34,21 +33,22 @@ Use this node when you want to:
 Imagine you want to create a new ruleset with the following name and rules:
 
 1. Add a CreateRuleset to your workflow
+
 1. Set the "name" parameter to:
 
-```
-MyBehavioralRules
-```
+    ```
+    MyBehavioralRules
+    ```
 
-3. Set the "rules" parameter to:
+1. Set the "rules" parameter to:
 
-```
-Rule 1: This is my first rule.
-Rule 2: This is my second rule.
-Rule 3: This is my third rule.
-```
+    ```
+    Rule 1: This is my first rule.
+    Rule 2: This is my second rule.
+    Rule 3: This is my third rule.
+    ```
 
-4. Connect the output of this node to an agent's Ruleset parameter
+1. Connect the output of this node to an agent's Ruleset parameter
 
 ## Important Notes
 

--- a/docs/nodes/text/create_multiline_text.md
+++ b/docs/nodes/text/create_multiline_text.md
@@ -34,18 +34,19 @@ Use the CreateMultilineText node when:
 A workflow to create a prompt for an AI assistant:
 
 1. Add a CreateMultilineText node to your workflow
+
 1. Set the "text" parameter to:
 
-```
-You are a helpful tour guide assistant.
-Please provide information about the following location:
-- History of the place
-- Main attractions
-- Best time to visit
-- Local cuisine
-```
+    ```
+    You are a helpful tour guide assistant.
+    Please provide information about the following location:
+    - History of the place
+    - Main attractions
+    - Best time to visit
+    - Local cuisine
+    ```
 
-3. Connect the output to an Agent node's prompt parameter
+1. Connect the output to an Agent node's prompt parameter
 
 ## Important Notes
 

--- a/docs/nodes/tools/tool_list.md
+++ b/docs/nodes/tools/tool_list.md
@@ -23,18 +23,18 @@ Use this node when you want to:
 ### Fields
 
 - **tools**: A list of tools to combine into a single list.
-  - Input type: List of objects
-  - Allowed modes: INPUT
-  - Default value: Empty list
-  - Tooltip: List of tools to combine
+    - Input type: List of objects
+    - Allowed modes: INPUT
+    - Default value: Empty list
+    - Tooltip: List of tools to combine
 
 ### Outputs
 
 - **tool_list**: The combined list of tools.
-  - Output type: List of objects
-  - Allowed modes: OUTPUT
-  - Default value: Empty list
-  - Tooltip: Combined list of tools
+    - Output type: List of objects
+    - Allowed modes: OUTPUT
+    - Default value: Empty list
+    - Tooltip: Combined list of tools
 
 ## Example
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,10 +1,10 @@
-# Griptape\*\*\*[nodes]\*\*\* Framework Glossary for Artists
+# Griptape **_Nodes_** Framework Glossary for Artists
 
-## What is Griptape\*\*\*[nodes]\*\*\*?
+## What is Griptape **_Nodes_**?
 
-Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps artists and creators build AI-powered projects without needing deep technical expertise. Think of it like a set of building blocks that you can connect together to create art, generate images, process text, or even build other workhorse applications.
+Griptape **_Nodes_** is a creative toolkit (built with Python) that helps artists and creators build AI-powered projects without needing deep technical expertise. Think of it like a set of building blocks that you can connect together to create art, generate images, process text, or even build other workhorse applications.
 
-### The Big Ones in the Griptape\*\*\*[nodes]\*\*\* world
+### The Big Ones in the Griptape **_Nodes_** world
 
 - **Workflow**: A document containing nodes, connections, and values. While technically a Workflow is also a Script, avoid calling them Scripts, so that the term Script can communicate a clearly different thing than the term Workflow. This is also what we call the saved file.
 
@@ -24,51 +24,51 @@ Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps
 
 - **Node**: A single piece of the puzzle in your workflow. Nodes are like LEGO blocks that you can connect to create something bigger. Each node does one specific thing (like generating an image or processing text). There are **types** of nodes:
 
-  - **DataNode**: A node that handles information — it can transform data from one form to another, or simply hold data you set.
-  - **ControlNode**: A node that will "do some work". Control Nodes usually take longer to run than DataNodes because, they're usually doing more work.
-  - **DriverNode**: A node that connects your project to outside services (like image generators or search engines).
+    - **DataNode**: A node that handles information — it can transform data from one form to another, or simply hold data you set.
+    - **ControlNode**: A node that will "do some work". Control Nodes usually take longer to run than DataNodes because, they're usually doing more work.
+    - **DriverNode**: A node that connects your project to outside services (like image generators or search engines).
 
 - **Tool**: A ready-to-use component that performs a specific function. Tools are like brushes in your digital toolkit — each designed for a specific purpose.
 
-  - **CalculatorTool**: Does math calculations for you.
-  - **DateTimeTool**: Works with dates and times.
-  - **FileManagerTool**: Helps manage files (saving, loading, etc.).
-  - **WebScraperTool**: Collects information from websites.
-  - **PromptSummaryTool**: Creates summaries of longer text.
+    - **CalculatorTool**: Does math calculations for you.
+    - **DateTimeTool**: Works with dates and times.
+    - **FileManagerTool**: Helps manage files (saving, loading, etc.).
+    - **WebScraperTool**: Collects information from websites.
+    - **PromptSummaryTool**: Creates summaries of longer text.
 
 - **Driver**: The connector between your project and external AI services or databases. Drivers are like adapters that let your project talk to specialized services.
 
-  - **PromptDriver**: Communicates with AI text generators (like GPT models).
-  - **WebSearchDriver**: Connects to search engines to find information.
-  - **EmbeddingDriver**: Transforms words and concepts into numerical form that AI can understand.
-  - **ImageGenerationDriver**: Connects to AI image generators (like DALL-E).
-  - **AudioTranscriptionDriver**: Converts spoken audio to written text.
+    - **PromptDriver**: Communicates with AI text generators (like GPT models).
+    - **WebSearchDriver**: Connects to search engines to find information.
+    - **EmbeddingDriver**: Transforms words and concepts into numerical form that AI can understand.
+    - **ImageGenerationDriver**: Connects to AI image generators (like DALL-E).
+    - **AudioTranscriptionDriver**: Converts spoken audio to written text.
 
 - **Engine**: The powerhouse that processes your creative requests. Engines are specialized components that transform inputs into creative outputs.
 
-  - **RagEngine**: Processes questions and generates answers based on provided information.
-  - **PromptSummaryEngine**: Creates concise summaries of longer text.
-  - **CsvExtractionEngine**: Pulls information from spreadsheet-like files.
-  - **JsonExtractionEngine**: Pulls information from structured data files.
+    - **RagEngine**: Processes questions and generates answers based on provided information.
+    - **PromptSummaryEngine**: Creates concise summaries of longer text.
+    - **CsvExtractionEngine**: Pulls information from spreadsheet-like files.
+    - **JsonExtractionEngine**: Pulls information from structured data files.
 
 - **Artifact**: A piece of content created during your project, like a generated image or text. Artifacts are the outputs of your creative process.
 
-  - **ErrorArtifact**: A notification when something goes wrong.
+    - **ErrorArtifact**: A notification when something goes wrong.
 
 - **Agent**: A helper that can perform tasks on your behalf, often using a combination of tools. Agents are like assistants that can navigate a sequence of operations for you.
 
 - **Ruleset**: A set of guidelines that control how your project behaves. Rulesets are like recipes that tell your project how to respond in different situations.
 
-  - **Rule**: A single instruction within a ruleset, like "if the user asks for an image, generate one."
+    - **Rule**: A single instruction within a ruleset, like "if the user asks for an image, generate one."
 
 ### Node Contents and Activities
 
 - **Parameter**: A setting or value you can adjust on a node. Parameters are like the knobs and sliders in a music synthesizer — they let you fine-tune how things work.
 
-  - **ParameterMode**: Describes if a parameter is for input, output, internal, or any combination.
-  - **ParameterValue**: The "internal" value for a parameter (this is the data the node works with internally)
-  - **ParameterOutputValues**: The results or "output" value for your parameters (this is the data that results from what the node did)
-  - **ParameterUIOptions**: Settings for how parameters appear in the user interface.
+    - **ParameterMode**: Describes if a parameter is for input, output, internal, or any combination.
+    - **ParameterValue**: The "internal" value for a parameter (this is the data the node works with internally)
+    - **ParameterOutputValues**: The results or "output" value for your parameters (this is the data that results from what the node did)
+    - **ParameterUIOptions**: Settings for how parameters appear in the user interface.
 
 - **Default Value**: The pre-set value a parameter has before you change it. This is like the factory settings on a device.
 
@@ -80,10 +80,10 @@ Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps
 
 - **Type Hints**: Labels that suggest what kind of information a parameter expects. These are like labels on art supply containers telling you what's inside.
 
-  - **Any**: A type hint meaning a parameter can accept any kind of information.
-  - **List**: A type hint for a collection of items (like an array of colors or shapes).
-  - **Literal**: A type hint indicating a parameter only accepts specific preset values.
-  - **Union type**: A type hint showing a parameter can accept multiple specific types of information.
+    - **Any**: A type hint meaning a parameter can accept any kind of information.
+    - **List**: A type hint for a collection of items (like an array of colors or shapes).
+    - **Literal**: A type hint indicating a parameter only accepts specific preset values.
+    - **Union type**: A type hint showing a parameter can accept multiple specific types of information.
 
 - **Connection**: The link that allows nodes to communicate with each other. Connections are like the cables connecting different pieces of equipment.
 
@@ -91,16 +91,16 @@ Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps
 
 - **Data Types**:
 
-  - **Dictionary (dict)**: A way to store information as pairs of labels and values. Dictionaries are like organized containers where each item has a unique label.
-  - **Key-Value Pair**: A label (key) paired with its corresponding information (value). Dictionaries are just a collection of Key-Value Pairs.
-  - **Integer (int)**: Whole numbers without decimal points, like 5, -10, or 1000.
-  - **Float (float)**: Numbers with decimal points, like 3.14, -0.5, or 2.0.
-  - **String (str)**: Text enclosed in quotes, like "hello", 'Python', or "123".
-  - **Boolean (bool)**: Represents either True or False.
-  - **List (list)**: An ordered collection of items that can be modified, like [1, 2, 3] or ["apple", "banana", "cherry"].
-  - **Tuple (tuple)**: An ordered collection of items that cannot be modified after creation, like (1, 2, 3) or ("red", "green", "blue").
-  - **Set (set)**: An unordered collection of unique items, like {1, 2, 3} or {"apple", "banana", "cherry"}.
-  - **None (NoneType)**: Represents the absence of a value or a null value.
+    - **Dictionary (dict)**: A way to store information as pairs of labels and values. Dictionaries are like organized containers where each item has a unique label.
+    - **Key-Value Pair**: A label (key) paired with its corresponding information (value). Dictionaries are just a collection of Key-Value Pairs.
+    - **Integer (int)**: Whole numbers without decimal points, like 5, -10, or 1000.
+    - **Float (float)**: Numbers with decimal points, like 3.14, -0.5, or 2.0.
+    - **String (str)**: Text enclosed in quotes, like "hello", 'Python', or "123".
+    - **Boolean (bool)**: Represents either True or False.
+    - **List (list)**: An ordered collection of items that can be modified, like [1, 2, 3] or ["apple", "banana", "cherry"].
+    - **Tuple (tuple)**: An ordered collection of items that cannot be modified after creation, like (1, 2, 3) or ("red", "green", "blue").
+    - **Set (set)**: An unordered collection of unique items, like {1, 2, 3} or {"apple", "banana", "cherry"}.
+    - **None (NoneType)**: Represents the absence of a value or a null value.
 
 - **Environment Variable**: Like secret notes that your computer keeps to help programs know important information.
 
@@ -113,7 +113,7 @@ Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps
 
 <a id="Configuration Settings"></a>
 
-- **Configuration Settings**: Parameters and options that control how the Griptape[nodes] engine and its components operate.
+- **Configuration Settings**: Parameters and options that control how the Griptape_nodes\_ engine and its components operate.
 
 <a id="Project Files"></a>
 
@@ -121,7 +121,7 @@ Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps
 
 <a id="Generated Assets"></a>
 
-- **Generated Assets**: Files and data produced by the Griptape[nodes] engine during execution, such as outputs, reports, or visualizations.
+- **Generated Assets**: Files and data produced by the Griptape_nodes\_ engine during execution, such as outputs, reports, or visualizations.
 
 <a id=".env"></a>
 
@@ -219,10 +219,10 @@ Griptape\*\*\*[nodes]\*\*\* is a creative toolkit (built with Python) that helps
 
 - **Exception Handling**: The way your project deals with errors. This is like having backup plans for when things go wrong.
 
-  - **Authentication Error**: An error that occurs when your project can't prove it has permission to use a service.
-  - **KeyError**: An error when your project tries to access information using an incorrect label.
-  - **SyntaxError**: An error caused by incorrect formatting in code.
-  - **ValueError**: An error when your project tries to use an inappropriate value.
+    - **Authentication Error**: An error that occurs when your project can't prove it has permission to use a service.
+    - **KeyError**: An error when your project tries to access information using an incorrect label.
+    - **SyntaxError**: An error caused by incorrect formatting in code.
+    - **ValueError**: An error when your project tries to use an inappropriate value.
 
 - **Metadata**: Extra information about your content or components. This is like the information stored in digital photo files (camera type, date taken, etc.).
 

--- a/docs/reference/retained_mode.md
+++ b/docs/reference/retained_mode.md
@@ -1,6 +1,6 @@
-# Griptape\*\*\*[nodes]\*\*\* Retained Mode Command Reference
+# Griptape **_Nodes_** Retained Mode Command Reference
 
-"Retained Mode" is python scripting interface to interact with the Griptape\*\*\*[nodes]\*\*\* framework. These methods allow users to create, modify, and manage nodes, parameters, connections, and flows through a simplified Python API.
+"Retained Mode" is python scripting interface to interact with the Griptape **_Nodes_** framework. These methods allow users to create, modify, and manage nodes, parameters, connections, and flows through a simplified Python API.
 
 > **Note:** The actual import command for RetainedMode is:
 >
@@ -24,10 +24,10 @@ Creates a new flow within the Griptape system.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | ⚪ |
-| parent_flow_name | string | ⚪ |
+| Name             | Argument Type | Required |
+| ---------------- | :-----------: | :------: |
+| flow_name        |    string     |    ⚪    |
+| parent_flow_name |    string     |    ⚪    |
 
 #### Return Value
 
@@ -49,9 +49,9 @@ Deletes an existing flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -73,9 +73,9 @@ Lists all flows within a parent flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| parent_flow_name | string | ⚪ |
+| Name             | Argument Type | Required |
+| ---------------- | :-----------: | :------: |
+| parent_flow_name |    string     |    ⚪    |
 
 #### Return Value
 
@@ -97,9 +97,9 @@ Lists all nodes within a flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -121,9 +121,9 @@ Executes a flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -145,9 +145,9 @@ Resets a flow to its initial state.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -169,9 +169,9 @@ Returns the current state of a flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -193,9 +193,9 @@ Cancels the execution of a flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -217,9 +217,9 @@ Executes a single node step in a flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -241,9 +241,9 @@ Executes a single execution step in a flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -265,9 +265,9 @@ Continues the execution of a paused flow.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| flow_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| flow_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -289,13 +289,13 @@ Creates a new node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_type | string | 🟢 |
-| specific_library_name | string | ⚪ |
-| node_name | string | ⚪ |
-| parent_flow_name | string | ⚪ |
-| metadata | dict | ⚪ |
+| Name                  | Argument Type | Required |
+| --------------------- | :-----------: | :------: |
+| node_type             |    string     |    🟢    |
+| specific_library_name |    string     |    ⚪    |
+| node_name             |    string     |    ⚪    |
+| parent_flow_name      |    string     |    ⚪    |
+| metadata              |     dict      |    ⚪    |
 
 #### Return Value
 
@@ -317,9 +317,9 @@ Deletes an existing node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| node_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -341,9 +341,9 @@ Executes a single node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| node_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -365,9 +365,9 @@ Returns the resolution state of a node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| node_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -389,9 +389,9 @@ Returns the metadata for a node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| node_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -413,10 +413,10 @@ Sets the metadata for a node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
-| metadata | dict | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| node_name |    string     |    🟢    |
+| metadata  |     dict      |    🟢    |
 
 #### Return Value
 
@@ -439,8 +439,8 @@ Checks if a node exists.
 #### Arguments
 
 | Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node | string | 🟢 |
+| ---- | :-----------: | :------: |
+| node |    string     |    🟢    |
 
 #### Return Value
 
@@ -462,9 +462,9 @@ Lists objects in the system.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| \*\*kwargs | dict | ⚪ |
+| Name       | Argument Type | Required |
+| ---------- | :-----------: | :------: |
+| \*\*kwargs |     dict      |    ⚪    |
 
 #### Return Value
 
@@ -487,8 +487,8 @@ Lists all parameters on a node.
 #### Arguments
 
 | Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node | string | 🟢 |
+| ---- | :-----------: | :------: |
+| node |    string     |    🟢    |
 
 #### Return Value
 
@@ -510,23 +510,23 @@ Adds a parameter to a node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
-| parameter_name | string | 🟢 |
-| default_value | any | 🟢 |
-| tooltip | string or list | 🟢 |
-| type | string | ⚪ |
-| input_types | list of strings | ⚪ |
-| output_type | string | ⚪ |
-| edit | boolean | ⚪ |
-| tooltip_as_input | string or list | ⚪ |
-| tooltip_as_property | string or list | ⚪ |
-| tooltip_as_output | string or list | ⚪ |
-| ui_options | ParameterUIOptions | ⚪ |
-| mode_allowed_input | boolean | ⚪ |
-| mode_allowed_property | boolean | ⚪ |
-| mode_allowed_output | boolean | ⚪ |
+| Name                  |   Argument Type    | Required |
+| --------------------- | :----------------: | :------: |
+| node_name             |       string       |    🟢    |
+| parameter_name        |       string       |    🟢    |
+| default_value         |        any         |    🟢    |
+| tooltip               |   string or list   |    🟢    |
+| type                  |       string       |    ⚪    |
+| input_types           |  list of strings   |    ⚪    |
+| output_type           |       string       |    ⚪    |
+| edit                  |      boolean       |    ⚪    |
+| tooltip_as_input      |   string or list   |    ⚪    |
+| tooltip_as_property   |   string or list   |    ⚪    |
+| tooltip_as_output     |   string or list   |    ⚪    |
+| ui_options            | ParameterUIOptions |    ⚪    |
+| mode_allowed_input    |      boolean       |    ⚪    |
+| mode_allowed_property |      boolean       |    ⚪    |
+| mode_allowed_output   |      boolean       |    ⚪    |
 
 #### Return Value
 
@@ -548,10 +548,10 @@ Removes a parameter from a node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
-| parameter_name | string | 🟢 |
+| Name           | Argument Type | Required |
+| -------------- | :-----------: | :------: |
+| node_name      |    string     |    🟢    |
+| parameter_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -573,10 +573,10 @@ Gets information about a parameter.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node | string | 🟢 |
-| param | string | 🟢 |
+| Name  | Argument Type | Required |
+| ----- | :-----------: | :------: |
+| node  |    string     |    🟢    |
+| param |    string     |    🟢    |
 
 #### Return Value
 
@@ -598,10 +598,10 @@ Gets the value of a parameter.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node | string | 🟢 |
-| param | string | 🟢 |
+| Name  | Argument Type | Required |
+| ----- | :-----------: | :------: |
+| node  |    string     |    🟢    |
+| param |    string     |    🟢    |
 
 #### Return Value
 
@@ -623,11 +623,11 @@ Sets the value of a parameter.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node | string | 🟢 |
-| param | string | 🟢 |
-| value | any | 🟢 |
+| Name  | Argument Type | Required |
+| ----- | :-----------: | :------: |
+| node  |    string     |    🟢    |
+| param |    string     |    🟢    |
+| value |      any      |    🟢    |
 
 #### Return Value
 
@@ -649,10 +649,10 @@ Creates a connection between two parameters.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| source | string | 🟢 |
-| destination | string | 🟢 |
+| Name        | Argument Type | Required |
+| ----------- | :-----------: | :------: |
+| source      |    string     |    🟢    |
+| destination |    string     |    🟢    |
 
 #### Return Value
 
@@ -674,9 +674,9 @@ Creates execution connections between a sequence of nodes.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| \*node_names | string(s) | 🟢 |
+| Name         | Argument Type | Required |
+| ------------ | :-----------: | :------: |
+| \*node_names |   string(s)   |    🟢    |
 
 #### Return Value
 
@@ -698,12 +698,12 @@ Deletes a connection between parameters.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| source_node_name | string | 🟢 |
-| source_param_name | string | 🟢 |
-| target_node_name | string | 🟢 |
-| target_param_name | string | 🟢 |
+| Name              | Argument Type | Required |
+| ----------------- | :-----------: | :------: |
+| source_node_name  |    string     |    🟢    |
+| source_param_name |    string     |    🟢    |
+| target_node_name  |    string     |    🟢    |
+| target_param_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -725,9 +725,9 @@ Lists all connections for a node.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| node_name | string | 🟢 |
+| Name      | Argument Type | Required |
+| --------- | :-----------: | :------: |
+| node_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -771,9 +771,9 @@ Lists all node types in a library.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| library_name | string | 🟢 |
+| Name         | Argument Type | Required |
+| ------------ | :-----------: | :------: |
+| library_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -795,10 +795,10 @@ Gets metadata for a node type.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| library_name | string | 🟢 |
-| node_type_name | string | 🟢 |
+| Name           | Argument Type | Required |
+| -------------- | :-----------: | :------: |
+| library_name   |    string     |    🟢    |
+| node_type_name |    string     |    🟢    |
 
 #### Return Value
 
@@ -820,9 +820,9 @@ Gets a configuration value.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| category_and_key | string | 🟢 |
+| Name             | Argument Type | Required |
+| ---------------- | :-----------: | :------: |
+| category_and_key |    string     |    🟢    |
 
 #### Return Value
 
@@ -844,10 +844,10 @@ Sets a configuration value.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| category_and_key | string | 🟢 |
-| value | any | 🟢 |
+| Name             | Argument Type | Required |
+| ---------------- | :-----------: | :------: |
+| category_and_key |    string     |    🟢    |
+| value            |      any      |    🟢    |
 
 #### Return Value
 
@@ -869,9 +869,9 @@ Gets all configuration values in a category.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| category | string | ⚪ |
+| Name     | Argument Type | Required |
+| -------- | :-----------: | :------: |
+| category |    string     |    ⚪    |
 
 #### Return Value
 
@@ -893,10 +893,10 @@ Sets configuration values for a category.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| category | string | ⚪ |
-| contents | dict | ⚪ |
+| Name     | Argument Type | Required |
+| -------- | :-----------: | :------: |
+| category |    string     |    ⚪    |
+| contents |     dict      |    ⚪    |
 
 #### Return Value
 
@@ -918,9 +918,9 @@ Executes arbitrary Python code.
 
 #### Arguments
 
-| Name | Argument Type | Required |
-|------|:---------------:|:-------:|
-| python_str | string | 🟢 |
+| Name       | Argument Type | Required |
+| ---------- | :-----------: | :------: |
+| python_str |    string     |    🟢    |
 
 #### Return Value
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,16 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["mdformat>=0.7.22", "pyright>=1.1.396", "ruff>=0.11.0", "typos>=1.30.2"]
+dev = [
+  "mdformat>=0.7.22",
+  "mdformat-gfm>=0.4.1",
+  "mdformat-frontmatter>=2.0.8",
+  "mdformat-footnote>=0.1.1",
+  "mdformat-mkdocs>=4.1.2",
+  "pyright>=1.1.396",
+  "ruff>=0.11.0",
+  "typos>=1.30.2",
+]
 docs = [
   "mkdocs-material>=9.6.9",
   "mkdocs>=1.5.2",

--- a/uv.lock
+++ b/uv.lock
@@ -314,6 +314,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mdformat" },
+    { name = "mdformat-footnote" },
+    { name = "mdformat-frontmatter" },
+    { name = "mdformat-gfm" },
+    { name = "mdformat-mkdocs" },
     { name = "pyright" },
     { name = "ruff" },
     { name = "typos" },
@@ -345,6 +349,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mdformat", specifier = ">=0.7.22" },
+    { name = "mdformat-footnote", specifier = ">=0.1.1" },
+    { name = "mdformat-frontmatter", specifier = ">=2.0.8" },
+    { name = "mdformat-gfm", specifier = ">=0.4.1" },
+    { name = "mdformat-mkdocs", specifier = ">=4.1.2" },
     { name = "pyright", specifier = ">=1.1.396" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "typos", specifier = ">=1.30.2" },
@@ -633,6 +641,88 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat-footnote"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/90/7f4b2729af8d691a57518e8202e90c3a638714437b5e753662982f744cb5/mdformat_footnote-0.1.1.tar.gz", hash = "sha256:3b85c4c84119f15f0b651df89c99a4f6f119fc46dca6b33f7edf4f09655d1126", size = 5224 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/aa/4736dc47867c60236a9992f2f779e85e5331e65e648434d6362c3ed2dae0/mdformat_footnote-0.1.1-py3-none-any.whl", hash = "sha256:30063aaa0f74c36257c2e80fa0cf00d7c71a5277f27e98109e8765ae8678a95b", size = 4120 },
+]
+
+[[package]]
+name = "mdformat-frontmatter"
+version = "2.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/aa/70876bec1e66f2b1ab26f31d226c09bf7b78d3d27f03c2642d1d69d1ae77/mdformat_frontmatter-2.0.8.tar.gz", hash = "sha256:c11190ae3f9c91ada78fbd820f5b221631b520484e0b644715aa0f6ed7f097ed", size = 3254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/51/b3da1292c32819c52a4e4242ad94c3c07189ca70d228b3909a58f1f3a819/mdformat_frontmatter-2.0.8-py3-none-any.whl", hash = "sha256:577396695af96ad66dff1ff781284ff3764a10be3ab8659f2ef842ab42264ebb", size = 3747 },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+    { name = "mdit-py-plugins" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/db/873bad63b36e390a33bc0cf7222442010997d3ccf29a1889f24d28fdeddd/mdformat_gfm-0.4.1.tar.gz", hash = "sha256:e189e728e50cfb15746abc6b3178ca0e2bebbb7a8d3d98fbc9e24bc1a4c65564", size = 7528 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/ba/3d4c680a2582593b8ba568ab60b119d93542fa39d757d65aae3c4f357e29/mdformat_gfm-0.4.1-py3-none-any.whl", hash = "sha256:63c92cfa5102f55779d4e04b16a79a6a5171e658c6c479175c0955fb4ca78dde", size = 8750 },
+]
+
+[[package]]
+name = "mdformat-mkdocs"
+version = "4.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdformat-gfm" },
+    { name = "mdit-py-plugins" },
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/9a/9c855818820345c814d008f118e4dd35a7159a84bc74f78dbd8be62a5fd0/mdformat_mkdocs-4.1.2.tar.gz", hash = "sha256:85017aa4cd6bcff68ca1c11a232bceef33fa7bfa181996f9c5004876af960de6", size = 26422 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/30/bad67c7b47b3806b415fcc9fba607e6d369706e931afdfa3815cdfff7586/mdformat_mkdocs-4.1.2-py3-none-any.whl", hash = "sha256:330774b40d27dc34ac56d216617968a7889de6adfb8641c510fb11d43ca257cf", size = 28608 },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104 },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316 },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -767,6 +857,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/44/c8/600c4201b6b9e72bab16802316d0c90ce04089f8e6bb5e064cd2a5abba7e/mkdocstrings_python-1.16.10.tar.gz", hash = "sha256:f9eedfd98effb612ab4d0ed6dd2b73aff6eba5215e0a65cea6d877717f75502e", size = 205771 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/37/19549c5e0179785308cc988a68e16aa7550e4e270ec8a9878334e86070c6/mkdocstrings_python-1.16.10-py3-none-any.whl", hash = "sha256:63bb9f01f8848a644bdb6289e86dc38ceddeaa63ecc2e291e3b2ca52702a6643", size = 124112 },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3b/7fa1fe835e2e93fd6d7b52b2f95ae810cf5ba133e1845f726f5a992d62c2/more-itertools-10.6.0.tar.gz", hash = "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b", size = 125009 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/62/0fe302c6d1be1c777cab0616e6302478251dfbf9055ad426f5d0def75c89/more_itertools-10.6.0-py3-none-any.whl", hash = "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89", size = 63038 },
 ]
 
 [[package]]
@@ -1161,6 +1260,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.18.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/46/f44d8be06b85bc7c4d8c95d658be2b68f27711f279bf9dd0612a5e4794f5/ruamel.yaml-0.18.10.tar.gz", hash = "sha256:20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58", size = 143447 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/36/dfc1ebc0081e6d39924a2cc53654497f967a084a436bb64402dfce4254d9/ruamel.yaml-0.18.10-py3-none-any.whl", hash = "sha256:30f22513ab2301b3d2b577adc121c6471f28734d3d9728581245f1e76468b4f1", size = 117729 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1411,6 +1519,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]
 
 [[package]]


### PR DESCRIPTION
Copied from griptape repo. `make format` now formats markdown files in a mkdocs compatible format.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--303.org.readthedocs.build//303/

<!-- readthedocs-preview griptape-nodes end -->