### PR TITLE
Don't return dict from LoadImage

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
@@ -30,8 +30,7 @@ class LoadImage(DataNode):
             metadata = image.get("meta", {})
             artifact = dict_to_image_url_artifact(image)
             if metadata:
-                # Return a dictionary with metadata
-                return {"type": "ImageUrlArtifact", "value": artifact.value, "meta": metadata}
+                artifact.meta = metadata
             return artifact
         return image
 

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ loaders-image = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.38.0"
+version = "0.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Verified that an example of one of the failing nodes (depth anything v2 for images) not built to accept dicts succeeds again.

![Screenshot 2025-06-24 at 7 57 42 AM](https://github.com/user-attachments/assets/9ab652c2-3f05-4848-a1e4-7bbe13870e79)
![Screenshot 2025-06-24 at 7 58 17 AM](https://github.com/user-attachments/assets/b3b3bdcb-153a-48b4-bc13-6e03b5fb8d56)

Also, version bump in uv.lock wasn't previously commit (expand diff to see I'm not adding deps or anything crazy)
