### PR TITLE
fix: don't install uv if already installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,24 +14,30 @@ fi
 cecho() { printf "%b%s%b\n" "$1" "$2" "$RESET"; } # colour echo
 # -----------------------------------
 
-echo ""
-cecho "$CYAN$BOLD" "Installing uv..."
-echo ""
-curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null
+# Check if uv is already installed
+if command -v uv >/dev/null 2>&1; then
+  cecho "$CYAN" "uv is already installed. Using existing installation..."
+  UV_PATH=$(command -v uv)
+else
+  cecho "$CYAN" "Installing uv..."
+  export UV_UNMANAGED_INSTALL="$HOME/.local/share/griptape_nodes/bin"
+  curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null
+  UV_PATH="$HOME/.local/share/griptape_nodes/bin/uv"
+fi
+
 cecho "$GREEN$BOLD" "uv installed successfully!"
 
-# Verify uv is on the user's PATH
-if ! command -v uv >/dev/null 2>&1; then
-  cecho "$RED" "Error: Griptape Nodes dependency 'uv' was installed but requires the terminal instance to be restarted to be run."
-  cecho "$RED" "Please close this terminal instance, open a new terminal instance, and then run the install command you performed earlier."
+# Verify uv installation
+if [ ! -f "$UV_PATH" ]; then
+  cecho "$RED" "Error: uv installation failed at expected path: $UV_PATH"
   exit 1
 fi
 
 echo ""
 cecho "$CYAN$BOLD" "Installing Griptape Nodes Engine..."
 echo ""
-~/.local/bin/uv tool update-shell
-~/.local/bin/uv tool install --force --python python3.12 griptape-nodes >/dev/null
+"$UV_PATH" tool update-shell
+"$UV_PATH" tool install --force --python python3.12 griptape-nodes >/dev/null
 
 cecho "$GREEN$BOLD" "**************************************"
 cecho "$GREEN$BOLD" "*      Installation complete!        *"

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -103,6 +103,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger("griptape_nodes")
 
 
+def _find_griptape_uv_bin() -> str:
+    """Find the uv binary, checking dedicated Griptape installation first, then system uv.
+
+    Returns:
+        Path to the uv binary to use
+    """
+    # Check for dedicated Griptape uv installation first
+    dedicated_uv_path = xdg_data_home() / "griptape_nodes" / "bin" / "uv"
+    if dedicated_uv_path.exists():
+        return str(dedicated_uv_path)
+
+    # Fall back to system uv installation
+    return uv.find_uv_bin()
+
+
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
 
@@ -945,7 +960,7 @@ class LibraryManager:
                 logger.info("Installing dependency '%s' with pip in venv at %s", package_name, venv_path)
                 subprocess.run(  # noqa: S603
                     [
-                        uv.find_uv_bin(),
+                        _find_griptape_uv_bin(),
                         "pip",
                         "install",
                         request.requirement_specifier,


### PR DESCRIPTION
If the user _doesn't_ have uv installed, we install it into the xdg data dir so that cleanup is easy.

Closes #1408