### PR TITLE
Prevent base64 in Conversation Memory

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/describe_image.py
@@ -210,6 +210,8 @@ class DescribeImage(ControlNode):
         # Run the agent
         yield lambda: agent.run([prompt, image_artifact])
         self.parameter_output_values["output"] = agent.output.value
+        # Insert a false memory to prevent the base64
+        agent.insert_false_memory(prompt=prompt, output=self.parameter_output_values["output"])
         try_throw_error(agent.output)
 
         # Set the output value for the agent


### PR DESCRIPTION
Was much simpler than we thought. Just meant doing some surgery on the conversation memory in the describe image node to prevent the base64 from being serialized. 
I checked other image nodes in the griptape nodes library (not advanced media library) using agents and didn't see any other examples that need this conversation memory surgery, so this was the only one I modified. 
closes #1306 