### PR TITLE
Added friendlier error message if image URL failed to download. Happens with shared workflows or if staticfiles gets wiped.

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
+++ b/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
@@ -12,12 +12,12 @@ from diffusers_nodes_library.common.parameters.huggingface_repo_parameter import
     HuggingFaceRepoParameter,  # type: ignore[reportMissingImports]
 )
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
     pil_to_image_artifact,  # type: ignore[reportMissingImports]
 )
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode

--- a/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
+++ b/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
@@ -12,7 +12,7 @@ from diffusers_nodes_library.common.parameters.huggingface_repo_parameter import
     HuggingFaceRepoParameter,  # type: ignore[reportMissingImports]
 )
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
@@ -55,12 +55,7 @@ class AnylineDetector(ControlNode):
             logger.exception("No input image specified")
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
         return input_image_pil

--- a/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
+++ b/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
@@ -55,7 +55,12 @@ class AnylineDetector(ControlNode):
             logger.exception("No input image specified")
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
         return input_image_pil

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/flux_control_net_parameters.py
@@ -51,7 +51,12 @@ class FluxControlNetParameters:
     def get_control_image_pil(self) -> Image:
         control_image_artifact = self._node.get_parameter_value("control_image")
         if isinstance(control_image_artifact, ImageUrlArtifact):
-            control_image_artifact = ImageLoader().parse(control_image_artifact.to_bytes())
+            try:
+                image_bytes = control_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{control_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            control_image_artifact = ImageLoader().parse(image_bytes)
         control_image_pil = image_artifact_to_pil(control_image_artifact)
         return control_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/flux_control_net_parameters.py
@@ -1,7 +1,7 @@
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/flux_control_net_parameters.py
@@ -1,5 +1,5 @@
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
 
@@ -51,12 +51,7 @@ class FluxControlNetParameters:
     def get_control_image_pil(self) -> Image:
         control_image_artifact = self._node.get_parameter_value("control_image")
         if isinstance(control_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = control_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{control_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            control_image_artifact = ImageLoader().parse(image_bytes)
+            control_image_artifact = load_image_from_url_artifact(control_image_artifact)
         control_image_pil = image_artifact_to_pil(control_image_artifact)
         return control_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
@@ -65,7 +65,12 @@ class UnionOneFluxControlNetParameters:
     def get_control_image_pil(self) -> Image:
         control_image_artifact = self._node.get_parameter_value("control_image")
         if isinstance(control_image_artifact, ImageUrlArtifact):
-            control_image_artifact = ImageLoader().parse(control_image_artifact.to_bytes())
+            try:
+                image_bytes = control_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{control_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            control_image_artifact = ImageLoader().parse(image_bytes)
         control_image_pil = image_artifact_to_pil(control_image_artifact)
         return control_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
@@ -1,9 +1,9 @@
 from collections import OrderedDict
 
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
 
@@ -65,12 +65,7 @@ class UnionOneFluxControlNetParameters:
     def get_control_image_pil(self) -> Image:
         control_image_artifact = self._node.get_parameter_value("control_image")
         if isinstance(control_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = control_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{control_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            control_image_artifact = ImageLoader().parse(image_bytes)
+            control_image_artifact = load_image_from_url_artifact(control_image_artifact)
         control_image_pil = image_artifact_to_pil(control_image_artifact)
         return control_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
@@ -42,7 +42,12 @@ class UnionTwoFluxControlNetParameters:
     def get_control_image_pil(self) -> Image:
         control_image_artifact = self._node.get_parameter_value("control_image")
         if isinstance(control_image_artifact, ImageUrlArtifact):
-            control_image_artifact = ImageLoader().parse(control_image_artifact.to_bytes())
+            try:
+                image_bytes = control_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{control_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            control_image_artifact = ImageLoader().parse(image_bytes)
         control_image_pil = image_artifact_to_pil(control_image_artifact)
         return control_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
@@ -1,7 +1,7 @@
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
@@ -1,5 +1,5 @@
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
 
@@ -42,12 +42,7 @@ class UnionTwoFluxControlNetParameters:
     def get_control_image_pil(self) -> Image:
         control_image_artifact = self._node.get_parameter_value("control_image")
         if isinstance(control_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = control_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{control_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            control_image_artifact = ImageLoader().parse(image_bytes)
+            control_image_artifact = load_image_from_url_artifact(control_image_artifact)
         control_image_pil = image_artifact_to_pil(control_image_artifact)
         return control_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
@@ -5,12 +5,12 @@ import diffusers  # type: ignore[reportMissingImports]
 import numpy as np
 import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,
     pil_to_image_artifact,
 )
+from utils.image_utils import load_image_from_url_artifact
 
 from diffusers_nodes_library.common.parameters.huggingface_repo_parameter import HuggingFaceRepoParameter
 from diffusers_nodes_library.common.parameters.seed_parameter import SeedParameter

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
@@ -5,7 +5,7 @@ import diffusers  # type: ignore[reportMissingImports]
 import numpy as np
 import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,
@@ -133,12 +133,7 @@ class DiptychFluxFillPipelineParameters:
     def get_input_image_pil(self) -> Image:
         input_image_artifact = self._node.get_parameter_value("input_image")
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         return input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/diptych_flux_fill_pipeline_parameters.py
@@ -133,7 +133,12 @@ class DiptychFluxFillPipelineParameters:
     def get_input_image_pil(self) -> Image:
         input_image_artifact = self._node.get_parameter_value("input_image")
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         return input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline_parameters.py
@@ -4,12 +4,12 @@ from typing import Any
 import diffusers  # type: ignore[reportMissingImports]
 import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,
     pil_to_image_artifact,
 )
+from utils.image_utils import load_image_from_url_artifact
 
 from diffusers_nodes_library.common.parameters.huggingface_repo_parameter import HuggingFaceRepoParameter
 from diffusers_nodes_library.common.parameters.seed_parameter import SeedParameter

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline_parameters.py
@@ -145,14 +145,24 @@ class FluxFillPipelineParameters:
     def get_input_image_pil(self) -> Image:
         input_image_artifact = self._node.get_parameter_value("input_image")
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         return input_image_pil.convert("RGB")
 
     def get_mask_image_pil(self) -> Image:
         mask_image_artifact = self._node.get_parameter_value("mask_image")
         if isinstance(mask_image_artifact, ImageUrlArtifact):
-            mask_image_artifact = ImageLoader().parse(mask_image_artifact.to_bytes())
+            try:
+                image_bytes = mask_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{mask_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            mask_image_artifact = ImageLoader().parse(image_bytes)
         mask_image_pil = image_artifact_to_pil(mask_image_artifact)
         return mask_image_pil.convert("L")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline_parameters.py
@@ -4,7 +4,7 @@ from typing import Any
 import diffusers  # type: ignore[reportMissingImports]
 import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,
@@ -145,24 +145,14 @@ class FluxFillPipelineParameters:
     def get_input_image_pil(self) -> Image:
         input_image_artifact = self._node.get_parameter_value("input_image")
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         return input_image_pil.convert("RGB")
 
     def get_mask_image_pil(self) -> Image:
         mask_image_artifact = self._node.get_parameter_value("mask_image")
         if isinstance(mask_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = mask_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{mask_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            mask_image_artifact = ImageLoader().parse(image_bytes)
+            mask_image_artifact = load_image_from_url_artifact(mask_image_artifact)
         mask_image_pil = image_artifact_to_pil(mask_image_artifact)
         return mask_image_pil.convert("L")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
@@ -125,7 +125,12 @@ class TilingFluxImg2ImgPipeline(ControlNode):
         strength = float(self.get_parameter_value("strength"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
@@ -5,12 +5,12 @@ import diffusers  # type: ignore[reportMissingImports]
 import PIL.Image
 import torch  # type: ignore[reportMissingImports]
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
     pil_to_image_artifact,  # type: ignore[reportMissingImports]
 )
+from utils.image_utils import load_image_from_url_artifact
 
 from diffusers_nodes_library.common.misc.tiling_image_processor import (
     TilingImageProcessor,  # type: ignore[reportMissingImports]

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
@@ -5,7 +5,7 @@ import diffusers  # type: ignore[reportMissingImports]
 import PIL.Image
 import torch  # type: ignore[reportMissingImports]
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
@@ -125,12 +125,7 @@ class TilingFluxImg2ImgPipeline(ControlNode):
         strength = float(self.get_parameter_value("strength"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
@@ -94,7 +94,12 @@ class CannyConvertImage(ControlNode):
         l2_gradient = bool(self.get_parameter_value("l2_gradient"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
 

--- a/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
@@ -5,7 +5,7 @@ import cv2  # type: ignore[reportMissingImports]
 import numpy as np
 import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
     pil_to_image_artifact,  # type: ignore[reportMissingImports]
@@ -94,12 +94,7 @@ class CannyConvertImage(ControlNode):
         l2_gradient = bool(self.get_parameter_value("l2_gradient"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
 

--- a/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
@@ -5,11 +5,11 @@ import cv2  # type: ignore[reportMissingImports]
 import numpy as np
 import PIL.Image
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
     pil_to_image_artifact,  # type: ignore[reportMissingImports]
 )
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/gaussian_blur_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/gaussian_blur_image.py
@@ -52,7 +52,12 @@ class GaussianBlurImage(ControlNode):
         radius = float(self.get_parameter_value("radius"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         output_image_pil = input_image_pil.filter(PIL.ImageFilter.GaussianBlur(radius=radius))

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/gaussian_blur_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/gaussian_blur_image.py
@@ -2,7 +2,7 @@ import logging
 
 import PIL.ImageFilter
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
@@ -52,12 +52,7 @@ class GaussianBlurImage(ControlNode):
         radius = float(self.get_parameter_value("radius"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         output_image_pil = input_image_pil.filter(PIL.ImageFilter.GaussianBlur(radius=radius))

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/grayscale_convert_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/grayscale_convert_image.py
@@ -41,7 +41,12 @@ class GrayscaleConvertImage(ControlNode):
         input_image_artifact = self.get_parameter_value("input_image")
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         output_image_pil = input_image_pil.convert("L")

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/grayscale_convert_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/grayscale_convert_image.py
@@ -1,7 +1,7 @@
 import logging
 
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
@@ -41,12 +41,7 @@ class GrayscaleConvertImage(ControlNode):
         input_image_artifact = self.get_parameter_value("input_image")
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         output_image_pil = input_image_pil.convert("L")

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/rescale_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/rescale_image.py
@@ -75,7 +75,12 @@ class RescaleImage(ControlNode):
         resample_strategy = str(self.get_parameter_value("resample_strategy"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
 

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/rescale_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/rescale_image.py
@@ -1,8 +1,8 @@
 import logging
 
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Resampling
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode

--- a/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/rescale_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/pillow_nodes_library/rescale_image.py
@@ -1,7 +1,7 @@
 import logging
 
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Resampling
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
@@ -75,12 +75,7 @@ class RescaleImage(ControlNode):
         resample_strategy = str(self.get_parameter_value("resample_strategy"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
 
         input_image_pil = image_artifact_to_pil(input_image_artifact)
 

--- a/libraries/griptape_nodes_advanced_media_library/spandrel_nodes_library/tiling_span.py
+++ b/libraries/griptape_nodes_advanced_media_library/spandrel_nodes_library/tiling_span.py
@@ -13,12 +13,12 @@ from diffusers_nodes_library.common.parameters.log_parameter import (  # type: i
     LogParameter,  # type: ignore[reportMissingImports]
 )
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,
     pil_to_image_artifact,
 )
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode

--- a/libraries/griptape_nodes_advanced_media_library/spandrel_nodes_library/tiling_span.py
+++ b/libraries/griptape_nodes_advanced_media_library/spandrel_nodes_library/tiling_span.py
@@ -13,7 +13,7 @@ from diffusers_nodes_library.common.parameters.log_parameter import (  # type: i
     LogParameter,  # type: ignore[reportMissingImports]
 )
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,
@@ -122,12 +122,7 @@ class TilingSPAN(ControlNode):
         tile_strategy = str(self.get_parameter_value("tile_strategy"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/spandrel_nodes_library/tiling_span.py
+++ b/libraries/griptape_nodes_advanced_media_library/spandrel_nodes_library/tiling_span.py
@@ -122,7 +122,12 @@ class TilingSPAN(ControlNode):
         tile_strategy = str(self.get_parameter_value("tile_strategy"))
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/transformers_nodes_library/depth_anything_for_depth_estimation.py
+++ b/libraries/griptape_nodes_advanced_media_library/transformers_nodes_library/depth_anything_for_depth_estimation.py
@@ -152,7 +152,12 @@ class DepthAnythingForDepthEstimation(ControlNode):
         input_image_artifact = self.get_parameter_value("input_image")
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            input_image_artifact = ImageLoader().parse(input_image_artifact.to_bytes())
+            try:
+                image_bytes = input_image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+            input_image_artifact = ImageLoader().parse(image_bytes)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/transformers_nodes_library/depth_anything_for_depth_estimation.py
+++ b/libraries/griptape_nodes_advanced_media_library/transformers_nodes_library/depth_anything_for_depth_estimation.py
@@ -11,13 +11,13 @@ from diffusers_nodes_library.common.utils.huggingface_utils import (  # type: ig
 )
 from diffusers_nodes_library.common.utils.logging_utils import StdoutCapture  # type: ignore[reportMissingImports]
 from griptape.artifacts import ImageUrlArtifact
-from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
     pil_to_image_artifact,  # type: ignore[reportMissingImports]
 )
 from transformers import AutoImageProcessor, AutoModelForDepthEstimation  # type: ignore[reportMissingImports]
+from utils.image_utils import load_image_from_url_artifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode

--- a/libraries/griptape_nodes_advanced_media_library/transformers_nodes_library/depth_anything_for_depth_estimation.py
+++ b/libraries/griptape_nodes_advanced_media_library/transformers_nodes_library/depth_anything_for_depth_estimation.py
@@ -11,7 +11,7 @@ from diffusers_nodes_library.common.utils.huggingface_utils import (  # type: ig
 )
 from diffusers_nodes_library.common.utils.logging_utils import StdoutCapture  # type: ignore[reportMissingImports]
 from griptape.artifacts import ImageUrlArtifact
-from griptape.loaders import ImageLoader
+from utils.image_utils import load_image_from_url_artifact
 from PIL.Image import Image
 from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
     image_artifact_to_pil,  # type: ignore[reportMissingImports]
@@ -152,12 +152,7 @@ class DepthAnythingForDepthEstimation(ControlNode):
         input_image_artifact = self.get_parameter_value("input_image")
 
         if isinstance(input_image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = input_image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{input_image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-            input_image_artifact = ImageLoader().parse(image_bytes)
+            input_image_artifact = load_image_from_url_artifact(input_image_artifact)
         input_image_pil = image_artifact_to_pil(input_image_artifact)
         input_image_pil = input_image_pil.convert("RGB")
 

--- a/libraries/griptape_nodes_advanced_media_library/utils/__init__.py
+++ b/libraries/griptape_nodes_advanced_media_library/utils/__init__.py
@@ -1,1 +1,1 @@
-# Utils for the Advanced Media Library
+"""Util nodes package."""

--- a/libraries/griptape_nodes_advanced_media_library/utils/__init__.py
+++ b/libraries/griptape_nodes_advanced_media_library/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils for the Advanced Media Library

--- a/libraries/griptape_nodes_advanced_media_library/utils/image_utils.py
+++ b/libraries/griptape_nodes_advanced_media_library/utils/image_utils.py
@@ -6,15 +6,14 @@ from requests.exceptions import RequestException
 
 
 def load_image_from_url_artifact(image_url_artifact: ImageUrlArtifact) -> ImageArtifact:
-    """
-    Load an ImageArtifact from an ImageUrlArtifact with proper error handling.
-    
+    """Load an ImageArtifact from an ImageUrlArtifact with proper error handling.
+
     Args:
         image_url_artifact: The ImageUrlArtifact to load
-        
+
     Returns:
         ImageArtifact: The loaded image artifact
-        
+
     Raises:
         ValueError: If image download fails with descriptive error message
     """
@@ -28,5 +27,5 @@ def load_image_from_url_artifact(image_url_artifact: ImageUrlArtifact) -> ImageA
             f"Error: {err}"
         )
         raise ValueError(details) from err
-    
+
     return ImageLoader().parse(image_bytes)

--- a/libraries/griptape_nodes_advanced_media_library/utils/image_utils.py
+++ b/libraries/griptape_nodes_advanced_media_library/utils/image_utils.py
@@ -1,0 +1,32 @@
+from urllib.error import URLError
+
+from griptape.artifacts import ImageArtifact, ImageUrlArtifact
+from griptape.loaders import ImageLoader
+from requests.exceptions import RequestException
+
+
+def load_image_from_url_artifact(image_url_artifact: ImageUrlArtifact) -> ImageArtifact:
+    """
+    Load an ImageArtifact from an ImageUrlArtifact with proper error handling.
+    
+    Args:
+        image_url_artifact: The ImageUrlArtifact to load
+        
+    Returns:
+        ImageArtifact: The loaded image artifact
+        
+    Raises:
+        ValueError: If image download fails with descriptive error message
+    """
+    try:
+        image_bytes = image_url_artifact.to_bytes()
+    except (URLError, RequestException, ConnectionError, TimeoutError) as err:
+        details = (
+            f"Failed to download image at '{image_url_artifact.value}'.\n"
+            f"If this workflow was shared from another engine installation, "
+            f"that image file will need to be regenerated.\n"
+            f"Error: {err}"
+        )
+        raise ValueError(details) from err
+    
+    return ImageLoader().parse(image_bytes)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
@@ -202,7 +202,13 @@ class DescribeImage(ControlNode):
         image_artifact = params.get("image", None)
 
         if isinstance(image_artifact, ImageUrlArtifact):
-            image_artifact = ImageLoader().parse(image_artifact.to_bytes())
+            try:
+                image_bytes = image_artifact.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+
+            image_artifact = ImageLoader().parse(image_bytes)
         if image_artifact is None:
             self.parameter_output_values["output"] = "No image provided"
             return

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
@@ -1,7 +1,6 @@
 from griptape.artifacts import ImageUrlArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.griptape_cloud_prompt_driver import GriptapeCloudPromptDriver
-from griptape.loaders import ImageLoader
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
 
@@ -10,6 +9,7 @@ from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNo
 from griptape_nodes.traits.options import Options
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
 from griptape_nodes_library.utils.error_utils import try_throw_error
+from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
 
 SERVICE = "Griptape"
 API_KEY_URL = "https://cloud.griptape.ai/configuration/api-keys"
@@ -202,13 +202,7 @@ class DescribeImage(ControlNode):
         image_artifact = params.get("image", None)
 
         if isinstance(image_artifact, ImageUrlArtifact):
-            try:
-                image_bytes = image_artifact.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{image_artifact.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-
-            image_artifact = ImageLoader().parse(image_bytes)
+            image_artifact = load_image_from_url_artifact(image_artifact)
         if image_artifact is None:
             self.parameter_output_values["output"] = "No image provided"
             return

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
@@ -60,7 +60,13 @@ class SaveImage(ControlNode):
             return
 
         if isinstance(image, ImageUrlArtifact):
-            image = ImageLoader().parse(image.to_bytes())
+            try:
+                image_bytes = image.to_bytes()
+            except Exception as err:
+                details = f"Failed to download image at '{image.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
+                raise ValueError(details) from err
+
+            image = ImageLoader().parse(image_bytes)
 
         output_file = self.parameter_values.get("output_path", DEFAULT_FILENAME)
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
-from griptape.loaders import ImageLoader
 
 from griptape_nodes.exe_types.core_types import (
     Parameter,
@@ -10,7 +9,7 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button
-from griptape_nodes_library.utils.image_utils import dict_to_image_url_artifact
+from griptape_nodes_library.utils.image_utils import dict_to_image_url_artifact, load_image_from_url_artifact
 
 DEFAULT_FILENAME = "griptape_nodes.png"
 
@@ -60,13 +59,7 @@ class SaveImage(ControlNode):
             return
 
         if isinstance(image, ImageUrlArtifact):
-            try:
-                image_bytes = image.to_bytes()
-            except Exception as err:
-                details = f"Failed to download image at '{image.value}'. If this workflow was shared from another engine installation, that image file will need to be regenerated. Error: {err}"
-                raise ValueError(details) from err
-
-            image = ImageLoader().parse(image_bytes)
+            image = load_image_from_url_artifact(image)
 
         output_file = self.parameter_values.get("output_path", DEFAULT_FILENAME)
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/image_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/image_utils.py
@@ -1,9 +1,12 @@
 import base64
 import io
 import uuid
+from urllib.error import URLError
 
-from griptape.artifacts import ImageUrlArtifact
+from griptape.artifacts import ImageArtifact, ImageUrlArtifact
+from griptape.loaders import ImageLoader
 from PIL import Image
+from requests.exceptions import RequestException
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -42,3 +45,29 @@ def save_pil_image_to_static_file(image: Image.Image, image_format: str = "PNG")
     url = GriptapeNodes.StaticFilesManager().save_static_file(image_bytes, filename)
 
     return ImageUrlArtifact(url)
+
+
+def load_image_from_url_artifact(image_url_artifact: ImageUrlArtifact) -> ImageArtifact:
+    """Load an ImageArtifact from an ImageUrlArtifact with proper error handling.
+
+    Args:
+        image_url_artifact: The ImageUrlArtifact to load
+
+    Returns:
+        ImageArtifact: The loaded image artifact
+
+    Raises:
+        ValueError: If image download fails with descriptive error message
+    """
+    try:
+        image_bytes = image_url_artifact.to_bytes()
+    except (URLError, RequestException, ConnectionError, TimeoutError) as err:
+        details = (
+            f"Failed to download image at '{image_url_artifact.value}'.\n"
+            f"If this workflow was shared from another engine installation, "
+            f"that image file will need to be regenerated.\n"
+            f"Error: {err}"
+        )
+        raise ValueError(details) from err
+
+    return ImageLoader().parse(image_bytes)


### PR DESCRIPTION
Closes #1291 