### PR TITLE
refactor: move rich handler to app

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -74,8 +74,12 @@ class EventLogHandler(logging.Handler):
         )
 
 
+griptape_nodes_logger = logging.getLogger("griptape_nodes")
 # When running as an app, we want to forward all log messages to the event queue so they can be sent to the GUI
-logging.getLogger("griptape_nodes").addHandler(EventLogHandler())
+griptape_nodes_logger.addHandler(EventLogHandler())
+griptape_nodes_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
+griptape_nodes_logger.setLevel(logging.INFO)
+
 # Logger for this module. Important that this is not the same as the griptape_nodes logger or else we'll have infinite log events.
 logger = logging.getLogger(__name__)
 console = Console()

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import IO, TYPE_CHECKING, Any, ClassVar, TextIO
 
-from rich.logging import RichHandler
-
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.retained_mode.events.app_events import (
     AppGetSessionRequest,
@@ -42,9 +40,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("griptape_nodes")
-logger.setLevel(logging.INFO)
-
-logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
 
 
 @dataclass


### PR DESCRIPTION
Every now and then I've noticed the rich handler not being used:
```
[05/03/25 15:36:44] INFO     Resolving GenerateImage_1
INFO:griptape_nodes:Resolving GenerateImage_1
                    INFO     Node TextInput_1 is processing.
INFO:griptape_nodes:Node TextInput_1 is processing.
                    INFO     Node TextInput_1 finished processing.
INFO:griptape_nodes:Node TextInput_1 finished processing.
                    INFO     TextInput_1 resolved.
INFO:griptape_nodes:TextInput_1 resolved.
```

 I'm not quite sure what triggers this, but this PR centralizes the handlers. Maybe it'll help.