### PR TITLE
fix!: don't load dotenv files in __init__

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -18,7 +18,6 @@ with console.status("Loading Griptape Nodes...") as status:
     from typing import Any, Literal
 
     import httpx
-    from dotenv import load_dotenv
     from rich.box import HEAVY_EDGE
     from rich.panel import Panel
     from rich.progress import Progress
@@ -83,8 +82,6 @@ os_manager = OSManager()
 
 def main() -> None:
     """Main entry point for the Griptape Nodes CLI."""
-    load_dotenv(ENV_FILE, override=True)
-
     # Hack to make paths "just work". # noqa: FIX004
     # Without this, packages like `nodes` don't properly import.
     # Long term solution could be to make `nodes` a proper src-layout package


### PR DESCRIPTION
This makes values in `~/.config/griptape_nodes/.env` take precedence over values in `{workspace}/.env` because they'll be loaded as environment variables (highest precedence).