### PR TITLE
Enhanced ForEach node expanding control parameter options.

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -686,6 +686,28 @@
       }
     },
     {
+      "class_name": "DictGetValueByKey",
+      "file_path": "griptape_nodes_library/dict/get_dict_value.py",
+      "metadata": {
+        "category": "dict",
+        "description": "Get a value from a dictionary by key with optional default handling",
+        "display_name": "Get Dictionary Value by Key",
+        "icon": "key",
+        "group": "general"
+      }
+    },
+    {
+      "class_name": "DictHasValueForKey",
+      "file_path": "griptape_nodes_library/dict/dict_has_value_for_key.py",
+      "metadata": {
+        "category": "dict",
+        "description": "Check if a dictionary has a value for a specific key",
+        "display_name": "Has Dictionary Value for Key",
+        "icon": "search-check",
+        "group": "general"
+      }
+    },
+    {
       "class_name": "GriptapeCloudImage",
       "file_path": "griptape_nodes_library/config/image/griptape_cloud_image_driver.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -1157,6 +1157,28 @@
       }
     },
     {
+      "class_name": "FilePathValidator",
+      "file_path": "griptape_nodes_library/text/file_path_validator.py",
+      "metadata": {
+        "category": "text",
+        "description": "Validates that file paths exist and are readable Python files",
+        "display_name": "File Path Validator",
+        "icon": "file-check",
+        "group": "validation"
+      }
+    },
+    {
+      "class_name": "PythonClassParser",
+      "file_path": "griptape_nodes_library/text/python_class_parser.py",
+      "metadata": {
+        "category": "text",
+        "description": "Parses Python file content to extract classes inheriting from RequestPayload or ResultPayload",
+        "display_name": "Python Class Parser",
+        "icon": "code",
+        "group": "parsing"
+      }
+    },
+    {
       "class_name": "Calculator",
       "file_path": "griptape_nodes_library/tools/calculator_tool.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/dict_has_value_for_key.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/dict_has_value_for_key.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import (
+    Parameter,
+    ParameterMode,
+)
+from griptape_nodes.exe_types.node_types import BaseNode, DataNode
+
+
+class DictHasValueForKey(DataNode):
+    """Check if a dictionary has a value for a specific key."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        # Input parameter for the dictionary
+        self.add_parameter(
+            Parameter(
+                name="dict",
+                input_types=["dict"],
+                type="dict",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value={},
+                tooltip="Dictionary to check for key",
+            )
+        )
+
+        # Input parameter for the key
+        self.add_parameter(
+            Parameter(
+                name="key",
+                input_types=["str"],
+                type="str",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value="",
+                tooltip="Key to check for in the dictionary",
+            )
+        )
+
+        # Output parameter for whether key exists
+        self.add_parameter(
+            Parameter(
+                name="has_key",
+                output_type="bool",
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=False,
+                tooltip="True if the key exists in the dictionary, False otherwise",
+                ui_options={"hide_property": True},
+            )
+        )
+
+    def _has_key(self) -> bool:
+        """Check if dictionary has the specified key."""
+        input_dict = self.get_parameter_value("dict")
+        key = self.get_parameter_value("key")
+        
+        if not isinstance(input_dict, dict) or not key:
+            return False
+        
+        return key in input_dict
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Update outputs when inputs change."""
+        if parameter.name in ["dict", "key"]:
+            has_key = self._has_key()
+            
+            # Set output values
+            self.parameter_output_values["has_key"] = has_key
+            self.set_parameter_value("has_key", has_key)
+            
+            # Show the output parameter
+            self.show_parameter_by_name("has_key")
+
+        return super().after_value_set(parameter, value)
+
+    def after_incoming_connection(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Update outputs when connections change."""
+        if target_parameter.name in ["dict", "key"]:
+            has_key = self._has_key()
+            self.parameter_output_values["has_key"] = has_key
+            
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def process(self) -> None:
+        """Process the node by checking if the dictionary has the key."""
+        has_key = self._has_key()
+        self.parameter_output_values["has_key"] = has_key

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/dict_has_value_for_key.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/dict_has_value_for_key.py
@@ -53,21 +53,21 @@ class DictHasValueForKey(DataNode):
         """Check if dictionary has the specified key."""
         input_dict = self.get_parameter_value("dict")
         key = self.get_parameter_value("key")
-        
+
         if not isinstance(input_dict, dict) or not key:
             return False
-        
+
         return key in input_dict
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Update outputs when inputs change."""
         if parameter.name in ["dict", "key"]:
             has_key = self._has_key()
-            
+
             # Set output values
             self.parameter_output_values["has_key"] = has_key
             self.set_parameter_value("has_key", has_key)
-            
+
             # Show the output parameter
             self.show_parameter_by_name("has_key")
 
@@ -83,7 +83,7 @@ class DictHasValueForKey(DataNode):
         if target_parameter.name in ["dict", "key"]:
             has_key = self._has_key()
             self.parameter_output_values["has_key"] = has_key
-            
+
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def process(self) -> None:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/get_dict_value.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/get_dict_value.py
@@ -87,32 +87,31 @@ class DictGetValueByKey(ControlNode):
         key = self.get_parameter_value("key")
         supply_default = self.get_parameter_value("supply_default_if_not_found")
         default_value = self.get_parameter_value("default_value_if_not_found")
-        
+
         if not isinstance(input_dict, dict):
             if supply_default:
                 return default_value
-            else:
-                raise ValueError("Input is not a dictionary")
-        
+            msg = "Input is not a dictionary"
+            raise ValueError(msg)
+
         if not key:
             if supply_default:
                 return default_value
-            else:
-                raise ValueError("Key cannot be empty")
-        
+            msg = "Key cannot be empty"
+            raise ValueError(msg)
+
         if key in input_dict:
             return input_dict[key]
-        else:
-            if supply_default:
-                return default_value
-            else:
-                raise KeyError(f"Key '{key}' not found in dictionary")
+        if supply_default:
+            return default_value
+        msg = f"Key '{key}' not found in dictionary"
+        raise KeyError(msg)
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Update outputs and visibility when inputs change."""
         if parameter.name == "supply_default_if_not_found":
             self._update_default_visibility()
-        
+
         if parameter.name in ["dict", "key", "supply_default_if_not_found", "default_value_if_not_found"]:
             try:
                 result_value = self._get_value()
@@ -138,14 +137,10 @@ class DictGetValueByKey(ControlNode):
                 self.parameter_output_values["value"] = result_value
             except Exception:
                 self.parameter_output_values["value"] = None
-            
+
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def process(self) -> None:
         """Process the node by getting the dictionary value."""
-        try:
-            result_value = self._get_value()
-            self.parameter_output_values["value"] = result_value
-        except Exception as e:
-            # Re-raise the exception during actual processing
-            raise e
+        result_value = self._get_value()
+        self.parameter_output_values["value"] = result_value

--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/get_dict_value.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/get_dict_value.py
@@ -1,0 +1,151 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import (
+    Parameter,
+    ParameterMode,
+)
+from griptape_nodes.exe_types.node_types import BaseNode, ControlNode
+
+
+class DictGetValueByKey(ControlNode):
+    """Get a value from a dictionary by key with optional default handling."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        # Input parameter for the dictionary
+        self.add_parameter(
+            Parameter(
+                name="dict",
+                input_types=["dict"],
+                type="dict",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value={},
+                tooltip="Dictionary to get value from",
+            )
+        )
+
+        # Input parameter for the key
+        self.add_parameter(
+            Parameter(
+                name="key",
+                input_types=["str"],
+                type="str",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value="",
+                tooltip="Key to lookup in the dictionary",
+            )
+        )
+
+        # Parameter for whether to supply default if not found
+        self.add_parameter(
+            Parameter(
+                name="supply_default_if_not_found",
+                input_types=["bool"],
+                type="bool",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value=True,
+                tooltip="If True, return default value when key not found. If False, throw exception when key not found.",
+            )
+        )
+
+        # Parameter for the default value (hidden by default)
+        self.add_parameter(
+            Parameter(
+                name="default_value_if_not_found",
+                input_types=["str", "int", "float", "bool", "dict", "list"],
+                type="any",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value=None,
+                tooltip="Default value to return when key is not found (only used if supply_default_if_not_found is True)",
+                ui_options={"hide": False},  # Will be controlled by show/hide logic
+            )
+        )
+
+        # Output parameter for the value
+        self.add_parameter(
+            Parameter(
+                name="value",
+                output_type="any",
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=None,
+                tooltip="Value found for the specified key, or default value if not found",
+            )
+        )
+
+    def _update_default_visibility(self) -> None:
+        """Show/hide the default value parameter based on supply_default_if_not_found."""
+        supply_default = self.get_parameter_value("supply_default_if_not_found")
+        if supply_default:
+            self.show_parameter_by_name("default_value_if_not_found")
+        else:
+            self.hide_parameter_by_name("default_value_if_not_found")
+
+    def _get_value(self) -> Any:
+        """Get value from dictionary by key with default handling."""
+        input_dict = self.get_parameter_value("dict")
+        key = self.get_parameter_value("key")
+        supply_default = self.get_parameter_value("supply_default_if_not_found")
+        default_value = self.get_parameter_value("default_value_if_not_found")
+        
+        if not isinstance(input_dict, dict):
+            if supply_default:
+                return default_value
+            else:
+                raise ValueError("Input is not a dictionary")
+        
+        if not key:
+            if supply_default:
+                return default_value
+            else:
+                raise ValueError("Key cannot be empty")
+        
+        if key in input_dict:
+            return input_dict[key]
+        else:
+            if supply_default:
+                return default_value
+            else:
+                raise KeyError(f"Key '{key}' not found in dictionary")
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Update outputs and visibility when inputs change."""
+        if parameter.name == "supply_default_if_not_found":
+            self._update_default_visibility()
+        
+        if parameter.name in ["dict", "key", "supply_default_if_not_found", "default_value_if_not_found"]:
+            try:
+                result_value = self._get_value()
+                self.parameter_output_values["value"] = result_value
+                self.set_parameter_value("value", result_value)
+            except Exception:
+                # Don't fail during parameter setting, just clear the output
+                self.parameter_output_values["value"] = None
+                self.set_parameter_value("value", None)
+
+        return super().after_value_set(parameter, value)
+
+    def after_incoming_connection(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Update outputs when connections change."""
+        if target_parameter.name in ["dict", "key", "supply_default_if_not_found", "default_value_if_not_found"]:
+            try:
+                result_value = self._get_value()
+                self.parameter_output_values["value"] = result_value
+            except Exception:
+                self.parameter_output_values["value"] = None
+            
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def process(self) -> None:
+        """Process the node by getting the dictionary value."""
+        try:
+            result_value = self._get_value()
+            self.parameter_output_values["value"] = result_value
+        except Exception as e:
+            # Re-raise the exception during actual processing
+            raise e

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
@@ -175,8 +175,11 @@ class ForEachEndNode(EndLoopNode):
                 # Break - will trigger break signal in get_next_control_output
                 pass
             case self.loop_end_condition_met_signal_input:
-                # Loop has ended naturally, output final results
-                self.parameter_output_values["results"] = results_list.copy()
+                # Loop has ended naturally, output final results from ForEach Start
+                final_results = self.get_parameter_value("results_list_input")
+                if final_results is None:
+                    final_results = []
+                self.parameter_output_values["results"] = final_results
                 return
 
         # Always output the current results list state
@@ -323,4 +326,6 @@ class ForEachEndNode(EndLoopNode):
         """Reset ForEach End state for a fresh workflow run."""
         self._results_list = []
         self._index = 0
+        # Clear any stale output parameter values from previous runs
+        self.parameter_output_values["results"] = []
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
@@ -44,21 +44,13 @@ class ForEachEndNode(EndLoopNode):
         )
         self.loop_start_node.ui_options = {"display_name": "Loop Start Node"}
 
-        # Visible control inputs
+        # Main control input and data parameter
         self.add_item_control = ControlParameterInput(
             tooltip="Add current item to output and continue loop", name="add_item"
         )
         self.add_item_control.ui_options = {"display_name": "Add Item to Output"}
 
-        self.skip_control = ControlParameterInput(
-            tooltip="Skip current item and continue to next iteration", name="skip_iteration"
-        )
-        self.skip_control.ui_options = {"display_name": "Skip to Next Iteration"}
-
-        self.break_control = ControlParameterInput(tooltip="Break out of loop immediately", name="break_loop")
-        self.break_control.ui_options = {"display_name": "Break Out of Loop"}
-
-        # Visible data input
+        # Data input for the item to add - positioned right under Add Item control
         self.new_item_to_add = Parameter(
             name="new_item_to_add",
             tooltip="Item to add to results list",
@@ -66,7 +58,11 @@ class ForEachEndNode(EndLoopNode):
             allowed_modes={ParameterMode.INPUT},
         )
 
-        # Visible outputs
+        # Loop completion output
+        self.exec_out = ControlParameterOutput(tooltip="Triggered when loop completes", name="exec_out")
+        self.exec_out.ui_options = {"display_name": "On Loop Complete"}
+
+        # Results output - positioned below On Loop Complete
         self.results = Parameter(
             name="results",
             tooltip="Collected loop results",
@@ -74,8 +70,14 @@ class ForEachEndNode(EndLoopNode):
             allowed_modes={ParameterMode.OUTPUT},
         )
 
-        self.exec_out = ControlParameterOutput(tooltip="Triggered when loop completes", name="exec_out")
-        self.exec_out.ui_options = {"display_name": "On Loop Complete"}
+        # Advanced control options for skip and break
+        self.skip_control = ControlParameterInput(
+            tooltip="Skip current item and continue to next iteration", name="skip_iteration"
+        )
+        self.skip_control.ui_options = {"display_name": "Skip to Next Iteration"}
+
+        self.break_control = ControlParameterInput(tooltip="Break out of loop immediately", name="break_loop")
+        self.break_control.ui_options = {"display_name": "Break Out of Loop"}
 
         # Hidden inputs from ForEachStart
         self.results_list_input = Parameter(
@@ -108,15 +110,19 @@ class ForEachEndNode(EndLoopNode):
         self.break_loop_signal_output.ui_options = {"hide": True, "display_name": "Break Loop Signal Output"}
         self.break_loop_signal_output.settable = False
 
-        # Add parameters in order
-        self.add_parameter(self.loop_start_node)
+        # Add main workflow parameters first
         self.add_parameter(self.add_item_control)
+        self.add_parameter(self.new_item_to_add)
+        self.add_parameter(self.exec_out)
+        self.add_parameter(self.results)
+        
+        # Add advanced control options before tethering connection
         self.add_parameter(self.skip_control)
         self.add_parameter(self.break_control)
-        self.add_parameter(self.new_item_to_add)
-        self.add_parameter(self.results)
-        self.add_parameter(self.exec_out)
 
+        # Add tethering connection just above hidden parameters
+        self.add_parameter(self.loop_start_node)
+        
         # Add hidden parameters
         self.add_parameter(self.results_list_input)
         self.add_parameter(self.loop_end_condition_met_signal_input)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
@@ -79,13 +79,6 @@ class ForEachEndNode(EndLoopNode):
         self.break_control.ui_options = {"display_name": "Break Out of Loop"}
 
         # Hidden inputs from ForEachStart
-        self.results_list_input = Parameter(
-            name="results_list_input",
-            tooltip="Results list from ForEach Start Node",
-            input_types=["list"],
-            allowed_modes={ParameterMode.INPUT},
-        )
-        self.results_list_input.ui_options = {"hide": True, "display_name": "Results List Input"}
 
         self.loop_end_condition_met_signal_input = ControlParameterInput(
             tooltip="Signal from ForEachStart when loop should end", name="loop_end_condition_met_signal_input"
@@ -121,7 +114,6 @@ class ForEachEndNode(EndLoopNode):
 
         # Add hidden parameters
         self.add_parameter(self.from_start)
-        self.add_parameter(self.results_list_input)
         self.add_parameter(self.loop_end_condition_met_signal_input)
         self.add_parameter(self.trigger_next_iteration_signal_output)
         self.add_parameter(self.break_loop_signal_output)
@@ -283,19 +275,9 @@ class ForEachEndNode(EndLoopNode):
         from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        # Create the four hidden signal connections needed for ForEach loop functionality:
+        # Create the three hidden signal connections needed for ForEach loop functionality:
 
-        # 1. Start → End: results_list → results_list_input
-        GriptapeNodes.handle_request(
-            CreateConnectionRequest(
-                source_node_name=start_node.name,
-                source_parameter_name="results_list",
-                target_node_name=self.name,
-                target_parameter_name="results_list_input",
-            )
-        )
-
-        # 2. Start → End: loop_end_condition_met_signal → loop_end_condition_met_signal_input
+        # 1. Start → End: loop_end_condition_met_signal → loop_end_condition_met_signal_input
         GriptapeNodes.handle_request(
             CreateConnectionRequest(
                 source_node_name=start_node.name,
@@ -305,7 +287,7 @@ class ForEachEndNode(EndLoopNode):
             )
         )
 
-        # 3. End → Start: trigger_next_iteration_signal_output → trigger_next_iteration_signal
+        # 2. End → Start: trigger_next_iteration_signal_output → trigger_next_iteration_signal
         GriptapeNodes.handle_request(
             CreateConnectionRequest(
                 source_node_name=self.name,
@@ -315,7 +297,7 @@ class ForEachEndNode(EndLoopNode):
             )
         )
 
-        # 4. End → Start: break_loop_signal_output → break_loop_signal
+        # 3. End → Start: break_loop_signal_output → break_loop_signal
         GriptapeNodes.handle_request(
             CreateConnectionRequest(
                 source_node_name=self.name,
@@ -334,19 +316,9 @@ class ForEachEndNode(EndLoopNode):
         from griptape_nodes.retained_mode.events.connection_events import DeleteConnectionRequest
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        # Remove the four hidden signal connections:
+        # Remove the three hidden signal connections:
 
-        # 1. Start → End: results_list → results_list_input
-        GriptapeNodes.handle_request(
-            DeleteConnectionRequest(
-                source_node_name=start_node.name,
-                source_parameter_name="results_list",
-                target_node_name=self.name,
-                target_parameter_name="results_list_input",
-            )
-        )
-
-        # 2. Start → End: loop_end_condition_met_signal → loop_end_condition_met_signal_input
+        # 1. Start → End: loop_end_condition_met_signal → loop_end_condition_met_signal_input
         GriptapeNodes.handle_request(
             DeleteConnectionRequest(
                 source_node_name=start_node.name,
@@ -356,7 +328,7 @@ class ForEachEndNode(EndLoopNode):
             )
         )
 
-        # 3. End → Start: trigger_next_iteration_signal_output → trigger_next_iteration_signal
+        # 2. End → Start: trigger_next_iteration_signal_output → trigger_next_iteration_signal
         GriptapeNodes.handle_request(
             DeleteConnectionRequest(
                 source_node_name=self.name,
@@ -366,7 +338,7 @@ class ForEachEndNode(EndLoopNode):
             )
         )
 
-        # 4. End → Start: break_loop_signal_output → break_loop_signal
+        # 3. End → Start: break_loop_signal_output → break_loop_signal
         GriptapeNodes.handle_request(
             DeleteConnectionRequest(
                 source_node_name=self.name,

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_end.py
@@ -124,8 +124,7 @@ class ForEachEndNode(EndLoopNode):
         self.add_parameter(self.break_loop_signal_output)
 
     def validate_before_node_run(self) -> list[Exception] | None:
-        # Clear results list before each node run to prevent accumulation
-        self._results_list = []
+        # Don't clear results list here - we need to accumulate across loop iterations
         exceptions = []
         if self.start_node is None:
             exceptions.append(Exception("Start node is not set on End Node."))
@@ -319,3 +318,9 @@ class ForEachEndNode(EndLoopNode):
 
         self.current_spotlight_parameter = None
         return False
+
+    def reset_for_workflow_run(self) -> None:
+        """Reset ForEach End state for a fresh workflow run."""
+        self._results_list = []
+        self._index = 0
+

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -171,10 +171,8 @@ class ForEachStartNode(StartLoopNode):
         # Main control flow
         self.exec_in = ControlParameterInput(tooltip="Start Loop", name="exec_in")
         self.exec_in.ui_options = {"display_name": "Start Loop"}
-        self.exec_out = ControlParameterOutput(tooltip="Execute for each item in the list", name="exec_out")
-        self.exec_out.ui_options = {"display_name": "On Each Item"}
         self.add_parameter(self.exec_in)
-        self.add_parameter(self.exec_out)
+        
         self.items_list = Parameter(
             name="items",
             tooltip="List of items to iterate through",
@@ -182,6 +180,11 @@ class ForEachStartNode(StartLoopNode):
             allowed_modes={ParameterMode.INPUT},
         )
         self.add_parameter(self.items_list)
+
+        # On Each Item control output - moved outside group for proper rendering
+        self.exec_out = ControlParameterOutput(tooltip="Execute for each item in the list", name="exec_out")
+        self.exec_out.ui_options = {"display_name": "On Each Item"}
+        self.add_parameter(self.exec_out)
 
         with ParameterGroup(name="For Each Item") as group:
             # Add current item output parameter

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -172,7 +172,7 @@ class ForEachStartNode(StartLoopNode):
         self.exec_in = ControlParameterInput(tooltip="Start Loop", name="exec_in")
         self.exec_in.ui_options = {"display_name": "Start Loop"}
         self.add_parameter(self.exec_in)
-        
+
         self.items_list = Parameter(
             name="items",
             tooltip="List of items to iterate through",
@@ -206,15 +206,15 @@ class ForEachStartNode(StartLoopNode):
             )
         self.add_node_element(group)
 
-        # Explicit tethering to ForEachEnd node
-        self.loop_end_node = Parameter(
-            name="loop_end_node",
+        # Explicit tethering to ForEachEnd node (hidden)
+        self.loop = Parameter(
+            name="loop",
             tooltip="Connected ForEach End Node",
             output_type=ParameterTypeBuiltin.ALL.value,
             allowed_modes={ParameterMode.OUTPUT},
         )
-        self.loop_end_node.ui_options = {"display_name": "Loop End Node"}
-        self.add_parameter(self.loop_end_node)
+        self.loop.ui_options = {"hide": True, "display_name": "Loop End Node"}
+        self.add_parameter(self.loop)
 
         # Hidden signal inputs from ForEachEnd
         self.trigger_next_iteration_signal = ControlParameterInput(
@@ -371,7 +371,7 @@ class ForEachStartNode(StartLoopNode):
                 )
             )
 
-        # Check if loop_end_node has outgoing connection to ForEach End
+        # Check if loop has outgoing connection to ForEach End
         if self.end_node is None:
             errors.append(
                 Exception(
@@ -432,7 +432,7 @@ class ForEachStartNode(StartLoopNode):
         target_node: BaseNode,
         target_parameter: Parameter,
     ) -> None:
-        if source_parameter == self.loop_end_node and isinstance(target_node, EndLoopNode):
+        if source_parameter == self.loop and isinstance(target_node, EndLoopNode):
             self.end_node = target_node
         return super().after_outgoing_connection(source_parameter, target_node, target_parameter)
 
@@ -442,6 +442,6 @@ class ForEachStartNode(StartLoopNode):
         target_node: BaseNode,
         target_parameter: Parameter,
     ) -> None:
-        if source_parameter == self.loop_end_node and isinstance(target_node, EndLoopNode):
+        if source_parameter == self.loop and isinstance(target_node, EndLoopNode):
             self.end_node = None
         return super().after_outgoing_connection_removed(source_parameter, target_node, target_parameter)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -94,15 +94,6 @@ class ForEachStartNode(StartLoopNode):
         self.break_loop_signal.ui_options = {"hide": True, "display_name": "Break Loop Signal"}
         self.break_loop_signal.settable = False
 
-        # Hidden data output - results list
-        self.results_list = Parameter(
-            name="results_list",
-            tooltip="Results list passed to ForEach End Node",
-            output_type="list",
-            allowed_modes={ParameterMode.OUTPUT},
-            default_value=[],
-        )
-        self.results_list.ui_options = {"hide": True}
 
         # Hidden control output - loop end condition
         self.loop_end_condition_met_signal = ControlParameterOutput(
@@ -114,7 +105,6 @@ class ForEachStartNode(StartLoopNode):
         # Add hidden parameters
         self.add_parameter(self.trigger_next_iteration_signal)
         self.add_parameter(self.break_loop_signal)
-        self.add_parameter(self.results_list)
         self.add_parameter(self.loop_end_condition_met_signal)
 
         # Control output tracking
@@ -308,7 +298,7 @@ class ForEachStartNode(StartLoopNode):
                     )
                 )
 
-            # Note: outgoing connections (results_list, loop_end_condition_met_signal) are tracked via end_node relationship
+            # Note: outgoing connections (loop_end_condition_met_signal) are tracked via end_node relationship
 
         return errors
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -132,14 +132,14 @@ class CompletedState(State):
     """Final state when loop is completed."""
 
     @staticmethod
-    def on_enter(context: "ForEachStartNode") -> type[State] | None:  # noqa: ARG004
-        """Loop is completed."""
+    def on_enter(context: "ForEachStartNode") -> type[State] | None:
+        """Loop is completed - set completion signal immediately."""
+        context.next_control_output = context.loop_end_condition_met_signal
         return None
 
     @staticmethod
-    def on_update(context: "ForEachStartNode") -> type[State] | None:
+    def on_update(context: "ForEachStartNode") -> type[State] | None:  # noqa: ARG004
         """Stay in completed state."""
-        context.next_control_output = None
         return None
 
     @staticmethod

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -270,6 +270,11 @@ class ForEachStartNode(StartLoopNode):
         self.current_index = 0
         self._items = []
         self.finished = False
+
+        # Clear the coupled ForEach End node's state for fresh workflow runs
+        if self.end_node:
+            self.end_node.reset_for_workflow_run()
+
         # Start FSM in initial state
         self._fsm.start(WaitingForStartState)
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -20,7 +20,7 @@ class WaitingForStartState(State):
     @staticmethod
     def on_enter(context: "ForEachStartNode") -> type[State] | None:
         """Initialize the items list on entry."""
-        # Always initialize items list
+        # Always initialize items list with fresh parameter value
         list_values = context.get_parameter_value("items")
         # Ensure the list is flattened
         if isinstance(list_values, list):
@@ -263,7 +263,8 @@ class ForEachStartNode(StartLoopNode):
         match self._entry_control_parameter:
             case self.exec_in | None:
                 # Starting the loop (either via connection or direct execution)
-                # FSM should already be initialized in WaitingForStartState
+                # Initialize FSM to WaitingForStartState to get fresh parameter values
+                self._fsm.start(WaitingForStartState)
                 self._fsm.update()
             case self.trigger_next_iteration_signal:
                 # Next iteration signal from ForEach End - advance to next item
@@ -300,9 +301,6 @@ class ForEachStartNode(StartLoopNode):
 
         if isinstance(self.end_node, ForEachEndNode):
             self.end_node.reset_for_workflow_run()
-
-        # Start FSM in initial state
-        self._fsm.start(WaitingForStartState)
 
         # Validate end node connection
         if self.end_node is None:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/for_each_start.py
@@ -293,6 +293,7 @@ class ForEachStartNode(StartLoopNode):
         self.current_index = 0
         self._items = []
         self.finished = False
+        self.next_control_output = None
 
         # Clear the coupled ForEach End node's state for fresh workflow runs
         from griptape_nodes_library.execution.for_each_end import ForEachEndNode

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
@@ -405,7 +405,7 @@ class IfElse(BaseNode):
 
     def initialize_spotlight(self) -> None:
         """Custom spotlight initialization - only include evaluate parameter initially.
-        
+
         This prevents automatic dependency resolution of both input branches.
         We'll conditionally add the appropriate branch in advance_parameter().
         """
@@ -416,25 +416,25 @@ class IfElse(BaseNode):
 
     def advance_parameter(self) -> bool:
         """Custom parameter advancement with conditional dependency resolution.
-        
+
         After evaluate is resolved, add ONLY the appropriate input branch to the dependency chain.
         This prevents resolving the unused branch entirely.
         """
         if self.current_spotlight_parameter is None:
             return False
-            
+
         # If we're currently on the evaluate parameter, decide which branch to resolve next
         if self.current_spotlight_parameter.name == "evaluate":
             try:
                 # Evaluate the condition to determine which branch we need
                 evaluation_result = self.check_evaluation()
-                
+
                 # Select the appropriate input parameter based on evaluation
                 if evaluation_result:
                     next_param = self.output_if_true
                 else:
                     next_param = self.output_if_false
-                    
+
                 # Only add the selected parameter if it has input connections
                 if ParameterMode.INPUT in next_param.get_mode():
                     # Link the selected parameter as the next in the chain
@@ -442,20 +442,19 @@ class IfElse(BaseNode):
                     next_param.prev = self.current_spotlight_parameter
                     self.current_spotlight_parameter = next_param
                     return True
-                else:
-                    # No input connections on the selected parameter, we're done
-                    self.current_spotlight_parameter = None
-                    return False
-                    
+                # No input connections on the selected parameter, we're done
+                self.current_spotlight_parameter = None
+                return False
+
             except Exception:
                 # If evaluation fails, don't resolve any input branches
                 self.current_spotlight_parameter = None
                 return False
-                
-        # For any other parameter, use default advancement behavior  
+
+        # For any other parameter, use default advancement behavior
         if self.current_spotlight_parameter.next is not None:
             self.current_spotlight_parameter = self.current_spotlight_parameter.next
             return True
-            
+
         self.current_spotlight_parameter = None
         return False

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
@@ -402,3 +402,60 @@ class IfElse(BaseNode):
             self._output_connected = False
 
         return super().after_outgoing_connection_removed(source_parameter, target_node, target_parameter)
+
+    def initialize_spotlight(self) -> None:
+        """Custom spotlight initialization - only include evaluate parameter initially.
+        
+        This prevents automatic dependency resolution of both input branches.
+        We'll conditionally add the appropriate branch in advance_parameter().
+        """
+        evaluate_param = self.get_parameter_by_name("evaluate")
+        if evaluate_param and ParameterMode.INPUT in evaluate_param.get_mode():
+            self.current_spotlight_parameter = evaluate_param
+            # Don't link to any other parameters yet - we'll decide conditionally
+
+    def advance_parameter(self) -> bool:
+        """Custom parameter advancement with conditional dependency resolution.
+        
+        After evaluate is resolved, add ONLY the appropriate input branch to the dependency chain.
+        This prevents resolving the unused branch entirely.
+        """
+        if self.current_spotlight_parameter is None:
+            return False
+            
+        # If we're currently on the evaluate parameter, decide which branch to resolve next
+        if self.current_spotlight_parameter.name == "evaluate":
+            try:
+                # Evaluate the condition to determine which branch we need
+                evaluation_result = self.check_evaluation()
+                
+                # Select the appropriate input parameter based on evaluation
+                if evaluation_result:
+                    next_param = self.output_if_true
+                else:
+                    next_param = self.output_if_false
+                    
+                # Only add the selected parameter if it has input connections
+                if ParameterMode.INPUT in next_param.get_mode():
+                    # Link the selected parameter as the next in the chain
+                    self.current_spotlight_parameter.next = next_param
+                    next_param.prev = self.current_spotlight_parameter
+                    self.current_spotlight_parameter = next_param
+                    return True
+                else:
+                    # No input connections on the selected parameter, we're done
+                    self.current_spotlight_parameter = None
+                    return False
+                    
+            except Exception:
+                # If evaluation fails, don't resolve any input branches
+                self.current_spotlight_parameter = None
+                return False
+                
+        # For any other parameter, use default advancement behavior  
+        if self.current_spotlight_parameter.next is not None:
+            self.current_spotlight_parameter = self.current_spotlight_parameter.next
+            return True
+            
+        self.current_spotlight_parameter = None
+        return False

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
@@ -1,30 +1,43 @@
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import ControlParameterInput, ControlParameterOutput, Parameter
+from griptape_nodes.exe_types.core_types import (
+    ControlParameterInput,
+    ControlParameterOutput,
+    Parameter,
+    ParameterGroup,
+    ParameterMode,
+    ParameterTypeBuiltin,
+)
 from griptape_nodes.exe_types.node_types import BaseNode
 
 
 class IfElse(BaseNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
+
+        # Control flow
         self.add_parameter(
             ControlParameterInput(
                 tooltip="If-Else Control Input",
                 name="exec_in",
             )
         )
+
         then_param = ControlParameterOutput(
             tooltip="If-else connection to go down if condition is met.",
             name="Then",
         )
         then_param.ui_options = {"display_name": "Then"}
         self.add_parameter(then_param)
+
         else_param = ControlParameterOutput(
             tooltip="If-else connection to go down if condition is not met.",
             name="Else",
         )
-        else_param._ui_options = {"display_name": "Else"}
+        else_param.ui_options = {"display_name": "Else"}
         self.add_parameter(else_param)
+
+        # Evaluation parameter
         self.add_parameter(
             Parameter(
                 name="evaluate",
@@ -33,8 +46,204 @@ class IfElse(BaseNode):
                 output_type="bool",
                 type="bool",
                 default_value=False,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
             )
         )
+
+        # Data flow outputs in a collapsible ParameterGroup
+        with ParameterGroup(name="Data Outputs") as group:
+            self.output_if_true = Parameter(
+                name="output_if_true",
+                tooltip="Data to output when condition is true",
+                input_types=["any"],
+                type="any",
+                allowed_modes={ParameterMode.INPUT},
+                default_value=None,
+            )
+
+            self.output_if_false = Parameter(
+                name="output_if_false",
+                tooltip="Data to output when condition is false",
+                input_types=["any"],
+                type="any",
+                allowed_modes={ParameterMode.INPUT},
+                default_value=None,
+            )
+
+            self.output = Parameter(
+                name="output",
+                tooltip="Selected output based on condition evaluation",
+                output_type=ParameterTypeBuiltin.ALL.value,
+                type=ParameterTypeBuiltin.ALL.value,
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=None,
+            )
+
+        self.add_node_element(group)
+
+        """
+        SOPHISTICATED TYPE MANAGEMENT SYSTEM - READ THIS OR SUFFER
+
+        This IfElse node handles complex type negotiations between:
+        1. Multiple input parameters (output_if_true, output_if_false)
+        2. One output parameter (output)
+        3. Target nodes that may accept multiple types
+
+        === ALL POSSIBLE SCENARIOS ===
+
+        SCENARIO 1: Fresh node, no connections
+        State: _possibility_space=[], _locked_type=None, no connections
+        Result: All params accept "any", output is "ALL"
+
+        SCENARIO 2: Connect output to single-type target (e.g., accepts only "string")
+        Flow: output → target(input_types=["string"])
+        State: _possibility_space=["string"], _locked_type=None, output connected
+        Result: Inputs accept ["string"], output stays "ALL" (flexible until input locks it)
+
+        SCENARIO 3: Connect output to multi-type target (e.g., accepts "string" OR "int")
+        Flow: output → target(input_types=["string", "int"])
+        State: _possibility_space=["string", "int"], _locked_type=None, output connected
+        Result: Inputs accept ["string", "int"], output stays "ALL"
+
+        SCENARIO 4: Input connection locks to specific type (building on scenario 2/3)
+        Flow: string_source(output_type="string") → output_if_true
+        State: _possibility_space=["string", "int"], _locked_type="string", input+output connected
+        Result: ALL params lock to "string" type
+
+        SCENARIO 5: Multiple compatible input connections
+        Flow: string_source → output_if_true, then another_string_source → output_if_false
+        State: _locked_type="string", both inputs connected
+        Result: All params stay locked to "string" (compatible)
+
+        SCENARIO 6: Attempted incompatible input connection (gracefully handled)
+        Flow: int_source(output_type="int") → output_if_true (when locked to "string")
+        State: _locked_type="string" (unchanged)
+        Result: Connection should be prevented by type system, but tracked if somehow made
+
+        SCENARIO 7: Remove input connection - unlock if no more inputs
+        Flow: Disconnect output_if_true (from scenario 4, only input was output_if_true)
+        State: _possibility_space=["string", "int"], _locked_type=None, output connected
+        Result: Return to flexible state - inputs accept ["string", "int"], output "ALL"
+
+        SCENARIO 8: Remove input connection - stay locked if other inputs remain
+        Flow: Disconnect output_if_true (from scenario 5, output_if_false still connected)
+        State: _locked_type="string" (unchanged), one input still connected
+        Result: All params stay locked to "string"
+
+        SCENARIO 9: Remove output connection - clear possibility space
+        Flow: Disconnect output (from any scenario with output connected)
+        State: _possibility_space=[], _output_connected=False
+        Result: If no inputs connected → reset to default. If inputs connected → stay locked.
+
+        SCENARIO 10: Inputs first, then output (reverse order)
+        Flow: string_source → output_if_true, THEN output → multi_type_target
+        State: _locked_type="string", then _possibility_space=["string", "int"]
+        Result: Already locked to "string", possibility space ignored (lock wins)
+
+        SCENARIO 11: Complete disconnection
+        Flow: Remove all connections from any scenario
+        State: _possibility_space=[], _locked_type=None, no connections
+        Result: Reset to default - all "any"/"ALL"
+
+        SCENARIO 12: Complex reconnection
+        Flow: Any scenario → disconnect all → reconnect in different order
+        Result: Behaves as if fresh node, follows same rules
+
+        === TYPE PRIORITY RULES ===
+        1. LOCKED TYPE WINS: If _locked_type exists, all params use that type
+        2. POSSIBILITY SPACE: If no lock but _possibility_space exists, inputs accept those types
+        3. DEFAULT FALLBACK: If neither exists, all params accept "any"/"ALL"
+
+        === STATE TRANSITIONS ===
+        DEFAULT → POSSIBILITY_SPACE (output connection made)
+        DEFAULT → LOCKED (input connection made)
+        POSSIBILITY_SPACE → LOCKED (input connection made)
+        LOCKED → POSSIBILITY_SPACE (all inputs removed, output remains)
+        LOCKED → DEFAULT (all connections removed)
+        POSSIBILITY_SPACE → DEFAULT (output connection removed)
+        """
+
+        # Sophisticated connection tracking for type management
+        self._possibility_space: list[str] = []  # Types acceptable to output target (from outgoing connections)
+        self._locked_type: str | None = None  # Specific type locked by first input connection
+        self._connected_inputs: set[str] = set()  # Track which inputs have connections
+        self._output_connected: bool = False  # Track if output has connections
+
+    def _update_parameter_types(self) -> None:
+        """Update all parameter types based on current state (locked type vs possibility space).
+
+        VALIDATION: This method handles all scenarios correctly:
+        - Scenarios 1,11: Default state → all "any"/"ALL"
+        - Scenarios 4,5,8,10: Locked state → all use _locked_type
+        - Scenarios 2,3,7: Possibility space → inputs flexible, output "ALL"
+        """
+        if self._locked_type:
+            # We're locked to a specific type - everything uses that type
+            self.output_if_true.input_types = [self._locked_type]
+            self.output_if_true.type = self._locked_type
+
+            self.output_if_false.input_types = [self._locked_type]
+            self.output_if_false.type = self._locked_type
+
+            self.output.output_type = self._locked_type
+            self.output.type = self._locked_type
+
+        elif self._possibility_space:
+            # We have a possibility space but no locked type
+            # Inputs can accept any type in the possibility space
+            self.output_if_true.input_types = self._possibility_space.copy()
+            self.output_if_true.type = "any"  # Can accept multiple types
+
+            self.output_if_false.input_types = self._possibility_space.copy()
+            self.output_if_false.type = "any"  # Can accept multiple types
+
+            # Output remains flexible since we don't know the specific type yet
+            self.output.output_type = ParameterTypeBuiltin.ALL.value
+            self.output.type = ParameterTypeBuiltin.ALL.value
+
+        else:
+            # Default state - no connections or constraints
+            self.output_if_true.input_types = ["any"]
+            self.output_if_true.type = "any"
+
+            self.output_if_false.input_types = ["any"]
+            self.output_if_false.type = "any"
+
+            self.output.output_type = ParameterTypeBuiltin.ALL.value
+            self.output.type = ParameterTypeBuiltin.ALL.value
+
+    def _can_accept_input_type(self, input_type: str) -> bool:
+        """Check if we can accept a new input connection of the given type."""
+        if self._locked_type:
+            # If locked, only accept the same type
+            return input_type == self._locked_type
+        if self._possibility_space:
+            # If we have a possibility space, input must be in it
+            return input_type in self._possibility_space
+        # Default state - accept any type
+        return True
+
+    def _set_locked_type(self, type_to_lock: str) -> None:
+        """Lock all parameters to a specific type."""
+        self._locked_type = type_to_lock
+        self._update_parameter_types()
+
+    def _clear_locked_type(self) -> None:
+        """Clear the locked type and restore flexibility."""
+        self._locked_type = None
+        self._update_parameter_types()
+
+    def _set_possibility_space(self, possible_types: list[str]) -> None:
+        """Set the possibility space for acceptable types."""
+        self._possibility_space = possible_types.copy()
+        if not self._locked_type:  # Only update if not locked
+            self._update_parameter_types()
+
+    def _clear_possibility_space(self) -> None:
+        """Clear the possibility space."""
+        self._possibility_space = []
+        if not self._locked_type:  # Only update if not locked
+            self._update_parameter_types()
 
     def check_evaluation(self) -> bool:
         value = self.get_parameter_value("evaluate")
@@ -70,8 +279,17 @@ class IfElse(BaseNode):
         raise TypeError(msg)
 
     def process(self) -> None:
-        value = self.check_evaluation()
-        self.parameter_output_values["evaluate"] = value
+        evaluation_result = self.check_evaluation()
+        self.parameter_output_values["evaluate"] = evaluation_result
+
+        # Select the appropriate output value based on evaluation
+        if evaluation_result:
+            selected_value = self.get_parameter_value("output_if_true")
+        else:
+            selected_value = self.get_parameter_value("output_if_false")
+
+        # Set the output value
+        self.parameter_output_values["output"] = selected_value
 
     # Override this method.
     def get_next_control_output(self) -> Parameter | None:
@@ -81,3 +299,105 @@ class IfElse(BaseNode):
         if self.parameter_output_values["evaluate"]:
             return self.get_parameter_by_name("Then")
         return self.get_parameter_by_name("Else")
+
+    def after_incoming_connection(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Handle incoming connections to input parameters.
+
+        VALIDATION: Handles scenarios 4,5,6,10 correctly:
+        - Scenario 4: First input locks type ✓
+        - Scenario 5: Compatible inputs stay locked ✓
+        - Scenario 6: Incompatible inputs handled gracefully ✓
+        - Scenario 10: Input-first order works ✓
+        """
+        if target_parameter.name in ["output_if_true", "output_if_false"]:
+            source_type = source_parameter.output_type or source_parameter.type
+
+            # Check if we can accept this type
+            if self._can_accept_input_type(source_type):
+                # If no locked type yet, this connection locks us to this type
+                if not self._locked_type:
+                    self._set_locked_type(source_type)
+
+                # Track this connection
+                self._connected_inputs.add(target_parameter.name)
+            else:
+                # This connection is not compatible - the system should prevent it
+                # but we'll track it anyway to be safe
+                self._connected_inputs.add(target_parameter.name)
+
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_outgoing_connection(
+        self,
+        source_parameter: Parameter,
+        target_node: BaseNode,
+        target_parameter: Parameter,
+    ) -> None:
+        """Handle outgoing connections from output parameter.
+
+        VALIDATION: Handles scenarios 2,3,10 correctly:
+        - Scenario 2: Single-type target sets possibility space ✓
+        - Scenario 3: Multi-type target sets possibility space ✓
+        - Scenario 10: Output-second order works (locked type wins) ✓
+        """
+        if source_parameter.name == "output":
+            # The target parameter defines what types are acceptable
+            target_input_types = target_parameter.input_types or [target_parameter.type]
+
+            # Set the possibility space based on what the target accepts
+            self._set_possibility_space(target_input_types)
+
+            # Track this connection
+            self._output_connected = True
+
+        return super().after_outgoing_connection(source_parameter, target_node, target_parameter)
+
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Handle removal of incoming connections.
+
+        VALIDATION: Handles scenarios 7,8,11 correctly:
+        - Scenario 7: Remove only input → unlock, restore possibility space ✓
+        - Scenario 8: Remove one input, others remain → stay locked ✓
+        - Scenario 11: Remove all inputs → reset to appropriate state ✓
+        """
+        if target_parameter.name in ["output_if_true", "output_if_false"]:
+            # Remove this connection from tracking
+            self._connected_inputs.discard(target_parameter.name)
+
+            # If no more input connections exist, clear the locked type
+            if not self._connected_inputs:
+                self._clear_locked_type()
+
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
+
+    def after_outgoing_connection_removed(
+        self,
+        source_parameter: Parameter,
+        target_node: BaseNode,
+        target_parameter: Parameter,
+    ) -> None:
+        """Handle removal of outgoing connections.
+
+        VALIDATION: Handles scenarios 9,11,12 correctly:
+        - Scenario 9: Remove output → clear possibility space, maintain lock if inputs exist ✓
+        - Scenario 11: Remove output as part of complete disconnection ✓
+         - Scenario 12: Part of reconnection flow ✓
+        """
+        if source_parameter.name == "output":
+            # Clear the possibility space
+            self._clear_possibility_space()
+
+            # Track this disconnection
+            self._output_connected = False
+
+        return super().after_outgoing_connection_removed(source_parameter, target_node, target_parameter)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/execution/if_else.py
@@ -52,6 +52,7 @@ class IfElse(BaseNode):
 
         # Data flow outputs in a collapsible ParameterGroup
         with ParameterGroup(name="Data Outputs") as group:
+            group.ui_options = {"collapsed": True}
             self.output_if_true = Parameter(
                 name="output_if_true",
                 tooltip="Data to output when condition is true",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/text/file_path_validator.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/text/file_path_validator.py
@@ -55,11 +55,11 @@ class FilePathValidator(ControlNode):
     def process(self) -> None:
         """Process the node by validating file paths."""
         file_paths = self.parameter_values.get("file_paths", [])
-        
+
         # Ensure file_paths is a list
         if not isinstance(file_paths, list):
             file_paths = [file_paths] if file_paths else []
-        
+
         valid_paths = []
         errors = []
 
@@ -67,32 +67,32 @@ class FilePathValidator(ControlNode):
             try:
                 # Convert to Path object for easier handling
                 path = Path(file_path)
-                
+
                 # Check if file exists
                 if not path.exists():
                     errors.append(f"File does not exist: {file_path}")
                     continue
-                
+
                 # Check if it's a file (not a directory)
                 if not path.is_file():
                     errors.append(f"Path is not a file: {file_path}")
                     continue
-                
+
                 # Check if it's a Python file
                 if path.suffix.lower() != ".py":
                     errors.append(f"Not a Python file: {file_path}")
                     continue
-                
+
                 # Check if file is readable
                 if not os.access(path, os.R_OK):
                     errors.append(f"File is not readable: {file_path}")
                     continue
-                
+
                 # If we get here, the file path is valid
                 valid_paths.append(str(path.resolve()))
-                
+
             except Exception as e:
-                errors.append(f"Error validating {file_path}: {str(e)}")
+                errors.append(f"Error validating {file_path}: {e!s}")
 
         # Set output values
         self.parameter_output_values["valid_paths"] = valid_paths

--- a/libraries/griptape_nodes_library/griptape_nodes_library/text/file_path_validator.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/text/file_path_validator.py
@@ -1,0 +1,103 @@
+import os
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import ControlNode
+
+
+class FilePathValidator(ControlNode):
+    """Validates that file paths exist and are readable Python files."""
+
+    def __init__(
+        self,
+        name: str,
+        metadata: dict[Any, Any] | None = None,
+    ) -> None:
+        super().__init__(name, metadata)
+
+        # Input parameter for list of file paths
+        self.add_parameter(
+            Parameter(
+                name="file_paths",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                input_types=["list"],
+                type="list",
+                default_value=[],
+                tooltip="List of file paths to validate",
+                ui_options={"multiline": True, "placeholder_text": "Enter file paths to validate..."},
+            )
+        )
+
+        # Output parameter for valid file paths
+        self.add_parameter(
+            Parameter(
+                name="valid_paths",
+                allowed_modes={ParameterMode.OUTPUT},
+                output_type="list",
+                default_value=[],
+                tooltip="List of valid file paths that exist and are readable",
+            )
+        )
+
+        # Output parameter for validation errors
+        self.add_parameter(
+            Parameter(
+                name="validation_errors",
+                allowed_modes={ParameterMode.OUTPUT},
+                output_type="str",
+                default_value="",
+                tooltip="Validation errors for invalid file paths",
+                ui_options={"multiline": True, "placeholder_text": "Validation errors will appear here..."},
+            )
+        )
+
+    def process(self) -> None:
+        """Process the node by validating file paths."""
+        file_paths = self.parameter_values.get("file_paths", [])
+        
+        # Ensure file_paths is a list
+        if not isinstance(file_paths, list):
+            file_paths = [file_paths] if file_paths else []
+        
+        valid_paths = []
+        errors = []
+
+        for file_path in file_paths:
+            try:
+                # Convert to Path object for easier handling
+                path = Path(file_path)
+                
+                # Check if file exists
+                if not path.exists():
+                    errors.append(f"File does not exist: {file_path}")
+                    continue
+                
+                # Check if it's a file (not a directory)
+                if not path.is_file():
+                    errors.append(f"Path is not a file: {file_path}")
+                    continue
+                
+                # Check if it's a Python file
+                if path.suffix.lower() != ".py":
+                    errors.append(f"Not a Python file: {file_path}")
+                    continue
+                
+                # Check if file is readable
+                if not os.access(path, os.R_OK):
+                    errors.append(f"File is not readable: {file_path}")
+                    continue
+                
+                # If we get here, the file path is valid
+                valid_paths.append(str(path.resolve()))
+                
+            except Exception as e:
+                errors.append(f"Error validating {file_path}: {str(e)}")
+
+        # Set output values
+        self.parameter_output_values["valid_paths"] = valid_paths
+        self.parameter_output_values["validation_errors"] = "\n".join(errors) if errors else ""
+
+        # Also set in parameter_values for get_value compatibility
+        self.parameter_values["valid_paths"] = valid_paths
+        self.parameter_values["validation_errors"] = "\n".join(errors) if errors else ""

--- a/libraries/griptape_nodes_library/griptape_nodes_library/text/python_class_parser.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/text/python_class_parser.py
@@ -1,0 +1,192 @@
+import ast
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import ControlNode
+
+
+class PythonClassParser(ControlNode):
+    """Parses Python file content to extract classes inheriting from RequestPayload or ResultPayload."""
+
+    def __init__(
+        self,
+        name: str,
+        metadata: dict[Any, Any] | None = None,
+    ) -> None:
+        super().__init__(name, metadata)
+
+        # Input parameter for Python file content
+        self.add_parameter(
+            Parameter(
+                name="file_content",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                input_types=["str"],
+                type="str",
+                default_value="",
+                tooltip="Python file content to parse",
+                ui_options={"multiline": True, "placeholder_text": "Python file content..."},
+            )
+        )
+
+        # Input parameter for file path (for context)
+        self.add_parameter(
+            Parameter(
+                name="file_path",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                input_types=["str"],
+                type="str",
+                default_value="",
+                tooltip="File path for context and error reporting",
+            )
+        )
+
+        # Output parameter for parsed class information
+        self.add_parameter(
+            Parameter(
+                name="class_info",
+                allowed_modes={ParameterMode.OUTPUT},
+                output_type="list",
+                default_value=[],
+                tooltip="List of class information dictionaries",
+            )
+        )
+
+        # Output parameter for parsing errors
+        self.add_parameter(
+            Parameter(
+                name="parsing_errors",
+                allowed_modes={ParameterMode.OUTPUT},
+                output_type="str",
+                default_value="",
+                tooltip="Any errors encountered during parsing",
+                ui_options={"multiline": True, "placeholder_text": "Parsing errors will appear here..."},
+            )
+        )
+
+    def _extract_docstring(self, node: ast.ClassDef) -> str | None:
+        """Extract docstring from a class node."""
+        if (
+            node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)
+        ):
+            return node.body[0].value.value
+        return None
+
+    def _get_class_definition(self, node: ast.ClassDef, lines: list[str]) -> str:
+        """Get the class definition including decorators and signature."""
+        start_line = node.lineno - 1
+        
+        # Find the actual start including decorators
+        actual_start = start_line
+        for decorator in node.decorator_list:
+            actual_start = min(actual_start, decorator.lineno - 1)
+        
+        # Find class body start (after colon)
+        class_body_start = start_line
+        for i in range(start_line, len(lines)):
+            if ":" in lines[i]:
+                class_body_start = i
+                break
+        
+        # Return from decorators to end of class signature
+        return "\n".join(lines[actual_start:class_body_start + 1])
+
+    def _inherits_from_payload(self, node: ast.ClassDef) -> str | None:
+        """Check if class inherits from RequestPayload or ResultPayload."""
+        for base in node.bases:
+            if isinstance(base, ast.Name):
+                if base.id in ("RequestPayload", "ResultPayload"):
+                    return base.id
+            elif isinstance(base, ast.Attribute):
+                # Handle cases like module.RequestPayload
+                if base.attr in ("RequestPayload", "ResultPayload"):
+                    return base.attr
+        return None
+
+    def _get_docstring_location(self, node: ast.ClassDef) -> tuple[int, int] | None:
+        """Get the line numbers where the docstring starts and ends."""
+        if not node.body:
+            return None
+            
+        first_stmt = node.body[0]
+        if (
+            isinstance(first_stmt, ast.Expr)
+            and isinstance(first_stmt.value, ast.Constant)
+            and isinstance(first_stmt.value.value, str)
+        ):
+            return (first_stmt.lineno, first_stmt.end_lineno or first_stmt.lineno)
+        return None
+
+    def process(self) -> None:
+        """Process the node by parsing Python class definitions."""
+        file_content = self.parameter_values.get("file_content", "")
+        file_path = self.parameter_values.get("file_path", "unknown")
+        
+        if not file_content:
+            self.parameter_output_values["class_info"] = []
+            self.parameter_output_values["parsing_errors"] = "No file content provided"
+            self.parameter_values["class_info"] = []
+            self.parameter_values["parsing_errors"] = "No file content provided"
+            return
+
+        try:
+            # Parse the Python code
+            tree = ast.parse(file_content)
+            lines = file_content.splitlines()
+            
+            class_info = []
+            errors = []
+            
+            # Walk through all nodes in the AST
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    # Check if this class inherits from RequestPayload or ResultPayload
+                    payload_type = self._inherits_from_payload(node)
+                    
+                    if payload_type:
+                        try:
+                            # Extract class information
+                            current_docstring = self._extract_docstring(node)
+                            docstring_location = self._get_docstring_location(node)
+                            class_definition = self._get_class_definition(node, lines)
+                            
+                            class_data = {
+                                "class_name": node.name,
+                                "payload_type": payload_type,
+                                "has_docstring": current_docstring is not None,
+                                "current_docstring": current_docstring or "",
+                                "docstring_start_line": docstring_location[0] if docstring_location else None,
+                                "docstring_end_line": docstring_location[1] if docstring_location else None,
+                                "class_start_line": node.lineno,
+                                "class_definition": class_definition,
+                                "file_path": file_path,
+                            }
+                            
+                            class_info.append(class_data)
+                            
+                        except Exception as e:
+                            errors.append(f"Error processing class {node.name}: {str(e)}")
+            
+            # Set output values
+            self.parameter_output_values["class_info"] = class_info
+            self.parameter_output_values["parsing_errors"] = "\n".join(errors) if errors else ""
+            
+            # Also set in parameter_values for get_value compatibility
+            self.parameter_values["class_info"] = class_info
+            self.parameter_values["parsing_errors"] = "\n".join(errors) if errors else ""
+            
+        except SyntaxError as e:
+            error_msg = f"Syntax error in {file_path}: {str(e)}"
+            self.parameter_output_values["class_info"] = []
+            self.parameter_output_values["parsing_errors"] = error_msg
+            self.parameter_values["class_info"] = []
+            self.parameter_values["parsing_errors"] = error_msg
+            
+        except Exception as e:
+            error_msg = f"Error parsing {file_path}: {str(e)}"
+            self.parameter_output_values["class_info"] = []
+            self.parameter_output_values["parsing_errors"] = error_msg
+            self.parameter_values["class_info"] = []
+            self.parameter_values["parsing_errors"] = error_msg

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -65,6 +65,9 @@ class BaseNode(ABC):
     stop_flow: bool = False
     root_ui_element: BaseNodeElement
     _tracked_parameters: list[BaseNodeElement]
+    _entry_control_parameter: Parameter | None = (
+        None  # The control input parameter used to enter this node during execution
+    )
 
     @property
     def parameters(self) -> list[Parameter]:
@@ -92,6 +95,7 @@ class BaseNode(ABC):
         self.root_ui_element._node_context = self
         self.process_generator = None
         self._tracked_parameters = []
+        self.set_entry_control_parameter(None)
 
     # This is gross and we need to have a universal pass on resolution state changes and emission of events. That's what this ticket does!
     # https://github.com/griptape-ai/griptape-nodes/issues/994
@@ -106,6 +110,18 @@ class BaseNode(ABC):
                 )
             )
         self.state = NodeResolutionState.UNRESOLVED
+        # NOTE: _entry_control_parameter is NOT cleared here as it represents execution context
+        # that should persist through the resolve/unresolve cycle during a single execution
+
+    def set_entry_control_parameter(self, parameter: Parameter | None) -> None:
+        """Set the control parameter that was used to enter this node.
+
+        This should only be called by the ControlFlowContext during execution.
+
+        Args:
+            parameter: The control input parameter that triggered this node's execution, or None to clear
+        """
+        self._entry_control_parameter = parameter
 
     def emit_parameter_changes(self) -> None:
         if self._tracked_parameters:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -204,6 +204,8 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
 
     def start_flow(self, start_node: BaseNode, debug_mode: bool = False) -> None:  # noqa: FBT001, FBT002
         self._context.current_node = start_node
+        # Set entry control parameter for initial node (None for workflow start)
+        start_node.set_entry_control_parameter(None)
         # Set up to debug
         self._context.paused = debug_mode
         self.start(ResolveNodeState)  # Begins the flow

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from griptape.events import EventBus
 
+from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.exe_types.type_validator import TypeValidator
 from griptape_nodes.machines.fsm import FSM, State
@@ -16,6 +18,15 @@ from griptape_nodes.retained_mode.events.execution_events import (
     CurrentControlNodeEvent,
     SelectedControlOutputEvent,
 )
+
+
+@dataclass
+class NextNodeInfo:
+    """Information about the next node to execute and how to reach it."""
+
+    node: BaseNode
+    entry_parameter: Parameter | None
+
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
@@ -36,18 +47,26 @@ class ControlFlowContext:
         self.resolution_machine = NodeResolutionMachine()
         self.current_node = None
 
-    def get_next_node(self, output_parameter: Parameter) -> BaseNode | None:
+    def get_next_node(self, output_parameter: Parameter) -> NextNodeInfo | None:
+        """Get the next node and the target parameter that will receive the control flow.
+
+        Returns:
+            NextNodeInfo | None: Information about the next node or None if no connection
+        """
         if self.current_node is not None:
             from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-            node = GriptapeNodes.FlowManager().get_connections().get_connected_node(self.current_node, output_parameter)
-            if node is not None:
-                node, _ = node
+            node_connection = (
+                GriptapeNodes.FlowManager().get_connections().get_connected_node(self.current_node, output_parameter)
+            )
+            if node_connection is not None:
+                node, entry_parameter = node_connection
+                return NextNodeInfo(node=node, entry_parameter=entry_parameter)
             # Continue Execution to the next node that needs to be executed using global execution queue
-            else:
-                # Get the next node in the execution queue, or None if queue is empty
-                node = GriptapeNodes.FlowManager().get_next_node_from_execution_queue()
-            return node
+            # Get the next node in the execution queue, or None if queue is empty
+            node = GriptapeNodes.FlowManager().get_next_node_from_execution_queue()
+            if node is not None:
+                return NextNodeInfo(node=node, entry_parameter=None)
         return None
 
     def reset(self) -> None:
@@ -111,10 +130,11 @@ class NextNodeState(State):
             context.current_node.stop_flow = False
             return CompleteState
         next_output = context.current_node.get_next_control_output()
-        next_node = None
+        next_node_info = None
+
         if next_output is not None:
             context.selected_output = next_output
-            next_node = context.get_next_node(context.selected_output)
+            next_node_info = context.get_next_node(context.selected_output)
             EventBus.publish_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(
@@ -130,11 +150,18 @@ class NextNodeState(State):
 
             # Get the next node in the execution queue, or None if queue is empty
             next_node = GriptapeNodes.FlowManager().get_next_node_from_execution_queue()
+            if next_node is not None:
+                next_node_info = NextNodeInfo(node=next_node, entry_parameter=None)
+
         # The parameter that will be evaluated next
-        if next_node is None:
+        if next_node_info is None:
             # If no node attached
             return CompleteState
-        context.current_node = next_node
+
+        # Always set the entry control parameter (None for execution queue nodes)
+        next_node_info.node.set_entry_control_parameter(next_node_info.entry_parameter)
+
+        context.current_node = next_node_info.node
         context.selected_output = None
         if not context.paused:
             return ResolveNodeState

--- a/src/griptape_nodes/machines/fsm.py
+++ b/src/griptape_nodes/machines/fsm.py
@@ -19,6 +19,11 @@ class State:
         """Called when exiting the state."""
         return
 
+    @staticmethod
+    def on_event(context: Any, event: Any) -> type["State"] | None:  # noqa: ARG004
+        """Called on an event, which may trigger a State transition."""
+        return None
+
 
 class FSM[T]:
     def __init__(self, context: T) -> None:
@@ -50,6 +55,15 @@ class FSM[T]:
             new_state = None
         else:
             new_state = self._current_state.on_update(self._context)
+
+        if new_state is not None:
+            self.transition_state(new_state)
+
+    def handle_event(self, event: Any) -> None:
+        if self._current_state is None:
+            new_state = None
+        else:
+            new_state = self._current_state.on_event(self._context, event)
 
         if new_state is not None:
             self.transition_state(new_state)

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1810,6 +1810,8 @@ class FlowManager:
     def unresolve_whole_flow(self, flow: ControlFlow) -> None:
         for node in flow.nodes.values():
             node.make_node_unresolved(current_states_to_trigger_change_event=None)
+            # Clear entry control parameter for new execution
+            node.set_entry_control_parameter(None)
 
     def flow_state(self, flow: ControlFlow) -> tuple[str | None, str | None]:  # noqa: ARG002
         if not self.check_for_existing_running_flow():


### PR DESCRIPTION
This is a major revamp to the ForEachStart and End nodes. Previously, ForEach could not take control parameter branches as part of its processing. I was trying to do a flow that could perform the following:

```
For Each item in items:
    if item has key("name"):
        add the item's value to the output set.
    else:
        continue (skip this one)
```

The IfElse node needed branching control flow logic, which wasn't supported by how the existing ForEach nodes were implemented. Also, there was no "skip" and no "break" options.

This led to a gigantic but fruitful rabbit hole where I discovered numerous gaps, such as assumptions that there would be at most a single control flow parameter, and no provenance for which control flow parameter was used to trigger a given node.

The ForEach nodes were beefed up with hidden parameters that allow the Start and End node to communicate via signals and to present an intuitive UI. These hidden parameters are automatically connected when the nodes get created, leveraging earlier logic for pairing nodes.

I will deliver a publishable workflow that leverages the functionality from this PR to detect docstring drift and generates accurate and comprehensive ones for the user to review.

Longer-term: the additional investment into control flow parameters will unlock capabilities such as state machines. 