### PR TITLE
refactor: hide uvicorn logs by default

### DIFF
--- a/src/griptape_nodes/app/api.py
+++ b/src/griptape_nodes/app/api.py
@@ -27,9 +27,11 @@ STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
 # URL path for the static server
 STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/static")
 # Log level for the static server
-STATIC_SERVER_LOG_LEVEL = os.getenv("STATIC_SERVER_LOG_LEVEL", "info").lower()
+STATIC_SERVER_LOG_LEVEL = os.getenv("STATIC_SERVER_LOG_LEVEL", "ERROR").lower()
 
 logger = logging.getLogger("griptape_nodes_api")
+logging.getLogger("uvicorn").addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
+
 
 # Global event queue - initialized as None and set when starting the API
 event_queue: Queue | None = None
@@ -166,10 +168,6 @@ def start_api(static_directory: Path, queue: Queue) -> None:
     global event_queue, static_dir  # noqa: PLW0603
     event_queue = queue
     static_dir = static_directory
-
-    logging.getLogger("uvicorn").addHandler(
-        RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True)
-    )
 
     if not static_dir.exists():
         static_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Creates unnecessary log noise. Amplified by the fact that we have two servers now (static, mcp).

This PR sets the log level to `ERROR` to avoid showing logs like `Waiting for application startup.`.

Current:
```
❮ make run/watch
uv run src/griptape_nodes/app/watch.py
Checking for updates...
Starting Griptape Nodes engine...
[07/29/25 12:22:51] INFO     Starting MCP GTN server...
INFO:     Started server process [94228]
[07/29/25 12:22:51] INFO     Started server process [94228]
INFO:     Waiting for application startup.
                    INFO     Waiting for application startup.
INFO:     Started server process [94228]
                    INFO     Started server process [94228]
INFO:     Waiting for application startup.
                    INFO     Waiting for application startup.
INFO:     Application startup complete.
                    INFO     Application startup complete.
                    INFO     GTN MCP server started with StreamableHTTP session manager!
INFO:     Application startup complete.
                    INFO     Application startup complete.
INFO:     Uvicorn running on http://localhost:8124 (Press CTRL+C to quit)
                    INFO     Uvicorn running on http://localhost:8124 (Press CTRL+C to quit)
INFO:     Uvicorn running on http://127.0.0.1:9927 (Press CTRL+C to quit)
                    INFO     Uvicorn running on http://127.0.0.1:9927 (Press CTRL+C to quit)
[07/29/25 12:22:51] INFO     Installing dependencies for library 'Griptape Nodes Library' with pip in venv at /Users/collindutter/Documents/griptape/griptape-nodes/libraries/griptape_nodes_library/.venv
                    INFO     Successfully loaded Library 'Griptape Nodes Library' from JSON file at /Users/collindutter/Documents/griptape/griptape-nodes/libraries/griptape_nodes_library/griptape_nodes_library.json
```