### PR TITLE
Maintain parity with existing control display names without changing underlying parameter names.

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1071,7 +1071,7 @@ class ControlParameterInput(ControlParameter):
         self,
         tooltip: str | list[dict] = "Connection from previous node in the execution chain",
         name: str = "exec_in",
-        display_name: str = "Flow In",
+        display_name: str | None = "Flow In",
         tooltip_as_input: str | list[dict] | None = None,
         tooltip_as_property: str | list[dict] | None = None,
         tooltip_as_output: str | list[dict] | None = None,
@@ -1083,7 +1083,11 @@ class ControlParameterInput(ControlParameter):
     ):
         allowed_modes = {ParameterMode.INPUT}
         input_types = [ParameterTypeBuiltin.CONTROL_TYPE.value]
-        ui_options = {"display_name": display_name}
+        
+        if display_name is None:
+            ui_options = None
+        else:
+            ui_options = {"display_name": display_name}
 
         # Call parent with a few explicit tweaks.
         super().__init__(
@@ -1108,7 +1112,7 @@ class ControlParameterOutput(ControlParameter):
         self,
         tooltip: str | list[dict] = "Connection to the next node in the execution chain",
         name: str = "exec_out",
-        display_name: str = "Flow Out",
+        display_name: str | None = "Flow Out",
         tooltip_as_input: str | list[dict] | None = None,
         tooltip_as_property: str | list[dict] | None = None,
         tooltip_as_output: str | list[dict] | None = None,
@@ -1120,7 +1124,11 @@ class ControlParameterOutput(ControlParameter):
     ):
         allowed_modes = {ParameterMode.OUTPUT}
         output_type = ParameterTypeBuiltin.CONTROL_TYPE.value
-        ui_options = {"display_name": display_name}
+        
+        if display_name is None:
+            ui_options = None
+        else:
+            ui_options = {"display_name": display_name}
 
         # Call parent with a few explicit tweaks.
         super().__init__(

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1040,6 +1040,7 @@ class ControlParameter(Parameter, ABC):
         traits: set[Trait.__class__ | Trait] | None = None,
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
+        ui_options: dict | None = None,
         *,
         user_defined: bool = False,
     ):
@@ -1059,6 +1060,7 @@ class ControlParameter(Parameter, ABC):
             traits=traits,
             converters=converters,
             validators=validators,
+            ui_options=ui_options,
             user_defined=user_defined,
             element_type=self.__class__.__name__,
         )
@@ -1069,6 +1071,7 @@ class ControlParameterInput(ControlParameter):
         self,
         tooltip: str | list[dict] = "Connection from previous node in the execution chain",
         name: str = "exec_in",
+        display_name: str = "Flow In",
         tooltip_as_input: str | list[dict] | None = None,
         tooltip_as_property: str | list[dict] | None = None,
         tooltip_as_output: str | list[dict] | None = None,
@@ -1080,6 +1083,7 @@ class ControlParameterInput(ControlParameter):
     ):
         allowed_modes = {ParameterMode.INPUT}
         input_types = [ParameterTypeBuiltin.CONTROL_TYPE.value]
+        ui_options = {"display_name": display_name}
 
         # Call parent with a few explicit tweaks.
         super().__init__(
@@ -1094,6 +1098,7 @@ class ControlParameterInput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
+            ui_options=ui_options,
             user_defined=user_defined,
         )
 
@@ -1103,6 +1108,7 @@ class ControlParameterOutput(ControlParameter):
         self,
         tooltip: str | list[dict] = "Connection to the next node in the execution chain",
         name: str = "exec_out",
+        display_name: str = "Flow Out",
         tooltip_as_input: str | list[dict] | None = None,
         tooltip_as_property: str | list[dict] | None = None,
         tooltip_as_output: str | list[dict] | None = None,
@@ -1114,6 +1120,7 @@ class ControlParameterOutput(ControlParameter):
     ):
         allowed_modes = {ParameterMode.OUTPUT}
         output_type = ParameterTypeBuiltin.CONTROL_TYPE.value
+        ui_options = {"display_name": display_name}
 
         # Call parent with a few explicit tweaks.
         super().__init__(
@@ -1128,6 +1135,7 @@ class ControlParameterOutput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
+            ui_options=ui_options,
             user_defined=user_defined,
         )
 

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1083,7 +1083,7 @@ class ControlParameterInput(ControlParameter):
     ):
         allowed_modes = {ParameterMode.INPUT}
         input_types = [ParameterTypeBuiltin.CONTROL_TYPE.value]
-        
+
         if display_name is None:
             ui_options = None
         else:
@@ -1124,7 +1124,7 @@ class ControlParameterOutput(ControlParameter):
     ):
         allowed_modes = {ParameterMode.OUTPUT}
         output_type = ParameterTypeBuiltin.CONTROL_TYPE.value
-        
+
         if display_name is None:
             ui_options = None
         else:


### PR DESCRIPTION
Fixes #1721 

Today, the editor is hard-coding "Flow In" and "Flow Out" and not using the parameter `name` field. 

If we were to flip the editor to always use the parameter `name` field, all control ports would switch to `exec_in` and `exec_out` which isn't very appealing to look at, but would be consistent.

If we were to then change all of our control port parameter names from "exec_in" and "exec_out" to "Flow In" and "Flow Out", all existing flows that used the control ports would break.

The editor does, however, respect the `display_name` field if passed as a ui_option. This change defaults Control In and Control Out to have "Flow In" and "Flow Out" specified as a display name. If the user doesn't specify those, we will be updating the editor to display the parameter name again and get rid of the hardcoding.