### PR TITLE
Add request/response for config path

### DIFF
--- a/src/griptape_nodes/retained_mode/events/config_events.py
+++ b/src/griptape_nodes/retained_mode/events/config_events.py
@@ -82,3 +82,21 @@ class SetConfigCategoryResultSuccess(ResultPayloadSuccess):
 @PayloadRegistry.register
 class SetConfigCategoryResultFailure(ResultPayloadFailure):
     pass
+
+
+@dataclass
+@PayloadRegistry.register
+class GetConfigPathRequest(RequestPayload):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class GetConfigPathResultSuccess(ResultPayloadSuccess):
+    config_path: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class GetConfigPathResultFailure(ResultPayloadFailure):
+    pass

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -13,6 +13,8 @@ from griptape_nodes.retained_mode.events.config_events import (
     GetConfigCategoryRequest,
     GetConfigCategoryResultFailure,
     GetConfigCategoryResultSuccess,
+    GetConfigPathRequest,
+    GetConfigPathResultSuccess,
     GetConfigValueRequest,
     GetConfigValueResultFailure,
     GetConfigValueResultSuccess,
@@ -22,8 +24,6 @@ from griptape_nodes.retained_mode.events.config_events import (
     SetConfigValueRequest,
     SetConfigValueResultFailure,
     SetConfigValueResultSuccess,
-    GetConfigPathResultSuccess,
-    GetConfigPathRequest,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.settings import Settings, WorkflowSettingsDetail
@@ -317,7 +317,7 @@ class ConfigManager:
         logger.info(details)
         return GetConfigValueResultSuccess(value=find_results)
 
-    def on_handle_get_config_path_request(self, request: GetConfigPathRequest) -> ResultPayload:
+    def on_handle_get_config_path_request(self, request: GetConfigPathRequest) -> ResultPayload:  # noqa: ARG002
         return GetConfigPathResultSuccess(config_path=str(USER_CONFIG_PATH))
 
     def _get_diff(self, old_value: Any, new_value: Any) -> dict[Any, Any]:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -21,7 +21,7 @@ from griptape_nodes.retained_mode.events.config_events import (
     SetConfigCategoryResultSuccess,
     SetConfigValueRequest,
     SetConfigValueResultFailure,
-    SetConfigValueResultSuccess,
+    SetConfigValueResultSuccess, GetConfigPathResultSuccess, GetConfigPathRequest,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.settings import Settings, WorkflowSettingsDetail
@@ -63,6 +63,7 @@ class ConfigManager:
             )
             event_manager.assign_manager_to_request_type(GetConfigValueRequest, self.on_handle_get_config_value_request)
             event_manager.assign_manager_to_request_type(SetConfigValueRequest, self.on_handle_set_config_value_request)
+            event_manager.assign_manager_to_request_type(GetConfigPathRequest, self.on_handle_get_config_path_request)
 
             event_manager.add_listener_to_app_event(
                 AppInitializationComplete,
@@ -313,6 +314,9 @@ class ConfigManager:
         details = f"Successfully returned the config value for section '{request.category_and_key}'."
         logger.info(details)
         return GetConfigValueResultSuccess(value=find_results)
+
+    def on_handle_get_config_path_request(self, request: GetConfigPathRequest) -> ResultPayload:
+        return GetConfigPathResultSuccess(config_path=str(USER_CONFIG_PATH))
 
     def _get_diff(self, old_value: Any, new_value: Any) -> dict[Any, Any]:
         """Generate a diff between the old and new values."""

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -21,7 +21,9 @@ from griptape_nodes.retained_mode.events.config_events import (
     SetConfigCategoryResultSuccess,
     SetConfigValueRequest,
     SetConfigValueResultFailure,
-    SetConfigValueResultSuccess, GetConfigPathResultSuccess, GetConfigPathRequest,
+    SetConfigValueResultSuccess,
+    GetConfigPathResultSuccess,
+    GetConfigPathRequest,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.settings import Settings, WorkflowSettingsDetail


### PR DESCRIPTION
Provide the editor with the ability to query the path to the config (settings?) file the engine is currently using.