### PR TITLE
fix: use correct python path for library venv

### DIFF
--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -4452,9 +4452,10 @@ class LibraryManager:
                     logger.debug("Created virtual environment at %s", library_venv_path)
 
                 # Grab the python executable from the virtual environment so that we can pip install there
-                library_venv_python_path = (
-                    library_venv_path / ("Scripts" if OSManager.is_windows() else "bin") / "python.exe"
-                ).resolve()
+                if OSManager.is_windows():
+                    library_venv_python_path = library_venv_path / "Scripts" / "python.exe"
+                else:
+                    library_venv_python_path = library_venv_path / "bin" / "python"
                 subprocess.run(  # noqa: S603
                     [
                         sys.executable,


### PR DESCRIPTION
`resolve` is not necessary and ends up resolving a version of the python binary that makes uv mad. And `python.exe` is definitely not a thing on mac.