### PR TITLE
feature/image_pulse_on_run

### DIFF
--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -78,7 +78,7 @@ class GenerateImage(ControlNode):
                 tooltip="None",
                 default_value=None,
                 allowed_modes={ParameterMode.OUTPUT},
-                ui_options={"pulse_on_update": True},
+                ui_options={"pulse_on_run": True},
             )
         )
         # Group for logging information.

--- a/nodes/griptape_nodes_library/image/create_image.py
+++ b/nodes/griptape_nodes_library/image/create_image.py
@@ -78,6 +78,7 @@ class GenerateImage(ControlNode):
                 tooltip="None",
                 default_value=None,
                 allowed_modes={ParameterMode.OUTPUT},
+                ui_options={"pulse_on_update": True},
             )
         )
         # Group for logging information.


### PR DESCRIPTION
adds a simple ui_option `pulse_on_run: true` on the Generate Image node.

With this ui_option, if you put it on an image parameter, it'll display an animation when the node is running.

fixes: https://github.com/griptape-ai/griptape-vsl-gui/issues/84