### PR TITLE
Set published workflow ID in metadata

### DIFF
--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -25,6 +25,7 @@ class WorkflowMetadata(BaseModel):
     is_template: bool | None = False
     creation_date: datetime | None = Field(default=None)
     last_modified_date: datetime | None = Field(default=None)
+    published_workflow_id: str | None = Field(default=None)
 
 
 class WorkflowRegistry(SingletonMixin):


### PR DESCRIPTION
* Set published workflow ID in metadata
  * When a Workflow is published, save the ID in the workflow script metadata
    * This can be used to update an existing workflow when the workflow is published again

Closes #1105 

https://www.loom.com/share/0770e81665614525b587eee850d6ebac?sid=d19ca370-1e2c-4e60-a9de-d1b6348b314a