### PR TITLE
Flag events as to whether or not they altered the current workflow. Clients can then know if the current workflow is dirty and needs to be resaved, for example.

### DIFF
--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -26,9 +26,13 @@ class RequestPayload(Payload, ABC):
     request_id: int | None = None
 
 
-# Result payload base class with abstract succeeded method
+# Result payload base class with abstract succeeded/failed methods, and indicator whether the current workflow was altered.
 class ResultPayload(Payload, ABC):
     """Base class for all result payloads."""
+
+    """When set to True, alerts clients that this result made changes to the workflow state.
+    Editors can use this to determine if the workflow is dirty and needs to be re-saved, for example."""
+    altered_workflow_state: bool = False
 
     @abstractmethod
     def succeeded(self) -> bool:
@@ -55,6 +59,12 @@ class ResultPayloadSuccess(ResultPayload, ABC):
         return True
 
 
+class ResultPayloadSuccessAlteredWorkflow(ResultPayloadSuccess, ABC):
+    """Specialization of ResultPayloadSuccess that embeds workflow altering for events guaranteed to affect it."""
+
+    altered_workflow_state: bool = True
+
+
 # Failure result payload abstract base class
 class ResultPayloadFailure(ResultPayload, ABC):
     """Abstract base class for failure result payloads."""
@@ -66,6 +76,12 @@ class ResultPayloadFailure(ResultPayload, ABC):
             bool: Always False
         """
         return False
+
+
+class ResultPayloadFailureAlteredWorkflow(ResultPayloadFailure, ABC):
+    """Specialization of ResultPayloadFailure that embeds workflow altering for events guaranteed to affect it."""
+
+    altered_workflow_state: bool = True
 
 
 class ExecutionPayload(Payload):

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -4,6 +4,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -22,7 +23,7 @@ class CreateConnectionRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateConnectionResultSuccess(ResultPayloadSuccess):
+class CreateConnectionResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -44,7 +45,7 @@ class DeleteConnectionRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteConnectionResultSuccess(ResultPayloadSuccess):
+class DeleteConnectionResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -6,6 +6,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -21,7 +22,7 @@ class ResolveNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ResolveNodeResultSuccess(ResultPayloadSuccess):
+class ResolveNodeResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -41,7 +42,7 @@ class StartFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class StartFlowResultSuccess(ResultPayloadSuccess):
+class StartFlowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -59,7 +60,7 @@ class CancelFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CancelFlowResultSuccess(ResultPayloadSuccess):
+class CancelFlowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -83,7 +84,7 @@ class UnresolveFlowResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
-class UnresolveFlowResultSuccess(ResultPayloadSuccess):
+class UnresolveFlowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -99,7 +100,7 @@ class SingleExecutionStepRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SingleExecutionStepResultSuccess(ResultPayloadSuccess):
+class SingleExecutionStepResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -117,7 +118,7 @@ class SingleNodeStepRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SingleNodeStepResultSuccess(ResolveNodeResultSuccess):
+class SingleNodeStepResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -136,7 +137,7 @@ class ContinueExecutionStepRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ContinueExecutionStepResultSuccess(ResultPayloadSuccess):
+class ContinueExecutionStepResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -4,6 +4,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -19,7 +20,7 @@ class CreateFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateFlowResultSuccess(ResultPayloadSuccess):
+class CreateFlowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     flow_name: str
 
 
@@ -38,7 +39,7 @@ class DeleteFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteFlowResultSuccess(ResultPayloadSuccess):
+class DeleteFlowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -4,6 +4,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -72,7 +73,7 @@ class RegisterLibraryFromFileRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RegisterLibraryFromFileResultSuccess(ResultPayloadSuccess):
+class RegisterLibraryFromFileResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     library_name: str
 
 
@@ -166,7 +167,7 @@ class UnloadLibraryFromRegistryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class UnloadLibraryFromRegistryResultSuccess(ResultPayloadSuccess):
+class UnloadLibraryFromRegistryResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -6,6 +6,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.connection_events import ListConnectionsForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
@@ -34,7 +35,7 @@ class CreateNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateNodeResultSuccess(ResultPayloadSuccess):
+class CreateNodeResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     node_name: str
 
 
@@ -53,7 +54,7 @@ class DeleteNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteNodeResultSuccess(ResultPayloadSuccess):
+class DeleteNodeResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -130,7 +131,7 @@ class SetNodeMetadataRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SetNodeMetadataResultSuccess(ResultPayloadSuccess):
+class SetNodeMetadataResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/object_events.py
+++ b/src/griptape_nodes/retained_mode/events/object_events.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
-    ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -18,7 +18,7 @@ class RenameObjectRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RenameObjectResultSuccess(ResultPayloadSuccess):
+class RenameObjectResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     final_name: str  # May not be the same as what was requested, if that bool was set
 
 
@@ -37,7 +37,7 @@ class ClearAllObjectStateRequest(RequestPayload):
 
 
 @PayloadRegistry.register
-class ClearAllObjectStateResultSuccess(ResultPayloadSuccess):
+class ClearAllObjectStateResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -10,6 +10,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -49,7 +50,7 @@ class AddParameterToNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class AddParameterToNodeResultSuccess(ResultPayloadSuccess):
+class AddParameterToNodeResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     parameter_name: str
     type: str
     node_name: str
@@ -71,7 +72,7 @@ class RemoveParameterFromNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RemoveParameterFromNodeResultSuccess(ResultPayloadSuccess):
+class RemoveParameterFromNodeResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -97,7 +98,7 @@ class SetParameterValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SetParameterValueResultSuccess(ResultPayloadSuccess):
+class SetParameterValueResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     finalized_value: Any
     data_type: str
 
@@ -202,7 +203,7 @@ class AlterParameterDetailsRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class AlterParameterDetailsResultSuccess(ResultPayloadSuccess):
+class AlterParameterDetailsResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -237,7 +238,7 @@ class GetParameterValueResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
-class OnParameterValueChanged(ResultPayloadSuccess):
+class OnParameterValueChanged(ResultPayloadSuccessAlteredWorkflow):
     node_name: str
     parameter_name: str
     data_type: str

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -5,6 +5,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    ResultPayloadSuccessAlteredWorkflow,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
@@ -17,7 +18,7 @@ class RunWorkflowFromScratchRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RunWorkflowFromScratchResultSuccess(ResultPayloadSuccess):
+class RunWorkflowFromScratchResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -35,7 +36,7 @@ class RunWorkflowWithCurrentStateRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RunWorkflowWithCurrentStateResultSuccess(ResultPayloadSuccess):
+class RunWorkflowWithCurrentStateResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -54,7 +55,7 @@ class RunWorkflowFromRegistryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RunWorkflowFromRegistryResultSuccess(ResultPayloadSuccess):
+class RunWorkflowFromRegistryResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -109,7 +110,7 @@ class DeleteWorkflowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteWorkflowResultSuccess(ResultPayloadSuccess):
+class DeleteWorkflowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 
@@ -128,7 +129,7 @@ class RenameWorkflowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RenameWorkflowResultSuccess(ResultPayloadSuccess):
+class RenameWorkflowResultSuccess(ResultPayloadSuccessAlteredWorkflow):
     pass
 
 


### PR DESCRIPTION
Partial fix for #637 while we figure out squelch vs. ignore

Adds a `altered_workflow_state` to `ResultPayload`. This can be set selectively based on how the engine behaved, e.g., "you asked me to set the value it's already at, so no change". 

May also elect to use the convenience specializations `ResultPayloadSuccessAlteredWorkflow` and `ResultPayloadFailureAlteredWorkflow` for results guaranteed to cause a change, such as deleting a node or creating a connection.
