### PR TITLE
Support gtc storage for published workflows

### DIFF
--- a/src/griptape_nodes/bootstrap/bootstrap_script.py
+++ b/src/griptape_nodes/bootstrap/bootstrap_script.py
@@ -29,10 +29,17 @@ if __name__ == "__main__":
         default=None,
         help="The input to the flow",
     )
+    parser.add_argument(
+        "-s",
+        "--storage-backend",
+        default="local",
+        help="The storage backend to use",
+    )
 
     args = parser.parse_args()
     workflow_name = args.workflow_name
     flow_input = args.input
+    storage_backend = args.storage_backend
 
     try:
         flow_input = json.loads(flow_input) if flow_input else {}
@@ -42,4 +49,6 @@ if __name__ == "__main__":
         raise
 
     workflow_runner = BootstrapWorkflowRunner()
-    workflow_runner.run(workflow_path="workflow.py", workflow_name=workflow_name, flow_input=flow_input)
+    workflow_runner.run(
+        workflow_path="workflow.py", workflow_name=workflow_name, flow_input=flow_input, storage_backend=storage_backend
+    )

--- a/src/griptape_nodes/bootstrap/workflow_runners/local_workflow_runner.py
+++ b/src/griptape_nodes/bootstrap/workflow_runners/local_workflow_runner.py
@@ -164,7 +164,7 @@ class LocalWorkflowRunner(WorkflowRunner):
 
         return output
 
-    def run(self, workflow_path: str, workflow_name: str, flow_input: Any, storage_backend: str) -> None:
+    def run(self, workflow_path: str, workflow_name: str, flow_input: Any, storage_backend: str = "local") -> None:
         """Executes a published workflow.
 
         Executes a workflow by setting up event listeners, registering libraries,

--- a/src/griptape_nodes/bootstrap/workflow_runners/subprocess_workflow_runner.py
+++ b/src/griptape_nodes/bootstrap/workflow_runners/subprocess_workflow_runner.py
@@ -32,12 +32,12 @@ class SubprocessWorkflowRunner(WorkflowRunner):
         try:
             threading.Thread(target=_serve_static_server, daemon=True).start()
             workflow_runner = LocalWorkflowRunner(libraries)
-            workflow_runner.run(workflow_path, workflow_name, flow_input)
+            workflow_runner.run(workflow_path, workflow_name, flow_input, "local")
         except Exception as e:
             exception_queue.put(e)
             raise
 
-    def run(self, workflow_path: str, workflow_name: str, flow_input: Any) -> None:
+    def run(self, workflow_path: str, workflow_name: str, flow_input: Any, storage_backend: str = "local") -> None:  # noqa: ARG002
         exception_queue = Queue()
         process = Process(
             target=self._subprocess_entry,

--- a/src/griptape_nodes/bootstrap/workflow_runners/workflow_runner.py
+++ b/src/griptape_nodes/bootstrap/workflow_runners/workflow_runner.py
@@ -7,5 +7,5 @@ logger = logging.getLogger(__name__)
 
 class WorkflowRunner(ABC):
     @abstractmethod
-    def run(self, workflow_path: str, workflow_name: str, flow_input: Any, storage_backend: str) -> None:
+    def run(self, workflow_path: str, workflow_name: str, flow_input: Any, storage_backend: str = "local") -> None:
         pass

--- a/src/griptape_nodes/bootstrap/workflow_runners/workflow_runner.py
+++ b/src/griptape_nodes/bootstrap/workflow_runners/workflow_runner.py
@@ -7,5 +7,5 @@ logger = logging.getLogger(__name__)
 
 class WorkflowRunner(ABC):
     @abstractmethod
-    def run(self, workflow_path: str, workflow_name: str, flow_input: Any) -> None:
+    def run(self, workflow_path: str, workflow_name: str, flow_input: Any, storage_backend: str) -> None:
         pass

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1707,10 +1707,9 @@ class WorkflowManager:
         for node in nodes:
             for param in node.parameters:
                 # Expose only the parameters that are relevant for workflow input and output.
-                # Those parameters are not of type CONTROL_TYPE, and are builtin types.
-                if param.type != ParameterTypeBuiltin.CONTROL_TYPE.value and param.type in [
-                    t.value for t in ParameterTypeBuiltin
-                ]:
+                # Excluding list types as the individual parameters are exposed in the workflow shape.
+                # TODO (https://github.com/griptape-ai/griptape-nodes/issues/1090): This is a temporary solution until we know how to handle container types.
+                if param.type != ParameterTypeBuiltin.CONTROL_TYPE.value and not param.type.startswith("list"):
                     if node.name in workflow_shape[workflow_shape_type]:
                         cast("dict", workflow_shape[workflow_shape_type][node.name])[param.name] = (
                             self._convert_parameter_to_minimal_dict(param)


### PR DESCRIPTION
* Support gtc storage for published workflows
  * The bootstrap script now accepts `--storage-backend` flag for specifying a storage type
    * The RunPublishedWorkflow API will handle setting that flag
* Handle failed workflow runs
  * Previously, a failed workflow run would report the correct events back to the Nodes API, but it would get stuck in an endless loop for the underlying StructureRun. Handle this by listening to the `ControlFlowCancelledEvent` event
* Allow various Parameter types for PublishedWorkflow StartNode and EndNodes
  * Explicitly ignoring `list` types for now due to the strangeness with our current  [StartFlow and EndFlow Nodes](https://github.com/griptape-ai/griptape-nodes/blob/main/libraries/griptape_nodes_library/griptape_nodes_library/workflows/start_flow.py#L18) making use of ParameterLists
    * The individual Parameters contained within the list are still exposed
* Enable setting storage backend config on init
 
![gtn_init](https://github.com/user-attachments/assets/80669ae2-4989-456d-ac77-c3857b61f491)


https://www.loom.com/share/3a6ccb755b3843a884e7f909372aa500?sid=4f4e1eca-8f4c-4ece-97ad-e66f9f53ac64

Closes #1378 