### PR TITLE
fix: move process_generator from node to resolution machine context

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -50,7 +50,6 @@ class BaseNode(ABC):
     parameter_output_values: dict[str, Any]
     stop_flow: bool = False
     root_ui_element: BaseNodeElement
-    process_generator: Generator | None
 
     @property
     def parameters(self) -> list[Parameter]:


### PR DESCRIPTION
Ensures nice cleanup when the flow is cancelled