### PR TITLE
Update/docs_scripting

### DIFF
--- a/docs/reference/retained_mode.md
+++ b/docs/reference/retained_mode.md
@@ -10,19 +10,16 @@
 >
 > However, for convenience, in the script editor of the GUI, this import is already done for you automatically, so you can freely use `cmd.` directly.
 
-## Go to:
-
-[Flow Operations](#flow-operations) · [Node Operations](#node-operations) · [Parameter Operations](#parameter-operations) · [Connection Operations](#connection-operations) · [Library Operations](#library-operations) · [Config Operations](#config-operations) · [Utility Operations](#utility-operations)
 
 ## Flow Operations
 
 ### create_flow
+Creates a new flow within the Griptape system.
 
 ```python
 cmd.create_flow(flow_name=None, parent_flow_name=None)
 ```
 
-Creates a new flow within the Griptape system.
 
 #### Arguments
 

--- a/docs/reference/retained_mode.md
+++ b/docs/reference/retained_mode.md
@@ -10,16 +10,15 @@
 >
 > However, for convenience, in the script editor of the GUI, this import is already done for you automatically, so you can freely use `cmd.` directly.
 
-
 ## Flow Operations
 
 ### create_flow
+
 Creates a new flow within the Griptape system.
 
 ```python
 cmd.create_flow(flow_name=None, parent_flow_name=None)
 ```
-
 
 #### Arguments
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ theme:
     - navigation.tabs
     - navigation.expand
     - navigation.top
+    - navigation.tabs.sticky
 
 markdown_extensions:
   - pymdownx.highlight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ theme:
     - navigation.expand
     - navigation.top
     - navigation.tabs.sticky
+    - navigation.sections
 
 markdown_extensions:
   - pymdownx.highlight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ markdown_extensions:
   - pymdownx.superfences
   - tables
   - md_in_html
+  - toc:
+      toc_depth: 3
 
 nav:
   - Home:


### PR DESCRIPTION
some quick mods for making the retained_mode page sidebar less busy

also updated the nave so we can get to all the header items when the page is small

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--1066.org.readthedocs.build/en/1066/

<!-- readthedocs-preview griptape-nodes end -->