### PR TITLE
fix: use correct keys for validation in compare image

### DIFF
--- a/src/griptape_nodes/traits/compare_images.py
+++ b/src/griptape_nodes/traits/compare_images.py
@@ -22,7 +22,7 @@ class CompareImagesTrait(Trait):
                 msg = f"Parameter {parameter.name} value must be a dictionary, got a {type(value).__name__} instead."
                 raise TypeError(msg)
 
-            expected_keys = {"image_1", "image_2"}
+            expected_keys = {"input_image_1", "input_image_2"}
             actual_keys = set(value.keys())
             if actual_keys != expected_keys:
                 missing = expected_keys - actual_keys


### PR DESCRIPTION
Does not fix #753 but gets rid of errors