### PR TITLE
feat: enable background work for agent nodes

### DIFF
--- a/nodes/griptape_nodes_library/agents/base_agent.py
+++ b/nodes/griptape_nodes_library/agents/base_agent.py
@@ -1,12 +1,9 @@
-from collections.abc import Iterator
-
-from griptape.artifacts import TextArtifact
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
-from griptape.structures import Agent, Structure
+from griptape.structures import Agent
 from griptape.tasks import PromptTask
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterList, ParameterMode
-from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 DEFAULT_MODEL = "gpt-4o"
@@ -128,8 +125,3 @@ class BaseAgent(ControlNode):
             task = agent.tasks[0]
             task.context = self.get_parameter_value("prompt_context")
         return agent
-
-    def process(
-        self,
-    ) -> AsyncResult[Iterator[TextArtifact] | Structure] | None:
-        pass

--- a/nodes/griptape_nodes_library/agents/create_agent.py
+++ b/nodes/griptape_nodes_library/agents/create_agent.py
@@ -1,9 +1,5 @@
-from collections.abc import Iterator
-from typing import cast
-
-from griptape.artifacts import TextArtifact
 from griptape.events import TextChunkEvent
-from griptape.structures import Agent, Structure
+from griptape.structures import Agent
 from griptape.utils import Stream
 
 from griptape_nodes.exe_types.node_types import AsyncResult
@@ -37,7 +33,7 @@ class CreateAgent(BaseAgent):
 
     def process(
         self,
-    ) -> AsyncResult[Iterator[TextArtifact] | Structure]:
+    ) -> AsyncResult[str]:
         # Get input values
         params = self.parameter_values
         prompt_driver = params.get("prompt_driver", self.get_default_prompt_driver())
@@ -67,18 +63,16 @@ class CreateAgent(BaseAgent):
         prompt = params.get("prompt", None)
         agent = self.set_context(agent)
         if prompt:
-            full_output = ""
             # Check and see if the prompt driver is a stream driver
             if self.is_stream(agent):
-                # Run the agent
-                agent_stream = cast("Iterator", (yield lambda: Stream(agent, event_types=[TextChunkEvent]).run(prompt)))
-                for artifact in agent_stream:
-                    full_output += artifact.value
-                    self.parameter_output_values["output"] = full_output
+                full_output = yield (
+                    lambda: "".join(
+                        artifact.value for artifact in Stream(agent, event_types=[TextChunkEvent]).run(prompt)
+                    )
+                )
             else:
                 # Run the agent
-                result = cast("Structure", (yield lambda: agent.run(prompt)))
-                full_output = result.output.value
+                full_output = yield lambda: agent.run(prompt).output.value
             self.parameter_output_values["output"] = full_output
         else:
             self.parameter_output_values["output"] = "Agent Created"

--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -339,7 +339,7 @@ class ExecuteNodeState(State):
                 func = current_node.process_generator.send(context.scheduled_value)
                 # Once we've passed on the scheduled value, we should clear it out just in case
                 context.scheduled_value = None
-                future = ExecuteNodeState.executor.submit(func)
+                future = ExecuteNodeState.executor.submit(with_contextvars(func))
                 future.add_done_callback(with_contextvars(on_future_done))
             except StopIteration:
                 logger.debug("Node %s generator is done.", current_node.name)


### PR DESCRIPTION
Refactors `create_agent.py` and `run_agent.py` to take advantage of background processing when streaming. I really don't love this syntax and it's further proof that we should implement `asyncio`'s event loop instead of our own so that we can take advantage nicities like `async for`.

Closes #400 