### PR TITLE
feat: add ability for certain events to bypass event queue

### DIFF
--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -5,6 +5,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
+    SkipTheLineMixin,
     WorkflowNotAlteredMixin,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
@@ -148,7 +149,7 @@ class AppEndSessionResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
-class SessionHeartbeatRequest(RequestPayload):
+class SessionHeartbeatRequest(RequestPayload, SkipTheLineMixin):
     """Request clients can use ensure the engine session is still active."""
 
 
@@ -166,7 +167,7 @@ class SessionHeartbeatResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
-class EngineHeartbeatRequest(RequestPayload):
+class EngineHeartbeatRequest(RequestPayload, SkipTheLineMixin):
     """Request clients can use to discover active engines and their status.
 
     Attributes:

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -62,6 +62,15 @@ class WorkflowNotAlteredMixin:
     altered_workflow_state: bool = field(default=False, init=False)
 
 
+class SkipTheLineMixin:
+    """Mixin for events that should skip the event queue and be processed immediately.
+
+    Events that implement this mixin will be handled directly without being added
+    to the event queue, allowing for priority processing of critical events like
+    heartbeats or other time-sensitive operations.
+    """
+
+
 # Success result payload abstract base class
 @dataclass(kw_only=True)
 class ResultPayloadSuccess(ResultPayload, ABC):


### PR DESCRIPTION
Necessary for the engine to respond to session heartbeats while other (maybe time consuming) events are being processed.

Tested by inserting an artificial `time.sleep` in one of the nodes.

Closes #1658