### PR TITLE
Update/ParameterMessage to subclass Parameter

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1153,13 +1153,6 @@ class ParameterMessage(Parameter):
 
         return data
 
-    def to_event(self, node: BaseNode) -> dict:
-        event_data = super().to_event(node)
-        dict_data = self.to_dict()
-        # Combine them both to get what we need for the UI.
-        event_data.update(dict_data)
-        return event_data
-
 
 class ParameterKeyValuePair(Parameter):
     def __init__(  # noqa: PLR0913


### PR DESCRIPTION
Up until now, ParameterMessage has been a subclass of BaseNodeElement. But as I've been working with it & trying to get it to update based on various parameter settings, it's been really tough to get it to update correctly.

I'd like to change it to be a subclass of Parameter instead, since that seems to be handling updates much better.