### PR TITLE
Add a connectivity check

### DIFF
--- a/src/griptape_nodes/__init__.py
+++ b/src/griptape_nodes/__init__.py
@@ -660,7 +660,7 @@ def _get_latest_version(package: str, install_source: str) -> str:
     if install_source == "pypi":
         update_url = PYPI_UPDATE_URL.format(package=package)
 
-        with httpx.Client() as client:
+        with httpx.Client(timeout=30.0) as client:
             # First check for connection issues before status issues
             response = _access_update_url(update_url, client)
             if not response:
@@ -668,7 +668,8 @@ def _get_latest_version(package: str, install_source: str) -> str:
             try:
                 response.raise_for_status()
                 data = response.json()
-                version = f"v{data['info']['version']}"
+                if "info" in data and "version" in data["info"]:
+                    version = f"v{data['info']['version']}"
             except httpx.HTTPStatusError as e:
                 console.print(f"[red]Error fetching latest version: {e}[/red]")
     elif install_source == "git":
@@ -676,7 +677,7 @@ def _get_latest_version(package: str, install_source: str) -> str:
         revision = LATEST_TAG
         update_url = GITHUB_UPDATE_URL.format(package=package, revision=revision)
 
-        with httpx.Client() as client:
+        with httpx.Client(timeout=30.0) as client:
             # First check for connection issues before status issues
             response = _access_update_url(update_url, client)
             if not response:

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -263,7 +263,7 @@ def _process_event_queue() -> None:
     timed_out = ws_ready_event.wait(timeout=15)
     if not timed_out:
         console.print(
-            "[red] The connection to the websocket timed out. Please check your internet connection and the status of Griptape Nodes API.[/red]"
+            "[red] The connection to the websocket timed out. Please check your internet connection or the status of Griptape Nodes API.[/red]"
         )
         sys.exit(1)
     while True:

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -262,7 +262,9 @@ def _process_event_queue() -> None:
     # Wait for WebSocket connection to be established before processing events
     timed_out = ws_ready_event.wait(timeout=15)
     if not timed_out:
-        console.print("[red] The connection to the websocket timed out. Please check your internet connection and the status of Griptape Nodes API.[/red]")
+        console.print(
+            "[red] The connection to the websocket timed out. Please check your internet connection and the status of Griptape Nodes API.[/red]"
+        )
         sys.exit(1)
     while True:
         event = event_queue.get(block=True)

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -6,6 +6,12 @@ import importlib.metadata
 import json
 from typing import Literal
 
+import httpx
+from httpx import Response
+from rich.console import Console
+
+console = Console()
+
 engine_version = importlib.metadata.version("griptape_nodes")
 
 
@@ -49,3 +55,76 @@ def get_complete_version_string() -> str:
     if commit_id is None:
         return f"{version} ({source})"
     return f"{version} ({source} - {commit_id})"
+
+
+def access_update_url(update_url: str, client: httpx.Client) -> Response | None:
+    """Small helper to reduce repetitive code for error handling."""
+    try:
+        response = client.get(update_url)
+    except httpx.RequestError as e:
+        console.print(f"[red]Error fetching latest version due to error: [/red][cyan]{e}[/cyan]")
+        console.print(
+            f"[red]Please check your internet connection or if you can access the following update url: [/red] [cyan]{update_url}[/cyan]"
+        )
+        return None
+    else:
+        return response
+
+
+def get_latest_version_pypi(package: str, pypi_url: str) -> str:
+    """Gets the latest version from PyPI.
+
+    Args:
+        package: The name of the package to fetch the latest version for.
+        pypi_url: The PyPI URL template to use.
+
+    Returns:
+        str: Latest release tag (e.g., "v0.31.4") or current version if fetch fails.
+    """
+    version = get_current_version()
+    update_url = pypi_url.format(package=package)
+
+    with httpx.Client(timeout=30.0) as client:
+        response = access_update_url(update_url, client)
+        if not response:
+            return version
+        try:
+            response.raise_for_status()
+            data = response.json()
+            if "info" in data and "version" in data["info"]:
+                version = f"v{data['info']['version']}"
+        except httpx.HTTPStatusError as e:
+            console.print(f"[red]Error fetching latest version: {e}[/red]")
+
+    return version
+
+
+def get_latest_version_git(package: str, github_url: str, latest_tag: str) -> str:
+    """Gets the latest version from Git.
+
+    Args:
+        package: The name of the package to fetch the latest version for.
+        github_url: The GitHub URL template to use.
+        latest_tag: The tag to fetch (usually 'latest').
+
+    Returns:
+        str: Latest commit SHA (first 7 characters) or current version if fetch fails.
+    """
+    version = get_current_version()
+    revision = latest_tag
+    update_url = github_url.format(package=package, revision=revision)
+
+    with httpx.Client(timeout=30.0) as client:
+        response = access_update_url(update_url, client)
+        if not response:
+            return version
+
+        try:
+            response.raise_for_status()
+            data = response.json()
+            if "object" in data and "sha" in data["object"]:
+                version = data["object"]["sha"][:7]
+        except httpx.HTTPStatusError as e:
+            console.print(f"[red]Error fetching latest version: {e}[/red]")
+
+    return version

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -15,7 +15,6 @@ def get_current_version() -> str:
 
 
 def get_install_source() -> tuple[Literal["git", "file", "pypi"], str | None]:
-    return ("git", None)
     """Determines the install source of the Griptape Nodes package.
 
     Returns:

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -15,6 +15,7 @@ def get_current_version() -> str:
 
 
 def get_install_source() -> tuple[Literal["git", "file", "pypi"], str | None]:
+    return ("git", None)
     """Determines the install source of the Griptape Nodes package.
 
     Returns:


### PR DESCRIPTION
Instead of hanging or providing a lengthy traceback, a simple connectivity check gives a friendly error message to users who are experiencing internet connection issues.