### PR TITLE
Fix: Options Dropdown Updating

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/utils/option_utils.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/utils/option_utils.py
@@ -1,20 +1,26 @@
-from griptape_nodes.exe_types.node_types import BaseNode
-from griptape_nodes.traits.options import Options
+from griptape_nodes.exe_types.core_types import BaseNode
+from griptape_nodes.exe_types.node_types import Options
 
 
 def update_option_choices(node: BaseNode, parameter_name: str, choices: list[str], default: str) -> None:
     """Updates the model selection parameter with a new set of choices.
 
+    This function is intended to be called by subclasses to set the available
+    models for the driver. It modifies the 'model' parameter's `Options` trait
+    to reflect the provided choices.
+
     Args:
-        node: The node containing the parameter to be updated.
-        parameter_name: The name of the parameter representing the model selection or the Parameter object itself.
+        node: The node containing the parameter to update.
+        parameter_name: The name of the parameter representing the model selection.
         choices: A list of model names to be set as choices.
         default: The default model name to be set. It must be one of the provided choices.
     """
     parameter = node.get_parameter_by_name(parameter_name)
     if parameter is not None:
-        trait = parameter.find_element_by_id("Options")
-        if trait and isinstance(trait, Options):
+        # Find the Options trait by type since element_id is a UUID
+        traits = parameter.find_elements_by_type(Options)
+        if traits:
+            trait = traits[0]  # Take the first Options trait
             trait.choices = choices
 
             if default in choices:
@@ -23,23 +29,38 @@ def update_option_choices(node: BaseNode, parameter_name: str, choices: list[str
             else:
                 msg = f"Default model '{default}' is not in the provided choices."
                 raise ValueError(msg)
+
+            # Update the manually set UI options to include the new simple_dropdown
+            if hasattr(parameter, "_ui_options") and parameter._ui_options:
+                parameter._ui_options["simple_dropdown"] = choices
+
+                # Force the parameter to emit an update event to refresh UI options
+                parameter._emit_alter_element_event_if_possible()
+        else:
+            msg = f"No Options trait found for parameter '{parameter_name}'."
+            raise ValueError(msg)
     else:
         msg = f"Parameter '{parameter_name}' not found for updating model choices."
         raise ValueError(msg)
 
 
 def remove_options_trait(node: BaseNode, parameter_name: str) -> None:
-    """Removes the options trait from the specified parameter.
+    """Removes the Options trait from the specified parameter.
 
     Args:
-        node: The node from which to remove the options trait.
-        parameter_name: The name of the parameter from which to remove the `Options` trait.
+        node: The node containing the parameter to update.
+        parameter_name: The name of the parameter to remove the Options trait from.
     """
     parameter = node.get_parameter_by_name(parameter_name)
     if parameter is not None:
-        trait = parameter.find_element_by_id("Options")
-        if trait and isinstance(trait, Options):
+        # Find the Options trait by type since element_id is a UUID
+        traits = parameter.find_elements_by_type(Options)
+        if traits:
+            trait = traits[0]  # Take the first Options trait
             parameter.remove_trait(trait)
+        else:
+            msg = f"No Options trait found for parameter '{parameter_name}'."
+            raise ValueError(msg)
     else:
         msg = f"Parameter '{parameter_name}' not found for removing options trait."
         raise ValueError(msg)

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -371,8 +371,23 @@ class BaseNodeElement:
         return event_data
 
 
-@dataclass(kw_only=True)
-class ParameterMessage(BaseNodeElement):
+class UIOptionsMixin:
+    """Mixin providing UI options update functionality for classes with ui_options."""
+
+    def update_ui_options_key(self, key: str, value: Any) -> None:
+        """Update a single UI option key."""
+        ui_options = self.ui_options
+        ui_options[key] = value
+        self.ui_options = ui_options
+
+    def update_ui_options(self, updates: dict[str, Any]) -> None:
+        """Update multiple UI options at once."""
+        ui_options = self.ui_options
+        ui_options.update(updates)
+        self.ui_options = ui_options
+
+
+class ParameterMessage(BaseNodeElement, UIOptionsMixin):
     """Represents a UI message element, such as a warning or informational text."""
 
     # Define default titles as a class-level constant
@@ -518,8 +533,7 @@ class ParameterMessage(BaseNodeElement):
         return event_data
 
 
-@dataclass(kw_only=True)
-class ParameterGroup(BaseNodeElement):
+class ParameterGroup(BaseNodeElement, UIOptionsMixin):
     """UI element for a group of parameters."""
 
     ui_options: dict = field(default_factory=dict)
@@ -630,7 +644,7 @@ class ParameterBase(BaseNodeElement, ABC):
         pass
 
 
-class Parameter(BaseNodeElement):
+class Parameter(BaseNodeElement, UIOptionsMixin):
     # This is the list of types that the Parameter can accept, either externally or when internally treated as a property.
     # Today, we can accept multiple types for input, but only a single output type.
     tooltip: str | list[dict]  # Default tooltip, can be string or list of dicts

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -367,8 +367,10 @@ class BaseNode(ABC):
         """
         parameter = self.get_parameter_by_name(param)
         if parameter is not None:
-            trait = parameter.find_element_by_id("Options")
-            if trait and isinstance(trait, Options):
+            # Find the Options trait by type since element_id is a UUID
+            traits = parameter.find_elements_by_type(Options)
+            if traits:
+                trait = traits[0]  # Take the first Options trait
                 trait.choices = choices
 
                 if default in choices:
@@ -377,6 +379,16 @@ class BaseNode(ABC):
                 else:
                     msg = f"Default model '{default}' is not in the provided choices."
                     raise ValueError(msg)
+
+                # Update the manually set UI options to include the new simple_dropdown
+                if hasattr(parameter, "_ui_options") and parameter._ui_options:
+                    parameter._ui_options["simple_dropdown"] = choices
+
+                    # Force the parameter to emit an update event to refresh UI options
+                    parameter._emit_alter_element_event_if_possible()
+            else:
+                msg = f"No Options trait found for parameter '{param}'."
+                raise ValueError(msg)
         else:
             msg = f"Parameter '{param}' not found for updating model choices."
             raise ValueError(msg)
@@ -392,9 +404,14 @@ class BaseNode(ABC):
         """
         parameter = self.get_parameter_by_name(param)
         if parameter is not None:
-            trait = parameter.find_element_by_id("Options")
-            if trait and isinstance(trait, Options):
+            # Find the Options trait by type since element_id is a UUID
+            traits = parameter.find_elements_by_type(Options)
+            if traits:
+                trait = traits[0]  # Take the first Options trait
                 parameter.remove_trait(trait)
+            else:
+                msg = f"No Options trait found for parameter '{param}'."
+                raise ValueError(msg)
         else:
             msg = f"Parameter '{param}' not found for removing options trait."
             raise ValueError(msg)


### PR DESCRIPTION
Fixes dynamic Options trait updates and adds reusable mixin for UI options management.

## Key Changes

Fixed Options Trait Finding
* Issue: find_element_by_id("Options") failed due to UUID element_ids
* Fix: Changed to find_elements_by_type(Options) in _update_option_choices and utility functions

Enhanced `_update_option_choices`
* Added: Automatic simple_dropdown updates in parameter._ui_options
* Added: _emit_alter_element_event_if_possible() to trigger UI refresh
* Result: simple_dropdown now updates automatically when Options trait choices change

Added UIOptionsMixin
* New: Reusable mixin with update_ui_options_key() and update_ui_options() methods
* Applied: To ParameterMessage, ParameterGroup, Parameter classes
* Benefit: Eliminates code duplication, consistent interface
