### PR TITLE
fix: verify parameter lists are populated

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -442,13 +442,13 @@ class Agent(ControlNode):
 
         # Get any tools
         # tools = self.get_parameter_value("tools")  # noqa: ERA001
-        tools = params.get("tools", [])
+        tools = [tool for tool in params.get("tools", []) if tool]
         if include_details and tools:
             self.append_value_to_parameter("logs", f"[Tools]: {', '.join([tool.name for tool in tools])}\n")
 
         # Get any rulesets
         # rulesets = self.get_parameter_value("rulesets")  # noqa: ERA001
-        rulesets = params.get("rulesets", [])
+        rulesets = [ruleset for ruleset in params.get("rulesets", []) if ruleset]
         if include_details and rulesets:
             self.append_value_to_parameter(
                 "logs", f"\n[Rulesets]: {', '.join([ruleset.name for ruleset in rulesets])}\n"


### PR DESCRIPTION
Adding an item to the parameter list leaves it populated with an empty list. i.e. `[[]]`. This fails when passing to the agent.

Long term might be better to find a better initial value?

Closes #1048 