### PR TITLE
fix: make safe serialize even safer

### DIFF
--- a/src/griptape_nodes/exe_types/type_validator.py
+++ b/src/griptape_nodes/exe_types/type_validator.py
@@ -26,12 +26,10 @@ class TypeValidator(SingletonMixin):
             return [cls.safe_serialize(item) for item in list(obj)]
         if isinstance(obj, (str, int, float, bool, list, dict, type(None))):
             return obj
-        try:
-            obj_dict = obj.to_dict()
-        except Exception:
-            logger.warning("Error serializing object: Going to use type name.")
-        else:
-            return obj_dict
+        if hasattr(obj, "to_dict"):
+            return obj.to_dict()
+        if hasattr(obj, "__dict__"):
+            return obj.__dict__
         if hasattr(obj, "id"):
             return {f"{type(obj).__name__} Object: {obj.id}"}
         return f"{type(obj).__name__} Object"


### PR DESCRIPTION
Original issue came from:
```
                    ERROR    Error serializing object: Going to use type name.
                             ╭─────────────────────────────────── Traceback (most recent call last) ───────────────────────────────────╮
                             │ /Users/collindutter/Documents/griptape/griptape-nodes/src/griptape_nodes/exe_types/type_validator.py:30 │
                             │ in safe_serialize                                                                                       │
                             │                                                                                                         │
                             │   27 │   │   if isinstance(obj, (str, int, float, bool, list, dict, type(None))):                       │
                             │   28 │   │   │   return obj                                                                             │
                             │   29 │   │   try:                                                                                       │
                             │ ❱ 30 │   │   │   obj_dict = obj.to_dict()                                                               │
                             │   31 │   │   except Exception:                                                                          │
                             │   32 │   │   │   logger.exception("Error serializing object: Going to use type name.")                  │
                             │   33 │   │   else:                                                                                      │
                             ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                             AttributeError: 'TextArtifactStorage' object has no attribute 'to_dict'
```
We really need to get away from the hand rolled serialization.
Closes #727