### PR TITLE
Modify Workflow Tests

### DIFF
--- a/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
+++ b/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
@@ -3,15 +3,15 @@
 #
 # [tool.griptape-nodes]
 # name = "compare_prompts"
-# schema_version = "0.4.0"
-# engine_version_created_with = "0.41.0"
+# schema_version = "0.6.1"
+# engine_version_created_with = "0.43.1"
 # node_libraries_referenced = [["Griptape Nodes Library", "0.41.0"]]
 # description = "See how 3 different approaches to prompts affect image generation."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_compare_prompts.webp"
 # is_griptape_provided = true
 # is_template = true
 # creation_date = 2025-05-01T01:00:00.000000+00:00
-# last_modified_date = 2025-07-07T13:38:11.127592-07:00
+# last_modified_date = 2025-08-01T14:07:31.729030-07:00
 #
 # ///
 
@@ -53,34 +53,38 @@ if not context_manager.has_current_workflow():
    would be difficult to serialize.
 """
 top_level_unique_values_dict = {
-    "f8c9f713-3d05-4ea0-900a-c5e9136edde7": pickle.loads(
+    "625fb631-4e7d-46de-beb3-377daaf2f54f": pickle.loads(
         b'\x80\x04\x95\xbf\x01\x00\x00\x00\x00\x00\x00X\xb8\x01\x00\x00This workflow serves as the lesson material for the tutorial located at:\n\nhttps://docs.griptapenodes.com/en/stable/ftue/03_compare_prompts/FTUE_03_compare_prompts/\n\nThe concepts covered are:\n\n- How to use one TextInput node to feed to multiple other inputs\n- Different approaches to prompt engineering\n- The GenerateImage "Enhance Prompt" feature and how it works behind the scenes\n- Comparing the results of different prompting techniques\n\x94.'
     ),
-    "8b76f498-6c37-4f08-8394-8dfa44698f17": pickle.loads(
+    "8f23b4aa-f0df-4677-bdea-b580fca4b0d9": pickle.loads(
         b"\x80\x04\x95\xf9\x00\x00\x00\x00\x00\x00\x00\x8c\xf5If you're following along with our Getting Started tutorials, check out the next suggested template: Photography_Team.\n\nLoad the next tutorial page here:\nhttps://docs.griptapenodes.com/en/stable/ftue/04_photography_team/FTUE_04_photography_team/\x94."
     ),
-    "a61dfec1-ae9f-4413-9d85-954b57438a54": pickle.loads(
+    "83428258-61af-4336-8b55-135a34cf660c": pickle.loads(
         b"\x80\x04\x95\xcf\x01\x00\x00\x00\x00\x00\x00X\xc8\x01\x00\x00Enhance the following prompt for an image generation engine. Return only the image generation prompt.\nInclude unique details that make the subject stand out.\nSpecify a specific depth of field, and time of day.\nUse dust in the air to create a sense of depth.\nUse a slight vignetting on the edges of the image.\nUse a color palette that is complementary to the subject.\nFocus on qualities that will make this the most professional looking photo in the world.\n\x94."
     ),
-    "1c8e89e3-370a-4287-86a4-d2022ba244d6": pickle.loads(
-        b"\x80\x04\x95#\x00\x00\x00\x00\x00\x00\x00\x8c\x1fA capybara eating with utensils\x94."
+    "5ed879bb-20cf-4479-815d-c9915fbd262b": pickle.loads(
+        b"\x80\x04\x95'\x00\x00\x00\x00\x00\x00\x00\x8c#A capybara eating soup with a spoon\x94."
     ),
-    "0d853469-86a3-4494-97ba-633657f9508e": pickle.loads(
+    "8fcd5bef-f968-40c7-ae47-f48517885ad0": pickle.loads(
         b"\x80\x04\x95\x08\x00\x00\x00\x00\x00\x00\x00\x8c\x04\\n\\n\x94."
     ),
-    "fd1e4b05-2e4a-4972-953d-78ea33041b09": pickle.loads(b"\x80\x04\x89."),
-    "b809636d-09a6-4259-b903-53d44eda0d0b": pickle.loads(
+    "844bc3fe-3f08-4d8a-bd48-147d2899a8c5": pickle.loads(b"\x80\x04\x89."),
+    "a0a5d21b-2a86-420f-b337-63577863f06e": pickle.loads(
         b"\x80\x04\x95\xf9\x00\x00\x00\x00\x00\x00\x00}\x94(\x8c\x04type\x94\x8c\rImageArtifact\x94\x8c\x02id\x94\x8c a1d85e8dfa5745b7a39be55cca4660fb\x94\x8c\treference\x94N\x8c\x04meta\x94}\x94(\x8c\x05model\x94\x8c\x08dall-e-3\x94\x8c\x06prompt\x94\x8c\x1fA capybara eating with utensils\x94u\x8c\x04name\x94\x8c$image_artifact_250411205314_ll63.png\x94\x8c\x05value\x94\x8c\x00\x94\x8c\x06format\x94\x8c\x03png\x94\x8c\x05width\x94M\x00\x04\x8c\x06height\x94M\x00\x04u."
     ),
-    "c19c655b-0e1b-4a91-9803-a80461e956f9": pickle.loads(b"\x80\x04\x88."),
-    "de286745-1f22-4914-85af-425fb857cd7d": pickle.loads(
+    "7dde7f2d-5a54-47dd-b2fe-3240cf0950d7": pickle.loads(b"\x80\x04\x88."),
+    "8523d769-1401-4450-ab15-0c022cfefad9": pickle.loads(
         b"\x80\x04\x95\x0b\x00\x00\x00\x00\x00\x00\x00\x8c\x07gpt-4.1\x94."
     ),
-    "dc7015b3-00a2-4c8a-a247-16d18dd72e26": pickle.loads(b"\x80\x04]\x94."),
-    "e7d259cf-ceba-411c-af5c-0527191a7044": pickle.loads(b"\x80\x04]\x94."),
+    "b916be58-243a-4717-b9e5-779f37b98469": pickle.loads(b"\x80\x04]\x94."),
+    "c1f87d01-c9b7-4c88-a03d-833e9bea8e43": pickle.loads(b"\x80\x04]\x94."),
 }
 
-flow0_name = GriptapeNodes.handle_request(CreateFlowRequest(parent_flow_name=None)).flow_name
+"# Create the Flow, then do work within it as context."
+
+flow0_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, set_as_new_context=False, metadata={})
+).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow0_name):
     node0_name = GriptapeNodes.handle_request(
@@ -317,264 +321,246 @@ with GriptapeNodes.ContextManager().flow(flow0_name):
         GriptapeNodes.handle_request(
             AlterParameterDetailsRequest(parameter_name="prompt", mode_allowed_property=False, initial_setup=True)
         )
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node5_name,
-        source_parameter_name="exec_out",
-        target_node_name=node6_name,
-        target_parameter_name="exec_in",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node2_name,
-        source_parameter_name="text",
-        target_node_name=node4_name,
-        target_parameter_name="input_1",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node6_name,
-        source_parameter_name="exec_out",
-        target_node_name=node7_name,
-        target_parameter_name="exec_in",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node7_name,
-        source_parameter_name="exec_out",
-        target_node_name=node8_name,
-        target_parameter_name="exec_in",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node7_name,
-        source_parameter_name="output",
-        target_node_name=node8_name,
-        target_parameter_name="prompt",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node4_name,
-        source_parameter_name="output",
-        target_node_name=node7_name,
-        target_parameter_name="prompt",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node3_name,
-        source_parameter_name="text",
-        target_node_name=node4_name,
-        target_parameter_name="input_2",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node3_name,
-        source_parameter_name="text",
-        target_node_name=node6_name,
-        target_parameter_name="prompt",
-        initial_setup=True,
-    )
-)
-
-GriptapeNodes.handle_request(
-    CreateConnectionRequest(
-        source_node_name=node3_name,
-        source_parameter_name="text",
-        target_node_name=node5_name,
-        target_parameter_name="prompt",
-        initial_setup=True,
-    )
-)
-
-with GriptapeNodes.ContextManager().node(node0_name):
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="note",
-            node_name=node0_name,
-            value=top_level_unique_values_dict["f8c9f713-3d05-4ea0-900a-c5e9136edde7"],
+        CreateConnectionRequest(
+            source_node_name=node5_name,
+            source_parameter_name="exec_out",
+            target_node_name=node6_name,
+            target_parameter_name="exec_in",
             initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node1_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="note",
-            node_name=node1_name,
-            value=top_level_unique_values_dict["8b76f498-6c37-4f08-8394-8dfa44698f17"],
-            initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node2_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="text",
-            node_name=node2_name,
-            value=top_level_unique_values_dict["a61dfec1-ae9f-4413-9d85-954b57438a54"],
-            initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node3_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="text",
-            node_name=node3_name,
-            value=top_level_unique_values_dict["1c8e89e3-370a-4287-86a4-d2022ba244d6"],
-            initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node4_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="input_1",
-            node_name=node4_name,
-            value=top_level_unique_values_dict["a61dfec1-ae9f-4413-9d85-954b57438a54"],
-            initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="input_2",
-            node_name=node4_name,
-            value=top_level_unique_values_dict["1c8e89e3-370a-4287-86a4-d2022ba244d6"],
+        CreateConnectionRequest(
+            source_node_name=node2_name,
+            source_parameter_name="text",
+            target_node_name=node4_name,
+            target_parameter_name="input_1",
             initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="merge_string",
-            node_name=node4_name,
-            value=top_level_unique_values_dict["0d853469-86a3-4494-97ba-633657f9508e"],
+        CreateConnectionRequest(
+            source_node_name=node6_name,
+            source_parameter_name="exec_out",
+            target_node_name=node7_name,
+            target_parameter_name="exec_in",
             initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node5_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="prompt",
-            node_name=node5_name,
-            value=top_level_unique_values_dict["1c8e89e3-370a-4287-86a4-d2022ba244d6"],
-            initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="enhance_prompt",
-            node_name=node5_name,
-            value=top_level_unique_values_dict["fd1e4b05-2e4a-4972-953d-78ea33041b09"],
+        CreateConnectionRequest(
+            source_node_name=node7_name,
+            source_parameter_name="exec_out",
+            target_node_name=node8_name,
+            target_parameter_name="exec_in",
             initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="output",
-            node_name=node5_name,
-            value=top_level_unique_values_dict["b809636d-09a6-4259-b903-53d44eda0d0b"],
+        CreateConnectionRequest(
+            source_node_name=node7_name,
+            source_parameter_name="output",
+            target_node_name=node8_name,
+            target_parameter_name="prompt",
             initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node6_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="prompt",
-            node_name=node6_name,
-            value=top_level_unique_values_dict["1c8e89e3-370a-4287-86a4-d2022ba244d6"],
-            initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="enhance_prompt",
-            node_name=node6_name,
-            value=top_level_unique_values_dict["c19c655b-0e1b-4a91-9803-a80461e956f9"],
+        CreateConnectionRequest(
+            source_node_name=node4_name,
+            source_parameter_name="output",
+            target_node_name=node7_name,
+            target_parameter_name="prompt",
             initial_setup=True,
-            is_output=False,
-        )
-    )
-
-with GriptapeNodes.ContextManager().node(node7_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="model",
-            node_name=node7_name,
-            value=top_level_unique_values_dict["de286745-1f22-4914-85af-425fb857cd7d"],
-            initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="tools",
-            node_name=node7_name,
-            value=top_level_unique_values_dict["dc7015b3-00a2-4c8a-a247-16d18dd72e26"],
+        CreateConnectionRequest(
+            source_node_name=node3_name,
+            source_parameter_name="text",
+            target_node_name=node4_name,
+            target_parameter_name="input_2",
             initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="rulesets",
-            node_name=node7_name,
-            value=top_level_unique_values_dict["e7d259cf-ceba-411c-af5c-0527191a7044"],
+        CreateConnectionRequest(
+            source_node_name=node3_name,
+            source_parameter_name="text",
+            target_node_name=node6_name,
+            target_parameter_name="prompt",
             initial_setup=True,
-            is_output=False,
         )
     )
     GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="include_details",
-            node_name=node7_name,
-            value=top_level_unique_values_dict["fd1e4b05-2e4a-4972-953d-78ea33041b09"],
+        CreateConnectionRequest(
+            source_node_name=node3_name,
+            source_parameter_name="text",
+            target_node_name=node5_name,
+            target_parameter_name="prompt",
             initial_setup=True,
-            is_output=False,
         )
     )
-
-with GriptapeNodes.ContextManager().node(node8_name):
-    GriptapeNodes.handle_request(
-        SetParameterValueRequest(
-            parameter_name="enhance_prompt",
-            node_name=node8_name,
-            value=top_level_unique_values_dict["fd1e4b05-2e4a-4972-953d-78ea33041b09"],
-            initial_setup=True,
-            is_output=False,
+    with GriptapeNodes.ContextManager().node(node0_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="note",
+                node_name=node0_name,
+                value=top_level_unique_values_dict["625fb631-4e7d-46de-beb3-377daaf2f54f"],
+                initial_setup=True,
+                is_output=False,
+            )
         )
-    )
+    with GriptapeNodes.ContextManager().node(node1_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="note",
+                node_name=node1_name,
+                value=top_level_unique_values_dict["8f23b4aa-f0df-4677-bdea-b580fca4b0d9"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node2_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="text",
+                node_name=node2_name,
+                value=top_level_unique_values_dict["83428258-61af-4336-8b55-135a34cf660c"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node3_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="text",
+                node_name=node3_name,
+                value=top_level_unique_values_dict["5ed879bb-20cf-4479-815d-c9915fbd262b"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node4_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="input_1",
+                node_name=node4_name,
+                value=top_level_unique_values_dict["83428258-61af-4336-8b55-135a34cf660c"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="input_2",
+                node_name=node4_name,
+                value=top_level_unique_values_dict["5ed879bb-20cf-4479-815d-c9915fbd262b"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="merge_string",
+                node_name=node4_name,
+                value=top_level_unique_values_dict["8fcd5bef-f968-40c7-ae47-f48517885ad0"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node5_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=node5_name,
+                value=top_level_unique_values_dict["5ed879bb-20cf-4479-815d-c9915fbd262b"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="enhance_prompt",
+                node_name=node5_name,
+                value=top_level_unique_values_dict["844bc3fe-3f08-4d8a-bd48-147d2899a8c5"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="output",
+                node_name=node5_name,
+                value=top_level_unique_values_dict["a0a5d21b-2a86-420f-b337-63577863f06e"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node6_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=node6_name,
+                value=top_level_unique_values_dict["5ed879bb-20cf-4479-815d-c9915fbd262b"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="enhance_prompt",
+                node_name=node6_name,
+                value=top_level_unique_values_dict["7dde7f2d-5a54-47dd-b2fe-3240cf0950d7"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node7_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="model",
+                node_name=node7_name,
+                value=top_level_unique_values_dict["8523d769-1401-4450-ab15-0c022cfefad9"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="tools",
+                node_name=node7_name,
+                value=top_level_unique_values_dict["b916be58-243a-4717-b9e5-779f37b98469"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="rulesets",
+                node_name=node7_name,
+                value=top_level_unique_values_dict["c1f87d01-c9b7-4c88-a03d-833e9bea8e43"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="include_details",
+                node_name=node7_name,
+                value=top_level_unique_values_dict["844bc3fe-3f08-4d8a-bd48-147d2899a8c5"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(node8_name):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="enhance_prompt",
+                node_name=node8_name,
+                value=top_level_unique_values_dict["844bc3fe-3f08-4d8a-bd48-147d2899a8c5"],
+                initial_setup=True,
+                is_output=False,
+            )
+        )

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -84,6 +85,8 @@ def clear_state_before_each_test() -> Generator[None, Any, None]:
     # Clean up after test
     clear_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
     GriptapeNodes.handle_request(clear_request)
+    # Wait 5 seconds between tests to prevent rate limiting.
+    time.sleep(5)
 
 
 @pytest.mark.parametrize("workflow_path", get_workflows())


### PR DESCRIPTION
- Added 5 second wait between running each test to prevent rate limiting. 
- Changed the prompt for compare_prompts (I am concerned that the safety warning was because of the word "knife"), so I made it a bit more family friendly. 

The two main repeating issues are rate limits, and safety warnings in compare_prompts. 