### PR TITLE
fix: preserve branched_from metadata during workflow rename

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1302,6 +1302,15 @@ class WorkflowManager:
             prior_workflow = WorkflowRegistry.get_workflow_by_name(file_name)
             # We'll use its creation date.
             creation_date = prior_workflow.metadata.creation_date
+        elif file_name:
+            # If no prior workflow exists for the new name, check if there's a current workflow
+            # context (e.g., during rename operations) to preserve metadata from
+            context_manager = GriptapeNodes.ContextManager()
+            if context_manager.has_current_workflow():
+                current_workflow_name = context_manager.get_current_workflow_name()
+                if current_workflow_name and WorkflowRegistry.has_workflow_with_name(current_workflow_name):
+                    prior_workflow = WorkflowRegistry.get_workflow_by_name(current_workflow_name)
+                    creation_date = prior_workflow.metadata.creation_date
 
         if (creation_date is None) or (creation_date == WorkflowManager.EPOCH_START):
             # Either a new workflow, or a backcompat situation.


### PR DESCRIPTION
The workflow rename operation was losing the branched_from metadata because the save process looked for an existing workflow with the new name instead of preserving metadata from the original workflow.

This fix modifies on_save_workflow_request to check for a current workflow context when no prior workflow exists for the new name, ensuring that metadata (including branched_from) is preserved during rename operations.