### PR TITLE
Cancel Runs on ClearAllObjects

### DIFF
--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -191,13 +191,13 @@ class ControlFlow:
         if not self.check_for_existing_running_flow():
             errormsg = "Flow has not yet been started. Cannot cancel flow that hasn't begun."
             raise Exception(errormsg)
-        del self.control_flow_machine
-        # Create a new control flow machine
-        # Cancel all future runs
         del self.flow_queue
         self.flow_queue = Queue()
+        if self.control_flow_machine.get_current_state():
+            self.control_flow_machine.reset_machine()
+        else:
+            self.control_flow_machine._context.resolution_machine.reset_machine()
         # Reset control flow machine
-        self.control_flow_machine = ControlFlowMachine(self)
         self.single_node_resolution = False
         logger.debug("Cancelling flow run")
 

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -421,6 +421,17 @@ class BaseNode(ABC):
     def set_config_value(self, service: str, value: str, new_value: str) -> None:
         self.config_manager.set_config_value(f"nodes.{service}.{value}", new_value)
 
+    def clear_node(self) -> None:
+        # set state to unresolved
+        self.state = NodeResolutionState.UNRESOLVED
+        # delete all output values potentially generated
+        self.parameter_output_values.clear()
+        # Remove the current spotlight
+        while self.current_spotlight_parameter is not None:
+            temp = self.current_spotlight_parameter.next
+            del self.current_spotlight_parameter
+            self.current_spotlight_parameter = temp
+
     def append_value_to_parameter(self, parameter_name: str, value: Any) -> None:
         # Add the value to the node
         if parameter_name in self.parameter_output_values:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -45,7 +45,7 @@ class ControlFlowContext:
     def reset(self) -> None:
         if self.current_node:
             self.current_node.clear_node()
-        self.current_node = None
+        del self.current_node
         self.resolution_machine.reset_machine()
         self.selected_output = None
         self.paused = False

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -42,6 +42,14 @@ class ControlFlowContext:
             node, _ = node
         return node
 
+    def reset(self) -> None:
+        if self.current_node:
+            self.current_node.clear_node()
+        self.current_node = None
+        self.resolution_machine.reset_machine()
+        self.selected_output = None
+        self.paused = False
+
 
 # GOOD!
 class ResolveNodeState(State):
@@ -171,3 +179,7 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
 
         if resolution_machine.is_complete() or (not resolution_machine.is_started()):
             self.update()
+
+    def reset_machine(self) -> None:
+        self._context.reset()
+        self._current_state = None

--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -50,6 +50,14 @@ class ResolutionContext:
         self.focus_stack = []
         self.paused = False
 
+    def reset(self) -> None:
+        if len(self.focus_stack) > 0:
+            node = self.focus_stack[-1].node
+            # clear the data node being resolved.
+            node.clear_node()
+        self.focus_stack.clear()
+        self.paused = False
+
 
 class InitializeSpotlightState(State):
     @staticmethod
@@ -406,3 +414,7 @@ class NodeResolutionMachine(FSM[ResolutionContext]):
 
     def is_started(self) -> bool:
         return self._current_state is not None
+
+    def reset_machine(self) -> None:
+        self._current_state = None
+        self._context.reset()

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -500,7 +500,9 @@ class ObjectManager:
         if context_mgr.has_current_flow():
             flow_name = context_mgr.pop_flow()
             if flow_name:
-                flow = GriptapeNodes.get_instance()._object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+                flow = GriptapeNodes.get_instance()._object_manager.attempt_get_object_by_name_as_type(
+                    flow_name, ControlFlow
+                )
                 if flow and flow.check_for_existing_running_flow():
                     result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow_name))
                     if not result.succeeded():

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -490,6 +490,12 @@ class ObjectManager:
             return ClearAllObjectStateResultFailure()
         # Let's try and clear it all.
         context_mgr = GriptapeNodes.ContextManager()
+        if context_mgr.has_current_flow():
+            flow_name = context_mgr.pop_flow()
+            if flow_name:
+                flow = GriptapeNodes.get_instance()._object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+                if flow and flow.check_for_existing_running_flow():
+                    GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow_name))
         while context_mgr.has_current_flow():
             while context_mgr.has_current_node():
                 while context_mgr.has_current_element():


### PR DESCRIPTION
closes #502 
Update run cancelling to fully reset all of the nodes and the state machines. 
Adds new reset_machine and reset methods in the context objects and in the machines.

Removed cancellation when trying to run a flow 2x back to back. Now it just prevents that behavior from happening, and the flow continues to run. 

There is some weirdness with outputs still - but that will have to do with being able to cancel the threads, which is not handled in this PR. 