### PR TITLE
Add __bool__ to ParameterContainer to prevent falsey failure freakouts.

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1219,6 +1219,23 @@ class ParameterContainer(Parameter, ABC):
             element_type=element_type,
         )
 
+    def __bool__(self) -> bool:
+        """Parameter containers are always truthy, even when empty.
+
+        This overrides Python's default truthiness behavior for containers with __len__().
+        By default, Python makes objects with __len__() falsy when len() == 0, which
+        caused bugs where empty ParameterList/ParameterDictionary objects would fail
+        'if param' checks and fall back to stale cached values instead of computing
+        fresh empty results.
+
+        Unlike standard Python containers, ParameterContainer objects represent
+        parameter structure/definitions rather than just data, so they remain
+        meaningful even when empty.
+
+        See: https://github.com/griptape-ai/griptape-nodes/issues/1799
+        """
+        return True
+
     @abstractmethod
     def add_child_parameter(self) -> Parameter:
         pass

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -576,7 +576,7 @@ class BaseNode(ABC):
         param = self.get_parameter_by_name(param_name)
         if param and isinstance(param, ParameterContainer):
             value = handle_container_parameter(self, param)
-            if value:
+            if value is not None:
                 return value
         if param_name in self.parameter_values:
             return self.parameter_values[param_name]


### PR DESCRIPTION
Fixes #1799 

ParameterContainers have a `__len__` override that, if it had zero children, would cause the object to behave as a falsey value. This caused checks like `if param` to return `False` when the container was empty. If the object implements `__bool__()`, this will countermand the falsey behavior. We want this as the empty container is still valid as an object.