### PR TITLE
feat: add support for multiple storage backends

### DIFF
--- a/src/griptape_nodes/drivers/__init__.py
+++ b/src/griptape_nodes/drivers/__init__.py
@@ -1,0 +1,1 @@
+"""Package for griptape nodes drivers."""

--- a/src/griptape_nodes/drivers/storage/__init__.py
+++ b/src/griptape_nodes/drivers/storage/__init__.py
@@ -1,0 +1,4 @@
+"""Package for griptape nodes storage drivers.
+
+Storage drivers are responsible for managing the storage and retrieval of files.
+"""

--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -1,0 +1,51 @@
+from abc import ABC, abstractmethod
+from typing import TypedDict
+
+
+class CreateSignedUploadUrlResponse(TypedDict):
+    """Response type for create_signed_upload_url method."""
+
+    url: str
+    headers: dict
+    method: str
+
+
+class BaseStorageDriver(ABC):
+    """Base class for storage drivers."""
+
+    @abstractmethod
+    def create_signed_upload_url(self, file_name: str) -> CreateSignedUploadUrlResponse:
+        """Create a signed upload URL for the given file name.
+
+        Args:
+            file_name: The name of the file to create a signed URL for.
+
+        Returns:
+            CreateSignedUploadUrlResponse: A dictionary containing the signed URL, headers, and operation type.
+        """
+        ...
+
+    @abstractmethod
+    def create_signed_download_url(self, file_name: str) -> str:
+        """Create a signed download URL for the given file name.
+
+        Args:
+            file_name: The name of the file to create a signed URL for.
+
+        Returns:
+            str: The signed URL for downloading the file.
+        """
+        ...
+
+    @abstractmethod
+    def create_static_file(self, content: bytes, file_name: str) -> str:
+        """Create a static file with the given content and file name.
+
+        Args:
+            content: The content of the file.
+            file_name: The name of the file.
+
+        Returns:
+            str: The URL of the created file and any additional headers to
+        """
+        ...

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -1,0 +1,119 @@
+import logging
+from urllib.parse import urljoin
+
+import httpx
+
+from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
+
+logger = logging.getLogger("griptape_nodes")
+
+
+class GriptapeCloudStorageDriver(BaseStorageDriver):
+    """Stores files using the Griptape Cloud's Asset APIs."""
+
+    def __init__(
+        self,
+        *,
+        bucket_id: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        headers: dict | None = None,
+    ) -> None:
+        """Initialize the GriptapeCloudStorageDriver.
+
+        Args:
+            bucket_id: The ID of the bucket to use. If not provided, a new bucket will be provisioned.
+            base_url: The base URL for the Griptape Cloud API. If not provided, it will default to "https://cloud.griptape.ai".
+            api_key: The API key for authentication. This is required.
+            headers: Additional headers to include in the requests. If not provided, the default headers will be used.
+        """
+        self.base_url = base_url if base_url is not None else "https://cloud.griptape.ai"
+        self.api_key = api_key
+        self.headers = (
+            headers
+            if headers is not None
+            else {
+                "Authorization": f"Bearer {self.api_key}",
+            }
+        )
+
+        if bucket_id is None:
+            self.bucket_id = self._provision_bucket()
+        else:
+            self.bucket_id = bucket_id
+
+    def create_signed_upload_url(self, file_name: str) -> CreateSignedUploadUrlResponse:
+        self._create_asset(file_name)
+
+        url = urljoin(self.base_url, f"/api/buckets/{self.bucket_id}/asset-urls/{file_name}")
+        try:
+            response = httpx.post(url, json={"method": "PUT"}, headers=self.headers)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = f"Failed to create presigned URL for file {file_name}: {e}"
+            logger.error(msg)
+            raise RuntimeError(msg) from e
+
+        response_data = response.json()
+
+        return {"url": response_data["url"], "headers": response_data.get("headers", {}), "method": "PUT"}
+
+    def create_signed_download_url(self, file_name: str) -> str:
+        url = urljoin(self.base_url, f"/api/buckets/{self.bucket_id}/asset-urls/{file_name}")
+        try:
+            response = httpx.post(url, json={"method": "GET"}, headers=self.headers)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = f"Failed to create presigned URL for file {file_name}: {e}"
+            logger.error(msg)
+            raise RuntimeError(msg) from e
+
+        response_data = response.json()
+
+        return response_data["url"]
+
+    def create_static_file(self, content: bytes, file_name: str) -> str:
+        self._create_asset(file_name)
+
+        response = self.create_signed_upload_url(file_name)
+        signed_url = response["url"]
+        headers = response["headers"]
+
+        try:
+            response = httpx.request(
+                response["method"],
+                signed_url,
+                files={"file": (file_name, content)},
+                headers={**self.headers, **headers},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = str(e)
+            logger.error(msg)
+            raise ValueError(msg) from e
+
+        return response.json()["url"]
+
+    def _create_asset(self, asset_name: str) -> str:
+        url = urljoin(self.base_url, f"/api/buckets/{self.bucket_id}/assets")
+        try:
+            response = httpx.put(url=url, json={"name": asset_name}, headers=self.headers)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = str(e)
+            logger.error(msg)
+            raise ValueError(msg) from e
+
+        return response.json()["name"]
+
+    def _provision_bucket(self) -> str:
+        url = urljoin(self.base_url, "/api/buckets")
+        try:
+            response = httpx.post(url=url, json={"name": "griptape-nodes"}, headers=self.headers)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = str(e)
+            logger.error(msg)
+            raise ValueError(msg) from e
+
+        return response.json()["bucket_id"]

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from urllib.parse import urljoin
 
 import httpx
@@ -23,12 +24,14 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
 
         Args:
             bucket_id: The ID of the bucket to use. If not provided, a new bucket will be provisioned.
-            base_url: The base URL for the Griptape Cloud API. If not provided, it will default to "https://cloud.griptape.ai".
-            api_key: The API key for authentication. This is required.
+            base_url: The base URL for the Griptape Cloud API. If not provided, it will be retrieved from the environment variable "GT_CLOUD_BASE_URL" or default to "https://cloud.griptape.ai".
+            api_key: The API key for authentication. If not provided, it will be retrieved from the environment variable "GT_CLOUD_API_KEY".
             headers: Additional headers to include in the requests. If not provided, the default headers will be used.
         """
-        self.base_url = base_url if base_url is not None else "https://cloud.griptape.ai"
-        self.api_key = api_key
+        self.base_url = (
+            base_url if base_url is not None else os.environ.get("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
+        )
+        self.api_key = api_key if api_key is not None else os.environ.get("GT_CLOUD_API_KEY")
         self.headers = (
             headers
             if headers is not None
@@ -47,7 +50,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
 
         url = urljoin(self.base_url, f"/api/buckets/{self.bucket_id}/asset-urls/{file_name}")
         try:
-            response = httpx.post(url, json={"method": "PUT"}, headers=self.headers)
+            response = httpx.post(url, json={"operation": "PUT"}, headers=self.headers)
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
             msg = f"Failed to create presigned URL for file {file_name}: {e}"

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -1,0 +1,74 @@
+import logging
+from urllib.parse import urljoin
+
+import httpx
+
+from griptape_nodes.app.app import STATIC_SERVER_ENABLED, STATIC_SERVER_HOST, STATIC_SERVER_PORT, STATIC_SERVER_URL
+from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
+
+logger = logging.getLogger("griptape_nodes")
+
+
+class LocalStorageDriver(BaseStorageDriver):
+    """Stores files using the engine's local static server."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        """Initialize the LocalStorageDriver.
+
+        Args:
+            base_url: The base URL for the static file server. If not provided, it will be constructed
+        """
+        if not STATIC_SERVER_ENABLED:
+            msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
+            raise ValueError(msg)
+        if base_url is None:
+            self.base_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}{STATIC_SERVER_URL}"
+        else:
+            self.base_url = base_url
+
+    def create_signed_upload_url(self, file_name: str) -> CreateSignedUploadUrlResponse:
+        static_url = urljoin(self.base_url, "/static-upload-urls")
+        try:
+            response = httpx.post(static_url, json={"file_name": file_name})
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = f"Failed to create presigned URL for file {file_name}: {e}"
+            logger.error(msg)
+            raise RuntimeError(msg) from e
+
+        response_data = response.json()
+        url = response_data.get("url")
+        if url is None:
+            msg = f"Failed to create presigned URL for file {file_name}: {response_data}"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        return {"url": url, "headers": response_data.get("headers", {}), "method": "PUT"}
+
+    def create_signed_download_url(self, file_name: str) -> str:
+        return urljoin(self.base_url, f"/static/{file_name}")
+
+    def create_static_file(self, content: bytes, file_name: str) -> str:
+        response = self.create_signed_upload_url(file_name)
+        signed_url = response["url"]
+        headers = response["headers"]
+        method = response["method"]
+
+        try:
+            response = httpx.request(
+                method, urljoin(signed_url, file_name), files={"file": (file_name, content)}, headers=headers
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = str(e)
+            logger.error(msg)
+            raise ValueError(msg) from e
+
+        response_data = response.json()
+        response_url = response_data.get("url")
+        if response_url is None:
+            msg = f"Failed to create static file {file_name}: {response_data}"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        return response_url

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -51,9 +51,35 @@ class CreateStaticFileUploadUrlRequest(RequestPayload):
 @PayloadRegistry.register
 class CreateStaticFileUploadUrlResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     url: str
+    headers: dict = field(default_factory=dict)
+    method: str = "PUT"
 
 
 @dataclass
 @PayloadRegistry.register
 class CreateStaticFileUploadUrlResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    error: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileDownloadUrlRequest(RequestPayload):
+    """Request to create a presigned URL for downloading a static file via a HTTP GET.
+
+    Args:
+        file_name: Name of the file to be uploaded
+    """
+
+    file_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileDownloadUrlResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    url: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileDownloadUrlResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     error: str

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -136,7 +136,9 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._workflow_manager = WorkflowManager(self._event_manager)
             self._arbitrary_code_exec_manager = ArbitraryCodeExecManager(self._event_manager)
             self._operation_depth_manager = OperationDepthManager(self._config_manager)
-            self._static_files_manager = StaticFilesManager(self._config_manager, self._event_manager)
+            self._static_files_manager = StaticFilesManager(
+                self._config_manager, self._secrets_manager, self._event_manager
+            )
 
             # Assign handlers now that these are created.
             self._event_manager.assign_manager_to_request_type(

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from xdg_base_dirs import xdg_data_home
@@ -96,3 +96,4 @@ class Settings(BaseModel):
         }
     )
     log_level: str = Field(default="INFO")
+    storage_backend: Literal["local", "gtc"] = Field(default="local")

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -1,18 +1,15 @@
 import base64
 import binascii
 import logging
-from urllib.parse import urljoin
 
-import httpx
 from xdg_base_dirs import xdg_config_home
 
-from griptape_nodes.app.app import (
-    STATIC_SERVER_ENABLED,
-    STATIC_SERVER_HOST,
-    STATIC_SERVER_PORT,
-    STATIC_SERVER_URL,
-)
+from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
+from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlRequest,
+    CreateStaticFileDownloadUrlResultFailure,
+    CreateStaticFileDownloadUrlResultSuccess,
     CreateStaticFileRequest,
     CreateStaticFileResultFailure,
     CreateStaticFileResultSuccess,
@@ -22,6 +19,7 @@ from griptape_nodes.retained_mode.events.static_file_events import (
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
+from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -31,15 +29,36 @@ USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config
 class StaticFilesManager:
     """A class to manage the creation and management of static files."""
 
-    def __init__(self, config_manager: ConfigManager, event_manager: EventManager | None = None) -> None:
+    def __init__(
+        self,
+        config_manager: ConfigManager,
+        secrets_manager: SecretsManager,
+        event_manager: EventManager | None = None,
+    ) -> None:
         """Initialize the StaticFilesManager.
 
         Args:
             config_manager: The ConfigManager instance to use for accessing the workspace path.
             event_manager: The EventManager instance to use for event handling.
+            secrets_manager: The SecretsManager instance to use for accessing secrets.
         """
         self.config_manager = config_manager
-        self.base_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}{STATIC_SERVER_URL}"
+
+        storage_backend = config_manager.get_config_value("storage_backend", default="local")
+
+        match storage_backend:
+            case "gtc":
+                self.storage_driver = GriptapeCloudStorageDriver(
+                    bucket_id=secrets_manager.get_secret("GT_CLOUD_BUCKET_ID", should_error_on_not_found=False),
+                    api_key=secrets_manager.get_secret("GT_CLOUD_API_KEY"),
+                )
+                secrets_manager.set_secret("GT_CLOUD_BUCKET_ID", self.storage_driver.bucket_id)
+            case "local":
+                self.storage_driver = LocalStorageDriver()
+            case _:
+                msg = f"Invalid storage backend: {storage_backend}"
+                raise ValueError(msg)
+
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(
                 CreateStaticFileRequest, self.on_handle_create_static_file_request
@@ -47,20 +66,15 @@ class StaticFilesManager:
             event_manager.assign_manager_to_request_type(
                 CreateStaticFileUploadUrlRequest, self.on_handle_create_static_file_upload_url_request
             )
+            event_manager.assign_manager_to_request_type(
+                CreateStaticFileDownloadUrlRequest, self.on_handle_create_static_file_download_url_request
+            )
 
     def on_handle_create_static_file_request(
         self,
         request: CreateStaticFileRequest,
     ) -> CreateStaticFileResultSuccess | CreateStaticFileResultFailure:
         file_name = request.file_name
-        response = self.on_handle_create_static_file_upload_url_request(
-            CreateStaticFileUploadUrlRequest(file_name=file_name)
-        )
-
-        if isinstance(response, CreateStaticFileUploadUrlResultFailure):
-            msg = f"Failed to create presigned URL for file {file_name}: {response.error}"
-            logger.error(msg)
-            return CreateStaticFileResultFailure(error=msg)
 
         try:
             content_bytes = base64.b64decode(request.content)
@@ -70,21 +84,13 @@ class StaticFilesManager:
             return CreateStaticFileResultFailure(error=msg)
 
         try:
-            response = httpx.put(urljoin(response.url, file_name), files={"file": (file_name, content_bytes)})
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            msg = str(e)
+            url = self.storage_driver.create_static_file(content_bytes, file_name)
+        except ValueError as e:
+            msg = f"Failed to create static file for file {file_name}: {e}"
             logger.error(msg)
             return CreateStaticFileResultFailure(error=msg)
 
-        response_data = response.json()
-        response_url = response_data.get("url")
-        if response_url is None:
-            msg = f"Failed to create static file {file_name}: {response_data}"
-            logger.error(msg)
-            return CreateStaticFileResultFailure(error=msg)
-
-        return CreateStaticFileResultSuccess(url=response_url)
+        return CreateStaticFileResultSuccess(url=url)
 
     def on_handle_create_static_file_upload_url_request(
         self,
@@ -99,27 +105,38 @@ class StaticFilesManager:
             A result object indicating success or failure.
         """
         file_name = request.file_name
-
-        static_url = urljoin(self.base_url, "/static-upload-urls")
         try:
-            response = httpx.post(
-                static_url,
-                json={"file_name": file_name},
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
+            response = self.storage_driver.create_signed_upload_url(file_name)
+        except ValueError as e:
             msg = f"Failed to create presigned URL for file {file_name}: {e}"
             logger.error(msg)
             return CreateStaticFileUploadUrlResultFailure(error=msg)
 
-        response_data = response.json()
-        url = response_data.get("url")
-        if url is None:
-            msg = f"Failed to create presigned URL for file {file_name}: {response_data}"
-            logger.error(msg)
-            return CreateStaticFileUploadUrlResultFailure(error=msg)
+        return CreateStaticFileUploadUrlResultSuccess(
+            url=response["url"], headers=response["headers"], method=response["method"]
+        )
 
-        return CreateStaticFileUploadUrlResultSuccess(url=url)
+    def on_handle_create_static_file_download_url_request(
+        self,
+        request: CreateStaticFileDownloadUrlRequest,
+    ) -> CreateStaticFileDownloadUrlResultSuccess | CreateStaticFileDownloadUrlResultFailure:
+        """Handle the request to create a presigned URL for downloading a static file.
+
+        Args:
+            request: The request object containing the file name.
+
+        Returns:
+            A result object indicating success or failure.
+        """
+        file_name = request.file_name
+        try:
+            url = self.storage_driver.create_signed_download_url(file_name)
+        except ValueError as e:
+            msg = f"Failed to create presigned URL for file {file_name}: {e}"
+            logger.error(msg)
+            return CreateStaticFileDownloadUrlResultFailure(error=msg)
+
+        return CreateStaticFileDownloadUrlResultSuccess(url=url)
 
     def save_static_file(self, data: bytes, file_name: str) -> str:
         """Saves a static file to the workspace directory.
@@ -133,17 +150,4 @@ class StaticFilesManager:
         Returns:
             The URL of the saved file.
         """
-        if not STATIC_SERVER_ENABLED:
-            msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
-            raise ValueError(msg)
-
-        response = self.on_handle_create_static_file_request(
-            CreateStaticFileRequest(file_name=file_name, content=base64.b64encode(data).decode("utf-8"))
-        )
-
-        if isinstance(response, CreateStaticFileResultFailure):
-            msg = f"Failed to create static file {file_name}: {response.error}"
-            logger.error(msg)
-            raise ValueError(msg)  # noqa: TRY004
-
-        return response.url
+        return self.storage_driver.create_static_file(data, file_name)


### PR DESCRIPTION
Now users can specify whether they'd like to upload files using the local static server (default), or use Griptape Cloud. The main advantage of using Griptape Cloud being that the engine can run on a separate machine from the UI.

Don't merge yet, there are some timing considerations with the UI. 