### PR TITLE
fix: remove :sparkles: aesthetic :sparkles: urls

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
@@ -161,10 +161,6 @@ class LoadImage(DataNode):
         if not url:
             return None
 
-        # Strip query parameters (like ?t=123456 cache busters)
-        if "?" in url:
-            url = url.split("?")[0]
-
         return url
 
     def __init__(self, **kwargs) -> None:


### PR DESCRIPTION
This was removing non-aesthetic, but essential, presigned url info.