### PR TITLE
Stores rejected hash values, too, to prevent unnecessary serialization attempts of large values. Wraps it into a class.

### DIFF
--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -218,16 +218,16 @@ class SerializedNodeCommands:
 
 @dataclass
 class ValueSerializationState:
-    class Serializable_State(ABC):
+    class State(ABC):
         pass
 
-    class Serializable(Serializable_State):
+    class Serializable(State):
         uuid: SerializedNodeCommands.UniqueParameterValueUUID
 
-    class NotSerializable(Serializable_State):
+    class NotSerializable(State):
         pass
 
-    _value_hash_to_unique_value_uuid: dict[Any, ValueSerializationState.Serializable_State]
+    _value_hash_to_unique_value_uuid: dict[Any, State]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from dataclasses import dataclass, field
 from typing import Any, NewType
 from uuid import uuid4
@@ -213,6 +214,20 @@ class SerializedNodeCommands:
     element_modification_commands: list[RequestPayload]
     node_library_details: LibraryNameAndVersion
     node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(str(uuid4())))
+
+
+@dataclass
+class ValueSerializationState:
+    class Serializable_State(ABC):
+        pass
+
+    class Serializable(Serializable_State):
+        uuid: SerializedNodeCommands.UniqueParameterValueUUID
+
+    class NotSerializable(Serializable_State):
+        pass
+
+    _value_hash_to_unique_value_uuid: dict[Any, ValueSerializationState.Serializable_State]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -76,6 +76,7 @@ from griptape_nodes.retained_mode.events.node_events import (
     DeleteNodeRequest,
     DeleteNodeResultFailure,
     DeserializeNodeFromCommandsRequest,
+    SerializedParameterValueTracker,
     SerializeNodeToCommandsRequest,
     SerializeNodeToCommandsResultSuccess,
 )
@@ -1132,7 +1133,7 @@ class FlowManager:
         # Track all parameter values that were in use by these Nodes (maps UUID to Parameter value)
         unique_parameter_uuid_to_values = {}
         # And track how values map into that map.
-        value_hash_to_unique_value_uuid = {}
+        serialized_parameter_value_tracker = SerializedParameterValueTracker()
 
         with GriptapeNodes.ContextManager().flow(flow_name):
             # The base flow creation, if desired.
@@ -1162,7 +1163,7 @@ class FlowManager:
                     # This might be dangerous if done over the wire.
                     serialize_node_request = SerializeNodeToCommandsRequest(
                         unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,  # Unique values
-                        value_hash_to_unique_value_uuid=value_hash_to_unique_value_uuid,  # Mapping values to UUIDs
+                        serialized_parameter_value_tracker=serialized_parameter_value_tracker,  # Mapping values to UUIDs
                     )
                     serialize_node_result = GriptapeNodes().handle_request(serialize_node_request)
                     if not isinstance(serialize_node_result, SerializeNodeToCommandsResultSuccess):

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1890,7 +1890,12 @@ class NodeManager:
                     return None
                 # The value should be serialized. Add it to the map of uniques.
                 unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
-                unique_parameter_uuid_to_values[unique_uuid] = value
+                try:
+                    unique_parameter_uuid_to_values[unique_uuid] = value.copy()
+                except Exception:
+                    details = f"Attempted to serialize parameter '{parameter_name}` on node '{node_name}'. The parameter value could not be copied. It will be serialized by value. If problems arise from this, ensure the type '{type(value)}' properly implements copy()."
+                    logger.warning(details)
+                    unique_parameter_uuid_to_values[unique_uuid] = value
                 serialized_parameter_value_tracker.add_as_serializable(value_id, unique_uuid)
 
         # Serialize it

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1848,12 +1848,14 @@ class NodeManager:
         return diff
 
     @staticmethod
-    def _handle_value_hashing(
+    def _handle_value_hashing(  # noqa: PLR0913
         value: Any,
-        value_hash_to_unique_value_uuid: dict,
+        serialized_parameter_value_tracker: SerializedParameterValueTracker,
         unique_parameter_uuid_to_values: dict,
-        is_output: bool,  # noqa: FBT001
         parameter_name: str,
+        node_name: str,
+        *,
+        is_output: bool,
     ) -> SerializedNodeCommands.IndirectSetParameterValueCommand | None:
         try:
             hash(value)
@@ -1876,17 +1878,18 @@ class NodeManager:
                 # Confirm that the author wants this parameter and/or class to be serialized.
                 # TODO: https://github.com/griptape-ai/griptape-nodes/issues/1179 ID a method for classes and/or parameters to be flagged for NOT serializability.
 
-            # Check if we can serialize it.
-            try:
-                pickle.dumps(value)
-            except Exception:
-                return None
-            # The value should be serialized. Add it to the map of uniques.
-            unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
-            value_hash_to_unique_value_uuid[value_id] = unique_uuid
-            try:
-                unique_parameter_uuid_to_values[unique_uuid] = value.copy()
-            except Exception:
+                # Check if we can serialize it.
+                try:
+                    pickle.dumps(value)
+                except Exception as err:
+                    # Not serializable; don't waste time on future attempts.
+                    serialized_parameter_value_tracker.add_as_not_serializable(value_id)
+
+                    details = f"Attempted to serialize parameter '{parameter_name}' on node '{node_name}'. The value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializaibilty or mark the parameter as not serializable. Error: {err}."
+                    logger.warning(details)
+                    return None
+                # The value should be serialized. Add it to the map of uniques.
+                unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
                 unique_parameter_uuid_to_values[unique_uuid] = value
                 serialized_parameter_value_tracker.add_as_serializable(value_id, unique_uuid)
 
@@ -1908,7 +1911,7 @@ class NodeManager:
         parameter: Parameter,
         node: BaseNode,
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
-        value_hash_to_unique_value_uuid: dict[Any, SerializedNodeCommands.UniqueParameterValueUUID],
+        serialized_parameter_value_tracker: SerializedParameterValueTracker,
     ) -> list[SerializedNodeCommands.IndirectSetParameterValueCommand] | None:
         """Generates code to save a parameter value for a node in a Griptape workflow.
 
@@ -1924,7 +1927,7 @@ class NodeManager:
             parameter (Parameter): The parameter object containing metadata
             node (BaseNode): The node object that contains the parameter
             unique_parameter_uuid_to_values (dict[SerializedNodeCommands.UniqueParameterValueUUID, Any]): Dictionary mapping unique value UUIDs to values
-            value_hash_to_unique_value_uuid (dict[Any, SerializedNodeCommands.UniqueParameterValueUUID]): Dictionary mapping value hashes to unique value UUIDs
+            serialized_parameter_value_tracker (SerializedParameterValueTracker): Object mapping maintaining value hashes to unique value UUIDs, and non-serializable values
 
         Returns:
             None (if no value to be serialized) or an IndirectSetParameterValueCommand linking the value to the unique value map
@@ -1948,7 +1951,12 @@ class NodeManager:
         commands = []
         if internal_value is not None:
             internal_command = NodeManager._handle_value_hashing(
-                internal_value, value_hash_to_unique_value_uuid, unique_parameter_uuid_to_values, False, parameter.name
+                value=internal_value,
+                serialized_parameter_value_tracker=serialized_parameter_value_tracker,
+                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+                is_output=False,
+                parameter_name=parameter.name,
+                node_name=node.name,
             )
             if internal_command is None:
                 details = f"Attempted to serialize set value for parameter'{parameter.name}' on node '{node.name}'. The set value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializaibilty or mark the parameter as not serializable."
@@ -1957,7 +1965,12 @@ class NodeManager:
                 commands.append(internal_command)
         if output_value is not None:
             output_command = NodeManager._handle_value_hashing(
-                output_value, value_hash_to_unique_value_uuid, unique_parameter_uuid_to_values, True, parameter.name
+                value=output_value,
+                serialized_parameter_value_tracker=serialized_parameter_value_tracker,
+                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+                is_output=True,
+                parameter_name=parameter.name,
+                node_name=node.name,
             )
             if output_command is None:
                 details = f"Attempted to serialize output value for parameter '{parameter.name}' on node '{node.name}'. The output value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializaibilty or mark the parameter as not serializable."

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1881,12 +1881,10 @@ class NodeManager:
                 # Check if we can serialize it.
                 try:
                     pickle.dumps(value)
-                except Exception as err:
+                except Exception:
                     # Not serializable; don't waste time on future attempts.
                     serialized_parameter_value_tracker.add_as_not_serializable(value_id)
-
-                    details = f"Attempted to serialize parameter '{parameter_name}' on node '{node_name}'. The value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializaibilty or mark the parameter as not serializable. Error: {err}."
-                    logger.warning(details)
+                    # Bail.
                     return None
                 # The value should be serialized. Add it to the map of uniques.
                 unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))


### PR DESCRIPTION
Closes #1211 