### PR TITLE
Update ContextManager to Track Objects

### DIFF
--- a/src/griptape_nodes/bootstrap/bootstrap_script.py
+++ b/src/griptape_nodes/bootstrap/bootstrap_script.py
@@ -17,6 +17,7 @@ from register_libraries_script import (  # type: ignore[import] - This import is
     register_libraries,
 )
 
+from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.retained_mode.events.base_events import (
     AppEvent,
@@ -63,9 +64,9 @@ def _load_user_workflow(path_to_workflow: str) -> None:
     spec.loader.exec_module(module)
 
 
-def _load_flow_for_workflow() -> str:
+def _load_flow_for_workflow() -> ControlFlow:
     context_manager = GriptapeNodes.ContextManager()
-    return context_manager.get_current_flow_name()
+    return context_manager.get_current_flow()
 
 
 def _set_workflow_context(workflow_name: str) -> None:
@@ -208,7 +209,8 @@ def run(workflow_name: str, flow_input: Any) -> None:
     # or nothing works. The name can be anything, but how about the workflow_name.
     _set_workflow_context(workflow_name=workflow_name)
     _load_user_workflow("workflow.py")
-    flow_name = _load_flow_for_workflow()
+    flow = _load_flow_for_workflow()
+    flow_name = flow.name
     # Now let's set the input to the flow
     _set_input_for_flow(flow_name=flow_name, flow_input=flow_input)
 

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -30,14 +30,14 @@ class CurrentNodes(NamedTuple):
 
 # The flow will own all of the nodes and the connections
 class ControlFlow:
-    name:str
+    name: str
     connections: Connections
     nodes: dict[str, BaseNode]
     control_flow_machine: ControlFlowMachine
     single_node_resolution: bool
     flow_queue: Queue[BaseNode]
 
-    def __init__(self, name:str) -> None:
+    def __init__(self, name: str) -> None:
         self.name = name
         self.connections = Connections()
         self.nodes = {}

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -30,13 +30,15 @@ class CurrentNodes(NamedTuple):
 
 # The flow will own all of the nodes and the connections
 class ControlFlow:
+    name:str
     connections: Connections
     nodes: dict[str, BaseNode]
     control_flow_machine: ControlFlowMachine
     single_node_resolution: bool
     flow_queue: Queue[BaseNode]
 
-    def __init__(self) -> None:
+    def __init__(self, name:str) -> None:
+        self.name = name
         self.connections = Connections()
         self.nodes = {}
         self.control_flow_machine = ControlFlowMachine(self)

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -155,7 +155,7 @@ class ContextManager:
             self.node = node
             self._element_stack = []
 
-        def push_element(self, element:BaseNodeElement) -> BaseNodeElement:
+        def push_element(self, element: BaseNodeElement) -> BaseNodeElement:
             """Push an element name onto this node's element stack."""
             self._element_stack.append(element)
             return element

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -14,6 +14,9 @@ from griptape_nodes.retained_mode.events.context_events import (
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from griptape_nodes.exe_types.core_types import BaseNodeElement
+    from griptape_nodes.exe_types.flow import ControlFlow
+    from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
     from griptape_nodes.retained_mode.events.node_events import SerializedSelectedNodesCommands
@@ -55,33 +58,33 @@ class ContextManager:
             self._name = name
             self._flow_stack = []
 
-        def push_flow(self, flow_name: str) -> str:
+        def push_flow(self, flow: ControlFlow) -> ControlFlow:
             """Push a flow name onto this workflow's flow stack."""
-            flow_context = ContextManager.FlowContextState(flow_name)
+            flow_context = ContextManager.FlowContextState(flow)
             self._flow_stack.append(flow_context)
-            return flow_name
+            return flow
 
-        def pop_flow(self) -> str:
+        def pop_flow(self) -> ControlFlow:
             """Pop the top flow from this workflow's flow stack."""
             if not self._flow_stack:
                 msg = f"Cannot pop Flow: no active Flows in Workflow '{self._name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             flow_context = self._flow_stack.pop()
-            return flow_context._name
+            return flow_context._flow
 
         def has_current_flow(self) -> bool:
             """Check if this workflow has an active flow."""
             return len(self._flow_stack) > 0
 
-        def get_current_flow_name(self) -> str:
-            """Get the name of the current flow in this workflow."""
+        def get_current_flow(self) -> ControlFlow:
+            """Get the current flow in this workflow."""
             if not self._flow_stack:
                 msg = f"No active Flow in Workflow '{self._name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             flow_context = self._flow_stack[-1]
-            return flow_context._name
+            return flow_context._flow
 
     class WorkflowContext:
         """A context manager for a Workflow."""
@@ -107,36 +110,36 @@ class ContextManager:
     class FlowContextState:
         """Internal class that represents a Flow's state which owns a stack of node names."""
 
-        _name: str
+        _flow: ControlFlow
         _node_stack: list[ContextManager.NodeContextState]
 
-        def __init__(self, name: str):
-            self._name = name
+        def __init__(self, flow: ControlFlow):
+            self._flow = flow
             self._node_stack = []
 
-        def push_node(self, node_name: str) -> str:
+        def push_node(self, node: BaseNode) -> BaseNode:
             """Push a node name onto this flow's node stack."""
-            node_context = ContextManager.NodeContextState(node_name)
+            node_context = ContextManager.NodeContextState(node)
             self._node_stack.append(node_context)
-            return node_name
+            return node
 
-        def pop_node(self) -> str:
+        def pop_node(self) -> BaseNode:
             """Pop the top node from this flow's node stack."""
             if not self._node_stack:
-                msg = f"Cannot pop Node: no active Nodes in Flow '{self._name}'"
+                msg = f"Cannot pop Node: no active Nodes in Flow '{self._flow.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             node_context = self._node_stack.pop()
-            return node_context.node_name
+            return node_context.node
 
-        def get_current_node_name(self) -> str:
+        def get_current_node(self) -> BaseNode:
             """Get the name of the current node in this flow."""
             if not self._node_stack:
-                msg = f"No active Node in Flow '{self._name}'"
+                msg = f"No active Node in Flow '{self._flow.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             node_context = self._node_stack[-1]
-            return node_context.node_name
+            return node_context.node
 
         def has_current_node(self) -> bool:
             """Check if this flow has an active node."""
@@ -145,31 +148,31 @@ class ContextManager:
     class NodeContextState:
         """Internal class that represents a Node's state which owns a stack of node elements."""
 
-        node_name: str
-        _element_stack: list[str]
+        node: BaseNode
+        _element_stack: list[BaseNodeElement]
 
-        def __init__(self, node_name: str):
-            self.node_name = node_name
+        def __init__(self, node: BaseNode):
+            self.node = node
             self._element_stack = []
 
-        def push_element(self, element_name: str) -> str:
+        def push_element(self, element:BaseNodeElement) -> BaseNodeElement:
             """Push an element name onto this node's element stack."""
-            self._element_stack.append(element_name)
-            return element_name
+            self._element_stack.append(element)
+            return element
 
-        def pop_element(self) -> str:
+        def pop_element(self) -> BaseNodeElement:
             """Pop the top element from this node's element stack."""
             if not self._element_stack:
-                msg = f"Cannot pop Element: no active Elements in Node '{self.node_name}'"
+                msg = f"Cannot pop Element: no active Elements in Node '{self.node.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
-            element_name = self._element_stack.pop()
-            return element_name
+            element = self._element_stack.pop()
+            return element
 
-        def get_current_element_name(self) -> str:
+        def get_current_element(self) -> BaseNodeElement:
             """Get the name of the current element in this node."""
             if not self._element_stack:
-                msg = f"No active Element in Node '{self.node_name}'"
+                msg = f"No active Element in Node '{self.node.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             return self._element_stack[-1]
@@ -183,14 +186,14 @@ class ContextManager:
         """A context manager for a Flow."""
 
         _manager: ContextManager
-        _flow_name: str
+        _flow: ControlFlow
 
-        def __init__(self, manager: ContextManager, flow_name: str):
+        def __init__(self, manager: ContextManager, flow: ControlFlow):
             self._manager = manager
-            self._flow_name = flow_name
+            self._flow = flow
 
-        def __enter__(self) -> str:
-            return self._manager.push_flow(self._flow_name)
+        def __enter__(self) -> ControlFlow:
+            return self._manager.push_flow(self._flow)
 
         def __exit__(
             self,
@@ -204,14 +207,14 @@ class ContextManager:
         """A context manager for a Node within a Flow."""
 
         _manager: ContextManager
-        _node_name: str
+        _node: BaseNode
 
-        def __init__(self, manager: ContextManager, node_name: str):
+        def __init__(self, manager: ContextManager, node: BaseNode):
             self._manager = manager
-            self._node_name = node_name
+            self._node = node
 
-        def __enter__(self) -> str:
-            return self._manager.push_node(self._node_name)
+        def __enter__(self) -> BaseNode:
+            return self._manager.push_node(self._node)
 
         def __exit__(
             self,
@@ -224,12 +227,12 @@ class ContextManager:
     class ElementContext:
         """A context manager for an Element within a Node."""
 
-        def __init__(self, manager: ContextManager, element_name: str):
+        def __init__(self, manager: ContextManager, element: BaseNodeElement):
             self._manager = manager
-            self._element_name = element_name
+            self._element = element
 
-        def __enter__(self) -> str:
-            return self._manager.push_element(self._element_name)
+        def __enter__(self) -> BaseNodeElement:
+            return self._manager.push_element(self._element)
 
         def __exit__(
             self,
@@ -301,38 +304,38 @@ class ContextManager:
         """
         return self.WorkflowContext(self, workflow_name)
 
-    def flow(self, flow_name: str) -> ContextManager.FlowContext:
+    def flow(self, flow: ControlFlow) -> ContextManager.FlowContext:
         """Create a context manager for a Flow context.
 
         Args:
-            flow_name: The name of the Flow to enter.
+            flow: The Flow object to enter.
 
         Returns:
             A context manager for the Flow context.
         """
-        return self.FlowContext(self, flow_name)
+        return self.FlowContext(self, flow)
 
-    def node(self, node_name: str) -> ContextManager.NodeContext:
+    def node(self, node: BaseNode) -> ContextManager.NodeContext:
         """Create a context manager for a Node context.
 
         Args:
-            node_name: The name of the Node to enter.
+            node: The Node object to enter.
 
         Returns:
             A context manager for the Node context.
         """
-        return self.NodeContext(self, node_name)
+        return self.NodeContext(self, node)
 
-    def element(self, element_name: str) -> ContextManager.ElementContext:
+    def element(self, element: BaseNodeElement) -> ContextManager.ElementContext:
         """Create a context manager for an Element context.
 
         Args:
-            element_name: The name of the Element to enter.
+            element: The Element object to enter.
 
         Returns:
             A context manager for the Element context.
         """
-        return self.ElementContext(self, element_name)
+        return self.ElementContext(self, element)
 
     def has_current_workflow(self) -> bool:
         """Check if there is an active Workflow context."""
@@ -381,11 +384,11 @@ class ContextManager:
         current_workflow = self._workflow_stack[-1]
         return current_workflow._name
 
-    def get_current_flow_name(self) -> str:
-        """Get the name of the current Flow context.
+    def get_current_flow(self) -> ControlFlow:
+        """Get the current Flow object.
 
         Returns:
-            The name of the current Flow.
+            The current Flow object.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.
@@ -395,9 +398,9 @@ class ContextManager:
             raise self.NoActiveFlowError(msg)
 
         current_workflow = self._workflow_stack[-1]
-        return current_workflow.get_current_flow_name()
+        return current_workflow.get_current_flow()
 
-    def get_current_node_name(self) -> str:
+    def get_current_node(self) -> BaseNode:
         """Get the name of the current Node within the current Flow.
 
         Returns:
@@ -413,9 +416,9 @@ class ContextManager:
 
         current_workflow = self._workflow_stack[-1]
         current_flow = current_workflow._flow_stack[-1]
-        return current_flow.get_current_node_name()
+        return current_flow.get_current_node()
 
-    def get_current_element_name(self) -> str:
+    def get_current_element(self) -> BaseNodeElement:
         """Get the name of the current element within the current node.
 
         Returns:
@@ -437,7 +440,7 @@ class ContextManager:
             raise self.EmptyStackError(msg)
 
         current_node = current_flow._node_stack[-1]
-        return current_node.get_current_element_name()
+        return current_node.get_current_element()
 
     def push_workflow(self, workflow_name: str) -> str:
         """Push a new Workflow context onto the stack.
@@ -468,30 +471,30 @@ class ContextManager:
         workflow_context = self._workflow_stack.pop()
         return workflow_context._name
 
-    def push_flow(self, flow_name: str) -> str:
+    def push_flow(self, flow: ControlFlow) -> ControlFlow:
         """Push a new Flow context onto the stack for the current Workflow.
 
         Args:
-            flow_name: The name of the Flow to enter.
+            flow: The Flow object to enter.
 
         Returns:
-            The name of the Flow that was entered.
+            The Flow object that was entered.
 
         Raises:
             NoActiveWorkflowError: If no Workflow context is active.
         """
         if not self.has_current_workflow():
-            msg = f"Cannot enter a Flow context '{flow_name}' without an active Workflow context"
+            msg = f"Cannot enter a Flow context '{flow.name}' without an active Workflow context"
             raise self.NoActiveWorkflowError(msg)
 
         current_workflow = self._workflow_stack[-1]
-        return current_workflow.push_flow(flow_name)
+        return current_workflow.push_flow(flow)
 
-    def pop_flow(self) -> str:
+    def pop_flow(self) -> ControlFlow:
         """Pop the current Flow context from the stack.
 
         Returns:
-            The name of the Flow that was popped.
+            The Flow object that was popped.
 
         Raises:
             EmptyStackError: If no Flow is active.
@@ -503,27 +506,27 @@ class ContextManager:
         current_workflow = self._workflow_stack[-1]
         return current_workflow.pop_flow()
 
-    def push_node(self, node_name: str) -> str:
+    def push_node(self, node: BaseNode) -> BaseNode:
         """Push a new Node context onto the stack for the current Flow.
 
         Args:
-            node_name: The name of the Node to enter.
+            node: The Node object to enter.
 
         Returns:
-            The name of the Node that was entered.
+            The Node object that was entered.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.
         """
         if not self.has_current_flow():
-            msg = f"Cannot enter a Node context '{node_name}' without an active Flow context"
+            msg = f"Cannot enter a Node context '{node.name}' without an active Flow context"
             raise self.NoActiveFlowError(msg)
 
         current_workflow = self._workflow_stack[-1]
         current_flow = current_workflow._flow_stack[-1]
-        return current_flow.push_node(node_name)
+        return current_flow.push_node(node)
 
-    def pop_node(self) -> str:
+    def pop_node(self) -> BaseNode:
         """Pop the current Node context from the stack for the current Flow.
 
         Returns:
@@ -541,21 +544,21 @@ class ContextManager:
         current_flow = current_workflow._flow_stack[-1]
         return current_flow.pop_node()
 
-    def push_element(self, element_name: str) -> str:
+    def push_element(self, element: BaseNodeElement) -> BaseNodeElement:
         """Push a new element onto the stack for the current node.
 
         Args:
-            element_name: The name of the element to enter.
+            element: The Element object to enter.
 
         Returns:
-            The name of the element that was entered.
+            The Element object that was entered.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.
-            EmptyStackError: If the current Flow has no active Nodes.
+            EmptyStackError: If the current Flow has no active Nodes or the current Node has no active Elements.
         """
         if not self.has_current_flow():
-            msg = f"Cannot enter an Element context '{element_name}' without an active Flow context"
+            msg = f"Cannot enter an Element context '{element.name}' without an active Flow context"
             raise self.NoActiveFlowError(msg)
 
         current_workflow = self._workflow_stack[-1]
@@ -566,13 +569,13 @@ class ContextManager:
             raise self.EmptyStackError(msg)
 
         current_node = current_flow._node_stack[-1]
-        return current_node.push_element(element_name)
+        return current_node.push_element(element)
 
-    def pop_element(self) -> str:
+    def pop_element(self) -> BaseNodeElement:
         """Pop the current element from the stack for the current node.
 
         Returns:
-            The name of the element that was popped.
+            The Element object that was popped.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -161,14 +161,15 @@ class FlowManager:
 
         # We'll explore #1 first by seeing if the Context Manager already has a current flow,
         # which would mean the canvas is already established:
+        parent = None
         if (parent_name is None) and (GriptapeNodes.ContextManager().has_current_flow()):
             # Aha! Just use that.
-            parent_name = GriptapeNodes.ContextManager().get_current_flow_name()
+            parent = GriptapeNodes.ContextManager().get_current_flow()
+            parent_name = parent.name
 
         # TODO: FIX THIS LOGIC MESS https://github.com/griptape-ai/griptape-nodes/issues/616
 
-        parent = None
-        if parent_name is not None:
+        if parent_name is not None and parent is None:
             parent = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(parent_name, ControlFlow)
         if parent_name is None:
             if self.does_canvas_exist():
@@ -196,13 +197,13 @@ class FlowManager:
         final_flow_name = GriptapeNodes.ObjectManager().generate_name_for_object(
             type_name="ControlFlow", requested_name=request.flow_name
         )
-        flow = ControlFlow()
+        flow = ControlFlow(name=final_flow_name)
         GriptapeNodes.ObjectManager().add_object_by_name(name=final_flow_name, obj=flow)
         self._name_to_parent_name[final_flow_name] = parent_name
 
         # See if we need to push it as the current context.
         if request.set_as_new_context:
-            GriptapeNodes.ContextManager().push_flow(final_flow_name)
+            GriptapeNodes.ContextManager().push_flow(flow)
 
         # Success
         details = f"Successfully created Flow '{final_flow_name}'."
@@ -217,6 +218,7 @@ class FlowManager:
 
     def on_delete_flow_request(self, request: DeleteFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
         flow_name = request.flow_name
+        flow = None
         if flow_name is None:
             # We want to delete whatever is at the top of the Current Context.
             if not GriptapeNodes.ContextManager().has_current_flow():
@@ -227,30 +229,31 @@ class FlowManager:
                 result = DeleteFlowResultFailure()
                 return result
             # We pop it off here, but we'll re-add it using context in a moment.
-            flow_name = GriptapeNodes.ContextManager().pop_flow()
+            flow = GriptapeNodes.ContextManager().pop_flow()
 
         # Does this Flow even exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+        if flow is None and flow_name is not None:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             details = f"Attempted to delete Flow '{flow_name}', but no Flow with that name could be found."
             logger.error(details)
             result = DeleteFlowResultFailure()
             return result
         if flow.check_for_existing_running_flow():
-            result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow_name))
+            result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow.name))
             if not result.succeeded():
                 details = f"Attempted to delete flow '{flow_name}'. Failed because running flow could not cancel."
                 logger.error(details)
                 return DeleteFlowResultFailure()
 
         # Let this Flow assume the Current Context while we delete everything within it.
-        with GriptapeNodes.ContextManager().flow(flow_name=flow_name):
+        with GriptapeNodes.ContextManager().flow(flow=flow):
             # Delete all child nodes in this Flow.
             list_nodes_request = ListNodesInFlowRequest()
             list_nodes_result = GriptapeNodes.handle_request(list_nodes_request)
             if not isinstance(list_nodes_result, ListNodesInFlowResultSuccess):
-                details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to get the list of Nodes owned by this Flow."
+                details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to get the list of Nodes owned by this Flow."
                 logger.error(details)
                 result = DeleteFlowResultFailure()
                 return result
@@ -259,7 +262,7 @@ class FlowManager:
                 delete_node_request = DeleteNodeRequest(node_name=node_name)
                 delete_node_result = GriptapeNodes.handle_request(delete_node_request)
                 if isinstance(delete_node_result, DeleteNodeResultFailure):
-                    details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to delete child Node '{node_name}'."
+                    details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to delete child Node '{node_name}'."
                     logger.error(details)
                     result = DeleteFlowResultFailure()
                     return result
@@ -276,21 +279,28 @@ class FlowManager:
                 result = DeleteFlowResultFailure()
                 return result
             flow_names = list_flows_result.flow_names
+            obj_mgr = GriptapeNodes.ObjectManager()
             for child_flow_name in flow_names:
-                with GriptapeNodes.ContextManager().flow(flow_name=child_flow_name):
+                child_flow = obj_mgr.attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
+                if child_flow is None:
+                    details = f"Attempted to delete Flow '{child_flow_name}', but no Flow with that name could be found."
+                    logger.error(details)
+                    result = DeleteFlowResultFailure()
+                    return result
+                with GriptapeNodes.ContextManager().flow(flow=child_flow):
                     # Delete them.
                     delete_flow_request = DeleteFlowRequest()
                     delete_flow_result = GriptapeNodes.handle_request(delete_flow_request)
                     if isinstance(delete_flow_result, DeleteFlowResultFailure):
-                        details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to delete child Flow '{child_flow_name}'."
+                        details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to delete child Flow '{child_flow.name}'."
                         logger.error(details)
                         result = DeleteFlowResultFailure()
                         return result
 
             # If we've made it this far, we have deleted all the children Flows and their nodes.
             # Remove the flow from our map.
-            obj_mgr.del_obj_by_name(flow_name)
-            del self._name_to_parent_name[flow_name]
+            obj_mgr.del_obj_by_name(flow.name)
+            del self._name_to_parent_name[flow.name]
 
         details = f"Successfully deleted Flow '{flow_name}'."
         logger.debug(details)
@@ -316,6 +326,7 @@ class FlowManager:
 
     def on_list_nodes_in_flow_request(self, request: ListNodesInFlowRequest) -> ResultPayload:
         flow_name = request.flow_name
+        flow = None
         if flow_name is None:
             # First check if we have a current flow
             if not GriptapeNodes.ContextManager().has_current_flow():
@@ -324,11 +335,12 @@ class FlowManager:
                 result = ListNodesInFlowResultFailure()
                 return result
             # Get the current flow from context
-            flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
-
+            flow = GriptapeNodes.ContextManager().get_current_flow()
+            flow_name = flow.name
         # Does this Flow even exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+        if flow is None:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             details = (
                 f"Attempted to list Nodes in Flow '{flow_name}'. Failed because no Flow with that name could be found."
@@ -393,6 +405,7 @@ class FlowManager:
     def on_create_connection_request(self, request: CreateConnectionRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, PLR0915, C901
         # Vet the two nodes first.
         source_node_name = request.source_node_name
+        source_node = None
         if source_node_name is None:
             # First check if we have a current node
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -401,17 +414,19 @@ class FlowManager:
                 return CreateConnectionResultFailure()
 
             # Get the current node from context
-            source_node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            source_node = GriptapeNodes.ContextManager().get_current_node()
+            source_node_name = source_node.name
+        if source_node is None:
+            try:
+                source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
+            except ValueError as err:
+                details = f'Connection failed: "{source_node_name}" does not exist. Error: {err}.'
+                logger.error(details)
 
-        try:
-            source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
-        except ValueError as err:
-            details = f'Connection failed: "{source_node_name}" does not exist. Error: {err}.'
-            logger.error(details)
-
-            return CreateConnectionResultFailure()
+                return CreateConnectionResultFailure()
 
         target_node_name = request.target_node_name
+        target_node = None
         if target_node_name is None:
             # First check if we have a current node
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -420,14 +435,15 @@ class FlowManager:
                 return CreateConnectionResultFailure()
 
             # Get the current node from context
-            target_node_name = GriptapeNodes.ContextManager().get_current_node_name()
-
-        try:
-            target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
-        except ValueError as err:
-            details = f'Connection failed: "{target_node_name}" does not exist. Error: {err}.'
-            logger.error(details)
-            return CreateConnectionResultFailure()
+            target_node = GriptapeNodes.ContextManager().get_current_node()
+            target_node_name = target_node.name
+        if target_node is None:
+            try:
+                target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
+            except ValueError as err:
+                details = f'Connection failed: "{target_node_name}" does not exist. Error: {err}.'
+                logger.error(details)
+                return CreateConnectionResultFailure()
 
         # The two nodes exist.
         # Get the parent flows.
@@ -656,7 +672,8 @@ class FlowManager:
         # Vet the two nodes first.
         source_node_name = request.source_node_name
         target_node_name = request.target_node_name
-
+        source_node = None
+        target_node = None
         if source_node_name is None:
             # First check if we have a current node
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -665,15 +682,16 @@ class FlowManager:
                 return DeleteConnectionResultFailure()
 
             # Get the current node from context
-            source_node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            source_node = GriptapeNodes.ContextManager().get_current_node()
+            source_node_name = source_node.name
+        if source_node is None:
+            try:
+                source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
+            except ValueError as err:
+                details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
+                logger.error(details)
 
-        try:
-            source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
-        except ValueError as err:
-            details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
-            logger.error(details)
-
-            return DeleteConnectionResultFailure()
+                return DeleteConnectionResultFailure()
 
         target_node_name = request.target_node_name
         if target_node_name is None:
@@ -684,14 +702,16 @@ class FlowManager:
                 return DeleteConnectionResultFailure()
 
             # Get the current node from context
-            target_node_name = GriptapeNodes.ContextManager().get_current_node_name()
-        try:
-            target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
-        except ValueError as err:
-            details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
-            logger.error(details)
+            target_node = GriptapeNodes.ContextManager().get_current_node()
+            target_node_name = target_node.name
+        if target_node is None:
+            try:
+                target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
+            except ValueError as err:
+                details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
+                logger.error(details)
 
-            return DeleteConnectionResultFailure()
+                return DeleteConnectionResultFailure()
 
         # The two nodes exist.
         # Get the parent flows.
@@ -1085,7 +1105,8 @@ class FlowManager:
             logger.error(details)
             return ListFlowsInCurrentContextResultFailure()
 
-        parent_flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+        parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+        parent_flow_name = parent_flow.name
 
         # Create a list of all child flow names that point DIRECTLY to us.
         ret_list = []
@@ -1102,22 +1123,24 @@ class FlowManager:
     # similar manager refactors: https://github.com/griptape-ai/griptape-nodes/issues/806
     def on_serialize_flow_to_commands(self, request: SerializeFlowToCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         flow_name = request.flow_name
+        flow = None
         if flow_name is None:
             if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+                flow = GriptapeNodes.ContextManager().get_current_flow()
+                flow_name = flow.name
             else:
                 details = "Attempted to serialize a Flow to commands from the Current Context. Failed because the Current Context was empty."
                 logger.error(details)
                 return SerializeFlowToCommandsResultFailure()
-
-        # Does this flow exist?
-        flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
-            details = (
-                f"Attempted to serialize Flow '{flow_name}' to commands, but no Flow with that name could be found."
-            )
-            logger.error(details)
-            return SerializeFlowToCommandsResultFailure()
+            # Does this flow exist?
+            flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+            if flow is None:
+                details = (
+                    f"Attempted to serialize Flow '{flow_name}' to commands, but no Flow with that name could be found."
+                )
+                logger.error(details)
+                return SerializeFlowToCommandsResultFailure()
 
         # Track all node libraries that were in use by these Nodes
         node_libraries_in_use = set()
@@ -1127,7 +1150,7 @@ class FlowManager:
         # And track how values map into that map.
         serialized_parameter_value_tracker = SerializedParameterValueTracker()
 
-        with GriptapeNodes.ContextManager().flow(flow_name):
+        with GriptapeNodes.ContextManager().flow(flow):
             # The base flow creation, if desired.
             if request.include_create_flow_command:
                 create_flow_request = CreateFlowRequest(parent_flow_name=None)
@@ -1150,7 +1173,12 @@ class FlowManager:
 
             # Serialize each node
             for node_name in nodes_in_flow_result.node_names:
-                with GriptapeNodes.ContextManager().node(node_name):
+                node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+                if node is None:
+                    details = f"Attempted to serialize Flow '{flow_name}'. Failed while attempting to serialize Node '{node_name}' within the Flow."
+                    logger.error(details)
+                    return SerializeFlowToCommandsResultFailure()
+                with GriptapeNodes.ContextManager().node(node):
                     # Note: the parameter value stuff is pass-by-reference, and we expect the values to be modified in place.
                     # This might be dangerous if done over the wire.
                     serialize_node_request = SerializeNodeToCommandsRequest(
@@ -1190,7 +1218,8 @@ class FlowManager:
                 create_connection_commands.append(create_connection_command)
 
             # Now sub-flows.
-            parent_flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+            parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+            parent_flow_name = parent_flow.name
             flows_in_flow_request = ListFlowsInFlowRequest(parent_flow_name=parent_flow_name)
             flows_in_flow_result = GriptapeNodes().handle_request(flows_in_flow_request)
             if not isinstance(flows_in_flow_result, ListFlowsInFlowResultSuccess):
@@ -1200,7 +1229,12 @@ class FlowManager:
 
             sub_flow_commands = []
             for child_flow in flows_in_flow_result.flow_names:
-                with GriptapeNodes.ContextManager().flow(flow_name=child_flow):
+                flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(child_flow, ControlFlow)
+                if flow is None:
+                    details = f"Attempted to serialize Flow '{flow_name}', but no Flow with that name could be found."
+                    logger.error(details)
+                    return SerializeFlowToCommandsResultFailure()
+                with GriptapeNodes.ContextManager().flow(flow=flow):
                     child_flow_request = SerializeFlowToCommandsRequest()
                     child_flow_result = GriptapeNodes().handle_request(child_flow_request)
                     if not isinstance(child_flow_result, SerializeFlowToCommandsResultSuccess):
@@ -1230,7 +1264,8 @@ class FlowManager:
         # Do we want to create a NEW Flow to deserialize into, or use the one in the Current Context?
         if request.serialized_flow_commands.create_flow_command is None:
             if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+                flow = GriptapeNodes.ContextManager().get_current_flow()
+                flow_name = flow.name
             else:
                 details = "Attempted to deserialize a set of Flow Creation commands into the Current Context. Failed because the Current Context was empty."
                 logger.error(details)

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -216,7 +216,8 @@ class FlowManager:
         result = CreateFlowResultSuccess(flow_name=final_flow_name)
         return result
 
-    def on_delete_flow_request(self, request: DeleteFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
+    # This needs to have a lot of branches to check the flow in all possible situations. In Current Context, or when the name is passed in.
+    def on_delete_flow_request(self, request: DeleteFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         flow_name = request.flow_name
         flow = None
         if flow_name is None:
@@ -283,7 +284,9 @@ class FlowManager:
             for child_flow_name in flow_names:
                 child_flow = obj_mgr.attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
                 if child_flow is None:
-                    details = f"Attempted to delete Flow '{child_flow_name}', but no Flow with that name could be found."
+                    details = (
+                        f"Attempted to delete Flow '{child_flow_name}', but no Flow with that name could be found."
+                    )
                     logger.error(details)
                     result = DeleteFlowResultFailure()
                     return result

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -194,6 +194,7 @@ class NodeManager:
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:
         # Validate as much as possible before we actually create one.
         parent_flow_name = request.override_parent_flow_name
+        parent_flow = None
         if parent_flow_name is None:
             # Try to get the current context flow
             if not GriptapeNodes.ContextManager().has_current_flow():
@@ -202,16 +203,18 @@ class NodeManager:
                 )
                 logger.error(details)
                 return CreateNodeResultFailure()
-            parent_flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+            parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+            parent_flow_name = parent_flow.name
 
         # Does this flow actually exist?
-        flow_mgr = GriptapeNodes.FlowManager()
-        try:
-            flow = flow_mgr.get_flow_by_name(parent_flow_name)
-        except KeyError as err:
-            details = f"Could not create Node of type '{request.node_type}'. Error: {err}"
-            logger.error(details)
-            return CreateNodeResultFailure()
+        if parent_flow is None:
+            flow_mgr = GriptapeNodes.FlowManager()
+            try:
+                parent_flow = flow_mgr.get_flow_by_name(parent_flow_name)
+            except KeyError as err:
+                details = f"Could not create Node of type '{request.node_type}'. Error: {err}"
+                logger.error(details)
+                return CreateNodeResultFailure()
 
         # Now ensure that we're giving a valid name.
         obj_mgr = GriptapeNodes.ObjectManager()
@@ -239,7 +242,7 @@ class NodeManager:
             return CreateNodeResultFailure()
 
         # Add it to the Flow.
-        flow.add_node(node)
+        parent_flow.add_node(node)
 
         # Record keeping.
         obj_mgr.add_object_by_name(node.name, node)
@@ -256,7 +259,7 @@ class NodeManager:
 
         # See if we want to push this into the context of the current flow.
         if request.set_as_new_context:
-            GriptapeNodes.ContextManager().push_node(final_node_name)
+            GriptapeNodes.ContextManager().push_node(node=node)
 
         # Success message based on whether we used Current Context or explicit flow
         if request.override_parent_flow_name is None:
@@ -331,6 +334,7 @@ class NodeManager:
 
     def on_delete_node_request(self, request: DeleteNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911 (complex logic, lots of edge cases)
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -340,18 +344,16 @@ class NodeManager:
                 logger.error(details)
                 return DeleteNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
+        if node is None:
+            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        if node is None:
+            details = f"Attempted to delete a Node '{node_name}', but no such Node was found."
+            logger.error(details)
+            return DeleteNodeResultFailure()
 
-        with GriptapeNodes.ContextManager().node(node_name=node_name):
-            # Does this node exist?
-            obj_mgr = GriptapeNodes.ObjectManager()
-
-            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
-            if node is None:
-                details = f"Attempted to delete a Node '{node_name}', but no such Node was found."
-                logger.error(details)
-                return DeleteNodeResultFailure()
-
+        with GriptapeNodes.ContextManager().node(node=node):
             parent_flow_name = self._name_to_parent_flow_name[node_name]
             try:
                 parent_flow = GriptapeNodes.FlowManager().get_flow_by_name(parent_flow_name)
@@ -403,7 +405,7 @@ class NodeManager:
         parent_flow.remove_node(node.name)
 
         # Now remove the record keeping
-        obj_mgr.del_obj_by_name(node_name)
+        GriptapeNodes.ObjectManager().del_obj_by_name(node_name)
         del self._name_to_parent_flow_name[node_name]
 
         # If we were part of the Current Context, pop it.
@@ -417,6 +419,7 @@ class NodeManager:
 
     def on_get_node_resolution_state_request(self, request: GetNodeResolutionStateRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -424,17 +427,18 @@ class NodeManager:
                 logger.error(details)
                 return GetNodeResolutionStateResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
-        # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get resolution state for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
-            result = GetNodeResolutionStateResultFailure()
-            return result
+            # Does this node exist?
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get resolution state for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+                result = GetNodeResolutionStateResultFailure()
+                return result
 
         node_state = node.state
 
@@ -448,6 +452,7 @@ class NodeManager:
 
     def on_get_node_metadata_request(self, request: GetNodeMetadataRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -455,18 +460,20 @@ class NodeManager:
                 logger.error(details)
                 return GetNodeMetadataResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get metadata for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
 
-            result = GetNodeMetadataResultFailure()
-            return result
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get metadata for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+
+                result = GetNodeMetadataResultFailure()
+                return result
 
         metadata = node.metadata
         details = f"Successfully retrieved metadata for a Node '{node_name}'."
@@ -479,6 +486,7 @@ class NodeManager:
 
     def on_set_node_metadata_request(self, request: SetNodeMetadataRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -486,18 +494,21 @@ class NodeManager:
                 logger.error(details)
                 return SetNodeMetadataResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to set metadata for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
 
-            result = SetNodeMetadataResultFailure()
-            return result
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to set metadata for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+
+                result = SetNodeMetadataResultFailure()
+                return result
+
         # We can't completely overwrite metadata.
         for key, value in request.metadata.items():
             node.metadata[key] = value
@@ -509,6 +520,7 @@ class NodeManager:
 
     def on_list_connections_for_node_request(self, request: ListConnectionsForNodeRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -516,18 +528,20 @@ class NodeManager:
                 logger.error(details)
                 return ListConnectionsForNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to list Connections for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
 
-            result = ListConnectionsForNodeResultFailure()
-            return result
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to list Connections for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+
+                result = ListConnectionsForNodeResultFailure()
+                return result
 
         parent_flow_name = self._name_to_parent_flow_name[node_name]
         try:
@@ -581,6 +595,7 @@ class NodeManager:
 
     def on_list_parameters_on_node_request(self, request: ListParametersOnNodeRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             # Get from the current context.
@@ -589,17 +604,19 @@ class NodeManager:
                 logger.error(details)
                 return ListParametersOnNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to list Parameters for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to list Parameters for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = ListParametersOnNodeResultFailure()
-            return result
+                result = ListParametersOnNodeResultFailure()
+                return result
 
         ret_list = [param.name for param in node.parameters]
 
@@ -613,6 +630,7 @@ class NodeManager:
 
     def on_add_parameter_to_node_request(self, request: AddParameterToNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             # Get from the current context.
@@ -621,18 +639,19 @@ class NodeManager:
                 logger.error(details)
                 return AddParameterToNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to add Parameter '{request.parameter_name}' to a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to add Parameter '{request.parameter_name}' to a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = AddParameterToNodeResultFailure()
-            return result
+                result = AddParameterToNodeResultFailure()
+                return result
 
         if request.parent_container_name and not request.initial_setup:
             parameter = node.get_parameter_by_name(request.parent_container_name)
@@ -745,6 +764,7 @@ class NodeManager:
 
     def on_remove_parameter_from_node_request(self, request: RemoveParameterFromNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             # Get the Current Context
@@ -755,18 +775,19 @@ class NodeManager:
                 result = RemoveParameterFromNodeResultFailure()
                 return result
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = RemoveParameterFromNodeResultFailure()
-            return result
+                result = RemoveParameterFromNodeResultFailure()
+                return result
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(request.parameter_name)
@@ -852,6 +873,8 @@ class NodeManager:
 
     def on_get_parameter_details_request(self, request: GetParameterDetailsRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node, but no Current Context was found."
@@ -859,18 +882,19 @@ class NodeManager:
 
                 result = GetParameterDetailsResultFailure()
                 return result
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = GetParameterDetailsResultFailure()
-            return result
+                result = GetParameterDetailsResultFailure()
+                return result
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(request.parameter_name)
@@ -910,23 +934,26 @@ class NodeManager:
 
     def on_get_node_element_details_request(self, request: GetNodeElementDetailsRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = f"Attempted to get element details for element '{request.specific_element_id}` from a Node, but no Current Context was found."
                 logger.error(details)
 
                 return GetNodeElementDetailsResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get element details for Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get element details for Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            return GetNodeElementDetailsResultFailure()
+                return GetNodeElementDetailsResultFailure()
 
         # Did they ask for a specific element ID?
         if request.specific_element_id is None:
@@ -1017,6 +1044,7 @@ class NodeManager:
 
     def on_alter_parameter_details_request(self, request: AlterParameterDetailsRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1024,16 +1052,18 @@ class NodeManager:
                 logger.error(details)
 
                 return AlterParameterDetailsResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            return AlterParameterDetailsResultFailure()
+                return AlterParameterDetailsResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(request.parameter_name)
@@ -1073,6 +1103,7 @@ class NodeManager:
     # For C901 (too complex): Need to give customers explicit reasons for failure on each case.
     def on_get_parameter_value_request(self, request: GetParameterValueRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1080,20 +1111,20 @@ class NodeManager:
                 logger.error(details)
 
                 return GetParameterValueResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
-
-        # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Parse the parameter name to check for list indexing
         param_name = request.parameter_name
 
-        # Get the node
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+        # Does this node exist?
         if node is None:
-            details = f'"{node_name}" not found'
-            logger.error(details)
-            return GetParameterValueResultFailure()
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f'"{node_name}" not found'
+                logger.error(details)
+                return GetParameterValueResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(param_name)
@@ -1128,25 +1159,27 @@ class NodeManager:
     # added ignoring C901 since this method is overly long because of granular error checking, not actual complexity.
     def on_set_parameter_value_request(self, request: SetParameterValueRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = f"Attempted to set parameter '{request.parameter_name}' value. Failed because no Node was found in the Current Context."
                 logger.error(details)
                 return SetParameterValueResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
-
-        # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Parse the parameter name to check for list indexing
         param_name = request.parameter_name
 
-        # Get the node
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+        # Does this node exist?
         if node is None:
-            details = f"Attempted to set parameter '{param_name}' value on node '{node_name}'. Failed because no such Node could be found."
-            logger.error(details)
-            return SetParameterValueResultFailure()
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to set parameter '{param_name}' value on node '{node_name}'. Failed because no such Node could be found."
+                logger.error(details)
+                return SetParameterValueResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(param_name)
@@ -1180,6 +1213,8 @@ class NodeManager:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
             logger.error(details)
             return SetParameterValueResultFailure()
+
+        obj_mgr = GriptapeNodes.ObjectManager()
         parent_flow = obj_mgr.attempt_get_object_by_name_as_type(parent_flow_name, ControlFlow)
         if not parent_flow:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
@@ -1257,6 +1292,8 @@ class NodeManager:
     # make debugger use friendly.
     def on_get_all_node_info_request(self, request: GetAllNodeInfoRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
         node_name = request.node_name
+        node = None
+
         # Get from the current context.
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1264,18 +1301,19 @@ class NodeManager:
                 logger.error(details)
                 return GetAllNodeInfoResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get all info for Node named '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get all info for Node named '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = GetAllNodeInfoResultFailure()
-            return result
+                result = GetAllNodeInfoResultFailure()
+                return result
 
         get_metadata_request = GetNodeMetadataRequest(node_name=node_name)
         get_metadata_result = self.on_get_node_metadata_request(get_metadata_request)
@@ -1350,20 +1388,24 @@ class NodeManager:
 
     def on_get_compatible_parameters_request(self, request: GetCompatibleParametersRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = "Attempted to get compatible parameters for node, but no current node was found."
                 logger.error(details)
                 return GetCompatibleParametersResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Vet the node
-        try:
-            node = self.get_node_by_name(node_name)
-        except ValueError as err:
-            details = f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist. Error: {err}."
-            logger.error(details)
-            return GetCompatibleParametersResultFailure()
+        if node is None:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist."
+                logger.error(details)
+                return GetCompatibleParametersResultFailure()
 
         # Vet the parameter.
         request_param = node.get_parameter_by_name(request.parameter_name)
@@ -1579,23 +1621,27 @@ class NodeManager:
 
     def on_serialize_node_to_commands(self, request: SerializeNodeToCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0912
         node_name = request.node_name
+        node = None
+
         if node_name is None:
-            if GriptapeNodes.ContextManager().has_current_node():
-                node_name = GriptapeNodes.ContextManager().get_current_node_name()
-            else:
+            if not GriptapeNodes.ContextManager().has_current_node():
                 details = "Attempted to serialize a Node to commands from the Current Context. Failed because the Current Context is empty."
                 logger.error(details)
                 return SerializeNodeToCommandsResultFailure()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to serialize Node '{node_name}' to commands. Failed because no Node with that name could be found."
-            logger.error(details)
-            return SerializeNodeToCommandsResultFailure()
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to serialize Node '{node_name}' to commands. Failed because no Node with that name could be found."
+                logger.error(details)
+                return SerializeNodeToCommandsResultFailure()
 
         # This is our current dude.
-        with GriptapeNodes.ContextManager().node(node_name=node_name):
+        with GriptapeNodes.ContextManager().node(node=node):
             # Get the library and version details.
             library_used = node.metadata["library"]
             # Get the library metadata so we can get the version.
@@ -1684,7 +1730,12 @@ class NodeManager:
 
         # Adopt the newly-created node as our current context.
         node_name = create_node_result.node_name
-        with GriptapeNodes.ContextManager().node(node_name=node_name):
+        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        if node is None:
+            details = f"Attempted to deserialize a serialized set of Node Creation commands. Failed to get node '{node_name}'."
+            logger.error(details)
+            return DeserializeNodeFromCommandsResultFailure()
+        with GriptapeNodes.ContextManager().node(node=node):
             for element_command in request.serialized_node_commands.element_modification_commands:
                 if isinstance(
                     element_command, (AlterParameterDetailsRequest, AddParameterToNodeRequest)
@@ -1803,7 +1854,11 @@ class NodeManager:
                 logger.error("Attempted to deserialize node but ran into an error on node serialization.")
                 return DeserializeSelectedNodesFromCommandsResultFailure()
             node_uuid_to_name[node_command.node_uuid] = result.node_name
-            with GriptapeNodes.ContextManager().node(result.node_name):
+            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(result.node_name, BaseNode)
+            if node is None:
+                logger.error("Attempted to deserialize node but ran into an error on node serialization.")
+                return DeserializeSelectedNodesFromCommandsResultFailure()
+            with GriptapeNodes.ContextManager().node(node=node):
                 parameter_commands = commands.set_parameter_value_commands[node_command.node_uuid]
                 for parameter_command in parameter_commands:
                     param_request = parameter_command.set_parameter_value_command

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1403,7 +1403,9 @@ class NodeManager:
             obj_mgr = GriptapeNodes.ObjectManager()
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
-                details = f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist."
+                details = (
+                    f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist."
+                )
                 logger.error(details)
                 return GetCompatibleParametersResultFailure()
 
@@ -1824,7 +1826,7 @@ class NodeManager:
         GriptapeNodes.ContextManager()._clipboard.parameter_uuid_to_values = unique_uuid_to_values
         return SerializeSelectedNodesToCommandsResultSuccess(final_result)
 
-    def on_deserialize_selected_nodes_from_commands(  # noqa: C901
+    def on_deserialize_selected_nodes_from_commands(  # noqa: C901, PLR0912
         self,
         request: DeserializeSelectedNodesFromCommandsRequest,
     ) -> ResultPayload:


### PR DESCRIPTION
ContextManager now uses objects instead of names. This will make renaming less damaging, and paves the way for us to begin to track objects separately from their names.
- For `node()`, `flow()`, and `element()`, you can still use name as a `str`, so workflow saving and loading still works with `with ContextManager().node()`, since creating objects in the python save files is extra work. 
- For `ControlFlow` objects, I added `.name` as a field. In a future PR I will update other cases where `.name` will be useful, but it seemed like flows should store their own names since nodes and elements do.