### PR TITLE
Adding send node message request type to allow custom signals to nodes. Nodes can implement a handler function to receive the message and generate a response.

### DIFF
--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -677,3 +677,53 @@ class DuplicateSelectedNodesResultFailure(WorkflowNotAlteredMixin, ResultPayload
     Common causes: nodes not found, constraints/conflicts,
     insufficient resources, connection duplication failures.
     """
+
+
+@dataclass
+@PayloadRegistry.register
+class SendNodeMessageRequest(RequestPayload):
+    """Send a message to a specific node.
+
+    Use when: External systems need to signal or send data directly to individual nodes,
+    implementing custom communication patterns, triggering node-specific behaviors.
+
+    Args:
+        node_name: Name of the target node (None for current context node)
+        optional_parameter_name: Optional parameter name this message relates to
+        message_type: String indicating message type for receiver parsing
+        message: Message payload of any type
+
+    Results: SendNodeMessageResultSuccess (with response) | SendNodeMessageResultFailure (node not found, handler error)
+    """
+
+    message_type: str
+    message: Any
+    node_name: str | None = None
+    optional_parameter_name: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class SendNodeMessageResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Node message sent and processed successfully.
+
+    Args:
+        response: Optional response data from the node's message handler
+    """
+
+    response: Any = None
+
+
+@dataclass
+@PayloadRegistry.register
+class SendNodeMessageResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Node message sending failed.
+
+    Common causes: node not found, no current context, message handler error,
+    unsupported message type.
+
+    Args:
+        response: Optional response data from the node's message handler (even on failure)
+    """
+
+    response: Any = None

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -73,6 +73,9 @@ from griptape_nodes.retained_mode.events.node_events import (
     ListParametersOnNodeRequest,
     ListParametersOnNodeResultFailure,
     ListParametersOnNodeResultSuccess,
+    SendNodeMessageRequest,
+    SendNodeMessageResultFailure,
+    SendNodeMessageResultSuccess,
     SerializedNodeCommands,
     SerializedParameterValueTracker,
     SerializedSelectedNodesCommands,
@@ -2538,3 +2541,52 @@ class NodeManager:
                 return SetLockNodeStateResultFailure(result_details=details)
         node.lock = request.lock
         return SetLockNodeStateResultSuccess(node_name=node_name, locked=node.lock)
+
+    def on_send_node_message_request(self, request: SendNodeMessageRequest) -> ResultPayload:
+        """Handle a SendNodeMessageRequest by calling the node's message callback.
+
+        Args:
+            request: The SendNodeMessageRequest containing message details
+
+        Returns:
+            ResultPayload: Success or failure result with callback response
+        """
+        node_name = request.node_name
+        node = None
+
+        if node_name is None:
+            # Get from the current context
+            if not GriptapeNodes.ContextManager().has_current_node():
+                details = "Attempted to send message to Node from Current Context. Failed because the Current Context is empty."
+                logger.error(details)
+                return SendNodeMessageResultFailure(result_details=details)
+
+            node = GriptapeNodes.ContextManager().get_current_node()
+            node_name = node.name
+
+        if node is None:
+            # Find the node by name
+            obj_mgr = GriptapeNodes.ObjectManager()
+            node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                details = f"Attempted to send message to Node '{node_name}', but no such Node was found."
+                logger.error(details)
+                return SendNodeMessageResultFailure(result_details=details)
+
+        # Call the node's message callback
+        callback_result = node.on_node_message_received(
+            optional_parameter_name=request.optional_parameter_name,
+            message_type=request.message_type,
+            message=request.message,
+        )
+
+        if not callback_result.success:
+            details = f"Failed to handle message for Node '{node_name}': {callback_result.details}"
+            logger.warning(details)
+            return SendNodeMessageResultFailure(
+                result_details=callback_result.details, response=callback_result.response
+            )
+
+        details = f"Successfully sent message to Node '{node_name}': {callback_result.details}"
+        logger.debug(details)
+        return SendNodeMessageResultSuccess(result_details=callback_result.details, response=callback_result.response)


### PR DESCRIPTION
Clients (such as the GUI editor or another node) can message another node via the `SendNodeMessageRequest`. This takes the destination node, an optional parameter name they are referring to, a message type, and a message payload.

If a node implements the `on_node_message_received` callback function, it will receive messages. It can then handle the message and respond with either a success or failure, a human-readable details string, and a response payload if they desire.