### PR TITLE
Prevent prompt_model_config from disappearing 

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -211,16 +211,20 @@ class Agent(ControlNode):
 
             """
             prompt_model_settings_param = self.get_parameter_by_name("prompt_model_config")
-            if value == CONNECTED_CHOICE and prompt_model_settings_param:
-                if prompt_model_settings_param._ui_options["hide"]:
-                    modified_parameters_set.add("prompt_model_config")
-                prompt_model_settings_param._ui_options["hide"] = False
-                return None
-            if value != CONNECTED_CHOICE and prompt_model_settings_param:
-                if not prompt_model_settings_param._ui_options["hide"]:
-                    modified_parameters_set.add("prompt_model_config")
-                prompt_model_settings_param._ui_options["hide"] = True
-                return None
+            if not (
+                "prompt_model_config" in self.parameter_values
+                and self.parameter_values["prompt_model_config"] is not None
+            ):
+                if value == CONNECTED_CHOICE and prompt_model_settings_param:
+                    if prompt_model_settings_param._ui_options["hide"]:
+                        modified_parameters_set.add("prompt_model_config")
+                    prompt_model_settings_param._ui_options["hide"] = False
+                    return None
+                if value != CONNECTED_CHOICE and prompt_model_settings_param:
+                    if not prompt_model_settings_param._ui_options["hide"]:
+                        modified_parameters_set.add("prompt_model_config")
+                    prompt_model_settings_param._ui_options["hide"] = True
+                    return None
 
         return super().after_value_set(parameter, value, modified_parameters_set)
 


### PR DESCRIPTION
closes #1052 

Checks if prompt_model_config exists and has a non-none value. If that is the case, then changing the model does not remove prompt model config. This is a workaround for now, and we should look into a more robust fix later.