### PR TITLE
Add randomize seed flags to flux pipelines

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/seed_parameter.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/seed_parameter.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+import torch  # type: ignore[reportMissingImports]
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import BaseNode
+
+
+class SeedParameter:
+    def __init__(self, node: BaseNode):
+        self._node = node
+
+    def add_input_parameters(self) -> None:
+        self._node.add_parameter(
+            Parameter(
+                name="randomize_seed",
+                input_types=["bool"],
+                type="bool",
+                output_type="bool",
+                tooltip="randomize the seed on each run",
+                default_value=False,
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="seed",
+                input_types=["int"],
+                type="int",
+                tooltip="seed",
+                default_value=42,
+            )
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any, modified_parameters_set: set[str]) -> None:
+        if parameter.name != "randomize_seed":
+            return
+
+        seed_parameter = self._node.get_parameter_by_name("seed")
+        if not seed_parameter:
+            msg = "Seed parameter not found"
+            raise RuntimeError(msg)
+
+        if value:
+            # Disable editing the seed if randomize_seed is True
+            seed_parameter.allowed_modes = {ParameterMode.OUTPUT}
+        else:
+            # Enable editing the seed if randomize_seed is False
+            seed_parameter.allowed_modes = {ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT}
+
+        modified_parameters_set.add("seed")
+
+    def preprocess(self) -> None:
+        if self._node.get_parameter_value("randomize_seed"):
+            self._node.publish_update_to_parameter("seed", torch.Generator().seed())
+
+    def get_seed(self) -> int:
+        return int(self._node.get_parameter_value("seed"))
+
+    def get_generator(self) -> torch.Generator:
+        return torch.Generator().manual_seed(self.get_seed())

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
@@ -14,6 +14,7 @@ from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
 )
 
 from diffusers_nodes_library.common.parameters.huggingface_repo_parameter import HuggingFaceRepoParameter
+from diffusers_nodes_library.common.parameters.seed_parameter import SeedParameter
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 
@@ -29,6 +30,7 @@ class DiptychFluxFillPipelineParameters:
                 "black-forest-labs/FLUX.1-Fill-dev",
             ],
         )
+        self._seed_parameter = SeedParameter(node)
         self._input_image_size = (None, None)
 
     def add_input_parameters(self) -> None:
@@ -98,14 +100,7 @@ class DiptychFluxFillPipelineParameters:
                 ui_options={"slider": {"min_val": 1, "max_val": 100}, "step": 1},
             )
         )
-        self._node.add_parameter(
-            Parameter(
-                name="seed",
-                input_types=["int"],
-                type="int",
-                tooltip="optional - random seed, default is random seed",
-            )
-        )
+        self._seed_parameter.add_input_parameters()
 
     def add_output_parameters(self) -> None:
         self._node.add_parameter(
@@ -121,11 +116,17 @@ class DiptychFluxFillPipelineParameters:
         errors = self._huggingface_repo_parameter.validate_before_node_run() or []
         return errors or None
 
+    def after_value_set(self, parameter: Parameter, value: Any, modified_parameters_set: set[str]) -> None:
+        self._seed_parameter.after_value_set(parameter, value, modified_parameters_set)
+
     def validate_before_node_process(self) -> None:
         input_image_pil = self.get_input_image_pil()
         if input_image_pil.width != 512:  # noqa: PLR2004
             msg = f"The input image's width must be 512. Current width: {input_image_pil.width}"
             raise RuntimeError(msg)
+
+    def preprocess(self) -> None:
+        self._seed_parameter.preprocess()
 
     def get_repo_revision(self) -> tuple[str, str]:
         return self._huggingface_repo_parameter.get_repo_revision()

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline.py
@@ -18,6 +18,7 @@ from diffusers_nodes_library.pipelines.flux.flux_loras_parameter import FluxLora
 from diffusers_nodes_library.pipelines.flux.flux_pipeline_memory_footprint import (
     optimize_flux_pipeline_memory_footprint,
 )  # type: ignore[reportMissingImports]
+from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 
 logger = logging.getLogger("diffusers_nodes_library")
@@ -45,10 +46,14 @@ class FluxFillPipeline(ControlNode):
         errors = self.pipe_params.validate_before_node_run()
         return errors or None
 
+    def after_value_set(self, parameter: Parameter, value: Any, modified_parameters_set: set[str]) -> None:
+        self.pipe_params.after_value_set(parameter, value, modified_parameters_set)
+
     def process(self) -> AsyncResult | None:
         yield lambda: self._process()
 
     def _process(self) -> AsyncResult | None:
+        self.pipe_params.preprocess()
         self.pipe_params.validate_before_node_process()
         self.pipe_params.publish_output_image_preview_placeholder()
         self.log_params.append_to_logs("Preparing models...\n")

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline.py
@@ -15,6 +15,7 @@ from diffusers_nodes_library.pipelines.flux.flux_pipeline_memory_footprint impor
 from diffusers_nodes_library.pipelines.flux.flux_pipeline_parameters import (
     FluxPipelineParameters,  # type: ignore[reportMissingImports]
 )
+from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 
 logger = logging.getLogger("diffusers_nodes_library")
@@ -31,6 +32,9 @@ class FluxPipeline(ControlNode):
         self.pipe_params.add_output_parameters()
         self.log_params.add_output_parameters()
 
+    def after_value_set(self, parameter: Parameter, value: Any, modified_parameters_set: set[str]) -> None:
+        self.pipe_params.after_value_set(parameter, value, modified_parameters_set)
+
     def validate_before_node_run(self) -> list[Exception] | None:
         errors = self.pipe_params.validate_before_node_run()
         return errors or None
@@ -39,6 +43,7 @@ class FluxPipeline(ControlNode):
         yield lambda: self._process()
 
     def _process(self) -> AsyncResult | None:
+        self.pipe_params.preprocess()
         self.pipe_params.publish_output_image_preview_placeholder()
         self.log_params.append_to_logs("Preparing models...\n")
 


### PR DESCRIPTION
Adding a "randomize_seed" toggle to the flux pipelines.
If randomize_seed is false, has an input pin and is editable.
If randomize_seed is true, has no input pin, is not editable, and generates a new seed at the start of a run. The new seed is displayed for reproducibility and also supplies an output pin for chaining.

Amaru approved in slack, but I'll add him here too.

I want to merge this despite the following caveats because the feature is usable and still better than current CX (even with the bugs):
- ~~https://github.com/griptape-ai/griptape-nodes/issues/1233~~  
   fixed by https://github.com/griptape-ai/griptape-vsl-gui/pull/758
- https://github.com/griptape-ai/griptape-nodes/issues/1234

Resolves #1215 

![Screenshot 2025-05-16 at 4 05 28 PM](https://github.com/user-attachments/assets/0d7aa35e-93c2-4c98-8287-0fc80674986c)
![Screenshot 2025-05-16 at 4 05 45 PM](https://github.com/user-attachments/assets/8484c882-8bee-4aaa-953b-dbe3ba4d4cd3)
![Screenshot 2025-05-16 at 4 05 54 PM](https://github.com/user-attachments/assets/e05354e4-d737-44b3-a935-48cc2874824e)

