### PR TITLE
Allow for Duplication of Nodes

### DIFF
--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -127,25 +127,6 @@ class GetTopLevelFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess
     flow_name: str | None
 
 
-@dataclass
-class IndirectConnectionSerialization:
-    """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
-
-    These are UUIDs referencing into the serialized_node_commands we maintain.
-
-    Attributes:
-        source_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the source node, as stored within the serialization.
-        source_parameter_name (str): Name of the source parameter.
-        target_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the target node.
-        target_parameter_name (str): Name of the target parameter.
-    """
-
-    source_node_uuid: SerializedNodeCommands.NodeUUID
-    source_parameter_name: str
-    target_node_uuid: SerializedNodeCommands.NodeUUID
-    target_parameter_name: str
-
-
 # A Flow's state can be serialized into a sequence of commands that the engine then runs.
 @dataclass
 class SerializedFlowCommands:
@@ -169,6 +150,24 @@ class SerializedFlowCommands:
         sub_flows_commands (list["SerializedFlowCommands"]): List of sub-flow commands. Cascades into sub-flows within this serialization.
     """
 
+    @dataclass
+    class IndirectConnectionSerialization:
+        """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
+
+        These are UUIDs referencing into the serialized_node_commands we maintain.
+
+        Attributes:
+            source_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the source node, as stored within the serialization.
+            source_parameter_name (str): Name of the source parameter.
+            target_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the target node.
+            target_parameter_name (str): Name of the target parameter.
+        """
+
+        source_node_uuid: SerializedNodeCommands.NodeUUID
+        source_parameter_name: str
+        target_node_uuid: SerializedNodeCommands.NodeUUID
+        target_parameter_name: str
+
     node_libraries_used: set[LibraryNameAndVersion]
     create_flow_command: CreateFlowRequest | None
     serialized_node_commands: list[SerializedNodeCommands]
@@ -178,7 +177,6 @@ class SerializedFlowCommands:
         SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]
     ]
     sub_flows_commands: list["SerializedFlowCommands"]
-
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -127,6 +127,25 @@ class GetTopLevelFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess
     flow_name: str | None
 
 
+@dataclass
+class IndirectConnectionSerialization:
+    """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
+
+    These are UUIDs referencing into the serialized_node_commands we maintain.
+
+    Attributes:
+        source_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the source node, as stored within the serialization.
+        source_parameter_name (str): Name of the source parameter.
+        target_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the target node.
+        target_parameter_name (str): Name of the target parameter.
+    """
+
+    source_node_uuid: SerializedNodeCommands.NodeUUID
+    source_parameter_name: str
+    target_node_uuid: SerializedNodeCommands.NodeUUID
+    target_parameter_name: str
+
+
 # A Flow's state can be serialized into a sequence of commands that the engine then runs.
 @dataclass
 class SerializedFlowCommands:
@@ -150,24 +169,6 @@ class SerializedFlowCommands:
         sub_flows_commands (list["SerializedFlowCommands"]): List of sub-flow commands. Cascades into sub-flows within this serialization.
     """
 
-    @dataclass
-    class IndirectConnectionSerialization:
-        """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
-
-        These are UUIDs referencing into the serialized_node_commands we maintain.
-
-        Attributes:
-            source_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the source node, as stored within the serialization.
-            source_parameter_name (str): Name of the source parameter.
-            target_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the target node.
-            target_parameter_name (str): Name of the target parameter.
-        """
-
-        source_node_uuid: SerializedNodeCommands.NodeUUID
-        source_parameter_name: str
-        target_node_uuid: SerializedNodeCommands.NodeUUID
-        target_parameter_name: str
-
     node_libraries_used: set[LibraryNameAndVersion]
     create_flow_command: CreateFlowRequest | None
     serialized_node_commands: list[SerializedNodeCommands]
@@ -177,6 +178,7 @@ class SerializedFlowCommands:
         SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]
     ]
     sub_flows_commands: list["SerializedFlowCommands"]
+
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -18,7 +18,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
-from httpx import RequestError
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -301,7 +301,7 @@ class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, Res
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestPayload):
     serialized_node_commands: list[SerializeNodeToCommandsResultSuccess]
-    serialzed_connection_commands: list[SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization]
+    serialized_connection_commands: list[SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization]
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -293,7 +293,7 @@ class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPa
 class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     # They will be passed with node_name, timestamp
     # Could be a flow command if it's all nodes in a flow.
-    serialized_selected_node_commands: SerializedSelectedNodeCommands
+    serialized_selected_node_commands: SerializedSelectedNodesCommands
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -11,8 +11,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     WorkflowAlteredMixin,
     WorkflowNotAlteredMixin,
 )
-from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, ListConnectionsForNodeResultSuccess
-from griptape_nodes.retained_mode.events.flow_events import IndirectConnectionSerialization, SerializedFlowCommands
+from griptape_nodes.retained_mode.events.connection_events import ListConnectionsForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
     GetParameterDetailsResultSuccess,
     GetParameterValueResultSuccess,
@@ -272,16 +271,34 @@ class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPa
 
 @dataclass
 @PayloadRegistry.register
-class SerializeSelectedNodestoCommandsSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     # They will be passed with node_name, timestamp
     # Could be a flow command if it's all nodes in a flow.
-    serialized_node_commands: SerializedSelectedNodeCommands | SerializedFlowCommands
+    @dataclass
+    class IndirectConnectionSerialization:
+        """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
+
+        These are UUIDs referencing into the serialized_node_commands we maintain.
+
+        Attributes:
+            source_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the source node, as stored within the serialization.
+            source_parameter_name (str): Name of the source parameter.
+            target_node_uuid (SerializedNodeCommands.NodeUUID): UUID of the target node.
+            target_parameter_name (str): Name of the target parameter.
+        """
+
+        source_node_uuid: SerializedNodeCommands.NodeUUID
+        source_parameter_name: str
+        target_node_uuid: SerializedNodeCommands.NodeUUID
+        target_parameter_name: str
+
+    serialized_node_commands: SerializedSelectedNodeCommands
     # Connection commands are None if it's a Serialized Flow Commands
     serialized_connection_commands: list[IndirectConnectionSerialization] | None
 
 @dataclass
 @PayloadRegistry.register
-class SerializeSelectedNodestoCommandsFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -218,8 +218,6 @@ class SerializedNodeCommands:
 @dataclass
 class SerializedSelectedNodeCommands:
     node_commands: list[SerializedNodeCommands]
-    # Has the UUIDs for Nodes and for Parameters
-    connection_commands: list[IndirectConnectionSerialization]
 
 @dataclass
 @PayloadRegistry.register
@@ -270,14 +268,16 @@ class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 @PayloadRegistry.register
 class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
     # They will be passed with node_name, timestamp
-    nodes_to_serialize:tuple[str,str]
+    nodes_to_serialize:list[tuple[str,str]]
 
 @dataclass
 @PayloadRegistry.register
 class SerializeSelectedNodestoCommandsSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     # They will be passed with node_name, timestamp
     # Could be a flow command if it's all nodes in a flow.
-    serialized_node_commands: SerializedNodeCommands | SerializedFlowCommands
+    serialized_node_commands: SerializedSelectedNodeCommands | SerializedFlowCommands
+    # Connection commands are None if it's a Serialized Flow Commands
+    serialized_connection_commands: list[IndirectConnectionSerialization] | None
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -18,6 +18,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from httpx import RequestError
 
 
 @dataclass
@@ -309,7 +310,7 @@ class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, Res
 
 @dataclass
 @PayloadRegistry.register
-class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestPayload):
+class DeserializeSelectedNodesFromCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
     pass
 
 
@@ -321,7 +322,7 @@ class DeserializeSelectedNodesFromCommandsResultSuccess(WorkflowAlteredMixin, Re
 
 @dataclass
 @PayloadRegistry.register
-class DeserializeSelectedNodesFromCommandsResultFailure(WorkflowAlteredMixin, ResultPayloadFailure):
+class DeserializeSelectedNodesFromCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -340,4 +341,22 @@ class DeserializeNodeFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPaylo
 @dataclass
 @PayloadRegistry.register
 class DeserializeNodeFromCommandsResultFailure(ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class DuplicateSelectedNodesRequest(WorkflowNotAlteredMixin, RequestPayload):
+    nodes_to_duplicate: list[tuple[str, str]]
+
+
+@dataclass
+@PayloadRegistry.register
+class DuplicateSelectedNodesResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class DuplicateSelectedNodesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -214,10 +214,6 @@ class SerializedNodeCommands:
     node_library_details: LibraryNameAndVersion
     node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(str(uuid4())))
 
-@dataclass
-class SerializedSelectedNodeCommands:
-    node_commands: list[SerializedNodeCommands]
-    parameter_commands: list[SerializedNodeCommands.IndirectSetParameterValueCommand]
 
 @dataclass
 @PayloadRegistry.register
@@ -263,7 +259,6 @@ class SerializeNodeToCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloa
 class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
-
 @dataclass
 @PayloadRegistry.register
 class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
@@ -293,7 +288,7 @@ class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, Res
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
-    serialized_node_commands: SerializedSelectedNodeCommands
+    serialized_node_commands: list[SerializeNodeToCommandsResultSuccess]
     # Connection commands are None if it's a Serialized Flow Commands
     serialized_connection_commands: list[IndirectConnectionSerialization] | None
 
@@ -305,7 +300,7 @@ class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, Res
 @dataclass
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestPayload):
-    serialized_node_commands: SerializedSelectedNodeCommands
+    serialized_node_commands: list[SerializeNodeToCommandsResultSuccess]
     serialzed_connection_commands: list[SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization]
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -311,7 +311,7 @@ class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestP
 @dataclass
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
-    pass
+    node_names: list[str]
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, NewType
+from typing import Any, NewType, NamedTuple
 from uuid import uuid4
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
@@ -18,7 +18,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
-
 
 @dataclass
 @PayloadRegistry.register
@@ -259,7 +258,6 @@ class SerializeNodeToCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloa
 class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
-
 @dataclass
 class SerializedSelectedNodesCommands:
     @dataclass
@@ -280,22 +278,32 @@ class SerializedSelectedNodesCommands:
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
-    serialized_node_commands: list[
-        tuple[SerializedNodeCommands, list[SerializedNodeCommands.IndirectSetParameterValueCommand]]
+    serialized_node_commands: list[SerializedNodeCommands]
+    set_parameter_value_commands: dict[
+        SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]
     ]
     serialized_connection_commands: list[IndirectConnectionSerialization]
 
+class NodeToTimestamp(NamedTuple):
+    """A named tuple for storing the node_name and the timestamp passed on selection.
+
+        Fields:
+            node_name: The name of the node selected
+            timestamp: The time the node was selected
+        """
+    node_name:str
+    timestamp:str
 
 @dataclass
 @PayloadRegistry.register
-class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
+class SerializeSelectedNodesToCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
     # They will be passed with node_name, timestamp
-    nodes_to_serialize: list[tuple[str, str]]
+    nodes_to_serialize: list[NodeToTimestamp]
 
 
 @dataclass
 @PayloadRegistry.register
-class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+class SerializeSelectedNodesToCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     # They will be passed with node_name, timestamp
     # Could be a flow command if it's all nodes in a flow.
     serialized_selected_node_commands: SerializedSelectedNodesCommands
@@ -303,7 +311,7 @@ class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, Res
 
 @dataclass
 @PayloadRegistry.register
-class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+class SerializeSelectedNodesToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 
@@ -346,7 +354,7 @@ class DeserializeNodeFromCommandsResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class DuplicateSelectedNodesRequest(WorkflowNotAlteredMixin, RequestPayload):
-    nodes_to_duplicate: list[tuple[str, str]]
+    nodes_to_duplicate: list[NodeToTimestamp]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -262,6 +262,11 @@ class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 
 @dataclass
 @PayloadRegistry.register
+class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
+    pass
+
+@dataclass
+@PayloadRegistry.register
 class DeserializeNodeFromCommandsRequest(RequestPayload):
     serialized_node_commands: SerializedNodeCommands
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -260,16 +260,7 @@ class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloa
     pass
 
 @dataclass
-@PayloadRegistry.register
-class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
-    # They will be passed with node_name, timestamp
-    nodes_to_serialize:list[tuple[str,str]]
-
-@dataclass
-@PayloadRegistry.register
-class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    # They will be passed with node_name, timestamp
-    # Could be a flow command if it's all nodes in a flow.
+class SerializedSelectedNodesCommands:
     @dataclass
     class IndirectConnectionSerialization:
         """Companion class to create connections from node IDs in a serialization, since we can't predict the names.
@@ -288,9 +279,21 @@ class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, Res
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
-    serialized_node_commands: list[SerializeNodeToCommandsResultSuccess]
-    # Connection commands are None if it's a Serialized Flow Commands
-    serialized_connection_commands: list[IndirectConnectionSerialization] | None
+    serialized_node_commands: list[tuple[SerializedNodeCommands, list[SerializedNodeCommands.IndirectSetParameterValueCommand]]]
+    serialized_connection_commands: list[IndirectConnectionSerialization]
+
+@dataclass
+@PayloadRegistry.register
+class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
+    # They will be passed with node_name, timestamp
+    nodes_to_serialize:list[tuple[str,str]]
+
+@dataclass
+@PayloadRegistry.register
+class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    # They will be passed with node_name, timestamp
+    # Could be a flow command if it's all nodes in a flow.
+    serialized_selected_node_commands: SerializedSelectedNodeCommands
 
 @dataclass
 @PayloadRegistry.register
@@ -300,8 +303,7 @@ class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, Res
 @dataclass
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestPayload):
-    serialized_node_commands: list[SerializeNodeToCommandsResultSuccess]
-    serialized_connection_commands: list[SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization]
+    pass
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -259,6 +259,7 @@ class SerializeNodeToCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloa
 class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
+
 @dataclass
 class SerializedSelectedNodesCommands:
     @dataclass
@@ -279,14 +280,18 @@ class SerializedSelectedNodesCommands:
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
-    serialized_node_commands: list[tuple[SerializedNodeCommands, list[SerializedNodeCommands.IndirectSetParameterValueCommand]]]
+    serialized_node_commands: list[
+        tuple[SerializedNodeCommands, list[SerializedNodeCommands.IndirectSetParameterValueCommand]]
+    ]
     serialized_connection_commands: list[IndirectConnectionSerialization]
+
 
 @dataclass
 @PayloadRegistry.register
 class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
     # They will be passed with node_name, timestamp
-    nodes_to_serialize:list[tuple[str,str]]
+    nodes_to_serialize: list[tuple[str, str]]
+
 
 @dataclass
 @PayloadRegistry.register
@@ -295,20 +300,24 @@ class SerializeSelectedNodestoCommandsResultSuccess(WorkflowNotAlteredMixin, Res
     # Could be a flow command if it's all nodes in a flow.
     serialized_selected_node_commands: SerializedSelectedNodesCommands
 
+
 @dataclass
 @PayloadRegistry.register
 class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
+
 
 @dataclass
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestPayload):
     pass
 
+
 @dataclass
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     node_names: list[str]
+
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, NewType, NamedTuple
+from typing import Any, NamedTuple, NewType
 from uuid import uuid4
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
@@ -18,6 +18,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
 
 @dataclass
 @PayloadRegistry.register
@@ -258,6 +259,7 @@ class SerializeNodeToCommandsResultSuccess(WorkflowNotAlteredMixin, ResultPayloa
 class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
+
 @dataclass
 class SerializedSelectedNodesCommands:
     @dataclass
@@ -284,15 +286,18 @@ class SerializedSelectedNodesCommands:
     ]
     serialized_connection_commands: list[IndirectConnectionSerialization]
 
+
 class NodeToTimestamp(NamedTuple):
     """A named tuple for storing the node_name and the timestamp passed on selection.
 
-        Fields:
-            node_name: The name of the node selected
-            timestamp: The time the node was selected
-        """
-    node_name:str
-    timestamp:str
+    Fields:
+        node_name: The name of the node selected
+        timestamp: The time the node was selected
+    """
+
+    node_name: str
+    timestamp: str
+
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -304,6 +304,23 @@ class SerializeSelectedNodestoCommandsResultFailure(WorkflowNotAlteredMixin, Res
 
 @dataclass
 @PayloadRegistry.register
+class DeserializeSelectedNodesFromCommandsRequest(WorkflowAlteredMixin, RequestPayload):
+    serialized_node_commands: SerializedSelectedNodeCommands
+    serialzed_connection_commands: list[SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization]
+
+@dataclass
+@PayloadRegistry.register
+class DeserializeSelectedNodesFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    pass
+
+@dataclass
+@PayloadRegistry.register
+class DeserializeSelectedNodesFromCommandsResultFailure(WorkflowAlteredMixin, ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
 class DeserializeNodeFromCommandsRequest(RequestPayload):
     serialized_node_commands: SerializedNodeCommands
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -11,7 +11,8 @@ from griptape_nodes.retained_mode.events.base_events import (
     WorkflowAlteredMixin,
     WorkflowNotAlteredMixin,
 )
-from griptape_nodes.retained_mode.events.connection_events import ListConnectionsForNodeResultSuccess
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, ListConnectionsForNodeResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import IndirectConnectionSerialization, SerializedFlowCommands
 from griptape_nodes.retained_mode.events.parameter_events import (
     GetParameterDetailsResultSuccess,
     GetParameterValueResultSuccess,
@@ -214,6 +215,11 @@ class SerializedNodeCommands:
     node_library_details: LibraryNameAndVersion
     node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(str(uuid4())))
 
+@dataclass
+class SerializedSelectedNodeCommands:
+    node_commands: list[SerializedNodeCommands]
+    # Has the UUIDs for Nodes and for Parameters
+    connection_commands: list[IndirectConnectionSerialization]
 
 @dataclass
 @PayloadRegistry.register
@@ -263,6 +269,19 @@ class SerializeNodeToCommandsResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 @dataclass
 @PayloadRegistry.register
 class SerializeSelectedNodestoCommandsRequest(WorkflowNotAlteredMixin, RequestPayload):
+    # They will be passed with node_name, timestamp
+    nodes_to_serialize:tuple[str,str]
+
+@dataclass
+@PayloadRegistry.register
+class SerializeSelectedNodestoCommandsSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    # They will be passed with node_name, timestamp
+    # Could be a flow command if it's all nodes in a flow.
+    serialized_node_commands: SerializedNodeCommands | SerializedFlowCommands
+
+@dataclass
+@PayloadRegistry.register
+class SerializeSelectedNodestoCommandsFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -217,6 +217,7 @@ class SerializedNodeCommands:
 @dataclass
 class SerializedSelectedNodeCommands:
     node_commands: list[SerializedNodeCommands]
+    parameter_commands: list[SerializedNodeCommands.IndirectSetParameterValueCommand]
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -31,6 +31,7 @@ class ContextManager:
     """
 
     _workflow_stack: list[ContextManager.WorkflowContextState]
+    clipboard: ClipBoard
 
     class WorkflowContextError(Exception):
         """Base exception for workflow context errors."""
@@ -263,7 +264,7 @@ class ContextManager:
     def __init__(self, event_manager: EventManager) -> None:
         """Initialize the context manager with empty workflow and flow stacks."""
         self._workflow_stack = []
-
+        self.clipboard = self.ClipBoard()
         event_manager.assign_manager_to_request_type(
             request_type=SetWorkflowContextRequest, callback=self.on_set_workflow_context_request
         )

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.retained_mode.events.context_events import (
     GetWorkflowContextRequest,
@@ -10,6 +10,8 @@ from griptape_nodes.retained_mode.events.context_events import (
     SetWorkflowContextRequest,
     SetWorkflowContextSuccess,
 )
+from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands, SerializedSelectedNodesCommands
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -235,6 +237,14 @@ class ContextManager:
             exc_traceback: TracebackType | None,
         ) -> None:
             self._manager.pop_element()
+
+    class ClipBoard:
+        """Keeps Commands for Copying or Pasting."""
+        # Contains flow, node, parameter, connections
+        flow_commands: SerializedFlowCommands | None
+        # Contains node and Parameter and relevant connections
+        node_commands: SerializedSelectedNodesCommands | None
+        parameter_uuid_to_values : dict[str, Any] | None
 
     def __init__(self, event_manager: EventManager) -> None:
         """Initialize the context manager with empty workflow and flow stacks."""

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -31,7 +31,7 @@ class ContextManager:
     """
 
     _workflow_stack: list[ContextManager.WorkflowContextState]
-    clipboard: ClipBoard
+    _clipboard: ClipBoard
 
     class WorkflowContextError(Exception):
         """Base exception for workflow context errors."""
@@ -264,7 +264,7 @@ class ContextManager:
     def __init__(self, event_manager: EventManager) -> None:
         """Initialize the context manager with empty workflow and flow stacks."""
         self._workflow_stack = []
-        self.clipboard = self.ClipBoard()
+        self._clipboard = self.ClipBoard()
         event_manager.assign_manager_to_request_type(
             request_type=SetWorkflowContextRequest, callback=self.on_set_workflow_context_request
         )

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -10,13 +10,13 @@ from griptape_nodes.retained_mode.events.context_events import (
     SetWorkflowContextRequest,
     SetWorkflowContextSuccess,
 )
-from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
-from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands, SerializedSelectedNodesCommands
 
 if TYPE_CHECKING:
     from types import TracebackType
 
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
+    from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+    from griptape_nodes.retained_mode.events.node_events import SerializedSelectedNodesCommands
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 logger = logging.getLogger("griptape_nodes")
@@ -240,11 +240,25 @@ class ContextManager:
 
     class ClipBoard:
         """Keeps Commands for Copying or Pasting."""
+
         # Contains flow, node, parameter, connections
         flow_commands: SerializedFlowCommands | None
         # Contains node and Parameter and relevant connections
         node_commands: SerializedSelectedNodesCommands | None
-        parameter_uuid_to_values : dict[str, Any] | None
+        parameter_uuid_to_values: dict[str, Any] | None
+
+        def __init__(self) -> None:
+            self.flow_commands = None
+            self.node_commands = None
+            self.parameter_uuid_to_values = None
+
+        def clear(self) -> None:
+            del self.flow_commands
+            self.flow_commands = None
+            del self.node_commands
+            self.node_commands = None
+            if self.parameter_uuid_to_values is not None:
+                self.parameter_uuid_to_values.clear()
 
     def __init__(self, event_manager: EventManager) -> None:
         """Initialize the context manager with empty workflow and flow stacks."""

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1812,7 +1812,6 @@ class NodeManager:
             if not result.succeeded():
                 details = f"Failed to create a connection between {connection_request.source_node_name} and {connection_request.target_node_name}"
                 logger.warning(details)
-        GriptapeNodes.ContextManager().clipboard.clear()
         return DeserializeSelectedNodesFromCommandsResultSuccess(node_names=list(node_uuid_to_name.values()))
 
     def on_duplicate_selected_nodes(self, request: DuplicateSelectedNodesRequest) -> ResultPayload:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1687,8 +1687,9 @@ class NodeManager:
         for node_name, _ in sorted_nodes:
             result = self.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
             if not result.succeeded():
-                return SerializeSelectedNodesToTcommandsFailure()
-        return result
+                return SerializeNodeToCommandsResultFailure()
+            node_commands.append(result)
+        return SerializeNodeToCommandsResultSuccess(serialized_node_commands=node_commands)
             # now we have all of our node commands. we need connections as well.
 
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -55,6 +55,8 @@ from griptape_nodes.retained_mode.events.node_events import (
     DeserializeNodeFromCommandsRequest,
     DeserializeNodeFromCommandsResultFailure,
     DeserializeNodeFromCommandsResultSuccess,
+    DeserializeSelectedNodesFromCommandsRequest,
+    DeserializeSelectedNodesFromCommandsResultSuccess,
     GetAllNodeInfoRequest,
     GetAllNodeInfoResultFailure,
     GetAllNodeInfoResultSuccess,
@@ -162,6 +164,7 @@ class NodeManager:
             DeserializeNodeFromCommandsRequest, self.on_deserialize_node_from_commands
         )
         event_manager.assign_manager_to_request_type(SerializeSelectedNodestoCommandsRequest, self.on_serialize_selected_nodes_to_commands)
+        event_manager.assign_manager_to_request_type(DeserializeSelectedNodesFromCommandsRequest, self.on_deserialize_selected_nodes_from_commands)
 
     def handle_node_rename(self, old_name: str, new_name: str) -> None:
         # Replace the old node name and its parent.
@@ -1732,9 +1735,16 @@ class NodeManager:
         return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=final_result, serialized_connection_commands=serialized_connections)
             # now we have all of our node commands. we need connections as well.
 
-
-
-        
+    def on_deserialize_selected_nodes_from_commands(self, request:DeserializeSelectedNodesFromCommandsRequest) -> ResultPayload:
+        serialized_node_commands = request.serialized_node_commands
+        connections = request.serialzed_connection_commands
+        for node_command in serialized_node_commands.node_commands:
+            result = self.on_deserialize_node_from_commands(DeserializeNodeFromCommandsRequest(serialized_node_commands=node_command))
+        for parameter_command in serialized_node_commands.parameter_commands:
+            pass
+        for connection_command in connections:
+            pass
+        return DeserializeSelectedNodesFromCommandsResultSuccess()
 
 
     @staticmethod

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1612,7 +1612,7 @@ class NodeManager:
                 node_type=node.__class__.__name__,
                 node_name=node_name,
                 specific_library_name=library_details.library_name,
-                metadata=node.metadata,
+                metadata=node.metadata.copy(),
             )
 
             # We're going to compare this node instance vs. a canonical one. Rez that one up.

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -14,7 +14,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterTypeBuiltin,
 )
 from griptape_nodes.exe_types.flow import ControlFlow
-from griptape_nodes.exe_types.node_types import BaseNode, Connection, NodeResolutionState
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.exe_types.type_validator import TypeValidator
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
@@ -76,14 +76,13 @@ from griptape_nodes.retained_mode.events.node_events import (
     ListParametersOnNodeRequest,
     ListParametersOnNodeResultFailure,
     ListParametersOnNodeResultSuccess,
-    SerializeSelectedNodesToCommandsRequest,
     SerializedNodeCommands,
     SerializedSelectedNodesCommands,
     SerializeNodeToCommandsRequest,
     SerializeNodeToCommandsResultFailure,
     SerializeNodeToCommandsResultSuccess,
-    SerializeSelectedNodestoCommandsRequest,
-    SerializeSelectedNodestoCommandsResultSuccess,
+    SerializeSelectedNodesToCommandsRequest,
+    SerializeSelectedNodesToCommandsResultSuccess,
     SetNodeMetadataRequest,
     SetNodeMetadataResultFailure,
     SetNodeMetadataResultSuccess,
@@ -172,7 +171,7 @@ class NodeManager:
             DeserializeNodeFromCommandsRequest, self.on_deserialize_node_from_commands
         )
         event_manager.assign_manager_to_request_type(
-            SerializeSelectedNodestoCommandsRequest, self.on_serialize_selected_nodes_to_commands
+            SerializeSelectedNodesToCommandsRequest, self.on_serialize_selected_nodes_to_commands
         )
         event_manager.assign_manager_to_request_type(
             DeserializeSelectedNodesFromCommandsRequest, self.on_deserialize_selected_nodes_from_commands
@@ -1704,6 +1703,8 @@ class NodeManager:
         sorted_nodes = sorted(nodes_to_serialize, key=lambda x: datetime.fromisoformat(x[1]))
         # This is node_uuid to the serialization command.
         node_commands = {}
+        # Node Name to UUID
+        node_name_to_uuid = {}
         connections_to_serialize = []
         # This is also node_uuid to the parameter serialization command.
         parameter_commands = {}
@@ -1724,6 +1725,7 @@ class NodeManager:
                 logger.error(details)
                 return SerializeNodeToCommandsResultFailure()
             node_commands[node_name] = result.serialized_node_commands
+            node_name_to_uuid[node_name] = result.serialized_node_commands.node_uuid
             parameter_commands[result.serialized_node_commands.node_uuid] = result.set_parameter_value_commands
             try:
                 flow_name = self.get_node_parent_flow_by_name(node_name)
@@ -1744,8 +1746,8 @@ class NodeManager:
                     connections_to_serialize.append(connection)
         serialized_connections = []
         for connection in connections_to_serialize:
-            source_node_uuid = node_commands[connection.get_source_node().name].node_uuid
-            target_node_uuid = node_commands[connection.get_target_node().name].node_uuid
+            source_node_uuid = node_name_to_uuid[connection.source_node.name]
+            target_node_uuid = node_name_to_uuid[connection.target_node.name]
             serialized_connections.append(
                 SerializedSelectedNodesCommands.IndirectConnectionSerialization(
                     source_node_uuid=source_node_uuid,
@@ -1756,12 +1758,14 @@ class NodeManager:
             )
         # Final result for serialized node commands
         final_result = SerializedSelectedNodesCommands(
-            serialized_node_commands=list(node_commands.values()), serialized_connection_commands=serialized_connections, set_parameter_value_commands=parameter_commands
+            serialized_node_commands=list(node_commands.values()),
+            serialized_connection_commands=serialized_connections,
+            set_parameter_value_commands=parameter_commands,
         )
         # Set everything in the clipboard!
         GriptapeNodes.ContextManager().clipboard.node_commands = final_result
         GriptapeNodes.ContextManager().clipboard.parameter_uuid_to_values = unique_uuid_to_values
-        return SerializeSelectedNodestoCommandsResultSuccess(final_result)
+        return SerializeSelectedNodesToCommandsResultSuccess(final_result)
 
     def on_deserialize_selected_nodes_from_commands(
         self,
@@ -1776,10 +1780,9 @@ class NodeManager:
             result = self.on_deserialize_node_from_commands(
                 DeserializeNodeFromCommandsRequest(serialized_node_commands=node_command)
             )
-            if not result.succeeded():
+            if not isinstance(result, DeserializeNodeFromCommandsResultSuccess):
                 logger.error("Attempted to deserialize node but ran into an error on node serialization.")
                 return DeserializeSelectedNodesFromCommandsResultFailure()
-            result = cast("DeserializeNodeFromCommandsResultSuccess", result)
             node_uuid_to_name[node_command.node_uuid] = result.node_name
             with GriptapeNodes.ContextManager().node(result.node_name):
                 parameter_commands = commands.set_parameter_value_commands[node_command.node_uuid]

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1741,7 +1741,7 @@ class NodeManager:
 
     def on_deserialize_selected_nodes_from_commands(self, request:DeserializeSelectedNodesFromCommandsRequest) -> ResultPayload:
         serialized_node_commands = request.serialized_node_commands
-        connections = request.serialzed_connection_commands
+        connections = request.serialized_connection_commands
         node_uuid_to_name = {}
         for node_command in serialized_node_commands:
             node_serialization = node_command.serialized_node_commands

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1684,9 +1684,10 @@ class NodeManager:
         nodes_to_serialize = request.nodes_to_serialize
         # Sorts tuples in order based on the timestamp
         sorted_nodes = sorted(nodes_to_serialize, key=lambda x: x[1])
-        node_commands = []
+        node_commands = {}
         parameter_commands = []
         connections_to_serialize = []
+        # How do i keep track fo node / parameters 
         # I need to store node names and parameter names to UUID 
         for node_name, _ in sorted_nodes:
             result = self.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
@@ -1694,7 +1695,8 @@ class NodeManager:
                 # TODO : create error
                 return SerializeNodeToCommandsResultFailure()
             result = cast("SerializeNodeToCommandsResultSuccess",result)
-            node_commands.append(result.serialized_node_commands)
+            node_commands[node_name] = result.serialized_node_commands
+            # How do I keep parameter UUIds?
             parameter_commands.extend(result.set_parameter_value_commands)
             flow_name = self.get_node_parent_flow_by_name(node_name)
             flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
@@ -1710,6 +1712,13 @@ class NodeManager:
                 if connection.target_node.name not in sorted_nodes:
                     continue
                 connections_to_serialize.append(connection)
+        serialized_connections = []
+        for connection in connections_to_serialize:
+            serialized_connections.append(
+                SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization(
+                    source_node_uuid=
+                )
+            )
         # Final result for serialized node commands
         final_result = SerializedSelectedNodeCommands(node_commands=node_commands, parameter_commands=parameter_commands)
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -68,7 +68,7 @@ from griptape_nodes.retained_mode.events.node_events import (
     ListParametersOnNodeResultFailure,
     ListParametersOnNodeResultSuccess,
     SerializeSelectedNodestoCommandsRequest,
-    SerializeSelectedNodestoCommandsSuccess,
+    SerializeSelectedNodestoCommandsResultSuccess,
     SerializedNodeCommands,
     SerializeNodeToCommandsRequest,
     SerializeNodeToCommandsResultFailure,
@@ -1697,11 +1697,12 @@ class NodeManager:
             flow_name = self.get_node_parent_flow_by_name(node_name)
             flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
             if flow is None:
-                # TODO: Creat error
+                # TODO: Create error
                 return SerializeNodeToCommandsResultFailure()
+            # Get outgoing connections
             # Set up Connections with Node name and parameter UUID
         # Now we have the node and parameter commands. Get Connections
-        return SerializeSelectedNodestoCommandsSuccess(serialized_node_commands=node_commands)
+        return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=node_commands, serialized_connection_commands=[])
             # now we have all of our node commands. we need connections as well.
 
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1800,6 +1800,7 @@ class NodeManager:
                             value = value.copy()
                         except Exception:  # noqa: S110
                             pass
+                        param_request.value = value
                         set_parameter_result = GriptapeNodes.handle_request(
                             parameter_command.set_parameter_value_command
                         )

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -73,6 +73,7 @@ from griptape_nodes.retained_mode.events.node_events import (
     SerializeNodeToCommandsRequest,
     SerializeNodeToCommandsResultFailure,
     SerializeNodeToCommandsResultSuccess,
+    SerializedSelectedNodeCommands,
     SetNodeMetadataRequest,
     SetNodeMetadataResultFailure,
     SetNodeMetadataResultSuccess,
@@ -1709,9 +1710,11 @@ class NodeManager:
                 if connection.target_node.name not in sorted_nodes:
                     continue
                 connections_to_serialize.append(connection)
+        # Final result for serialized node commands
+        final_result = SerializedSelectedNodeCommands(node_commands=node_commands, parameter_commands=parameter_commands)
 
         # Now we have the node and parameter commands. Get Connections
-        return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=node_commands, serialized_connection_commands=[])
+        return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=final_result, serialized_connection_commands=[])
             # now we have all of our node commands. we need connections as well.
 
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1758,7 +1758,6 @@ class NodeManager:
         # Set everything in the clipboard!
         GriptapeNodes.ContextManager().clipboard.node_commands = final_result
         GriptapeNodes.ContextManager().clipboard.parameter_uuid_to_values = unique_uuid_to_values
-        self.on_deserialize_selected_nodes_from_commands(DeserializeSelectedNodesFromCommandsRequest())
         return SerializeSelectedNodestoCommandsResultSuccess(final_result)
 
     def on_deserialize_selected_nodes_from_commands(
@@ -1767,7 +1766,7 @@ class NodeManager:
     ) -> ResultPayload:
         commands = GriptapeNodes.ContextManager().clipboard.node_commands
         if commands is None:
-            return DeserializeNodeFromCommandsResultFailure()
+            return DeserializeSelectedNodesFromCommandsResultFailure()
         connections = commands.serialized_connection_commands
         node_uuid_to_name = {}
         for node_command, parameter_commands in commands.serialized_node_commands:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -482,9 +482,6 @@ class NodeManager:
             return result
         # We can't completely overwrite metadata.
         for key, value in request.metadata.items():
-            if key.lower() == "selected" and value:
-                # Add this to the selected objects list. in ORDER!
-                GriptapeNodes.ObjectManager()._selected_objects.append(node)
             node.metadata[key] = value
         details = f"Successfully set metadata for a Node '{node_name}'."
         logger.debug(details)
@@ -1681,9 +1678,22 @@ class NodeManager:
         return DeserializeNodeFromCommandsResultSuccess(node_name=node_name)
 
     def on_serialize_selected_nodes_to_commands(self, request: SerializeSelectedNodestoCommandsRequest) -> ResultPayload:
+        """This will take the selected nodes in the Object manager and serialize them into commands."""
         # TODO: If this is all of the nodes in a flow, should it just serialize the whole flow?
-        # This should serialize connections bt the nodes as well. 
-        """This will take the selected nodes in the Object manager and serialize them into commands"""
+        nodes_to_serialize = request.nodes_to_serialize
+        # Sorts tuples in order based on the timestamp
+        sorted_nodes = sorted(nodes_to_serialize, key=lambda x: x[1])
+        node_commands = []
+        for node_name, _ in sorted_nodes:
+            result = self.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+            if not result.succeeded():
+                return SerializeSelectedNodesToTcommandsFailure()
+        return result
+            # now we have all of our node commands. we need connections as well.
+
+
+
+        
 
 
     @staticmethod

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1763,15 +1763,15 @@ class NodeManager:
             set_parameter_value_commands=parameter_commands,
         )
         # Set everything in the clipboard!
-        GriptapeNodes.ContextManager().clipboard.node_commands = final_result
-        GriptapeNodes.ContextManager().clipboard.parameter_uuid_to_values = unique_uuid_to_values
+        GriptapeNodes.ContextManager()._clipboard.node_commands = final_result
+        GriptapeNodes.ContextManager()._clipboard.parameter_uuid_to_values = unique_uuid_to_values
         return SerializeSelectedNodesToCommandsResultSuccess(final_result)
 
     def on_deserialize_selected_nodes_from_commands(
         self,
         request: DeserializeSelectedNodesFromCommandsRequest,  # noqa: ARG002
     ) -> ResultPayload:
-        commands = GriptapeNodes.ContextManager().clipboard.node_commands
+        commands = GriptapeNodes.ContextManager()._clipboard.node_commands
         if commands is None:
             return DeserializeSelectedNodesFromCommandsResultFailure()
         connections = commands.serialized_connection_commands
@@ -1791,7 +1791,7 @@ class NodeManager:
                     # Set the Node name
                     param_request.node_name = result.node_name
                     # Set the new value
-                    table = GriptapeNodes.ContextManager().clipboard.parameter_uuid_to_values
+                    table = GriptapeNodes.ContextManager()._clipboard.parameter_uuid_to_values
                     if table and parameter_command.unique_value_uuid in table:
                         value = table[parameter_command.unique_value_uuid]
                         # Using try-except-pass instead of contextlib.suppress because it's clearer.

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1705,20 +1705,21 @@ class NodeManager:
             if flow is None:
                 # TODO: Create error
                 return SerializeNodeToCommandsResultFailure()
-            node_connections = [
-                flow.connections.connections[connection_id]
-                for category_dict in flow.connections.outgoing_index[node_name].values()
-                for connection_id in category_dict
-            ]
-            for connection in node_connections:
-                if connection.target_node.name not in sorted_nodes:
-                    continue
-                connections_to_serialize.append(connection)
+            if node_name in flow.connections.outgoing_index:
+                node_connections = [
+                    flow.connections.connections[connection_id]
+                    for category_dict in flow.connections.outgoing_index[node_name].values()
+                    for connection_id in category_dict
+                ]
+                for connection in node_connections:
+                    if connection.target_node.name not in [values[0] for values in sorted_nodes]:
+                        continue
+                    connections_to_serialize.append(connection)
         serialized_connections = []
         for connection in connections_to_serialize:
             connection = cast("Connection",connection)
-            source_node_uuid = node_commands[connection.get_source_node().name].node_uuid
-            target_node_uuid = node_commands[connection.get_target_node().name].node_uuid
+            source_node_uuid = node_commands[connection.get_source_node().name].serialized_node_commands.node_uuid
+            target_node_uuid = node_commands[connection.get_target_node().name].serialized_node_commands.node_uuid
             serialized_connections.append(
                 SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization(
                     source_node_uuid=source_node_uuid,

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1793,7 +1793,13 @@ class NodeManager:
                     # Set the new value
                     table = GriptapeNodes.ContextManager().clipboard.parameter_uuid_to_values
                     if table and parameter_command.unique_value_uuid in table:
-                        param_request.value = table[parameter_command.unique_value_uuid]
+                        value = table[parameter_command.unique_value_uuid]
+                        # Using try-except-pass instead of contextlib.suppress because it's clearer.
+                        try:  # noqa: SIM105
+                            # If we're pasting multiple times - we need to create a new copy for each paste so they don't all have the same reference.
+                            value = value.copy()
+                        except Exception:  # noqa: S110
+                            pass
                         set_parameter_result = GriptapeNodes.handle_request(
                             parameter_command.set_parameter_value_command
                         )

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -12,7 +12,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterTypeBuiltin,
 )
 from griptape_nodes.exe_types.flow import ControlFlow
-from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+from griptape_nodes.exe_types.node_types import BaseNode, Connection, NodeResolutionState
 from griptape_nodes.exe_types.type_validator import TypeValidator
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
@@ -1714,16 +1714,22 @@ class NodeManager:
                 connections_to_serialize.append(connection)
         serialized_connections = []
         for connection in connections_to_serialize:
+            connection = cast("Connection",connection)
+            source_node_uuid = node_commands[connection.get_source_node().name].node_uuid
+            target_node_uuid = node_commands[connection.get_target_node().name].node_uuid
             serialized_connections.append(
                 SerializeSelectedNodestoCommandsResultSuccess.IndirectConnectionSerialization(
-                    source_node_uuid=
+                    source_node_uuid=source_node_uuid,
+                    source_parameter_name=connection.source_parameter.name,
+                    target_node_uuid=target_node_uuid,
+                    target_parameter_name=connection.target_parameter.name
                 )
             )
         # Final result for serialized node commands
-        final_result = SerializedSelectedNodeCommands(node_commands=node_commands, parameter_commands=parameter_commands)
+        final_result = SerializedSelectedNodeCommands(node_commands=list(node_commands.values()), parameter_commands=parameter_commands)
 
         # Now we have the node and parameter commands. Get Connections
-        return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=final_result, serialized_connection_commands=[])
+        return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=final_result, serialized_connection_commands=serialized_connections)
             # now we have all of our node commands. we need connections as well.
 
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -23,6 +23,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     ResultPayloadFailure,
 )
 from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
     DeleteConnectionRequest,
     DeleteConnectionResultFailure,
     IncomingConnection,
@@ -1732,8 +1733,11 @@ class NodeManager:
         final_result = list(node_commands.values())
 
         # Now we have the node and parameter commands. Get Connections
-        return SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=final_result, serialized_connection_commands=serialized_connections)
+        yay =  SerializeSelectedNodestoCommandsResultSuccess(serialized_node_commands=final_result, serialized_connection_commands=serialized_connections)
+        # testing
+        #self.on_deserialize_selected_nodes_from_commands(request=DeserializeSelectedNodesFromCommandsRequest(serialized_node_commands=final_result, serialzed_connection_commands=serialized_connections))
             # now we have all of our node commands. we need connections as well.
+        return yay
 
     def on_deserialize_selected_nodes_from_commands(self, request:DeserializeSelectedNodesFromCommandsRequest) -> ResultPayload:
         serialized_node_commands = request.serialized_node_commands
@@ -1752,8 +1756,15 @@ class NodeManager:
                     param_request.node_name = result.node_name
                     set_parameter_result = GriptapeNodes.handle_request(parameter_command.set_parameter_value_command)
                     # TODO: What do i need to do to finish this off
+        # create Connections
         for connection_command in connections:
-            pass
+            connection_request = CreateConnectionRequest(
+                source_node_name=node_uuid_to_name[connection_command.source_node_uuid],
+                source_parameter_name=connection_command.source_parameter_name,
+                target_node_name=node_uuid_to_name[connection_command.target_node_uuid],
+                target_parameter_name=connection_command.target_parameter_name
+            )
+            result = GriptapeNodes.handle_request(connection_request)
         return DeserializeSelectedNodesFromCommandsResultSuccess(node_names=list(node_uuid_to_name.values()))
 
 

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -261,4 +261,3 @@ class ObjectManager:
                     GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(child.name, obj.name))
                     return
         del self._name_to_objects[name]
-

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -37,9 +37,11 @@ logger = logging.getLogger("griptape_nodes")
 
 class ObjectManager:
     _name_to_objects: dict[str, object]
+    _selected_objects: list[object]
 
     def __init__(self, _event_manager: EventManager) -> None:
         self._name_to_objects = {}
+        self._selected_objects = []
         _event_manager.assign_manager_to_request_type(
             request_type=RenameObjectRequest, callback=self.on_rename_object_request
         )
@@ -105,7 +107,8 @@ class ObjectManager:
             )
             return ClearAllObjectStateResultFailure()
         # Let's try and clear it all.
-
+        # Clear selected objects
+        self._selected_objects.clear()
         # Cancel any running flows.
         flows = self.get_filtered_subset(type=ControlFlow)
         for flow_name, flow in flows.items():
@@ -262,3 +265,6 @@ class ObjectManager:
                     GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(child.name, obj.name))
                     return
         del self._name_to_objects[name]
+
+    def clear_selected_objects(self) -> None:
+        self._selected_objects.clear()

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -133,7 +133,7 @@ class ObjectManager:
                     context_mgr.pop_node()
                 context_mgr.pop_flow()
             context_mgr.pop_workflow()
-        context_mgr.clipboard.clear()
+        context_mgr._clipboard.clear()
         details = "Successfully cleared all object state (deleted everything)."
         logger.debug(details)
         return ClearAllObjectStateResultSuccess()

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -123,7 +123,7 @@ class ObjectManager:
             logger.error(details)
             return ClearAllObjectStateResultFailure()
 
-        # Clare the current context.
+        # Clear the current context.
         context_mgr = GriptapeNodes.ContextManager()
         while context_mgr.has_current_workflow():
             while context_mgr.has_current_flow():
@@ -133,7 +133,7 @@ class ObjectManager:
                     context_mgr.pop_node()
                 context_mgr.pop_flow()
             context_mgr.pop_workflow()
-
+        context_mgr.clipboard.clear()
         details = "Successfully cleared all object state (deleted everything)."
         logger.debug(details)
         return ClearAllObjectStateResultSuccess()

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -37,11 +37,9 @@ logger = logging.getLogger("griptape_nodes")
 
 class ObjectManager:
     _name_to_objects: dict[str, object]
-    _selected_objects: list[object]
 
     def __init__(self, _event_manager: EventManager) -> None:
         self._name_to_objects = {}
-        self._selected_objects = []
         _event_manager.assign_manager_to_request_type(
             request_type=RenameObjectRequest, callback=self.on_rename_object_request
         )
@@ -107,8 +105,6 @@ class ObjectManager:
             )
             return ClearAllObjectStateResultFailure()
         # Let's try and clear it all.
-        # Clear selected objects
-        self._selected_objects.clear()
         # Cancel any running flows.
         flows = self.get_filtered_subset(type=ControlFlow)
         for flow_name, flow in flows.items():
@@ -266,5 +262,3 @@ class ObjectManager:
                     return
         del self._name_to_objects[name]
 
-    def clear_selected_objects(self) -> None:
-        self._selected_objects.clear()


### PR DESCRIPTION
closes #1153 

Creates several new events:
`SerializeSelectedNodestoCommandsRequest` which takes a list of the node names and the timestamp they were selected.
`DeserializeSelectedNodesFromCommandsRequest` which takes no parameters. 
`DuplicateSelectedNodesRequest` which takes a list of the node names and the timestamp they were selected.

For Cmd C - `SerializeSelectedNodestoCommandsRequest`, which copies
For Cmd V -`DeserializeSelectedNodesFromCommandsRequest`, which pastes
For Cmd D- `DuplicateSelectedNodesRequest` which copies and pastes together. 


These should allow all selected nodes, their parameter values, and their connections between each other to be serialized and deserialized on paste. 