### PR TITLE
Force unresolved resolution state if pickle fails

### DIFF
--- a/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
+++ b/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
@@ -16,7 +16,8 @@
 # ///
 
 import pickle
-from griptape_nodes.node_library.library_registry import IconVariant, NodeMetadata
+
+from griptape_nodes.node_library.library_registry import NodeMetadata
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest
 from griptape_nodes.retained_mode.events.library_events import (
@@ -25,7 +26,6 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import (
-    AddParameterToNodeRequest,
     AlterParameterDetailsRequest,
     SetParameterValueRequest,
 )

--- a/libraries/griptape_nodes_library/workflows/templates/coordinating_agents.py
+++ b/libraries/griptape_nodes_library/workflows/templates/coordinating_agents.py
@@ -16,7 +16,8 @@
 # ///
 
 import pickle
-from griptape_nodes.node_library.library_registry import IconVariant, NodeMetadata
+
+from griptape_nodes.node_library.library_registry import NodeMetadata
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest
 from griptape_nodes.retained_mode.events.library_events import (
@@ -25,7 +26,6 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import (
-    AddParameterToNodeRequest,
     AlterParameterDetailsRequest,
     SetParameterValueRequest,
 )

--- a/libraries/griptape_nodes_library/workflows/templates/photography_team.py
+++ b/libraries/griptape_nodes_library/workflows/templates/photography_team.py
@@ -16,7 +16,8 @@
 # ///
 
 import pickle
-from griptape_nodes.node_library.library_registry import IconVariant, NodeMetadata
+
+from griptape_nodes.node_library.library_registry import NodeMetadata
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest
 from griptape_nodes.retained_mode.events.library_events import (

--- a/libraries/griptape_nodes_library/workflows/templates/prompt_an_image.py
+++ b/libraries/griptape_nodes_library/workflows/templates/prompt_an_image.py
@@ -16,8 +16,8 @@
 # ///
 
 import pickle
-from griptape_nodes.node_library.library_registry import IconVariant, NodeMetadata
-from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+
+from griptape_nodes.node_library.library_registry import NodeMetadata
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest
 from griptape_nodes.retained_mode.events.library_events import (
     GetAllInfoForAllLibrariesRequest,
@@ -25,8 +25,6 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import (
-    AddParameterToNodeRequest,
-    AlterParameterDetailsRequest,
     SetParameterValueRequest,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1923,6 +1923,8 @@ class NodeManager:
                 )
                 if set_param_value_requests is not None:
                     set_value_commands.extend(set_param_value_requests)
+                else:
+                    create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
 
         # Hooray
         serialized_node_commands = SerializedNodeCommands(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1837,7 +1837,7 @@ class NodeManager:
             validation_succeeded=(len(all_exceptions) == 0), exceptions=all_exceptions
         )
 
-    def on_serialize_node_to_commands(self, request: SerializeNodeToCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0912
+    def on_serialize_node_to_commands(self, request: SerializeNodeToCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0912, PLR0915
         node_name = request.node_name
         node = None
 


### PR DESCRIPTION
Pickles were failing and nodes were still 'resolved', which was causing errors in subsequent runs.
Force node to be marked as unresolved. 