### PR TITLE
Allow setting settable during save/load

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -641,7 +641,11 @@ class Parameter(BaseNodeElement):
     tooltip_as_input: str | list[dict] | None = None
     tooltip_as_property: str | list[dict] | None = None
     tooltip_as_output: str | list[dict] | None = None
+
+    # "settable" here means whether it can be assigned to during regular business operation.
+    # During save/load, this value IS still serialized to save its proper state.
     settable: bool = True
+
     user_defined: bool = False
     _allowed_modes: set = field(
         default_factory=lambda: {

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1435,8 +1435,8 @@ class NodeManager:
             result = SetParameterValueResultFailure()
             return result
 
-        # Validate that parameters can be set at all
-        if not parameter.settable:
+        # Validate that parameters can be set at all (note: we want the value to be set during initial setup, but not after)
+        if not parameter.settable and not request.initial_setup:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because that Parameter was flagged as not settable."
             logger.error(details)
             result = SetParameterValueResultFailure()


### PR DESCRIPTION
Fixes #1795 

Clarified that `settable` only stops the value from being changed during regular operation. Save/load still serializes it properly.