### PR TITLE
Serializtion with stable module names despite dynamic module loading.

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -121,16 +121,16 @@ class LibraryManager:
     # in generated workflow code by providing stable, predictable import paths.
     #
     # Example mappings:
-    # _dynamic_to_stable_module_mapping = {
+    # dynamic to stable module mapping:
     #     "dynamic_module_image_to_video_py_123456789": "griptape_nodes.node_libraries.runwayml_library.image_to_video"
-    # }
-    # _stable_to_dynamic_module_mapping = {
+    #
+    # stable to dynamic module mapping:
     #     "griptape_nodes.node_libraries.runwayml_library.image_to_video": "dynamic_module_image_to_video_py_123456789"
-    # }
-    # _library_to_stable_modules = {
+    #
+    # library to stable modules:
     #     "RunwayML Library": {"griptape_nodes.node_libraries.runwayml_library.image_to_video", "griptape_nodes.node_libraries.runwayml_library.text_to_image"},
     #     "Sandbox Library": {"griptape_nodes.node_libraries.sandbox.my_custom_node"}
-    # }
+    #
     _dynamic_to_stable_module_mapping: dict[str, str]  # dynamic_module_name -> stable_namespace
     _stable_to_dynamic_module_mapping: dict[str, str]  # stable_namespace -> dynamic_module_name
     _library_to_stable_modules: dict[str, set[str]]  # library_name -> set of stable_namespaces
@@ -945,7 +945,8 @@ class LibraryManager:
         # Register the stable alias in sys.modules
         sys.modules[stable_namespace] = module
 
-        logger.debug(f"Registered stable alias: {stable_namespace} -> {dynamic_module_name} (library: {library_key})")
+        details = f"Registered stable alias: {stable_namespace} -> {dynamic_module_name} (library: {library_key})"
+        logger.debug(details)
 
     def _unregister_stable_module_alias(self, dynamic_module_name: str) -> None:
         """Unregister a stable alias for a dynamic module during hot reload.
@@ -968,7 +969,8 @@ class LibraryManager:
             del self._dynamic_to_stable_module_mapping[dynamic_module_name]
             del self._stable_to_dynamic_module_mapping[stable_namespace]
 
-            logger.debug(f"Unregistered stable alias: {stable_namespace}")
+            details = f"Unregistered stable alias: {stable_namespace}"
+            logger.debug(details)
 
     def _unregister_all_stable_module_aliases_for_library(self, library_name: str) -> None:
         """Unregister all stable module aliases for a library during library unload/reload.
@@ -981,7 +983,8 @@ class LibraryManager:
             return
 
         stable_namespaces = self._library_to_stable_modules[library_key].copy()
-        logger.debug(f"Unregistering {len(stable_namespaces)} stable aliases for library: {library_name}")
+        details = f"Unregistering {len(stable_namespaces)} stable aliases for library: {library_name}"
+        logger.debug(details)
 
         for stable_namespace in stable_namespaces:
             # Remove from sys.modules if it exists
@@ -996,7 +999,8 @@ class LibraryManager:
 
         # Clear the library's module set
         del self._library_to_stable_modules[library_key]
-        logger.debug(f"Completed cleanup of stable aliases for library: {library_name}")
+        details = f"Completed cleanup of stable aliases for library: '{library_name}'."
+        logger.debug(details)
 
     def get_stable_namespace_for_dynamic_module(self, dynamic_module_name: str) -> str | None:
         """Get the stable namespace for a dynamic module name.
@@ -1081,7 +1085,8 @@ class LibraryManager:
                 spec.loader.exec_module(module)
                 # Register new stable alias
                 self._register_stable_module_alias(module_name, stable_namespace, module, library_name)
-                logger.debug(f"Hot reloaded module: {module_name} from {file_path}")
+                details = f"Hot reloaded module: {module_name} from {file_path}"
+                logger.debug(details)
             except Exception as e:
                 # Restore the old module in case of failure
                 sys.modules[module_name] = old_module


### PR DESCRIPTION
Fixes #1572 

Fix workflow serialization for dynamically loaded modules (VideoUrlArtifact, ReferenceImageArtifact)

  Problem

  Root Cause: Workflows containing objects from dynamically loaded libraries (RunwayML, custom libraries) fail with
  "pickle data was truncated" errors when serialized and later reloaded.

  Technical Details:
  - Dynamic modules get hash-based names like dynamic_module_image_to_video_py_123456789
  - When pickle serializes objects, it embeds these module names in the binary data
  - When workflows run later in fresh Python processes, these module names don't exist
  - Python fails to import the non-existent modules, causing workflow execution to fail

  Affected Objects:
  - VideoUrlArtifact from RunwayML library
  - ReferenceImageArtifact from RunwayML library
  - Any custom artifacts from dynamically loaded libraries
  - Nested objects in containers (ParameterArrays, lists, dicts)

  Solution Approach

  1. Stable Namespace Mapping System
  Created a deterministic mapping from dynamic module names to stable import paths:
  - dynamic_module_image_to_video_py_123456789 → griptape_nodes.node_libraries.runwayml_library.image_to_video
  - dynamic_module_create_reference_image_py_987654321 →
  griptape_nodes.node_libraries.runwayml_library.create_reference_image

  2. Recursive Dynamic Module Patching
  - Temporarily patch class __module__ attributes before pickling
  - Patch instance module_name fields (set by SerializableMixin)
  - Handle nested objects in containers recursively
  - Restore original names after pickling to avoid side effects

  3. Runtime Import Registration
  - Register stable namespaces in sys.modules when libraries load
  - Enable generated workflows to import stable namespaces successfully

  Concrete Examples

  Before (Broken)

  Generated workflow imports:
  # Import would fail - module doesn't exist
  from dynamic_module_image_to_video_py_123456789 import VideoUrlArtifact

  Pickle data contains:
  b'...dynamic_module_image_to_video_py_123456789\x94\x8c\x10VideoUrlArtifact...'

  Result: ModuleNotFoundError when workflow runs

  After (Fixed)

  Generated workflow imports:
  # Import succeeds - stable namespace registered in sys.modules
  from griptape_nodes.node_libraries.runwayml_library.image_to_video import VideoUrlArtifact

  Pickle data contains:
  b'...griptape_nodes.node_libraries.runwayml_library.image_to_video\x94\x8c\x10VideoUrlArtifact...'

  Result: ✅ Workflow loads and executes successfully

  Nested Object Fix

  Before: ParameterArray containing ReferenceImageArtifact still had dynamic module references
  # Pickle data for list container
  'ff6e095d-666b-4978-8b4f-96096621e39b':
  pickle.loads(b'...\x8c<dynamic_module_create_reference_image_py_1395362441757938297\x94...')

  After: Recursive patching fixes nested objects too
  # Pickle data for list container  
  '844545ab-d991-497d-84b5-0b131f7fc449':
  pickle.loads(b'...\x8cEgriptape_nodes.node_libraries.runwayml_library.create_reference_image\x94...')

  Implementation Details

  Key Files Modified

  src/griptape_nodes/retained_mode/managers/library_manager.py
  - Added stable namespace mapping system with 3 tracking dictionaries
  - _register_stable_module_alias() - registers stable namespaces in sys.modules
  - _unregister_all_stable_module_aliases_for_library() - bulk cleanup on library unload
  - get_stable_namespace_for_dynamic_module() - public API for namespace resolution

  src/griptape_nodes/retained_mode/managers/workflow_manager.py
  - Added _walk_object_tree() - unified recursive traversal helper
  - Added _patch_and_pickle_object() - recursive dynamic module patching with proper restoration
  - Added _collect_object_imports() - recursive import statement collection
  - Updated _generate_unique_values_code() to use new patching system

  Algorithm Details

  Recursive Patching Process:
  1. Walk through entire object tree (lists, tuples, dicts, object attributes)
  2. For each object from a dynamic module:
    - Get stable namespace from mapping
    - Patch class.__module__ (affects pickle class reference)
    - Patch instance.module_name (affects SerializableMixin serialization)
  3. Pickle with stable references
  4. Restore all original names to avoid side effects

  Stable Namespace Generation:
  def _create_stable_namespace(self, library_name: str, file_path: Path) -> str:
      safe_library_name = library_name.lower().replace(" ", "_")
      safe_file_name = file_path.stem.replace("-", "_")
      return f"griptape_nodes.node_libraries.{safe_library_name}.{safe_file_name}"

  Testing

  Validation Steps:
  1. ✅ Created workflow with RunwayML nodes (VideoUrlArtifact, ReferenceImageArtifact)
  2. ✅ Generated workflow file shows stable imports
  3. ✅ Pickle data contains stable module references (no dynamic_module_* names)
  4. ✅ Workflow loads successfully in editor (confirms import resolution)
  5. ✅ Nested objects in ParameterArrays now use stable namespaces

  Before/After Comparison:
  - 1130_test.py (before): Contains dynamic_module_create_reference_image_py_1395362441757938297
  - 1151.py (after): Contains griptape_nodes.node_libraries.runwayml_library.create_reference_image

  Benefits

  - ✅ Fixes RunwayML workflow serialization - No more "pickle data was truncated" errors
  - ✅ Enables workflow portability - Generated workflows work across different environments
  - ✅ Supports hot reloading - Library updates maintain stable references
  - ✅ Handles complex nesting - Works with ParameterArrays and deep object hierarchies
  - ✅ Maintains backwards compatibility - Existing workflows continue to work
  - ✅ Supports all dynamic libraries - Solution works for any dynamically loaded library

  This fix resolves the core issue preventing RunwayML library workflows from being serialized and reloaded, enabling
   full workflow portability and sharing.