### PR TITLE
Convert serialization's index-based mapping of connection and parameter value to UUID-based.

### DIFF
--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -142,38 +142,40 @@ class SerializedFlowCommands:
         serialized_node_commands (list[SerializedNodeCommands]): List of serialized commands for nodes.
             Handles creating all of the nodes themselves, along with configuring them. Does NOT set Parameter values,
             which is done as a separate step.
-        serialized_connections (list[SerializedFlowCommands.IndexedConnectionSerialization]): List of serialized connections.
+        serialized_connections (list[SerializedFlowCommands.IndirectConnectionSerialization]): List of serialized connections.
             Creates the connections between Nodes.
-        unique_parameter_values (list[Any]): Records the unique Parameter values used by the Flow.
-        set_parameter_value_commands (list[list[SerializedNodeCommands.IndexedSetParameterValueCommand]]): List of commands
-            to set parameter values, indexed by node, during deserialization.
+        unique_parameter_uuid_to_values (dict[SerializedNodeCommands.UniqueParameterValueUUID, Any]): Records the unique Parameter values used by the Flow.
+        set_parameter_value_commands (dict[SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]]): List of commands
+            to set parameter values, keyed by node UUID, during deserialization.
         sub_flows_commands (list["SerializedFlowCommands"]): List of sub-flow commands. Cascades into sub-flows within this serialization.
     """
 
     @dataclass
-    class IndexedConnectionSerialization:
-        """Companion class to create connections from node indices, since we can't predict the names.
+    class IndirectConnectionSerialization:
+        """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
 
-        These are indices into the serialized_node_commands list we maintain.
+        These are UUIDs referencing into the serialized_node_commands we maintain.
 
         Attributes:
-            source_node_index (int): Index of the source node.
+            source_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the source node, as stored within the serialization.
             source_parameter_name (str): Name of the source parameter.
-            target_node_index (int): Index of the target node.
+            target_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the target node.
             target_parameter_name (str): Name of the target parameter.
         """
 
-        source_node_index: int
+        source_node_uuid: SerializedNodeCommands.NodeUUID
         source_parameter_name: str
-        target_node_index: int
+        target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
     node_libraries_used: set[LibraryNameAndVersion]
     create_flow_command: CreateFlowRequest | None
     serialized_node_commands: list[SerializedNodeCommands]
-    serialized_connections: list[IndexedConnectionSerialization]
-    unique_parameter_values: list[Any]
-    set_parameter_value_commands: list[list[SerializedNodeCommands.IndexedSetParameterValueCommand]]
+    serialized_connections: list[IndirectConnectionSerialization]
+    unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any]
+    set_parameter_value_commands: dict[
+        SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]
+    ]
     sub_flows_commands: list["SerializedFlowCommands"]
 
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -192,8 +192,9 @@ class SerializedNodeCommands:
             as during copy/paste or duplicate.
     """
 
-    NodeUUID = NewType("NodeUUID", UUID)
-    UniqueParameterValueUUID = NewType("UniqueParameterValueUUID", UUID)
+    # Have to use str instead of the UUID class because it's not JSON serializable >:-/
+    NodeUUID = NewType("NodeUUID", str)
+    UniqueParameterValueUUID = NewType("UniqueParameterValueUUID", str)
 
     @dataclass
     class IndirectSetParameterValueCommand:
@@ -211,7 +212,7 @@ class SerializedNodeCommands:
     create_node_command: CreateNodeRequest
     element_modification_commands: list[RequestPayload]
     node_library_details: LibraryNameAndVersion
-    node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(uuid4()))
+    node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(str(uuid4())))
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Any, NewType
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, cast
+from uuid import uuid4
 
 from griptape.events import EventBus
 
@@ -1631,8 +1632,8 @@ class NodeManager:
                 set_param_value_request = NodeManager._handle_parameter_value_saving(
                     parameter=parameter,
                     node=node,
-                    value_hash_to_unique_value_index=request.value_hash_to_unique_value_index,
-                    unique_values=request.unique_parameter_values_list,
+                    unique_parameter_uuid_to_values=request.unique_parameter_uuid_to_values,
+                    value_hash_to_unique_value_uuid=request.value_hash_to_unique_value_uuid,
                 )
                 if set_param_value_request is not None:
                     set_value_commands.append(set_param_value_request)
@@ -1687,27 +1688,27 @@ class NodeManager:
     def _handle_parameter_value_saving(
         parameter: Parameter,
         node: BaseNode,
-        value_hash_to_unique_value_index: dict[Any, int],
-        unique_values: list[Any],
-    ) -> SerializedNodeCommands.IndexedSetParameterValueCommand | None:
+        unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
+        value_hash_to_unique_value_uuid: dict[Any, SerializedNodeCommands.UniqueParameterValueUUID],
+    ) -> SerializedNodeCommands.IndirectSetParameterValueCommand | None:
         """Generates code to save a parameter value for a node in a Griptape workflow.
 
         This function handles the process of creating commands that will reconstruct and set
         parameter values for nodes. It performs the following steps:
         1. Retrieves the parameter value from the node's parameter values or output values
-        2. Checks if the value has already been created in our list of unique values
-        3. If so, it records the index for later correlation.
-        4. If not, it adds the value to the uniques list and records the new index.
+        2. Checks if the value has already been created in our map of unique values
+        3. If so, it records the unique value UUID for later correlation.
+        4. If not, it adds the value to the uniques map and records the new UUID.
         5. Creates a SetParameterValueRequest to reconstruct this for the node
 
         Args:
             parameter (Parameter): The parameter object containing metadata
             node (BaseNode): The node object that contains the parameter
-            value_hash_to_unique_value_index (dict[Any, int]): Dictionary mapping value hashes to indices in unique_values list
-            unique_values (list[Any]): List of unique values
+            unique_parameter_uuid_to_values (dict[SerializedNodeCommands.UniqueParameterValueUUID, Any]): Dictionary mapping unique value UUIDs to values
+            value_hash_to_unique_value_uuid (dict[Any, SerializedNodeCommands.UniqueParameterValueUUID]): Dictionary mapping value hashes to unique value UUIDs
 
         Returns:
-            None (if no value to be serialized) or an IndexedSetParameterValueCommand linking the value to the unique value list
+            None (if no value to be serialized) or an IndirectSetParameterValueCommand linking the value to the unique value map
 
         Notes:
             - Parameter output values take precedence over regular parameter values
@@ -1736,14 +1737,14 @@ class NodeManager:
             # Couldn't get a hash. Use the object's ID
             value_id = id(value)
 
-        if value_id in value_hash_to_unique_value_index:
+        if value_id in value_hash_to_unique_value_uuid:
             # We have a match on this value. We're all good.
-            unique_index = value_hash_to_unique_value_index[value_id]
+            unique_uuid = value_hash_to_unique_value_uuid[value_id]
         else:
-            # This one is new for us. Append it to the list of uniques.
-            unique_index = len(unique_values)
-            value_hash_to_unique_value_index[value_id] = unique_index
-            unique_values.append(value)
+            # This one is new for us. Add it to the map of uniques.
+            unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(uuid4())
+            value_hash_to_unique_value_uuid[value_id] = unique_uuid
+            unique_parameter_uuid_to_values[unique_uuid] = value
 
         # Serialize it
         set_value_command = SetParameterValueRequest(
@@ -1752,8 +1753,8 @@ class NodeManager:
             is_output=is_output,
             initial_setup=True,
         )
-        indexed_set_value_command = SerializedNodeCommands.IndexedSetParameterValueCommand(
+        indexed_set_value_command = SerializedNodeCommands.IndirectSetParameterValueCommand(
             set_parameter_value_command=set_value_command,
-            unique_value_index=unique_index,
+            unique_value_uuid=unique_uuid,
         )
         return indexed_set_value_command

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1742,7 +1742,7 @@ class NodeManager:
             unique_uuid = value_hash_to_unique_value_uuid[value_id]
         else:
             # This one is new for us. Add it to the map of uniques.
-            unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(uuid4())
+            unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
             value_hash_to_unique_value_uuid[value_id] = unique_uuid
             unique_parameter_uuid_to_values[unique_uuid] = value
 


### PR DESCRIPTION
Closes #1165 

You can still run code like this in the editor:

```
from griptape_nodes.retained_mode.events.flow_events import SerializeFlowToCommandsRequest, DeserializeFlowFromCommandsRequest
serialized_flow_request = SerializeFlowToCommandsRequest(include_create_flow_command=False)
serialized_flow_result = api.handle_request(serialized_flow_request)
deserialized_flow_request = DeserializeFlowFromCommandsRequest(serialized_flow_result.serialized_flow_commands)
deserialized_flow_result = api.handle_request(deserialized_flow_request)
```

...but now we'll be able to look up by UUID, which is necessary for reliable codegen and portable copy/paste/duplicate.