### PR TITLE
318-image-generation-prompt-on-create-image-should-be-multiline

### DIFF
--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -53,7 +53,7 @@ class CreateImage(ControlNode):
                 tooltip="None",
                 default_value="",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={"placeholder_text": "Enter your image generation prompt here."},
+                ui_options={"multiline": True, "placeholder_text": "Enter your image generation prompt here."},
             )
         )
         self.add_parameter(

--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -57,7 +57,14 @@ class CreateImage(ControlNode):
             )
         )
         self.add_parameter(
-            Parameter(name="enhance_prompt", input_types=["bool"], type="bool", tooltip="None", default_value=True)
+            Parameter(
+                name="enhance_prompt",
+                input_types=["bool"],
+                type="bool",
+                tooltip="None",
+                default_value=True,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
         )
         self.add_parameter(
             Parameter(


### PR DESCRIPTION
set prompt to multiline
removed output port from enhance_prompt

![image](https://github.com/user-attachments/assets/d6274a13-27c2-4ff7-8aec-1eedfd0fe765)
