### PR TITLE
Fix Audio and Image Node

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/audio/load_audio.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/audio/load_audio.py
@@ -15,13 +15,14 @@ class LoadAudio(DataNode):
             input_types=["AudioArtifact", "AudioUrlArtifact"],
             type="AudioArtifact",
             output_type="AudioUrlArtifact",
+            default_value=None,
             ui_options={"clickable_file_browser": True, "expander": True},
             tooltip="The audio that has been generated.",
         )
         self.add_parameter(audio_parameter)
 
     def process(self) -> None:
-        audio = self.parameter_values["audio"]
+        audio = self.get_parameter_value("audio")
 
         if isinstance(audio, dict):
             audio_artifact = dict_to_audio_url_artifact(audio)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
@@ -15,6 +15,7 @@ class LoadImage(DataNode):
             input_types=["ImageArtifact", "ImageUrlArtifact"],
             type="ImageArtifact",
             output_type="ImageUrlArtifact",
+            default_value=None,
             ui_options={"clickable_file_browser": True, "expander": True},
             tooltip="The image that has been generated.",
         )
@@ -22,7 +23,7 @@ class LoadImage(DataNode):
         # Add input parameter for model selection
 
     def process(self) -> None:
-        image = self.parameter_values["image"]
+        image = self.get_parameter_value("image")
 
         if isinstance(image, dict):
             image_artifact = dict_to_image_url_artifact(image)


### PR DESCRIPTION
Quick two line changes to prevent the LoadImage and LoadAudio nodes from breaking when they are not set. 