### PR TITLE
Libraries sync

### DIFF
--- a/docs/command_line_interface.md
+++ b/docs/command_line_interface.md
@@ -69,17 +69,17 @@ Subcommands:
 - `uninstall` - Uninstall the CLI, removing configuration and data directories
 - `version` - Display the current version of the CLI
 
-### `assets`
+### `libraries`
 
-Manage local assets (libraries, workflows, etc.).
+Manage local libraries.
 
 ```
-griptape-nodes assets SUBCOMMAND
+griptape-nodes libraries SUBCOMMAND
 ```
 
 Subcommands:
 
-- `update` - Update bundled assets to the latest version
+- `sync` - Sync libraries with your current engine version
 
 ## Configuration
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,14 +87,14 @@ If you would like to _manually_ update, you can always use either of these comma
 
 ```bash
 griptape-nodes self update
-griptape-nodes assets update
+griptape-nodes libraries sync
 ```
 
 or
 
 ```bash
 gtn self update
-gtn assets update
+gtn libraries sync
 ```
 
 ## I'm seeing `failed to locate pyvenv.cfg: The system cannot find the file specified.` - What should I do?

--- a/src/griptape_nodes/updater/__init__.py
+++ b/src/griptape_nodes/updater/__init__.py
@@ -21,7 +21,7 @@ def main() -> None:
     """Entry point for the updater CLI."""
     try:
         _download_and_run_installer()
-        _sync_assets()
+        _sync_libraries()
     except subprocess.CalledProcessError:
         console.print("[red]Error during update process.[/red]")
     else:
@@ -50,20 +50,20 @@ def _download_and_run_installer() -> None:
         console.print("[green]Finished updating self.[/green]")
 
 
-def _sync_assets() -> None:
-    """Syncs the assets for the engine."""
-    console.print("[bold green]Syncing assets...[/bold green]")
+def _sync_libraries() -> None:
+    """Syncs the libraries for the engine."""
+    console.print("[bold green]Syncing libraries...[/bold green]")
     try:
         subprocess.run(  # noqa: S603
-            ["griptape-nodes", "assets", "sync"],  # noqa: S607
+            ["griptape-nodes", "libraries", "sync"],  # noqa: S607
             text=True,
             check=True,
         )
     except subprocess.CalledProcessError as e:
-        console.print(f"[red]Error during asset sync: {e}[/red]")
+        console.print(f"[red]Error during libraries sync: {e}[/red]")
         raise
     else:
-        console.print("[green]Finished syncing assets.[/green]")
+        console.print("[green]Finished syncing libraries.[/green]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Rename `gtn assets sync` to `gtn libraries sync`. "Assets" is not a term we use anywhere else, let's be honest about what it is.
- Init the libraries during `gtn libraries sync`. This enables library troubleshooting/set-up to be done without booting up the engine.
- Don't blow away existing libraries in the libraries directory when syncing.
Closes #1504 
Closes #1509 