### PR TITLE
Publish Workflow Event updates

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -422,7 +422,7 @@ def __broadcast_app_initialization_complete(nodes_app_url: str) -> None:
     # Broadcast this to anybody who wants a callback on "hey, the app's ready to roll"
     payload = app_events.AppInitializationComplete()
     app_event = AppEvent(payload=payload)
-    __process_app_event(app_event)
+    event_queue.put(app_event)
 
     engine_version_request = app_events.GetEngineVersionRequest()
     engine_version_result = GriptapeNodes.get_instance().handle_engine_version_request(engine_version_request)

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -13,7 +13,7 @@ from griptape_nodes.utils.metaclasses import SingletonMeta
 
 
 class WorkflowMetadata(BaseModel):
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.4.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.5.0"
 
     name: str
     schema_version: str
@@ -25,7 +25,6 @@ class WorkflowMetadata(BaseModel):
     is_template: bool | None = False
     creation_date: datetime | None = Field(default=None)
     last_modified_date: datetime | None = Field(default=None)
-    published_workflow_id: str | None = Field(default=None)
 
 
 class WorkflowRegistry(metaclass=SingletonMeta):

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -37,6 +37,24 @@ class ListRegisteredLibrariesResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 
 @dataclass
 @PayloadRegistry.register
+class ListCapableLibraryEventHandlersRequest(RequestPayload):
+    request_type: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ListCapableLibraryEventHandlersResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    handlers: list[str]
+
+
+@dataclass
+@PayloadRegistry.register
+class ListCapableLibraryEventHandlersResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
 class ListNodeTypesInLibraryRequest(RequestPayload):
     library: str
 

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -181,12 +181,13 @@ class LoadWorkflowMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
 @PayloadRegistry.register
 class PublishWorkflowRequest(RequestPayload):
     workflow_name: str
+    publisher_name: str
 
 
 @dataclass
 @PayloadRegistry.register
 class PublishWorkflowResultSuccess(ResultPayloadSuccess):
-    workflow_id: str
+    published_workflow_file_path: str
 
 
 @dataclass


### PR DESCRIPTION
* Publish Workflow Event updates
  * New request type for `ListCapableEventHandlersRequest`
    * Maintain `_library_event_handler_mappings` in the LibraryManager 
  * New shape for `PublishWorkflowRequest`
    * Offload handling to the registered Library's handler
  * Lots o' red for the WorkflowManager and workflow stuff
    * Remove `published_workflow_id` from workflow metadata 
    * Get rid of all Cloud publishing stuff in the engine
    * Refactor save logic to use private method 