### PR TITLE
fix: specify language in RTD previews

### DIFF
--- a/.github/workflows/pull-request-links.yml
+++ b/.github/workflows/pull-request-links.yml
@@ -20,5 +20,3 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: ${{ secrets.READTHEDOCS_PROJECT_SLUG }} 
-          single-version: 'false'
-          project-language: ""


### PR DESCRIPTION
Fixes RTD preview links by removing settings that were specific to the framework.
<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--688.org.readthedocs.build/en/688/

<!-- readthedocs-preview griptape-nodes end -->