### PR TITLE
feat: sync assets based on current engine version

### DIFF
--- a/src/griptape_nodes/updater/__init__.py
+++ b/src/griptape_nodes/updater/__init__.py
@@ -19,12 +19,19 @@ os_manager = OSManager()
 
 def main() -> None:
     """Entry point for the updater CLI."""
-    _download_and_run_installer()
-    if os_manager.is_windows():
-        # On Windows, the terminal prompt doesn't refresh after the update finishes.
-        # This gives the appearance of the program hanging, but it is not.
-        # This is a workaround to manually refresh the terminal.
-        console.print("[bold yellow]Please press Enter to exit updater...[/bold yellow]")
+    try:
+        _download_and_run_installer()
+        _sync_assets()
+    except subprocess.CalledProcessError:
+        console.print("[red]Error during update process.[/red]")
+    else:
+        console.print("[green]Finished updating self.[/green]")
+        console.print("[green]Run 'griptape-nodes' (or 'gtn') to restart the engine.[/green]")
+        if os_manager.is_windows():
+            # On Windows, the terminal prompt doesn't refresh after the update finishes.
+            # This gives the appearance of the program hanging, but it is not.
+            # This is a workaround to manually refresh the terminal.
+            console.print("[yellow]Please press Enter to exit updater...[/yellow]")
 
 
 def _download_and_run_installer() -> None:
@@ -37,10 +44,26 @@ def _download_and_run_installer() -> None:
             check=True,
         )
     except subprocess.CalledProcessError as e:
-        console.print(f"[bold red]Error during update: {e}[/bold red]")
+        console.print(f"[red]Error during update: {e}[/red]")
+        raise
     else:
-        console.print("[bold green]Finished updating self.[/bold green]")
-        console.print("[bold green]Run 'griptape-nodes' (or 'gtn') to restart the engine.[/bold green]")
+        console.print("[green]Finished updating self.[/green]")
+
+
+def _sync_assets() -> None:
+    """Syncs the assets for the engine."""
+    console.print("[bold green]Syncing assets...[/bold green]")
+    try:
+        subprocess.run(  # noqa: S603
+            ["griptape-nodes", "assets", "sync"],  # noqa: S607
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        console.print(f"[red]Error during asset sync: {e}[/red]")
+        raise
+    else:
+        console.print("[green]Finished syncing assets.[/green]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Sync the assets from your current engine version rather than latest. 
- Clear out assets directory before copying over. Ensures no stray library data.
- Run asset sync during `gtn self update`.

Closes #1034