### PR TITLE
fix: consider config files in workspace directory

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -147,11 +147,8 @@ def _prompt_for_workspace(workspace_directory_arg: str | None) -> None:
             )
             workspace_path = Path(workspace_directory).expanduser().resolve()
 
-            current_config = json.loads(CONFIG_FILE.read_text())
-            current_config["workspace_directory"] = str(workspace_path)
-            CONFIG_FILE.write_text(json.dumps(current_config, indent=2))
-
-            config_manager.load_user_config()
+            config_manager.workspace_path = workspace_path
+            config_manager.set_config_value("workspace_directory", str(workspace_path))
 
             valid_workspace = True
         except OSError as e:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -3,6 +3,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from pydantic_settings import SettingsConfigDict
+from xdg_base_dirs import xdg_config_home
+
 from griptape_nodes.retained_mode.events.base_events import ResultPayload
 from griptape_nodes.retained_mode.events.config_events import (
     GetConfigCategoryRequest,
@@ -19,10 +22,12 @@ from griptape_nodes.retained_mode.events.config_events import (
     SetConfigValueResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.settings import Settings, WorkflowSettingsDetail, _find_config_files
+from griptape_nodes.retained_mode.managers.settings import Settings, WorkflowSettingsDetail
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
 
 logger = logging.getLogger("griptape_nodes")
+
+CONFIG_DIR = xdg_config_home() / "griptape_nodes"
 
 
 class ConfigManager:
@@ -65,14 +70,13 @@ class ConfigManager:
         return Path(self._workspace_path).resolve()
 
     @workspace_path.setter
-    def workspace_path(self, path: str) -> None:
+    def workspace_path(self, path: str | Path) -> None:
         """Set the base file path in the configuration.
 
         Args:
             path: The path to set as the base file path.
         """
         self._workspace_path = str(Path(path).resolve())
-        self.set_config_value("workspace_directory", self._workspace_path)
 
     @property
     def user_config_path(self) -> Path:
@@ -91,19 +95,47 @@ class ConfigManager:
             List of Path objects representing the config files.
         """
         possible_config_files = [
-            *_find_config_files("griptape_nodes_config", "json"),
-            *_find_config_files("griptape_nodes_config", "toml"),
-            *_find_config_files("griptape_nodes_config", "yaml"),
+            *self._find_config_files("griptape_nodes_config.json"),
             self.workspace_path / "griptape_nodes_config.json",
+            *self._find_config_files("griptape_nodes_config.toml"),
+            self.workspace_path / "griptape_nodes_config.toml",
+            *self._find_config_files("griptape_nodes_config.yaml"),
+            self.workspace_path / "griptape_nodes_config.yaml",
         ]
 
         return [config_file for config_file in possible_config_files if config_file.exists()]
 
     def load_user_config(self) -> None:
         """Load user configuration from the config file."""
+        # We need to load the fully merged config once so that
+        # we can get the workspace directory which will inform where to get more config files.
+        # Workspace directory should probably be decoupled from the config file.
+        Settings.model_config = SettingsConfigDict(
+            json_file=self._find_config_files("griptape_nodes_config.json"),
+            toml_file=self._find_config_files("griptape_nodes_config.toml"),
+            yaml_file=self._find_config_files("griptape_nodes_config.yaml"),
+        )
+        settings = Settings()
+        workspace_path = Path(settings.workspace_directory).resolve()
+
+        # Now we load the config again, this time considering the workspace directory.
+        Settings.model_config = SettingsConfigDict(
+            json_file=[
+                *self._find_config_files("griptape_nodes_config.json"),
+                workspace_path / "griptape_nodes_config.json",
+            ],
+            toml_file=[
+                *self._find_config_files("griptape_nodes_config.toml"),
+                workspace_path / "griptape_nodes_config.toml",
+            ],
+            yaml_file=[
+                *self._find_config_files("griptape_nodes_config.yaml"),
+                workspace_path / "griptape_nodes_config.yaml",
+            ],
+        )
         settings = Settings()
         self.user_config = settings.model_dump()
-        self._workspace_path = settings.workspace_directory
+        self.workspace_path = settings.workspace_directory
 
     def save_user_workflow_json(self, workflow_file_name: str) -> None:
         workflow_details = WorkflowSettingsDetail(file_name=workflow_file_name, is_griptape_provided=False)
@@ -169,14 +201,25 @@ class ConfigManager:
             value: The value to associate with the key.
         """
         delta = set_dot_value({}, key, value)
+        workspace_dir = self.workspace_path
         if key == "log_level":
             try:
                 logger.setLevel(value.upper())
             except ValueError:
                 logger.error("Invalid log level %s. Defaulting to INFO.", value)
                 logger.setLevel(logging.INFO)
+        elif key == "workspace_directory":
+            # If the key is workspace_directory, we want to write the value
+            # to the home config directory (~/.config/griptape_nodes) and not the workspace directory.
+            workspace_dir = CONFIG_DIR
+            self.workspace_path = value
         self.user_config = merge_dicts(self.user_config, delta)
-        self._write_user_config_delta(delta)
+        self._write_user_config_delta(delta, workspace_dir)
+
+        # If the key is workspace_directory, we need to fully reload the user config
+        # because the workspace changing may influence the config files we load.
+        if key == "workspace_directory":
+            self.load_user_config()
 
     def on_handle_get_config_category_request(self, request: GetConfigCategoryRequest) -> ResultPayload:
         if request.category is None or request.category == "":
@@ -211,8 +254,7 @@ class ConfigManager:
 
         if request.category is None or request.category == "":
             # Assign the whole shebang.
-            self.user_config = request.contents
-            self._write_user_config_delta(request.contents)
+            self._write_user_config_delta(request.contents, self.user_config_path)
             details = "Successfully assigned the entire config dictionary."
             logger.info(details)
             return SetConfigCategoryResultSuccess()
@@ -250,7 +292,7 @@ class ConfigManager:
         logger.info(details)
         return SetConfigValueResultSuccess()
 
-    def _write_user_config_delta(self, user_config_delta: dict) -> None:
+    def _write_user_config_delta(self, user_config_delta: dict, workspace_dir: Path) -> None:
         """Write the user configuration to the config file.
 
         This method creates the config file if it doesn't exist and writes the
@@ -258,11 +300,35 @@ class ConfigManager:
 
         Args:
             user_config_delta: The user configuration delta to write to the file Will be merged with the existing config on disk.
+            workspace_dir: The path to the config file
         """
-        if not self.user_config_path.exists():
-            self.user_config_path.parent.mkdir(parents=True, exist_ok=True)
-            self.user_config_path.touch()
-            self.user_config_path.write_text(json.dumps({}, indent=2))
-        current_config = json.loads(self.user_config_path.read_text())
+        user_config_path = workspace_dir / "griptape_nodes_config.json"
+
+        if not user_config_path.exists():
+            user_config_path.parent.mkdir(parents=True, exist_ok=True)
+            user_config_path.touch()
+            user_config_path.write_text(json.dumps({}, indent=2))
+        current_config = json.loads(user_config_path.read_text())
         merged_config = merge_dicts(current_config, user_config_delta)
-        self.user_config_path.write_text(json.dumps(merged_config, indent=2))
+        user_config_path.write_text(json.dumps(merged_config, indent=2))
+
+    def _find_config_files(self, filename: str) -> list[Path]:
+        """Find configuration files in the workspace directory and parent directories.
+
+        Searches in the following priority order:
+        1. XDG_CONFIG_HOME (e.g., `~/.config/griptape_nodes/griptape_nodes_config.json`)
+        2. Current working directory
+        3. Parent directories up to HOME
+        """
+        config_files = []
+
+        # Search XDG_CONFIG_HOME (e.g., `~/.config/griptape_nodes/griptape_nodes_config.json`)
+        config_files.append(xdg_config_home() / "griptape_nodes" / filename)
+
+        # Recursively search parent directories up to HOME
+        current_path = Path.cwd()
+        while current_path not in (Path.home(), current_path.parent) and current_path != current_path.parent:
+            config_files.append(current_path / filename)
+            current_path = current_path.parent
+
+        return config_files

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -10,34 +10,7 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
     YamlConfigSettingsSource,
 )
-from xdg_base_dirs import xdg_config_dirs, xdg_config_home, xdg_data_home
-
-
-def _find_config_files(filename: str, extension: str) -> list[Path]:
-    config_files = []
-
-    # Recursively search parent directories up to HOME
-    current_path = Path.cwd()
-    while current_path not in (Path.home(), current_path.parent) and current_path != current_path.parent:
-        config_files.append(current_path / f"{filename}.{extension}")
-        current_path = current_path.parent
-
-    # Search `GriptapeNodes/` inside home directory (a frequently installed location)
-    config_files.append(Path.home() / "GriptapeNodes" / f"{filename}.{extension}")
-
-    # Search `GriptapeNodes/` inside current working directory (this is the implicit default)
-    config_files.append(Path.cwd() / "GriptapeNodes" / f"{filename}.{extension}")
-
-    # Search XDG_CONFIG_HOME (e.g., `~/.config/griptape_nodes/griptape_nodes_config.yaml`)
-    config_files.append(xdg_config_home() / "griptape_nodes" / f"{filename}.{extension}")
-
-    # Search XDG_CONFIG_DIRS (e.g., `/etc/xdg/griptape_nodes/gt_nodes.yaml`)
-    config_files.extend([Path(xdg_dir) / "griptape_nodes" / f"{filename}.{extension}" for xdg_dir in xdg_config_dirs()])
-
-    # Reverse the list so that the most specific paths are checked first
-    config_files.reverse()
-
-    return config_files
+from xdg_base_dirs import xdg_data_home
 
 
 @dataclass
@@ -125,12 +98,6 @@ class Settings(BaseSettings):
         }
     )
     log_level: str = Field(default="INFO")
-
-    class Config:
-        json_file = _find_config_files("griptape_nodes_config", "json")
-        toml_file = _find_config_files("griptape_nodes_config", "toml")
-        yaml_file = _find_config_files("griptape_nodes_config", "yaml")
-        extra = "allow"
 
     @classmethod
     def settings_customise_sources(


### PR DESCRIPTION
This one was tricky because it's a chicken and egg problem. The `workspace_directory` is set in configuration files, but the `workspace_directory` _informs_ the configuration files. I'm not in love with the solution because it requires loading the settings twice, but it makes some overdue refactors and solves the immediate problem.

Closes #422 