### PR TITLE
refactor: move process_generator from node to resolution machine context (#580)

### DIFF
--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -210,7 +210,7 @@ class ControlFlow:
         current_control_node = self.control_flow_machine._context.current_node.name
         focus_stack_for_node = self.control_flow_machine._context.resolution_machine._context.focus_stack
         if len(focus_stack_for_node):
-            current_resolving_node = focus_stack_for_node[-1].name
+            current_resolving_node = focus_stack_for_node[-1].node.name
         else:
             current_resolving_node = None
         return current_control_node, current_resolving_node

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1358,7 +1358,7 @@ class FlowManager:
             flow.start_flow(flow_name, start_node, debug_mode)
         except Exception as e:
             details = f"Failed to kick off flow with name {flow_name}. Exception occurred: {e} "
-            logger.error(details)
+            logger.exception(details)
             if flow.check_for_existing_running_flow():
                 # Cancel the flow run.
                 cancel_request = CancelFlowRequest(flow_name=flow_name)
@@ -1387,7 +1387,7 @@ class FlowManager:
             control_node, resolving_node = flow.flow_state()
         except Exception as e:
             details = f"Failed to get flow state of flow with name {flow_name}. Exception occurred: {e} "
-            logger.error(details)
+            logger.exception(details)
             return GetFlowStateResultFailure()
         details = f"Successfully got flow state for flow with name {flow_name}."
         logger.debug(details)


### PR DESCRIPTION
Refactor `process_generator` and `scheduled_value` to live on the `focus_stack`. May help scenarios where there are many overlapping background processes.