### PR TITLE
Track Object IDs instead of names 

### DIFF
--- a/src/griptape_nodes/bootstrap/bootstrap_script.py
+++ b/src/griptape_nodes/bootstrap/bootstrap_script.py
@@ -17,6 +17,7 @@ from register_libraries_script import (  # type: ignore[import] - This import is
     register_libraries,
 )
 
+from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.retained_mode.events.base_events import (
     AppEvent,
@@ -63,9 +64,9 @@ def _load_user_workflow(path_to_workflow: str) -> None:
     spec.loader.exec_module(module)
 
 
-def _load_flow_for_workflow() -> str:
+def _load_flow_for_workflow() -> ControlFlow:
     context_manager = GriptapeNodes.ContextManager()
-    return context_manager.get_current_flow_name()
+    return context_manager.get_current_flow()
 
 
 def _set_workflow_context(workflow_name: str) -> None:
@@ -208,7 +209,8 @@ def run(workflow_name: str, flow_input: Any) -> None:
     # or nothing works. The name can be anything, but how about the workflow_name.
     _set_workflow_context(workflow_name=workflow_name)
     _load_user_workflow("workflow.py")
-    flow_name = _load_flow_for_workflow()
+    flow = _load_flow_for_workflow()
+    flow_name = flow.name
     # Now let's set the input to the flow
     _set_input_for_flow(flow_name=flow_name, flow_input=flow_input)
 

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import field
 import logging
 from queue import Queue
 from typing import TYPE_CHECKING, NamedTuple
+import uuid
 
 from griptape.events import EventBus
 
@@ -36,6 +38,7 @@ class ControlFlow:
     control_flow_machine: ControlFlowMachine
     single_node_resolution: bool
     flow_queue: Queue[BaseNode]
+    element_id: str = field(default_factory=lambda: str(uuid.uuid4().hex))
 
     def __init__(self, name: str) -> None:
         self.name = name

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -30,14 +30,14 @@ class CurrentNodes(NamedTuple):
 
 # The flow will own all of the nodes and the connections
 class ControlFlow:
-    name:str
+    name: str
     connections: Connections
     nodes: dict[str, BaseNode]
     control_flow_machine: ControlFlowMachine
     single_node_resolution: bool
     flow_queue: Queue[BaseNode]
 
-    def __init__(self, name:str) -> None:
+    def __init__(self, name: str) -> None:
         self.name = name
         self.connections = Connections()
         self.nodes = {}

--- a/src/griptape_nodes/exe_types/flow.py
+++ b/src/griptape_nodes/exe_types/flow.py
@@ -30,13 +30,15 @@ class CurrentNodes(NamedTuple):
 
 # The flow will own all of the nodes and the connections
 class ControlFlow:
+    name:str
     connections: Connections
     nodes: dict[str, BaseNode]
     control_flow_machine: ControlFlowMachine
     single_node_resolution: bool
     flow_queue: Queue[BaseNode]
 
-    def __init__(self) -> None:
+    def __init__(self, name:str) -> None:
+        self.name = name
         self.connections = Connections()
         self.nodes = {}
         self.control_flow_machine = ControlFlowMachine(self)

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable
+from dataclasses import field
 from enum import StrEnum, auto
 from typing import Any, TypeVar
 
@@ -52,6 +54,8 @@ class NodeResolutionState(StrEnum):
 
 class BaseNode(ABC):
     # Owned by a flow
+    # non-changeable Node Id on creation.
+    element_id: str = field(default_factory= lambda: str(uuid.uuid4().hex))
     name: str
     metadata: dict[Any, Any]
 

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -13,11 +13,11 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @dataclass
 @PayloadRegistry.register
 class CreateConnectionRequest(RequestPayload):
-    source_parameter_name: str
-    target_parameter_name: str
+    source_parameter_id: str
+    target_parameter_id: str
     # If node name is None, use the Current Context
-    source_node_name: str | None = None
-    target_node_name: str | None = None
+    source_node_id: str | None = None
+    target_node_id: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
 
@@ -39,9 +39,9 @@ class CreateConnectionResultFailure(ResultPayloadFailure):
 class DeleteConnectionRequest(RequestPayload):
     source_parameter_name: str
     target_parameter_name: str
-    # If node name is None, use the Current Context
-    source_node_name: str | None = None
-    target_node_name: str | None = None
+    # If node id is None, use the Current Context
+    source_node_id: str | None = None
+    target_node_id: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -60,12 +60,12 @@ class DeleteConnectionResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class ListConnectionsForNodeRequest(RequestPayload):
     # If node name is None, use the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
 class IncomingConnection:
-    source_node_name: str
+    source_node_id: str
     source_parameter_name: str
     target_parameter_name: str
 
@@ -73,7 +73,7 @@ class IncomingConnection:
 @dataclass
 class OutgoingConnection:
     source_parameter_name: str
-    target_node_name: str
+    target_node_id: str
     target_parameter_name: str
 
 

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -13,8 +13,8 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @dataclass
 @PayloadRegistry.register
 class CreateConnectionRequest(RequestPayload):
-    source_parameter_id: str
-    target_parameter_id: str
+    source_parameter_name: str
+    target_parameter_name: str
     # If node name is None, use the Current Context
     source_node_id: str | None = None
     target_node_id: str | None = None

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -20,6 +20,30 @@ class CreateConnectionRequest(RequestPayload):
     target_node_id: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
+    
+    @property
+    def source_node_name(self) -> str | None:
+        """Get the source node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the source node if source_node_id is provided, otherwise None
+        """
+        if self.source_node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.source_node_id)
+        
+    @property
+    def target_node_name(self) -> str | None:
+        """Get the target node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the target node if target_node_id is provided, otherwise None
+        """
+        if self.target_node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.target_node_id)
 
 
 @dataclass
@@ -42,6 +66,30 @@ class DeleteConnectionRequest(RequestPayload):
     # If node id is None, use the Current Context
     source_node_id: str | None = None
     target_node_id: str | None = None
+    
+    @property
+    def source_node_name(self) -> str | None:
+        """Get the source node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the source node if source_node_id is provided, otherwise None
+        """
+        if self.source_node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.source_node_id)
+        
+    @property
+    def target_node_name(self) -> str | None:
+        """Get the target node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the target node if target_node_id is provided, otherwise None
+        """
+        if self.target_node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.target_node_id)
 
 
 @dataclass
@@ -61,6 +109,18 @@ class DeleteConnectionResultFailure(ResultPayloadFailure):
 class ListConnectionsForNodeRequest(RequestPayload):
     # If node name is None, use the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -17,7 +17,7 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @dataclass
 @PayloadRegistry.register
 class ResolveNodeRequest(RequestPayload):
-    node_name: str
+    node_id: str
     debug_mode: bool = False
 
 

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -96,7 +96,7 @@ class UnresolveFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
 @dataclass
 @PayloadRegistry.register
 class SingleExecutionStepRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass
@@ -114,7 +114,7 @@ class SingleExecutionStepResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class SingleNodeStepRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass
@@ -133,7 +133,7 @@ class SingleNodeStepResultFailure(ResolveNodeResultFailure):
 @dataclass
 @PayloadRegistry.register
 class ContinueExecutionStepRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass
@@ -151,7 +151,7 @@ class ContinueExecutionStepResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class GetFlowStateRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -36,8 +36,8 @@ class ResolveNodeResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class StartFlowRequest(RequestPayload):
-    flow_name: str
-    flow_node_name: str | None = None
+    flow_id: str
+    flow_node_id: str | None = None
     debug_mode: bool = False
 
 
@@ -56,7 +56,7 @@ class StartFlowResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class CancelFlowRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass
@@ -74,7 +74,7 @@ class CancelFlowResultFailure(ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class UnresolveFlowRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -170,7 +170,7 @@ class GetFlowStateResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class GetIsFlowRunningRequest(RequestPayload):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -19,6 +19,16 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 class ResolveNodeRequest(RequestPayload):
     node_id: str
     debug_mode: bool = False
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -39,6 +49,16 @@ class StartFlowRequest(RequestPayload):
     flow_id: str
     flow_node_id: str | None = None
     debug_mode: bool = False
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -57,6 +77,16 @@ class StartFlowResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class CancelFlowRequest(RequestPayload):
     flow_id: str
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -75,6 +105,16 @@ class CancelFlowResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class UnresolveFlowRequest(RequestPayload):
     flow_id: str
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -97,6 +137,16 @@ class UnresolveFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
 @PayloadRegistry.register
 class SingleExecutionStepRequest(RequestPayload):
     flow_id: str
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -115,6 +165,16 @@ class SingleExecutionStepResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class SingleNodeStepRequest(RequestPayload):
     flow_id: str
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -134,6 +194,16 @@ class SingleNodeStepResultFailure(ResolveNodeResultFailure):
 @PayloadRegistry.register
 class ContinueExecutionStepRequest(RequestPayload):
     flow_id: str
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -152,6 +222,16 @@ class ContinueExecutionStepResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class GetFlowStateRequest(RequestPayload):
     flow_id: str
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -38,7 +38,7 @@ class CreateFlowResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class DeleteFlowRequest(RequestPayload):
     # If None is passed, assumes we're deleting the flow in the Current Context.
-    flow_name: str | None = None
+    flow_id: str | None = None
 
 
 @dataclass
@@ -57,13 +57,13 @@ class DeleteFlowResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class ListNodesInFlowRequest(RequestPayload):
     # If None is passed, assumes we're using the flow in the Current Context.
-    flow_name: str | None = None
+    flow_id: str | None = None
 
 
 @dataclass
 @PayloadRegistry.register
 class ListNodesInFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    node_names: list[str]
+    node_ids: list[str]
 
 
 @dataclass
@@ -86,7 +86,7 @@ class ListFlowsInCurrentContextRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class ListFlowsInCurrentContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    flow_names: list[str]
+    flow_ids: list[str]
 
 
 @dataclass
@@ -100,13 +100,13 @@ class ListFlowsInCurrentContextResultFailure(WorkflowNotAlteredMixin, ResultPayl
 @PayloadRegistry.register
 class ListFlowsInFlowRequest(RequestPayload):
     # Pass in None to get the canvas.
-    parent_flow_name: str | None = None
+    parent_flow_id: str | None = None
 
 
 @dataclass
 @PayloadRegistry.register
 class ListFlowsInFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    flow_names: list[str]
+    flow_ids: list[str]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -25,7 +25,7 @@ class CreateFlowRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class CreateFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass
@@ -124,7 +124,7 @@ class GetTopLevelFlowRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class GetTopLevelFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    flow_name: str | None
+    flow_id: str | None
 
 
 # A Flow's state can be serialized into a sequence of commands that the engine then runs.
@@ -191,7 +191,7 @@ class SerializeFlowToCommandsRequest(RequestPayload):
             Copy/paste can make use of this.
     """
 
-    flow_name: str | None = None
+    flow_id: str | None = None
     include_create_flow_command: bool = True
 
 
@@ -216,7 +216,7 @@ class DeserializeFlowFromCommandsRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class DeserializeFlowFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
-    flow_name: str
+    flow_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -16,7 +16,7 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @dataclass(kw_only=True)
 @PayloadRegistry.register
 class CreateFlowRequest(RequestPayload):
-    parent_flow_name: str | None
+    parent_flow_id: str | None
     flow_name: str | None = None
     # When True, this Flow will be pushed as the new Current Context.
     set_as_new_context: bool = True

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -26,6 +26,7 @@ class CreateFlowRequest(RequestPayload):
 @PayloadRegistry.register
 class CreateFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     flow_id: str
+    flow_name: str
 
 
 @dataclass
@@ -39,6 +40,18 @@ class CreateFlowResultFailure(ResultPayloadFailure):
 class DeleteFlowRequest(RequestPayload):
     # If None is passed, assumes we're deleting the flow in the Current Context.
     flow_id: str | None = None
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow if flow_id is provided, otherwise None
+        """
+        if self.flow_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -58,6 +71,18 @@ class DeleteFlowResultFailure(ResultPayloadFailure):
 class ListNodesInFlowRequest(RequestPayload):
     # If None is passed, assumes we're using the flow in the Current Context.
     flow_id: str | None = None
+    
+    @property
+    def flow_name(self) -> str | None:
+        """Get the flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the flow if flow_id is provided, otherwise None
+        """
+        if self.flow_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.flow_id)
 
 
 @dataclass
@@ -101,6 +126,18 @@ class ListFlowsInCurrentContextResultFailure(WorkflowNotAlteredMixin, ResultPayl
 class ListFlowsInFlowRequest(RequestPayload):
     # Pass in None to get the canvas.
     parent_flow_id: str | None = None
+    
+    @property
+    def parent_flow_name(self) -> str | None:
+        """Get the parent flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the parent flow if parent_flow_id is provided, otherwise None
+        """
+        if self.parent_flow_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.parent_flow_id)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -62,7 +62,7 @@ class CreateNodeResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class DeleteNodeRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context.
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -42,6 +42,18 @@ class CreateNodeRequest(RequestPayload):
     initial_setup: bool = False
     # When True, this Node will be pushed as the current Node within the Current Context.
     set_as_new_context: bool = False
+    
+    @property
+    def override_parent_flow_name(self) -> str | None:
+        """Get the override parent flow name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the override parent flow if override_parent_flow_id is provided, otherwise None
+        """
+        if self.override_parent_flow_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.override_parent_flow_id)
 
 
 @dataclass
@@ -64,6 +76,18 @@ class CreateNodeResultFailure(ResultPayloadFailure):
 class DeleteNodeRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context.
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -83,6 +107,18 @@ class DeleteNodeResultFailure(ResultPayloadFailure):
 class GetNodeResolutionStateRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -102,6 +138,17 @@ class GetNodeResolutionStateResultFailure(WorkflowNotAlteredMixin, ResultPayload
 class ListParametersOnNodeRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
     node_id: str | None = None
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -121,6 +168,18 @@ class ListParametersOnNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
 class GetNodeMetadataRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -141,6 +200,18 @@ class SetNodeMetadataRequest(RequestPayload):
     metadata: dict
     # If None is passed, assumes we're using the Node in the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -35,7 +35,7 @@ class CreateNodeRequest(RequestPayload):
     specific_library_name: str | None = None
     node_name: str | None = None
     # If None is passed, assumes we're using the flow in the Current Context
-    override_parent_flow_name: str | None = None
+    override_parent_flow_id: str | None = None
     metadata: dict | None = None
     resolution: str = NodeResolutionState.UNRESOLVED.value
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
@@ -49,6 +49,7 @@ class CreateNodeRequest(RequestPayload):
 class CreateNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     node_name: str
     node_type: str
+    node_id: str
     specific_library_name: str | None = None
 
 
@@ -81,7 +82,7 @@ class DeleteNodeResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class GetNodeResolutionStateRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
@@ -100,7 +101,7 @@ class GetNodeResolutionStateResultFailure(WorkflowNotAlteredMixin, ResultPayload
 @PayloadRegistry.register
 class ListParametersOnNodeRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
@@ -119,7 +120,7 @@ class ListParametersOnNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
 @PayloadRegistry.register
 class GetNodeMetadataRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
@@ -139,7 +140,7 @@ class GetNodeMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure
 class SetNodeMetadataRequest(RequestPayload):
     metadata: dict
     # If None is passed, assumes we're using the Node in the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
@@ -160,7 +161,7 @@ class SetNodeMetadataResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class GetAllNodeInfoRequest(RequestPayload):
     # If None is passed, assumes we're using the Node in the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
@@ -290,7 +291,7 @@ class SerializeNodeToCommandsRequest(RequestPayload):
             are preserved to prevent duplicate serialization attempts.
     """
 
-    node_name: str | None = None
+    node_id: str | None = None
     unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any] = field(
         default_factory=dict
     )
@@ -377,7 +378,7 @@ class DeserializeSelectedNodesFromCommandsRequest(WorkflowNotAlteredMixin, Reque
 @dataclass
 @PayloadRegistry.register
 class DeserializeSelectedNodesFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
-    node_names: list[str]
+    node_ids: list[str]
 
 
 @dataclass
@@ -396,6 +397,7 @@ class DeserializeNodeFromCommandsRequest(RequestPayload):
 @PayloadRegistry.register
 class DeserializeNodeFromCommandsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     node_name: str
+    node_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -93,7 +93,7 @@ class SetParameterValueRequest(RequestPayload):
     parameter_name: str
     value: Any
     # If node name is None, use the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
     data_type: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -41,6 +41,18 @@ class AddParameterToNodeRequest(RequestPayload):
     parent_container_name: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
     @classmethod
     def create(cls, **kwargs) -> AddParameterToNodeRequest:
@@ -73,6 +85,18 @@ class RemoveParameterFromNodeRequest(RequestPayload):
     parameter_name: str
     # If node id is None, use the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -99,6 +123,18 @@ class SetParameterValueRequest(RequestPayload):
     initial_setup: bool = False
     # is_output is true when the value being saved is from an output value. Used when loading a workflow from a file.
     is_output: bool = False
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -120,6 +156,18 @@ class GetParameterDetailsRequest(RequestPayload):
     parameter_name: str
     # If node name is None, use the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -151,7 +199,6 @@ class GetParameterDetailsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFai
 @PayloadRegistry.register
 class AlterParameterDetailsRequest(RequestPayload):
     parameter_name: str
-    # If node name is None, use the Current Context
     node_id: str | None = None
     type: str | None = None
     input_types: list[str] | None = None
@@ -166,8 +213,19 @@ class AlterParameterDetailsRequest(RequestPayload):
     mode_allowed_output: bool | None = None
     ui_options: dict | None = None
     traits: set[str] | None = None
-    # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
     @classmethod
     def create(cls, **kwargs) -> AlterParameterDetailsRequest:
@@ -224,6 +282,18 @@ class GetParameterValueRequest(RequestPayload):
     parameter_name: str
     # If node id is None, use the Current Context
     node_id: str | None = None
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass
@@ -279,9 +349,21 @@ class GetCompatibleParametersResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 @dataclass
 @PayloadRegistry.register
 class GetNodeElementDetailsRequest(RequestPayload):
-    # If node name is None, use the Current Context
+    # If node id is None, use the Current Context
     node_id: str | None = None
     specific_element_id: str | None = None  # Pass None to use the root
+    
+    @property
+    def node_name(self) -> str | None:
+        """Get the node name for backward compatibility with operation_manager.
+        
+        Returns:
+            The name of the node if node_id is provided, otherwise None
+        """
+        if self.node_id is None:
+            return None
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        return GriptapeNodes.ObjectManager().get_name_by_id(self.node_id)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 @PayloadRegistry.register
 class AddParameterToNodeRequest(RequestPayload):
     # If node name is None, use the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
     parameter_name: str | None = None
     default_value: Any | None = None
     tooltip: str | list[dict] | None = None
@@ -58,7 +58,7 @@ class AddParameterToNodeRequest(RequestPayload):
 class AddParameterToNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     parameter_name: str
     type: str
-    node_name: str
+    node_id: str
 
 
 @dataclass
@@ -71,8 +71,8 @@ class AddParameterToNodeResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class RemoveParameterFromNodeRequest(RequestPayload):
     parameter_name: str
-    # If node name is None, use the Current Context
-    node_name: str | None = None
+    # If node id is None, use the Current Context
+    node_id: str | None = None
 
 
 @dataclass
@@ -119,7 +119,7 @@ class SetParameterValueResultFailure(ResultPayloadFailure):
 class GetParameterDetailsRequest(RequestPayload):
     parameter_name: str
     # If node name is None, use the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
 
 
 @dataclass
@@ -152,7 +152,7 @@ class GetParameterDetailsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFai
 class AlterParameterDetailsRequest(RequestPayload):
     parameter_name: str
     # If node name is None, use the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
     type: str | None = None
     input_types: list[str] | None = None
     output_type: str | None = None
@@ -222,8 +222,8 @@ class AlterParameterDetailsResultFailure(ResultPayloadFailure):
 @PayloadRegistry.register
 class GetParameterValueRequest(RequestPayload):
     parameter_name: str
-    # If node name is None, use the Current Context
-    node_name: str | None = None
+    # If node id is None, use the Current Context
+    node_id: str | None = None
 
 
 @dataclass
@@ -255,8 +255,8 @@ class OnParameterValueChanged(WorkflowAlteredMixin, ResultPayloadSuccess):
 class GetCompatibleParametersRequest(RequestPayload):
     parameter_name: str
     is_output: bool
-    # If node name is None, use the Current Context
-    node_name: str | None = None
+    # If node id is None, use the Current Context
+    node_id: str | None = None
 
 
 class ParameterAndMode(NamedTuple):
@@ -280,7 +280,7 @@ class GetCompatibleParametersResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 @PayloadRegistry.register
 class GetNodeElementDetailsRequest(RequestPayload):
     # If node name is None, use the Current Context
-    node_name: str | None = None
+    node_id: str | None = None
     specific_element_id: str | None = None  # Pass None to use the root
 
 

--- a/src/griptape_nodes/retained_mode/events/validation_events.py
+++ b/src/griptape_nodes/retained_mode/events/validation_events.py
@@ -36,7 +36,7 @@ class ValidateFlowDependenciesResultFailure(WorkflowNotAlteredMixin, ResultPaylo
 @PayloadRegistry.register
 class ValidateNodeDependenciesRequest(RequestPayload):
     # Same inputs as StartFlow
-    node_name: str
+    node_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/validation_events.py
+++ b/src/griptape_nodes/retained_mode/events/validation_events.py
@@ -14,8 +14,8 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 @PayloadRegistry.register
 class ValidateFlowDependenciesRequest(RequestPayload):
     # Same inputs as StartFlow
-    flow_name: str
-    flow_node_name: str | None = None
+    flow_id: str
+    flow_node_id: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -155,7 +155,7 @@ class ContextManager:
             self.node = node
             self._element_stack = []
 
-        def push_element(self, element:BaseNodeElement) -> BaseNodeElement:
+        def push_element(self, element: BaseNodeElement) -> BaseNodeElement:
             """Push an element name onto this node's element stack."""
             self._element_stack.append(element)
             return element

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -14,6 +14,9 @@ from griptape_nodes.retained_mode.events.context_events import (
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from griptape_nodes.exe_types.core_types import BaseNodeElement
+    from griptape_nodes.exe_types.flow import ControlFlow
+    from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
     from griptape_nodes.retained_mode.events.node_events import SerializedSelectedNodesCommands
@@ -55,33 +58,33 @@ class ContextManager:
             self._name = name
             self._flow_stack = []
 
-        def push_flow(self, flow_name: str) -> str:
+        def push_flow(self, flow: ControlFlow) -> ControlFlow:
             """Push a flow name onto this workflow's flow stack."""
-            flow_context = ContextManager.FlowContextState(flow_name)
+            flow_context = ContextManager.FlowContextState(flow)
             self._flow_stack.append(flow_context)
-            return flow_name
+            return flow
 
-        def pop_flow(self) -> str:
+        def pop_flow(self) -> ControlFlow:
             """Pop the top flow from this workflow's flow stack."""
             if not self._flow_stack:
                 msg = f"Cannot pop Flow: no active Flows in Workflow '{self._name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             flow_context = self._flow_stack.pop()
-            return flow_context._name
+            return flow_context._flow
 
         def has_current_flow(self) -> bool:
             """Check if this workflow has an active flow."""
             return len(self._flow_stack) > 0
 
-        def get_current_flow_name(self) -> str:
-            """Get the name of the current flow in this workflow."""
+        def get_current_flow(self) -> ControlFlow:
+            """Get the current flow in this workflow."""
             if not self._flow_stack:
                 msg = f"No active Flow in Workflow '{self._name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             flow_context = self._flow_stack[-1]
-            return flow_context._name
+            return flow_context._flow
 
     class WorkflowContext:
         """A context manager for a Workflow."""
@@ -107,36 +110,36 @@ class ContextManager:
     class FlowContextState:
         """Internal class that represents a Flow's state which owns a stack of node names."""
 
-        _name: str
+        _flow: ControlFlow
         _node_stack: list[ContextManager.NodeContextState]
 
-        def __init__(self, name: str):
-            self._name = name
+        def __init__(self, flow: ControlFlow):
+            self._flow = flow
             self._node_stack = []
 
-        def push_node(self, node_name: str) -> str:
+        def push_node(self, node: BaseNode) -> BaseNode:
             """Push a node name onto this flow's node stack."""
-            node_context = ContextManager.NodeContextState(node_name)
+            node_context = ContextManager.NodeContextState(node)
             self._node_stack.append(node_context)
-            return node_name
+            return node
 
-        def pop_node(self) -> str:
+        def pop_node(self) -> BaseNode:
             """Pop the top node from this flow's node stack."""
             if not self._node_stack:
-                msg = f"Cannot pop Node: no active Nodes in Flow '{self._name}'"
+                msg = f"Cannot pop Node: no active Nodes in Flow '{self._flow.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             node_context = self._node_stack.pop()
-            return node_context.node_name
+            return node_context.node
 
-        def get_current_node_name(self) -> str:
+        def get_current_node(self) -> BaseNode:
             """Get the name of the current node in this flow."""
             if not self._node_stack:
-                msg = f"No active Node in Flow '{self._name}'"
+                msg = f"No active Node in Flow '{self._flow.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             node_context = self._node_stack[-1]
-            return node_context.node_name
+            return node_context.node
 
         def has_current_node(self) -> bool:
             """Check if this flow has an active node."""
@@ -145,31 +148,31 @@ class ContextManager:
     class NodeContextState:
         """Internal class that represents a Node's state which owns a stack of node elements."""
 
-        node_name: str
-        _element_stack: list[str]
+        node: BaseNode
+        _element_stack: list[BaseNodeElement]
 
-        def __init__(self, node_name: str):
-            self.node_name = node_name
+        def __init__(self, node: BaseNode):
+            self.node = node
             self._element_stack = []
 
-        def push_element(self, element_name: str) -> str:
+        def push_element(self, element:BaseNodeElement) -> BaseNodeElement:
             """Push an element name onto this node's element stack."""
-            self._element_stack.append(element_name)
-            return element_name
+            self._element_stack.append(element)
+            return element
 
-        def pop_element(self) -> str:
+        def pop_element(self) -> BaseNodeElement:
             """Pop the top element from this node's element stack."""
             if not self._element_stack:
-                msg = f"Cannot pop Element: no active Elements in Node '{self.node_name}'"
+                msg = f"Cannot pop Element: no active Elements in Node '{self.node.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
-            element_name = self._element_stack.pop()
-            return element_name
+            element = self._element_stack.pop()
+            return element
 
-        def get_current_element_name(self) -> str:
+        def get_current_element(self) -> BaseNodeElement:
             """Get the name of the current element in this node."""
             if not self._element_stack:
-                msg = f"No active Element in Node '{self.node_name}'"
+                msg = f"No active Element in Node '{self.node.name}'"
                 raise ContextManager.EmptyStackError(msg)
 
             return self._element_stack[-1]
@@ -183,14 +186,14 @@ class ContextManager:
         """A context manager for a Flow."""
 
         _manager: ContextManager
-        _flow_name: str
+        _flow: ControlFlow
 
-        def __init__(self, manager: ContextManager, flow_name: str):
+        def __init__(self, manager: ContextManager, flow: ControlFlow):
             self._manager = manager
-            self._flow_name = flow_name
+            self._flow = flow
 
-        def __enter__(self) -> str:
-            return self._manager.push_flow(self._flow_name)
+        def __enter__(self) -> ControlFlow:
+            return self._manager.push_flow(self._flow)
 
         def __exit__(
             self,
@@ -204,14 +207,14 @@ class ContextManager:
         """A context manager for a Node within a Flow."""
 
         _manager: ContextManager
-        _node_name: str
+        _node: BaseNode
 
-        def __init__(self, manager: ContextManager, node_name: str):
+        def __init__(self, manager: ContextManager, node: BaseNode):
             self._manager = manager
-            self._node_name = node_name
+            self._node = node
 
-        def __enter__(self) -> str:
-            return self._manager.push_node(self._node_name)
+        def __enter__(self) -> BaseNode:
+            return self._manager.push_node(self._node)
 
         def __exit__(
             self,
@@ -224,12 +227,12 @@ class ContextManager:
     class ElementContext:
         """A context manager for an Element within a Node."""
 
-        def __init__(self, manager: ContextManager, element_name: str):
+        def __init__(self, manager: ContextManager, element: BaseNodeElement):
             self._manager = manager
-            self._element_name = element_name
+            self._element = element
 
-        def __enter__(self) -> str:
-            return self._manager.push_element(self._element_name)
+        def __enter__(self) -> BaseNodeElement:
+            return self._manager.push_element(self._element)
 
         def __exit__(
             self,
@@ -301,38 +304,38 @@ class ContextManager:
         """
         return self.WorkflowContext(self, workflow_name)
 
-    def flow(self, flow_name: str) -> ContextManager.FlowContext:
+    def flow(self, flow: ControlFlow) -> ContextManager.FlowContext:
         """Create a context manager for a Flow context.
 
         Args:
-            flow_name: The name of the Flow to enter.
+            flow: The Flow object to enter.
 
         Returns:
             A context manager for the Flow context.
         """
-        return self.FlowContext(self, flow_name)
+        return self.FlowContext(self, flow)
 
-    def node(self, node_name: str) -> ContextManager.NodeContext:
+    def node(self, node: BaseNode) -> ContextManager.NodeContext:
         """Create a context manager for a Node context.
 
         Args:
-            node_name: The name of the Node to enter.
+            node: The Node object to enter.
 
         Returns:
             A context manager for the Node context.
         """
-        return self.NodeContext(self, node_name)
+        return self.NodeContext(self, node)
 
-    def element(self, element_name: str) -> ContextManager.ElementContext:
+    def element(self, element: BaseNodeElement) -> ContextManager.ElementContext:
         """Create a context manager for an Element context.
 
         Args:
-            element_name: The name of the Element to enter.
+            element: The Element object to enter.
 
         Returns:
             A context manager for the Element context.
         """
-        return self.ElementContext(self, element_name)
+        return self.ElementContext(self, element)
 
     def has_current_workflow(self) -> bool:
         """Check if there is an active Workflow context."""
@@ -381,11 +384,11 @@ class ContextManager:
         current_workflow = self._workflow_stack[-1]
         return current_workflow._name
 
-    def get_current_flow_name(self) -> str:
-        """Get the name of the current Flow context.
+    def get_current_flow(self) -> ControlFlow:
+        """Get the current Flow object.
 
         Returns:
-            The name of the current Flow.
+            The current Flow object.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.
@@ -395,9 +398,9 @@ class ContextManager:
             raise self.NoActiveFlowError(msg)
 
         current_workflow = self._workflow_stack[-1]
-        return current_workflow.get_current_flow_name()
+        return current_workflow.get_current_flow()
 
-    def get_current_node_name(self) -> str:
+    def get_current_node(self) -> BaseNode:
         """Get the name of the current Node within the current Flow.
 
         Returns:
@@ -413,9 +416,9 @@ class ContextManager:
 
         current_workflow = self._workflow_stack[-1]
         current_flow = current_workflow._flow_stack[-1]
-        return current_flow.get_current_node_name()
+        return current_flow.get_current_node()
 
-    def get_current_element_name(self) -> str:
+    def get_current_element(self) -> BaseNodeElement:
         """Get the name of the current element within the current node.
 
         Returns:
@@ -437,7 +440,7 @@ class ContextManager:
             raise self.EmptyStackError(msg)
 
         current_node = current_flow._node_stack[-1]
-        return current_node.get_current_element_name()
+        return current_node.get_current_element()
 
     def push_workflow(self, workflow_name: str) -> str:
         """Push a new Workflow context onto the stack.
@@ -468,30 +471,30 @@ class ContextManager:
         workflow_context = self._workflow_stack.pop()
         return workflow_context._name
 
-    def push_flow(self, flow_name: str) -> str:
+    def push_flow(self, flow: ControlFlow) -> ControlFlow:
         """Push a new Flow context onto the stack for the current Workflow.
 
         Args:
-            flow_name: The name of the Flow to enter.
+            flow: The Flow object to enter.
 
         Returns:
-            The name of the Flow that was entered.
+            The Flow object that was entered.
 
         Raises:
             NoActiveWorkflowError: If no Workflow context is active.
         """
         if not self.has_current_workflow():
-            msg = f"Cannot enter a Flow context '{flow_name}' without an active Workflow context"
+            msg = f"Cannot enter a Flow context '{flow.name}' without an active Workflow context"
             raise self.NoActiveWorkflowError(msg)
 
         current_workflow = self._workflow_stack[-1]
-        return current_workflow.push_flow(flow_name)
+        return current_workflow.push_flow(flow)
 
-    def pop_flow(self) -> str:
+    def pop_flow(self) -> ControlFlow:
         """Pop the current Flow context from the stack.
 
         Returns:
-            The name of the Flow that was popped.
+            The Flow object that was popped.
 
         Raises:
             EmptyStackError: If no Flow is active.
@@ -503,27 +506,27 @@ class ContextManager:
         current_workflow = self._workflow_stack[-1]
         return current_workflow.pop_flow()
 
-    def push_node(self, node_name: str) -> str:
+    def push_node(self, node: BaseNode) -> BaseNode:
         """Push a new Node context onto the stack for the current Flow.
 
         Args:
-            node_name: The name of the Node to enter.
+            node: The Node object to enter.
 
         Returns:
-            The name of the Node that was entered.
+            The Node object that was entered.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.
         """
         if not self.has_current_flow():
-            msg = f"Cannot enter a Node context '{node_name}' without an active Flow context"
+            msg = f"Cannot enter a Node context '{node.name}' without an active Flow context"
             raise self.NoActiveFlowError(msg)
 
         current_workflow = self._workflow_stack[-1]
         current_flow = current_workflow._flow_stack[-1]
-        return current_flow.push_node(node_name)
+        return current_flow.push_node(node)
 
-    def pop_node(self) -> str:
+    def pop_node(self) -> BaseNode:
         """Pop the current Node context from the stack for the current Flow.
 
         Returns:
@@ -541,21 +544,21 @@ class ContextManager:
         current_flow = current_workflow._flow_stack[-1]
         return current_flow.pop_node()
 
-    def push_element(self, element_name: str) -> str:
+    def push_element(self, element: BaseNodeElement) -> BaseNodeElement:
         """Push a new element onto the stack for the current node.
 
         Args:
-            element_name: The name of the element to enter.
+            element: The Element object to enter.
 
         Returns:
-            The name of the element that was entered.
+            The Element object that was entered.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.
-            EmptyStackError: If the current Flow has no active Nodes.
+            EmptyStackError: If the current Flow has no active Nodes or the current Node has no active Elements.
         """
         if not self.has_current_flow():
-            msg = f"Cannot enter an Element context '{element_name}' without an active Flow context"
+            msg = f"Cannot enter an Element context '{element.name}' without an active Flow context"
             raise self.NoActiveFlowError(msg)
 
         current_workflow = self._workflow_stack[-1]
@@ -566,13 +569,13 @@ class ContextManager:
             raise self.EmptyStackError(msg)
 
         current_node = current_flow._node_stack[-1]
-        return current_node.push_element(element_name)
+        return current_node.push_element(element)
 
-    def pop_element(self) -> str:
+    def pop_element(self) -> BaseNodeElement:
         """Pop the current element from the stack for the current node.
 
         Returns:
-            The name of the element that was popped.
+            The Element object that was popped.
 
         Raises:
             NoActiveFlowError: If no Flow context is active.

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -317,7 +317,7 @@ class ContextManager:
         """
         if isinstance(flow, str):
             try:
-                control_flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow, ControlFlow)
+                control_flow = GriptapeNodes.ObjectManager().get_object_by_id_as_type(flow, ControlFlow)
                 if control_flow is None:
                     msg = f"Flow '{flow}' not found in current workflow."
                     logger.error(msg)

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -401,7 +401,10 @@ class FlowManager:
                 details = f'Connection failed: "{source_node_id}" does not exist. Error: {err}.'
                 logger.error(details)
                 return CreateConnectionResultFailure()
-
+        if source_node is None:
+            details = "Attempted to create a Connection. Failed because source node didn't exist."
+            logger.error(details)
+            return CreateConnectionResultFailure()
         target_node_id = request.target_node_id
         if target_node_id is None:
             # First check if we have a current node
@@ -420,7 +423,10 @@ class FlowManager:
                 details = f'Connection failed: "{target_node_id}" does not exist. Error: {err}.'
                 logger.error(details)
                 return CreateConnectionResultFailure()
-
+        if target_node is None:
+            details = "Attempted to create a Connection. Failed because target node didn't exist."
+            logger.error(details)
+            return CreateConnectionResultFailure()
         # The two nodes exist.
         # Get the parent flows.
         source_flow_id = None
@@ -429,7 +435,7 @@ class FlowManager:
             source_flow_id = GriptapeNodes.NodeManager().get_node_parent_flow_by_id(source_node_id)
             source_flow = self.get_flow_by_id(flow_id=source_flow_id)
         except KeyError as err:
-            details = f'Connection "{source_node.name}.{request.source_parameter_id}" to "{target_node.name}.{request.target_parameter_id}" failed: {err}.'
+            details = f'Connection "{source_node.name}.{request.source_parameter_name}" to "{target_node.name}.{request.target_parameter_name}" failed: {err}.'
             logger.error(details)
             return CreateConnectionResultFailure()
 
@@ -438,7 +444,7 @@ class FlowManager:
             target_flow_id = GriptapeNodes.NodeManager().get_node_parent_flow_by_id(target_node_id)
             target_flow = self.get_flow_by_id(flow_id=target_flow_id)
         except KeyError as err:
-            details = f'Connection "{source_node.name}.{request.source_parameter_id}" to "{target_node.name}.{request.target_parameter_id}" failed: {err}.'
+            details = f'Connection "{source_node.name}.{request.source_parameter_name}" to "{target_node.name}.{request.target_parameter_name}" failed: {err}.'
             logger.error(details)
             return CreateConnectionResultFailure()
 
@@ -461,7 +467,7 @@ class FlowManager:
             details = f'Connection failed: "{target_node.name}.{request.target_parameter_name}" not found'
             logger.error(details)
             return CreateConnectionResultFailure()
-        
+
         # Validate parameter modes accept this type of connection.
         source_modes_allowed = source_param.allowed_modes
         if ParameterMode.OUTPUT not in source_modes_allowed:
@@ -672,7 +678,10 @@ class FlowManager:
                 details = f'Connection not deleted "{source_node_id}.{request.source_parameter_name}" to "{target_node_id}.{request.target_parameter_name}". Error: {err}'
                 logger.error(details)
                 return DeleteConnectionResultFailure()
-
+        if source_node is None:
+            details = "Attempted to delete a Connection. Failed because source node didn't exist."
+            logger.error(details)
+            return DeleteConnectionResultFailure()
         target_node_id = request.target_node_id
         if target_node_id is None:
             # First check if we have a current node
@@ -691,9 +700,12 @@ class FlowManager:
                 details = f'Connection not deleted "{source_node.name}.{request.source_parameter_name}" to "{target_node_id}.{request.target_parameter_name}". Error: {err}'
                 logger.error(details)
                 return DeleteConnectionResultFailure()
-
         # The two nodes exist.
         # Get the parent flows.
+        if target_node is None:
+            details = "Attempted to delete a Connection. Failed because target node didn't exist."
+            logger.error(details)
+            return DeleteConnectionResultFailure()
         source_flow_id = None
         source_flow = None
         try:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -145,10 +145,10 @@ class FlowManager:
                 flow = GriptapeNodes.ObjectManager().get_object_by_id_as_type(flow_id, ControlFlow)
                 if flow is None:
                     continue
-                return GetTopLevelFlowResultSuccess(flow_name=flow.name)
+                return GetTopLevelFlowResultSuccess(flow_id=flow.element_id)
         msg = "Attempted to get top level flow, but no such flow exists"
         logger.debug(msg)
-        return GetTopLevelFlowResultSuccess(flow_name=None)
+        return GetTopLevelFlowResultSuccess(flow_id=None)
 
     def does_canvas_exist(self) -> bool:
         """Determines if there is already an existing flow with no parent flow.Returns True if there is an existing flow with no parent flow.Return False if there is no existing flow with no parent flow."""
@@ -208,7 +208,7 @@ class FlowManager:
         details = f"Successfully created Flow '{final_flow_name}'."
         log_level = logging.DEBUG
         logger.log(level=log_level, msg=details)
-        result = CreateFlowResultSuccess(flow_name=final_flow_name)
+        result = CreateFlowResultSuccess(flow_name=final_flow_name, flow_id=flow.element_id)
         return result
 
     # This needs to have a lot of branches to check the flow in all possible situations. In Current Context, or when the name is passed in.
@@ -550,13 +550,13 @@ class FlowManager:
             if delete_old_result.failed():
                 old_source_node = GriptapeNodes.ObjectManager().get_object_by_id_as_type(old_source_node_id, BaseNode)
                 old_target_node = GriptapeNodes.ObjectManager().get_object_by_id_as_type(old_target_node_id, BaseNode)
-                details = f"Attempted to connect '{source_node.name}.{request.source_parameter_name}'. Failed because there was a previous connection from '{old_source_node.name}.{old_source_param_name}' to '{old_target_node.name}.{old_target_param_name}' that could not be deleted."
+                details = f"Attempted to connect '{source_node.name}.{request.source_parameter_name}'. Failed because there was a previous connection from '{old_source_node.name if old_source_node else old_source_node_id}.{old_source_param_name}' to '{old_target_node.name if old_target_node else old_target_node_id}.{old_target_param_name}' that could not be deleted."
                 logger.error(details)
                 return CreateConnectionResultFailure()
 
             old_source_node = GriptapeNodes.ObjectManager().get_object_by_id_as_type(old_source_node_id, BaseNode)
             old_target_node = GriptapeNodes.ObjectManager().get_object_by_id_as_type(old_target_node_id, BaseNode)
-            details = f"Deleted the previous connection from '{old_source_node.name}.{old_source_param_name}' to '{old_target_node.name}.{old_target_param_name}' to make room for the new connection."
+            details = f"Deleted the previous connection from '{old_source_node.name if old_source_node else old_source_node_id}.{old_source_param_name}' to '{old_target_node.name if old_target_node else old_target_node_id}.{old_target_param_name}' to make room for the new connection."
             logger.debug(details)
         try:
             # Actually create the Connection.

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -161,14 +161,15 @@ class FlowManager:
 
         # We'll explore #1 first by seeing if the Context Manager already has a current flow,
         # which would mean the canvas is already established:
+        parent = None
         if (parent_name is None) and (GriptapeNodes.ContextManager().has_current_flow()):
             # Aha! Just use that.
-            parent_name = GriptapeNodes.ContextManager().get_current_flow_name()
+            parent = GriptapeNodes.ContextManager().get_current_flow()
+            parent_name = parent.name
 
         # TODO: FIX THIS LOGIC MESS https://github.com/griptape-ai/griptape-nodes/issues/616
 
-        parent = None
-        if parent_name is not None:
+        if parent_name is not None and parent is None:
             parent = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(parent_name, ControlFlow)
         if parent_name is None:
             if self.does_canvas_exist():
@@ -196,13 +197,13 @@ class FlowManager:
         final_flow_name = GriptapeNodes.ObjectManager().generate_name_for_object(
             type_name="ControlFlow", requested_name=request.flow_name
         )
-        flow = ControlFlow()
+        flow = ControlFlow(name=final_flow_name)
         GriptapeNodes.ObjectManager().add_object_by_name(name=final_flow_name, obj=flow)
         self._name_to_parent_name[final_flow_name] = parent_name
 
         # See if we need to push it as the current context.
         if request.set_as_new_context:
-            GriptapeNodes.ContextManager().push_flow(final_flow_name)
+            GriptapeNodes.ContextManager().push_flow(flow)
 
         # Success
         details = f"Successfully created Flow '{final_flow_name}'."
@@ -217,6 +218,7 @@ class FlowManager:
 
     def on_delete_flow_request(self, request: DeleteFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
         flow_name = request.flow_name
+        flow = None
         if flow_name is None:
             # We want to delete whatever is at the top of the Current Context.
             if not GriptapeNodes.ContextManager().has_current_flow():
@@ -227,30 +229,31 @@ class FlowManager:
                 result = DeleteFlowResultFailure()
                 return result
             # We pop it off here, but we'll re-add it using context in a moment.
-            flow_name = GriptapeNodes.ContextManager().pop_flow()
+            flow = GriptapeNodes.ContextManager().pop_flow()
 
         # Does this Flow even exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+        if flow is None and flow_name is not None:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             details = f"Attempted to delete Flow '{flow_name}', but no Flow with that name could be found."
             logger.error(details)
             result = DeleteFlowResultFailure()
             return result
         if flow.check_for_existing_running_flow():
-            result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow_name))
+            result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow.name))
             if not result.succeeded():
                 details = f"Attempted to delete flow '{flow_name}'. Failed because running flow could not cancel."
                 logger.error(details)
                 return DeleteFlowResultFailure()
 
         # Let this Flow assume the Current Context while we delete everything within it.
-        with GriptapeNodes.ContextManager().flow(flow_name=flow_name):
+        with GriptapeNodes.ContextManager().flow(flow=flow):
             # Delete all child nodes in this Flow.
             list_nodes_request = ListNodesInFlowRequest()
             list_nodes_result = GriptapeNodes.handle_request(list_nodes_request)
             if not isinstance(list_nodes_result, ListNodesInFlowResultSuccess):
-                details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to get the list of Nodes owned by this Flow."
+                details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to get the list of Nodes owned by this Flow."
                 logger.error(details)
                 result = DeleteFlowResultFailure()
                 return result
@@ -259,7 +262,7 @@ class FlowManager:
                 delete_node_request = DeleteNodeRequest(node_name=node_name)
                 delete_node_result = GriptapeNodes.handle_request(delete_node_request)
                 if isinstance(delete_node_result, DeleteNodeResultFailure):
-                    details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to delete child Node '{node_name}'."
+                    details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to delete child Node '{node_name}'."
                     logger.error(details)
                     result = DeleteFlowResultFailure()
                     return result
@@ -276,21 +279,28 @@ class FlowManager:
                 result = DeleteFlowResultFailure()
                 return result
             flow_names = list_flows_result.flow_names
+            obj_mgr = GriptapeNodes.ObjectManager()
             for child_flow_name in flow_names:
-                with GriptapeNodes.ContextManager().flow(flow_name=child_flow_name):
+                child_flow = obj_mgr.attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
+                if child_flow is None:
+                    details = f"Attempted to delete Flow '{child_flow_name}', but no Flow with that name could be found."
+                    logger.error(details)
+                    result = DeleteFlowResultFailure()
+                    return result
+                with GriptapeNodes.ContextManager().flow(flow=child_flow):
                     # Delete them.
                     delete_flow_request = DeleteFlowRequest()
                     delete_flow_result = GriptapeNodes.handle_request(delete_flow_request)
                     if isinstance(delete_flow_result, DeleteFlowResultFailure):
-                        details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to delete child Flow '{child_flow_name}'."
+                        details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to delete child Flow '{child_flow.name}'."
                         logger.error(details)
                         result = DeleteFlowResultFailure()
                         return result
 
             # If we've made it this far, we have deleted all the children Flows and their nodes.
             # Remove the flow from our map.
-            obj_mgr.del_obj_by_name(flow_name)
-            del self._name_to_parent_name[flow_name]
+            obj_mgr.del_obj_by_name(flow.name)
+            del self._name_to_parent_name[flow.name]
 
         details = f"Successfully deleted Flow '{flow_name}'."
         logger.debug(details)
@@ -316,6 +326,7 @@ class FlowManager:
 
     def on_list_nodes_in_flow_request(self, request: ListNodesInFlowRequest) -> ResultPayload:
         flow_name = request.flow_name
+        flow = None
         if flow_name is None:
             # First check if we have a current flow
             if not GriptapeNodes.ContextManager().has_current_flow():
@@ -324,11 +335,12 @@ class FlowManager:
                 result = ListNodesInFlowResultFailure()
                 return result
             # Get the current flow from context
-            flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
-
+            flow = GriptapeNodes.ContextManager().get_current_flow()
+            flow_name = flow.name
         # Does this Flow even exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+        if flow is None:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             details = (
                 f"Attempted to list Nodes in Flow '{flow_name}'. Failed because no Flow with that name could be found."
@@ -393,6 +405,7 @@ class FlowManager:
     def on_create_connection_request(self, request: CreateConnectionRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, PLR0915, C901
         # Vet the two nodes first.
         source_node_name = request.source_node_name
+        source_node = None
         if source_node_name is None:
             # First check if we have a current node
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -401,17 +414,19 @@ class FlowManager:
                 return CreateConnectionResultFailure()
 
             # Get the current node from context
-            source_node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            source_node = GriptapeNodes.ContextManager().get_current_node()
+            source_node_name = source_node.name
+        if source_node is None:
+            try:
+                source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
+            except ValueError as err:
+                details = f'Connection failed: "{source_node_name}" does not exist. Error: {err}.'
+                logger.error(details)
 
-        try:
-            source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
-        except ValueError as err:
-            details = f'Connection failed: "{source_node_name}" does not exist. Error: {err}.'
-            logger.error(details)
-
-            return CreateConnectionResultFailure()
+                return CreateConnectionResultFailure()
 
         target_node_name = request.target_node_name
+        target_node = None
         if target_node_name is None:
             # First check if we have a current node
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -420,14 +435,15 @@ class FlowManager:
                 return CreateConnectionResultFailure()
 
             # Get the current node from context
-            target_node_name = GriptapeNodes.ContextManager().get_current_node_name()
-
-        try:
-            target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
-        except ValueError as err:
-            details = f'Connection failed: "{target_node_name}" does not exist. Error: {err}.'
-            logger.error(details)
-            return CreateConnectionResultFailure()
+            target_node = GriptapeNodes.ContextManager().get_current_node()
+            target_node_name = target_node.name
+        if target_node is None:
+            try:
+                target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
+            except ValueError as err:
+                details = f'Connection failed: "{target_node_name}" does not exist. Error: {err}.'
+                logger.error(details)
+                return CreateConnectionResultFailure()
 
         # The two nodes exist.
         # Get the parent flows.
@@ -656,7 +672,8 @@ class FlowManager:
         # Vet the two nodes first.
         source_node_name = request.source_node_name
         target_node_name = request.target_node_name
-
+        source_node = None
+        target_node = None
         if source_node_name is None:
             # First check if we have a current node
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -665,15 +682,16 @@ class FlowManager:
                 return DeleteConnectionResultFailure()
 
             # Get the current node from context
-            source_node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            source_node = GriptapeNodes.ContextManager().get_current_node()
+            source_node_name = source_node.name
+        if source_node is None:
+            try:
+                source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
+            except ValueError as err:
+                details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
+                logger.error(details)
 
-        try:
-            source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
-        except ValueError as err:
-            details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
-            logger.error(details)
-
-            return DeleteConnectionResultFailure()
+                return DeleteConnectionResultFailure()
 
         target_node_name = request.target_node_name
         if target_node_name is None:
@@ -684,14 +702,16 @@ class FlowManager:
                 return DeleteConnectionResultFailure()
 
             # Get the current node from context
-            target_node_name = GriptapeNodes.ContextManager().get_current_node_name()
-        try:
-            target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
-        except ValueError as err:
-            details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
-            logger.error(details)
+            target_node = GriptapeNodes.ContextManager().get_current_node()
+            target_node_name = target_node.name
+        if target_node is None:
+            try:
+                target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
+            except ValueError as err:
+                details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
+                logger.error(details)
 
-            return DeleteConnectionResultFailure()
+                return DeleteConnectionResultFailure()
 
         # The two nodes exist.
         # Get the parent flows.
@@ -1085,7 +1105,8 @@ class FlowManager:
             logger.error(details)
             return ListFlowsInCurrentContextResultFailure()
 
-        parent_flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+        parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+        parent_flow_name = parent_flow.name
 
         # Create a list of all child flow names that point DIRECTLY to us.
         ret_list = []
@@ -1102,22 +1123,24 @@ class FlowManager:
     # similar manager refactors: https://github.com/griptape-ai/griptape-nodes/issues/806
     def on_serialize_flow_to_commands(self, request: SerializeFlowToCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         flow_name = request.flow_name
+        flow = None
         if flow_name is None:
             if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+                flow = GriptapeNodes.ContextManager().get_current_flow()
+                flow_name = flow.name
             else:
                 details = "Attempted to serialize a Flow to commands from the Current Context. Failed because the Current Context was empty."
                 logger.error(details)
                 return SerializeFlowToCommandsResultFailure()
-
-        # Does this flow exist?
-        flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
-            details = (
-                f"Attempted to serialize Flow '{flow_name}' to commands, but no Flow with that name could be found."
-            )
-            logger.error(details)
-            return SerializeFlowToCommandsResultFailure()
+            # Does this flow exist?
+            flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+            if flow is None:
+                details = (
+                    f"Attempted to serialize Flow '{flow_name}' to commands, but no Flow with that name could be found."
+                )
+                logger.error(details)
+                return SerializeFlowToCommandsResultFailure()
 
         # Track all node libraries that were in use by these Nodes
         node_libraries_in_use = set()
@@ -1127,7 +1150,7 @@ class FlowManager:
         # And track how values map into that map.
         serialized_parameter_value_tracker = SerializedParameterValueTracker()
 
-        with GriptapeNodes.ContextManager().flow(flow_name):
+        with GriptapeNodes.ContextManager().flow(flow):
             # The base flow creation, if desired.
             if request.include_create_flow_command:
                 create_flow_request = CreateFlowRequest(parent_flow_name=None)
@@ -1150,7 +1173,12 @@ class FlowManager:
 
             # Serialize each node
             for node_name in nodes_in_flow_result.node_names:
-                with GriptapeNodes.ContextManager().node(node_name):
+                node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+                if node is None:
+                    details = f"Attempted to serialize Flow '{flow_name}'. Failed while attempting to serialize Node '{node_name}' within the Flow."
+                    logger.error(details)
+                    return SerializeFlowToCommandsResultFailure()
+                with GriptapeNodes.ContextManager().node(node):
                     # Note: the parameter value stuff is pass-by-reference, and we expect the values to be modified in place.
                     # This might be dangerous if done over the wire.
                     serialize_node_request = SerializeNodeToCommandsRequest(
@@ -1190,7 +1218,8 @@ class FlowManager:
                 create_connection_commands.append(create_connection_command)
 
             # Now sub-flows.
-            parent_flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+            parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+            parent_flow_name = parent_flow.name
             flows_in_flow_request = ListFlowsInFlowRequest(parent_flow_name=parent_flow_name)
             flows_in_flow_result = GriptapeNodes().handle_request(flows_in_flow_request)
             if not isinstance(flows_in_flow_result, ListFlowsInFlowResultSuccess):
@@ -1200,7 +1229,12 @@ class FlowManager:
 
             sub_flow_commands = []
             for child_flow in flows_in_flow_result.flow_names:
-                with GriptapeNodes.ContextManager().flow(flow_name=child_flow):
+                flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(child_flow, ControlFlow)
+                if flow is None:
+                    details = f"Attempted to serialize Flow '{flow_name}', but no Flow with that name could be found."
+                    logger.error(details)
+                    return SerializeFlowToCommandsResultFailure()
+                with GriptapeNodes.ContextManager().flow(flow=flow):
                     child_flow_request = SerializeFlowToCommandsRequest()
                     child_flow_result = GriptapeNodes().handle_request(child_flow_request)
                     if not isinstance(child_flow_result, SerializeFlowToCommandsResultSuccess):
@@ -1230,7 +1264,8 @@ class FlowManager:
         # Do we want to create a NEW Flow to deserialize into, or use the one in the Current Context?
         if request.serialized_flow_commands.create_flow_command is None:
             if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+                flow = GriptapeNodes.ContextManager().get_current_flow()
+                flow_name = flow.name
             else:
                 details = "Attempted to deserialize a set of Flow Creation commands into the Current Context. Failed because the Current Context was empty."
                 logger.error(details)

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -216,7 +216,8 @@ class FlowManager:
         result = CreateFlowResultSuccess(flow_name=final_flow_name)
         return result
 
-    def on_delete_flow_request(self, request: DeleteFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
+    # This needs to have a lot of branches to check the flow in all possible situations. In Current Context, or when the name is passed in.
+    def on_delete_flow_request(self, request: DeleteFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         flow_name = request.flow_name
         flow = None
         if flow_name is None:
@@ -283,7 +284,9 @@ class FlowManager:
             for child_flow_name in flow_names:
                 child_flow = obj_mgr.attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
                 if child_flow is None:
-                    details = f"Attempted to delete Flow '{child_flow_name}', but no Flow with that name could be found."
+                    details = (
+                        f"Attempted to delete Flow '{child_flow_name}', but no Flow with that name could be found."
+                    )
                     logger.error(details)
                     result = DeleteFlowResultFailure()
                     return result

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -335,7 +335,7 @@ class NodeManager:
         return None
 
     def on_delete_node_request(self, request: DeleteNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911 (complex logic, lots of edge cases)
-        node_name = request.node_name
+        node_name = request.node_id
         node = None
         if node_name is None:
             # Get from the current context.

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -405,9 +405,9 @@ class NodeManager:
         return DeleteNodeResultSuccess()
 
     def on_get_node_resolution_state_request(self, request: GetNodeResolutionStateRequest) -> ResultPayload:
-        node_name = request.node_name
+        node_id = request.node_id
         node = None
-        if node_name is None:
+        if node_id is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = "Attempted to get resolution state for a Node from the Current Context. Failed because the Current Context is empty."
@@ -415,21 +415,20 @@ class NodeManager:
                 return GetNodeResolutionStateResultFailure()
 
             node = GriptapeNodes.ContextManager().get_current_node()
-            node_name = node.name
-
-        if node is None:
+            node_id = node.element_id
+        else:
             # Does this node exist?
             obj_mgr = GriptapeNodes.ObjectManager()
-            node = obj_mgr.get_object_by_id_as_type(node_name, BaseNode)
-            if node is None:
-                details = f"Attempted to get resolution state for a Node '{node_name}', but no such Node was found."
-                logger.error(details)
-                result = GetNodeResolutionStateResultFailure()
-                return result
+            node = obj_mgr.get_object_by_id_as_type(node_id, BaseNode)
+        if node is None:
+            details = f"Attempted to get resolution state for a Node '{node_id}', but no such Node was found."
+            logger.error(details)
+            result = GetNodeResolutionStateResultFailure()
+            return result
 
         node_state = node.state
 
-        details = f"Successfully got resolution state for Node '{node_name}'."
+        details = f"Successfully got resolution state for Node '{node.name}'."
         logger.debug(details)
 
         result = GetNodeResolutionStateResultSuccess(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -194,6 +194,7 @@ class NodeManager:
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:
         # Validate as much as possible before we actually create one.
         parent_flow_name = request.override_parent_flow_name
+        parent_flow = None
         if parent_flow_name is None:
             # Try to get the current context flow
             if not GriptapeNodes.ContextManager().has_current_flow():
@@ -202,16 +203,18 @@ class NodeManager:
                 )
                 logger.error(details)
                 return CreateNodeResultFailure()
-            parent_flow_name = GriptapeNodes.ContextManager().get_current_flow_name()
+            parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+            parent_flow_name = parent_flow.name
 
         # Does this flow actually exist?
-        flow_mgr = GriptapeNodes.FlowManager()
-        try:
-            flow = flow_mgr.get_flow_by_name(parent_flow_name)
-        except KeyError as err:
-            details = f"Could not create Node of type '{request.node_type}'. Error: {err}"
-            logger.error(details)
-            return CreateNodeResultFailure()
+        if parent_flow is None:
+            flow_mgr = GriptapeNodes.FlowManager()
+            try:
+                parent_flow = flow_mgr.get_flow_by_name(parent_flow_name)
+            except KeyError as err:
+                details = f"Could not create Node of type '{request.node_type}'. Error: {err}"
+                logger.error(details)
+                return CreateNodeResultFailure()
 
         # Now ensure that we're giving a valid name.
         obj_mgr = GriptapeNodes.ObjectManager()
@@ -239,7 +242,7 @@ class NodeManager:
             return CreateNodeResultFailure()
 
         # Add it to the Flow.
-        flow.add_node(node)
+        parent_flow.add_node(node)
 
         # Record keeping.
         obj_mgr.add_object_by_name(node.name, node)
@@ -256,7 +259,7 @@ class NodeManager:
 
         # See if we want to push this into the context of the current flow.
         if request.set_as_new_context:
-            GriptapeNodes.ContextManager().push_node(final_node_name)
+            GriptapeNodes.ContextManager().push_node(node=node)
 
         # Success message based on whether we used Current Context or explicit flow
         if request.override_parent_flow_name is None:
@@ -331,6 +334,7 @@ class NodeManager:
 
     def on_delete_node_request(self, request: DeleteNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911 (complex logic, lots of edge cases)
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -340,18 +344,16 @@ class NodeManager:
                 logger.error(details)
                 return DeleteNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
+        if node is None:
+            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        if node is None:
+            details = f"Attempted to delete a Node '{node_name}', but no such Node was found."
+            logger.error(details)
+            return DeleteNodeResultFailure()
 
-        with GriptapeNodes.ContextManager().node(node_name=node_name):
-            # Does this node exist?
-            obj_mgr = GriptapeNodes.ObjectManager()
-
-            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
-            if node is None:
-                details = f"Attempted to delete a Node '{node_name}', but no such Node was found."
-                logger.error(details)
-                return DeleteNodeResultFailure()
-
+        with GriptapeNodes.ContextManager().node(node=node):
             parent_flow_name = self._name_to_parent_flow_name[node_name]
             try:
                 parent_flow = GriptapeNodes.FlowManager().get_flow_by_name(parent_flow_name)
@@ -403,7 +405,7 @@ class NodeManager:
         parent_flow.remove_node(node.name)
 
         # Now remove the record keeping
-        obj_mgr.del_obj_by_name(node_name)
+        GriptapeNodes.ObjectManager().del_obj_by_name(node_name)
         del self._name_to_parent_flow_name[node_name]
 
         # If we were part of the Current Context, pop it.
@@ -417,6 +419,7 @@ class NodeManager:
 
     def on_get_node_resolution_state_request(self, request: GetNodeResolutionStateRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -424,17 +427,18 @@ class NodeManager:
                 logger.error(details)
                 return GetNodeResolutionStateResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
-        # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get resolution state for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
-            result = GetNodeResolutionStateResultFailure()
-            return result
+            # Does this node exist?
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get resolution state for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+                result = GetNodeResolutionStateResultFailure()
+                return result
 
         node_state = node.state
 
@@ -448,6 +452,7 @@ class NodeManager:
 
     def on_get_node_metadata_request(self, request: GetNodeMetadataRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -455,18 +460,20 @@ class NodeManager:
                 logger.error(details)
                 return GetNodeMetadataResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get metadata for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
 
-            result = GetNodeMetadataResultFailure()
-            return result
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get metadata for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+
+                result = GetNodeMetadataResultFailure()
+                return result
 
         metadata = node.metadata
         details = f"Successfully retrieved metadata for a Node '{node_name}'."
@@ -479,6 +486,7 @@ class NodeManager:
 
     def on_set_node_metadata_request(self, request: SetNodeMetadataRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -486,18 +494,21 @@ class NodeManager:
                 logger.error(details)
                 return SetNodeMetadataResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to set metadata for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
 
-            result = SetNodeMetadataResultFailure()
-            return result
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to set metadata for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+
+                result = SetNodeMetadataResultFailure()
+                return result
+
         # We can't completely overwrite metadata.
         for key, value in request.metadata.items():
             node.metadata[key] = value
@@ -509,6 +520,7 @@ class NodeManager:
 
     def on_list_connections_for_node_request(self, request: ListConnectionsForNodeRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
         if node_name is None:
             # Get from the current context.
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -516,18 +528,20 @@ class NodeManager:
                 logger.error(details)
                 return ListConnectionsForNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to list Connections for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
 
-            result = ListConnectionsForNodeResultFailure()
-            return result
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to list Connections for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
+
+                result = ListConnectionsForNodeResultFailure()
+                return result
 
         parent_flow_name = self._name_to_parent_flow_name[node_name]
         try:
@@ -581,6 +595,7 @@ class NodeManager:
 
     def on_list_parameters_on_node_request(self, request: ListParametersOnNodeRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             # Get from the current context.
@@ -589,17 +604,19 @@ class NodeManager:
                 logger.error(details)
                 return ListParametersOnNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to list Parameters for a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to list Parameters for a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = ListParametersOnNodeResultFailure()
-            return result
+                result = ListParametersOnNodeResultFailure()
+                return result
 
         ret_list = [param.name for param in node.parameters]
 
@@ -613,6 +630,7 @@ class NodeManager:
 
     def on_add_parameter_to_node_request(self, request: AddParameterToNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             # Get from the current context.
@@ -621,18 +639,19 @@ class NodeManager:
                 logger.error(details)
                 return AddParameterToNodeResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to add Parameter '{request.parameter_name}' to a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to add Parameter '{request.parameter_name}' to a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = AddParameterToNodeResultFailure()
-            return result
+                result = AddParameterToNodeResultFailure()
+                return result
 
         if request.parent_container_name and not request.initial_setup:
             parameter = node.get_parameter_by_name(request.parent_container_name)
@@ -745,6 +764,7 @@ class NodeManager:
 
     def on_remove_parameter_from_node_request(self, request: RemoveParameterFromNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             # Get the Current Context
@@ -755,18 +775,19 @@ class NodeManager:
                 result = RemoveParameterFromNodeResultFailure()
                 return result
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = RemoveParameterFromNodeResultFailure()
-            return result
+                result = RemoveParameterFromNodeResultFailure()
+                return result
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(request.parameter_name)
@@ -852,6 +873,8 @@ class NodeManager:
 
     def on_get_parameter_details_request(self, request: GetParameterDetailsRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node, but no Current Context was found."
@@ -859,18 +882,19 @@ class NodeManager:
 
                 result = GetParameterDetailsResultFailure()
                 return result
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = GetParameterDetailsResultFailure()
-            return result
+                result = GetParameterDetailsResultFailure()
+                return result
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(request.parameter_name)
@@ -910,23 +934,26 @@ class NodeManager:
 
     def on_get_node_element_details_request(self, request: GetNodeElementDetailsRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = f"Attempted to get element details for element '{request.specific_element_id}` from a Node, but no Current Context was found."
                 logger.error(details)
 
                 return GetNodeElementDetailsResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get element details for Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get element details for Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            return GetNodeElementDetailsResultFailure()
+                return GetNodeElementDetailsResultFailure()
 
         # Did they ask for a specific element ID?
         if request.specific_element_id is None:
@@ -1017,6 +1044,7 @@ class NodeManager:
 
     def on_alter_parameter_details_request(self, request: AlterParameterDetailsRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1024,16 +1052,18 @@ class NodeManager:
                 logger.error(details)
 
                 return AlterParameterDetailsResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            return AlterParameterDetailsResultFailure()
+                return AlterParameterDetailsResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(request.parameter_name)
@@ -1073,6 +1103,7 @@ class NodeManager:
     # For C901 (too complex): Need to give customers explicit reasons for failure on each case.
     def on_get_parameter_value_request(self, request: GetParameterValueRequest) -> ResultPayload:
         node_name = request.node_name
+        node = None
 
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1080,20 +1111,20 @@ class NodeManager:
                 logger.error(details)
 
                 return GetParameterValueResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
-
-        # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Parse the parameter name to check for list indexing
         param_name = request.parameter_name
 
-        # Get the node
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+        # Does this node exist?
         if node is None:
-            details = f'"{node_name}" not found'
-            logger.error(details)
-            return GetParameterValueResultFailure()
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f'"{node_name}" not found'
+                logger.error(details)
+                return GetParameterValueResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(param_name)
@@ -1128,25 +1159,27 @@ class NodeManager:
     # added ignoring C901 since this method is overly long because of granular error checking, not actual complexity.
     def on_set_parameter_value_request(self, request: SetParameterValueRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = f"Attempted to set parameter '{request.parameter_name}' value. Failed because no Node was found in the Current Context."
                 logger.error(details)
                 return SetParameterValueResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
-
-        # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Parse the parameter name to check for list indexing
         param_name = request.parameter_name
 
-        # Get the node
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+        # Does this node exist?
         if node is None:
-            details = f"Attempted to set parameter '{param_name}' value on node '{node_name}'. Failed because no such Node could be found."
-            logger.error(details)
-            return SetParameterValueResultFailure()
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to set parameter '{param_name}' value on node '{node_name}'. Failed because no such Node could be found."
+                logger.error(details)
+                return SetParameterValueResultFailure()
 
         # Does the Parameter actually exist on the Node?
         parameter = node.get_parameter_by_name(param_name)
@@ -1180,6 +1213,8 @@ class NodeManager:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
             logger.error(details)
             return SetParameterValueResultFailure()
+
+        obj_mgr = GriptapeNodes.ObjectManager()
         parent_flow = obj_mgr.attempt_get_object_by_name_as_type(parent_flow_name, ControlFlow)
         if not parent_flow:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
@@ -1257,6 +1292,8 @@ class NodeManager:
     # make debugger use friendly.
     def on_get_all_node_info_request(self, request: GetAllNodeInfoRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0915
         node_name = request.node_name
+        node = None
+
         # Get from the current context.
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
@@ -1264,18 +1301,19 @@ class NodeManager:
                 logger.error(details)
                 return GetAllNodeInfoResultFailure()
 
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        obj_mgr = GriptapeNodes.ObjectManager()
-
-        node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to get all info for Node named '{node_name}', but no such Node was found."
-            logger.error(details)
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get all info for Node named '{node_name}', but no such Node was found."
+                logger.error(details)
 
-            result = GetAllNodeInfoResultFailure()
-            return result
+                result = GetAllNodeInfoResultFailure()
+                return result
 
         get_metadata_request = GetNodeMetadataRequest(node_name=node_name)
         get_metadata_result = self.on_get_node_metadata_request(get_metadata_request)
@@ -1350,20 +1388,24 @@ class NodeManager:
 
     def on_get_compatible_parameters_request(self, request: GetCompatibleParametersRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         node_name = request.node_name
+        node = None
+
         if node_name is None:
             if not GriptapeNodes.ContextManager().has_current_node():
                 details = "Attempted to get compatible parameters for node, but no current node was found."
                 logger.error(details)
                 return GetCompatibleParametersResultFailure()
-            node_name = GriptapeNodes.ContextManager().get_current_node_name()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Vet the node
-        try:
-            node = self.get_node_by_name(node_name)
-        except ValueError as err:
-            details = f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist. Error: {err}."
-            logger.error(details)
-            return GetCompatibleParametersResultFailure()
+        if node is None:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist."
+                logger.error(details)
+                return GetCompatibleParametersResultFailure()
 
         # Vet the parameter.
         request_param = node.get_parameter_by_name(request.parameter_name)
@@ -1579,23 +1621,27 @@ class NodeManager:
 
     def on_serialize_node_to_commands(self, request: SerializeNodeToCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0912
         node_name = request.node_name
+        node = None
+
         if node_name is None:
-            if GriptapeNodes.ContextManager().has_current_node():
-                node_name = GriptapeNodes.ContextManager().get_current_node_name()
-            else:
+            if not GriptapeNodes.ContextManager().has_current_node():
                 details = "Attempted to serialize a Node to commands from the Current Context. Failed because the Current Context is empty."
                 logger.error(details)
                 return SerializeNodeToCommandsResultFailure()
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
 
         # Does this node exist?
-        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
-            details = f"Attempted to serialize Node '{node_name}' to commands. Failed because no Node with that name could be found."
-            logger.error(details)
-            return SerializeNodeToCommandsResultFailure()
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to serialize Node '{node_name}' to commands. Failed because no Node with that name could be found."
+                logger.error(details)
+                return SerializeNodeToCommandsResultFailure()
 
         # This is our current dude.
-        with GriptapeNodes.ContextManager().node(node_name=node_name):
+        with GriptapeNodes.ContextManager().node(node=node):
             # Get the library and version details.
             library_used = node.metadata["library"]
             # Get the library metadata so we can get the version.
@@ -1684,7 +1730,12 @@ class NodeManager:
 
         # Adopt the newly-created node as our current context.
         node_name = create_node_result.node_name
-        with GriptapeNodes.ContextManager().node(node_name=node_name):
+        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        if node is None:
+            details = f"Attempted to deserialize a serialized set of Node Creation commands. Failed to get node '{node_name}'."
+            logger.error(details)
+            return DeserializeNodeFromCommandsResultFailure()
+        with GriptapeNodes.ContextManager().node(node=node):
             for element_command in request.serialized_node_commands.element_modification_commands:
                 if isinstance(
                     element_command, (AlterParameterDetailsRequest, AddParameterToNodeRequest)
@@ -1803,7 +1854,11 @@ class NodeManager:
                 logger.error("Attempted to deserialize node but ran into an error on node serialization.")
                 return DeserializeSelectedNodesFromCommandsResultFailure()
             node_uuid_to_name[node_command.node_uuid] = result.node_name
-            with GriptapeNodes.ContextManager().node(result.node_name):
+            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(result.node_name, BaseNode)
+            if node is None:
+                logger.error("Attempted to deserialize node but ran into an error on node serialization.")
+                return DeserializeSelectedNodesFromCommandsResultFailure()
+            with GriptapeNodes.ContextManager().node(node=node):
                 parameter_commands = commands.set_parameter_value_commands[node_command.node_uuid]
                 for parameter_command in parameter_commands:
                     param_request = parameter_command.set_parameter_value_command

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1403,7 +1403,9 @@ class NodeManager:
             obj_mgr = GriptapeNodes.ObjectManager()
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
-                details = f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist."
+                details = (
+                    f"Attempted to get compatible parameters for node '{node_name}', but that node does not exist."
+                )
                 logger.error(details)
                 return GetCompatibleParametersResultFailure()
 
@@ -1824,7 +1826,7 @@ class NodeManager:
         GriptapeNodes.ContextManager()._clipboard.parameter_uuid_to_values = unique_uuid_to_values
         return SerializeSelectedNodesToCommandsResultSuccess(final_result)
 
-    def on_deserialize_selected_nodes_from_commands(  # noqa: C901
+    def on_deserialize_selected_nodes_from_commands(  # noqa: C901, PLR0912
         self,
         request: DeserializeSelectedNodesFromCommandsRequest,
     ) -> ResultPayload:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -179,18 +179,6 @@ class NodeManager:
         )
         event_manager.assign_manager_to_request_type(DuplicateSelectedNodesRequest, self.on_duplicate_selected_nodes)
 
-    def handle_node_rename(self, old_name: str, new_name: str) -> None:
-        # Replace the old node name and its parent.
-        parent = self._name_to_parent_flow_name[old_name]
-        self._name_to_parent_flow_name[new_name] = parent
-        del self._name_to_parent_flow_name[old_name]
-
-    def handle_flow_rename(self, old_name: str, new_name: str) -> None:
-        # Find all instances where a node had the old parent and update it to the new one.
-        for node_name, parent_flow_name in self._name_to_parent_flow_name.items():
-            if parent_flow_name == old_name:
-                self._name_to_parent_flow_name[node_name] = new_name
-
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:
         # Validate as much as possible before we actually create one.
         parent_flow_name = request.override_parent_flow_name

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -268,3 +268,6 @@ class ObjectManager:
                     return
         if element_id:
             del self._id_to_objects[element_id]
+
+    def get_obj_by_id(self, element_id: str) -> object | None:
+        return self._id_to_objects.get(element_id, None)

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -76,21 +76,8 @@ class ObjectManager:
             # We'll use the next available name.
             final_name = next_name
 
-            # Let the object's manager know. TODO: https://github.com/griptape-ai/griptape-nodes/issues/869
-        match source_obj:
-            case ControlFlow():
-                GriptapeNodes.FlowManager().handle_flow_rename(old_name=request.object_name, new_name=final_name)
-            case BaseNode():
-                GriptapeNodes.NodeManager().handle_node_rename(old_name=request.object_name, new_name=final_name)
-            case _:
-                details = f"Attempted to rename an object named '{request.object_name}', but that object wasn't of a type supported for rename."
-                logger.error(details)
-                return RenameObjectResultFailure(next_available_name=None)
-
-        # Update the object table.
-        self._name_to_objects[final_name] = source_obj
-        del self._name_to_objects[request.object_name]
-
+            # Let the object's manager know. TODO: https://github.com/griptape-ai/griptape-nodes/issues/86
+        source_obj.name = final_name
         details = f"Successfully renamed object '{request.object_name}' to '{final_name}`."
         log_level = logging.DEBUG
         if final_name != request.requested_name:

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -139,26 +139,27 @@ class RetainedMode:
         flow_name: str | None = None,
         parent_flow_name: str | None = None,
     ) -> ResultPayload:
+
         request = CreateFlowRequest(parent_flow_name=parent_flow_name, flow_name=flow_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def delete_flow(cls, flow_name: str) -> ResultPayload:
         request = DeleteFlowRequest(flow_name=flow_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_flows(cls, parent_flow_name: str | None = None) -> ResultPayload:
         request = ListFlowsInFlowRequest(parent_flow_name=parent_flow_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_nodes_in_flow(cls, flow_name: str) -> ResultPayload:
         request = ListNodesInFlowRequest(flow_name=flow_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     # NODE OPERATIONS
@@ -178,7 +179,7 @@ class RetainedMode:
             override_parent_flow_name=parent_flow_name,
             metadata=metadata,
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         # Check if result is successful before accessing node_name
         if hasattr(result, "node_name"):
             return result.node_name
@@ -192,37 +193,37 @@ class RetainedMode:
         node_name: str,
     ) -> ResultPayload:
         request = DeleteNodeRequest(node_name=node_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_resolution_state_for_node(cls, node_name: str) -> ResultPayload:
         request = GetNodeResolutionStateRequest(node_name=node_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_metadata_for_node(cls, node_name: str) -> ResultPayload:
         request = GetNodeMetadataRequest(node_name=node_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def set_metadata_for_node(cls, node_name: str, metadata: dict[Any, Any]) -> ResultPayload:
         request = SetNodeMetadataRequest(node_name=node_name, metadata=metadata)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_connections_for_node(cls, node_name: str) -> ResultPayload:
         request = ListConnectionsForNodeRequest(node_name=node_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def list_params(cls, node: str) -> ResultPayload:
         request = ListParametersOnNodeRequest(node_name=node)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result.parameter_names
 
     @classmethod
@@ -279,14 +280,14 @@ class RetainedMode:
                 mode_allowed_output=mode_allowed_output,
                 ui_options=ui_options,
             )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     # remove_parameter_from_node
     @classmethod
     def del_param(cls, node_name: str, parameter_name: str) -> ResultPayload:
         request = RemoveParameterFromNodeRequest(parameter_name=parameter_name, node_name=node_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     """
@@ -295,7 +296,7 @@ class RetainedMode:
         event = GetParameterDetailsRequest(
             parameter_name=parameter_name, node_name=node_name
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
     """
 
@@ -310,7 +311,7 @@ class RetainedMode:
             **kwargs: Additional arguments
         """
         request = GetParameterDetailsRequest(parameter_name=param, node_name=node)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
@@ -390,7 +391,7 @@ class RetainedMode:
             parameter_name=base_param_name,
             node_name=node_name,
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
 
         if not result.succeeded():
             return False, result
@@ -438,14 +439,14 @@ class RetainedMode:
                 node_name=node_name,
                 value=value,
             )
-            return GriptapeNodes().handle_request(request)
+            return GriptapeNodes.handle_request(request)
 
         # Get the container value
         request = GetParameterValueRequest(
             parameter_name=base_param_name,
             node_name=node_name,
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
 
         if not result.succeeded():
             return result
@@ -491,7 +492,7 @@ class RetainedMode:
             node_name=node_name,
             value=container,
         )
-        return GriptapeNodes().handle_request(set_request)
+        return GriptapeNodes.handle_request(set_request)
 
     @classmethod
     def get_value(cls, *args, **kwargs) -> Any:
@@ -508,7 +509,7 @@ class RetainedMode:
             parameter_name=base_param_name,
             node_name=node,
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
 
         if result.succeeded():
             # Now see if there were any indices specified.
@@ -578,7 +579,7 @@ class RetainedMode:
                 node_name=node,
                 value=value,
             )
-            result = GriptapeNodes().handle_request(request)
+            result = GriptapeNodes.handle_request(request)
             logger.info("\nD:%s", f"{result=}")
         else:
             # We have indices. Get the value of the container first, then attempt to move all the way up to the end.
@@ -586,7 +587,7 @@ class RetainedMode:
                 parameter_name=base_param_name,
                 node_name=node,
             )
-            result = GriptapeNodes().handle_request(request)
+            result = GriptapeNodes.handle_request(request)
 
             if not result.succeeded():
                 logger.error(
@@ -637,7 +638,7 @@ class RetainedMode:
                             node_name=node,
                             value=base_container,  # Re-assign the entire updated container.
                         )
-                        result = GriptapeNodes().handle_request(request)
+                        result = GriptapeNodes.handle_request(request)
                         return result
                     # Advance.
                     curr_pos_value = curr_pos_value[idx_or_key_as_int]
@@ -663,7 +664,7 @@ class RetainedMode:
             target_node_name=dst_node,
             target_parameter_name=dst_param,
         )
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     @classmethod
     def exec_chain(cls, *node_names) -> dict:
@@ -694,7 +695,7 @@ class RetainedMode:
                 target_parameter_name="exec_in",
             )
 
-            result = GriptapeNodes().handle_request(request)
+            result = GriptapeNodes.handle_request(request)
             results[f"{source_node} -> {target_node}"] = result
 
             # Track failures without halting execution
@@ -721,101 +722,101 @@ class RetainedMode:
             target_node_name=target_node_name,
             target_parameter_name=target_param_name,
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     # LIBRARY OPERATIONS
     @classmethod
     def get_available_libraries(cls) -> ResultPayload:
         request = ListRegisteredLibrariesRequest()
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_node_types_in_library(cls, library_name: str) -> ResultPayload:
         request = ListNodeTypesInLibraryRequest(library=library_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_node_metadata_from_library(cls, library_name: str, node_type_name: str) -> ResultPayload:
         request = GetNodeMetadataFromLibraryRequest(library=library_name, node_type=node_type_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     # FLOW OPERATIONS
     @classmethod
     def run_flow(cls, flow_name: str) -> ResultPayload:
         request = StartFlowRequest(flow_name=flow_name, debug_mode=False)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def run_node(cls, node_name: str) -> ResultPayload:
         request = ResolveNodeRequest(node_name=node_name)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def single_step(cls, flow_name: str) -> ResultPayload:
         request = SingleNodeStepRequest(flow_name=flow_name)
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     @classmethod
     def single_execution_step(cls, flow_name: str) -> ResultPayload:
         request = SingleExecutionStepRequest(flow_name=flow_name)
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     @classmethod
     def continue_flow(cls, flow_name: str) -> ResultPayload:
         request = ContinueExecutionStepRequest(flow_name=flow_name)
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     @classmethod
     def reset_flow(cls, flow_name: str) -> ResultPayload:
         request = UnresolveFlowRequest(flow_name=flow_name)
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     @classmethod
     def cancel_flow(cls, flow_name: str) -> ResultPayload:
         request = CancelFlowRequest(flow_name=flow_name)
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     @classmethod
     def get_flow_state(cls, flow_name: str) -> ResultPayload:
         request = GetFlowStateRequest(flow_name=flow_name)
-        return GriptapeNodes().handle_request(request)
+        return GriptapeNodes.handle_request(request)
 
     # ARBITRARY PYTHON EXECUTION
     @classmethod
     def run_arbitrary_python(cls, python_str: str) -> ResultPayload:
         request = RunArbitraryPythonStringRequest(python_string=python_str)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     # CONFIG MANAGER
     @classmethod
     def get_config_value(cls, category_and_key: str) -> ResultPayload:
         request = GetConfigValueRequest(category_and_key=category_and_key)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def set_config_value(cls, category_and_key: str, value: Any) -> ResultPayload:
         request = SetConfigValueRequest(category_and_key=category_and_key, value=value)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def get_config_category(cls, category: str | None) -> ResultPayload:
         request = GetConfigCategoryRequest(category=category)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
     def set_config_category(cls, category: str | None, contents: dict[str, Any]) -> ResultPayload:
         request = SetConfigCategoryRequest(category=category, contents=contents)
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod
@@ -825,7 +826,7 @@ class RetainedMode:
             requested_name=requested_name,
             allow_next_closest_name_available=True,
         )
-        result = GriptapeNodes().handle_request(request)
+        result = GriptapeNodes.handle_request(request)
         return result
 
     @classmethod


### PR DESCRIPTION
- Using names to keep track of all of our objects created clunkiness when trying to rename. 
- Using IDs instead will be more robust and prevent weirdness with naming and copying. 
- This will have to be merged with an editor change that uses IDs instead of names for events. 