### PR TITLE
Maintain the GenerateImage for serialization by marking it as a PROPERTY, not just OUTPUT.

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/create_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/create_image.py
@@ -95,8 +95,9 @@ class GenerateImage(ControlNode):
                 type="ImageUrlArtifact",
                 tooltip="None",
                 default_value=None,
-                allowed_modes={ParameterMode.OUTPUT},
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
                 ui_options={"pulse_on_run": True},
+                settable=False,  # Ensures this serializes on save, but don't let user set it.
             )
         )
         # Group for logging information.


### PR DESCRIPTION
Fixes #1935 

Also flagged it as not settable, so user can't select a new one 😤 