### PR TITLE
Create WorkflowMetadata from request input

### DIFF
--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -3252,6 +3252,9 @@ class WorkflowManager:
 
     def on_register_workflow_request(self, request: RegisterWorkflowRequest) -> ResultPayload:
         try:
+            if isinstance(request.metadata, dict):
+                request.metadata = WorkflowMetadata(**request.metadata)
+
             workflow = WorkflowRegistry.generate_new_workflow(metadata=request.metadata, file_path=request.file_name)
         except Exception as e:
             details = f"Failed to register workflow with name '{request.metadata.name}'. Error: {e}"


### PR DESCRIPTION
A RegisterWorkflowRequest that comes from the engine has all the right types, but an event that comes from the editor has metadata with type `dict`, causing all sorts of type issues down the call stack. This change checks if metadata is a dict and creates a WorkflowMetadata from that information if so.