### PR TITLE
Add preview placeholder

### DIFF
--- a/nodes/diffusers_nodes_library/flux_pipeline.py
+++ b/nodes/diffusers_nodes_library/flux_pipeline.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Iterator
 from typing import Any, ClassVar
 
+import PIL.Image
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
 from pillow_nodes_library.utils import pil_to_image_artifact  # type: ignore[reportMissingImports]
@@ -228,6 +229,11 @@ class FluxPipeline(ControlNode):
         num_inference_steps = int(self.parameter_values["num_inference_steps"])
         guidance_scale = float(self.parameter_values["guidance_scale"])
         seed = int(self.parameter_values["seed"]) if ("seed" in self.parameter_values) else None
+
+        # Immediately set a preview placeholder image to make it react quickly and adjust
+        # the size of the image preview on the node.
+        preview_placeholder_image = PIL.Image.new('RGB', (width, height), color='black')
+        self.publish_update_to_parameter("output_image", pil_to_image_artifact(preview_placeholder_image))
 
         self.append_value_to_parameter("logs", "Preparing models...\n")
         with self._append_stdout_to_logs():

--- a/nodes/diffusers_nodes_library/tiling_flux_img_2_img_pipeline.py
+++ b/nodes/diffusers_nodes_library/tiling_flux_img_2_img_pipeline.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
 from griptape.loaders import ImageLoader
 from PIL.Image import Image
@@ -297,6 +298,12 @@ class TilingFluxImg2ImgPipeline(ControlNode):
             input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
+
+        # The output image will be the same size as the input image.
+        # Immediately set a preview placeholder image to make it react quickly and adjust
+        # the size of the image preview on the node.
+        preview_placeholder_image = PIL.Image.new('RGB', input_image_pil.size, color='black')
+        self.publish_update_to_parameter("output_image", pil_to_image_artifact(preview_placeholder_image))
 
         # Adjust tile size so that it is not much bigger than the input image.
         largest_reasonable_tile_width = next_multiple_ge(input_image_pil.width, 16)


### PR DESCRIPTION
Displays a black image in the output with correct dimensions while waiting for first preview image. Only on the "amaru" nodes.