### PR TITLE
feat: show session updates in a panel

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -299,7 +299,7 @@ def __broadcast_app_initialization_complete(nodes_app_url: str) -> None:
     message = Panel(
         Align.center(
             f"[bold green]Engine is ready to receive events[/bold green]\n"
-            f"[bold blue]Return to: [link={nodes_app_url}]{nodes_app_url}[/link][/bold blue] to access the IDE",
+            f"Return to [bold blue][link={nodes_app_url}]{nodes_app_url}[/link][/bold blue] to access the IDE",
             vertical="middle",
         ),
         title="🚀 Griptape Nodes Engine Started",


### PR DESCRIPTION
New sessions and session changes are now shown in a panel. Same session requests are logged.
![image](https://github.com/user-attachments/assets/ffc83679-0dd1-489f-9536-1bcc94d144cc)

I personally find this a bit noisy. As a user I don't really care about session information (any more than other logs), I just want my editor and engine to connect in intuitive and seamless ways.

Closes #401 