### PR TITLE
fix: handle dictionaries that look like image url artifacts

### DIFF
--- a/nodes/griptape_nodes_library/image/load_image.py
+++ b/nodes/griptape_nodes_library/image/load_image.py
@@ -1,6 +1,3 @@
-from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
-
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes_library.utils.image_utils import dict_to_image_artifact
@@ -15,7 +12,7 @@ class LoadImage(DataNode):
         self.description = "Load an image"
         image_parameter = Parameter(
             name="image",
-            input_types=["ImageArtifact", "BlobArtifact", "ImageUrlArtifact"],
+            input_types=["ImageArtifact", "ImageUrlArtifact"],
             type="ImageArtifact",
             output_type="ImageArtifact",
             ui_options={"clickable_file_browser": True, "expander": True},
@@ -27,10 +24,9 @@ class LoadImage(DataNode):
     def process(self) -> None:
         image = self.parameter_values["image"]
 
-        if isinstance(image, ImageUrlArtifact):
-            image_artifact = ImageLoader().parse(image.to_bytes())
-        else:
-            # Convert to ImageArtifact
+        if isinstance(image, dict):
             image_artifact = dict_to_image_artifact(image)
+        else:
+            image_artifact = image
 
         self.parameter_output_values["image"] = image_artifact

--- a/nodes/griptape_nodes_library/image/save_image.py
+++ b/nodes/griptape_nodes_library/image/save_image.py
@@ -15,7 +15,7 @@ from griptape_nodes_library.utils.image_utils import dict_to_image_artifact
 DEFAULT_FILENAME = "griptape_nodes.png"
 
 
-def to_image_artifact(image: ImageArtifact | dict) -> ImageArtifact:
+def to_image_artifact(image: ImageArtifact | dict) -> ImageArtifact | ImageUrlArtifact:
     """Convert an image or a dictionary to an ImageArtifact."""
     if isinstance(image, dict):
         return dict_to_image_artifact(image)

--- a/nodes/griptape_nodes_library/utils/image_utils.py
+++ b/nodes/griptape_nodes_library/utils/image_utils.py
@@ -1,20 +1,22 @@
 import base64
 
-from griptape.artifacts import ImageArtifact
+from griptape.artifacts import ImageArtifact, ImageUrlArtifact
 from griptape.loaders import ImageLoader
 
 
-def dict_to_image_artifact(image_dict: dict, image_format: str | None = None) -> ImageArtifact:
+def dict_to_image_artifact(image_dict: dict, image_format: str | None = None) -> ImageArtifact | ImageUrlArtifact:
     """Convert a dictionary representation of an image to an ImageArtifact."""
     # Get the base64 encoded string
-    base64_data = image_dict["value"]
+    value = image_dict["value"]
+    if image_dict["type"] == "ImageUrlArtifact":
+        return ImageUrlArtifact(value)
 
     # If the base64 string has a prefix like "data:image/png;base64,", remove it
-    if "base64," in base64_data:
-        base64_data = base64_data.split("base64,")[1]
+    if "base64," in value:
+        value = value.split("base64,")[1]
 
     # Decode the base64 string to bytes
-    image_bytes = base64.b64decode(base64_data)
+    image_bytes = base64.b64decode(value)
 
     # Determine the format from the MIME type if not specified
     if not image_format and "type" in image_dict:


### PR DESCRIPTION
The UI sends over this:

```
cmd.set_value("LoadImage_1.image",value="{'value': 'http://localhost:8124/static/1498DAE5-AAA7-44AA-8EF9-FC51F42AD140_1_105_c.jpg', 'type': 'ImageUrlArtifact', ...some more...)
```

The node was properly handling this when type was `ImageArtifact`, but broke when that was changed on the UI.

Closes #754 