### PR TITLE
feat: overhaul sessions

### DIFF
--- a/src/griptape_nodes/app/__init__.py
+++ b/src/griptape_nodes/app/__init__.py
@@ -1,5 +1,14 @@
 """App package."""
 
-from griptape_nodes.app.app import start_app
+import os
+
+if os.getenv("GTN_USE_SESSIONS", "False").lower() == "true":
+    # Sessions are only available in the staging environment
+    os.environ["GRIPTAPE_NODES_API_BASE_URL"] = os.getenv(
+        "GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes-staging.griptape.ai"
+    )
+    from griptape_nodes.app.app_sessions import start_app
+else:
+    from griptape_nodes.app.app import start_app
 
 __all__ = ["start_app"]

--- a/src/griptape_nodes/app/app_sessions.py
+++ b/src/griptape_nodes/app/app_sessions.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import asyncio
+import binascii
+import json
+import logging
+import os
+import signal
+import sys
+import threading
+from pathlib import Path
+from queue import Queue
+from typing import Any, cast
+from urllib.parse import urljoin
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from griptape.events import (
+    EventBus,
+    EventListener,
+)
+from rich.align import Align
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.panel import Panel
+from websockets.asyncio.client import connect
+from websockets.exceptions import ConnectionClosed, WebSocketException
+
+# This import is necessary to register all events, even if not technically used
+from griptape_nodes.retained_mode.events import app_events, execution_events
+from griptape_nodes.retained_mode.events.base_events import (
+    AppEvent,
+    EventRequest,
+    EventResultFailure,
+    EventResultSuccess,
+    ExecutionEvent,
+    ExecutionGriptapeNodeEvent,
+    GriptapeNodeEvent,
+    ProgressEvent,
+    deserialize_event,
+)
+from griptape_nodes.retained_mode.events.logger_events import LogHandlerEvent
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# This is a global event queue that will be used to pass events between threads
+event_queue = Queue()
+
+# Global WebSocket connection for sending events
+ws_connection_for_sending = None
+event_loop = None
+
+# Whether to enable the static server
+STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "true"
+# Host of the static server
+STATIC_SERVER_HOST = os.getenv("STATIC_SERVER_HOST", "localhost")
+# Port of the static server
+STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
+# URL path for the static server
+STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/static")
+# Log level for the static server
+STATIC_SERVER_LOG_LEVEL = os.getenv("STATIC_SERVER_LOG_LEVEL", "info").lower()
+
+
+class EventLogHandler(logging.Handler):
+    """Custom logging handler that emits log messages as AppEvents.
+
+    This is used to forward log messages to the event queue so they can be sent to the GUI.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        event_queue.put(
+            AppEvent(
+                payload=LogHandlerEvent(message=record.getMessage(), levelname=record.levelname, created=record.created)
+            )
+        )
+
+
+# Logger for this module. Important that this is not the same as the griptape_nodes logger or else we'll have infinite log events.
+logger = logging.getLogger("griptape_nodes_app")
+console = Console()
+
+
+def start_app() -> None:
+    """Main entry point for the Griptape Nodes app.
+
+    Starts the event loop and listens for events from the Nodes API.
+    """
+    _init_event_listeners()
+
+    griptape_nodes_logger = logging.getLogger("griptape_nodes")
+    # When running as an app, we want to forward all log messages to the event queue so they can be sent to the GUI
+    griptape_nodes_logger.addHandler(EventLogHandler())
+    griptape_nodes_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
+    griptape_nodes_logger.setLevel(logging.INFO)
+
+    # Listen for any signals to exit the app
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, lambda *_: sys.exit(0))
+
+    # SSE subscription pushes events into event_queue
+    threading.Thread(target=_listen_for_api_events, daemon=True).start()
+
+    if STATIC_SERVER_ENABLED:
+        threading.Thread(target=_serve_static_server, daemon=True).start()
+
+    _process_event_queue()
+
+
+def _serve_static_server() -> None:
+    """Run FastAPI with Uvicorn in order to serve static files produced by nodes."""
+    config_manager = GriptapeNodes.ConfigManager()
+    app = FastAPI()
+
+    static_dir = config_manager.workspace_path / config_manager.merged_config["static_files_directory"]
+
+    if not static_dir.exists():
+        static_dir.mkdir(parents=True, exist_ok=True)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            os.getenv("GRIPTAPE_NODES_UI_BASE_URL", "https://app.nodes.griptape.ai"),
+            "https://app.nodes-staging.griptape.ai",
+            "http://localhost:5173",
+        ],
+        allow_credentials=True,
+        allow_methods=["OPTIONS", "GET", "POST", "PUT"],
+        allow_headers=["*"],
+    )
+
+    app.mount(
+        STATIC_SERVER_URL,
+        StaticFiles(directory=static_dir),
+        name="static",
+    )
+
+    @app.post("/static-upload-urls")
+    async def create_static_file_upload_url(request: Request) -> dict:
+        """Create a URL for uploading a static file.
+
+        Similar to a presigned URL, but for uploading files to the static server.
+        """
+        base_url = request.base_url
+        body = await request.json()
+        file_name = body["file_name"]
+        url = urljoin(str(base_url), f"/static-uploads/{file_name}")
+
+        return {"url": url}
+
+    @app.put("/static-uploads/{file_name:str}")
+    async def create_static_file(request: Request, file_name: str) -> dict:
+        """Upload a static file to the static server."""
+        if not STATIC_SERVER_ENABLED:
+            msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
+            raise ValueError(msg)
+
+        if not static_dir.exists():
+            static_dir.mkdir(parents=True, exist_ok=True)
+        data = await request.body()
+        try:
+            Path(static_dir / file_name).write_bytes(data)
+        except binascii.Error as e:
+            msg = f"Invalid base64 encoding for file {file_name}."
+            logger.error(msg)
+            raise HTTPException(status_code=400, detail=msg) from e
+        except (OSError, PermissionError) as e:
+            msg = f"Failed to write file {file_name} to {config_manager.workspace_path}: {e}"
+            logger.error(msg)
+            raise HTTPException(status_code=500, detail=msg) from e
+
+        static_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}{STATIC_SERVER_URL}/{file_name}"
+        return {"url": static_url}
+
+    @app.post("/engines/request")
+    async def create_event(request: Request) -> None:
+        body = await request.json()
+        if "payload" in body:
+            __process_api_event(body["payload"])
+
+    logging.getLogger("uvicorn").addHandler(
+        RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True)
+    )
+
+    uvicorn.run(
+        app, host=STATIC_SERVER_HOST, port=STATIC_SERVER_PORT, log_level=STATIC_SERVER_LOG_LEVEL, log_config=None
+    )
+
+
+def _init_event_listeners() -> None:
+    """Set up the Griptape EventBus EventListeners."""
+    EventBus.add_event_listener(
+        event_listener=EventListener(on_event=__process_node_event, event_types=[GriptapeNodeEvent])
+    )
+
+    EventBus.add_event_listener(
+        event_listener=EventListener(
+            on_event=__process_execution_node_event,
+            event_types=[ExecutionGriptapeNodeEvent],
+        )
+    )
+
+    EventBus.add_event_listener(
+        event_listener=EventListener(
+            on_event=__process_progress_event,
+            event_types=[ProgressEvent],
+        )
+    )
+
+    EventBus.add_event_listener(
+        event_listener=EventListener(
+            on_event=__process_app_event,  # pyright: ignore[reportArgumentType] TODO: https://github.com/griptape-ai/griptape-nodes/issues/868
+            event_types=[AppEvent],  # pyright: ignore[reportArgumentType] TODO: https://github.com/griptape-ai/griptape-nodes/issues/868
+        )
+    )
+
+
+async def _alisten_for_api_requests() -> None:
+    """Listen for events from the Nodes API and process them asynchronously."""
+    global ws_connection_for_sending, event_loop  # noqa: PLW0603
+    event_loop = asyncio.get_running_loop()  # Store the event loop reference
+    nodes_app_url = os.getenv("GRIPTAPE_NODES_UI_BASE_URL", "https://nodes.griptape.ai")
+    logger.info("Listening for events from Nodes API via async WebSocket")
+
+    # Auto reconnect https://websockets.readthedocs.io/en/stable/reference/asyncio/client.html#opening-a-connection
+    connection_stream = __create_async_websocket_connection()
+    initialized = False
+    async for ws_connection in connection_stream:
+        try:
+            ws_connection_for_sending = ws_connection  # Store for sending events
+            if not initialized:
+                __broadcast_app_initialization_complete(nodes_app_url)
+                initialized = True
+
+            async for message in ws_connection:
+                try:
+                    data = json.loads(message)
+
+                    payload = data.get("payload", {})
+                    __process_api_event(payload)
+                except Exception:
+                    logger.exception("Error processing event, skipping.")
+        except ConnectionClosed:
+            continue
+        except Exception as e:
+            logger.error("Error while listening for events. Retrying in 2 seconds... %s", e)
+            await asyncio.sleep(2)
+
+
+def _listen_for_api_events() -> None:
+    """Run the async WebSocket listener in an event loop."""
+    asyncio.run(_alisten_for_api_requests())
+
+
+def __process_node_event(event: GriptapeNodeEvent) -> None:
+    """Process GriptapeNodeEvents and send them to the API."""
+    # Emit the result back to the GUI
+    result_event = event.wrapped_event
+    if isinstance(result_event, EventResultSuccess):
+        dest_socket = "success_result"
+    elif isinstance(result_event, EventResultFailure):
+        dest_socket = "failure_result"
+    else:
+        msg = f"Unknown/unsupported result event type encountered: '{type(result_event)}'."
+        raise TypeError(msg) from None
+
+    # Don't send events over the wire that don't have a request_id set (e.g. engine-internal events)
+    event_json = result_event.json()
+    __schedule_async_task(__emit_message(dest_socket, event_json))
+
+
+def __process_execution_node_event(event: ExecutionGriptapeNodeEvent) -> None:
+    """Process ExecutionGriptapeNodeEvents and send them to the API."""
+    result_event = event.wrapped_event
+    if type(result_event.payload).__name__ == "NodeStartProcessEvent":
+        GriptapeNodes.EventManager().current_active_node = result_event.payload.node_name
+    event_json = result_event.json()
+
+    if type(result_event.payload).__name__ == "ResumeNodeProcessingEvent":
+        node_name = result_event.payload.node_name
+        logger.info("Resuming Node '%s'", node_name)
+        flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+        request = EventRequest(request=execution_events.SingleExecutionStepRequest(flow_name=flow_name))
+        event_queue.put(request)
+
+    if type(result_event.payload).__name__ == "NodeFinishProcessEvent":
+        if result_event.payload.node_name != GriptapeNodes.EventManager().current_active_node:
+            msg = "Node start and finish do not match."
+            raise KeyError(msg) from None
+        GriptapeNodes.EventManager().current_active_node = None
+    __schedule_async_task(__emit_message("execution_event", event_json))
+
+
+def __process_progress_event(gt_event: ProgressEvent) -> None:
+    """Process Griptape framework events and send them to the API."""
+    node_name = gt_event.node_name
+    if node_name:
+        value = gt_event.value
+        payload = execution_events.GriptapeEvent(
+            node_name=node_name, parameter_name=gt_event.parameter_name, type=type(gt_event).__name__, value=value
+        )
+        event_to_emit = ExecutionEvent(payload=payload)
+        __schedule_async_task(__emit_message("execution_event", event_to_emit.json()))
+
+
+def __process_app_event(event: AppEvent) -> None:
+    """Process AppEvents and send them to the API."""
+    # Let Griptape Nodes broadcast it.
+    GriptapeNodes.broadcast_app_event(event.payload)
+
+    __schedule_async_task(__emit_message("app_event", event.json()))
+
+
+def _process_event_queue() -> None:
+    """Listen for events in the event queue and process them.
+
+    Event queue will be populated by background threads listening for events from the Nodes API.
+    """
+    while True:
+        event = event_queue.get(block=True)
+        if isinstance(event, EventRequest):
+            request_payload = event.request
+            GriptapeNodes.handle_request(request_payload)
+        elif isinstance(event, AppEvent):
+            __process_app_event(event)
+        else:
+            logger.warning("Unknown event type encountered: '%s'.", type(event))
+
+        event_queue.task_done()
+
+
+def __create_async_websocket_connection() -> Any:
+    """Create an async WebSocket connection to the Nodes API."""
+    secrets_manager = GriptapeNodes.SecretsManager()
+    api_key = secrets_manager.get_secret("GT_CLOUD_API_KEY")
+    if api_key is None:
+        message = Panel(
+            Align.center(
+                "[bold red]Nodes API key is not set, please run [code]gtn init[/code] with a valid key: [/bold red]"
+                "[code]gtn init --api-key <your key>[/code]\n"
+                "[bold red]You can generate a new key from [/bold red][bold blue][link=https://nodes.griptape.ai]https://nodes.griptape.ai[/link][/bold blue]",
+            ),
+            title="🔑 ❌ Missing Nodes API Key",
+            border_style="red",
+            padding=(1, 4),
+        )
+        console.print(message)
+        sys.exit(1)
+
+    endpoint = urljoin(
+        os.getenv("GRIPTAPE_NODES_API_BASE_URL", "https://api.nodes.griptape.ai").replace("http", "ws"),
+        "/ws/engines/events?publish_channel=responses&subscribe_channel=requests",
+    )
+
+    return connect(
+        endpoint,
+        additional_headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+
+async def __emit_message(event_type: str, payload: str) -> None:
+    """Send a message via WebSocket asynchronously."""
+    global ws_connection_for_sending  # noqa: PLW0602
+    if ws_connection_for_sending is None:
+        logger.warning("WebSocket connection not available for sending message")
+        return
+
+    try:
+        body = {"type": event_type, "payload": json.loads(payload) if payload else {}}
+        await ws_connection_for_sending.send(json.dumps(body))
+    except WebSocketException as e:
+        logger.error("Error sending event to Nodes API: %s", e)
+    except Exception as e:
+        logger.error("Unexpected error while sending event to Nodes API: %s", e)
+
+
+def __schedule_async_task(coro: Any) -> None:
+    """Schedule an async coroutine to run in the event loop from a sync context."""
+    if event_loop and event_loop.is_running():
+        asyncio.run_coroutine_threadsafe(coro, event_loop)
+    else:
+        logger.warning("Event loop not available for scheduling async task")
+
+
+def __broadcast_app_initialization_complete(nodes_app_url: str) -> None:
+    """Broadcast the AppInitializationComplete event to all listeners.
+
+    This is used to notify the GUI that the app is ready to receive events.
+    """
+    # Initialize engine ID and persistent data
+    from griptape_nodes.retained_mode.events.base_events import BaseEvent
+
+    BaseEvent.initialize_engine_id()
+    BaseEvent.initialize_session_id()
+
+    # Broadcast this to anybody who wants a callback on "hey, the app's ready to roll"
+    payload = app_events.AppInitializationComplete()
+    app_event = AppEvent(payload=payload)
+    __process_app_event(app_event)
+
+    engine_version_request = app_events.GetEngineVersionRequest()
+    engine_version_result = GriptapeNodes.get_instance().handle_engine_version_request(engine_version_request)
+    if isinstance(engine_version_result, app_events.GetEngineVersionResultSuccess):
+        engine_version = f"v{engine_version_result.major}.{engine_version_result.minor}.{engine_version_result.patch}"
+    else:
+        engine_version = "<UNKNOWN ENGINE VERSION>"
+
+    # Get current session ID
+    session_id = GriptapeNodes.get_session_id()
+    session_info = f" | Session: {session_id[:8]}..." if session_id else " | No Session"
+
+    message = Panel(
+        Align.center(
+            f"[bold green]Engine is ready to receive events[/bold green]\n"
+            f"[bold blue]Return to: [link={nodes_app_url}]{nodes_app_url}[/link] to access the Workflow Editor[/bold blue]",
+            vertical="middle",
+        ),
+        title="🚀 Griptape Nodes Engine Started",
+        subtitle=f"[green]{engine_version}{session_info}[/green]",
+        border_style="green",
+        padding=(1, 4),
+    )
+    console.print(message)
+
+
+def __process_api_event(data: dict) -> None:
+    """Process API events and send them to the event queue."""
+    try:
+        data["request"]
+    except KeyError:
+        msg = "Error: 'request' was expected but not found."
+        raise RuntimeError(msg) from None
+
+    try:
+        event_type = data["event_type"]
+        if event_type != "EventRequest":
+            msg = "Error: 'event_type' was found on request, but did not match 'EventRequest' as expected."
+            raise RuntimeError(msg) from None
+    except KeyError:
+        msg = "Error: 'event_type' not found in request."
+        raise RuntimeError(msg) from None
+
+    # Now attempt to convert it into an EventRequest.
+    try:
+        request_event: EventRequest = cast("EventRequest", deserialize_event(json_data=data))
+    except Exception as e:
+        msg = f"Unable to convert request JSON into a valid EventRequest object. Error Message: '{e}'"
+        raise RuntimeError(msg) from None
+
+    # Add a request_id to the payload
+    request_id = request_event.request.request_id
+    request_event.request.request_id = request_id
+
+    # Add the event to the queue
+    event_queue.put(request_event)
+
+    return request_id

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -12,8 +12,7 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
 @dataclass
 @PayloadRegistry.register
-class AppStartSessionRequest(RequestPayload):
-    session_id: str
+class AppStartSessionRequest(RequestPayload): ...
 
 
 @dataclass
@@ -68,5 +67,115 @@ class GetEngineVersionResultSuccess(ResultPayloadSuccess):
 
 @dataclass
 @PayloadRegistry.register
-class GetEngineVersionResultFailure(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+class GetEngineVersionResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     pass
+
+
+@dataclass
+@PayloadRegistry.register
+class AppEndSessionRequest(RequestPayload):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class AppEndSessionResultSuccess(ResultPayloadSuccess):
+    session_id: str | None
+
+
+@dataclass
+@PayloadRegistry.register
+class AppEndSessionResultFailure(ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class SessionHeartbeatRequest(RequestPayload):
+    """Request clients can use ensure the engine session is still active."""
+
+
+@dataclass
+@PayloadRegistry.register
+class SessionHeartbeatResultSuccess(ResultPayloadSuccess):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class SessionHeartbeatResultFailure(ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class EngineHeartbeatRequest(RequestPayload):
+    """Request clients can use to discover active engines and their status.
+
+    Attributes:
+        heartbeat_id: Unique identifier for the heartbeat request, used to correlate requests and responses.
+
+    """
+
+    heartbeat_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class EngineHeartbeatResultSuccess(ResultPayloadSuccess):
+    heartbeat_id: str
+    engine_version: str
+    engine_id: str | None
+    session_id: str | None
+    timestamp: str
+    instance_type: str | None
+    instance_region: str | None
+    instance_provider: str | None
+    deployment_type: str | None
+    public_ip: str | None
+    current_workflow: str | None
+    workflow_file_path: str | None
+    has_active_flow: bool
+    engine_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class EngineHeartbeatResultFailure(ResultPayloadFailure):
+    heartbeat_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class SetEngineNameRequest(RequestPayload):
+    engine_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class SetEngineNameResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    engine_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class SetEngineNameResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    error_message: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEngineNameRequest(RequestPayload):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEngineNameResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    engine_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEngineNameResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    error_message: str

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -2,21 +2,41 @@ from __future__ import annotations
 
 import importlib.metadata
 import logging
+import os
 import re
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import IO, TYPE_CHECKING, Any, TextIO
 
+import httpx
+
 from griptape_nodes.exe_types.core_types import BaseNodeElement, Parameter, ParameterContainer, ParameterGroup
 from griptape_nodes.exe_types.flow import ControlFlow
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import (
+    AppEndSessionRequest,
+    AppEndSessionResultFailure,
+    AppEndSessionResultSuccess,
     AppGetSessionRequest,
     AppGetSessionResultSuccess,
     AppStartSessionRequest,
     AppStartSessionResultSuccess,
+    EngineHeartbeatRequest,
+    EngineHeartbeatResultFailure,
+    EngineHeartbeatResultSuccess,
+    GetEngineNameRequest,
+    GetEngineNameResultFailure,
+    GetEngineNameResultSuccess,
     GetEngineVersionRequest,
     GetEngineVersionResultFailure,
     GetEngineVersionResultSuccess,
+    SessionHeartbeatRequest,
+    SessionHeartbeatResultFailure,
+    SessionHeartbeatResultSuccess,
+    SetEngineNameRequest,
+    SetEngineNameResultFailure,
+    SetEngineNameResultSuccess,
 )
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
@@ -35,6 +55,8 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     AlterParameterDetailsRequest,
 )
+from griptape_nodes.retained_mode.utils.engine_identity import EngineIdentity
+from griptape_nodes.retained_mode.utils.session_persistence import SessionPersistence
 from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
@@ -179,7 +201,20 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._event_manager.assign_manager_to_request_type(
                 AppStartSessionRequest, self.handle_session_start_request
             )
+            self._event_manager.assign_manager_to_request_type(AppEndSessionRequest, self.handle_session_end_request)
             self._event_manager.assign_manager_to_request_type(AppGetSessionRequest, self.handle_get_session_request)
+            self._event_manager.assign_manager_to_request_type(
+                SessionHeartbeatRequest, self.handle_session_heartbeat_request
+            )
+            self._event_manager.assign_manager_to_request_type(
+                EngineHeartbeatRequest, self.handle_engine_heartbeat_request
+            )
+            self._event_manager.assign_manager_to_request_type(
+                GetEngineNameRequest, self.handle_get_engine_name_request
+            )
+            self._event_manager.assign_manager_to_request_type(
+                SetEngineNameRequest, self.handle_set_engine_name_request
+            )
 
     @classmethod
     def get_instance(cls) -> GriptapeNodes:
@@ -302,25 +337,202 @@ class GriptapeNodes(metaclass=SingletonMeta):
             logger.error(details)
             return GetEngineVersionResultFailure()
 
-    def handle_session_start_request(self, request: AppStartSessionRequest) -> ResultPayload:
-        if BaseEvent._session_id is None:
-            details = f"Session '{request.session_id}' started at {datetime.now(tz=UTC)}."
-        else:
-            if BaseEvent._session_id == request.session_id:
-                details = f"Session '{request.session_id}' already in place. No action taken."
-            else:
-                details = f"Attempted to start a session with ID '{request.session_id}' but this engine instance already had a session ID `{BaseEvent._session_id}' in place. Replacing it."
-
+    def handle_session_start_request(self, request: AppStartSessionRequest) -> ResultPayload:  # noqa: ARG002
+        current_session_id = BaseEvent._session_id
+        if current_session_id is None:
+            # Client wants a new session
+            current_session_id = uuid.uuid4().hex
+            BaseEvent._session_id = current_session_id
+            # Persist the session ID to XDG state directory
+            SessionPersistence.persist_session(current_session_id)
+            details = f"New session '{current_session_id}' started at {datetime.now(tz=UTC)}."
             logger.info(details)
+        else:
+            details = f"Session '{current_session_id}' already active. Joining..."
 
-        BaseEvent._session_id = request.session_id
+        return AppStartSessionResultSuccess(current_session_id)
 
-        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/855
+    def handle_session_end_request(self, _: AppEndSessionRequest) -> ResultPayload:
+        try:
+            previous_session_id = BaseEvent._session_id
+            if BaseEvent._session_id is None:
+                details = "No active session to end."
+                logger.info(details)
+            else:
+                details = f"Session '{BaseEvent._session_id}' ended at {datetime.now(tz=UTC)}."
+                logger.info(details)
+                BaseEvent._session_id = None
+                # Clear the persisted session ID from XDG state directory
+                SessionPersistence.clear_persisted_session()
 
-        return AppStartSessionResultSuccess(request.session_id)
+            return AppEndSessionResultSuccess(session_id=previous_session_id)
+        except Exception as err:
+            details = f"Failed to end session due to '{err}'."
+            logger.error(details)
+            return AppEndSessionResultFailure()
 
     def handle_get_session_request(self, _: AppGetSessionRequest) -> ResultPayload:
         return AppGetSessionResultSuccess(session_id=BaseEvent._session_id)
+
+    def handle_session_heartbeat_request(self, request: SessionHeartbeatRequest) -> ResultPayload:  # noqa: ARG002
+        """Handle session heartbeat requests.
+
+        Simply verifies that the session is active and responds with success.
+        """
+        try:
+            if BaseEvent._session_id is None:
+                logger.warning("Session heartbeat received but no active session found")
+                return SessionHeartbeatResultFailure()
+
+            logger.debug("Session heartbeat successful for session: %s", BaseEvent._session_id)
+            return SessionHeartbeatResultSuccess()
+        except Exception as err:
+            logger.error("Failed to handle session heartbeat: %s", err)
+            return SessionHeartbeatResultFailure()
+
+    def handle_engine_heartbeat_request(self, request: EngineHeartbeatRequest) -> ResultPayload:
+        """Handle engine heartbeat requests.
+
+        Returns engine status information including version, session state, and system metrics.
+        """
+        try:
+            # Get instance information based on environment variables
+            instance_info = self._get_instance_info()
+
+            # Get current workflow information
+            workflow_info = self._get_current_workflow_info()
+
+            # Get engine name
+            engine_name = EngineIdentity.get_engine_name()
+
+            logger.debug("Engine heartbeat successful")
+            return EngineHeartbeatResultSuccess(
+                heartbeat_id=request.heartbeat_id,
+                engine_version=engine_version,
+                engine_name=engine_name,
+                engine_id=BaseEvent._engine_id,
+                session_id=BaseEvent._session_id,
+                timestamp=datetime.now(tz=UTC).isoformat(),
+                **instance_info,
+                **workflow_info,
+            )
+        except Exception as err:
+            logger.error("Failed to handle engine heartbeat: %s", err)
+            return EngineHeartbeatResultFailure(heartbeat_id=request.heartbeat_id)
+
+    def handle_get_engine_name_request(self, request: GetEngineNameRequest) -> ResultPayload:  # noqa: ARG002
+        """Handle requests to get the current engine name."""
+        try:
+            engine_name = EngineIdentity.get_engine_name()
+            logger.debug("Retrieved engine name: %s", engine_name)
+            return GetEngineNameResultSuccess(engine_name=engine_name)
+        except Exception as err:
+            error_message = f"Failed to get engine name: {err}"
+            logger.error(error_message)
+            return GetEngineNameResultFailure(error_message=error_message)
+
+    def handle_set_engine_name_request(self, request: SetEngineNameRequest) -> ResultPayload:
+        """Handle requests to set a new engine name."""
+        try:
+            # Validate engine name (basic validation)
+            if not request.engine_name or not request.engine_name.strip():
+                error_message = "Engine name cannot be empty"
+                logger.warning(error_message)
+                return SetEngineNameResultFailure(error_message=error_message)
+
+            # Set the new engine name
+            EngineIdentity.set_engine_name(request.engine_name.strip())
+            logger.info("Engine name set to: %s", request.engine_name.strip())
+            return SetEngineNameResultSuccess(engine_name=request.engine_name.strip())
+
+        except Exception as err:
+            error_message = f"Failed to set engine name: {err}"
+            logger.error(error_message)
+            return SetEngineNameResultFailure(error_message=error_message)
+
+    def _get_instance_info(self) -> dict[str, str | None]:
+        """Get instance information from environment variables.
+
+        Returns instance type, region, provider, and public IP information if available.
+        """
+        instance_info: dict[str, str | None] = {
+            "instance_type": os.getenv("GTN_INSTANCE_TYPE"),
+            "instance_region": os.getenv("GTN_INSTANCE_REGION"),
+            "instance_provider": os.getenv("GTN_INSTANCE_PROVIDER"),
+        }
+
+        # Determine deployment type based on presence of instance environment variables
+        instance_info["deployment_type"] = "griptape_hosted" if any(instance_info.values()) else "local"
+
+        # Get public IP address
+        public_ip = self._get_public_ip()
+        if public_ip:
+            instance_info["public_ip"] = public_ip
+
+        return instance_info
+
+    def _get_public_ip(self) -> str | None:
+        """Get the public IP address of this device.
+
+        Returns the public IP address if available, None otherwise.
+        """
+        try:
+            # Try multiple services in case one is down
+            services = [
+                "https://api.ipify.org",
+                "https://ipinfo.io/ip",
+                "https://icanhazip.com",
+            ]
+
+            for service in services:
+                try:
+                    with httpx.Client(timeout=5.0) as client:
+                        response = client.get(service)
+                        response.raise_for_status()
+                        public_ip = response.text.strip()
+                        if public_ip:
+                            logger.debug("Retrieved public IP from %s: %s", service, public_ip)
+                            return public_ip
+                except Exception as err:
+                    logger.debug("Failed to get public IP from %s: %s", service, err)
+                    continue
+            logger.warning("Unable to retrieve public IP from any service")
+        except Exception as err:
+            logger.warning("Failed to get public IP: %s", err)
+            return None
+        else:
+            return None
+
+    def _get_current_workflow_info(self) -> dict[str, Any]:
+        """Get information about the currently loaded workflow.
+
+        Returns workflow name, file path, and status information if available.
+        """
+        workflow_info = {
+            "current_workflow": None,
+            "workflow_file_path": None,
+            "has_active_flow": False,
+        }
+
+        try:
+            context_manager = self._context_manager
+
+            # Check if there's an active workflow
+            if context_manager.has_current_workflow():
+                workflow_name = context_manager.get_current_workflow_name()
+                workflow_info["current_workflow"] = workflow_name
+                workflow_info["has_active_flow"] = context_manager.has_current_flow()
+
+                # Get workflow file path from registry
+                if WorkflowRegistry.has_workflow_with_name(workflow_name):
+                    workflow = WorkflowRegistry.get_workflow_by_name(workflow_name)
+                    absolute_path = WorkflowRegistry.get_complete_file_path(workflow.file_path)
+                    workflow_info["workflow_file_path"] = absolute_path
+
+        except Exception as err:
+            logger.warning("Failed to get current workflow info: %s", err)
+
+        return workflow_info
 
 
 def create_flows_in_order(flow_name: str, flow_manager: FlowManager, created_flows: list, file: IO) -> list | None:

--- a/src/griptape_nodes/retained_mode/utils/__init__.py
+++ b/src/griptape_nodes/retained_mode/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the retained mode system."""

--- a/src/griptape_nodes/retained_mode/utils/engine_identity.py
+++ b/src/griptape_nodes/retained_mode/utils/engine_identity.py
@@ -1,0 +1,131 @@
+"""Manages engine identity for a single engine per machine.
+
+Handles engine ID, name storage, and generation for unique engine identification.
+"""
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from xdg_base_dirs import xdg_data_home
+
+from .name_generator import generate_engine_name
+
+
+class EngineIdentity:
+    """Manages engine identity for a single engine per machine."""
+
+    _ENGINE_DATA_FILE = "engine.json"
+
+    @classmethod
+    def _get_engine_data_dir(cls) -> Path:
+        """Get the XDG data directory for engine identity storage."""
+        return xdg_data_home() / "griptape_nodes"
+
+    @classmethod
+    def _get_engine_data_file(cls) -> Path:
+        """Get the path to the engine data storage file."""
+        return cls._get_engine_data_dir() / cls._ENGINE_DATA_FILE
+
+    @classmethod
+    def _load_engine_data(cls) -> dict:
+        """Load engine data from storage.
+
+        Returns:
+            dict: Engine data including id, name, timestamps
+        """
+        engine_data_file = cls._get_engine_data_file()
+
+        if engine_data_file.exists():
+            try:
+                with engine_data_file.open("r") as f:
+                    data = json.load(f)
+                    if isinstance(data, dict):
+                        return data
+            except (json.JSONDecodeError, OSError):
+                # If file is corrupted, return empty dict
+                pass
+
+        return {}
+
+    @classmethod
+    def _save_engine_data(cls, engine_data: dict) -> None:
+        """Save engine data to storage.
+
+        Args:
+            engine_data: Engine data to save
+        """
+        engine_data_dir = cls._get_engine_data_dir()
+        engine_data_dir.mkdir(parents=True, exist_ok=True)
+
+        engine_data_file = cls._get_engine_data_file()
+        with engine_data_file.open("w") as f:
+            json.dump(engine_data, f, indent=2)
+
+    @classmethod
+    def get_engine_data(cls) -> dict:
+        """Get the engine data, creating default if it doesn't exist.
+
+        Returns:
+            dict: The engine data
+        """
+        engine_data = cls._load_engine_data()
+
+        if not engine_data or "id" not in engine_data:
+            # Create default engine data
+            engine_data = {
+                "id": os.getenv("GTN_ENGINE_ID") or str(uuid.uuid4()),
+                "name": generate_engine_name(),
+                "created_at": datetime.now(tz=UTC).isoformat(),
+            }
+            cls._save_engine_data(engine_data)
+
+        return engine_data
+
+    @classmethod
+    def get_engine_id(cls) -> str:
+        """Get the engine ID.
+
+        Returns:
+            str: The engine ID (UUID)
+        """
+        engine_data = cls.get_engine_data()
+        return engine_data["id"]
+
+    @classmethod
+    def get_engine_name(cls) -> str:
+        """Get the engine name.
+
+        Returns:
+            str: The engine name
+        """
+        engine_data = cls.get_engine_data()
+        return engine_data["name"]
+
+    @classmethod
+    def set_engine_name(cls, engine_name: str) -> None:
+        """Set and persist the engine name.
+
+        Args:
+            engine_name: The new engine name to set
+        """
+        engine_data = cls._load_engine_data()
+
+        # Ensure we have basic engine data
+        if not engine_data or "id" not in engine_data:
+            engine_data = cls.get_engine_data()
+
+        engine_data["name"] = engine_name
+        engine_data["updated_at"] = datetime.now(tz=UTC).isoformat()
+        cls._save_engine_data(engine_data)
+
+    @classmethod
+    def get_engine_data_file_path(cls) -> Path:
+        """Get the path where engine data is stored (for debugging/inspection).
+
+        Returns:
+            Path: The path to the engine data file
+        """
+        return cls._get_engine_data_file()

--- a/src/griptape_nodes/retained_mode/utils/name_generator.py
+++ b/src/griptape_nodes/retained_mode/utils/name_generator.py
@@ -1,0 +1,162 @@
+"""Generates random fun names for engines like 'admirable-finch' or 'ancient-green-cat'.
+
+Used for default engine naming when no custom name is provided.
+"""
+
+import random
+
+ADJECTIVES = [
+    "admirable",
+    "ancient",
+    "brave",
+    "bright",
+    "calm",
+    "clever",
+    "cool",
+    "cozy",
+    "daring",
+    "dreamy",
+    "eager",
+    "elegant",
+    "epic",
+    "fancy",
+    "fierce",
+    "fluffy",
+    "gentle",
+    "golden",
+    "graceful",
+    "happy",
+    "honest",
+    "jolly",
+    "kind",
+    "lively",
+    "lucky",
+    "magical",
+    "mighty",
+    "noble",
+    "peaceful",
+    "playful",
+    "proud",
+    "quiet",
+    "radiant",
+    "serene",
+    "shiny",
+    "silver",
+    "smooth",
+    "stellar",
+    "swift",
+    "tender",
+    "valiant",
+    "vibrant",
+    "warm",
+    "wise",
+    "wonderful",
+    "zesty",
+]
+
+ANIMALS = [
+    "ant",
+    "bear",
+    "cat",
+    "deer",
+    "eagle",
+    "finch",
+    "goat",
+    "hawk",
+    "ibis",
+    "jay",
+    "kiwi",
+    "llama",
+    "mouse",
+    "newt",
+    "owl",
+    "panda",
+    "quail",
+    "rabbit",
+    "seal",
+    "tiger",
+    "urchin",
+    "viper",
+    "whale",
+    "xerus",
+    "yak",
+    "zebra",
+    "badger",
+    "crane",
+    "dove",
+    "elk",
+    "fox",
+    "gecko",
+    "heron",
+    "iguana",
+    "jackal",
+    "koala",
+    "lynx",
+    "mole",
+    "narwhal",
+    "otter",
+    "penguin",
+    "quokka",
+    "raven",
+    "swan",
+    "turtle",
+    "unicorn",
+    "vulture",
+    "wolf",
+    "xenops",
+    "yellowhammer",
+]
+
+COLORS = [
+    "amber",
+    "azure",
+    "bronze",
+    "coral",
+    "crimson",
+    "emerald",
+    "forest",
+    "golden",
+    "indigo",
+    "jade",
+    "lavender",
+    "magenta",
+    "navy",
+    "orange",
+    "pink",
+    "rose",
+    "ruby",
+    "sage",
+    "teal",
+    "violet",
+    "white",
+    "yellow",
+    "black",
+    "blue",
+    "brown",
+    "cyan",
+    "gray",
+    "green",
+    "lime",
+    "maroon",
+    "olive",
+    "purple",
+    "red",
+    "silver",
+]
+
+
+def generate_engine_name() -> str:
+    """Generate a random engine name in the format 'adjective-animal' or 'adjective-color-animal'.
+
+    Returns:
+        str: A randomly generated engine name
+    """
+    adjective = random.choice(ADJECTIVES)  # noqa: S311
+    animal = random.choice(ANIMALS)  # noqa: S311
+
+    # 30% chance to include a color for more variety
+    color_chance = 0.3
+    if random.random() < color_chance:  # noqa: S311
+        color = random.choice(COLORS)  # noqa: S311
+        return f"{adjective}-{color}-{animal}"
+    return f"{adjective}-{animal}"

--- a/src/griptape_nodes/retained_mode/utils/session_persistence.py
+++ b/src/griptape_nodes/retained_mode/utils/session_persistence.py
@@ -1,0 +1,105 @@
+"""Manages session persistence using XDG state directory.
+
+Handles storing and retrieving active session information across engine restarts.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from xdg_base_dirs import xdg_state_home
+
+
+class SessionPersistence:
+    """Manages session persistence for active session tracking."""
+
+    _SESSION_STATE_FILE = "session.json"
+
+    @classmethod
+    def _get_session_state_dir(cls) -> Path:
+        """Get the XDG state directory for session persistence."""
+        return xdg_state_home() / "griptape_nodes"
+
+    @classmethod
+    def _get_session_state_file(cls) -> Path:
+        """Get the path to the session state storage file."""
+        return cls._get_session_state_dir() / cls._SESSION_STATE_FILE
+
+    @classmethod
+    def _load_session_data(cls) -> dict:
+        """Load session data from storage.
+
+        Returns:
+            dict: Session data including id, timestamps
+        """
+        session_state_file = cls._get_session_state_file()
+
+        if session_state_file.exists():
+            try:
+                with session_state_file.open("r") as f:
+                    data = json.load(f)
+                    if isinstance(data, dict):
+                        return data
+            except (json.JSONDecodeError, OSError):
+                # If file is corrupted, return empty dict
+                pass
+
+        return {}
+
+    @classmethod
+    def _save_session_data(cls, session_data: dict) -> None:
+        """Save session data to storage.
+
+        Args:
+            session_data: Session data to save
+        """
+        session_state_dir = cls._get_session_state_dir()
+        session_state_dir.mkdir(parents=True, exist_ok=True)
+
+        session_state_file = cls._get_session_state_file()
+        with session_state_file.open("w") as f:
+            json.dump(session_data, f, indent=2)
+
+    @classmethod
+    def persist_session(cls, session_id: str) -> None:
+        """Persist the active session ID to storage.
+
+        Args:
+            session_id: The session ID to persist
+        """
+        session_data = {
+            "session_id": session_id,
+            "started_at": datetime.now(tz=UTC).isoformat(),
+            "last_updated": datetime.now(tz=UTC).isoformat(),
+        }
+        cls._save_session_data(session_data)
+
+    @classmethod
+    def get_persisted_session_id(cls) -> str | None:
+        """Get the persisted session ID if it exists.
+
+        Returns:
+            str | None: The persisted session ID or None if no session is persisted
+        """
+        session_data = cls._load_session_data()
+        return session_data.get("session_id")
+
+    @classmethod
+    def clear_persisted_session(cls) -> None:
+        """Clear the persisted session data."""
+        session_state_file = cls._get_session_state_file()
+        if session_state_file.exists():
+            try:
+                session_state_file.unlink()
+            except OSError:
+                # If we can't delete the file, just clear its contents
+                cls._save_session_data({})
+
+    @classmethod
+    def has_persisted_session(cls) -> bool:
+        """Check if there is a persisted session.
+
+        Returns:
+            bool: True if there is a persisted session, False otherwise
+        """
+        return cls.get_persisted_session_id() is not None


### PR DESCRIPTION
This PR introduces new event types and architectural changes to support a comprehensive overhaul of session management in both the API and UI.

## New Event Types

### App Events
**AppStartSessionRequest**
- **Breaking Change**: No longer accepts `session_id` in the request body
- Session IDs are now generated server-side by the engine rather than client-side

**AppEndSessionRequest**
- New event type for properly terminating sessions with an engine

### Heartbeat Events
**SessionHeartbeatRequest**
- Enables clients to maintain connection health with the engine after session establishment
- Replaces previous ad-hoc heartbeat mechanism

**EngineHeartbeatRequest**  
- Allows sessionless clients to discover and connect to available engines
- Response includes comprehensive engine metadata for client decision-making

### Engine Management Events
**SetEngineNameRequest / GetEngineNameRequest**
- Engines now support persistent naming for better organization
- Names are stored in `xdg_data_home/engine.json`
- Useful for clients managing multiple engine instances

## Architectural Changes

### Structured Heartbeat System
The previous special-case `Heartbeat` request has been replaced with proper event types (`EngineHeartbeatRequest` and `SessionHeartbeatRequest`). This provides:
- Consistent event handling patterns
- Better type safety and validation
- Foundation for future priority-based event processing

### Engine Identity and Persistence
Engines now receive auto-generated identifiers (id, name) during initialization, stored in `xdg_data_home/engine.json`. 

**Important Limitation**: This design intentionally prevents multiple engine instances on the same machine. I believe  session-based multiplexing (single engine managing multiple process sessions) should the recommended approach for scaling rather than spinning up multiple engine processes.

Closes #664