### PR TITLE
fix: correctly save static files

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -16,7 +16,7 @@ from urllib.parse import urljoin
 import httpx
 import uvicorn
 from dotenv import get_key
-from fastapi import FastAPI, HTTPException, Request, UploadFile
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from griptape.events import (
@@ -154,15 +154,15 @@ def _serve_static_server() -> None:
         return {"url": url}
 
     @app.put("/static-uploads/{file_name:str}")
-    async def create_static_file(file: UploadFile, file_name: str) -> dict:
+    async def create_static_file(request: Request, file_name: str) -> dict:
         """Upload a static file to the static server."""
         if not STATIC_SERVER_ENABLED:
             msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
             raise ValueError(msg)
 
-        data = await file.read()
         if not static_dir.exists():
             static_dir.mkdir(parents=True, exist_ok=True)
+        data = await request.body()
         try:
             Path(static_dir / file_name).write_bytes(data)
         except binascii.Error as e:

--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -36,16 +36,3 @@ class BaseStorageDriver(ABC):
             str: The signed URL for downloading the file.
         """
         ...
-
-    @abstractmethod
-    def create_static_file(self, content: bytes, file_name: str) -> str:
-        """Create a static file with the given content and file name.
-
-        Args:
-            content: The content of the file.
-            file_name: The name of the file.
-
-        Returns:
-            str: The URL of the created file and any additional headers to
-        """
-        ...

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -72,28 +72,6 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
 
         return response_data["url"]
 
-    def create_static_file(self, content: bytes, file_name: str) -> str:
-        self._create_asset(file_name)
-
-        response = self.create_signed_upload_url(file_name)
-        signed_url = response["url"]
-        headers = response["headers"]
-
-        try:
-            response = httpx.request(
-                response["method"],
-                signed_url,
-                files={"file": (file_name, content)},
-                headers={**self.headers, **headers},
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            msg = str(e)
-            logger.error(msg)
-            raise ValueError(msg) from e
-
-        return response.json()["url"]
-
     def _create_asset(self, asset_name: str) -> str:
         url = urljoin(self.base_url, f"/api/buckets/{self.bucket_id}/assets")
         try:

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -47,28 +47,3 @@ class LocalStorageDriver(BaseStorageDriver):
 
     def create_signed_download_url(self, file_name: str) -> str:
         return urljoin(self.base_url, f"/static/{file_name}")
-
-    def create_static_file(self, content: bytes, file_name: str) -> str:
-        response = self.create_signed_upload_url(file_name)
-        signed_url = response["url"]
-        headers = response["headers"]
-        method = response["method"]
-
-        try:
-            response = httpx.request(
-                method, urljoin(signed_url, file_name), files={"file": (file_name, content)}, headers=headers
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            msg = str(e)
-            logger.error(msg)
-            raise ValueError(msg) from e
-
-        response_data = response.json()
-        response_url = response_data.get("url")
-        if response_url is None:
-            msg = f"Failed to create static file {file_name}: {response_data}"
-            logger.error(msg)
-            raise ValueError(msg)
-
-        return response_url

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import logging
 
+import httpx
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
@@ -85,7 +86,7 @@ class StaticFilesManager:
             return CreateStaticFileResultFailure(error=msg)
 
         try:
-            url = self.storage_driver.create_static_file(content_bytes, file_name)
+            url = self.save_static_file(content_bytes, file_name)
         except ValueError as e:
             msg = f"Failed to create static file for file {file_name}: {e}"
             logger.error(msg)
@@ -151,4 +152,21 @@ class StaticFilesManager:
         Returns:
             The URL of the saved file.
         """
-        return self.storage_driver.create_static_file(data, file_name)
+        response = self.storage_driver.create_signed_upload_url(file_name)
+
+        try:
+            response = httpx.request(
+                response["method"],
+                response["url"],
+                content=data,
+                headers=response["headers"],
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            msg = str(e.response.json())
+            logger.error(msg)
+            raise ValueError(msg) from e
+
+        url = self.storage_driver.create_signed_download_url(file_name)
+
+        return url


### PR DESCRIPTION
Moves driver-specific logic for creating static files out into the manager. This is more consistent with how the UI makes its operations.

Also refactors our static server to use the body as the upload contents, rather than an explicit "file" field. This is more consistent with how other pre-signed urls work.

Together these fix an issue with nodes calling `save_static_file`