### PR TITLE
feat: add events for uploading to static server via URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "fastapi>=0.115.12",
   "uvicorn>=0.34.2",
   "packaging>=25.0",
+  "python-multipart>=0.0.20",
 ]
 
 [dependency-groups]

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import binascii
 import json
 import logging
 import os
 import signal
 import sys
 import threading
+from pathlib import Path
 from queue import Queue
 from time import sleep
 from typing import Any, cast
@@ -14,7 +16,7 @@ from urllib.parse import urljoin
 import httpx
 import uvicorn
 from dotenv import get_key
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from griptape.events import (
@@ -137,6 +139,43 @@ def _serve_static_server() -> None:
         StaticFiles(directory=static_dir),
         name="static",
     )
+
+    @app.post("/static-upload-urls")
+    async def create_static_file_upload_url(request: Request) -> dict:
+        """Create a URL for uploading a static file.
+
+        Similar to a presigned URL, but for uploading files to the static server.
+        """
+        base_url = request.base_url
+        body = await request.json()
+        file_name = body["file_name"]
+        url = urljoin(str(base_url), f"/static-uploads/{file_name}")
+
+        return {"url": url}
+
+    @app.put("/static-uploads/{file_name:str}")
+    async def create_static_file(file: UploadFile, file_name: str) -> dict:
+        """Upload a static file to the static server."""
+        if not STATIC_SERVER_ENABLED:
+            msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
+            raise ValueError(msg)
+
+        data = await file.read()
+        if not static_dir.exists():
+            static_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            Path(static_dir / file_name).write_bytes(data)
+        except binascii.Error as e:
+            msg = f"Invalid base64 encoding for file {file_name}."
+            logger.error(msg)
+            raise HTTPException(status_code=400, detail=msg) from e
+        except (OSError, PermissionError) as e:
+            msg = f"Failed to write file {file_name} to {config_manager.workspace_path}: {e}"
+            logger.error(msg)
+            raise HTTPException(status_code=500, detail=msg) from e
+
+        static_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}{STATIC_SERVER_URL}/{file_name}"
+        return {"url": static_url}
 
     @app.post("/engines/request")
     async def create_event(request: Request) -> None:

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -33,3 +33,27 @@ class CreateStaticFileResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucces
 @PayloadRegistry.register
 class CreateStaticFileResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     error: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileUploadUrlRequest(RequestPayload):
+    """Request to create a presigned URL for uploading a static file via a HTTP PUT.
+
+    Args:
+        file_name: Name of the file to be uploaded
+    """
+
+    file_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileUploadUrlResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    url: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileUploadUrlResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    error: str

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -1,14 +1,24 @@
 import base64
 import binascii
 import logging
-from pathlib import Path
+from urllib.parse import urljoin
 
+import httpx
 from xdg_base_dirs import xdg_config_home
 
+from griptape_nodes.app.app import (
+    STATIC_SERVER_ENABLED,
+    STATIC_SERVER_HOST,
+    STATIC_SERVER_PORT,
+    STATIC_SERVER_URL,
+)
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileRequest,
     CreateStaticFileResultFailure,
     CreateStaticFileResultSuccess,
+    CreateStaticFileUploadUrlRequest,
+    CreateStaticFileUploadUrlResultFailure,
+    CreateStaticFileUploadUrlResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -29,9 +39,13 @@ class StaticFilesManager:
             event_manager: The EventManager instance to use for event handling.
         """
         self.config_manager = config_manager
+        self.base_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}{STATIC_SERVER_URL}"
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(
                 CreateStaticFileRequest, self.on_handle_create_static_file_request
+            )
+            event_manager.assign_manager_to_request_type(
+                CreateStaticFileUploadUrlRequest, self.on_handle_create_static_file_upload_url_request
             )
 
     def on_handle_create_static_file_request(
@@ -39,22 +53,73 @@ class StaticFilesManager:
         request: CreateStaticFileRequest,
     ) -> CreateStaticFileResultSuccess | CreateStaticFileResultFailure:
         file_name = request.file_name
+        response = self.on_handle_create_static_file_upload_url_request(
+            CreateStaticFileUploadUrlRequest(file_name=file_name)
+        )
+
+        if isinstance(response, CreateStaticFileUploadUrlResultFailure):
+            msg = f"Failed to create presigned URL for file {file_name}: {response.error}"
+            logger.error(msg)
+            return CreateStaticFileResultFailure(error=msg)
+
         try:
-            url = self.save_static_file(base64.b64decode(request.content), file_name)
-        except binascii.Error:
-            msg = f"Invalid base64 encoding for file {file_name}."
+            content_bytes = base64.b64decode(request.content)
+        except (binascii.Error, ValueError) as e:
+            msg = f"Failed to decode base64 content for file {file_name}: {e}"
             logger.error(msg)
             return CreateStaticFileResultFailure(error=msg)
-        except (OSError, PermissionError) as e:
-            msg = f"Failed to write file {file_name} to {self.config_manager.workspace_path}: {e}"
-            logger.error(msg)
-            return CreateStaticFileResultFailure(error=msg)
-        except ValueError as e:
+
+        try:
+            response = httpx.put(urljoin(response.url, file_name), files={"file": (file_name, content_bytes)})
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
             msg = str(e)
             logger.error(msg)
             return CreateStaticFileResultFailure(error=msg)
-        else:
-            return CreateStaticFileResultSuccess(url=url)
+
+        response_data = response.json()
+        response_url = response_data.get("url")
+        if response_url is None:
+            msg = f"Failed to create static file {file_name}: {response_data}"
+            logger.error(msg)
+            return CreateStaticFileResultFailure(error=msg)
+
+        return CreateStaticFileResultSuccess(url=response_url)
+
+    def on_handle_create_static_file_upload_url_request(
+        self,
+        request: CreateStaticFileUploadUrlRequest,
+    ) -> CreateStaticFileUploadUrlResultSuccess | CreateStaticFileUploadUrlResultFailure:
+        """Handle the request to create a presigned URL for uploading a static file.
+
+        Args:
+            request: The request object containing the file name.
+
+        Returns:
+            A result object indicating success or failure.
+        """
+        file_name = request.file_name
+
+        static_url = urljoin(self.base_url, "/static-upload-urls")
+        try:
+            response = httpx.post(
+                static_url,
+                json={"file_name": file_name},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = f"Failed to create presigned URL for file {file_name}: {e}"
+            logger.error(msg)
+            return CreateStaticFileUploadUrlResultFailure(error=msg)
+
+        response_data = response.json()
+        url = response_data.get("url")
+        if url is None:
+            msg = f"Failed to create presigned URL for file {file_name}: {response_data}"
+            logger.error(msg)
+            return CreateStaticFileUploadUrlResultFailure(error=msg)
+
+        return CreateStaticFileUploadUrlResultSuccess(url=url)
 
     def save_static_file(self, data: bytes, file_name: str) -> str:
         """Saves a static file to the workspace directory.
@@ -68,24 +133,17 @@ class StaticFilesManager:
         Returns:
             The URL of the saved file.
         """
-        from griptape_nodes.app.app import (
-            STATIC_SERVER_ENABLED,
-            STATIC_SERVER_HOST,
-            STATIC_SERVER_PORT,
-            STATIC_SERVER_URL,
-        )
-
         if not STATIC_SERVER_ENABLED:
             msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
             raise ValueError(msg)
 
-        file_path = Path(
-            self.config_manager.workspace_path / self.config_manager.merged_config["static_files_directory"]
+        response = self.on_handle_create_static_file_request(
+            CreateStaticFileRequest(file_name=file_name, content=base64.b64encode(data).decode("utf-8"))
         )
-        if not file_path.exists():
-            file_path.mkdir(parents=True, exist_ok=True)
-        Path(file_path / file_name).write_bytes(data)
 
-        static_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}{STATIC_SERVER_URL}/{file_name}"
+        if isinstance(response, CreateStaticFileResultFailure):
+            msg = f"Failed to create static file {file_name}: {response.error}"
+            logger.error(msg)
+            raise ValueError(msg)  # noqa: TRY004
 
-        return static_url
+        return response.url

--- a/uv.lock
+++ b/uv.lock
@@ -396,6 +396,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "tomlkit" },
     { name = "uv" },
     { name = "uvicorn" },
@@ -434,6 +435,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "uv", specifier = ">=0.6.16" },
     { name = "uvicorn", specifier = ">=0.34.2" },
@@ -1369,6 +1371,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds two new endpoints to the static server:

- `PUT /static-uploads/{file_name:str}`: Accepts a file to upload and saves it to the static files directory. Technically clients can interact with this endpoint directly but it is recommended to use the `/static-upload-urls` first.
- `POST /static-upload-urls`: Generates a URL to the `/static-uploads` endpoint.

A new event has been added to interact with the `static-upload-url` endpoint:

- `CreateStaticFileUploadUrlRequest`

Today the only upload backend we support is the engine's endpoints, but this could be easily generalized for other services (GTC, S3, etc.).

To interact with this endpoint, the caller (UI) will:
1. Make a request to this endpoint to receive a static upload URL. The static upload URL will be specific to the upload backend.
2. Make a request to the URL according to the upload backend. There may be subtle differences in how each backend works and the UI will need to be aware of these to some degree.

The existing `CreateStaticFileRequest` has been updated to use these new endpoints rather than owning the logic itself.