### PR TITLE
fix: change how/where engine_id/session_id are set on events

### DIFF
--- a/src/griptape_nodes/app/app_sessions.py
+++ b/src/griptape_nodes/app/app_sessions.py
@@ -494,8 +494,6 @@ def __broadcast_app_initialization_complete(nodes_app_url: str) -> None:
 
     This is used to notify the GUI that the app is ready to receive events.
     """
-    GriptapeNodes.EngineIdentityManager().initialize_engine_id()
-
     # Broadcast this to anybody who wants a callback on "hey, the app's ready to roll"
     payload = app_events.AppInitializationComplete()
     app_event = AppEvent(payload=payload)

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -111,29 +111,11 @@ class BaseEvent(BaseModel, ABC):
     """Abstract base class for all events."""
 
     # Instance fields for engine and session identification
-    engine_id: str | None = Field(default=None)
-    session_id: str | None = Field(default=None)
+    _engine_id: ClassVar[str | None] = None
+    _session_id: ClassVar[str | None] = None
 
-    def model_post_init(self, _context: Any) -> None:
-        """Post-initialization hook to auto-populate session_id and engine_id if not provided.
-
-        context: The context in which the model is being initialized.
-
-        """
-        # Auto-populate engine_id from class variable if not explicitly provided
-        if self.engine_id is None:
-            # Import here to avoid circular imports
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-            self.engine_id = GriptapeNodes.EngineIdentityManager().initialize_engine_id()
-
-        # Auto-populate session_id from class variable if not explicitly provided
-        if self.session_id is None:
-            # Import here to avoid circular imports
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-            # Get current session ID
-            self.session_id = GriptapeNodes.SessionManager().get_saved_session_id()
+    engine_id: str | None = Field(default_factory=lambda: BaseEvent._engine_id)
+    session_id: str | None = Field(default_factory=lambda: BaseEvent._session_id)
 
     # Custom JSON encoder for the payload
     class Config:

--- a/src/griptape_nodes/retained_mode/managers/engine_identity_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/engine_identity_manager.py
@@ -7,6 +7,7 @@ engine ID and name operations.
 import logging
 from pathlib import Path
 
+from griptape_nodes.retained_mode.events.base_events import BaseEvent
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.utils.engine_identity import EngineIdentity
 
@@ -52,6 +53,7 @@ class EngineIdentityManager:
         """Initialize the engine ID if not already set."""
         if cls._active_engine_id is None:
             engine_id = EngineIdentity.get_engine_id()
+            BaseEvent._engine_id = engine_id
             cls._active_engine_id = engine_id
             logger.debug("Initialized engine ID: %s", engine_id)
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1548,6 +1548,9 @@ class LibraryManager:
         self._remove_missing_libraries_from_config(config_category=user_libraries_section)
 
     def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
+        GriptapeNodes.SessionManager().get_saved_session_id()
+        GriptapeNodes.EngineIdentityManager().initialize_engine_id()
+
         # App just got init'd. See if there are library JSONs to load!
         self.load_all_libraries_from_config()
 

--- a/src/griptape_nodes/retained_mode/managers/session_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/session_manager.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from xdg_base_dirs import xdg_state_home
 
+from griptape_nodes.retained_mode.events.base_events import BaseEvent
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 logger = logging.getLogger("griptape_nodes")
@@ -31,6 +32,7 @@ class SessionManager:
         Args:
             event_manager: The EventManager instance to use for event handling.
         """
+        BaseEvent._session_id = self._active_session_id
         if event_manager is not None:
             # Register event handlers here when session events are defined
             pass
@@ -197,6 +199,7 @@ class SessionManager:
 
         # Set as active session
         cls._active_session_id = session_id
+        BaseEvent._session_id = session_id
         logger.info("Saved and activated session: %s for engine: %s", session_id, engine_id)
 
     @classmethod
@@ -217,6 +220,7 @@ class SessionManager:
         if sessions:
             first_session_id = sessions[0].get("session_id")
             # Set as active for future calls
+            BaseEvent._session_id = first_session_id
             cls._active_session_id = first_session_id
             logger.debug("Retrieved first saved session as active: %s for engine: %s", first_session_id, engine_id)
             return first_session_id
@@ -228,6 +232,7 @@ class SessionManager:
         """Clear all saved session data for the current engine."""
         # Clear active session
         cls._active_session_id = None
+        BaseEvent._session_id = None
 
         engine_id = cls._get_current_engine_id()
         session_state_file = cls._get_session_state_file(engine_id)


### PR DESCRIPTION
This is a mess (thanks claude). Will clean up in a future PR because this will haunt me.

Fixes recursive logs.