### PR TITLE
delay prompt_driver creation in AgentManager

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -48,32 +48,32 @@ class AgentManager:
                 GetConversationMemoryRequest, self.on_handle_get_conversation_memory_request
             )
 
-    def _initialize_prompt_driver(self) -> None:
+    def _initialize_prompt_driver(self) -> GriptapeCloudPromptDriver:
         api_key = secrets_manager.get_secret(API_KEY_ENV_VAR)
         if not api_key:
             msg = f"Secret '{API_KEY_ENV_VAR}' not found"
             raise ValueError(msg)
-        self.prompt_driver = GriptapeCloudPromptDriver(api_key=api_key)
+        return GriptapeCloudPromptDriver(api_key=api_key)
 
     def on_handle_run_agent_request(self, request: RunAgentRequest) -> ResultPayload:
         try:
             if self.prompt_driver is None:
-                self._initialize_prompt_driver()
+                self.prompt_driver = self._initialize_prompt_driver()
+            task_output = PromptTask(
+                request.input, prompt_driver=self.prompt_driver, conversation_memory=self.conversation_memory
+            ).run()
+            if isinstance(task_output, ErrorArtifact):
+                details = f"Error running agent: {task_output.value}"
+                logger.error(details)
+                return RunAgentResultFailure(error=task_output.to_json())
+            return RunAgentResultSuccess(output=task_output.to_json())
         except Exception as e:
-            return RunAgentResultFailure(ErrorArtifact(e))
-        task_output = PromptTask(
-            request.input, prompt_driver=self.prompt_driver, conversation_memory=self.conversation_memory
-        ).run()
-        if isinstance(task_output, ErrorArtifact):
-            details = f"Error running agent: {task_output.value}"
-            logger.error(details)
-            return RunAgentResultFailure(error=task_output.to_json())
-        return RunAgentResultSuccess(output=task_output.to_json())
+            return RunAgentResultFailure(ErrorArtifact(e).to_json())
 
     def on_handle_configure_agent_request(self, request: ConfigureAgentRequest) -> ResultPayload:
         try:
             if self.prompt_driver is None:
-                self._initialize_prompt_driver()
+                self.prompt_driver = self._initialize_prompt_driver()
             for key, value in request.prompt_driver.items():
                 setattr(self.prompt_driver, key, value)
         except Exception as e:


### PR DESCRIPTION
Create the prompt_driver for the agent on the first event called, instead of on agent_manager initialization. This reduces blast radius from a failure creating the prompt_driver to the event, instead of globally.