### PR TITLE
feat: Add TranscribeAudio node with OpenAI integration

### DIFF
--- a/docs/nodes/audio/load_audio.md
+++ b/docs/nodes/audio/load_audio.md
@@ -1,0 +1,46 @@
+# LoadAudio
+
+## What is it?
+
+The LoadAudio node is a simple building block that lets you bring an audio file into your workflow. Think of it as picking up an audio recording so you can use it in your project.
+
+## When would I use it?
+
+Use this node when you want to:
+
+- Use an audio file that was created by another node
+- Pass an audio file to other nodes in your workflow
+- Process an audio file as part of your project
+
+## How to use it
+
+### Basic Setup
+
+1. Add the LoadAudio node to your workflow
+1. Connect it to a source of audio (like the Transcribe Audio node)
+
+### Parameters
+
+- **audio**: The audio to load (this can be connected to an output from another node)
+
+### Outputs
+
+- **audio**: The loaded audio that can be used by other nodes in your flow
+
+## Example
+
+Imagine you've captured audio with the Microphone node and now want to use it elsewhere:
+
+1. Connect the "audio" output from your Microphone node to the "audio" input of the LoadAudio
+1. The LoadAudio will make the audio available to use in the rest of your workflow
+
+## Important Notes
+
+- The LoadAudio simply passes the audio through - it doesn't change the audio itself
+- You can click the file browser icon to select an audio file from your computer
+- The audio preview can be expanded by clicking the expander icon
+
+## Common Issues
+
+- **No Audio Showing**: Make sure you've properly connected an audio source to this node
+- **Wrong Audio Type**: Make sure you're connecting an AudioArtifact or AudioUrlArtifact to this node 

--- a/docs/nodes/audio/microphone.md
+++ b/docs/nodes/audio/microphone.md
@@ -1,0 +1,53 @@
+# Microphone
+
+## What is it?
+
+The Microphone node allows you to capture audio directly from your computer's microphone. It's a simple way to record audio input that can be used in your workflow.
+
+## When would I use it?
+
+Use this node when you want to:
+
+- Record audio directly from your microphone
+- Capture voice input for transcription
+- Create audio recordings as part of your workflow
+- Provide real-time audio input to other nodes
+
+## How to use it
+
+### Basic Setup
+
+1. Add the Microphone node to your workflow
+1. Click the microphone icon to start recording
+1. Speak or provide audio input
+1. Stop recording when finished
+
+### Parameters
+
+- **audio**: The captured audio output (AudioArtifact)
+
+### Outputs
+
+- **audio**: The recorded audio that can be used by other nodes in your flow
+
+## Example
+
+A simple workflow to record and transcribe audio:
+
+1. Add a Microphone node to your workflow
+2. Record your audio input
+3. Connect the "audio" output to a TranscribeAudio node
+4. The transcription will be available in the TranscribeAudio node's output
+
+## Important Notes
+
+- The node requires microphone permissions in your browser
+- Audio is captured in real-time
+- The quality of the recording depends on your microphone and system settings
+- The node supports various audio formats through the AudioArtifact interface
+
+## Common Issues
+
+- **No Microphone Access**: Ensure your browser has permission to access your microphone
+- **Poor Audio Quality**: Check your microphone settings and system audio configuration
+- **Recording Not Starting**: Make sure no other application is using the microphone 

--- a/docs/nodes/audio/transcribe_audio.md
+++ b/docs/nodes/audio/transcribe_audio.md
@@ -1,0 +1,63 @@
+# TranscribeAudio
+
+## What is it?
+
+The TranscribeAudio node uses OpenAI's models to convert audio into text. It supports multiple transcription models and can work with both direct model configuration and agent-based transcription.
+
+## When would I use it?
+
+Use this node when you want to:
+
+- Convert speech to text
+- Transcribe audio recordings
+- Extract text from audio files
+- Process voice input into written form
+- Create transcripts of audio content
+
+## How to use it
+
+### Basic Setup
+
+1. Add the TranscribeAudio node to your workflow
+1. Connect an audio source to the "audio" input
+1. Choose a transcription model or connect an agent
+1. Run the node to generate the transcription
+
+### Parameters
+
+- **agent**: An optional existing agent configuration to use for transcription
+- **model**: The transcription model to use (defaults to "gpt-4o-mini-transcribe")
+- **audio**: The audio file to transcribe (required)
+- **output**: The transcribed text output
+
+### Outputs
+
+- **output**: The transcribed text from the audio
+- **agent**: The agent object used for transcription, which can be connected to other nodes
+
+## Example
+
+A complete workflow for recording and transcribing audio:
+
+1. Add a Microphone node to capture audio
+2. Connect the Microphone's "audio" output to the TranscribeAudio node's "audio" input
+3. Select your preferred transcription model
+4. Run the workflow
+5. The transcribed text will be available in the "output" parameter
+
+## Important Notes
+
+- The node requires a valid OpenAI API key set up in your environment as `OPENAI_API_KEY`
+- Available models include:
+  - gpt-4o-mini-transcribe
+  - gpt-4o-transcribe
+  - whisper-1
+- You can provide your own agent configuration for more customized behavior
+- The quality of transcription depends on the audio quality and the selected model
+
+## Common Issues
+
+- **Missing API Key**: Ensure your OpenAI API key is properly set up as the environment variable
+- **No Audio Provided**: Make sure you've connected a valid audio source to the "audio" input
+- **Poor Transcription Quality**: Try using a different model or improving the audio quality
+- **Processing Errors**: Very long audio files or poor audio quality might result in less accurate transcriptions 

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -209,6 +209,15 @@
       }
     },
     {
+      "class_name": "TranscribeAudio",
+      "file_path": "griptape_nodes_library/audio/transcribe_audio.py",
+      "metadata": {
+        "category": "audio",
+        "description": "Transcribe audio files into text.\nRequires an OpenAI API key.",
+        "display_name": "Transcribe Audio"
+      }
+    },
+    {
       "class_name": "Microphone",
       "file_path": "griptape_nodes_library/audio/microphone.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library/audio/transcribe_audio.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/audio/transcribe_audio.py
@@ -1,0 +1,212 @@
+from griptape.drivers.audio_transcription.base_audio_transcription_driver import BaseAudioTranscriptionDriver
+from griptape.drivers.audio_transcription.openai import OpenAiAudioTranscriptionDriver
+from griptape.loaders import AudioLoader
+from griptape.structures import Structure
+from griptape.tasks import AudioTranscriptionTask
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
+from griptape_nodes.traits.options import Options
+from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
+from griptape_nodes_library.audio.audio_url_artifact import AudioUrlArtifact
+from griptape_nodes_library.utils.audio_utils import dict_to_audio_url_artifact
+from griptape_nodes_library.utils.error_utils import try_throw_error
+
+SERVICE = "OpenAI"
+API_KEY_URL = "https://platform.openai.com/api-keys"
+API_KEY_ENV_VAR = "OPENAI_API_KEY"
+MODEL_CHOICES = ["gpt-4o-mini-transcribe", "gpt-4o-transcribe", "whisper-1"]
+DEFAULT_MODEL = MODEL_CHOICES[0]
+
+
+class TranscribeAudio(ControlNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.add_parameter(
+            Parameter(
+                name="agent",
+                type="Agent",
+                output_type="Agent",
+                tooltip="An agent that can be used to transcribe the audio.",
+                default_value=None,
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="model",
+                type="str",
+                output_type="str",
+                default_value=DEFAULT_MODEL,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                tooltip="Choose a model, or connect an AudioTranscription Model Configuration or an Agent",
+                traits={Options(choices=MODEL_CHOICES)},
+                ui_options={"display_name": "audio transcription model"},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="audio",
+                input_types=["AudioArtifact", "AudioUrlArtifact"],
+                type="AudioArtifact",
+                output_type="AudioUrlArtifact",
+                default_value=None,
+                ui_options={"clickable_file_browser": True, "expander": True},
+                tooltip="Audio to transcribe",
+            )
+        )
+
+        self.add_parameter(
+            Parameter(
+                name="output",
+                output_type="str",
+                type="str",
+                tooltip="None",
+                default_value=None,
+                allowed_modes={ParameterMode.OUTPUT},
+                ui_options={
+                    "placeholder_text": "The description of the image",
+                    "multiline": True,
+                    "display_name": "output",
+                },
+            )
+        )
+
+        pm = ParameterMessage(
+            name="openai_api_key_message",
+            title="OPENAI_API_KEY Required",
+            variant="warning",
+            value="This node requires an OPENAI_API_KEY.\n\nPlease get an API key and set the key in your Griptape Settings.",
+            button_link=str(API_KEY_URL),
+            button_text="Get API Key",
+        )
+        self.add_node_element(pm)
+        self.clear_api_key_check()
+
+    def clear_api_key_check(self) -> bool:
+        # Check to see if the API key is set, if not we'll show the message
+        # TODO(jason): Implement a better way to check for the API key after https://github.com/griptape-ai/griptape-nodes/issues/1309
+        message_name = "openai_api_key_message"
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
+        if api_key:
+            self.hide_message_by_name(message_name)
+            return True
+        self.show_message_by_name(message_name)
+        return False
+
+    def validate_before_workflow_run(self) -> list[Exception] | None:
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/871
+        exceptions = []
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
+        self.clear_api_key_check()
+        if not api_key:
+            msg = f"{API_KEY_ENV_VAR} is not defined"
+            exceptions.append(KeyError(msg))
+            return exceptions
+        return exceptions if exceptions else None
+
+    def after_incoming_connection(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "agent":
+            self.hide_parameter_by_name("model")
+            modified_parameters_set.add("model")
+
+        if target_parameter.name == "model" and source_parameter.name == "text_to_speech_model_config":
+            # Check and see if the incoming connection is from a prompt model config or an agent.
+            target_parameter.type = source_parameter.type
+            target_parameter.remove_trait(trait_type=target_parameter.find_elements_by_type(Options)[0])
+            target_parameter._ui_options["display_name"] = source_parameter.ui_options.get(
+                "display_name", source_parameter.name
+            )
+            modified_parameters_set.add("model")
+
+        return super().after_incoming_connection(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+        modified_parameters_set: set[str],
+    ) -> None:
+        if target_parameter.name == "agent":
+            self.show_parameter_by_name("model")
+            modified_parameters_set.add("model")
+        # Check and see if the incoming connection is from an agent. If so, we'll hide the model parameter
+        if target_parameter.name == "model":
+            target_parameter.type = "str"
+            target_parameter.add_trait(Options(choices=MODEL_CHOICES))
+            target_parameter.set_default_value(DEFAULT_MODEL)
+            target_parameter.default_value = DEFAULT_MODEL
+            target_parameter._ui_options["display_name"] = "text to speech model"
+            self.set_parameter_value("model", DEFAULT_MODEL)
+
+            modified_parameters_set.add("model")
+        return super().after_incoming_connection_removed(
+            source_node, source_parameter, target_parameter, modified_parameters_set
+        )
+
+    def process(self) -> AsyncResult[Structure]:
+        # Get the parameters from the node
+        model_input = self.get_parameter_value("model")
+        agent = None
+
+        # If an agent is provided, we'll use and ensure it's using a PromptTask
+        # If a prompt_driver is provided, we'll use that
+        # If neither are provided, we'll create a new one with the selected model.
+        # Otherwise, we'll just use the default model
+        agent = self.get_parameter_value("agent")
+        if isinstance(agent, dict):
+            agent = GtAgent().from_dict(agent)
+        else:
+            agent = GtAgent()
+
+        #
+        # Get the audio_transcription_driver
+        if isinstance(model_input, BaseAudioTranscriptionDriver):
+            driver = model_input
+        else:
+            if model_input not in MODEL_CHOICES:
+                model_input = DEFAULT_MODEL
+            driver = OpenAiAudioTranscriptionDriver(
+                model=model_input, api_key=self.get_config_value(SERVICE, API_KEY_ENV_VAR)
+            )
+        audio = self.get_parameter_value("audio")
+        if audio is None:
+            self.parameter_output_values["output"] = "No audio provided"
+            return
+        if isinstance(audio, dict):
+            audio_artifact = dict_to_audio_url_artifact(audio)
+        else:
+            audio_artifact = audio
+
+        if isinstance(audio_artifact, AudioUrlArtifact):
+            audio_artifact = AudioLoader().parse(audio_artifact.to_bytes())
+        task = AudioTranscriptionTask(audio_artifact, audio_transcription_driver=driver)
+
+        # Set the new audio transcription task
+        agent.swap_task(task)
+
+        # Run the agent
+        yield lambda: agent.run([task])
+        self.parameter_output_values["output"] = agent.output.value
+        try_throw_error(agent.output)
+
+        agent.insert_false_memory(
+            prompt="I'm passing you some audio to transcribe. /link/to/audiofile",
+            output=f"<Thought>I temporarily used an Audio Transcription tool</Thought>{agent.output.value}",
+            tool="AudioTranscriptionTool",
+        )
+
+        # Reset the agent
+        agent.restore_task()
+
+        # Set the output value for the agent
+        self.parameter_output_values["agent"] = agent.to_dict()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,10 @@ nav:
               - Reroute: nodes/execution/reroute.md
           - Agents:
               - Agent: nodes/agents/create_agent.md
+          - Audio:
+              - Load Audio: nodes/audio/load_audio.md
+              - Microphone: nodes/audio/microphone.md
+              - Transcribe Audio: nodes/audio/transcribe_audio.md
           - Configs:
               - Anthropic Prompt: nodes/config/anthropic_prompt_driver.md
               - Cohere Prompt: nodes/config/cohere_prompt_driver.md


### PR DESCRIPTION
# Title
feat: Add TranscribeAudio node with OpenAI integration

# Description
Adds the TranscribeAudio node for converting audio to text using OpenAI's models (gpt-4o-mini-transcribe, gpt-4o-transcribe, whisper-1). The node includes:

- Support for both direct model selection and agent-based transcription
- Optional agent integration that temporarily swaps in the AudioTranscription task and inserts a false memory for conversation continuity
- Integration with existing LoadAudio and Microphone nodes
- New ParameterMessage UI element to guide users on OpenAI API key setup
- Complete documentation for all audio-related nodes

Requires OPENAI_API_KEY environment variable for operation.