### PR TITLE
Retain user configured library settings values

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -890,7 +890,9 @@ class LibraryManager:
                 else:
                     # We had an existing category. Union our changes into it (not replacing anything that matched).
                     existing_category_contents = get_category_result.contents
-                    existing_category_contents.update(library_data_setting.contents)
+                    existing_category_contents |= {
+                        k: v for k, v in library_data_setting.contents.items() if k not in existing_category_contents
+                    }
                     set_category_request = SetConfigCategoryRequest(
                         category=library_data_setting.category, contents=existing_category_contents
                     )


### PR DESCRIPTION
* Retain user configured library settings values
  * The existing code sets the values to the Library default on load, rather than retaining whatever values may have been set by the User 