### PR TITLE
Added ability to define new settings within a node library.

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -79,6 +79,14 @@ class ScriptDefinition(BaseModel):
     file_path: str
 
 
+class Setting(BaseModel):
+    """Defines a library-specific setting, which will automatically be injected into the user's Configuration."""
+
+    category: str  # Name of the category in the config
+    contents: dict[str, Any]  # The actual settings content
+    description: str | None = None  # Optional description for the setting
+
+
 class LibrarySchema(BaseModel):
     """Schema for a library definition file.
 
@@ -94,6 +102,7 @@ class LibrarySchema(BaseModel):
     nodes: list[NodeDefinition]
     workflows: list[WorkflowDefinition] | None = None
     scripts: list[ScriptDefinition] | None = None
+    settings: list[Setting] | None = None
     is_default_library: bool = False
 
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -25,6 +25,12 @@ from griptape_nodes.node_library.library_registry import LibraryRegistry, Librar
 from griptape_nodes.retained_mode.events.app_events import (
     AppInitializationComplete,
 )
+from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigCategoryRequest,
+    GetConfigCategoryResultSuccess,
+    SetConfigCategoryRequest,
+    SetConfigCategoryResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import (
     GetAllInfoForAllLibrariesRequest,
     GetAllInfoForAllLibrariesResultFailure,
@@ -500,8 +506,44 @@ class LibraryManager:
             logger.error(details)
             return RegisterLibraryFromFileResultFailure()
 
+        # We are at least potentially viable.
+        # Record all problems that occurred
         problems = []
-        any_successes = False
+
+        # Check the library's custom config settings.
+        if library_data.settings is not None:
+            # Assign them into the config space.
+            for library_data_setting in library_data.settings:
+                # Does the category exist?
+                get_category_request = GetConfigCategoryRequest(category=library_data_setting.category)
+                get_category_result = GriptapeNodes.handle_request(get_category_request)
+                if not isinstance(get_category_result, GetConfigCategoryResultSuccess):
+                    # That's OK, we'll invent it. Or at least we'll try.
+                    create_new_category_request = SetConfigCategoryRequest(
+                        category=library_data_setting.category, contents=library_data_setting.contents
+                    )
+                    create_new_category_result = GriptapeNodes.handle_request(create_new_category_request)
+                    if not isinstance(create_new_category_result, SetConfigCategoryResultSuccess):
+                        problems.append(f"Failed to create new config category '{library_data_setting.category}'.")
+                        details = f"Failed attempting to create new config category '{library_data_setting.category}' for library '{library_data.name}'."
+                        logger.error(details)
+                        continue  # SKIP IT
+                else:
+                    # We had an existing category. Union our changes into it (not replacing anything that matched).
+                    existing_category_contents = get_category_result.contents
+                    existing_category_contents.update(library_data_setting.contents)
+                    set_category_request = SetConfigCategoryRequest(
+                        category=library_data_setting.category, contents=existing_category_contents
+                    )
+                    set_category_result = GriptapeNodes.handle_request(set_category_request)
+                    if not isinstance(set_category_result, SetConfigCategoryResultSuccess):
+                        problems.append(f"Failed to update config category '{library_data_setting.category}'.")
+                        details = f"Failed attempting to update config category '{library_data_setting.category}' for library '{library_data.name}'."
+                        logger.error(details)
+                        continue  # SKIP IT
+
+        # Attempt to load nodes from the library.
+        any_nodes_loaded_successesfully = False
         # Process each node in the metadata
         for node_definition in library_data.nodes:
             # Resolve relative path to absolute path
@@ -534,9 +576,9 @@ class LibraryManager:
                 continue  # SKIP IT
 
             # If we got here, at least one node came in.
-            any_successes = True
+            any_nodes_loaded_successesfully = True
 
-        if not any_successes:
+        if not any_nodes_loaded_successesfully:
             self._library_file_path_to_info[file_path] = LibraryManager.LibraryInfo(
                 library_path=file_path,
                 library_name=library_data.name,


### PR DESCRIPTION
Expanded the library schema to include custom, per-library settings. For example, in the griptape_nodes_library.json file:

```
{
    "name": "My Cool Library",
    "library_schema_version": "0.1.0",
    <SNIP>
    "settings": [
        {
            "description": "Environment variables for storing secrets for new AI service's nodes",
            "category": "nodes.TheCoolestServiceOnTheBlock",
            "contents": {
                "TCSOTB_ACCESS_KEY": "$TCSOTB_ACCESS_KEY", 
                "TCSOTB_SECRET_KEY": "$TCSOTB_SECRET_KEY" 
            }
        }
    ]
}
```

It seems to play nice with secrets, too.