### PR TITLE
fix: remove automatic bucket provisioning

### DIFF
--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -40,10 +40,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             }
         )
 
-        if bucket_id is None:
-            self.bucket_id = self._provision_bucket()
-        else:
-            self.bucket_id = bucket_id
+        self.bucket_id = bucket_id
 
     def create_signed_upload_url(self, file_name: str) -> CreateSignedUploadUrlResponse:
         self._create_asset(file_name)
@@ -108,15 +105,3 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             raise ValueError(msg) from e
 
         return response.json()["name"]
-
-    def _provision_bucket(self) -> str:
-        url = urljoin(self.base_url, "/api/buckets")
-        try:
-            response = httpx.post(url=url, json={"name": "griptape-nodes"}, headers=self.headers)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            msg = str(e)
-            logger.error(msg)
-            raise ValueError(msg) from e
-
-        return response.json()["bucket_id"]

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -49,10 +49,11 @@ class StaticFilesManager:
         match storage_backend:
             case "gtc":
                 self.storage_driver = GriptapeCloudStorageDriver(
-                    bucket_id=secrets_manager.get_secret("GT_CLOUD_BUCKET_ID", should_error_on_not_found=False),
+                    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/1332
+                    # Automatically provision a bucket if it doesn't exist
+                    bucket_id=secrets_manager.get_secret("GT_CLOUD_BUCKET_ID"),
                     api_key=secrets_manager.get_secret("GT_CLOUD_API_KEY"),
                 )
-                secrets_manager.set_secret("GT_CLOUD_BUCKET_ID", self.storage_driver.bucket_id)
             case "local":
                 self.storage_driver = LocalStorageDriver()
             case _:


### PR DESCRIPTION
This was leading to a race condition which caused multiple buckets to be provisioned. This is a semi-advanced use-case, we can include this in documentation for multi-machine setups.

Related #1332 