### PR TITLE
Reorder to match docs

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -11,9 +11,9 @@ class AppInitializationComplete(BaseModel):
     )
     workflows_to_register: list[str] = Field(
         default_factory=lambda: [
+            str(xdg_data_home() / "griptape_nodes/workflows/templates/prompt_an_image.py"),
             str(xdg_data_home() / "griptape_nodes/workflows/templates/translator.py"),
             str(xdg_data_home() / "griptape_nodes/workflows/templates/compare_prompts.py"),
-            str(xdg_data_home() / "griptape_nodes/workflows/templates/prompt_an_image.py"),
             str(xdg_data_home() / "griptape_nodes/workflows/templates/photography_team.py"),
         ]
     )


### PR DESCRIPTION
Closes #904 

Reordered template workflows to have parity with https://docs.griptapenodes.com/en/stable/