### PR TITLE
Fix Uninstall Empty Caveats

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -345,21 +345,21 @@ def _uninstall_self() -> None:
 
     # Remove config directory
     if CONFIG_DIR.exists():
-        console.print(f"Removing config directory '{CONFIG_DIR}'...")
+        console.print(f"[bold]Removing config directory '{CONFIG_DIR}'...[/bold]")
         try:
             shutil.rmtree(CONFIG_DIR)
         except OSError as exc:
-            console.print(f"[bold red]Error removing config directory '{CONFIG_DIR}': {exc}[/bold red]")
+            console.print(f"[red]Error removing config directory '{CONFIG_DIR}': {exc}[/red]")
     else:
         console.print(f"[yellow]Config directory '{CONFIG_DIR}' does not exist; skipping.[/yellow]")
 
     # Remove data directory
     if DATA_DIR.exists():
-        console.print(f"Removing data directory '{DATA_DIR}'...")
+        console.print(f"[bold]Removing data directory '{DATA_DIR}'...[/bold]")
         try:
             shutil.rmtree(DATA_DIR)
         except OSError as exc:
-            console.print(f"[bold red]Error removing data directory '{DATA_DIR}': {exc}[/bold red]")
+            console.print(f"[bold]Error removing data directory '{DATA_DIR}': {exc}[/bold]")
     else:
         console.print(f"[yellow]Data directory '{DATA_DIR}' does not exist; skipping.[/yellow]")
 
@@ -367,7 +367,7 @@ def _uninstall_self() -> None:
     executable_path = shutil.which("griptape-nodes")
     executable_removed = False
     if executable_path:
-        console.print(f"Removing Griptape Nodes executable ({executable_path})...")
+        console.print(f"[bold]Removing Griptape Nodes executable ({executable_path})...[/bold]")
         try:
             subprocess.run(
                 ["uv", "tool", "uninstall", "griptape-nodes"],
@@ -380,7 +380,7 @@ def _uninstall_self() -> None:
     else:
         console.print("[yellow]Griptape Nodes executable not found; skipping removal.[/yellow]")
 
-    console.print("[bold green]Uninstall complete![/bold green]\n")
+    console.print("[bold green]Uninstall complete![/bold green]")
 
     caveats = []
     # Handle any remaining config files not removed by design

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -382,19 +382,23 @@ def _uninstall_self() -> None:
 
     console.print("[bold green]Uninstall complete![/bold green]\n")
 
-    console.print("[bold]Caveats:[/bold]")
+    caveats = []
     # Handle any remaining config files not removed by design
     remaining_config_files = config_manager.config_files
     if remaining_config_files:
-        console.print("- Some config files were intentionally not removed:")
-        for file in remaining_config_files:
-            console.print(f"\t[yellow]- {file}[/yellow]")
+        caveats.append("- Some config files were intentionally not removed:")
+        caveats.extend(f"\t[yellow]- {file}[/yellow]" for file in remaining_config_files)
 
     if not executable_removed:
-        console.print(
-            "- The uninstaller was not able to remove the 'griptape-nodes' executable. "
+        caveats.append(
+            "- The uninstaller was not able to remove the Griptape Nodes executable. "
             "Please remove the executable manually by running '[bold]uv tool uninstall griptape-nodes[/bold]'."
         )
+
+    if caveats:
+        console.print("[bold]Caveats:[/bold]")
+        for line in caveats:
+            console.print(line)
 
     # Exit the process
     sys.exit(0)


### PR DESCRIPTION
Only show caveats if there are some. Fixes this type of output:
```
❮ gtn uninstall
Uninstalling Griptape Nodes...
Removing config directory '/Users/collindutter/.config/griptape_nodes'...
Data directory '/Users/collindutter/.local/share/griptape_nodes' does not exist; skipping.
Removing Griptape Nodes executable (/Users/collindutter/.local/bin/griptape-nodes)...
Uninstalled 2 executables: griptape-nodes, gtn
Uninstall complete!

Caveats:
```

Also cleans up some of the output.