### PR TITLE
Include complete version info in launch engine box

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -31,7 +31,7 @@ with console.status("Loading Griptape Nodes...") as status:
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.os_manager import OSManager
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
-    from griptape_nodes.utils.version_utils import get_current_version, get_install_source
+    from griptape_nodes.utils.version_utils import get_complete_version_string, get_current_version, get_install_source
 
 CONFIG_DIR = xdg_config_home() / "griptape_nodes"
 DATA_DIR = xdg_data_home() / "griptape_nodes"
@@ -724,8 +724,6 @@ def _sync_libraries() -> None:
 
 def _print_current_version() -> None:
     """Prints the current version of the script."""
-    from griptape_nodes.utils.version_utils import get_complete_version_string
-
     version_string = get_complete_version_string()
     console.print(f"[bold green]{version_string}[/bold green]")
 

--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -724,12 +724,10 @@ def _sync_libraries() -> None:
 
 def _print_current_version() -> None:
     """Prints the current version of the script."""
-    version = __get_current_version()
-    source, commit_id = __get_install_source()
-    if commit_id is None:
-        console.print(f"[bold green]{version} ({source})[/bold green]")
-    else:
-        console.print(f"[bold green]{version} ({source} - {commit_id})[/bold green]")
+    from griptape_nodes.utils.version_utils import get_complete_version_string
+
+    version_string = get_complete_version_string()
+    console.print(f"[bold green]{version_string}[/bold green]")
 
 
 def _print_user_config() -> None:

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib.metadata
 import logging
 import os
 import re
@@ -11,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.utils.version_utils import engine_version
 from griptape_nodes.retained_mode.events.app_events import (
     AppConnectionEstablished,
     AppEndSessionRequest,
@@ -78,7 +78,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("griptape_nodes")
 
 
-engine_version = importlib.metadata.version("griptape_nodes")
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
-from griptape_nodes.utils.version_utils import engine_version
 from griptape_nodes.retained_mode.events.app_events import (
     AppConnectionEstablished,
     AppEndSessionRequest,
@@ -46,6 +45,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
     DeleteFlowRequest,
 )
 from griptape_nodes.utils.metaclasses import SingletonMeta
+from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
@@ -76,8 +76,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("griptape_nodes")
-
-
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -39,6 +39,7 @@ from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
 )
+from griptape_nodes.utils.version_utils import get_complete_version_string
 from griptape_nodes.retained_mode.events.config_events import (
     GetConfigCategoryRequest,
     GetConfigCategoryResultSuccess,
@@ -1594,8 +1595,6 @@ class LibraryManager:
         GriptapeNodes.WorkflowManager().on_libraries_initialization_complete()
 
         # Print the engine ready message
-        from griptape_nodes.utils.version_utils import get_complete_version_string
-
         engine_version = get_complete_version_string()
 
         # Get current session ID

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -39,7 +39,7 @@ from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
 )
-from griptape_nodes.utils.version_utils import get_complete_version_string
+from griptape_nodes.utils.version_utils import get_current_version
 from griptape_nodes.retained_mode.events.config_events import (
     GetConfigCategoryRequest,
     GetConfigCategoryResultSuccess,
@@ -97,7 +97,7 @@ from griptape_nodes.retained_mode.managers.library_lifecycle.library_provenance.
 )
 from griptape_nodes.retained_mode.managers.library_lifecycle.library_status import LibraryStatus
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
-from griptape_nodes.utils.version_utils import get_complete_version_string
+from griptape_nodes.utils.version_utils import get_current_version
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1596,7 +1596,7 @@ class LibraryManager:
         GriptapeNodes.WorkflowManager().on_libraries_initialization_complete()
 
         # Print the engine ready message
-        engine_version = get_complete_version_string()
+        engine_version = get_current_version()
 
         # Get current session ID
         session_id = GriptapeNodes.get_session_id()

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -39,7 +39,6 @@ from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
 )
-from griptape_nodes.utils.version_utils import get_current_version
 from griptape_nodes.retained_mode.events.config_events import (
     GetConfigCategoryRequest,
     GetConfigCategoryResultSuccess,
@@ -97,7 +96,7 @@ from griptape_nodes.retained_mode.managers.library_lifecycle.library_provenance.
 )
 from griptape_nodes.retained_mode.managers.library_lifecycle.library_status import LibraryStatus
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
-from griptape_nodes.utils.version_utils import get_current_version
+from griptape_nodes.utils.version_utils import get_complete_version_string
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1596,7 +1595,7 @@ class LibraryManager:
         GriptapeNodes.WorkflowManager().on_libraries_initialization_complete()
 
         # Print the engine ready message
-        engine_version = get_current_version()
+        engine_version = get_complete_version_string()
 
         # Get current session ID
         session_id = GriptapeNodes.get_session_id()

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1594,14 +1594,9 @@ class LibraryManager:
         GriptapeNodes.WorkflowManager().on_libraries_initialization_complete()
 
         # Print the engine ready message
-        engine_version_request = GetEngineVersionRequest()
-        engine_version_result = GriptapeNodes.get_instance().handle_engine_version_request(engine_version_request)
-        if isinstance(engine_version_result, GetEngineVersionResultSuccess):
-            engine_version = (
-                f"v{engine_version_result.major}.{engine_version_result.minor}.{engine_version_result.patch}"
-            )
-        else:
-            engine_version = "<UNKNOWN ENGINE VERSION>"
+        from griptape_nodes.utils.version_utils import get_complete_version_string
+
+        engine_version = get_complete_version_string()
 
         # Get current session ID
         session_id = GriptapeNodes.get_session_id()

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -97,6 +97,7 @@ from griptape_nodes.retained_mode.managers.library_lifecycle.library_provenance.
 )
 from griptape_nodes.retained_mode.managers.library_lifecycle.library_status import LibraryStatus
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
+from griptape_nodes.utils.version_utils import get_complete_version_string
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -1,0 +1,51 @@
+"""Version utilities for Griptape Nodes."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from typing import Literal
+
+from griptape_nodes.retained_mode.griptape_nodes import engine_version
+
+
+def get_current_version() -> str:
+    """Returns the current version of the Griptape Nodes package."""
+    return f"v{engine_version}"
+
+
+def get_install_source() -> tuple[Literal["git", "file", "pypi"], str | None]:
+    """Determines the install source of the Griptape Nodes package.
+
+    Returns:
+        tuple: A tuple containing the install source and commit ID (if applicable).
+    """
+    dist = importlib.metadata.distribution("griptape_nodes")
+    direct_url_text = dist.read_text("direct_url.json")
+    # installing from pypi doesn't have a direct_url.json file
+    if direct_url_text is None:
+        return "pypi", None
+
+    direct_url_info = json.loads(direct_url_text)
+    url = direct_url_info.get("url")
+    if url.startswith("file://"):
+        return "file", None
+    if "vcs_info" in direct_url_info:
+        return "git", direct_url_info["vcs_info"].get("commit_id")[:7]
+    # Fall back to pypi if no other source is found
+    return "pypi", None
+
+
+def get_complete_version_string() -> str:
+    """Returns the complete version string including install source and commit ID.
+
+    Format: v1.2.3 (source) or v1.2.3 (source - commit_id)
+
+    Returns:
+        Complete version string with source and commit info.
+    """
+    version = get_current_version()
+    source, commit_id = get_install_source()
+    if commit_id is None:
+        return f"{version} ({source})"
+    return f"{version} ({source} - {commit_id})"

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -6,7 +6,7 @@ import importlib.metadata
 import json
 from typing import Literal
 
-from griptape_nodes.retained_mode.griptape_nodes import engine_version
+engine_version = importlib.metadata.version("griptape_nodes")
 
 
 def get_current_version() -> str:

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -28,7 +28,7 @@ def get_install_source() -> tuple[Literal["git", "file", "pypi"], str | None]:
 
     direct_url_info = json.loads(direct_url_text)
     url = direct_url_info.get("url")
-    if url.startswith("file://"):
+    if url and url.startswith("file://"):
         return "file", None
     if "vcs_info" in direct_url_info:
         return "git", direct_url_info["vcs_info"].get("commit_id")[:7]


### PR DESCRIPTION
Fixes #1370

Extracts existing version logic from the CLI and adds complete version information to the launch engine box.

## Changes
- Created reusable version utility module `src/griptape_nodes/utils/version_utils.py`
- Updated launch engine box to show install source (pypi/git/file) and commit ID
- Refactored `gtn self version` command to use shared utility

The launch box now displays complete version information like `v1.2.3 (git - abc1234)` instead of just `v1.2.3`, making it clear whether the engine is running from latest, stable, or a development version.

Generated with [Claude Code](https://claude.ai/code)