### PR TITLE
Template files generate workflows when save attempted.

### DIFF
--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -52,6 +52,11 @@ class WorkflowRegistry(SingletonMixin):
         return instance._workflows[name]
 
     @classmethod
+    def has_workflow_with_name(cls, name: str) -> bool:
+        instance = cls()
+        return name in instance._workflows
+
+    @classmethod
     def list_workflows(cls) -> dict[str, dict]:
         instance = cls()
         return {key: instance._workflows[key].get_workflow_metadata() for key in instance._workflows}

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -745,12 +745,12 @@ class WorkflowManager:
                     new_file_name = f"{file_name}_{curr_idx}"
                     new_file_name_with_extension = f"{new_file_name}.py"
                     new_file_full_path = config_manager.workspace_path.joinpath(new_file_name_with_extension)
-                    if not new_file_full_path.exists():
-                        free_file_found = True
-                        file_name = new_file_name
-                    else:
+                    if new_file_full_path.exists():
                         # Keep going.
                         curr_idx += 1
+                    else:
+                        free_file_found = True
+                        file_name = new_file_name
 
         # open my file
         if not file_name:


### PR DESCRIPTION
Closes #555 

If the user attempts to save a workflow that is a template, it will instead generate a new workflow in the customer's workspace directory with a non-colliding file name.