### PR TITLE
Refactor: Updating methods on nodes to be more generalized

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -143,7 +143,7 @@ class Agent(ControlNode):
         )
 
         # Group for less commonly used configuration options.
-        with ParameterGroup(group_name="Advanced options") as advanced_group:
+        with ParameterGroup(name="Advanced options") as advanced_group:
             ParameterList(
                 name="tools",
                 input_types=["Tool"],
@@ -175,7 +175,7 @@ class Agent(ControlNode):
         )
 
         # Group for logging information.
-        with ParameterGroup(group_name="Logs") as logs_group:
+        with ParameterGroup(name="Logs") as logs_group:
             Parameter(name="include_details", type="bool", default_value=False, tooltip="Include extra details.")
 
             Parameter(
@@ -248,11 +248,11 @@ class Agent(ControlNode):
         # If an existing agent is connected, hide parameters related to creating a new one.
         if target_parameter.name == "agent":
             groups_to_toggle = ["Advanced options"]
-            for group_name in groups_to_toggle:
-                group = self.get_group_by_name_or_element_id(group_name)
+            for name in groups_to_toggle:
+                group = self.get_group_by_name_or_element_id(name)
                 if group:
                     group.ui_options["hide"] = True
-                    modified_parameters_set.add(group_name)
+                    modified_parameters_set.add(name)
 
             params_to_toggle = ["model", "tools", "rulesets", "prompt_model_config"]
             for param_name in params_to_toggle:
@@ -302,11 +302,11 @@ class Agent(ControlNode):
         # If the agent connection is removed, show agent creation parameters.
         if target_parameter.name == "agent":
             groups_to_toggle = ["Advanced options"]
-            for group_name in groups_to_toggle:
-                group = self.get_group_by_name_or_element_id(group_name)
+            for name in groups_to_toggle:
+                group = self.get_group_by_name_or_element_id(name)
                 if group:
                     group.ui_options["hide"] = False
-                    modified_parameters_set.add(group.group_name)
+                    modified_parameters_set.add(group.name)
 
             params_to_toggle = ["model", "tools", "rulesets", "prompt_model_config"]
             for param_name in params_to_toggle:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/base_driver.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/base_driver.py
@@ -77,24 +77,6 @@ class BaseDriver(DataNode):
     # Public API Methods
     # -----------------------------------------------------------------------------
 
-    def remove_parameter_by_name(self, name: str) -> None:
-        """Removes a parameter by its name from the node.
-
-        This method will hopefully be elevated to the base class in the future.
-
-        Args:
-            name: The name of the parameter to remove.
-
-        """
-        try:
-            param = self.get_parameter_by_name(name)
-            if param is not None:
-                self.remove_parameter(param)
-        except Exception as e:
-            # Handle the case where the parameter is not found or cannot be removed
-            msg = f"Error removing parameter '{name}'."
-            raise ValueError(msg) from e
-
     def params_to_sparse_dict(
         self,
         params: dict,

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/image/grok_image_driver.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/image/grok_image_driver.py
@@ -28,7 +28,7 @@ class GrokImage(BaseImageDriver):
         self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
 
         # remove the 'size' parameter
-        self.remove_parameter_by_name("image_size")
+        self.remove_parameter_element_by_name("image_size")
 
     def process(self) -> None:
         # Get the parameters from the node

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -69,9 +69,9 @@ class AmazonBedrockPrompt(BasePrompt):
             param.default_value = MODEL_CHOICES[0]
 
         # Remove unused parameters for Amazon Bedrock
-        self.remove_parameter_by_name("seed")
-        self.remove_parameter_by_name("min_p")
-        self.remove_parameter_by_name("top_k")
+        self.remove_parameter_element_by_name("seed")
+        self.remove_parameter_element_by_name("min_p")
+        self.remove_parameter_element_by_name("top_k")
 
         # Amazon Bedrock tends to fail if max_tokens isn't set
         self.set_parameter_value("max_tokens", 100)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/anthropic_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/anthropic_prompt.py
@@ -58,7 +58,7 @@ class AnthropicPrompt(BasePrompt):
         )
 
         # Remove the 'seed' parameter as it's not directly used by GriptapeCloudPromptDriver.
-        self.remove_parameter_by_name("seed")
+        self.remove_parameter_element_by_name("seed")
 
     def process(self) -> None:
         """Processes the node configuration to create an AnthropicPromptDriver.

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/base_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/base_prompt.py
@@ -31,7 +31,6 @@ class BasePrompt(BaseDriver):
     - Defines common LLM parameters accessible via `self.parameter_values`.
     - Provides `_get_common_driver_args` to easily collect arguments for drivers based on base parameters.
     - Provides `_validate_api_key` to standardize API key validation logic.
-    - Provides `remove_parameter_by_name` to remove unsupported base parameters.
     - Provides `_update_option_choices` to set driver-specific model lists for the 'model' parameter.
     Note: The `process` method in this base class creates a `DummyPromptDriver`
     primarily to establish the output socket type. It does not utilize the

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/cohere_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/cohere_prompt.py
@@ -53,8 +53,8 @@ class CoherePrompt(BasePrompt):
         self._replace_param_by_name(param_name="top_k", new_param_name="k")
 
         # Remove the 'seed' parameter as it's not directly used by Cohere.
-        self.remove_parameter_by_name("seed")
-        self.remove_parameter_by_name("response_format")
+        self.remove_parameter_element_by_name("seed")
+        self.remove_parameter_element_by_name("response_format")
 
     def process(self) -> None:
         """Processes the node configuration to create a CoherePromptDriver.

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/griptape_cloud_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/griptape_cloud_prompt.py
@@ -52,10 +52,10 @@ class GriptapeCloudPrompt(BasePrompt):
         self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
 
         # Remove the 'seed' parameter as it's not directly used by GriptapeCloudPromptDriver.
-        self.remove_parameter_by_name("seed")
+        self.remove_parameter_element_by_name("seed")
 
         # Remove `top_k` parameter as it's not used by Griptape Cloud.
-        self.remove_parameter_by_name("top_k")
+        self.remove_parameter_element_by_name("top_k")
 
         # Replace `min_p` with `top_p` for Griptape Cloud.
         self._replace_param_by_name(param_name="min_p", new_param_name="top_p", default_value=0.9)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/grok_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/grok_prompt.py
@@ -52,8 +52,8 @@ class GrokPrompt(BasePrompt):
         self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
 
         # Remove `top_k` parameter as it's not used by Grok.
-        self.remove_parameter_by_name("seed")
-        self.remove_parameter_by_name("top_k")
+        self.remove_parameter_element_by_name("seed")
+        self.remove_parameter_element_by_name("top_k")
 
         # Replace `min_p` with `top_p` for Grok.
         self._replace_param_by_name(param_name="min_p", new_param_name="top_p", default_value=0.9)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/openai_prompt.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/config/prompt/openai_prompt.py
@@ -52,10 +52,10 @@ class OpenAiPrompt(BasePrompt):
         self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
 
         # Remove the 'seed' parameter as it's not directly used by OpenAiPromptDriver.
-        self.remove_parameter_by_name("seed")
+        self.remove_parameter_element_by_name("seed")
 
         # Remove `top_k` parameter as it's not used by OpenAi.
-        self.remove_parameter_by_name("top_k")
+        self.remove_parameter_element_by_name("top_k")
 
         # Replace `min_p` with `top_p` for OpenAi.
         self._replace_param_by_name(param_name="min_p", new_param_name="top_p", default_value=0.9)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/create_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/create_image.py
@@ -82,7 +82,7 @@ class GenerateImage(ControlNode):
             )
         )
         # Group for logging information.
-        with ParameterGroup(group_name="Logs") as logs_group:
+        with ParameterGroup(name="Logs") as logs_group:
             Parameter(name="include_details", type="bool", default_value=False, tooltip="Include extra details.")
 
             Parameter(

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -203,7 +203,7 @@ class BaseNodeElement:
             {
               "element_id": "container-1",
               "element_type": "ParameterGroup",
-              "group_name": "Group 1",
+              "name": "Group 1",
               "children": [
                 {
                     "element_id": "A",
@@ -245,6 +245,16 @@ class BaseNodeElement:
                 return found
         return None
 
+    def find_element_by_name(self, element_name: str) -> BaseNodeElement | None:
+        # Modified so ParameterGroups also just have name as a field.
+        if getattr(self, "name", None) == element_name:
+            return self
+        for child in self._children:
+            found = child.find_element_by_name(element_name)
+            if found is not None:
+                return found
+        return None
+
     def find_elements_by_type(self, element_type: type[N], *, find_recursively: bool = True) -> list[N]:
         """Returns a list of child elements that are instances of type specified. Optionally do this recursively."""
         elements: list[N] = []
@@ -266,7 +276,7 @@ class ParameterGroup(BaseNodeElement):
     """UI element for a group of parameters."""
 
     ui_options: dict = field(default_factory=dict)
-    group_name: str
+    name: str
 
     def to_dict(self) -> dict[str, Any]:
         """Returns a nested dictionary representation of this node and its children.
@@ -275,7 +285,7 @@ class ParameterGroup(BaseNodeElement):
             {
               "element_id": "container-1",
               "element_type": "ParameterGroup",
-              "group_name": "Group 1",
+              "name": "Group 1",
               "children": [
                 {
                     "element_id": "A",
@@ -289,13 +299,13 @@ class ParameterGroup(BaseNodeElement):
         # Get the parent's version first.
         our_dict = super().to_dict()
         # Add in our deltas.
-        our_dict["group_name"] = self.group_name
+        our_dict["name"] = self.name
         our_dict["ui_options"] = self.ui_options
         return our_dict
 
     def equals(self, other: ParameterGroup) -> dict:
-        self_dict = {"group_name": self.group_name, "ui_options": self.ui_options}
-        other_dict = {"group_name": other.group_name, "ui_options": other.ui_options}
+        self_dict = {"name": self.name, "ui_options": self.ui_options}
+        other_dict = {"name": other.name, "ui_options": other.ui_options}
         if self_dict == other_dict:
             return {}
         differences = {}

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -278,7 +278,6 @@ class ParameterGroup(BaseNodeElement):
 
     ui_options: dict = field(default_factory=dict)
 
-
     def to_dict(self) -> dict[str, Any]:
         """Returns a nested dictionary representation of this node and its children.
 
@@ -319,7 +318,6 @@ class ParameterGroup(BaseNodeElement):
 
 # TODO: https://github.com/griptape-ai/griptape-nodes/issues/856
 class ParameterBase(BaseNodeElement, ABC):
-
     @property
     @abstractmethod
     def tooltip(self) -> str | list[dict]:

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -161,6 +161,7 @@ class ParameterType:
 class BaseNodeElement:
     element_id: str = field(default_factory=lambda: str(uuid.uuid4().hex))
     element_type: str = field(default_factory=lambda: BaseNodeElement.__name__)
+    name: str = field(default_factory=lambda: str(f"{BaseNodeElement.__name__}_{uuid.uuid4().hex}"))
 
     _children: list[BaseNodeElement] = field(default_factory=list)
     _stack: ClassVar[list[BaseNodeElement]] = []
@@ -247,7 +248,7 @@ class BaseNodeElement:
 
     def find_element_by_name(self, element_name: str) -> BaseNodeElement | None:
         # Modified so ParameterGroups also just have name as a field.
-        if getattr(self, "name", None) == element_name:
+        if self.name == element_name:
             return self
         for child in self._children:
             found = child.find_element_by_name(element_name)
@@ -276,7 +277,7 @@ class ParameterGroup(BaseNodeElement):
     """UI element for a group of parameters."""
 
     ui_options: dict = field(default_factory=dict)
-    name: str
+
 
     def to_dict(self) -> dict[str, Any]:
         """Returns a nested dictionary representation of this node and its children.
@@ -318,7 +319,6 @@ class ParameterGroup(BaseNodeElement):
 
 # TODO: https://github.com/griptape-ai/griptape-nodes/issues/856
 class ParameterBase(BaseNodeElement, ABC):
-    name: str  # must be unique from other parameters in Node
 
     @property
     @abstractmethod

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -224,25 +224,20 @@ class BaseNode(ABC):
             raise ValueError(msg)
         self.add_node_element(param)
 
-    def remove_parameter(self, param: Parameter) -> None:
-        for child in param.find_elements_by_type(Parameter):
+    def remove_parameter_element_by_name(self, element_name: str) -> None:
+        element = self.root_ui_element.find_element_by_name(element_name)
+        if element is not None:
+            self.remove_parameter_element(element)
+
+    def remove_parameter_element(self, param: BaseNodeElement) -> None:
+        for child in param.find_elements_by_type(BaseNodeElement):
             self.remove_node_element(child)
         self.remove_node_element(param)
-
-    def remove_group_by_name(self, group: str) -> bool:
-        group_items = self.root_ui_element.find_elements_by_type(ParameterGroup)
-        for group_item in group_items:
-            if group_item.group_name == group:
-                for child in group_item.find_elements_by_type(BaseNodeElement):
-                    self.remove_node_element(child)
-                self.remove_node_element(group_item)
-                return True
-        return False
 
     def get_group_by_name_or_element_id(self, group: str) -> ParameterGroup | None:
         group_items = self.root_ui_element.find_elements_by_type(ParameterGroup)
         for group_item in group_items:
-            if group in (group_item.group_name, group_item.element_id):
+            if group in (group_item.name, group_item.element_id):
                 return group_item
         return None
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -325,9 +325,7 @@ def handle_parameter_creation_saving(node: BaseNode, values_created: dict) -> tu
                         break
                 if relevant:
                     diff["node_name"] = node.name
-                    diff["parameter_name"] = (
-                        parameter.group_name if isinstance(parameter, ParameterGroup) else parameter.name
-                    )
+                    diff["parameter_name"] = parameter.name
                     diff["initial_setup"] = True
                     creation_request = AlterParameterDetailsRequest.create(**diff)
                     code_string = f"GriptapeNodes.handle_request({creation_request})\n"
@@ -530,7 +528,7 @@ def manage_alter_details(parameter: Parameter | ParameterGroup, base_node_obj: B
         else:
             return vars(parameter)
     else:
-        base_param_group = base_node_obj.get_group_by_name_or_element_id(parameter.group_name)
+        base_param_group = base_node_obj.get_group_by_name_or_element_id(parameter.name)
         if base_param_group is not None:
             diff = base_param_group.equals(parameter)
         else:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -759,7 +759,7 @@ class NodeManager:
         if parameter_group is not None:
             for child in parameter_group.find_elements_by_type(Parameter):
                 GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(child.name, node_name))
-            node.remove_group_by_name(request.parameter_name)
+            node.remove_parameter_element_by_name(request.parameter_name)
             return RemoveParameterFromNodeResultSuccess()
 
         # No tricky stuff, users!
@@ -816,7 +816,7 @@ class NodeManager:
 
         # Delete the Parameter itself.
         if parameter is not None:
-            node.remove_parameter(parameter)
+            node.remove_parameter_element(parameter)
         else:
             details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{node_name}'. Failed because parameter didn't exist."
             logger.error(details)

--- a/tests/integration/retained_mode/events/test_node_events.py
+++ b/tests/integration/retained_mode/events/test_node_events.py
@@ -230,7 +230,7 @@ class TestNodeEvents:
                         {
                             "element_id": ANY,
                             "element_type": "ParameterGroup",
-                            "group_name": "Agent Config",
+                            "name": "Agent Config",
                             "children": [
                                 {
                                     "element_id": ANY,
@@ -252,7 +252,7 @@ class TestNodeEvents:
                         {
                             "element_id": ANY,
                             "element_type": "ParameterGroup",
-                            "group_name": "Agent Tools",
+                            "name": "Agent Tools",
                             "children": [
                                 {
                                     "element_id": ANY,

--- a/tests/unit/exe_types/test_core_types.py
+++ b/tests/unit/exe_types/test_core_types.py
@@ -11,7 +11,7 @@ class TestBaseNodeElement:
         with BaseNodeElement() as root:
             with BaseNodeElement():
                 BaseNodeElement()
-                with ParameterGroup(group_name="group1"):
+                with ParameterGroup(name="group1"):
                     BaseNodeElement(element_id="leaf1")
             with BaseNodeElement():
                 BaseNodeElement(element_id="leaf2")
@@ -54,7 +54,7 @@ class TestBaseNodeElement:
                         {
                             "element_id": ANY,
                             "element_type": "ParameterGroup",
-                            "group_name": "group1",
+                            "name": "group1",
                             "ui_options": {},
                             "children": [{"element_id": "leaf1", "element_type": "BaseNodeElement", "children": []}],
                         },
@@ -109,7 +109,7 @@ class TestBaseNodeElement:
                         {
                             "element_id": ANY,
                             "element_type": "ParameterGroup",
-                            "group_name": "group1",
+                            "name": "group1",
                             "ui_options": {},
                             "children": [
                                 {
@@ -188,7 +188,7 @@ class TestBaseNodeElement:
                         {
                             "element_id": ANY,
                             "element_type": "ParameterGroup",
-                            "group_name": "group1",
+                            "name": "group1",
                             "ui_options": {},
                             "children": [],
                         },
@@ -235,7 +235,7 @@ class TestBaseNodeElement:
 
 class TestParameterGroup:
     def test_init(self) -> None:
-        assert ParameterGroup(group_name="test")
+        assert ParameterGroup(name="test")
 
 
 class TestParameter:


### PR DESCRIPTION
closes #412 

Adds a remove parameter by name method to `BaseNode`, and updates methods to remove elements by name instead of specifically parameters. (this now includes ParameterGroups, ParameterContainers, and Traits) 

Changes group to have the field `name` instead of `group_name` to keep it consistent across Parameters and ParameterGroups