### PR TITLE
Cancellation/Error Improvements

### DIFF
--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -101,7 +101,8 @@ class ControlFlow:
             self.control_flow_machine.start_flow(start_node, debug_mode)
             self.flow_queue.task_done()
         except Exception:
-            self.cancel_flow_run()
+            if self.check_for_existing_running_flow():
+                self.cancel_flow_run()
             raise
 
     def check_for_existing_running_flow(self) -> bool:

--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -254,7 +254,7 @@ class ExecuteNodeState(State):
                 logger.debug("Pausing Node %s to run background work", current_node.name)
                 return None
         except Exception as e:
-            logger.error("Error processing node '%s': %s", current_node.name, e)
+            logger.exception("Error processing node '%s", current_node.name)
             msg = f"Canceling flow run. Node '{current_node.name}' encountered a problem: {e}"
             current_node.state = NodeResolutionState.UNRESOLVED
             current_focus.process_generator = None

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -821,7 +821,7 @@ class FlowManager:
             flow.start_flow(start_node, debug_mode)
         except Exception as e:
             details = f"Failed to kick off flow with name {flow_name}. Exception occurred: {e} "
-            logger.exception(details)
+            logger.error(details)
             return StartFlowResultFailure(validation_exceptions=[e])
 
         details = f"Successfully kicked off flow with name {flow_name}"


### PR DESCRIPTION
This PR brings two changes:
1. Check the existence of a running flow before attempting to cancel it. [#750](#750) suggests that we may want to suppress the error, but I think it's better that we instead safely check.
2. Rearrange some of the error/exception logs such that exceptions in nodes produce a stack trace. Previously these were being suppressed while confusing engine internals were being shown. Logs now look like:
```
                    ERROR    Error processing node 'LoadImage_1': Image is not set
                             ╭─────────────────────────────────── Traceback (most recent call last) ───────────────────────────────────╮
                             │ /Users/collindutter/Documents/griptape/griptape-nodes/src/griptape_nodes/machines/node_resolution.py:25 │
                             │ 2 in on_update                                                                                          │
                             │                                                                                                         │
                             │   249 │   │   logger.info("Node %s is processing.", current_node.name)                                  │
                             │   250 │   │                                                                                             │
                             │   251 │   │   try:                                                                                      │
                             │ ❱ 252 │   │   │   work_is_scheduled = ExecuteNodeState._process_node(current_focus)                     │
                             │   253 │   │   │   if work_is_scheduled:                                                                 │
                             │   254 │   │   │   │   logger.debug("Pausing Node %s to run background work",                            │
                             │       current_node.name)                                                                                │
                             │   255 │   │   │   │   return None                                                                       │
                             │                                                                                                         │
                             │ /Users/collindutter/Documents/griptape/griptape-nodes/src/griptape_nodes/machines/node_resolution.py:37 │
                             │ 9 in _process_node                                                                                      │
                             │                                                                                                         │
                             │   376 │   │   # Only start the processing if we don't already have a generator                          │
                             │   377 │   │   logger.debug("Node %s process generator: %s", current_node.name,                          │
                             │       current_focus.process_generator)                                                                  │
                             │   378 │   │   if current_focus.process_generator is None:                                               │
                             │ ❱ 379 │   │   │   result = current_node.process()                                                       │
                             │   380 │   │   │                                                                                         │
                             │   381 │   │   │   # If the process returned a generator, we need to store it for later                  │
                             │   382 │   │   │   if isinstance(result, Generator):                                                     │
                             │                                                                                                         │
                             │ /users/collindutter/Documents/griptape/griptape-nodes/nodes/griptape_nodes_library/image/load_image.py: │
                             │ 26 in process                                                                                           │
                             │                                                                                                         │
                             │   23 │                                                                                                  │
                             │   24 │   def process(self) -> None:                                                                     │
                             │   25 │   │   image = self.parameter_values["image"]                                                     │
                             │ ❱ 26 │   │   raise ValueError("Image is not set")                                                       │
                             │   27 │   │                                                                                              │
                             │   28 │   │   if isinstance(image, dict):                                                                │
                             │   29 │   │   │   image_artifact = dict_to_image_artifact(image)                                         │
                             ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                             ValueError: Image is not set
[04/30/25 16:51:11] DEBUG    Cancelling flow run
                    ERROR    Failed to kick off flow with name untitled_2. Exception occurred: Canceling flow run. Node 'LoadImage_1'
                             encountered a problem: Image is not set
```

Closes #755 