### PR TITLE
Image Generation Fixes

### DIFF
--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -100,7 +100,6 @@ class GenerateImage(ControlNode):
             prompt_driver = GriptapeCloudPromptDriver(
                 model="gpt-4o",
                 api_key=self.get_config_value(SERVICE, API_KEY_ENV_VAR),
-                stream=True,
             )
             agent = Agent(prompt_driver=prompt_driver)
         else:

--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -45,6 +45,11 @@ class GenerateImage(ControlNode):
             )
         )
 
+        def validate_prompt(_param: Parameter, value: str) -> None:
+            if not value:
+                msg = "Prompt is required for image generation."
+                raise ValueError(msg)
+
         self.add_parameter(
             Parameter(
                 name="prompt",
@@ -55,6 +60,7 @@ class GenerateImage(ControlNode):
                 default_value="",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 ui_options={"multiline": True, "placeholder_text": "Enter your image generation prompt here."},
+                validators=[validate_prompt],
             )
         )
         self.add_parameter(


### PR DESCRIPTION
Last bit of fixes for #489. Streaming causes the text chunks to go into the image display because the parameter is named `output` and we [hardcode](https://github.com/griptape-ai/griptape-vsl-gui/blob/ec28559e1671fbc16bf5b38e143db79b4a7d03e3/src/components/FlowEditor.tsx?plain=1#L1073-L1075) handle that in the UI. Long term, `ProgressEvent`s will be a more robust solution here.


Closes #489
Closes https://github.com/griptape-ai/griptape-vsl-gui/issues/311 
Closes https://github.com/griptape-ai/griptape-vsl-gui/issues/309
Closes https://github.com/griptape-ai/griptape-vsl-gui/issues/310
Closes https://github.com/griptape-ai/griptape-vsl-gui/issues/317