### PR TITLE
316-fix-issue-where-no-default-value-is-set-and-no-value-on-the-node-eg-create-float-had-no-value-set

### DIFF
--- a/nodes/griptape_nodes_library/number/create_float.py
+++ b/nodes/griptape_nodes_library/number/create_float.py
@@ -17,7 +17,6 @@ class CreateFloat(DataNode):
         super().__init__(name, metadata)
 
         self.value = value
-        # Add output parameter for the string
         self.add_parameter(
             Parameter(
                 name="float",

--- a/nodes/griptape_nodes_library/number/create_float.py
+++ b/nodes/griptape_nodes_library/number/create_float.py
@@ -16,11 +16,12 @@ class CreateFloat(DataNode):
     ) -> None:
         super().__init__(name, metadata)
 
+        self.value = value
         # Add output parameter for the string
         self.add_parameter(
             Parameter(
                 name="float",
-                default_value=value,
+                default_value=self.value,
                 output_type="float",
                 type="float",
                 allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
@@ -29,5 +30,4 @@ class CreateFloat(DataNode):
         )
 
     def process(self) -> None:
-        value = self.parameter_values.get("float", 0.0)
-        self.parameter_output_values["float"] = value
+        self.parameter_output_values["float"] = self.parameter_values.get("float", self.value)

--- a/nodes/griptape_nodes_library/number/create_float.py
+++ b/nodes/griptape_nodes_library/number/create_float.py
@@ -29,4 +29,4 @@ class CreateFloat(DataNode):
         )
 
     def process(self) -> None:
-        self.parameter_output_values["float"] = self.parameter_values.get("float", self.value)
+        self.parameter_output_values["float"] = self.parameter_values.get("float")

--- a/nodes/griptape_nodes_library/number/create_float.py
+++ b/nodes/griptape_nodes_library/number/create_float.py
@@ -12,7 +12,7 @@ class CreateFloat(DataNode):
         self,
         name: str,
         metadata: dict[Any, Any] | None = None,
-        value: str = "",
+        value: float = 0.0,
     ) -> None:
         super().__init__(name, metadata)
 
@@ -29,5 +29,5 @@ class CreateFloat(DataNode):
         )
 
     def process(self) -> None:
-        # Simply output the default value or any updated property value
-        self.parameter_output_values["float"] = self.parameter_values["float"]
+        value = self.parameter_values.get("float", 0.0)
+        self.parameter_output_values["float"] = value

--- a/nodes/griptape_nodes_library/number/create_int.py
+++ b/nodes/griptape_nodes_library/number/create_int.py
@@ -16,11 +16,11 @@ class CreateInteger(DataNode):
     ) -> None:
         super().__init__(name, metadata)
 
-        # Add output parameter for the string
+        self.value = value
         self.add_parameter(
             Parameter(
                 name="integer",
-                default_value=value,
+                default_value=self.value,
                 output_type="int",
                 type="int",
                 allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
@@ -29,5 +29,4 @@ class CreateInteger(DataNode):
         )
 
     def process(self) -> None:
-        value = self.parameter_values.get("integer", 0)
-        self.parameter_output_values["integer"] = value
+        self.parameter_output_values["integer"] = self.parameter_values.get("integer", self.value)

--- a/nodes/griptape_nodes_library/number/create_int.py
+++ b/nodes/griptape_nodes_library/number/create_int.py
@@ -29,4 +29,4 @@ class CreateInteger(DataNode):
         )
 
     def process(self) -> None:
-        self.parameter_output_values["integer"] = self.parameter_values.get("integer", self.value)
+        self.parameter_output_values["integer"] = self.parameter_values.get("integer")

--- a/nodes/griptape_nodes_library/number/create_int.py
+++ b/nodes/griptape_nodes_library/number/create_int.py
@@ -12,7 +12,7 @@ class CreateInteger(DataNode):
         self,
         name: str,
         metadata: dict[Any, Any] | None = None,
-        value: str = "",
+        value: int = 0,
     ) -> None:
         super().__init__(name, metadata)
 
@@ -29,5 +29,5 @@ class CreateInteger(DataNode):
         )
 
     def process(self) -> None:
-        # Simply output the default value or any updated property value
-        self.parameter_output_values["integer"] = self.parameter_values["integer"]
+        value = self.parameter_values.get("integer", 0)
+        self.parameter_output_values["integer"] = value

--- a/nodes/griptape_nodes_library/number/display_float.py
+++ b/nodes/griptape_nodes_library/number/display_float.py
@@ -26,4 +26,4 @@ class DisplayFloat(DataNode):
         )
 
     def process(self) -> None:
-        self.parameter_output_values["float"] = self.parameter_values.get("float", self.value)
+        self.parameter_output_values["float"] = self.parameter_values.get("float")

--- a/nodes/griptape_nodes_library/number/display_float.py
+++ b/nodes/griptape_nodes_library/number/display_float.py
@@ -11,7 +11,7 @@ class DisplayFloat(DataNode):
         self,
         name: str,
         metadata: dict[Any, Any] | None = None,
-        value: str = "",
+        value: float = 0.0,
     ) -> None:
         super().__init__(name, metadata)
 
@@ -26,5 +26,5 @@ class DisplayFloat(DataNode):
         )
 
     def process(self) -> None:
-        # Simply output the default value or any updated property value
-        self.parameter_output_values["float"] = self.parameter_values["float"]
+        value = self.parameter_values.get("float", 0.0)
+        self.parameter_output_values["float"] = value

--- a/nodes/griptape_nodes_library/number/display_float.py
+++ b/nodes/griptape_nodes_library/number/display_float.py
@@ -15,16 +15,15 @@ class DisplayFloat(DataNode):
     ) -> None:
         super().__init__(name, metadata)
 
-        # Add output parameter for the string
+        self.value = value
         self.add_parameter(
             Parameter(
                 name="float",
-                default_value=value,
+                default_value=self.value,
                 type="float",
                 tooltip="The number to display",
             )
         )
 
     def process(self) -> None:
-        value = self.parameter_values.get("float", 0.0)
-        self.parameter_output_values["float"] = value
+        self.parameter_output_values["float"] = self.parameter_values.get("float", self.value)

--- a/nodes/griptape_nodes_library/number/display_int.py
+++ b/nodes/griptape_nodes_library/number/display_int.py
@@ -11,14 +11,14 @@ class DisplayInteger(DataNode):
         self,
         name: str,
         metadata: dict[Any, Any] | None = None,
-        value: str = "",
+        value: int = 0,
     ) -> None:
         super().__init__(name, metadata)
 
         # Add output parameter for the string
         self.add_parameter(
             Parameter(
-                name="int",
+                name="integer",
                 default_value=value,
                 type="int",
                 tooltip="The number to display",
@@ -26,5 +26,5 @@ class DisplayInteger(DataNode):
         )
 
     def process(self) -> None:
-        # Simply output the default value or any updated property value
-        self.parameter_output_values["int"] = self.parameter_values["int"]
+        value = self.parameter_values.get("integer", 0)
+        self.parameter_output_values["integer"] = value

--- a/nodes/griptape_nodes_library/number/display_int.py
+++ b/nodes/griptape_nodes_library/number/display_int.py
@@ -26,4 +26,4 @@ class DisplayInteger(DataNode):
         )
 
     def process(self) -> None:
-        self.parameter_output_values["integer"] = self.parameter_values.get("integer", self.value)
+        self.parameter_output_values["integer"] = self.parameter_values.get("integer")

--- a/nodes/griptape_nodes_library/number/display_int.py
+++ b/nodes/griptape_nodes_library/number/display_int.py
@@ -15,16 +15,15 @@ class DisplayInteger(DataNode):
     ) -> None:
         super().__init__(name, metadata)
 
-        # Add output parameter for the string
+        self.value = value
         self.add_parameter(
             Parameter(
                 name="integer",
-                default_value=value,
+                default_value=self.value,
                 type="int",
                 tooltip="The number to display",
             )
         )
 
     def process(self) -> None:
-        value = self.parameter_values.get("integer", 0)
-        self.parameter_output_values["integer"] = value
+        self.parameter_output_values["integer"] = self.parameter_values.get("integer", self.value)


### PR DESCRIPTION
fixed errors on create and display float and integer.

* values were being set as strings, so now are set as correct types
* didn't catch for values not being set, now  we are.