### PR TITLE
Requests that can reasonably be run within a node context now take `node_name` as optional. Will attempt to use the Current Context if so.

### DIFF
--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -57,7 +57,8 @@ class DeleteConnectionResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class ListConnectionsForNodeRequest(RequestPayload):
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -11,10 +11,11 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @dataclass
 @PayloadRegistry.register
 class CreateConnectionRequest(RequestPayload):
-    source_node_name: str
     source_parameter_name: str
-    target_node_name: str
     target_parameter_name: str
+    # If node name is None, use the Current Context
+    source_node_name: str | None = None
+    target_node_name: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
 
@@ -34,10 +35,11 @@ class CreateConnectionResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class DeleteConnectionRequest(RequestPayload):
-    source_node_name: str
     source_parameter_name: str
-    target_node_name: str
     target_parameter_name: str
+    # If node name is None, use the Current Context
+    source_node_name: str | None = None
+    target_node_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -66,7 +66,8 @@ class DeleteNodeResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class GetNodeResolutionStateRequest(RequestPayload):
-    node_name: str
+    # If None is passed, assumes we're using the Node in the Current Context
+    node_name: str | None = None
 
 
 @dataclass
@@ -84,7 +85,8 @@ class GetNodeResolutionStateResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class ListParametersOnNodeRequest(RequestPayload):
-    node_name: str
+    # If None is passed, assumes we're using the Node in the Current Context
+    node_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -104,7 +104,8 @@ class ListParametersOnNodeResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class GetNodeMetadataRequest(RequestPayload):
-    node_name: str
+    # If None is passed, assumes we're using the Node in the Current Context
+    node_name: str | None = None
 
 
 @dataclass
@@ -122,8 +123,9 @@ class GetNodeMetadataResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class SetNodeMetadataRequest(RequestPayload):
-    node_name: str
     metadata: dict
+    # If None is passed, assumes we're using the Node in the Current Context
+    node_name: str | None = None
 
 
 @dataclass
@@ -143,7 +145,8 @@ class SetNodeMetadataResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class GetAllNodeInfoRequest(RequestPayload):
-    node_name: str
+    # If None is passed, assumes we're using the Node in the Current Context
+    node_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -27,6 +27,9 @@ class CreateNodeRequest(RequestPayload):
     resolution: str = NodeResolutionState.UNRESOLVED.value
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
+    # When True, this Flow will be pushed as the current Node within the Current Context.
+    # TODO(griptape): Remove the None once the lynchpin commit on editor side is in place (issue #454 in editor repo): https://github.com/griptape-ai/griptape-nodes/issues/530
+    set_as_new_context: bool | None = None
 
 
 @dataclass
@@ -44,7 +47,8 @@ class CreateNodeResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class DeleteNodeRequest(RequestPayload):
-    node_name: str
+    # If None is passed, assumes we're using the Node in the Current Context.
+    node_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -17,7 +17,8 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @dataclass
 @PayloadRegistry.register
 class AddParameterToNodeRequest(RequestPayload):
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
     parameter_name: str | None = None
     default_value: Any | None = None
     tooltip: str | list[dict] | None = None
@@ -64,7 +65,8 @@ class AddParameterToNodeResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class RemoveParameterFromNodeRequest(RequestPayload):
     parameter_name: str
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
 
 
 @dataclass
@@ -83,8 +85,9 @@ class RemoveParameterFromNodeResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class SetParameterValueRequest(RequestPayload):
     parameter_name: str
-    node_name: str
     value: Any
+    # If node name is None, use the Current Context
+    node_name: str | None = None
     data_type: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
@@ -109,7 +112,8 @@ class SetParameterValueResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class GetParameterDetailsRequest(RequestPayload):
     parameter_name: str
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
 
 
 @dataclass
@@ -141,7 +145,8 @@ class GetParameterDetailsResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class AlterParameterDetailsRequest(RequestPayload):
     parameter_name: str
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
     type: str | None = None
     input_types: list[str] | None = None
     output_type: str | None = None
@@ -211,7 +216,8 @@ class AlterParameterDetailsResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class GetParameterValueRequest(RequestPayload):
     parameter_name: str
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
 
 
 @dataclass
@@ -241,9 +247,10 @@ class OnParameterValueChanged(ResultPayloadSuccess):
 @dataclass
 @PayloadRegistry.register
 class GetCompatibleParametersRequest(RequestPayload):
-    node_name: str
     parameter_name: str
     is_output: bool
+    # If node name is None, use the Current Context
+    node_name: str | None = None
 
 
 class ParameterAndMode(NamedTuple):
@@ -266,7 +273,8 @@ class GetCompatibleParametersResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class GetNodeElementDetailsRequest(RequestPayload):
-    node_name: str
+    # If node name is None, use the Current Context
+    node_name: str | None = None
     specific_element_id: str | None = None  # Pass None to use the root
 
 


### PR DESCRIPTION
Closes #463 