### PR TITLE
Echo exceptions at app level and handle all exceptions for library loading

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -150,8 +150,9 @@ def _listen_for_api_events() -> None:
                             except Exception:
                                 logger.exception("Error processing event, skipping.")
 
-        except Exception:
-            logger.error("Error while listening for events. Retrying in 2 seconds.")
+        except Exception as e:
+            details = f"Error while listening for events. Retrying in 2 seconds.: {e}"
+            logger.error(details)
             sleep(2)
             init = False
 


### PR DESCRIPTION
Closes #507 

Without app.py echoing what the exception was, I would have gone crazy figuring this out. It led me to where the problem was: we were only catching one specific type of exception during library loading. Expanded with a catch-all.