### PR TITLE
Do not unresolve a node that is actively resolving on param change

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1480,11 +1480,7 @@ class NodeManager:
                 return SetParameterValueResultFailure()
         if request.initial_setup is False and not request.is_output and modified:
             # Mark node as unresolved, broadcast an event
-            node.make_node_unresolved(
-                current_states_to_trigger_change_event=set(
-                    {NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
-                )
-            )
+            node.make_node_unresolved(current_states_to_trigger_change_event=set({NodeResolutionState.RESOLVED}))
             # Get the flow
             # Pass the value through!
             # Optional data_type parameter for internal handling!


### PR DESCRIPTION
Now that we fetch the params during resolution, we don't want to unresolve the node during resolution.

https://griptape-ai.slack.com/archives/C0876P576SG/p1754510568108759