### PR TITLE
fix: don't allow new nodes to be created in a resolving state

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -208,6 +208,9 @@ class NodeManager:
         state = request.resolution
         if state == NodeResolutionState.RESOLVING:
             state = NodeResolutionState.UNRESOLVED
+            logger.warning(
+                "Node '%s' was created in a RESOLVING state. This is not allowed. Setting to UNRESOLVED.", node.name
+            )
         node.state = NodeResolutionState(state)
 
         # See if we want to push this into the context of the current flow.

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -204,7 +204,11 @@ class NodeManager:
         obj_mgr.add_object_by_name(node.name, node)
         self._name_to_parent_flow_name[node.name] = parent_flow_name
 
-        node.state = NodeResolutionState(request.resolution)
+        # We don't want to start in a resolving state, bump it back to unresolved.
+        state = request.resolution
+        if state == NodeResolutionState.RESOLVING:
+            state = NodeResolutionState.UNRESOLVED
+        node.state = NodeResolutionState(state)
 
         # See if we want to push this into the context of the current flow.
         if request.set_as_new_context:


### PR DESCRIPTION
This can happen if the user saves the workflow while it's resolving. The resolving state is persisted in the script file and respawns the flow in a wonky state on subsequent runs.

```python
GriptapeNodes.handle_request(
    CreateNodeRequest(
        request_id=None,
        node_type="AgentToTool",
        specific_library_name=None,
        node_name="AgentToTool_1",
        override_parent_flow_name="untitled",
        resolution="resolving",
        initial_setup=True,
        set_as_new_context=False,
    )
)

```

Closes #733 
This ^ was happening because the previous node would not resolve and so the values were all garbled. There is probably some future work to be done to more gracefully handle wonky scenarios like this.