### PR TITLE
Fix altered workflow result flag

### DIFF
--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -36,13 +36,13 @@ class AppGetSessionRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class AppGetSessionResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class AppGetSessionResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     session_id: str | None
 
 
 @dataclass
 @PayloadRegistry.register
-class AppGetSessionResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class AppGetSessionResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -68,5 +68,5 @@ class GetEngineVersionResultSuccess(ResultPayloadSuccess):
 
 @dataclass
 @PayloadRegistry.register
-class GetEngineVersionResultFailure(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetEngineVersionResultFailure(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     pass

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -46,16 +46,18 @@ class ResultPayload(Payload, ABC):
         return not self.succeeded()
 
 
+@dataclass
 class WorkflowAlteredMixin:
     """Mixin for a ResultPayload that guarantees that a workflow was altered."""
 
-    altered_workflow_state: bool = True
+    altered_workflow_state: bool = field(default=True, init=False)
 
 
+@dataclass
 class WorkflowNotAlteredMixin:
     """Mixin for a ResultPayload that guarantees that a workflow was NOT altered."""
 
-    altered_workflow_state: bool = False
+    altered_workflow_state: bool = field(default=False, init=False)
 
 
 # Success result payload abstract base class

--- a/src/griptape_nodes/retained_mode/events/config_events.py
+++ b/src/griptape_nodes/retained_mode/events/config_events.py
@@ -18,13 +18,13 @@ class GetConfigValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigValueResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetConfigValueResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     value: Any
 
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigValueResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetConfigValueResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -55,13 +55,13 @@ class GetConfigCategoryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigCategoryResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetConfigCategoryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     contents: dict[str, Any]
 
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigCategoryResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetConfigCategoryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -92,13 +92,13 @@ class GetConfigPathRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigPathResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetConfigPathResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     config_path: str | None = None
 
 
 @dataclass
 @PayloadRegistry.register
-class GetConfigPathResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetConfigPathResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -24,7 +24,7 @@ class CreateConnectionRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateConnectionResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class CreateConnectionResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -46,7 +46,7 @@ class DeleteConnectionRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteConnectionResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class DeleteConnectionResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -79,12 +79,12 @@ class OutgoingConnection:
 
 @dataclass
 @PayloadRegistry.register
-class ListConnectionsForNodeResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListConnectionsForNodeResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     incoming_connections: list[IncomingConnection]
     outgoing_connections: list[OutgoingConnection]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListConnectionsForNodeResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListConnectionsForNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -23,7 +23,7 @@ class ResolveNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ResolveNodeResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class ResolveNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -43,7 +43,7 @@ class StartFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class StartFlowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class StartFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -61,7 +61,7 @@ class CancelFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CancelFlowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class CancelFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -85,7 +85,7 @@ class UnresolveFlowResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
-class UnresolveFlowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class UnresolveFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -101,7 +101,7 @@ class SingleExecutionStepRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SingleExecutionStepResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class SingleExecutionStepResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -119,7 +119,7 @@ class SingleNodeStepRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SingleNodeStepResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class SingleNodeStepResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -138,7 +138,7 @@ class ContinueExecutionStepRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ContinueExecutionStepResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class ContinueExecutionStepResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -156,14 +156,14 @@ class GetFlowStateRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetFlowStateResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetFlowStateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     control_node: str | None
     resolving_node: str | None
 
 
 @dataclass
 @PayloadRegistry.register
-class GetFlowStateResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetFlowStateResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -175,13 +175,13 @@ class GetIsFlowRunningRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetIsFlowRunningResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetIsFlowRunningResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     is_running: bool
 
 
 @dataclass
 @PayloadRegistry.register
-class GetIsFlowRunningResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetIsFlowRunningResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -21,7 +21,7 @@ class CreateFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateFlowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class CreateFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     flow_name: str
 
 
@@ -40,7 +40,7 @@ class DeleteFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteFlowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class DeleteFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -59,13 +59,13 @@ class ListNodesInFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListNodesInFlowResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListNodesInFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     node_names: list[str]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListNodesInFlowResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListNodesInFlowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -82,13 +82,13 @@ class ListFlowsInCurrentContextRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListFlowsInCurrentContextResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListFlowsInCurrentContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     flow_names: list[str]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListFlowsInCurrentContextResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListFlowsInCurrentContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -102,13 +102,13 @@ class ListFlowsInFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListFlowsInFlowResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListFlowsInFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     flow_names: list[str]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListFlowsInFlowResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListFlowsInFlowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -120,5 +120,5 @@ class GetTopLevelFlowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetTopLevelFlowResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetTopLevelFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     flow_name: str | None

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -18,13 +18,13 @@ class ListRegisteredLibrariesRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListRegisteredLibrariesResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListRegisteredLibrariesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     libraries: list[str]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListRegisteredLibrariesResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListRegisteredLibrariesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -36,13 +36,13 @@ class ListNodeTypesInLibraryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListNodeTypesInLibraryResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListNodeTypesInLibraryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     node_types: list[str]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListNodeTypesInLibraryResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListNodeTypesInLibraryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -55,13 +55,13 @@ class GetNodeMetadataFromLibraryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeMetadataFromLibraryResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetNodeMetadataFromLibraryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     metadata: dict
 
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeMetadataFromLibraryResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetNodeMetadataFromLibraryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -74,7 +74,7 @@ class RegisterLibraryFromFileRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RegisterLibraryFromFileResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RegisterLibraryFromFileResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     library_name: str
 
 
@@ -92,13 +92,13 @@ class ListCategoriesInLibraryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListCategoriesInLibraryResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListCategoriesInLibraryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     categories: list[dict]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListCategoriesInLibraryResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListCategoriesInLibraryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -110,13 +110,13 @@ class GetLibraryMetadataRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetLibraryMetadataResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetLibraryMetadataResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     metadata: dict
 
 
 @dataclass
 @PayloadRegistry.register
-class GetLibraryMetadataResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetLibraryMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -129,7 +129,7 @@ class GetAllInfoForLibraryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetAllInfoForLibraryResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetAllInfoForLibraryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     library_metadata_details: GetLibraryMetadataResultSuccess
     category_details: ListCategoriesInLibraryResultSuccess
     node_type_name_to_node_metadata_details: dict[str, GetNodeMetadataFromLibraryResultSuccess]
@@ -137,7 +137,7 @@ class GetAllInfoForLibraryResultSuccess(ResultPayloadSuccess, WorkflowNotAltered
 
 @dataclass
 @PayloadRegistry.register
-class GetAllInfoForLibraryResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetAllInfoForLibraryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -150,13 +150,13 @@ class GetAllInfoForAllLibrariesRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetAllInfoForAllLibrariesResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetAllInfoForAllLibrariesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     library_name_to_library_info: dict[str, GetAllInfoForLibraryResultSuccess]
 
 
 @dataclass
 @PayloadRegistry.register
-class GetAllInfoForAllLibrariesResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetAllInfoForAllLibrariesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -168,7 +168,7 @@ class UnloadLibraryFromRegistryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class UnloadLibraryFromRegistryResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class UnloadLibraryFromRegistryResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -35,7 +35,7 @@ class CreateNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateNodeResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class CreateNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     node_name: str
 
 
@@ -54,7 +54,7 @@ class DeleteNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteNodeResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class DeleteNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -73,13 +73,13 @@ class GetNodeResolutionStateRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeResolutionStateResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetNodeResolutionStateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     state: str
 
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeResolutionStateResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetNodeResolutionStateResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -92,13 +92,13 @@ class ListParametersOnNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListParametersOnNodeResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListParametersOnNodeResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     parameter_names: list[str]
 
 
 @dataclass
 @PayloadRegistry.register
-class ListParametersOnNodeResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListParametersOnNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -111,13 +111,13 @@ class GetNodeMetadataRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeMetadataResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetNodeMetadataResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     metadata: dict
 
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeMetadataResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetNodeMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -131,7 +131,7 @@ class SetNodeMetadataRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SetNodeMetadataResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class SetNodeMetadataResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -158,7 +158,7 @@ class ParameterInfoValue:
 
 @dataclass
 @PayloadRegistry.register
-class GetAllNodeInfoResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetAllNodeInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     metadata: dict
     node_resolution_state: str
     connections: ListConnectionsForNodeResultSuccess
@@ -168,5 +168,5 @@ class GetAllNodeInfoResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin)
 
 @dataclass
 @PayloadRegistry.register
-class GetAllNodeInfoResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetAllNodeInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/object_events.py
+++ b/src/griptape_nodes/retained_mode/events/object_events.py
@@ -19,7 +19,7 @@ class RenameObjectRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RenameObjectResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RenameObjectResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     final_name: str  # May not be the same as what was requested, if that bool was set
 
 
@@ -38,7 +38,7 @@ class ClearAllObjectStateRequest(RequestPayload):
 
 
 @PayloadRegistry.register
-class ClearAllObjectStateResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class ClearAllObjectStateResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -17,11 +17,11 @@ class OpenAssociatedFileRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class OpenAssociatedFileResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class OpenAssociatedFileResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     pass
 
 
 @dataclass
 @PayloadRegistry.register
-class OpenAssociatedFileResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class OpenAssociatedFileResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -51,7 +51,7 @@ class AddParameterToNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class AddParameterToNodeResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class AddParameterToNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     parameter_name: str
     type: str
     node_name: str
@@ -73,7 +73,7 @@ class RemoveParameterFromNodeRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RemoveParameterFromNodeResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RemoveParameterFromNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -99,7 +99,7 @@ class SetParameterValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SetParameterValueResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class SetParameterValueResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     finalized_value: Any
     data_type: str
 
@@ -120,7 +120,7 @@ class GetParameterDetailsRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetParameterDetailsResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetParameterDetailsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     element_id: str
     type: str
     input_types: list[str]
@@ -139,7 +139,7 @@ class GetParameterDetailsResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredM
 
 @dataclass
 @PayloadRegistry.register
-class GetParameterDetailsResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetParameterDetailsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -204,7 +204,7 @@ class AlterParameterDetailsRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class AlterParameterDetailsResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class AlterParameterDetailsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -224,7 +224,7 @@ class GetParameterValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetParameterValueResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetParameterValueResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     input_types: list[str]
     type: str
     output_type: str
@@ -233,13 +233,13 @@ class GetParameterValueResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMix
 
 @dataclass
 @PayloadRegistry.register
-class GetParameterValueResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetParameterValueResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
 @dataclass
 @PayloadRegistry.register
-class OnParameterValueChanged(ResultPayloadSuccess, WorkflowAlteredMixin):
+class OnParameterValueChanged(WorkflowAlteredMixin, ResultPayloadSuccess):
     node_name: str
     parameter_name: str
     data_type: str
@@ -262,13 +262,13 @@ class ParameterAndMode(NamedTuple):
 
 @dataclass
 @PayloadRegistry.register
-class GetCompatibleParametersResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetCompatibleParametersResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     valid_parameters_by_node: dict[str, list[ParameterAndMode]]
 
 
 @dataclass
 @PayloadRegistry.register
-class GetCompatibleParametersResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetCompatibleParametersResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -282,11 +282,11 @@ class GetNodeElementDetailsRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeElementDetailsResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetNodeElementDetailsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     element_details: dict[str, Any]
 
 
 @dataclass
 @PayloadRegistry.register
-class GetNodeElementDetailsResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetNodeElementDetailsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/secrets_events.py
+++ b/src/griptape_nodes/retained_mode/events/secrets_events.py
@@ -18,13 +18,13 @@ class GetSecretValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetSecretValueResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetSecretValueResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     value: Any
 
 
 @dataclass
 @PayloadRegistry.register
-class GetSecretValueResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetSecretValueResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -37,13 +37,13 @@ class SetSecretValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SetSecretValueResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class SetSecretValueResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     pass
 
 
 @dataclass
 @PayloadRegistry.register
-class SetSecretValueResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class SetSecretValueResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -55,13 +55,13 @@ class GetAllSecretValuesRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class GetAllSecretValuesResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class GetAllSecretValuesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     values: dict[str, Any]
 
 
 @dataclass
 @PayloadRegistry.register
-class GetAllSecretValuesResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class GetAllSecretValuesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -73,11 +73,11 @@ class DeleteSecretValueRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteSecretValueResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class DeleteSecretValueResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     pass
 
 
 @dataclass
 @PayloadRegistry.register
-class DeleteSecretValueResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class DeleteSecretValueResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -25,11 +25,11 @@ class CreateStaticFileRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class CreateStaticFileResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class CreateStaticFileResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     url: str
 
 
 @dataclass
 @PayloadRegistry.register
-class CreateStaticFileResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class CreateStaticFileResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     error: str

--- a/src/griptape_nodes/retained_mode/events/validation_events.py
+++ b/src/griptape_nodes/retained_mode/events/validation_events.py
@@ -20,7 +20,7 @@ class ValidateFlowDependenciesRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ValidateFlowDependenciesResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ValidateFlowDependenciesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     validation_succeeded: bool
     exceptions: list[Exception]
 
@@ -28,7 +28,7 @@ class ValidateFlowDependenciesResultSuccess(ResultPayloadSuccess, WorkflowNotAlt
 # if it doesn't have a dependency we want
 @dataclass
 @PayloadRegistry.register
-class ValidateFlowDependenciesResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ValidateFlowDependenciesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -41,7 +41,7 @@ class ValidateNodeDependenciesRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ValidateNodeDependenciesResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ValidateNodeDependenciesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     validation_succeeded: bool
     exceptions: list[Exception]
 
@@ -49,5 +49,5 @@ class ValidateNodeDependenciesResultSuccess(ResultPayloadSuccess, WorkflowNotAlt
 # if it doesn't have a dependency we want
 @dataclass
 @PayloadRegistry.register
-class ValidateNodeDependenciesResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ValidateNodeDependenciesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -19,7 +19,7 @@ class RunWorkflowFromScratchRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RunWorkflowFromScratchResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RunWorkflowFromScratchResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -37,7 +37,7 @@ class RunWorkflowWithCurrentStateRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RunWorkflowWithCurrentStateResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RunWorkflowWithCurrentStateResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -56,7 +56,7 @@ class RunWorkflowFromRegistryRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RunWorkflowFromRegistryResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RunWorkflowFromRegistryResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -75,13 +75,13 @@ class RegisterWorkflowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RegisterWorkflowResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class RegisterWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     workflow_name: str
 
 
 @dataclass
 @PayloadRegistry.register
-class RegisterWorkflowResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class RegisterWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -93,13 +93,13 @@ class ListAllWorkflowsRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ListAllWorkflowsResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class ListAllWorkflowsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     workflows: dict
 
 
 @dataclass
 @PayloadRegistry.register
-class ListAllWorkflowsResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class ListAllWorkflowsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -111,7 +111,7 @@ class DeleteWorkflowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class DeleteWorkflowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class DeleteWorkflowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -130,7 +130,7 @@ class RenameWorkflowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class RenameWorkflowResultSuccess(ResultPayloadSuccess, WorkflowAlteredMixin):
+class RenameWorkflowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     pass
 
 
@@ -148,13 +148,13 @@ class SaveWorkflowRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class SaveWorkflowResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class SaveWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     file_path: str
 
 
 @dataclass
 @PayloadRegistry.register
-class SaveWorkflowResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class SaveWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -166,11 +166,11 @@ class LoadWorkflowMetadata(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class LoadWorkflowMetadataResultSuccess(ResultPayloadSuccess, WorkflowNotAlteredMixin):
+class LoadWorkflowMetadataResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     metadata: WorkflowMetadata
 
 
 @dataclass
 @PayloadRegistry.register
-class LoadWorkflowMetadataResultFailure(ResultPayloadFailure, WorkflowNotAlteredMixin):
+class LoadWorkflowMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass


### PR DESCRIPTION
Contains a few changes to ensure the `altered_workflow_state` flag actually makes it to the serialized response payload.

Inheritance order and decorators make all the difference here. Without them, the Python objects will report the correct `altered_workflow_state` attribute value as set by the mixin, but it won't end up in the JSON. We love Python, don't we, folks?