### PR TITLE
381 add some "where am i installed?" stuff to faq + unifying some getting started/configuration content re: workspace dir

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,11 +1,51 @@
 # Frequently Asked Questions
 
-### How do I uninstall?
+## Where does my stuff save?
 
-Uninstalling Griptape [nodes] is easy:
+Can't find where Griptape [nodes] is hiding on your system? No worries! Run this command in your terminal to reveal where everything is stored:
 
+For Mac/Linux:
+```bash
+find ~/.local -name "*griptape*" -o -name "*gtn*" | sort
 ```
+
+For Windows PowerShell:
+```powershell
+Get-ChildItem -Path $env:LOCALAPPDATA -Recurse -Filter "*griptape*" | Select-Object FullName
+```
+
+## Where is Griptape [nodes] installed?
+
+Looking for the exact installation location of your Griptape [nodes]? This command will show you precisely where it's installed:
+
+For Mac/Linux:
+```bash
+echo -e "Main executable: $(readlink -f $(which gtn))\nApp directory: $(find ~/.local/share -type d -name "griptape_nodes" -o -name "griptape-nodes" | head -1)"
+```
+
+For Windows PowerShell:
+```powershell
+Write-Host "Main executable: $(Get-Command gtn | Select-Object -ExpandProperty Source)"
+Write-Host "App directory: $(Get-ChildItem -Path $env:LOCALAPPDATA -Recurse -Directory -Filter "*griptape*" | Select-Object -First 1 -ExpandProperty FullName)"
+```
+
+## How do I uninstall?
+
+Need to part ways with Griptape [nodes]? It's a simple goodbye with a single command:
+
+```bash
 griptape-nodes uninstall
 ```
 
+
 When regret inevitably washes over you, have no fear. Open arms await; just revisit [Getting Started](getting_started.md)
+
+## Where can I provide feedback or ask questions?
+
+You can connect with us through several channels:
+
+- [Website](https://www.griptape.ai) - Visit our homepage for general information
+- [Discord](https://discord.gg/gnWRz88eym) - Join our community for questions and discussions
+- [GitHub](https://github.com/griptape-ai/griptape-nodes) - Submit issues or contribute to the codebase
+
+These same links are also available as the three icons in the footer (bottom right) of every documentation page.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## Where does my stuff save?
 
-Can't find where Griptape [nodes] is hiding on your system? No worries! Run this command in your terminal to reveal where everything is stored:
+Run this command in your terminal to reveal where stuff is stored:
 
 For Mac/Linux:
 ```bash

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -68,8 +68,6 @@ Workspace Directory (/Users/user/Documents/local-dev/nodes-test-eng/GriptapeNode
 
 Pressing Enter will use the default: `<current_working_directory>/GriptapeNodes`, where `<current_working_directory>` is the directory from which you're running the `gtn` command. Alternatively, you can specify any location you prefer.
 
-Pressing Enter will use the default: `working directory/GriptapeNodes`. Alternatively, you can set another location.
-
 > You can always return to this dialog using the `gtn init` command if you need to make changes in the future.
 
 **Second**, you'll be prompted for your Griptape Cloud API Key. Return to the web browser and click the *Generate API Key* button. Copy that key and enter it in the next step.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,7 +51,7 @@ You'll see this message when installation has completed:
 
 ## 3. Configuration
 
-**First**, you'll be prompted to set your *workspace directory*. The workspace directory is the root for your projects, saved workflows, and potentially project-specific settings.
+**First**, you'll be prompted to set your *workspace directory*. Your workspace directory is where the Griptape [nodes] engine will save [configuration settings](reference/glossary.md#Configuration Settings), [project files](reference/glossary.md#Project Files), and [generated assets](reference/glossary.md#Generated Assets). It will also contain a [.env](reference/glossary.md#.env) for your project [secret keys](reference/glossary.md#Secret Keys).
 ```
 ╭───────────────────────────────────────────────────────────────────╮
 │ Workspace Directory                                               │

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,20 +51,22 @@ You'll see this message when installation has completed:
 
 ## 3. Configuration
 
-**First**, you'll be prompted to set your *workspace directory*. Your workspace directory is where the Griptape [nodes] engine will save \[configuration settings\](reference/glossary.md#Configuration Settings), \[project files\](reference/glossary.md#Project Files), and \[generated assets\](reference/glossary.md#Generated Assets). It will also contain a [.env](reference/glossary.md#.env) for your project \[secret keys\](reference/glossary.md#Secret Keys).
-
+**First**, you'll be prompted to set your *workspace directory*. The workspace directory is the root for your projects, saved workflows, and potentially project-specific settings.
 ```
 ╭───────────────────────────────────────────────────────────────────╮
 │ Workspace Directory                                               │
-│     Select the workspace directory.  This is the location where   │
-│     Griptape Nodes will store your saved workflows, configuration │
-│     data, and secrets.                                            │
+│     Select the workspace directory. This is the root for your     │
+│     projects, saved workflows, and potentially project-specific   │
+│     settings. By default, this will be set to                     │
+│     "<current_working_directory>/GriptapeNodes", which is the     │
+│     directory from which you run the 'gtn' command.               │
 │     You may enter a custom directory or press Return to accept    │
-│     the default workspace directory                               │
+│     the default workspace directory.                              │
 ╰───────────────────────────────────────────────────────────────────╯
-
 Workspace Directory (/Users/user/Documents/local-dev/nodes-test-eng/GriptapeNodes)
 ```
+
+Pressing Enter will use the default: `<current_working_directory>/GriptapeNodes`, where `<current_working_directory>` is the directory from which you're running the `gtn` command. Alternatively, you can specify any location you prefer.
 
 Pressing Enter will use the default: `working directory/GriptapeNodes`. Alternatively, you can set another location.
 


### PR DESCRIPTION


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--382.org.readthedocs.build//382/

<!-- readthedocs-preview griptape-nodes end -->