### PR TITLE
Handle unexpected error message shapes

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/error_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/error_utils.py
@@ -16,10 +16,8 @@ def get_error_message(error: str) -> str:
             if isinstance(error_dict, dict) and "error" in error_dict:
                 if "message" in error_dict["error"]:
                     return str(error_dict["error"]["message"])
-                else:
-                    return str(error_dict["error"])
-            else:
-                return str(error_dict)
+                return str(error_dict["error"])
+            return str(error_dict)
     except (SyntaxError, ValueError, KeyError):
         pass
     return error

--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/error_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/error_utils.py
@@ -14,7 +14,12 @@ def get_error_message(error: str) -> str:
             # ast.literal_eval can safely parse Python literal structures
             error_dict = ast.literal_eval(error_dict)
             if isinstance(error_dict, dict) and "error" in error_dict:
-                return error_dict["error"]["message"]
+                if "message" in error_dict["error"]:
+                    return str(error_dict["error"]["message"])
+                else:
+                    return str(error_dict["error"])
+            else:
+                return str(error_dict)
     except (SyntaxError, ValueError, KeyError):
         pass
     return error


### PR DESCRIPTION
Kyle hit an issue where `message` wasn't defined. I figured we might as well make this whole function safer/less assumptive