### PR TITLE
Indicate GetConfig as read-only guarantee

### DIFF
--- a/src/griptape_nodes/retained_mode/events/config_events.py
+++ b/src/griptape_nodes/retained_mode/events/config_events.py
@@ -92,11 +92,11 @@ class GetConfigPathRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigPathResultSuccess(ResultPayloadSuccess):
+class GetConfigPathResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
     config_path: str | None = None
 
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigPathResultFailure(ResultPayloadFailure):
+class GetConfigPathResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
     pass


### PR DESCRIPTION
Super quick change to indicate that the get config events are guaranteed not to alter the workflow.