### PR TITLE
fix: determine engine version before runtime deps are installed

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -24,6 +24,7 @@ with console.status("Loading Griptape Nodes...") as status:
     from xdg_base_dirs import xdg_config_home, xdg_data_home
 
     from griptape_nodes.app import start_app
+    from griptape_nodes.retained_mode.griptape_nodes import engine_version
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.os_manager import OSManager
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -490,9 +491,7 @@ def _process_args(args: argparse.Namespace) -> None:  # noqa: C901, PLR0912
 
 def __get_current_version() -> str:
     """Returns the current version of the Griptape Nodes package."""
-    version = importlib.metadata.version("griptape_nodes")
-
-    return f"v{version}"
+    return f"v{engine_version}"
 
 
 def __get_install_source() -> tuple[Literal["git", "file", "pypi"], str | None]:

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import re
 from dataclasses import dataclass
@@ -60,6 +61,9 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("griptape_nodes")
+
+
+engine_version = importlib.metadata.version("griptape_nodes")
 
 
 @dataclass
@@ -240,19 +244,15 @@ class GriptapeNodes(metaclass=SingletonMeta):
             raise ValueError(msg)
 
     def handle_engine_version_request(self, request: GetEngineVersionRequest) -> ResultPayload:  # noqa: ARG002
-        import importlib.metadata
-
         try:
-            engine_version_str = importlib.metadata.version("griptape_nodes")
-
-            engine_ver = Version.from_string(engine_version_str)
+            engine_ver = Version.from_string(engine_version)
             if engine_ver:
                 return GetEngineVersionResultSuccess(
                     major=engine_ver.major,
                     minor=engine_ver.minor,
                     patch=engine_ver.patch,
                 )
-            details = f"Attempted to get engine version. Failed because version string '{engine_version_str}' wasn't in expected major.minor.patch format."
+            details = f"Attempted to get engine version. Failed because version string '{engine_ver}' wasn't in expected major.minor.patch format."
             logger.error(details)
             return GetEngineVersionResultFailure()
         except Exception as err:


### PR DESCRIPTION
Somehow the engine version is being misreported. Presumably from a library that installs `griptape-nodes`. Terrifying. This PR makes it so the engine version is collected at the very start.