### PR TITLE
Save Resolution State

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1125,7 +1125,7 @@ class NodeManager:
         return result
 
     # added ignoring C901 since this method is overly long because of granular error checking, not actual complexity.
-    def on_set_parameter_value_request(self, request: SetParameterValueRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
+    def on_set_parameter_value_request(self, request: SetParameterValueRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1184,12 +1184,13 @@ class NodeManager:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
             logger.error(details)
             return SetParameterValueResultFailure()
-        try:
-            parent_flow.connections.unresolve_future_nodes(node)
-        except Exception as err:
-            details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because Exception: {err}"
-            logger.error(details)
-            return SetParameterValueResultFailure()
+        if not request.initial_setup:
+            try:
+                parent_flow.connections.unresolve_future_nodes(node)
+            except Exception as err:
+                details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because Exception: {err}"
+                logger.error(details)
+                return SetParameterValueResultFailure()
 
         # Values are actually stored on the NODE.
         try:
@@ -1614,7 +1615,7 @@ class NodeManager:
                 specific_library_name=library_details.library_name,
                 metadata=node.metadata.copy(),
                 # If it is actively resolving, mark as unresolved.
-                resolution= NodeResolutionState.RESOLVED if node.state == NodeResolutionState.RESOLVED else NodeResolutionState.UNRESOLVED
+                resolution=node.state.value,
             )
 
             # We're going to compare this node instance vs. a canonical one. Rez that one up.

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1613,6 +1613,8 @@ class NodeManager:
                 node_name=node_name,
                 specific_library_name=library_details.library_name,
                 metadata=node.metadata.copy(),
+                # If it is actively resolving, mark as unresolved.
+                resolution= NodeResolutionState.RESOLVED if node.state == NodeResolutionState.RESOLVED else NodeResolutionState.UNRESOLVED
             )
 
             # We're going to compare this node instance vs. a canonical one. Rez that one up.


### PR DESCRIPTION
closes #1200 
When saving a workflow, it saves resolution state so you can pick up where you left off:
without running the whole workflow. 