### PR TITLE
Standard node library's templates were resaved with an "_1" suffix; removed that.

### DIFF
--- a/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
+++ b/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
@@ -2,7 +2,7 @@
 # dependencies = []
 #
 # [tool.griptape-nodes]
-# name = "compare_prompts_1"
+# name = "compare_prompts"
 # schema_version = "0.3.0"
 # description = "See how 3 different approaches to prompts affect image generation."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_compare_prompts.webp"

--- a/libraries/griptape_nodes_library/workflows/templates/coordinating_agents.py
+++ b/libraries/griptape_nodes_library/workflows/templates/coordinating_agents.py
@@ -2,7 +2,7 @@
 # dependencies = []
 #
 # [tool.griptape-nodes]
-# name = "coordinating_agents_1"
+# name = "coordinating_agents"
 # schema_version = "0.3.0"
 # description = "Multiple agents, with different jobs."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_coordinating_agents.webp"

--- a/libraries/griptape_nodes_library/workflows/templates/photography_team.py
+++ b/libraries/griptape_nodes_library/workflows/templates/photography_team.py
@@ -2,7 +2,7 @@
 # dependencies = []
 #
 # [tool.griptape-nodes]
-# name = "photography_team_1"
+# name = "photography_team"
 # schema_version = "0.3.0"
 # description = "A team of experts develop a prompt."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_photography_team.webp"


### PR DESCRIPTION
Fixes #1384 