### PR TITLE
Added ReloadAllLibraries request

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -196,3 +196,29 @@ class UnloadLibraryFromRegistryResultSuccess(WorkflowAlteredMixin, ResultPayload
 @PayloadRegistry.register
 class UnloadLibraryFromRegistryResultFailure(ResultPayloadFailure):
     pass
+
+
+@dataclass
+@PayloadRegistry.register
+class ReloadAllLibrariesRequest(RequestPayload):
+    """WARNING: This request will CLEAR ALL CURRENT WORKFLOW STATE!
+
+    Reloading all libraries requires clearing all existing workflows, nodes, and execution state
+    because there is no way to comprehensively erase references to old Python modules.
+    All current work will be lost and must be recreated after the reload operation completes.
+
+    Use this operation only when you need to pick up changes to library code during development
+    or when library corruption requires a complete reset.
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class ReloadAllLibrariesResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class ReloadAllLibrariesResultFailure(ResultPayloadFailure):
+    pass

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -72,10 +72,14 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromRequirementSpecifierRequest,
     RegisterLibraryFromRequirementSpecifierResultFailure,
     RegisterLibraryFromRequirementSpecifierResultSuccess,
+    ReloadAllLibrariesRequest,
+    ReloadAllLibrariesResultFailure,
+    ReloadAllLibrariesResultSuccess,
     UnloadLibraryFromRegistryRequest,
     UnloadLibraryFromRegistryResultFailure,
     UnloadLibraryFromRegistryResultSuccess,
 )
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
 
@@ -147,6 +151,7 @@ class LibraryManager:
         event_manager.assign_manager_to_request_type(
             UnloadLibraryFromRegistryRequest, self.unload_library_from_registry_request
         )
+        event_manager.assign_manager_to_request_type(ReloadAllLibrariesRequest, self.reload_all_libraries_request)
 
         event_manager.add_listener_to_app_event(
             AppInitializationComplete,
@@ -1255,3 +1260,37 @@ class LibraryManager:
                 library for library in libraries_to_register_category if library.lower() not in paths_to_remove
             ]
             config_mgr.set_config_value(config_category, libraries_to_register_category)
+
+    def reload_all_libraries_request(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
+        # Start with a clean slate.
+        clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
+        clear_all_result = GriptapeNodes.handle_request(clear_all_request)
+        if not clear_all_result.succeeded():
+            details = "Failed to clear the existing object state when preparing to reload all libraries."
+            logger.error(details)
+            return ReloadAllLibrariesResultFailure()
+
+        # Unload all libraries now.
+        all_libraries_request = ListRegisteredLibrariesRequest()
+        all_libraries_result = GriptapeNodes.handle_request(all_libraries_request)
+        if not isinstance(all_libraries_result, ListRegisteredLibrariesResultSuccess):
+            details = "When preparing to reload all libraries, failed to get registered libraries."
+            logger.error(details)
+            return ReloadAllLibrariesResultFailure()
+
+        for library_name in all_libraries_result.libraries:
+            unload_library_request = UnloadLibraryFromRegistryRequest(library_name=library_name)
+            unload_library_result = GriptapeNodes.handle_request(unload_library_request)
+            if not unload_library_result.succeeded():
+                details = f"When preparing to reload all libraries, failed to unload library '{library_name}'."
+                logger.error(details)
+                return ReloadAllLibrariesResultFailure()
+
+        # Load (or reload, which should trigger a hot reload) all libraries
+        self.load_all_libraries_from_config()
+
+        details = (
+            "Successfully reloaded all libraries. All object state was cleared and previous libraries were unloaded."
+        )
+        logger.info(details)
+        return ReloadAllLibrariesResultSuccess()


### PR DESCRIPTION
Stepping stone to #1514 

The order of operations here will be:
1. Get this event into the engine and out in a release
2. Move the editor to use this event when hot reloading libraries instead of counting on the workflow reload to load all libraries
3. Get the editor out in a release
4. Change the engine to stop reloading libraries on every workflow load
5. Enjoy the speeeeeed