### PR TITLE
Feature/set_parameter_to_default_value

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/agents/agent.py
@@ -220,6 +220,11 @@ class Agent(ControlNode):
         target_parameter: Parameter,
         modified_parameters_set: set[str],
     ) -> None:
+        # Reset to default values
+        if any(param in target_parameter.name for param in ["tool", "ruleset", "agent", "model"]):
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
         # If the agent connection is removed, show agent creation parameters.
         if target_parameter.name == "agent":
             params_to_toggle = ["model", "tools", "rulesets"]
@@ -231,12 +236,8 @@ class Agent(ControlNode):
             target_parameter.type = "str"
             target_parameter.add_trait(Options(choices=MODEL_CHOICES))
             # Sometimes the value is not set to the default value - these are all attemnpts to get it to work.
-            target_parameter.set_default_value(DEFAULT_MODEL)
-            target_parameter.default_value = DEFAULT_MODEL
             self.set_parameter_value("model", DEFAULT_MODEL)
-
             target_parameter._ui_options["display_name"] = "prompt model"
-
             modified_parameters_set.add("model")
 
         # If the additional context connection is removed, make it editable again.

--- a/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_bool.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_bool.py
@@ -43,6 +43,21 @@ class ToBool(DataNode):
     ) -> None:
         pass
 
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "from":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
     def to_bool(self, input_value: Any) -> bool:
         result = False  # Default return value
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_dict.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_dict.py
@@ -44,6 +44,21 @@ class ToDictionary(DataNode):
     ) -> None:
         pass
 
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "from":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
     def process(self) -> None:
         # Get the input value
         params = self.parameter_values

--- a/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_float.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_float.py
@@ -44,6 +44,21 @@ class ToFloat(DataNode):
     ) -> None:
         pass
 
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "from":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
     def to_float(self, input_value: Any) -> float:
         result = 0.0  # Default return value
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_int.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_int.py
@@ -44,6 +44,21 @@ class ToInteger(DataNode):
     ) -> None:
         pass
 
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "from":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
     def to_int(self, input_value: Any) -> int:
         result = 0  # Default return value
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_text.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/convert/to_text.py
@@ -43,6 +43,21 @@ class ToText(DataNode):
     ) -> None:
         pass
 
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "from":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
     def process(self) -> None:
         # Get the input value
         params = self.parameter_values

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/display_dict.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/display_dict.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.node_types import BaseNode, DataNode
 
 
 class DisplayDictionary(DataNode):
@@ -33,6 +33,21 @@ class DisplayDictionary(DataNode):
                 ui_options={"multiline": True, "placeholder_text": "The dictionary content will be displayed here."},
                 allowed_modes={ParameterMode.PROPERTY},
             )
+        )
+
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "dictionary":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
         )
 
     def process(self) -> None:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/merge_key_value_pair.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/merge_key_value_pair.py
@@ -5,7 +5,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterList,
     ParameterMode,
 )
-from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.node_types import BaseNode, DataNode
 
 
 class MergeKeyValuePairs(DataNode):
@@ -34,6 +34,21 @@ class MergeKeyValuePairs(DataNode):
                 default_value="",
                 tooltip="The merged key value pair result.",
             )
+        )
+
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if "KeyValuePair" in target_parameter.name:
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
         )
 
     def get_kv_pairs(self) -> list:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/save_dict.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/save_dict.py
@@ -5,7 +5,7 @@ from griptape_nodes.exe_types.core_types import (
     Parameter,
     ParameterMode,
 )
-from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.node_types import BaseNode, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes.traits.button import Button
 
@@ -38,6 +38,21 @@ class SaveDictionary(ControlNode):
                 tooltip="The output filename",
                 traits={Button(button_type="save")},
             )
+        )
+
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "dict":
+            self.set_parameter_to_default_value(target_parameter.name)
+            modified_parameters_set.add(target_parameter.name)
+
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
         )
 
     def process(self) -> None:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/compare_numbers.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/compare_numbers.py
@@ -33,7 +33,7 @@ class CompareNumbers(BaseNode):
                 input_types=["str"],
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=["A == B", "A != B", "A < B", "A > B", "A <= B", "A >= B"])},
-                default_value="==",
+                default_value="A == B",
             )
         )
         self.add_parameter(

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/create_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/create_image.py
@@ -271,6 +271,9 @@ IMPORTANT: Output must be a single, raw prompt string for an image generation mo
         modified_parameters_set: set[str],
     ) -> None:
         """Callback after a Connection TO this Node was REMOVED."""
+        if target_parameter.name == "agent":
+            self.set_parameter_to_default_value("model")
+
         # Remove the state maintenance of the connection to the prompt Parameter
         if target_parameter.name == "prompt":
             self._has_connection_to_prompt = False

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
@@ -140,6 +140,7 @@ class DescribeImage(ControlNode):
         modified_parameters_set: set[str],
     ) -> None:
         if target_parameter.name == "agent":
+            self.set_parameter_to_default_value("agent")
             self.show_parameter_by_name("model")
             modified_parameters_set.add("model")
         # Check and see if the incoming connection is from an agent. If so, we'll hide the model parameter

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -273,6 +273,18 @@ class BaseNode(ABC):
         """Shows one or more parameters by name."""
         self._set_parameter_visibility(names, visible=True)
 
+    def set_parameter_to_default_value(self, param_name: str) -> None:
+        """Sets a Parameter's value to its default value.
+
+        Args:
+            param_name: the name of the Parameter on this node that is about to be changed
+        """
+        parameter = self.get_parameter_by_name(param_name)
+        if parameter is None:
+            err = f"Attempted to set value for Parameter '{param_name}' but no such Parameter could be found."
+            raise KeyError(err)
+        self.set_parameter_value(param_name, parameter.default_value)
+
     def initialize_spotlight(self) -> None:
         # Make a deep copy of all of the parameters and create the linked list.
         curr_param = None


### PR DESCRIPTION
fixes #1238

Adds a method to BaseNode called `set_parameter_to_default_value` which takes a paramter and resets it to the default value or None.

this is usually called in the `after_incoming_connection_removed` method on a node to ensure values are reset to the expected default.