### PR TITLE
Registered workflows are now a list and not a dict. WARNING: Requires a config reset for now.

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -26,7 +26,7 @@ from griptape_nodes.retained_mode.events.config_events import (
     SetConfigValueResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.settings import Settings, WorkflowSettingsDetail
+from griptape_nodes.retained_mode.managers.settings import Settings
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
 
 logger = logging.getLogger("griptape_nodes")
@@ -178,21 +178,20 @@ class ConfigManager:
         return env_var_names
 
     def save_user_workflow_json(self, workflow_file_name: str) -> None:
-        workflow_details = WorkflowSettingsDetail(file_name=workflow_file_name, is_griptape_provided=False)
         config_loc = "app_events.on_app_initialization_complete.workflows_to_register"
         existing_workflows = self.get_config_value(config_loc)
         if not existing_workflows:
             existing_workflows = []
-        existing_workflows.append(workflow_details.__dict__)
+        existing_workflows.append(workflow_file_name)
         self.set_config_value(config_loc, existing_workflows)
 
-    def delete_user_workflow(self, workflow: dict) -> None:
+    def delete_user_workflow(self, workflow_file_name: str) -> None:
         default_workflows = self.get_config_value("app_events.on_app_initialization_complete.workflows_to_register")
         if default_workflows:
             default_workflows = [
                 saved_workflow
                 for saved_workflow in default_workflows
-                if saved_workflow["file_name"] != workflow["file_path"]
+                if (saved_workflow.lower() != workflow_file_name.lower())
             ]
             self.set_config_value("app_events.on_app_initialization_complete.workflows_to_register", default_workflows)
 

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -6,32 +5,15 @@ from pydantic import BaseModel, ConfigDict, Field
 from xdg_base_dirs import xdg_data_home
 
 
-@dataclass
-class WorkflowSettingsDetail:
-    """Griptape-provided workflows are pathed differently and display in the GUI in a different section."""
-
-    file_name: str
-    is_griptape_provided: bool
-
-
 class AppInitializationComplete(BaseModel):
     libraries_to_register: list[str] = Field(
         default_factory=lambda: [str(xdg_data_home() / "griptape_nodes/nodes/griptape_nodes_library.json")]
     )
-    workflows_to_register: list[WorkflowSettingsDetail] = Field(
+    workflows_to_register: list[str] = Field(
         default_factory=lambda: [
-            WorkflowSettingsDetail(
-                file_name=str(xdg_data_home() / "griptape_nodes/workflows/templates/translator.py"),
-                is_griptape_provided=True,
-            ),
-            WorkflowSettingsDetail(
-                file_name=str(xdg_data_home() / "griptape_nodes/workflows/templates/compare_prompts.py"),
-                is_griptape_provided=True,
-            ),
-            WorkflowSettingsDetail(
-                file_name=str(xdg_data_home() / "griptape_nodes/workflows/templates/prompt_an_image.py"),
-                is_griptape_provided=True,
-            ),
+            str(xdg_data_home() / "griptape_nodes/workflows/templates/translator.py"),
+            str(xdg_data_home() / "griptape_nodes/workflows/templates/compare_prompts.py"),
+            str(xdg_data_home() / "griptape_nodes/workflows/templates/prompt_an_image.py"),
         ]
     )
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -818,7 +818,7 @@ class WorkflowManager:
         # save the created workflow to a personal json file
         registered_workflows = WorkflowRegistry.list_workflows()
         if file_name not in registered_workflows:
-            config_manager.save_user_workflow_json(relative_file_path)
+            config_manager.save_user_workflow_json(str(file_path))
             WorkflowRegistry.generate_new_workflow(metadata=workflow_metadata, file_path=relative_file_path)
         details = f"Successfully saved workflow to: {file_path}"
         logger.info(details)

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -413,7 +413,7 @@ class WorkflowManager:
             return DeleteWorkflowResultFailure()
         config_manager = GriptapeNodes.ConfigManager()
         try:
-            config_manager.delete_user_workflow(workflow.__dict__)
+            config_manager.delete_user_workflow(workflow.file_path)
         except Exception as e:
             details = f"Failed to remove workflow from user config with name '{request.name}'. Exception: {e}"
             logger.error(details)


### PR DESCRIPTION
Stepping stone towards #555 

Once we have these as a list, we can now interrogate metadata directly for `is_template` and use this to save templates as COPIES of workflows in the customer's directory.