### PR TITLE
Eliminates the flood of error toasts that would appear when an engine reconnected 

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -886,7 +886,12 @@ class WorkflowManager:
             # See how our desired version compares against the actual library we (may) have.
             # See if the library exists.
             library_metadata_request = GetLibraryMetadataRequest(library=library_name)
-            library_metadata_result = GriptapeNodes.handle_request(library_metadata_request)
+            # NOTE: Per https://github.com/griptape-ai/griptape-vsl-gui/issues/1123, we
+            # generate a FLOOD of error messages here that can swamp the GUI. We'll call
+            # directly instead of the usual handle_request() path so we don't generate those.
+            library_metadata_result = GriptapeNodes.LibraryManager().get_library_metadata_request(
+                library_metadata_request
+            )
             if not isinstance(library_metadata_result, GetLibraryMetadataResultSuccess):
                 # Metadata failed to be found.
                 had_critical_error = True


### PR DESCRIPTION
Fixes https://github.com/griptape-ai/griptape-vsl-gui/issues/1123

Internally, when checking for workflow fitness, we would issue a `GetLibraryMetadataRequest` via `handle_request`. Any workflow that had a missing library would then generate a `GetLibraryMetadataResultFailure`, which would go to the GUI in a flood of toasts. This got exponentially worse the more workflows one had.

Now we call the LibraryManager directly instead of going through the `handle_request` during this process. This eliminates broadcasting the failure.