### PR TITLE
fix: don't resume processing when cancelling

### DIFF
--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -57,11 +57,6 @@ class ResolutionContext:
             node.clear_node()
             self.focus_stack[-1].process_generator = None
             self.focus_stack[-1].scheduled_value = None
-            EventBus.publish_event(
-                ExecutionGriptapeNodeEvent(
-                    wrapped_event=ExecutionEvent(payload=ResumeNodeProcessingEvent(node_name=node.name))
-                )
-            )
         self.focus_stack.clear()
         self.paused = False
 

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -922,7 +922,7 @@ class FlowManager:
         except Exception as e:
             details = f"Could not advance to the next step of a running workflow. Exception: {e}"
             logger.error(details)
-            return SingleNodeStepResultFailure(validation_exceptions=[])
+            return SingleNodeStepResultFailure(validation_exceptions=[e])
         details = f"Successfully advanced to the next step of a running workflow with name {flow_name}"
         logger.debug(details)
 


### PR DESCRIPTION
From my testing it appears this is not needed and solves the immediate problem.

Closes #702