### PR TITLE
feat: add ability for nodes to yield background work

### DIFF
--- a/nodes/griptape_nodes_library/agents/base_agent.py
+++ b/nodes/griptape_nodes_library/agents/base_agent.py
@@ -1,9 +1,12 @@
+from collections.abc import Iterator
+
+from griptape.artifacts import TextArtifact
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
-from griptape.structures import Agent
+from griptape.structures import Agent, Structure
 from griptape.tasks import PromptTask
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterList, ParameterMode
-from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 DEFAULT_MODEL = "gpt-4o"
@@ -126,5 +129,7 @@ class BaseAgent(ControlNode):
             task.context = self.get_parameter_value("prompt_context")
         return agent
 
-    def process(self) -> None:
+    def process(
+        self,
+    ) -> AsyncResult[Iterator[TextArtifact] | Structure] | None:
         pass

--- a/nodes/griptape_nodes_library/agents/create_agent.py
+++ b/nodes/griptape_nodes_library/agents/create_agent.py
@@ -1,7 +1,12 @@
+from collections.abc import Iterator
+from typing import cast
+
+from griptape.artifacts import TextArtifact
 from griptape.events import TextChunkEvent
-from griptape.structures import Agent
+from griptape.structures import Agent, Structure
 from griptape.utils import Stream
 
+from griptape_nodes.exe_types.node_types import AsyncResult
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes_library.agents.base_agent import BaseAgent
 
@@ -30,7 +35,9 @@ class CreateAgent(BaseAgent):
             return rulesets
         return []
 
-    def process(self) -> None:
+    def process(
+        self,
+    ) -> AsyncResult[Iterator[TextArtifact] | Structure]:
         # Get input values
         params = self.parameter_values
         prompt_driver = params.get("prompt_driver", self.get_default_prompt_driver())
@@ -64,12 +71,13 @@ class CreateAgent(BaseAgent):
             # Check and see if the prompt driver is a stream driver
             if self.is_stream(agent):
                 # Run the agent
-                for artifact in Stream(agent, event_types=[TextChunkEvent]).run(prompt):
+                agent_stream = cast("Iterator", (yield lambda: Stream(agent, event_types=[TextChunkEvent]).run(prompt)))
+                for artifact in agent_stream:
                     full_output += artifact.value
                     self.parameter_output_values["output"] = full_output
             else:
                 # Run the agent
-                result = agent.run(prompt)
+                result = cast("Structure", (yield lambda: agent.run(prompt)))
                 full_output = result.output.value
             self.parameter_output_values["output"] = full_output
         else:

--- a/nodes/griptape_nodes_library/agents/run_agent.py
+++ b/nodes/griptape_nodes_library/agents/run_agent.py
@@ -1,8 +1,17 @@
+import logging
+from collections.abc import Iterator
+from typing import cast
+
+from griptape.artifacts import TextArtifact
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
-from griptape.structures import Agent
+from griptape.structures import Agent, Structure
 from griptape.utils import Stream
 
+from griptape_nodes.exe_types.node_types import AsyncResult
 from griptape_nodes_library.agents.create_agent import CreateAgent
+
+logger = logging.getLogger("griptape_nodes")
+
 
 DEFAULT_MODEL = "gpt-4o"
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -29,7 +38,7 @@ class RunAgent(CreateAgent):
         if param:
             self.remove_parameter(param)
 
-    def process(self) -> None:
+    def process(self) -> AsyncResult[Iterator[TextArtifact] | Structure]:
         # Get input values
         params = self.parameter_values
         agent_dict = params.get("agent", None)
@@ -52,11 +61,12 @@ class RunAgent(CreateAgent):
             # Check and see if the prompt driver is a stream driver
             if self.is_stream(agent):
                 # Run the agent
-                for artifact in Stream(agent).run(prompt):
+                agent_stream = cast("Iterator", (yield lambda: Stream(agent).run(prompt)))
+                for artifact in agent_stream:
                     full_output += artifact.value
             else:
                 # Run the agent
-                result = agent.run(prompt)
+                result = cast("Structure", (yield lambda: agent.run(prompt)))
                 full_output = result.output.value
             self.parameter_output_values["output"] = full_output
         else:

--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -1,10 +1,11 @@
 from griptape.drivers.image_generation.griptape_cloud import GriptapeCloudImageGenerationDriver
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
+from griptape.structures import Structure
 from griptape.structures.agent import Agent
 from griptape.tasks import PromptImageGenerationTask
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
@@ -91,10 +92,9 @@ class CreateImage(ControlNode):
             return exceptions
         return exceptions if exceptions else None
 
-    def process(self) -> None:
+    def process(self) -> AsyncResult[Structure]:
         # Get the parameters from the node
         params = self.parameter_values
-
         agent = params.get("agent", None)
         if not agent:
             prompt_driver = GriptapeCloudPromptDriver(
@@ -110,7 +110,9 @@ class CreateImage(ControlNode):
 
         if enhance_prompt:
             logger.info("Enhancing prompt...")
-            result = agent.run(
+            # agent.run is a blocking operation that will hold up the rest of the engine.
+            # By using `yield lambda`, the engine can run this in the background and resume when it's done.
+            result = yield lambda: agent.run(
                 [
                     """
 Enhance the following prompt for an image generation engine. Return only the image generation prompt.
@@ -143,8 +145,9 @@ Focus on qualities that will make this the most professional looking photo in th
         # Add the actual image gen *task
         agent.add_task(PromptImageGenerationTask(**kwargs))
 
-        # Run the agent
-        result = agent.run(prompt)
+        # Run the agent asynchronously
+        result = yield lambda: agent.run(prompt)
+
         self.parameter_output_values["output"] = result.output
         try_throw_error(agent.output)
         # Reset the agent

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -113,7 +113,6 @@ class ControlFlow:
         self.single_node_resolution = True
         # Get the node resolution machine for the current flow!
         resolution_machine = self.control_flow_machine._context.resolution_machine
-        self.control_flow_machine._context.current_node = node
         # Set debug mode
         resolution_machine.change_debug_mode(debug_mode)
         # Resolve the node.

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -8,6 +8,7 @@ from griptape_nodes.exe_types.connections import Connections
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import NodeResolutionState, StartNode
 from griptape_nodes.machines.control_flow import CompleteState, ControlFlowMachine
+from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
@@ -74,27 +75,25 @@ class ControlFlow:
                         return True
         return False
 
-    def start_flow(self, start_node: BaseNode | None = None, debug_mode: bool = False) -> None:  # noqa: FBT001, FBT002
+    def start_flow(self, flow_name: str, start_node: BaseNode | None = None, debug_mode: bool = False) -> None:  # noqa: FBT001, FBT002
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
         if self.check_for_existing_running_flow():
             # If flow already exists, throw an error
             errormsg = "Flow already has been started. Cannot start flow when it has already been started."
             raise Exception(errormsg)
-        if start_node:
-            logger.info("start with %s", start_node.name)
-            self.control_flow_machine.start_flow(start_node, debug_mode)
-        elif not self.flow_queue.empty():
+
+        if start_node is None:
+            if self.flow_queue.empty():
+                errormsg = "No Flow exists. You must create at least one control connection."
+                raise Exception(errormsg)
             start_node = self.flow_queue.get()
-            self.control_flow_machine.start_flow(start_node, debug_mode)
-            self.flow_queue.task_done()
-            if not debug_mode:
-                while not self.flow_queue.empty():
-                    if not self.check_for_existing_running_flow():
-                        start_node = self.flow_queue.get()
-                        self.control_flow_machine.start_flow(start_node, debug_mode)
-                        self.flow_queue.task_done()
-        else:
-            errormsg = "No Flow exists. You must create at least one control connection."
-            raise Exception(errormsg)
+
+        self.control_flow_machine.start_flow(start_node, debug_mode)
+        self.flow_queue.task_done()
+        if not debug_mode and not self.flow_queue.empty() and not self.check_for_existing_running_flow():
+            next_node = self.flow_queue.get()
+            GriptapeNodes().handle_request(StartFlowRequest(flow_name=flow_name, flow_node_name=next_node.name))
 
     def check_for_existing_running_flow(self) -> bool:
         if self.control_flow_machine._current_state is not CompleteState and self.control_flow_machine._current_state:
@@ -114,6 +113,7 @@ class ControlFlow:
         self.single_node_resolution = True
         # Get the node resolution machine for the current flow!
         resolution_machine = self.control_flow_machine._context.resolution_machine
+        self.control_flow_machine._context.current_node = node
         # Set debug mode
         resolution_machine.change_debug_mode(debug_mode)
         # Resolve the node.

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1,6 +1,8 @@
+import logging
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Generator
 from enum import Enum, auto
-from typing import Any, Self
+from typing import Any, Self, TypeVar
 
 from griptape.events import BaseEvent
 
@@ -16,6 +18,12 @@ from griptape_nodes.exe_types.core_types import (
     ParameterTypeBuiltin,
 )
 from griptape_nodes.retained_mode.events.parameter_events import RemoveParameterFromNodeRequest
+
+logger = logging.getLogger("griptape_nodes")
+
+T = TypeVar("T")
+
+AsyncResult = Generator[Callable[[], T], T]
 
 
 class NodeResolutionState(Enum):
@@ -38,6 +46,7 @@ class BaseNode(ABC):
     parameter_output_values: dict[str, Any]
     stop_flow: bool = False
     root_ui_element: BaseNodeElement
+    process_generator: Generator | None
 
     @property
     def parameters(self) -> list[Parameter]:
@@ -64,6 +73,7 @@ class BaseNode(ABC):
         self.parameter_output_values = {}
         self.root_ui_element = BaseNodeElement()
         self.config_manager = GriptapeNodes.ConfigManager()
+        self.process_generator = None
 
     def make_node_unresolved(self) -> None:
         self.state = NodeResolutionState.UNRESOLVED
@@ -365,7 +375,7 @@ class BaseNode(ABC):
     # Abstract method to process the node. Must be defined by the type
     # Must save the values of the output parameters in NodeContext.
     @abstractmethod
-    def process(self) -> None:
+    def process[T](self) -> AsyncResult | None:
         pass
 
     # if not implemented, it will return no issues.

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -156,16 +156,17 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         self._context.resolution_machine.change_debug_mode(debug_mode)
 
     def granular_step(self) -> None:
-        self._context.resolution_machine.change_debug_mode(True)
-        if self._context.resolution_machine.is_complete() or (not self._context.resolution_machine.is_started()):
+        resolution_machine = self._context.resolution_machine
+        resolution_machine.change_debug_mode(True)
+        resolution_machine.update()
+
+        if resolution_machine.is_complete() or (not resolution_machine.is_started()):
             self.update()
-        else:
-            self._context.resolution_machine.update()
 
     def node_step(self) -> None:
         resolution_machine = self._context.resolution_machine
         resolution_machine.change_debug_mode(False)
+        resolution_machine.update()
+
         if resolution_machine.is_complete() or (not resolution_machine.is_started()):
             self.update()
-        else:
-            resolution_machine.update()

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -247,6 +247,12 @@ class NodeStartProcessEvent(ExecutionPayload):
 
 @dataclass
 @PayloadRegistry.register
+class ResumeNodeProcessingEvent(ExecutionPayload):
+    node_name: str
+
+
+@dataclass
+@PayloadRegistry.register
 class NodeFinishProcessEvent(ExecutionPayload):
     node_name: str
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1238,7 +1238,7 @@ class FlowManager:
             return StartFlowResultFailure(validation_exceptions=[e])
         # By now, it has been validated with no exceptions.
         try:
-            flow.start_flow(start_node, debug_mode)
+            flow.start_flow(flow_name, start_node, debug_mode)
         except Exception as e:
             details = f"Failed to kick off flow with name {flow_name}. Exception occurred: {e} "
             logger.error(details)


### PR DESCRIPTION
These expressions will be run in a background thread. Node processing will resume when they are done.

Before this is merged the UI needs to be fixed to properly track finished node executions.

Closes #361 
Closes #312