### PR TITLE
feat: accept request events on local static server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,16 @@ To point your local engine at a different API instance (e.g., a local Griptape N
 GRIPTAPE_NODES_API_BASE_URL=http://localhost:8001 uv run gtn
 ```
 
+**Connecting to a Different UI**
+
+> Internal Griptape Developers with access to UI project
+
+To point your local engine at a different UI instance (e.g., a local Griptape Nodes UI), set the `GRIPTAPE_NODES_UI_BASE_URL` environment variable:
+
+```shell
+GRIPTAPE_NODES_UI_BASE_URL=http://localhost:5173 uv run gtn
+```
+
 ## Configuration for Development
 
 Griptape Nodes uses a configuration loading system. For full details, see the [Configuration Documentation](docs/configuration.md). Here's what's crucial for development:

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
@@ -19,7 +19,7 @@ class CreateStaticFileRequest(RequestPayload):
         file_name: Name of the file to create
     """
 
-    content: str
+    content: str = field(metadata={"omit_from_result": True})
     file_name: str
 
 

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import fields
 from typing import TYPE_CHECKING
 
 from griptape.events import EventBus
@@ -83,6 +84,11 @@ class EventManager:
                 retained_mode_str = None
                 if depth_manager.is_top_level():
                     retained_mode_str = depth_manager.request_retained_mode_translation(request)
+
+                # Some requests have fields marked as "omit_from_result" which should be removed from the request
+                for field in fields(request):
+                    if field.metadata.get("omit_from_result", False):
+                        setattr(request, field.name, None)
                 if result_payload.succeeded():
                     result_event = EventResultSuccess(
                         request=request,


### PR DESCRIPTION
This PR makes two key changes:
1. Updates the fastapi static server to act as an event source. The UI can [take advantage of](https://github.com/griptape-ai/griptape-vsl-gui/pull/648) this by sending heavy events like `CreateStaticFilesRequest` over this local channel. These events will be processed like any other event from the server and the results will be sent over the regular event server.
2. Adds the ability for requests to mark certain fields as `omit_from_result`. These fields will be cleared out on the request before it goes back with the result.
 
Open question: should all events work this way? UI -> local -> API -> UI

Closes #1006
Closes #947