### PR TITLE
add method to get a flat ParameterList

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -322,8 +322,6 @@ class Agent(ControlNode):
         Returns:
             An AsyncResult indicating the structure being processed (the agent).
         """
-        # Get the parameters from the node
-        params = self.parameter_values
         model_input = self.get_parameter_value("model")
         agent = None
         include_details = self.get_parameter_value("include_details")

--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -250,7 +250,6 @@ class Agent(ControlNode):
         )
 
     # --- Validation ---
-
     def validate_before_workflow_run(self) -> list[Exception] | None:
         """Performs pre-run validation checks for the node.
 
@@ -337,13 +336,14 @@ class Agent(ControlNode):
 
         # Get any tools
         # tools = self.get_parameter_value("tools")  # noqa: ERA001
-        tools = [tool for tool in params.get("tools", []) if tool]
+        tools = self.get_parameter_list_value("tools")
+        logger.info(f"Tools: {tools}")
         if include_details and tools:
             self.append_value_to_parameter("logs", f"[Tools]: {', '.join([tool.name for tool in tools])}\n")
 
         # Get any rulesets
-        # rulesets = self.get_parameter_value("rulesets")  # noqa: ERA001
-        rulesets = [ruleset for ruleset in params.get("rulesets", []) if ruleset]
+        rulesets = self.get_parameter_list_value("rulesets")
+        logger.info(f"Rulesets: {rulesets}")
         if include_details and rulesets:
             self.append_value_to_parameter(
                 "logs",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -335,13 +335,11 @@ class Agent(ControlNode):
         # Get any tools
         # tools = self.get_parameter_value("tools")  # noqa: ERA001
         tools = self.get_parameter_list_value("tools")
-        logger.info(f"Tools: {tools}")
         if include_details and tools:
             self.append_value_to_parameter("logs", f"[Tools]: {', '.join([tool.name for tool in tools])}\n")
 
         # Get any rulesets
         rulesets = self.get_parameter_list_value("rulesets")
-        logger.info(f"Rulesets: {rulesets}")
         if include_details and rulesets:
             self.append_value_to_parameter(
                 "logs",

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterable
 from enum import StrEnum, auto
 from typing import Any, TypeVar
 
@@ -410,6 +410,26 @@ class BaseNode(ABC):
             if value:
                 return value
         return param.default_value if param else None
+
+    def get_parameter_list_value(self, param: str) -> list:
+        """Flattens the given param from self.params into a single list.
+
+        Args:
+            param (str): Name of the param key in self.params.
+
+        Returns:
+            list: Flattened list of items from the param.
+        """
+
+        def _flatten(items: Iterable[Any]) -> Generator[Any, None, None]:
+            for item in items:
+                if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+                    yield from _flatten(item)
+                elif item:
+                    yield item
+
+        raw = self.get_parameter_value(param) or []  # ← Fallback for None
+        return list(_flatten(raw))
 
     def remove_parameter_value(self, param_name: str) -> None:
         parameter = self.get_parameter_by_name(param_name)


### PR DESCRIPTION
There was a bug that would allow a ruleset_list to be connected to a single ruleset item.

Instead of removing that functionality, I errored on giving the agent the ability to handle it better by creating a new method `get_parameter_list_value`.

This will returned a flattened list of items from a ParameterList in case someone does something like:

`input_types=["Ruleset", "List[Ruleset"]`

and just wants it as a flat list.

fixes: #1096