### PR TITLE
fix: use correct imports

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/utils/option_utils.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/utils/option_utils.py
@@ -1,5 +1,5 @@
-from griptape_nodes.exe_types.core_types import BaseNode
-from griptape_nodes.exe_types.node_types import Options
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.traits.options import Options
 
 
 def update_option_choices(node: BaseNode, parameter_name: str, choices: list[str], default: str) -> None:


### PR DESCRIPTION
```
[08/05/25 20:51:24] INFO     Installing dependencies for library 'Griptape Nodes Library' with pip in venv at
                             C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_library\.venv
[08/05/25 20:51:25] INFO     Successfully loaded Library 'Griptape Nodes Library' from JSON file at
                             C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_library\griptape_nodes_library.json
                    INFO     Installing dependencies for library 'Griptape Nodes Advanced Media Library' with pip in
                             venv at C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\.venv
[08/05/25 20:51:29] ERROR    Attempted to load node 'DepthAnythingForDepthEstimationImage' from
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\transformers
                             _nodes_library\depth_anything_for_depth_estimation_image.py'. Failed because an exception
                             occurred: Attempted to load class 'DepthAnythingForDepthEstimationImage'. Error: Module at
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\transformers
                             _nodes_library\depth_anything_for_depth_estimation_image.py' failed to load with error:
                             cannot import name 'BaseNode' from 'griptape_nodes.exe_types.core_types'
                             (C:\Users\nab-demo\AppData\Roaming\uv\tools\griptape-nodes\Lib\site-packages\griptape_node
                             s\exe_types\core_types.py)
[08/05/25 20:51:36] ERROR    Attempted to load node 'DinoSam2ImageDetector' from
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\dino_sam2_li
                             brary\dino_sam_2_image_detector.py'. Failed because an exception occurred: Attempted to
                             load class 'DinoSam2ImageDetector'. Error: Module at
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\dino_sam2_li
                             brary\dino_sam_2_image_detector.py' failed to load with error: cannot import name
                             'BaseNode' from 'griptape_nodes.exe_types.core_types'
                             (C:\Users\nab-demo\AppData\Roaming\uv\tools\griptape-nodes\Lib\site-packages\griptape_node
                             s\exe_types\core_types.py)
                    ERROR    Attempted to load node 'DepthAnythingForDepthEstimationVideo' from
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\transformers
                             _nodes_library\depth_anything_for_depth_estimation_video.py'. Failed because an exception
                             occurred: Attempted to load class 'DepthAnythingForDepthEstimationVideo'. Error: Module at
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\transformers
                             _nodes_library\depth_anything_for_depth_estimation_video.py' failed to load with error:
                             cannot import name 'BaseNode' from 'griptape_nodes.exe_types.core_types'
                             (C:\Users\nab-demo\AppData\Roaming\uv\tools\griptape-nodes\Lib\site-packages\griptape_node
                             s\exe_types\core_types.py)
                    ERROR    Attempted to load node 'DinoSam2VideoDetector' from
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\dino_sam2_li
                             brary\dino_sam_2_video_detector.py'. Failed because an exception occurred: Attempted to
                             load class 'DinoSam2VideoDetector'. Error: Module at
                             'C:\ProgramData\GriptapeNodes\libraries\griptape_nodes_advanced_media_library\dino_sam2_li
                             brary\dino_sam_2_video_detector.py' failed to load with error: cannot import name
                             'BaseNode' from 'griptape_nodes.exe_types.core_types'
                             (C:\Users\nab-demo\AppData\Roaming\uv\tools\griptape-nodes\Lib\site-packages\griptape_node
                             s\exe_types\core_types.py)
```