### PR TITLE
Fix CI Formatting

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Init environment
         uses: ./.github/actions/init-environment
       - name: Run formatter
-        run: uv run ruff format --check
+        run: make check/format
   type-check:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ check: check/format check/lint check/types check/spell ## Run all checks.
 .PHONY: check/format
 check/format:
 	@uv run ruff format --check
-	@uv run mdformat --check .
+	@uv run mdformat --check . --exclude .venv/**/*.md
 
 .PHONY: check/lint
 check/lint:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,11 +5,13 @@
 Run this command in your terminal to reveal where stuff is stored:
 
 For Mac/Linux:
+
 ```bash
 find ~/.local -name "*griptape*" -o -name "*gtn*" | sort
 ```
 
 For Windows PowerShell:
+
 ```powershell
 Get-ChildItem -Path $env:LOCALAPPDATA -Recurse -Filter "*griptape*" | Select-Object FullName
 ```
@@ -19,11 +21,13 @@ Get-ChildItem -Path $env:LOCALAPPDATA -Recurse -Filter "*griptape*" | Select-Obj
 Looking for the exact installation location of your Griptape [nodes]? This command will show you precisely where it's installed:
 
 For Mac/Linux:
+
 ```bash
 echo -e "Main executable: $(readlink -f $(which gtn))\nApp directory: $(find ~/.local/share -type d -name "griptape_nodes" -o -name "griptape-nodes" | head -1)"
 ```
 
 For Windows PowerShell:
+
 ```powershell
 Write-Host "Main executable: $(Get-Command gtn | Select-Object -ExpandProperty Source)"
 Write-Host "App directory: $(Get-ChildItem -Path $env:LOCALAPPDATA -Recurse -Directory -Filter "*griptape*" | Select-Object -First 1 -ExpandProperty FullName)"
@@ -36,7 +40,6 @@ Need to part ways with Griptape [nodes]? It's a simple goodbye with a single com
 ```bash
 griptape-nodes uninstall
 ```
-
 
 When regret inevitably washes over you, have no fear. Open arms await; just revisit [Getting Started](getting_started.md)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,7 +51,8 @@ You'll see this message when installation has completed:
 
 ## 3. Configuration
 
-**First**, you'll be prompted to set your *workspace directory*. Your workspace directory is where the Griptape [nodes] engine will save [configuration settings](reference/glossary.md#Configuration Settings), [project files](reference/glossary.md#Project Files), and [generated assets](reference/glossary.md#Generated Assets). It will also contain a [.env](reference/glossary.md#.env) for your project [secret keys](reference/glossary.md#Secret Keys).
+**First**, you'll be prompted to set your *workspace directory*. Your workspace directory is where the Griptape [nodes] engine will save \[configuration settings\](reference/glossary.md#Configuration Settings), \[project files\](reference/glossary.md#Project Files), and \[generated assets\](reference/glossary.md#Generated Assets). It will also contain a [.env](reference/glossary.md#.env) for your project \[secret keys\](reference/glossary.md#Secret Keys).
+
 ```
 ╭───────────────────────────────────────────────────────────────────╮
 │ Workspace Directory                                               │

--- a/docs/how_to/making_custom_nodes.md
+++ b/docs/how_to/making_custom_nodes.md
@@ -17,13 +17,14 @@ This template provides a structured foundation with all the necessary boilerplat
 ## Custom Node Development Workflow
 
 1. **Use the template repository** - Create your own repository from the GitHub template
-2. **Set up your environment** - Clone the repo to your Griptape Nodes workspace directory 
-3. **Configure your library** - Rename directories and update package information in `pyproject.toml`
-4. **Create your nodes** - Define node classes (either ControlNode or DataNode) with appropriate parameters
-5. **Implement your logic** - Code the required `process()` method and any additional functionality
-6. **Configure library metadata** - Set up your library.json file with nodes and category information
-7. **Register with the engine** - Add your library to Griptape Nodes through the settings interface
-8. **Test and use** - Create flows using your custom nodes in the Griptape Nodes interface
+1. **Set up your environment** - Clone the repo to your Griptape Nodes workspace directory
+1. **Configure your library** - Rename directories and update package information in `pyproject.toml`
+1. **Create your nodes** - Define node classes (either ControlNode or DataNode) with appropriate parameters
+1. **Implement your logic** - Code the required `process()` method and any additional functionality
+1. **Configure library metadata** - Set up your library.json file with nodes and category information
+1. **Register with the engine** - Add your library to Griptape Nodes through the settings interface
+1. **Test and use** - Create flows using your custom nodes in the Griptape Nodes interface
+
 ## Best Practices for Custom Node Development
 
 - Keep nodes focused on single responsibilities

--- a/docs/how_to/making_custom_scripts.md
+++ b/docs/how_to/making_custom_scripts.md
@@ -19,11 +19,13 @@ Retained mode provides a comprehensive interface for interacting with Griptape N
 There are two primary ways to develop and use scripts in Griptape Nodes:
 
 1. **Using the Script Editor** - Create scripts directly in the Griptape Nodes script editor for immediate execution
+
     - Access the script editor through the Griptape Nodes interface
     - Write your script using retained mode commands
     - Execute directly from the editor to modify or control your flows
 
-2. **Importing External Scripts** - Import pre-written scripts into the script editor
+1. **Importing External Scripts** - Import pre-written scripts into the script editor
+
     - Create reusable script modules in external files
     - Import them using Python's import system in the script editor
     - Execute the imported functionality from within the editor

--- a/docs/nodes/agents/create_agent.md
+++ b/docs/nodes/agents/create_agent.md
@@ -18,8 +18,8 @@ Use this node when you want to:
 ### Basic Setup
 
 1. Add the CreateAgent to your workspace
-2. Configure the agent's capabilities (tools and rulesets)
-3. Connect it to your flow
+1. Configure the agent's capabilities (tools and rulesets)
+1. Connect it to your flow
 
 ### Parameters
 
@@ -39,14 +39,13 @@ Use this node when you want to:
 
 Imagine you want to create an agent that can write haikus based on prompt_context:
 
-
 1. Add a KeyValuePair
-2. Set the "key" to "topic" and "value" to "swimming"
-3. Add a CreateAgent
-4. Set the "prompt" to "write me a haiku about {{topic}}"
-5. Connect the KeyValuePair dictionary output to the CreateAgent prompt_context input
-5. Run the workflow
-6. The CreateAgent "output" will contain a haiku about swimming!
+1. Set the "key" to "topic" and "value" to "swimming"
+1. Add a CreateAgent
+1. Set the "prompt" to "write me a haiku about {{topic}}"
+1. Connect the KeyValuePair dictionary output to the CreateAgent prompt_context input
+1. Run the workflow
+1. The CreateAgent "output" will contain a haiku about swimming!
 
 ## Important Notes
 
@@ -54,7 +53,7 @@ Imagine you want to create an agent that can write haikus based on prompt_contex
 - The node supports both streaming and non-streaming prompt drivers
 - Tools and rulesets can be provided as individual items or as lists
 - The prompt_context parameter allows you to provide additional context to the agent as a dictionary
-- By default, you need a valid Griptape API key set up in your environment as `GT_CLOUD_API_KEY` for the node to work.  Depending on the models you want to use, the keys you need will be different.
+- By default, you need a valid Griptape API key set up in your environment as `GT_CLOUD_API_KEY` for the node to work. Depending on the models you want to use, the keys you need will be different.
 - CreateAgent is designed for detailed configuration while RunAgent is for execution. Use CreateAgent when you need to:
     - Configure an agent once and run it multiple times with different prompts
     - Set up complex combinations of tools and rulesets

--- a/docs/nodes/agents/run_agent.md
+++ b/docs/nodes/agents/run_agent.md
@@ -18,8 +18,8 @@ Use this node when you want to:
 ### Basic Setup
 
 1. Add the RunAgent to your workspace
-2. Connect it to your flow
-3. Provide a prompt or connect an existing agent
+1. Connect it to your flow
+1. Provide a prompt or connect an existing agent
 
 ### Parameters
 
@@ -37,16 +37,16 @@ Use this node when you want to:
 Imagine you want to ask an AI agent a question:
 
 1. Add a RunAgent
-2. Add contextual information to "prompt_context" if needed (such as {"user_location": "New York"})
-3. In the "prompt" field, type: "Explain quantum computing in simple terms"
-4. Run the node
-5. The "output" will contain the agent's explanation of quantum computing
+1. Add contextual information to "prompt_context" if needed (such as {"user_location": "New York"})
+1. In the "prompt" field, type: "Explain quantum computing in simple terms"
+1. Run the node
+1. The "output" will contain the agent's explanation of quantum computing
 
 Or with an existing agent:
 
 1. Connect an agent output from another node to the RunAgent's "agent" input
-2. Provide a new prompt and any additional context
-3. Run the node to get a response using the connected agent's capabilities
+1. Provide a new prompt and any additional context
+1. Run the node to get a response using the connected agent's capabilities
 
 ## Important Notes
 
@@ -55,15 +55,15 @@ Or with an existing agent:
 - You need a valid Griptape API key set up in your environment as `GT_CLOUD_API_KEY`
 - If you don't provide a prompt, the node will just create the agent without running it and the output will contain exactly "Agent Created"
 - RunAgent is more execution-focused while CreateAgent is configuration-focused. Use RunAgent when you:
-  - Need to quickly run a prompt without complex configuration
-  - Want to use a pre-configured agent that was created earlier in your workflow
-  - Are building a chain of conversational interactions
+    - Need to quickly run a prompt without complex configuration
+    - Want to use a pre-configured agent that was created earlier in your workflow
+    - Are building a chain of conversational interactions
 - When connecting multiple RunAgent nodes by passing the agent output to the next node's agent input:
-  - Conversation memory is preserved throughout the chain
-  - The agent will "remember" all previous prompts and responses
-  - Context builds up across nodes, allowing for follow-up questions
-  - References to earlier information will be understood by the agent
-  - This enables building complex multi-turn conversations across your workflow
+    - Conversation memory is preserved throughout the chain
+    - The agent will "remember" all previous prompts and responses
+    - Context builds up across nodes, allowing for follow-up questions
+    - References to earlier information will be understood by the agent
+    - This enables building complex multi-turn conversations across your workflow
 
 ## Common Issues
 


### PR DESCRIPTION
Use `make/check` rather than `ruff format` command in github actions. This was originally done because of `mdformat` trying to format `.venv` in CI but we can work around that.
<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--393.org.readthedocs.build//393/

<!-- readthedocs-preview griptape-nodes end -->