### PR TITLE
Connection virtual functions in BaseNode were using `Self`, but that meant derived classes weren't able to override those functions correctly.

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from enum import StrEnum, auto
-from typing import Any, Self, TypeVar
+from typing import Any, TypeVar
 
 from griptape.events import BaseEvent, EventBus
 
@@ -83,7 +85,7 @@ class BaseNode(ABC):
 
     def allow_incoming_connection(
         self,
-        source_node: Self,  # noqa: ARG002
+        source_node: BaseNode,  # noqa: ARG002
         source_parameter: Parameter,  # noqa: ARG002
         target_parameter: Parameter,  # noqa: ARG002
     ) -> bool:
@@ -93,7 +95,7 @@ class BaseNode(ABC):
     def allow_outgoing_connection(
         self,
         source_parameter: Parameter,  # noqa: ARG002
-        target_node: Self,  # noqa: ARG002
+        target_node: BaseNode,  # noqa: ARG002
         target_parameter: Parameter,  # noqa: ARG002
     ) -> bool:
         """Callback to confirm allowing a Connection going OUT of this Node."""
@@ -101,7 +103,7 @@ class BaseNode(ABC):
 
     def after_incoming_connection(
         self,
-        source_node: Self,  # noqa: ARG002
+        source_node: BaseNode,  # noqa: ARG002
         source_parameter: Parameter,  # noqa: ARG002
         target_parameter: Parameter,  # noqa: ARG002
     ) -> None:
@@ -111,7 +113,7 @@ class BaseNode(ABC):
     def after_outgoing_connection(
         self,
         source_parameter: Parameter,  # noqa: ARG002
-        target_node: Self,  # noqa: ARG002
+        target_node: BaseNode,  # noqa: ARG002
         target_parameter: Parameter,  # noqa: ARG002
     ) -> None:
         """Callback after a Connection has been established OUT of this Node."""
@@ -119,7 +121,7 @@ class BaseNode(ABC):
 
     def after_incoming_connection_removed(
         self,
-        source_node: Self,  # noqa: ARG002
+        source_node: BaseNode,  # noqa: ARG002
         source_parameter: Parameter,  # noqa: ARG002
         target_parameter: Parameter,  # noqa: ARG002
     ) -> None:
@@ -129,7 +131,7 @@ class BaseNode(ABC):
     def after_outgoing_connection_removed(
         self,
         source_parameter: Parameter,  # noqa: ARG002
-        target_node: Self,  # noqa: ARG002
+        target_node: BaseNode,  # noqa: ARG002
         target_parameter: Parameter,  # noqa: ARG002
     ) -> None:
         """Callback after a Connection OUT of this Node was REMOVED."""

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -4366,7 +4366,6 @@ class LibraryManager:
                         )
                     )
                 )
-                print("HI ZACH HERE ARE THE SITE PACKAGES", site_packages)
                 sys.path.insert(0, site_packages)
         except subprocess.CalledProcessError as e:
             # Failed to create the library


### PR DESCRIPTION
also fixed the haunted lint print