### PR TITLE
Adds a Sandbox Library setting that automatically loads Python files located within a Sandbox directory

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -84,6 +84,8 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.1.0"
+
     name: str
     library_schema_version: str
     metadata: LibraryMetadata

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -54,6 +54,10 @@ class Settings(BaseModel):
         default="staticfiles",
         description="Path to the static files directory, relative to the workspace directory.",
     )
+    sandbox_library_directory: str = Field(
+        default="sandbox_library",
+        description="Path to the sandbox library directory (useful while developing nodes). If presented as just a directory (e.g., 'sandbox_library') it will be interpreted as being relative to the workspace directory.",
+    )
     app_events: AppEvents = Field(default_factory=AppEvents)
     nodes: dict[str, Any] = Field(
         default_factory=lambda: {


### PR DESCRIPTION
Per title, this adds a setting where nodes can be rapidly iterated on.

By default, this goes into the workspace under the "sandbox_library" subdir, but this can be overwritten.

All .py files in that directory are attempted to be loaded as a dynamically-assembled library.

