### PR TITLE
Initial commit for publish workflow event

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -6,10 +6,7 @@
     "description": "Default nodes for Griptape Nodes.",
     "library_version": "0.1.0",
     "engine_version": "0.1.0",
-    "tags": [
-      "Griptape",
-      "AI"
-    ]
+    "tags": ["Griptape", "AI"]
   },
   "categories": [
     {
@@ -138,6 +135,14 @@
         "title": "Utility",
         "description": "Utility nodes like save, etc., etc.",
         "icon": "Cog"
+      }
+    },
+    {
+      "workflows": {
+        "color": "border-gray-500",
+        "title": "Workflows",
+        "description": "Nodes for executing Workflows.",
+        "icon": "Workflow"
       }
     }
   ],
@@ -590,6 +595,15 @@
         "category": "convert",
         "description": "AgentToTool node.",
         "display_name": "Agent To Tool"
+      }
+    },
+    {
+      "class_name": "PublishedWorkflow",
+      "file_path": "griptape_nodes_library/workflows/published_workflow.py",
+      "metadata": {
+        "category": "workflows",
+        "description": "PublishedWorkflow node.",
+        "display_name": "Published Workflow"
       }
     }
   ],

--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -96,7 +96,10 @@ class Agent(ControlNode):
                 tooltip="The main text prompt to send to the agent.",
                 default_value="",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={"multiline": True, "placeholder_text": "Talk with the Agent."},
+                ui_options={
+                    "multiline": True,
+                    "placeholder_text": "Talk with the Agent.",
+                },
                 converters=[strip_whitespace],
             )
         )
@@ -452,7 +455,8 @@ class Agent(ControlNode):
         rulesets = [ruleset for ruleset in params.get("rulesets", []) if ruleset]
         if include_details and rulesets:
             self.append_value_to_parameter(
-                "logs", f"\n[Rulesets]: {', '.join([ruleset.name for ruleset in rulesets])}\n"
+                "logs",
+                f"\n[Rulesets]: {', '.join([ruleset.name for ruleset in rulesets])}\n",
             )
 
         # Get the prompt

--- a/libraries/griptape_nodes_library/griptape_nodes_library/workflows/__init__.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Workflows nodes package."""

--- a/libraries/griptape_nodes_library/griptape_nodes_library/workflows/library_style.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/workflows/library_style.json
@@ -1,0 +1,6 @@
+{
+  "color": "border-gray-500",
+  "title": "Workflows",
+  "description": "Nodes for executing Workflows.",
+  "icon": "Workflow"
+}

--- a/libraries/griptape_nodes_library/griptape_nodes_library/workflows/published_workflow.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/workflows/published_workflow.py
@@ -175,7 +175,7 @@ class PublishedWorkflow(ControlNode):
         modified_parameters_set = set()
         for param in self.parameters:
             if param.name not in valid_parameter_names:
-                self.remove_parameter(param)
+                self.remove_parameter_element(param)
                 modified_parameters_set.add(param.name)
         return modified_parameters_set
 
@@ -246,7 +246,7 @@ class PublishedWorkflow(ControlNode):
                 err_msg = f"Error fetching workflow: {e!s}"
                 raise ValueError(err_msg) from e
 
-    def validate_node(self) -> list[Exception] | None:
+    def validate_before_workflow_run(self) -> list[Exception] | None:
         # All env values are stored in the SecretsManager. Check if they exist using this method.
         exceptions = []
 
@@ -321,7 +321,7 @@ class PublishedWorkflow(ControlNode):
         response = self._get_workflow_run(workflow_id, workflow_run_id)
         run_status = response.json()["status"]
 
-        while run_status not in ["SUCCEEDED", "FAILED", "ERROR", "CANCELED"]:
+        while run_status not in ["SUCCEEDED", "FAILED", "ERROR", "CANCELLED"]:
             response = self._get_workflow_run(workflow_id, workflow_run_id)
             run_status = response.json()["status"]
             time.sleep(3)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/workflows/published_workflow.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/workflows/published_workflow.py
@@ -1,0 +1,328 @@
+import json
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, cast
+from urllib.parse import urljoin
+
+import httpx
+from httpx import Response
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.retained_mode.events.connection_events import (
+    DeleteConnectionRequest,
+    DeleteConnectionResultSuccess,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.options import Options
+
+DEFAULT_WORKFLOW_BASE_ENDPOINT = urljoin(
+    os.getenv("GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes.griptape.ai"),
+    "/api/workflows",
+)
+API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
+SERVICE = "Griptape"
+
+
+@dataclass(eq=False)
+class WorkflowOptions(Options):
+    choices_value_lookup: dict[str, Any] = field(kw_only=True)
+
+    def converters_for_trait(self) -> list[Callable]:
+        def converter(value: Any) -> Any:
+            if value not in self.choices:
+                value = self.choices[0]
+            value = self.choices_value_lookup.get(value, self.choices[0])["id"]
+            return value
+
+        return [converter]
+
+    def validators_for_trait(self) -> list[Callable[[Parameter, Any], Any]]:
+        def validator(param: Parameter, value: Any) -> None:  # noqa: ARG001
+            if value not in (self.choices_value_lookup.get(x, self.choices[0])["id"] for x in self.choices):
+                msg = "Choice not allowed"
+
+                def raise_error() -> None:
+                    raise ValueError(msg)
+
+                raise_error()
+
+        return [validator]
+
+
+class PublishedWorkflow(ControlNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.config = GriptapeNodes.ConfigManager()
+        self.flow_manager = GriptapeNodes.FlowManager()
+        self.node_manager = GriptapeNodes.NodeManager()
+        self.workflows = self._get_workflow_options()
+        self.choices = list(map(PublishedWorkflow._workflow_to_name_and_id, self.workflows))
+
+        self.add_parameter(
+            Parameter(
+                name="workflow_id",
+                default_value=(self.workflows[0]["id"] if self.workflows else None),
+                input_types=["str"],
+                output_type="str",
+                type="str",
+                traits={
+                    WorkflowOptions(
+                        choices=list(map(PublishedWorkflow._workflow_to_name_and_id, self.workflows)),
+                        choices_value_lookup={PublishedWorkflow._workflow_to_name_and_id(w): w for w in self.workflows},
+                    )
+                },
+                allowed_modes={
+                    ParameterMode.INPUT,
+                    ParameterMode.OUTPUT,
+                    ParameterMode.PROPERTY,
+                },
+                tooltip="workflow",
+            )
+        )
+
+    @classmethod
+    def _workflow_to_name_and_id(cls, workflow: dict[str, Any]) -> str:
+        return f"{workflow['name']} ({workflow['id']})"
+
+    def _get_headers(self) -> dict[str, str]:
+        api_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_workflow_options(self) -> list[dict[str, Any]]:
+        try:
+            list_workflows_response = self._list_workflows()
+            data = list_workflows_response.json()
+            return data.get("workflows", [])
+        except Exception:
+            return []
+
+    def _list_workflows(self) -> Response:
+        httpx_client = httpx.Client(base_url=DEFAULT_WORKFLOW_BASE_ENDPOINT)
+        url = urljoin(
+            DEFAULT_WORKFLOW_BASE_ENDPOINT,
+            "/api/workflows",
+        )
+        response = httpx_client.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response
+
+    def _get_workflow(self) -> Response:
+        httpx_client = httpx.Client(base_url=DEFAULT_WORKFLOW_BASE_ENDPOINT)
+        workflow_id = self.get_parameter_value("workflow_id")
+        url = urljoin(
+            DEFAULT_WORKFLOW_BASE_ENDPOINT,
+            f"/api/workflows/{workflow_id}",
+        )
+        response = httpx_client.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response
+
+    def _purge_old_connections(self) -> None:
+        connection_request: ListConnectionsForNodeRequest = ListConnectionsForNodeRequest(node_name=self.name)
+        result = self.node_manager.on_list_connections_for_node_request(request=connection_request)
+        if isinstance(result, ListConnectionsForNodeResultSuccess):
+            for con in result.incoming_connections:
+                del_req: DeleteConnectionRequest = DeleteConnectionRequest(
+                    source_parameter_name=con.source_parameter_name,
+                    target_parameter_name=con.target_parameter_name,
+                    source_node_name=con.source_node_name,
+                    target_node_name=self.name,
+                )
+                del_result = self.flow_manager.on_delete_connection_request(request=del_req)
+                if not isinstance(del_result, DeleteConnectionResultSuccess):
+                    err_msg = f"Error deleting connection for node {self.name}: {del_result}"
+                    raise TypeError(err_msg)
+            for con in result.outgoing_connections:
+                del_req: DeleteConnectionRequest = DeleteConnectionRequest(
+                    source_parameter_name=con.source_parameter_name,
+                    target_parameter_name=con.target_parameter_name,
+                    source_node_name=self.name,
+                    target_node_name=con.target_node_name,
+                )
+                del_result = self.flow_manager.on_delete_connection_request(request=del_req)
+                if not isinstance(del_result, DeleteConnectionResultSuccess):
+                    err_msg = f"Error deleting connection for node {self.name}: {del_result}"
+                    raise TypeError(err_msg)
+        else:
+            err_msg = f"Error fetching connections for node {self.name}: {result}"
+            raise TypeError(err_msg)
+
+    def _purge_old_parameters(self, valid_parameter_names: set[str]) -> set[str]:
+        # Always maintain these parameters
+        valid_parameter_names.update(
+            [
+                "exec_in",
+                "exec_out",
+                "workflow_id",
+            ]
+        )
+
+        modified_parameters_set = set()
+        for param in self.parameters:
+            if param.name not in valid_parameter_names:
+                self.remove_parameter(param)
+                modified_parameters_set.add(param.name)
+        return modified_parameters_set
+
+    def after_value_set(self, parameter: Parameter, value: Any, modified_parameters_set: set[str]) -> None:
+        """Callback after a value has been set on this Node."""
+        # If the workflow_id is set, we can fetch the workflow.
+        if parameter.name == "workflow_id" and value is not None:
+            try:
+                response = self._get_workflow()
+                workflow = response.json()
+                self.workflow_details = workflow
+
+                self._purge_old_connections()
+
+                modified_parameters_set.update(
+                    self._purge_old_parameters({i for i, v in cast("dict[str, Any]", workflow["input"]).items()})
+                )
+                modified_parameters_set.update(
+                    self._purge_old_parameters({i for i, v in cast("dict[str, Any]", workflow["output"]).items()})
+                )
+
+                self.add_parameter(
+                    Parameter(
+                        name="workflow_name",
+                        type="str",
+                        input_types=["str"],
+                        default_value=workflow["name"],
+                        tooltip="The name of the published Nodes Workflow.",
+                        allowed_modes={
+                            ParameterMode.OUTPUT,
+                        },
+                        user_defined=False,
+                        settable=False,
+                    )
+                )
+                modified_parameters_set.add("workflow_name")
+
+                for params in workflow["input"].values():
+                    for param, info in params.items():
+                        kwargs: dict[str, Any] = {**info}
+                        kwargs["allowed_modes"] = {
+                            ParameterMode.INPUT,
+                        }
+                        self.add_parameter(Parameter(**kwargs))
+                        modified_parameters_set.add(param)
+                for params in workflow["output"].values():
+                    for param, info in params.items():
+                        kwargs: dict[str, Any] = {**info}
+                        kwargs["allowed_modes"] = {
+                            ParameterMode.OUTPUT,
+                        }
+                        self.add_parameter(Parameter(**kwargs))
+                        modified_parameters_set.add(param)
+
+            except Exception as e:
+                err_msg = f"Error fetching workflow: {e!s}"
+                raise ValueError(err_msg) from e
+
+    def validate_node(self) -> list[Exception] | None:
+        # All env values are stored in the SecretsManager. Check if they exist using this method.
+        exceptions = []
+
+        def raise_error(msg: str) -> None:
+            raise ValueError(msg)
+
+        try:
+            api_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
+
+            if not api_key:
+                msg = f"API key for {SERVICE} is not set."
+                raise_error(msg)
+
+            if not self.get_parameter_value("workflow_id"):
+                msg = "Workflow ID is not set."
+                raise_error(msg)
+
+            if (self.workflow_details.get("status", None)) not in ["READY"]:
+                response = self._get_workflow()
+                response.raise_for_status()
+                workflow = response.json()
+                if workflow["status"] != "READY":
+                    msg = f"Workflow ID {self.get_parameter_value('workflow_id')} is not ready. Status: {workflow['status']}"
+                    raise_error(msg)
+                self.workflow_details = workflow
+
+        except Exception as e:
+            # Add any exceptions to your list to return
+            exceptions.append(e)
+            return exceptions
+        # if there are exceptions, they will display when the user tries to run the flow with the node.
+        return exceptions if exceptions else None
+
+    def _get_workflow_run_input(self) -> dict[str, Any]:
+        workflow_run_input: dict[str, Any] = {}
+
+        for node_name, params in self.workflow_details["input"].items():
+            for param_name in params:
+                workflow_run_input[node_name] = {param_name: self.get_parameter_value(param_name)}
+
+        return workflow_run_input
+
+    def _create_workflow_run(self) -> Response:
+        httpx_client = httpx.Client(base_url=DEFAULT_WORKFLOW_BASE_ENDPOINT)
+        url = urljoin(
+            DEFAULT_WORKFLOW_BASE_ENDPOINT,
+            f"/api/workflows/{self.get_parameter_value('workflow_id')}/runs",
+        )
+        response = httpx_client.post(url, headers=self._get_headers(), json=self._get_workflow_run_input())
+        response.raise_for_status()
+        return response
+
+    def _get_workflow_run(self, workflow_id: str, workflow_run_id: str) -> Response:
+        httpx_client = httpx.Client(base_url=DEFAULT_WORKFLOW_BASE_ENDPOINT)
+        url = urljoin(
+            DEFAULT_WORKFLOW_BASE_ENDPOINT,
+            f"/api/workflows/{workflow_id}/workflow-runs/{workflow_run_id}",
+        )
+        response = httpx_client.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return response
+
+    def _poll_workflow_run(self, workflow_id: str, workflow_run_id: str) -> Response:
+        response = self._get_workflow_run(workflow_id, workflow_run_id)
+        run_status = response.json()["status"]
+
+        while run_status not in ["SUCCEEDED", "FAILED", "ERROR", "CANCELED"]:
+            response = self._get_workflow_run(workflow_id, workflow_run_id)
+            run_status = response.json()["status"]
+            time.sleep(3)
+
+        return response
+
+    def _process(self) -> Response:
+        create_run_response = self._create_workflow_run()
+        res_json = create_run_response.json()
+        workflow_id = res_json["workflow_id"]
+        workflow_run_id = res_json["id"]
+        response = self._poll_workflow_run(workflow_id, workflow_run_id)
+
+        response_data = response.json()
+        if response_data["status"] == "SUCCEEDED" and response_data["output"]:
+            for params in json.loads(response_data["output"]).values():
+                for param, val in params.items():
+                    if param in [param.name for param in self.parameters]:
+                        self.append_value_to_parameter(param, value=val)
+
+        return Response(
+            json=response_data,
+            status_code=200,
+        )
+
+    def process(
+        self,
+    ) -> AsyncResult[None]:
+        yield lambda: None
+        self._process()

--- a/src/griptape_nodes/bootstrap/__init__.py
+++ b/src/griptape_nodes/bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Bootstrap package."""

--- a/src/griptape_nodes/bootstrap/bootstrap_script.py
+++ b/src/griptape_nodes/bootstrap/bootstrap_script.py
@@ -93,7 +93,6 @@ def __handle_node_event(event: GriptapeNodeEvent) -> None:
     event_json = result_event.json()
     event_log = f"GriptapeNodeEvent: {event_json}"
     logger.info(event_log)
-    queue.put(event)
 
 
 def __handle_execution_node_event(event: ExecutionGriptapeNodeEvent) -> None:
@@ -127,13 +126,11 @@ def __handle_execution_node_event(event: ExecutionGriptapeNodeEvent) -> None:
 def __handle_progress_event(gt_event: ProgressEvent) -> None:
     event_log = f"ProgressEvent: {gt_event}"
     logger.info(event_log)
-    queue.put(gt_event)
 
 
 def __handle_app_event(event: AppEvent) -> None:
     event_log = f"AppEvent: {event.payload}"
     logger.info(event_log)
-    queue.put(event)
 
 
 def _submit_output(output: dict) -> None:

--- a/src/griptape_nodes/bootstrap/bootstrap_script.py
+++ b/src/griptape_nodes/bootstrap/bootstrap_script.py
@@ -1,0 +1,261 @@
+import argparse
+import importlib.util
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from queue import Queue
+from typing import Any
+
+from dotenv import load_dotenv
+from griptape.artifacts import TextArtifact
+from griptape.drivers.event_listener.griptape_cloud_event_listener_driver import GriptapeCloudEventListenerDriver
+from griptape.events import BaseEvent, EventBus, EventListener, FinishStructureRunEvent
+
+from griptape_nodes.exe_types.node_types import EndNode, StartNode
+from griptape_nodes.retained_mode.events.base_events import (
+    AppEvent,
+    EventRequest,
+    ExecutionGriptapeNodeEvent,
+    GriptapeNodeEvent,
+    ProgressEvent,
+)
+from griptape_nodes.retained_mode.events.execution_events import SingleExecutionStepRequest, StartFlowRequest
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+load_dotenv()
+
+queue = Queue()
+
+
+def _load_user_workflow(path_to_workflow: str) -> None:
+    # Ensure file_path is a Path object
+    file_path = Path(path_to_workflow)
+
+    # Generate a unique module name
+    module_name = f"dynamic_module_{file_path.name.replace('.', '_')}_{hash(str(file_path))}"
+
+    # Load the module specification
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module specification from {file_path}"
+        raise ImportError(msg)
+
+    # Create the module
+    module = importlib.util.module_from_spec(spec)
+
+    # Add to sys.modules to handle recursive imports
+    sys.modules[module_name] = module
+
+    # Execute the module
+    spec.loader.exec_module(module)
+
+
+def _handle_event(event: BaseEvent) -> None:
+    try:
+        if isinstance(event, GriptapeNodeEvent):
+            __handle_node_event(event)
+        elif isinstance(event, ExecutionGriptapeNodeEvent):
+            __handle_execution_node_event(event)
+        elif isinstance(event, ProgressEvent):
+            __handle_progress_event(event)
+        elif isinstance(event, AppEvent):
+            __handle_app_event(event)
+        else:
+            msg = f"Unknown event type: {type(event)}"
+            logger.info(msg)
+            queue.put(event)
+    except Exception as e:
+        logger.info(e)
+
+
+def __handle_node_event(event: GriptapeNodeEvent) -> None:
+    result_event = event.wrapped_event
+    event_json = result_event.json()
+    event_log = f"GriptapeNodeEvent: {event_json}"
+    logger.info(event_log)
+    queue.put(event)
+
+
+def __handle_execution_node_event(event: ExecutionGriptapeNodeEvent) -> None:
+    result_event = event.wrapped_event
+    if type(result_event.payload).__name__ == "NodeStartProcessEvent":
+        event_log = f"NodeStartProcessEvent: {result_event.payload}"
+        logger.info(event_log)
+
+    elif type(result_event.payload).__name__ == "ResumeNodeProcessingEvent":
+        event_log = f"ResumeNodeProcessingEvent: {result_event.payload}"
+        logger.info(event_log)
+
+        # Here we need to handle the resume event since this is the callback mechanism
+        # for the flow to be resumed for any Node that yields a generator in its process method.
+        node_name = result_event.payload.node_name
+        flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+        request = EventRequest(request=SingleExecutionStepRequest(flow_name=flow_name))
+        GriptapeNodes.handle_request(request.request)
+
+    elif type(result_event.payload).__name__ == "NodeFinishProcessEvent":
+        event_log = f"NodeFinishProcessEvent: {result_event.payload}"
+        logger.info(event_log)
+
+    else:
+        event_log = f"ExecutionGriptapeNodeEvent: {result_event.payload}"
+        logger.info(event_log)
+
+    queue.put(event)
+
+
+def __handle_progress_event(gt_event: ProgressEvent) -> None:
+    event_log = f"ProgressEvent: {gt_event}"
+    logger.info(event_log)
+    queue.put(gt_event)
+
+
+def __handle_app_event(event: AppEvent) -> None:
+    event_log = f"AppEvent: {event.payload}"
+    logger.info(event_log)
+    queue.put(event)
+
+
+def _submit_output(output: dict) -> None:
+    if "GT_CLOUD_STRUCTURE_RUN_ID" in os.environ:
+        kwargs: dict = {
+            "batched": False,
+        }
+        if "GT_CLOUD_BASE_URL" in os.environ:
+            base_url = os.environ["GT_CLOUD_BASE_URL"]
+            if "http://localhost" in base_url or "http://127.0.0.1" in base_url:
+                kwargs["headers"] = {}
+        gtc_event_listener = GriptapeCloudEventListenerDriver(**kwargs)
+        gtc_event_listener.try_publish_event_payload(
+            FinishStructureRunEvent(output_task_output=TextArtifact(json.dumps(output))).to_dict()
+        )
+
+
+def _set_input_for_flow(flow_name: str, flow_input: dict[str, dict]) -> None:
+    control_flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
+    nodes = control_flow.nodes
+    for node_name, node in nodes.items():
+        if isinstance(node, StartNode):
+            param_map: dict | None = flow_input.get(node_name)
+            if param_map is not None:
+                for parameter_name, parameter_value in param_map.items():
+                    request = SetParameterValueRequest(
+                        parameter_name=parameter_name,
+                        value=parameter_value,
+                        node_name=node_name,
+                    )
+                    result = GriptapeNodes.handle_request(request)
+
+                    if result.failed():
+                        msg = f"Failed to set parameter {parameter_name} for node {node_name}."
+                        raise ValueError(msg)
+
+
+def _get_output_for_flow(flow_name: str) -> dict:
+    control_flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
+    nodes = control_flow.nodes
+    output = {}
+    for node_name, node in nodes.items():
+        if isinstance(node, EndNode):
+            output[node_name] = node.parameter_values
+
+    return output
+
+
+def run(flow_name: str, flow_input: Any) -> None:
+    """Executes a published workflow.
+
+    Executes a workflow by setting up event listeners, registering libraries,
+    loading the user-defined workflow, and running the specified flow.
+
+    Parameters:
+        flow_name: The name of the flow to execute.
+        flow_input: Input data for the flow, typically a dictionary.
+
+    Returns:
+        None
+    """
+    EventBus.add_event_listener(
+        event_listener=EventListener(
+            on_event=_handle_event,
+        )
+    )
+
+    # Register all of our relevant libraries
+    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/951
+    # These should all come from the customer's published script and installed
+    # along with other dependencies.
+    request = RegisterLibraryFromFileRequest(file_path="libraries/griptape_nodes_library/griptape_nodes_library.json")
+    result = GriptapeNodes.handle_request(request)
+
+    if result.failed():
+        raise ValueError
+
+    # Execute the customer's script to establish the layout of nodes, etc.
+    _load_user_workflow("workflow.py")
+    # Now let's set the input to the flow
+    _set_input_for_flow(flow_name=flow_name, flow_input=flow_input)
+
+    # Now send the run command to actually execute it
+    request = StartFlowRequest(flow_name=flow_name)
+    result = GriptapeNodes.handle_request(request)
+
+    if result.failed():
+        raise ValueError
+
+    logger.info("Workflow started!")
+
+    # Wait for the control flow to finish
+    is_flow_finished = False
+    while not is_flow_finished:
+        try:
+            event = queue.get(block=True)
+            if isinstance(event, ExecutionGriptapeNodeEvent):
+                result_event = event.wrapped_event
+
+                if type(result_event.payload).__name__ == "ControlFlowResolvedEvent":
+                    _submit_output(_get_output_for_flow(flow_name=flow_name))
+                    is_flow_finished = True
+                    logger.info("Workflow finished!")
+
+            queue.task_done()
+
+        except Exception as e:
+            msg = f"Error handling queue event: {e}"
+            logger.info(msg)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-n",
+        "--flow-name",
+        default=None,
+        help="Set the Flow Name to run",
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        default=None,
+        help="The input to the flow",
+    )
+
+    args = parser.parse_args()
+    flow_name = args.flow_name
+    flow_input = args.input
+
+    try:
+        flow_input = json.loads(flow_input) if flow_input else {}
+    except Exception as e:
+        msg = f"Error decoding JSON input: {e}"
+        logger.info(msg)
+        raise
+
+    run(flow_name=flow_name, flow_input=flow_input)

--- a/src/griptape_nodes/bootstrap/structure_config.yaml
+++ b/src/griptape_nodes/bootstrap/structure_config.yaml
@@ -1,12 +1,12 @@
 version: 1.0
 runtime: python3
-runtime_version: 3.13
+runtime_version: 3.12
 build:
-    requirements_file: requirements.txt
-    cache_build_dependencies: # Configures caching (for faster deployments!)
-        enabled: true # Toggles caching
-        watched_files: # List of files that will trigger a full rebuild of the Structure
-        - requirements.txt
-        - structure_config.yaml
+  requirements_file: requirements.txt
+  cache_build_dependencies: # Configures caching (for faster deployments!)
+    enabled: true # Toggles caching
+    watched_files: # List of files that will trigger a full rebuild of the Structure
+      - requirements.txt
+      - structure_config.yaml
 run:
-    main_file: structure.py
+  main_file: structure.py

--- a/src/griptape_nodes/bootstrap/structure_config.yaml
+++ b/src/griptape_nodes/bootstrap/structure_config.yaml
@@ -1,0 +1,12 @@
+version: 1.0
+runtime: python3
+runtime_version: 3.13
+build:
+    requirements_file: requirements.txt
+    cache_build_dependencies: # Configures caching (for faster deployments!)
+        enabled: true # Toggles caching
+        watched_files: # List of files that will trigger a full rebuild of the Structure
+        - requirements.txt
+        - structure_config.yaml
+run:
+    main_file: structure.py

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -174,3 +174,21 @@ class LoadWorkflowMetadataResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSu
 @PayloadRegistry.register
 class LoadWorkflowMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
+
+
+@dataclass
+@PayloadRegistry.register
+class PublishWorkflowRequest(RequestPayload):
+    workflow_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class PublishWorkflowResultSuccess(ResultPayloadSuccess):
+    workflow_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class PublishWorkflowResultFailure(ResultPayloadFailure):
+    pass

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -17,14 +17,29 @@ from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionResultFailure,
     GetEngineVersionResultSuccess,
 )
-from griptape_nodes.retained_mode.events.base_events import AppPayload, BaseEvent, RequestPayload, ResultPayload
-from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, DeleteFlowRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, AlterParameterDetailsRequest
+from griptape_nodes.retained_mode.events.base_events import (
+    AppPayload,
+    BaseEvent,
+    RequestPayload,
+    ResultPayload,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    DeleteFlowRequest,
+)
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    AlterParameterDetailsRequest,
+)
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
-    from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import ArbitraryCodeExecManager
+    from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
+        ArbitraryCodeExecManager,
+    )
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.context_manager import ContextManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -32,10 +47,14 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
     from griptape_nodes.retained_mode.managers.node_manager import NodeManager
     from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
-    from griptape_nodes.retained_mode.managers.operation_manager import OperationDepthManager
+    from griptape_nodes.retained_mode.managers.operation_manager import (
+        OperationDepthManager,
+    )
     from griptape_nodes.retained_mode.managers.os_manager import OSManager
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
-    from griptape_nodes.retained_mode.managers.static_files_manager import StaticFilesManager
+    from griptape_nodes.retained_mode.managers.static_files_manager import (
+        StaticFilesManager,
+    )
     from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
 
@@ -85,7 +104,9 @@ class GriptapeNodes(metaclass=SingletonMeta):
     _static_files_manager: StaticFilesManager
 
     def __init__(self) -> None:
-        from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import ArbitraryCodeExecManager
+        from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
+            ArbitraryCodeExecManager,
+        )
         from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
         from griptape_nodes.retained_mode.managers.context_manager import ContextManager
         from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -93,11 +114,17 @@ class GriptapeNodes(metaclass=SingletonMeta):
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
         from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
-        from griptape_nodes.retained_mode.managers.operation_manager import OperationDepthManager
+        from griptape_nodes.retained_mode.managers.operation_manager import (
+            OperationDepthManager,
+        )
         from griptape_nodes.retained_mode.managers.os_manager import OSManager
         from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
-        from griptape_nodes.retained_mode.managers.static_files_manager import StaticFilesManager
-        from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
+        from griptape_nodes.retained_mode.managers.static_files_manager import (
+            StaticFilesManager,
+        )
+        from griptape_nodes.retained_mode.managers.workflow_manager import (
+            WorkflowManager,
+        )
 
         # Initialize only if our managers haven't been created yet
         if not hasattr(self, "_event_manager"):
@@ -134,7 +161,11 @@ class GriptapeNodes(metaclass=SingletonMeta):
         event_mgr = GriptapeNodes.EventManager()
         obj_depth_mgr = GriptapeNodes.OperationDepthManager()
         workflow_mgr = GriptapeNodes.WorkflowManager()
-        return event_mgr.handle_request(request=request, operation_depth_mgr=obj_depth_mgr, workflow_mgr=workflow_mgr)
+        return event_mgr.handle_request(
+            request=request,
+            operation_depth_mgr=obj_depth_mgr,
+            workflow_mgr=workflow_mgr,
+        )
 
     @classmethod
     def broadcast_app_event(cls, app_event: AppPayload) -> None:
@@ -225,7 +256,9 @@ class GriptapeNodes(metaclass=SingletonMeta):
             engine_ver = Version.from_string(engine_version_str)
             if engine_ver:
                 return GetEngineVersionResultSuccess(
-                    major=engine_ver.major, minor=engine_ver.minor, patch=engine_ver.patch
+                    major=engine_ver.major,
+                    minor=engine_ver.minor,
+                    patch=engine_ver.patch,
                 )
             details = f"Attempted to get engine version. Failed because version string '{engine_version_str}' wasn't in expected major.minor.patch format."
             logger.error(details)

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1079,6 +1079,12 @@ class WorkflowManager:
         """
         for node in nodes:
             for param in node.parameters:
+                # The user_defined flag is utilized here since the StartFlow and EndFlow Nodes make use of
+                # ParameterLists, which enable Workflow authors to define their own Parameters as children, and
+                # by default the user_defined flag is set to True for the children. Filtering on that flag keeps
+                # the workflow shape clean and only includes the Parameters that are actually defined/usable by the
+                # Published Workflow.
+                # TODO: https://github.com/griptape-ai/griptape-nodes/issues/1090
                 if param.user_defined:
                     if node.name in workflow_shape[workflow_shape_type]:
                         cast("dict", workflow_shape[workflow_shape_type][node.name])[param.name] = (


### PR DESCRIPTION
* Initial commit for publish workflow event
  * Handle `PublishWorkflowRequest` in engine
    * Bundle a workflow into a zip
    * Deploy the zip through the Nodes API to GTC, submitting workflow_name as well as input/output shapes to the API
  * PublishedWorkflow Node capable of being configured with a workflow_id, and used as a ControlNode within a Flow to invoke the hosted Workflow with input Parameters, and return values for the output Parameters

Closes #356 
Closes #765 

TODO
---
* Handle bundling libraries properly. Right now, only default libraries are included
* Frontend fixes for dynamically creating Parameters resulting from `after_value_set` callback
* Frontend fixes for Parameter Options to handle option choices of a different type than their value after conversion

Issues
---
* It seems that the PublishedWorkflow Node is not always targeted to resolve when clicking RunWorkflow. Seems like an engine issue. Clicking RunNode does cause it to execute successfully. The Node does not show as running in the Editor also, though it does complete processing and returns the output.