### PR TITLE
refactor: clean up use of release tags

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -1,4 +1,4 @@
-name: Create Nightly release
+name: Create Latest Release
 
 on:
   schedule:
@@ -18,14 +18,14 @@ jobs:
       - name: Create Tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: "nightly"
+          tag: "latest"
         run: |
           git tag "$tag" -f
           git push origin "$tag" -f --tags
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: "nightly"
+          tag: "latest"
         run: |
           gh release edit "$tag" \
               --repo="$GITHUB_REPOSITORY" \

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,4 +1,4 @@
-name: Create release
+name: Create Stable Release
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ version/commit: ## Commit version.
 .PHONY: version/publish
 version/publish: ## Create and push git tags.
 	@git tag v$$(make version/get)
-	@git tag latest stable -f
+	@git tag stable -f
 	@git push -f --tags
 	@git push
 	

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Griptape Nodes provides a powerful, visual, node-based interface for building an
 **Learn More:**
 
 - **Full Documentation:** [docs.griptapenodes.com](https://docs.griptapenodes.com)
-- **Installation:** [docs.griptapenodes.com/en/latest/installation/](https://docs.griptapenodes.com/en/latest/installation/)
-- **Engine Configuration:** [docs.griptapenodes.com/en/latest/configuration/](https://docs.griptapenodes.com/en/latest/configuration/)
+- **Installation:** [docs.griptapenodes.com/en/stable/installation/](https://docs.griptapenodes.com/en/latest/installation/)
+- **Engine Configuration:** [docs.griptapenodes.com/en/stable/configuration/](https://docs.griptapenodes.com/en/latest/configuration/)
 
 ______________________________________________________________________
 


### PR DESCRIPTION
- Drop "nightly" in favor of RTD-friendly "latest"
- Replace latest doc links with stable