### PR TITLE
fix: correctly handle rulesets

### DIFF
--- a/nodes/griptape_nodes_library/agents/base_agent.py
+++ b/nodes/griptape_nodes_library/agents/base_agent.py
@@ -45,9 +45,9 @@ class BaseAgent(ControlNode):
                 tooltip="",
                 allowed_modes={ParameterMode.INPUT},
             )
-            Parameter(
+            ParameterList(
                 name="rulesets",
-                input_types=["list[Ruleset]", "Ruleset"],
+                input_types=["Ruleset"],
                 tooltip="Rulesets to apply to the agent to control its behavior.",
                 allowed_modes={ParameterMode.INPUT},
             )

--- a/nodes/griptape_nodes_library/agents/create_agent.py
+++ b/nodes/griptape_nodes_library/agents/create_agent.py
@@ -28,7 +28,7 @@ class CreateAgent(BaseAgent):
         return []
 
     def get_rulesets(self) -> list:
-        rulesets = self.parameter_values.get("rulesets", None)
+        rulesets = self.get_parameter_value("rulesets")
         if rulesets:
             if not isinstance(rulesets, list):
                 rulesets = [rulesets]

--- a/nodes/griptape_nodes_library/rules/ruleset_list.py
+++ b/nodes/griptape_nodes_library/rules/ruleset_list.py
@@ -19,7 +19,7 @@ class RulesetList(DataNode):
                 name="ruleset_1",
                 input_types=["Ruleset"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Ruleset to add to the list",
             )
         )
@@ -28,7 +28,7 @@ class RulesetList(DataNode):
                 name="ruleset_2",
                 input_types=["Ruleset"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Ruleset to add to the list",
             )
         )
@@ -37,7 +37,7 @@ class RulesetList(DataNode):
                 name="ruleset_3",
                 input_types=["Ruleset"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Ruleset to add to the list",
             )
         )
@@ -46,7 +46,7 @@ class RulesetList(DataNode):
                 name="ruleset_4",
                 input_types=["Ruleset"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Ruleset to add to the list",
             )
         )
@@ -57,7 +57,7 @@ class RulesetList(DataNode):
                 name="rulesets",
                 output_type="list[Ruleset]",
                 allowed_modes={ParameterMode.OUTPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Combined list of Rulesets",
             )
         )

--- a/nodes/griptape_nodes_library/tools/tool_list.py
+++ b/nodes/griptape_nodes_library/tools/tool_list.py
@@ -19,7 +19,7 @@ class ToolList(DataNode):
                 name="tool_1",
                 input_types=["Tool"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Tool to add to the list",
             )
         )
@@ -28,7 +28,7 @@ class ToolList(DataNode):
                 name="tool_2",
                 input_types=["Tool"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Tool to add to the list",
             )
         )
@@ -37,7 +37,7 @@ class ToolList(DataNode):
                 name="tool_3",
                 input_types=["Tool"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Tool to add to the list",
             )
         )
@@ -46,7 +46,7 @@ class ToolList(DataNode):
                 name="tool_4",
                 input_types=["Tool"],
                 allowed_modes={ParameterMode.INPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Tool to add to the list",
             )
         )
@@ -57,7 +57,7 @@ class ToolList(DataNode):
                 name="tools",
                 output_type="list[Tool]",
                 allowed_modes={ParameterMode.OUTPUT},
-                default_value=[],
+                default_value=None,
                 tooltip="Combined list of tools",
             )
         )


### PR DESCRIPTION
Makes the usage of `RulesetList` consistent with the implementation `ToolsList` which fixes them not resolving.

Note that there is a minor regression in that you can no longer attach a single Ruleset directly. This is the same problem with any `ParameterList` field so we should track it separately: https://github.com/griptape-ai/griptape-nodes/issues/473.

Closes #433
Closes #434