### PR TITLE
Raise error if space detected in Parameter name

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -204,6 +204,9 @@ class BaseNode(ABC):
 
     def add_parameter(self, param: Parameter) -> None:
         """Adds a Parameter to the Node. Control and Data Parameters are all treated equally."""
+        if any(char.isspace() for char in param.name):
+            msg = "Parameter names cannot currently any whitespace characters. Please see https://github.com/griptape-ai/griptape-nodes/issues/714 to check the status on a remedy for this issue."
+            raise ValueError(msg)
         if self.does_name_exist(param.name):
             msg = "Cannot have duplicate names on parameters."
             raise ValueError(msg)


### PR DESCRIPTION
Fixes #711 

Save files are broken if a Parameter with a space appears in it. We have #714 to remedy this.