### PR TITLE
Added Advanced Library class for library-level callbacks

### DIFF
--- a/src/griptape_nodes/node_library/advanced_node_library.py
+++ b/src/griptape_nodes/node_library/advanced_node_library.py
@@ -38,7 +38,6 @@ class AdvancedNodeLibrary:
             library_data: The library schema containing metadata and node definitions
             library: The library instance that will contain the loaded nodes
         """
-        pass
 
     def after_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:
         """Called after all nodes have been loaded from the library.
@@ -50,4 +49,3 @@ class AdvancedNodeLibrary:
             library_data: The library schema containing metadata and node definitions
             library: The library instance containing the loaded nodes
         """
-        pass

--- a/src/griptape_nodes/node_library/advanced_node_library.py
+++ b/src/griptape_nodes/node_library/advanced_node_library.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from griptape_nodes.node_library.library_registry import Library, LibrarySchema
+
+
+class AdvancedNodeLibrary:
+    """Base class for advanced node libraries with callback support.
+
+    Library modules can inherit from this class to provide custom initialization
+    and cleanup logic that runs before and after node loading.
+
+    Example usage:
+        ```python
+        # In your library's advanced library module file:
+        from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+
+        class MyLibrary(AdvancedNodeLibrary):
+            def before_library_nodes_loaded(self, library_data, library):
+                # Set up any prerequisites before nodes are loaded
+                print(f"About to load nodes for {library_data.name}")
+
+            def after_library_nodes_loaded(self, library_data, library):
+                # Perform any cleanup or additional setup after nodes are loaded
+                print(f"Finished loading {len(library.get_registered_nodes())} nodes")
+        ```
+    """
+
+    def before_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:
+        """Called before any nodes are loaded from the library.
+
+        This method is called after the library instance is created but before
+        any individual node classes are dynamically loaded and registered.
+
+        Args:
+            library_data: The library schema containing metadata and node definitions
+            library: The library instance that will contain the loaded nodes
+        """
+        pass
+
+    def after_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:
+        """Called after all nodes have been loaded from the library.
+
+        This method is called after all node classes have been successfully
+        loaded and registered with the library.
+
+        Args:
+            library_data: The library schema containing metadata and node definitions
+            library: The library instance containing the loaded nodes
+        """
+        pass

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -9,6 +9,7 @@ from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -94,7 +95,7 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.1.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.2.0"
 
     name: str
     library_schema_version: str
@@ -105,6 +106,7 @@ class LibrarySchema(BaseModel):
     scripts: list[str] | None = None
     settings: list[Setting] | None = None
     is_default_library: bool | None = None
+    advanced_library_path: str | None = None
 
 
 class LibraryRegistry(metaclass=SingletonMeta):
@@ -120,13 +122,16 @@ class LibraryRegistry(metaclass=SingletonMeta):
         library_data: LibrarySchema,
         *,
         mark_as_default_library: bool = False,
+        advanced_library: AdvancedNodeLibrary | None = None,
     ) -> Library:
         instance = cls()
 
         if library_data.name in instance._libraries:
             msg = f"Library '{library_data.name}' already registered."
             raise KeyError(msg)
-        library = Library(library_data=library_data, is_default_library=mark_as_default_library)
+        library = Library(
+            library_data=library_data, is_default_library=mark_as_default_library, advanced_library=advanced_library
+        )
         instance._libraries[library_data.name] = library
         return library
 
@@ -237,12 +242,14 @@ class Library:
     # Maintain fast lookups for node class name to class and to its metadata.
     _node_types: dict[str, type[BaseNode]]
     _node_metadata: dict[str, NodeMetadata]
+    _advanced_library: AdvancedNodeLibrary | None
 
     def __init__(
         self,
         library_data: LibrarySchema,
         *,
         is_default_library: bool = False,
+        advanced_library: AdvancedNodeLibrary | None = None,
     ) -> None:
         self._library_data = library_data
 
@@ -254,6 +261,7 @@ class Library:
 
         self._node_types = {}
         self._node_metadata = {}
+        self._advanced_library = advanced_library
 
     def register_new_node_type(self, node_class: type[BaseNode], metadata: NodeMetadata) -> str | None:
         """Register a new node type in this library. Returns an error string for forensics, or None if all clear."""
@@ -313,3 +321,11 @@ class Library:
 
     def get_metadata(self) -> LibraryMetadata:
         return self._library_data.metadata
+
+    def get_advanced_library(self) -> AdvancedNodeLibrary | None:
+        """Get the advanced library instance for this library.
+
+        Returns:
+            The AdvancedNodeLibrary instance, or None if not set
+        """
+        return self._advanced_library


### PR DESCRIPTION
Create a file in your library called `my_cool_library.py` and put the following in it:

```
  "library_schema_version": "0.2.0",
  "advanced_library_path": "my_cool_library.py",
 ```

Then define it as such:

```
from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary


class GriptapeNodesLibraryAdvanced(AdvancedNodeLibrary):
    """Advanced library implementation for the default Griptape Nodes Library.
    
    This demonstrates the callback system for library-level initialization.
    """

    def before_library_nodes_loaded(self, library_data, library):
        """Called before any nodes are loaded from the library."""
        print(f"🚀 Starting to load nodes for '{library_data.name}' library...")
        print(f"   Library version: {library_data.metadata.library_version}")
        print(f"   Total nodes to load: {len(library_data.nodes)}")

    def after_library_nodes_loaded(self, library_data, library):
        """Called after all nodes have been loaded from the library."""
        loaded_nodes = library.get_registered_nodes()
        print(f"✅ Finished loading '{library_data.name}' library!")
        print(f"   Successfully loaded {len(loaded_nodes)} nodes")
        print(f"   Library is ready for use")
```

This gives us two hooks (now, expandable to more later) that we can use for library-level callbacks. If you want to register your event handlers, here's where you can do it.
