### PR TITLE
revert: don't suppress requests without request_id

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -168,8 +168,6 @@ def __process_node_event(event: GriptapeNodeEvent) -> None:
         raise TypeError(msg) from None
 
     # Don't send events over the wire that don't have a request_id set (e.g. engine-internal events)
-    if result_event.request.request_id is None:
-        return
     event_json = result_event.json()
     socket.emit(dest_socket, event_json)
 


### PR DESCRIPTION
Turns out the UI needs this to listen on side effects.

Needed for https://github.com/griptape-ai/griptape-vsl-gui/pull/477