### PR TITLE
refactor: remove reliance on griptape's SingletonMixin

### DIFF
--- a/src/griptape_nodes/exe_types/type_validator.py
+++ b/src/griptape_nodes/exe_types/type_validator.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from griptape.mixins.singleton_mixin import SingletonMixin
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 logger = logging.getLogger(__name__)
 
 ALLOWED_NUM_ARGS = 2
 
 
-class TypeValidator(SingletonMixin):
+class TypeValidator(metaclass=SingletonMeta):
     """A type string validator that checks against known types.
 
     Implemented as a singleton to ensure consistent behavior across an application.

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, NamedTuple, Self, cast
 
-from griptape.mixins.singleton_mixin import SingletonMixin
 from pydantic import BaseModel
+
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
@@ -94,7 +95,7 @@ class LibrarySchema(BaseModel):
     is_default_library: bool | None = None
 
 
-class LibraryRegistry(SingletonMixin):
+class LibraryRegistry(metaclass=SingletonMeta):
     """Singleton registry to manage many libraries."""
 
     _libraries: dict[str, Library]

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -4,12 +4,12 @@ from datetime import datetime  # noqa: TC003 (can't put into type checking block
 from pathlib import Path
 from typing import ClassVar
 
-from griptape.mixins.singleton_mixin import SingletonMixin
 from pydantic import BaseModel, Field
 
 from griptape_nodes.node_library.library_registry import (
     LibraryNameAndVersion,  # noqa: TC001 (putting this into type checking causes it to not be defined)
 )
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 
 class WorkflowMetadata(BaseModel):
@@ -28,7 +28,7 @@ class WorkflowMetadata(BaseModel):
     published_workflow_id: str | None = Field(default=None)
 
 
-class WorkflowRegistry(SingletonMixin):
+class WorkflowRegistry(metaclass=SingletonMeta):
     class _RegistryKey:
         """Private class for workflow construction."""
 

--- a/src/griptape_nodes/retained_mode/events/payload_registry.py
+++ b/src/griptape_nodes/retained_mode/events/payload_registry.py
@@ -1,14 +1,14 @@
 from typing import ClassVar
 
-from griptape.mixins.singleton_mixin import SingletonMixin
 from typing_extensions import TypeVar
 
 from griptape_nodes.retained_mode.events.base_events import Payload
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 T = TypeVar("T", bound=Payload, default=Payload)
 
 
-class PayloadRegistry(SingletonMixin):
+class PayloadRegistry(metaclass=SingletonMeta):
     """Registry for payload types."""
 
     _registry: ClassVar[dict[str, type[Payload]]] = {}

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -4,7 +4,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import IO, TYPE_CHECKING, Any, ClassVar, TextIO
+from typing import IO, TYPE_CHECKING, Any, TextIO
 
 from griptape_nodes.exe_types.core_types import BaseNodeElement, Parameter, ParameterContainer, ParameterGroup
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -34,6 +34,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     AlterParameterDetailsRequest,
 )
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
@@ -77,15 +78,6 @@ class Version:
 
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}.{self.patch}"
-
-
-class SingletonMeta(type):
-    _instances: ClassVar[dict] = {}
-
-    def __call__(cls, *args, **kwargs) -> Any:
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__call__(*args, **kwargs)
-        return cls._instances[cls]
 
 
 class GriptapeNodes(metaclass=SingletonMeta):

--- a/src/griptape_nodes/traits/trait_registry.py
+++ b/src/griptape_nodes/traits/trait_registry.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from griptape.mixins.singleton_mixin import SingletonMixin
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Trait
 
 
 # This should probably register upon creation
-class TraitRegistry(SingletonMixin):
+class TraitRegistry(metaclass=SingletonMeta):
     # I'm going to create a dictionary that stores all of the created traits we have so far?
     # Traits will be associated with certain key words
     key_to_trait: ClassVar[dict[str, list[Trait.__class__]]] = {}

--- a/src/griptape_nodes/utils/metaclasses.py
+++ b/src/griptape_nodes/utils/metaclasses.py
@@ -1,0 +1,10 @@
+from typing import Any, ClassVar
+
+
+class SingletonMeta(type):
+    _instances: ClassVar[dict] = {}
+
+    def __call__(cls, *args, **kwargs) -> Any:
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
In some places we used `SingletonMeta`, in others we used griptape's `SingletonMixin`. This PR standardizes on the `SingletonMeta`.  In general we should avoid using the more "internal" aspects of griptape.