### PR TITLE
feature/returning mimetype

### DIFF
--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -18,6 +18,7 @@ class FileSystemEntry:
     is_dir: bool
     size: int
     modified_time: float
+    mime_type: str | None = None  # None for directories, mimetype for files
 
 
 @dataclass


### PR DESCRIPTION

fixes: #1761

* Added mime_type field to FileSystemEntry: Optional str | None field that contains the detected MIME type for files, or None for directories

* Created _detect_mime_type() helper method: Efficient mimetype detection using Python's mimetypes module with fallback to "text/plain" for unknown types

* Updated directory listing logic: Modified OSManager.on_list_directory_request() to detect and include mimetype information when creating FileSystemEntry objects
