### PR TITLE
new/bedrock_prompt_node

### DIFF
--- a/nodes/griptape_nodes_library.json
+++ b/nodes/griptape_nodes_library.json
@@ -85,7 +85,7 @@
       }
     },
     {
-      "image/upscale":{
+      "image/upscale": {
         "color": "border-purple-500",
         "title": "Image/Upscale",
         "description": "Image upscaling related nodes.",
@@ -273,6 +273,15 @@
         "category": "config/image",
         "description": "Node for OpenAI Image Generation Driver.",
         "display_name": "Open Ai Image"
+      }
+    },
+    {
+      "class_name": "AmazonBedrockPrompt",
+      "file_path": "griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py",
+      "metadata": {
+        "category": "config/prompt",
+        "description": "Node for Amazon Bedrock Prompt Driver.",
+        "display_name": "Amazon Bedrock Prompt"
       }
     },
     {

--- a/nodes/griptape_nodes_library/config/base_driver.py
+++ b/nodes/griptape_nodes_library/config/base_driver.py
@@ -153,6 +153,24 @@ class BaseDriver(DataNode):
             msg = f"Parameter '{param}' not found for updating model choices."
             raise ValueError(msg)
 
+    def _remove_options_trait(self, param: str) -> None:
+        """Removes the options trait from the specified parameter.
+
+        This method is intended to be called by subclasses to remove the
+        `Options` trait from a parameter, if it exists.
+
+        Args:
+            param: The name of the parameter from which to remove the `Options` trait.
+        """
+        parameter = self.get_parameter_by_name(param)
+        if parameter is not None:
+            trait = parameter.find_element_by_id("Options")
+            if trait and isinstance(trait, Options):
+                parameter.remove_trait(trait)
+        else:
+            msg = f"Parameter '{param}' not found for removing options trait."
+            raise ValueError(msg)
+
     def _replace_param_by_name(  # noqa: PLR0913
         self,
         param_name: str,

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -133,26 +133,13 @@ class AmazonBedrockPrompt(BasePrompt):
         configuration details.
         """
         exceptions = []
-        exceptions.append(
-            self._validate_api_key(
-                service_name=SERVICE,
-                api_key_env_var=AWS_ACCESS_KEY_ID_ENV_VAR,
-                api_key_url=API_KEY_URL,
-            )
-        )
-        exceptions.append(
-            self._validate_api_key(
-                service_name=SERVICE,
-                api_key_env_var=AWS_SECRET_ACCESS_KEY_ENV_VAR,
-                api_key_url=API_KEY_URL,
-            )
-        )
-        exceptions.append(
-            self._validate_api_key(
-                service_name=SERVICE,
-                api_key_env_var=AWS_DEFAULT_REGION_ENV_VAR,
-                api_key_url=API_KEY_URL,
-            )
-        )
-
+        api_keys_to_check = [
+            AWS_ACCESS_KEY_ID_ENV_VAR,
+            AWS_SECRET_ACCESS_KEY_ENV_VAR,
+            AWS_DEFAULT_REGION_ENV_VAR,
+        ]
+        for key in api_keys_to_check:
+            valid_key = self._validate_api_key(service_name=SERVICE, api_key_env_var=key, api_key_url=API_KEY_URL)
+            if valid_key is not None:
+                exceptions.append(valid_key)
         return exceptions if any(exceptions) else None

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -62,9 +62,8 @@ class AmazonBedrockPrompt(BasePrompt):
         # Update the 'model' parameter for Amazon Bedrock specifics.
         self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
 
-        # Remove the 'seed' parameter as it's not applicable for Amazon Bedrock.
+        # Remove unused parameters for Amazon Bedrock
         self.remove_parameter_by_name("seed")
-
         self.remove_parameter_by_name("min_p")
         self.remove_parameter_by_name("top_k")
 

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -130,13 +130,32 @@ class AmazonBedrockPrompt(BasePrompt):
         self.parameter_output_values["prompt_model_config"] = driver
 
     def validate_node(self) -> list[Exception] | None:
-        """Validates that the Amazon Bedrock API key is configured correctly.
+        """Validates that the Amazon Bedrock API keys are configured correctly.
 
         Calls the base class helper `_validate_api_key` with Amazon Bedrock-specific
         configuration details.
         """
-        return self._validate_api_key(
-            service_name=SERVICE,
-            api_key_env_var=AWS_ACCESS_KEY_ID_ENV_VAR,
-            api_key_url=API_KEY_URL,
+        exceptions = []
+        exceptions.append(
+            self._validate_api_key(
+                service_name=SERVICE,
+                api_key_env_var=AWS_ACCESS_KEY_ID_ENV_VAR,
+                api_key_url=API_KEY_URL,
+            )
         )
+        exceptions.append(
+            self._validate_api_key(
+                service_name=SERVICE,
+                api_key_env_var=AWS_SECRET_ACCCESS_KEY_ENV_VAR,
+                api_key_url=API_KEY_URL,
+            )
+        )
+        exceptions.append(
+            self._validate_api_key(
+                service_name=SERVICE,
+                api_key_env_var=AWS_DEFAULT_REGION_ENV_VAR,
+                api_key_url=API_KEY_URL,
+            )
+        )
+
+        return exceptions if any(exceptions) else None

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -1,0 +1,122 @@
+"""Defines the OpenAiPrompt node for configuring the OpenAi Prompt Driver.
+
+This module provides the `OpenAiPrompt` class, which allows users
+to configure and utilize the OpenAi prompt service within the Griptape
+Nodes framework. It inherits common prompt parameters from `BasePrompt`, sets
+OpenAi specific model options, requires a OpenAi API key via
+node configuration, and instantiates the `OpenAiPromptDriver`.
+"""
+
+from griptape.drivers.prompt.amazon_bedrock import AmazonBedrockPromptDriver as GtAmazonBedrockPromptDriver
+
+from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
+
+# --- Constants ---
+
+SERVICE = "Amazon"
+API_KEY_URL = "https://aws.amazon.com/console/bedrock/home?region=us-east-1#api-keys"
+AWS_ACCESS_KEY_ID_ENV_VAR = "AWS_ACCESS_KEY_ID"
+AWS_DEFAULT_REGION_ENV_VAR = "AWS_DEFAULT_REGION"
+AWS_SECRET_ACCCESS_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY"  # noqa: S105
+MODEL_CHOICES = [
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-opus-20240229-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "amazon.titan-text-premier-v1:0",
+    "amazon.titan-text-express-v1",
+    "amazon.titan-text-lite-v1",
+]
+DEFAULT_MODEL = MODEL_CHOICES[0]
+
+
+class AmazonBedrockPrompt(BasePrompt):
+    """Node for configuring and providing a Amazon Bedrock Chat Prompt Driver.
+
+    Inherits from `BasePrompt` to leverage common LLM parameters. This node
+    customizes the available models to those supported by Amazon Bedrock,
+    removes parameters not applicable to Amazon Bedrock (like 'seed'), and
+    requires a Amazon Bedrock API key to be set in the node's configuration
+    under the 'Amazon Bedrock' service.
+
+    The `process` method gathers the configured parameters and the API key,
+    utilizes the `_get_common_driver_args` helper from `BasePrompt`, adds
+    Amazon Bedrock specific configurations, then instantiates a
+    `AmazonBedrockPromptDriver` and assigns it to the 'prompt_model_config'
+    output parameter.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        """Initializes the AmazonBedrockPrompt node.
+
+        Calls the superclass initializer, then modifies the inherited 'model'
+        parameter to use Amazon Bedrock specific models and sets a default.
+        It also removes the 'seed' parameter inherited from `BasePrompt` as it's
+        not directly supported by the Amazon Bedrock driver implementation.
+        """
+        super().__init__(**kwargs)
+
+        # --- Customize Inherited Parameters ---
+
+        # Update the 'model' parameter for Amazon Bedrock specifics.
+        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+
+        # Amazon Bedrock tends to fail if max_tokens isn't set
+        self.set_parameter_value("max_tokens", 100)
+
+    def process(self) -> None:
+        """Processes the node configuration to create a AmazonBedrockPromptDriver.
+
+        Retrieves parameter values set on the node and the required API key from
+        the node's configuration system. It constructs the arguments dictionary
+        for the `AmazonBedrockPromptDriver`, instantiates the
+        driver, and assigns it to the 'prompt_model_config' output parameter.
+
+        Raises:
+            KeyError: If the Amazon Bedrock API key is not found in the node configuration
+                      (though `validate_node` should prevent this during execution).
+        """
+        # Retrieve all parameter values set on the node UI or via input connections.
+        params = self.parameter_values
+
+        # --- Get Common Driver Arguments ---
+        # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.
+        common_args = self._get_common_driver_args(params)
+
+        # --- Prepare OpenAi Specific Arguments ---
+        specific_args = {}
+
+        # Get the selected model.
+        specific_args["model"] = self.get_parameter_value("model")
+        specific_args["min_p"] = self.get_parameter_value("min_p")
+        specific_args["top_k"] = self.get_parameter_value("top_k")
+
+        # Handle parameters that go into 'extra_params' for Amazon Bedrock.
+        extra_params = {}
+
+        # Assign extra_params if not empty
+        if extra_params:
+            specific_args["extra_params"] = extra_params
+
+        # --- Combine Arguments and Instantiate Driver ---
+        # Combine common arguments with Amazon Bedrock specific arguments.
+        # Specific args take precedence if there's an overlap (though unlikely here).
+        all_kwargs = {**common_args, **specific_args}
+
+        # Create the Amazon Bedrock prompt driver instance.
+        driver = GtAmazonBedrockPromptDriver(**all_kwargs)
+
+        # Set the output parameter 'prompt_model_config'.
+        self.parameter_output_values["prompt_model_config"] = driver
+
+    def validate_node(self) -> list[Exception] | None:
+        """Validates that the Amazon Bedrock API key is configured correctly.
+
+        Calls the base class helper `_validate_api_key` with Amazon Bedrock-specific
+        configuration details.
+        """
+        return self._validate_api_key(
+            service_name=SERVICE,
+            api_key_env_var=AWS_ACCESS_KEY_ID_ENV_VAR,
+            api_key_url=API_KEY_URL,
+        )

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -14,7 +14,7 @@ from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
 # --- Constants ---
 
 SERVICE = "Amazon"
-API_KEY_URL = "https://aws.amazon.com/console/bedrock/home?region=us-east-1#api-keys"
+API_KEY_URL = "https://console.aws.amazon.com/iam/home?#/security_credentials"
 AWS_ACCESS_KEY_ID_ENV_VAR = "AWS_ACCESS_KEY_ID"
 AWS_DEFAULT_REGION_ENV_VAR = "AWS_DEFAULT_REGION"
 AWS_SECRET_ACCCESS_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY"  # noqa: S105
@@ -61,6 +61,12 @@ class AmazonBedrockPrompt(BasePrompt):
         # Update the 'model' parameter for Amazon Bedrock specifics.
         self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
 
+        # Remove the 'seed' parameter as it's not applicable for Amazon Bedrock.
+        self.remove_parameter_by_name("seed")
+
+        self.remove_parameter_by_name("min_p")
+        self.remove_parameter_by_name("top_k")
+
         # Amazon Bedrock tends to fail if max_tokens isn't set
         self.set_parameter_value("max_tokens", 100)
 
@@ -88,10 +94,8 @@ class AmazonBedrockPrompt(BasePrompt):
 
         # Get the selected model.
         specific_args["model"] = self.get_parameter_value("model")
-        specific_args["min_p"] = self.get_parameter_value("min_p")
-        specific_args["top_k"] = self.get_parameter_value("top_k")
-
         # Handle parameters that go into 'extra_params' for Amazon Bedrock.
+
         extra_params = {}
 
         # Assign extra_params if not empty

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -18,7 +18,7 @@ SERVICE = "Amazon"
 API_KEY_URL = "https://console.aws.amazon.com/iam/home?#/security_credentials"
 AWS_ACCESS_KEY_ID_ENV_VAR = "AWS_ACCESS_KEY_ID"
 AWS_DEFAULT_REGION_ENV_VAR = "AWS_DEFAULT_REGION"
-AWS_SECRET_ACCCESS_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY"  # noqa: S105
+AWS_SECRET_ACCESS_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY"  # noqa: S105
 MODEL_CHOICES = [
     "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "anthropic.claude-3-opus-20240229-v1:0",
@@ -74,7 +74,7 @@ class AmazonBedrockPrompt(BasePrompt):
     def start_session(self) -> boto3.Session:
         """Starts a session with Amazon Bedrock using the provided AWS credentials."""
         aws_access_key_id = self.get_config_value(SERVICE, AWS_ACCESS_KEY_ID_ENV_VAR)
-        aws_secret_access_key = self.get_config_value(SERVICE, AWS_SECRET_ACCCESS_KEY_ENV_VAR)
+        aws_secret_access_key = self.get_config_value(SERVICE, AWS_SECRET_ACCESS_KEY_ENV_VAR)
         aws_default_region = self.get_config_value(SERVICE, AWS_DEFAULT_REGION_ENV_VAR)
 
         try:
@@ -151,7 +151,7 @@ class AmazonBedrockPrompt(BasePrompt):
         exceptions.append(
             self._validate_api_key(
                 service_name=SERVICE,
-                api_key_env_var=AWS_SECRET_ACCCESS_KEY_ENV_VAR,
+                api_key_env_var=AWS_SECRET_ACCESS_KEY_ENV_VAR,
                 api_key_url=API_KEY_URL,
             )
         )

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -114,13 +114,6 @@ class AmazonBedrockPrompt(BasePrompt):
 
         # Get the selected model.
         specific_args["model"] = self.get_parameter_value("model")
-        # Handle parameters that go into 'extra_params' for Amazon Bedrock.
-
-        extra_params = {}
-
-        # Assign extra_params if not empty
-        if extra_params:
-            specific_args["extra_params"] = extra_params
 
         # --- Combine Arguments and Instantiate Driver ---
         # Combine common arguments with Amazon Bedrock specific arguments.

--- a/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/nodes/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -1,10 +1,10 @@
-"""Defines the OpenAiPrompt node for configuring the OpenAi Prompt Driver.
+"""Defines the AmazonBedrockPrompt node for configuring the Amazon Bedrock Prompt Driver.
 
-This module provides the `OpenAiPrompt` class, which allows users
-to configure and utilize the OpenAi prompt service within the Griptape
+This module provides the `AmazonBedrockPrompt` class, which allows users
+to configure and utilize the Amazon Bedrock prompt service within the Griptape
 Nodes framework. It inherits common prompt parameters from `BasePrompt`, sets
-OpenAi specific model options, requires a OpenAi API key via
-node configuration, and instantiates the `OpenAiPromptDriver`.
+Amazon Bedrock specific model options, requires a Amazon API Keys via
+node configuration, and instantiates the `AmazonBedrockPromptDriver`.
 """
 
 import boto3
@@ -59,8 +59,14 @@ class AmazonBedrockPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Amazon Bedrock specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Amazon Bedrock offers a lot of different models, so instead of using
+        # a dropdown, we'll provide just a text field for the user to enter the model name
+        # and set the default to the first model in the list.
+        # TODO(griptape): Add a method to query the available models from Amazon Bedrock.
+        self._remove_options_trait(param="model")
+        param = self.get_parameter_by_name("model")
+        if param is not None:
+            param.default_value = MODEL_CHOICES[0]
 
         # Remove unused parameters for Amazon Bedrock
         self.remove_parameter_by_name("seed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = "~=3.12"
 dependencies = [
-  "griptape[drivers-prompt-anthropic,drivers-prompt-ollama,loaders-image,drivers-web-scraper-trafilatura,drivers-web-search-duckduckgo]>=1.6.2",
+  "griptape[drivers-prompt-anthropic,drivers-prompt-ollama,drivers-prompt-amazon-bedrock,loaders-image,drivers-web-scraper-trafilatura,drivers-web-search-duckduckgo]>=1.6.2",
   "pydantic>=2.10.6",
   "python-dotenv>=1.0.1",
   "xdg-base-dirs>=6.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.38.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/43/3c2d1bbbef0d187c1dc0e7ec7e8f213c7653c8464ba903613bf856656fcb/boto3-1.38.7.tar.gz", hash = "sha256:0269f793f0affc646b95c2cd12d42a4db49d5f30ef1073f616a112a384933f8e", size = 111804, upload-time = "2025-05-01T19:09:00.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/fc/9a50d28515b35fcc6f33fad33732951a5c9fd8fba096e47c0df7885d72ae/boto3-1.38.7-py3-none-any.whl", hash = "sha256:c548983189b0a88f09cd4c572519b1923695b25cd877def58b61e03f41a6fd96", size = 139901, upload-time = "2025-05-01T19:08:57.387Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.38.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/c7/e290008036749e43f615adada8b7e73bf2405d4b1913de375b5c8f01daa1/botocore-1.38.7.tar.gz", hash = "sha256:5c6df7171390437683072aadc0d2dfbcbfa72df52a134a5d4bed811ed214c3df", size = 13869944, upload-time = "2025-05-01T19:08:46.839Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/65/074339f9f48a4152b9d9f1a73d39a202e652c00354507455baacdca5efe9/botocore-1.38.7-py3-none-any.whl", hash = "sha256:a002ec18cc02c4b039d20c39ca88ecf2fdb9533c0a5f3670e8c0fcdd3ee4a045", size = 13531844, upload-time = "2025-05-01T19:08:40.731Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -330,6 +358,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+drivers-prompt-amazon-bedrock = [
+    { name = "anthropic" },
+    { name = "boto3" },
+]
 drivers-prompt-anthropic = [
     { name = "anthropic" },
 ]
@@ -353,7 +385,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cohere" },
     { name = "fastapi" },
-    { name = "griptape", extra = ["drivers-prompt-anthropic", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "loaders-image"] },
+    { name = "griptape", extra = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "loaders-image"] },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -390,7 +422,7 @@ test = [
 requires-dist = [
     { name = "cohere", specifier = ">=5.14.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
-    { name = "griptape", extras = ["drivers-prompt-anthropic", "drivers-prompt-ollama", "loaders-image", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo"], git = "https://github.com/griptape-ai/griptape.git?branch=main" },
+    { name = "griptape", extras = ["drivers-prompt-anthropic", "drivers-prompt-ollama", "drivers-prompt-amazon-bedrock", "loaders-image", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo"], git = "https://github.com/griptape-ai/griptape.git?branch=main" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -566,6 +598,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/0f/77a63ca7aa5fed9a1b9135af57e190d905bcd3702b36aca46a01090d39ad/jiter-0.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f0b2827fb88dda2cbecbbc3e596ef08d69bda06c6f57930aec8e79505dc17001", size = 317281, upload-time = "2025-03-10T21:36:22.959Z" },
     { url = "https://files.pythonhosted.org/packages/f9/39/a3a1571712c2bf6ec4c657f0d66da114a63a2e32b7e4eb8e0b83295ee034/jiter-0.9.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:062b756ceb1d40b0b28f326cba26cfd575a4918415b036464a52f08632731e5a", size = 350273, upload-time = "2025-03-10T21:36:24.414Z" },
     { url = "https://files.pythonhosted.org/packages/ee/47/3729f00f35a696e68da15d64eb9283c330e776f3b5789bac7f2c0c4df209/jiter-0.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6f7838bc467ab7e8ef9f387bd6de195c43bad82a569c1699cb822f6609dd4cdf", size = 206867, upload-time = "2025-03-10T21:36:25.843Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
 ]
 
 [[package]]
@@ -1479,6 +1520,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/72/43b123e4db52144c8add336581de52185097545981ff6e9e58a21861c250/ruff-0.11.7-py3-none-win32.whl", hash = "sha256:f25dfb853ad217e6e5f1924ae8a5b3f6709051a13e9dad18690de6c8ff299e26", size = 10362436, upload-time = "2025-04-24T18:49:27.377Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a0/3e58cd76fdee53d5c8ce7a56d84540833f924ccdf2c7d657cb009e604d82/ruff-0.11.7-py3-none-win_amd64.whl", hash = "sha256:0a931d85959ceb77e92aea4bbedfded0a31534ce191252721128f77e5ae1f98a", size = 11566676, upload-time = "2025-04-24T18:49:30.938Z" },
     { url = "https://files.pythonhosted.org/packages/68/ca/69d7c7752bce162d1516e5592b1cc6b6668e9328c0d270609ddbeeadd7cf/ruff-0.11.7-py3-none-win_arm64.whl", hash = "sha256:778c1e5d6f9e91034142dfd06110534ca13220bfaad5c3735f6cb844654f6177", size = 10677936, upload-time = "2025-04-24T18:49:34.392Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/9e/73b14aed38ee1f62cd30ab93cd0072dec7fb01f3033d116875ae3e7b8b44/s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c", size = 149178, upload-time = "2025-04-22T21:08:09.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/64/d2b49620039b82688aeebd510bd62ff4cdcdb86cbf650cc72ae42c5254a3/s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18", size = 84773, upload-time = "2025-04-22T21:08:08.265Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
adds amazon bedrock prompt driver.

Currently provides list of default models, but will update later with another task to pull this list dynamically from the user's available models, or swap this out for a plain text field.

fixes #785 