### PR TITLE
fix: handle more status codes when connecting to API

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -63,7 +63,7 @@ def _run_init(
     _prompt_for_api_key(api_key=api_key)
     _prompt_for_libraries_to_register(register_advanced_library=register_advanced_library)
     _update_assets()
-    console.print("Initialization complete! You can now run the engine with 'griptape-nodes' (or just 'gtn').")
+    console.print("[bold green]Initialization complete![/bold green]")
 
 
 def _start_engine(*, no_update: bool) -> None:
@@ -74,6 +74,7 @@ def _start_engine(*, no_update: bool) -> None:
     """
     if not CONFIG_DIR.exists():
         # Default init flow if there is no config directory
+        console.print("[bold green]Config directory not found. Initializing...[/bold green]")
         _run_init()
         webbrowser.open(NODES_APP_URL)
 
@@ -81,6 +82,7 @@ def _start_engine(*, no_update: bool) -> None:
     if not no_update:
         _auto_update_self()
 
+    console.print("[bold green]Starting Griptape Nodes engine...[/bold green]")
     start_app()
 
 
@@ -276,6 +278,7 @@ def _get_latest_version(package: str) -> str:
 
 def _auto_update_self() -> None:
     """Automatically updates the script to the latest version if the user confirms."""
+    console.print("[bold green]Checking for updates...[/bold green]")
     current_version = __get_current_version()
     latest_version = _get_latest_version(PACKAGE_NAME)
 

--- a/src/griptape_nodes/app/nodes_api_socket_manager.py
+++ b/src/griptape_nodes/app/nodes_api_socket_manager.py
@@ -100,16 +100,18 @@ class NodesApiSocketManager:
                 logger.debug("Error: ", exc_info=True)
                 sleep(5)
             except InvalidStatus as e:
-                if e.response.status_code in {401, 403}:
-                    message = Panel(
-                        Align.center(
-                            "[bold red]Nodes API key is invalid, please re-run [code]gtn init[/code] with a valid key: [/bold red]"
-                            "[code]gtn init --api-key <your key>[/code]\n"
-                            "[bold red]You can generate a new key from [/bold red][bold blue][link=https://nodes.griptape.ai]https://nodes.griptape.ai[/link][/bold blue]",
-                        ),
-                        title="🔑 ❌ Invalid Nodes API Key",
-                        border_style="red",
-                        padding=(1, 4),
-                    )
-                    console.print(message)
-                    sys.exit(1)
+                message = Panel(
+                    Align.center(
+                        f"[bold red]Nodes API key is invalid ({e.response.status_code}), please re-run [code]gtn init[/code] with a valid key: [/bold red]"
+                        "[code]gtn init --api-key <your key>[/code]\n"
+                        "[bold red]You can generate a new key from [/bold red][bold blue][link=https://nodes.griptape.ai]https://nodes.griptape.ai[/link][/bold blue]",
+                    ),
+                    title="🔑 ❌ Invalid Nodes API Key",
+                    border_style="red",
+                    padding=(1, 4),
+                )
+                console.print(message)
+                sys.exit(1)
+            except Exception:
+                logger.exception("Unexpected error while connecting to Nodes API")
+                sys.exit(1)


### PR DESCRIPTION
Turns out if you paste in a REALLY bad api key the server throws a 500. This was silently failing in a loop. Updated our error handling to cover more cases.

PR also tweaks/adds some messaging.

Closes #971
Closes #973
Closes #969