### PR TITLE
Add `gtn config show <path>` command to display specific config values

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -334,7 +334,7 @@ def _get_args() -> argparse.Namespace:
     config_show_parser.add_argument(
         "config_path",
         nargs="?",
-        help="Optional config path to show specific value (e.g., 'workspace' for workspace directory).",
+        help="Optional config path to show specific value (e.g., 'workspace_directory').",
     )
     config_subparsers.add_parser("list", help="List configuration values.")
     config_subparsers.add_parser("reset", help="Reset configuration to defaults.")


### PR DESCRIPTION
Add `gtn config show <path>` command to display specific config values

- Extend config show subcommand to accept optional config path parameter
- Add special case mapping 'workspace' -> 'workspace_directory' for convenience
- Support dot notation for nested config values (e.g., app_events.foo.bar)
- Display single values as plain text, complex values as JSON
- Exit with error code 1 if config path not found

Resolves: #1363

Generated with [Claude Code](https://claude.ai/code)