### PR TITLE
refactor: use new uv version interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,16 +147,28 @@ The documentation website ([docs.griptapenodes.com](https://docs.griptapenodes.c
 ## Making a Release (Maintainers)
 
 1. Check out the `main` branch locally:
+
     ```shell
     git checkout main
     git pull origin main
     ```
-1. Set the new release version (this creates Git tags):
+
+1. Bump the new release version:
+
     ```shell
-    # Example for version 0.8.0
+    # e.g. bumping 0.8.0 to 0.8.1
     make version/patch
     ```
-1. Publish the release (pushes tags to trigger GitHub Actions workflow):
+
+    or:
+
+    ```shell
+    # e.g. bumping 0.8.0 to 0.9.0
+    make version/minor
+    ```
+
+1. Publish the release (creates and pushes tags to Github):
+
     ```shell
     make version/publish
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ The documentation website ([docs.griptapenodes.com](https://docs.griptapenodes.c
 1. Set the new release version (this creates Git tags):
     ```shell
     # Example for version 0.8.0
-    make version/set v=0.8.0
+    make version/patch
     ```
 1. Publish the release (pushes tags to trigger GitHub Actions workflow):
     ```shell

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,35 @@
 .PHONY: version/get
-version/get: ## Set version.
-	@uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version
+version/get: ## Get version.
+	@uv version | awk '{print $$2}'
 	
 .PHONY: version/set
 version/set: ## Set version.
-	@uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version ${v}
+	@uv version $(v)
+	@make version/commit
+
+.PHONY: version/patch
+version/patch: ## Bump patch version.
+	@uv version --bump patch
+	@make version/commit
+
+.PHONY: version/minor
+version/minor: ## Bump minor version.
+	@uv version --bump minor
+	@make version/commit
+
+.PHONY: version/major
+version/major: ## Bump major version.
+	@uv version --bump major
+	@make version/commit
+
+.PHONY: version/commit
+version/commit: ## Commit version.
 	@uv lock
 	@git add pyproject.toml uv.lock
 	@git commit -m "chore: bump v$$(make version/get)"
 
 .PHONY: version/publish
-version/publish: ## Push git tag and publish version to PyPI.
+version/publish: ## Create and push git tags.
 	@git tag v$$(make version/get)
 	@git tag latest -f
 	@git push -f --tags


### PR DESCRIPTION
As of `uv>=0.7.1` there is now a dedicated version interface which means we can remove the hacky toml parsing.