### PR TITLE
Change status emojis to ASCII

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/huggingface_model_parameter.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/huggingface_model_parameter.py
@@ -93,19 +93,18 @@ class HuggingFaceModelParameter(ABC):
     def get_help_message(self) -> str:
         download_commands = "\n".join([f"  - `{cmd}`" for cmd in self.get_download_commands()])
         return (
-            "📥 How to download the models:\n"
+            "How to download the models:\n"
             "1. Setup huggingface-cli as per our docs: https://docs.griptapenodes.com/en/stable/how_to/installs/hugging_face/ \n"
             "2. Download at least one model:\n"
             f"{download_commands}\n"
-            "3. Save, close, then open the again workflow. (❌ Do not just reload the page)\n"
+            "3. Save, close, then open the again workflow. ([red]X[/red] Do not just reload the page)\n"
             "\n"
-            "✅ If successful, you should see a dropdown with the available models.\n"
-            "❌ If not successful because download fails then check huggingface-cli docs.\n"
-            "❌ If not successful for some other reason then reach out to us on Discord or GitHub.\n"
+            "[green]OK[/green] If successful, you should see a dropdown with the available models.\n"
+            "[red]X[/red] If not successful because download fails then check huggingface-cli docs.\n"
+            "[red]X[/red] If not successful for some other reason then reach out to us on Discord or GitHub.\n"
             "\n"
             "Note: Currently this is the only supported method for downloading models. \n"
             "Hopefully this gets more intuitive (and customizable) soon!\n"
-            "- from ✊📼🍜 with ❤️\n"
         )
 
     @abstractmethod

--- a/libraries/griptape_nodes_advanced_media_library/openpose_nodes_library/huggingface_repo_file_parameter.py
+++ b/libraries/griptape_nodes_advanced_media_library/openpose_nodes_library/huggingface_repo_file_parameter.py
@@ -105,19 +105,18 @@ class HuggingFaceRepoFileParameter:
     def get_help_message(self) -> str:
         download_commands = "\n".join([f"  - `{cmd}`" for cmd in self.get_download_commands()])
         return (
-            "📥 How to download the OpenPose models:\n"
+            "How to download the OpenPose models:\n"
             "1. Setup huggingface-cli as per our docs: https://docs.griptapenodes.com/en/stable/how_to/installs/hugging_face/ \n"
             "2. Download at least one model:\n"
             f"{download_commands}\n"
-            "3. Save, close, then open the again workflow. (❌ Do not just reload the page)\n"
+            "3. Save, close, then open the again workflow. ([red]X[/red] Do not just reload the page)\n"
             "\n"
-            "✅ If successful, you should see a dropdown with the available models.\n"
-            "❌ If not successful because download fails then check huggingface-cli docs.\n"
-            "❌ If not successful for some other reason then reach out to us on Discord or GitHub.\n"
+            "[green]OK[/green] If successful, you should see a dropdown with the available models.\n"
+            "[red]X[/red] If not successful because download fails then check huggingface-cli docs.\n"
+            "[red]X[/red] If not successful for some other reason then reach out to us on Discord or GitHub.\n"
             "\n"
             "Note: Currently this is the only supported method for downloading models. \n"
             "Hopefully this gets more intuitive (and customizable) soon!\n"
-            "- from ✊📼🍜 with ❤️\n"
         )
 
     def _repo_file_revision_to_key(self, repo_file_revision: tuple[str, str, str]) -> str:

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -118,7 +118,7 @@ def _ensure_api_key() -> str:
                 "[code]gtn init --api-key <your key>[/code]\n"
                 "[bold red]You can generate a new key from [/bold red][bold blue][link=https://nodes.griptape.ai]https://nodes.griptape.ai[/link][/bold blue]",
             ),
-            title="🔑 ❌ Missing Nodes API Key",
+            title="[red]X[/red] Missing Nodes API Key",
             border_style="red",
             padding=(1, 4),
         )

--- a/src/griptape_nodes/mcp_server/ws_request_manager.py
+++ b/src/griptape_nodes/mcp_server/ws_request_manager.py
@@ -41,7 +41,7 @@ class WebSocketConnectionManager:
         try:
             message = json.dumps(data)
             await self.websocket.send(message)
-            logger.debug("📤 Sent message: %s", message)
+            logger.debug("Sent message: %s", message)
         except Exception as e:
             logger.error("Failed to send message: %s", e)
             raise
@@ -157,7 +157,7 @@ class AsyncRequestManager(Generic[T]):  # noqa: UP046
 
         except Exception as e:
             self.connection_manager.connected = False
-            logger.error("🔴 WebSocket connection failed: %s", str(e))
+            logger.error("[red]X[/red] WebSocket connection failed: %s", str(e))
             msg = f"Failed to connect to WebSocket: {e!s}"
             raise ConnectionError(msg) from e
 
@@ -192,7 +192,7 @@ class AsyncRequestManager(Generic[T]):  # noqa: UP046
         """Send an event to the API without waiting for a response."""
         from griptape_nodes.app.app import _determine_request_topic
 
-        logger.debug("📝 Creating Event: %s - %s", request_type, json.dumps(payload))
+        logger.debug("Creating Event: %s - %s", request_type, json.dumps(payload))
 
         data = {"event_type": "EventRequest", "request_type": request_type, "request": payload}
         topic = _determine_request_topic()
@@ -231,7 +231,7 @@ class AsyncRequestManager(Generic[T]):  # noqa: UP046
         def success_handler(response: Any, _: Any) -> None:
             if not response_future.done():
                 result = response.get("payload", {}).get("result", "Success")
-                logger.debug("✅ Request succeeded: %s", result)
+                logger.debug("[green]OK[/green] Request succeeded: %s", result)
                 response_future.set_result(result)
 
         def failure_handler(response: Any, _: Any) -> None:
@@ -239,14 +239,14 @@ class AsyncRequestManager(Generic[T]):  # noqa: UP046
                 error = (
                     response.get("payload", {}).get("result", {}).get("exception", "Unknown error") or "Unknown error"
                 )
-                logger.error("❌ Request failed: %s", error)
+                logger.error("[red]X[/red] Request failed: %s", error)
                 response_future.set_exception(Exception(error))
 
         # Generate request ID and subscribe
         request_id = self.connection_manager.subscribe_to_request_event(success_handler, failure_handler)
         payload["request_id"] = request_id
 
-        logger.debug("🚀 Request (%s): %s %s", request_id, request_type, json.dumps(payload))
+        logger.debug("Request (%s): %s %s", request_id, request_type, json.dumps(payload))
 
         try:
             # Send the event

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -240,10 +240,10 @@ class LibraryManager:
 
         # Status emojis mapping
         status_emoji = {
-            LibraryStatus.GOOD: "✅",
-            LibraryStatus.FLAWED: "🟡",
-            LibraryStatus.UNUSABLE: "❌",
-            LibraryStatus.MISSING: "❓",
+            LibraryStatus.GOOD: "[green]OK[/green]",
+            LibraryStatus.FLAWED: "[yellow]![/yellow]",
+            LibraryStatus.UNUSABLE: "[red]X[/red]",
+            LibraryStatus.MISSING: "[red]?[/red]",
         }
 
         # Add rows for each library info
@@ -256,7 +256,7 @@ class LibraryManager:
             # Library name column with emoji based on status
             emoji = status_emoji.get(lib_info.status, "ERROR: Unknown/Unexpected Library Status")
             name = lib_info.library_name if lib_info.library_name else "*UNKNOWN*"
-            library_name = f"{emoji} {name}"
+            library_name = f"{emoji} - {name}"
 
             library_version = lib_info.library_version
             if library_version:
@@ -1596,7 +1596,7 @@ class LibraryManager:
                 f"[bold blue]Return to: [link={nodes_app_url}]{nodes_app_url}[/link] to access the Workflow Editor[/bold blue]",
                 vertical="middle",
             ),
-            title="🚀 Griptape Nodes Engine Started",
+            title="Griptape Nodes Engine Started",
             subtitle=f"[green]{engine_version}{session_info}[/green]",
             border_style="green",
             padding=(1, 4),

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -389,19 +389,19 @@ class WorkflowManager:
 
         # Status emojis mapping
         status_emoji = {
-            self.WorkflowStatus.GOOD: "✅",
-            self.WorkflowStatus.FLAWED: "🟡",
-            self.WorkflowStatus.UNUSABLE: "❌",
-            self.WorkflowStatus.MISSING: "❓",
+            self.WorkflowStatus.GOOD: "[green]OK[/green]",
+            self.WorkflowStatus.FLAWED: "[yellow]![/yellow]",
+            self.WorkflowStatus.UNUSABLE: "[red]X[/red]",
+            self.WorkflowStatus.MISSING: "[red]?[/red]",
         }
 
         dependency_status_emoji = {
-            self.WorkflowDependencyStatus.PERFECT: "✅",
-            self.WorkflowDependencyStatus.GOOD: "👌",
-            self.WorkflowDependencyStatus.CAUTION: "🟡",
-            self.WorkflowDependencyStatus.BAD: "❌",
-            self.WorkflowDependencyStatus.MISSING: "❓",
-            self.WorkflowDependencyStatus.UNKNOWN: "❓",
+            self.WorkflowDependencyStatus.PERFECT: "[green]OK[/green]",
+            self.WorkflowDependencyStatus.GOOD: "[green]GOOD[/green]",
+            self.WorkflowDependencyStatus.CAUTION: "[yellow]CAUTION[/yellow]",
+            self.WorkflowDependencyStatus.BAD: "[red]BAD[/red]",
+            self.WorkflowDependencyStatus.MISSING: "[red]MISSING[/red]",
+            self.WorkflowDependencyStatus.UNKNOWN: "[red]UNKNOWN[/red]",
         }
 
         # Add rows for each workflow info
@@ -414,7 +414,7 @@ class WorkflowManager:
             # Workflow name column with emoji based on status
             emoji = status_emoji.get(wf_info.status, "ERR: Unknown/Unexpected Workflow Status")
             name = wf_info.workflow_name if wf_info.workflow_name else "*UNKNOWN*"
-            workflow_name = f"{emoji} {name}"
+            workflow_name = f"{emoji} - {name}"
 
             # Problems column - format with numbers if there's more than one
             problems = "\n".join(wf_info.problems) if wf_info.problems else "No problems detected."
@@ -423,11 +423,11 @@ class WorkflowManager:
             if wf_info.status == self.WorkflowStatus.MISSING or (
                 wf_info.status == self.WorkflowStatus.UNUSABLE and not wf_info.workflow_dependencies
             ):
-                dependencies = "❓ UNKNOWN"
+                dependencies = "[red]?[/red] UNKNOWN"
             else:
                 dependencies = (
                     "\n".join(
-                        f"{dependency_status_emoji.get(dep.status, '?')} {dep.library_name} ({dep.version_requested}): {dep.status.value}"
+                        f"{dependency_status_emoji.get(dep.status, '?')} - {dep.library_name} ({dep.version_requested}): {dep.status.value}"
                         for dep in wf_info.workflow_dependencies
                     )
                     if wf_info.workflow_dependencies

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -1460,7 +1460,7 @@ class RetainedMode:
         if command_name:
             func = getattr(cls, command_name, None)
             if not func or not callable(func):
-                return f"❌ No such command: {command_name}"
+                return f"[red]X[/red] No such command: {command_name}"
 
             doc = inspect.getdoc(func) or "No documentation available."
             sig_lines = _fancy_signature(func)


### PR DESCRIPTION
I'm sorry

```
The error is still occurring because the Unicode characters themselves are the problem. Even with legacy_windows=True, Rich still tries to
  encode those specific Unicode emoji characters (✅, 🟡, ❌, ❓) and Windows cp1252 can't handle them.

  The only reliable fix is to replace the Unicode characters with ASCII alternatives:
```