### PR TITLE
Update Parameter Events

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -217,7 +217,12 @@ class BaseNodeElement:
                 # Track change if different
                 if old_value != new_value:
                     # it needs to be static so we can call these methods.
-                    self._changes[func.__name__] = new_value
+                    if func.__name__ == "allowed_modes" and isinstance(new_value, set):
+                        self._changes["mode_allowed_input"] = ParameterMode.INPUT in new_value
+                        self._changes["mode_allowed_output"] = ParameterMode.OUTPUT in new_value
+                        self._changes["mode_allowed_property"] = ParameterMode.PROPERTY in new_value
+                    else:
+                        self._changes[func.__name__] = new_value
                     if self._node_context is not None and self not in self._node_context._tracked_parameters:
                         self._node_context._tracked_parameters.append(self)
                 return result

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -480,7 +480,9 @@ class BaseNode(ABC):
                 return element_item
         return None
 
-    def set_parameter_value(self, param_name: str, value: Any, *, initial_setup:bool = False, emit_change: bool = True) -> None:
+    def set_parameter_value(  # noqa: C901
+        self, param_name: str, value: Any, *, initial_setup: bool = False, emit_change: bool = True
+    ) -> None:
         """Attempt to set a Parameter's value.
 
         The Node may choose to store a different value (or type) than what was passed in.
@@ -499,6 +501,7 @@ class BaseNode(ABC):
             param_name: the name of the Parameter on this node that is about to be changed
             value: the value intended to be set
             emit_change: whether to emit a parameter lifecycle event, defaults to True
+            initial_setup: Whether this value is being set as the initial setup on the node, defaults to False. When True, the value is not given to any before/after hooks.
 
         Returns:
             A set of parameter names within this node that were modified as a result
@@ -555,7 +558,12 @@ class BaseNode(ABC):
                 new_parent_value = handle_container_parameter(self, parent_parameter)
                 if new_parent_value is not None:
                     # set that new value if it exists.
-                    self.set_parameter_value(parameter.parent_container_name, new_parent_value, initial_setup=initial_setup,emit_change=False)
+                    self.set_parameter_value(
+                        parameter.parent_container_name,
+                        new_parent_value,
+                        initial_setup=initial_setup,
+                        emit_change=False,
+                    )
 
     def kill_parameter_children(self, parameter: Parameter) -> None:
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -480,7 +480,7 @@ class BaseNode(ABC):
                 return element_item
         return None
 
-    def set_parameter_value(self, param_name: str, value: Any, *, emit_change: bool = True) -> None:
+    def set_parameter_value(self, param_name: str, value: Any, *, initial_setup:bool = False, emit_change: bool = True) -> None:
         """Attempt to set a Parameter's value.
 
         The Node may choose to store a different value (or type) than what was passed in.
@@ -526,23 +526,25 @@ class BaseNode(ABC):
 
         # Allow custom node logic to prepare and possibly mutate the value before it is actually set.
         # Record any parameters modified for cascading.
-        try:
-            final_value = self.before_value_set(parameter=parameter, value=candidate_value)
-        except TypeError:
-            final_value = self.before_value_set(
-                parameter=parameter, value=candidate_value, modified_parameters_set=set()
-            )
-        # ACTUALLY SET THE NEW VALUE
-        self.parameter_values[param_name] = final_value
-
-        # If a parameter value has been set at the top level of a container, wipe all children.
-        # Allow custom node logic to respond after it's been set. Record any modified parameters for cascading.
-        try:
-            self.after_value_set(parameter=parameter, value=final_value)
-        except TypeError:
-            self.after_value_set(parameter=parameter, value=final_value, modified_parameters_set=set())
-        if emit_change:
-            self._emit_parameter_lifecycle_event(parameter)
+        if not initial_setup:
+            try:
+                final_value = self.before_value_set(parameter=parameter, value=candidate_value)
+            except TypeError:
+                final_value = self.before_value_set(
+                    parameter=parameter, value=candidate_value, modified_parameters_set=set()
+                )
+            # ACTUALLY SET THE NEW VALUE
+            self.parameter_values[param_name] = final_value
+            # If a parameter value has been set at the top level of a container, wipe all children.
+            # Allow custom node logic to respond after it's been set. Record any modified parameters for cascading.
+            try:
+                self.after_value_set(parameter=parameter, value=final_value)
+            except TypeError:
+                self.after_value_set(parameter=parameter, value=final_value, modified_parameters_set=set())
+            if emit_change:
+                self._emit_parameter_lifecycle_event(parameter)
+        else:
+            self.parameter_values[param_name] = candidate_value
         # handle with container parameters
         if parameter.parent_container_name is not None:
             # Does it have a parent container
@@ -553,7 +555,7 @@ class BaseNode(ABC):
                 new_parent_value = handle_container_parameter(self, parent_parameter)
                 if new_parent_value is not None:
                     # set that new value if it exists.
-                    self.set_parameter_value(parameter.parent_container_name, new_parent_value, emit_change=False)
+                    self.set_parameter_value(parameter.parent_container_name, new_parent_value, initial_setup=initial_setup,emit_change=False)
 
     def kill_parameter_children(self, parameter: Parameter) -> None:
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -608,32 +608,33 @@ class FlowManager:
             return CreateConnectionResultFailure()
 
         # Let the source make any internal handling decisions now that the Connection has been made.
-        try:
-            source_node.after_outgoing_connection(
-                source_parameter=source_param, target_node=target_node, target_parameter=target_param
-            )
-        except TypeError:
-            source_node.after_outgoing_connection(
-                source_parameter=source_param,
-                target_node=target_node,
-                target_parameter=target_param,
-                modified_parameters_set=set(),
-            )
+        if not request.initial_setup:
+            try:
+                source_node.after_outgoing_connection(
+                    source_parameter=source_param, target_node=target_node, target_parameter=target_param
+                )
+            except TypeError:
+                source_node.after_outgoing_connection(
+                    source_parameter=source_param,
+                    target_node=target_node,
+                    target_parameter=target_param,
+                    modified_parameters_set=set(),
+                )
 
-        # And target.
-        try:
-            target_node.after_incoming_connection(
-                source_node=source_node,
-                source_parameter=source_param,
-                target_parameter=target_param,
-            )
-        except TypeError:
-            target_node.after_incoming_connection(
-                source_node=source_node,
-                source_parameter=source_param,
-                target_parameter=target_param,
-                modified_parameters_set=set(),
-            )
+            # And target.
+            try:
+                target_node.after_incoming_connection(
+                    source_node=source_node,
+                    source_parameter=source_param,
+                    target_parameter=target_param,
+                )
+            except TypeError:
+                target_node.after_incoming_connection(
+                    source_node=source_node,
+                    source_parameter=source_param,
+                    target_parameter=target_param,
+                    modified_parameters_set=set(),
+                )
 
         details = f'Connected "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}"'
         logger.debug(details)

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1478,7 +1478,7 @@ class NodeManager:
             return NodeManager.ModifiedReturnValue(object_created, modified)
         # Otherwise use set_parameter_value. This calls our converters and validators.
         old_value = node.get_parameter_value(request.parameter_name)
-        node.set_parameter_value(request.parameter_name, object_created)
+        node.set_parameter_value(request.parameter_name, object_created, initial_setup=request.initial_setup)
         # Get the "converted" value here.
         finalized_value = node.get_parameter_value(request.parameter_name)
         if old_value != finalized_value:


### PR DESCRIPTION
- Prevents unnecessary calls to before/after_value_set and before/after_incoming_connection on workflow load.  
- Fixes a bug I discovered where modes are not properly being sent to the gui with [this PR](https://github.com/griptape-ai/griptape-vsl-gui/pull/971)