### PR TITLE
Secret Improvements

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -41,7 +41,7 @@ secrets_manager = SecretsManager(config_manager)
 
 def main() -> None:
     """Main entry point for the Griptape Nodes CLI."""
-    load_dotenv(ENV_FILE)
+    load_dotenv(ENV_FILE, override=True)
 
     # Hack to make paths "just work". # noqa: FIX004
     # Without this, packages like `nodes` don't properly import.

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import IO, TYPE_CHECKING, Any, ClassVar, TextIO
 
-from dotenv import load_dotenv
 from rich.logging import RichHandler
 
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -40,8 +39,6 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
     from griptape_nodes.retained_mode.managers.static_files_manager import StaticFilesManager
     from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
-
-load_dotenv()
 
 
 logger = logging.getLogger("griptape_nodes")

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -125,7 +125,7 @@ class SecretsManager:
         if not ENV_VAR_PATH.exists():
             ENV_VAR_PATH.touch()
         set_key(ENV_VAR_PATH, secret_name, secret_value)
-        load_dotenv(ENV_VAR_PATH)
+        load_dotenv(ENV_VAR_PATH, override=True)
 
     @staticmethod
     def _apply_secret_name_compliance(secret_name: str) -> str:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -3,7 +3,7 @@ import re
 from os import getenv
 from pathlib import Path
 
-from dotenv import dotenv_values, get_key, set_key, unset_key
+from dotenv import dotenv_values, get_key, load_dotenv, set_key, unset_key
 from dotenv.main import DotEnv
 from xdg_base_dirs import xdg_config_home
 
@@ -125,6 +125,7 @@ class SecretsManager:
         if not ENV_VAR_PATH.exists():
             ENV_VAR_PATH.touch()
         set_key(ENV_VAR_PATH, secret_name, secret_value)
+        load_dotenv(ENV_VAR_PATH)
 
     @staticmethod
     def _apply_secret_name_compliance(secret_name: str) -> str:

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, NamedTuple, TypeVar, cast
 
 import tomlkit
-from dotenv import load_dotenv
 from rich.box import HEAVY_EDGE
 from rich.console import Console
 from rich.panel import Panel
@@ -82,7 +81,6 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
-load_dotenv()
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Reload secrets after settings them.
Secrets file takes precedence over system environment variables.
Removed stray `load_dotenv`s.

Closes https://github.com/griptape-ai/griptape-vsl-gui/issues/559