### PR TITLE
revert: don't use OS-assigned port number

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Griptape Nodes uses a variety of environment variables for influencing its low-l
 - **`GRIPTAPE_NODES_API_BASE_URL`**: The base URL for the Griptape Nodes API (default `https://api.nodes.griptape.ai`). This is used to connect the engine to the Workflow Editor.
 - **`GT_CLOUD_API_KEY`**: The API key for authenticating with the Griptape Cloud API. This is required for the engine to function properly.
 - **`STATIC_SERVER_HOST`**: The host for the static server (default `localhost`). This is used to serve static files from the engine.
-- **`STATIC_SERVER_PORT`**: The port for the static server (default OS assigned). This is used to serve static files from the engine.
+- **`STATIC_SERVER_PORT`**: The port for the static server (default `8124`). This is used to serve static files from the engine.
 - **`STATIC_SERVER_URL`**: The URL path for the static server (default `/static`). This is used to serve static files from the engine.
 - **`STATIC_SERVER_LOG_LEVEL`**: The log level for the static server (default `info`). This is used to control the verbosity of the static server logs.
 - **`STATIC_SERVER_ENABLED`**: Whether the static server is enabled (default `true`. This is used to control whether the static server is started or not.

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import signal
-import socket
 import sys
 import threading
 from queue import Queue
@@ -53,17 +52,11 @@ STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "t
 # Host of the static server
 STATIC_SERVER_HOST = os.getenv("STATIC_SERVER_HOST", "localhost")
 # Port of the static server
-STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "0"))
+STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
 # URL path for the static server
 STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/static")
 # Log level for the static server
 STATIC_SERVER_LOG_LEVEL = os.getenv("STATIC_SERVER_LOG_LEVEL", "info").lower()
-
-if STATIC_SERVER_ENABLED:
-    # Try binding to a port. If we bind to 0 (the default), the OS will pick an available port.
-    sock = socket.socket()
-    sock.bind(("", STATIC_SERVER_PORT))
-    STATIC_SERVER_PORT = sock.getsockname()[1]
 
 
 class EventLogHandler(logging.Handler):


### PR DESCRIPTION
We are not resilliant against changing ports since we save the full url (with the port) of static files. Long term we may want to investigate some sort of local domain. Picked a random port outside the crowded dev server cluster (3000, 5000, 8000, 8080)

Reverts https://github.com/griptape-ai/griptape-nodes/pull/657