### PR TITLE
change output name of describeImage node

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
@@ -91,7 +91,7 @@ class DescribeImage(ControlNode):
                 ui_options={
                     "placeholder_text": "The description of the image",
                     "multiline": True,
-                    "display_name": "image description",
+                    "display_name": "output",
                 },
             )
         )


### PR DESCRIPTION
I noticed an small detail in the describeImage node, where the output was called "image description" instead of "output." This could likely make it more confusing for users and it is much more straightforward to simply call it "output." I have made a pull request so that this can be fixed.