### PR TITLE
refactor: don't store presigned urls, mint them on demand

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/load_image.py
@@ -4,6 +4,7 @@ from griptape.artifacts import ImageUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes_library.traits.presigned_url_generator import PresignedUrlGenerator
 from griptape_nodes_library.utils.artifact_path_tethering import (
     ArtifactPathTethering,
     ArtifactTetheringConfig,
@@ -46,6 +47,7 @@ class LoadImage(DataNode):
             },
             tooltip="The loaded image.",
         )
+        self.image_parameter.add_trait(PresignedUrlGenerator())
         self.add_parameter(self.image_parameter)
 
         # Use the tethering utility to create the properly configured path parameter
@@ -68,7 +70,6 @@ class LoadImage(DataNode):
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         # Delegate tethering logic to helper
-        self._tethering.on_after_value_set(parameter, value)
         return super().after_value_set(parameter, value)
 
     def process(self) -> None:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/traits/__init__.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/traits/__init__.py
@@ -1,0 +1,5 @@
+"""Traits package for griptape nodes library."""
+
+from .presigned_url_generator import PresignedUrlGenerator
+
+__all__ = ["PresignedUrlGenerator"]

--- a/libraries/griptape_nodes_library/griptape_nodes_library/traits/presigned_url_generator.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/traits/presigned_url_generator.py
@@ -1,0 +1,116 @@
+"""Presigned URL generator trait for converting asset URLs to presigned URLs."""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Trait
+from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlRequest,
+    CreateStaticFileDownloadUrlResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+@dataclass(eq=False)
+class PresignedUrlGenerator(Trait):
+    """Trait that converts asset URLs to presigned URLs when parameter values are accessed.
+
+    This trait converts URLs into presigned download URLs when the parameter value is retrieved.
+    When this trait is applied, any HTTP/HTTPS URL will be converted to a presigned download URL
+    using the static file system.
+
+    Usage example:
+        parameter.add_trait(PresignedUrlGenerator())
+
+    Conversion rules:
+    - HTTP/HTTPS URLs: Convert to presigned download URL
+    - Non-URL values: Pass through unchanged
+    """
+
+    element_id: str = field(default_factory=lambda: "PresignedUrlGeneratorTrait")
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @classmethod
+    def get_trait_keys(cls) -> list[str]:
+        return ["presigned_url_generator"]
+
+    def ui_options_for_trait(self) -> dict:
+        return {}
+
+    def display_options_for_trait(self) -> dict:
+        return {}
+
+    def validators_for_trait(self) -> list:
+        return []
+
+    def converters_for_trait(self) -> list:
+        return []
+
+    def read_converters_for_trait(self) -> list:
+        def convert_asset_url_to_presigned(value: Any) -> Any:
+            """Convert asset URLs to presigned URLs when accessing parameter values."""
+            if not value:
+                return value
+
+            # Handle dictionary format (most common for artifacts)
+            if isinstance(value, dict):
+                url = value.get("value")
+                if url and self._should_convert_url(url):
+                    presigned_url = self._convert_to_presigned_url(url)
+                    if presigned_url != url:
+                        # Create a copy to avoid mutating the original
+                        converted_value = value.copy()
+                        converted_value["value"] = presigned_url
+                        return converted_value
+                return value
+
+            # Handle direct string URLs
+            if isinstance(value, str) and self._should_convert_url(value):
+                return self._convert_to_presigned_url(value)
+
+            # Handle artifact objects with a value attribute
+            if hasattr(value, "value") and not isinstance(value, str):
+                artifact_value = value.value  # type: ignore[attr-defined]
+                if self._should_convert_url(artifact_value):
+                    # For artifact objects, we need to create a new instance with the presigned URL
+                    # Since we can't easily clone arbitrary artifact objects, we'll modify the value directly
+                    # This is safe because the conversion is temporary for access purposes
+                    original_value = artifact_value
+                    presigned_url = self._convert_to_presigned_url(original_value)
+                    if presigned_url != original_value:
+                        value.value = presigned_url  # type: ignore[attr-defined]
+                return value
+
+            return value
+
+        return [convert_asset_url_to_presigned]
+
+    def _should_convert_url(self, url: str | None) -> bool:
+        """Check if a URL should be converted to presigned URL."""
+        if not url or not isinstance(url, str):
+            return False
+
+        # If this trait is applied, we always want to generate presigned download URLs
+        return url.startswith(("http://", "https://"))
+
+    def _convert_to_presigned_url(self, url: str) -> str:
+        """Convert a URL to a presigned download URL."""
+        try:
+            # Request presigned download URL by passing the asset_url directly
+            # The storage manager will handle URL parsing using the appropriate storage driver
+            download_request = CreateStaticFileDownloadUrlRequest(asset_url=url)
+            download_result = GriptapeNodes.handle_request(download_request)
+
+            if isinstance(download_result, CreateStaticFileDownloadUrlResultSuccess):
+                return download_result.url
+
+        except Exception as e:
+            # Log the exception but continue with fallback behavior
+            logging.getLogger("griptape_nodes").debug("Failed to convert URL to presigned URL: %s", e)
+
+        # If we can't generate a presigned URL, return the original URL
+        # This allows fallback behavior rather than breaking functionality
+        return url

--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -43,6 +43,30 @@ class BaseStorageDriver(ABC):
         ...
 
     @abstractmethod
+    def create_asset_url(self, file_name: str) -> str:
+        """Create a persistent asset URL for the given file name.
+
+        Args:
+            file_name: The name of the file to create an asset URL for.
+
+        Returns:
+            str: The persistent asset URL for the file.
+        """
+        ...
+
+    @abstractmethod
+    def extract_file_name_from_url(self, url: str) -> str | None:
+        """Extract the file name from a URL that matches this storage driver's URL patterns.
+
+        Args:
+            url: The URL to extract the file name from.
+
+        Returns:
+            str | None: The extracted file name, or None if the URL doesn't match this driver's patterns.
+        """
+        ...
+
+    @abstractmethod
     def delete_file(self, file_name: str) -> None:
         """Delete a file from storage.
 

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -78,11 +78,13 @@ class CreateStaticFileUploadUrlResultSuccess(WorkflowNotAlteredMixin, ResultPayl
         url: Presigned URL for uploading the file
         headers: HTTP headers required for the upload request
         method: HTTP method to use for upload (typically PUT)
+        asset_url: Persistent asset URL for the file (non-presigned)
     """
 
     url: str
     headers: dict = field(default_factory=dict)
     method: str = "PUT"
+    asset_url: str = ""
 
 
 @dataclass
@@ -106,12 +108,14 @@ class CreateStaticFileDownloadUrlRequest(RequestPayload):
     enabling temporary download links, controlling file access permissions.
 
     Args:
-        file_name: Name of the file to be downloaded
+        file_name: Name of the file to be downloaded (used when asset_url is not provided)
+        asset_url: Asset URL to parse and extract file name from (takes precedence over file_name)
 
     Results: CreateStaticFileDownloadUrlResultSuccess (with URL) | CreateStaticFileDownloadUrlResultFailure (URL creation error)
     """
 
-    file_name: str
+    file_name: str | None = None
+    asset_url: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2512,7 +2512,8 @@ class NodeManager:
             output_value = node.parameter_output_values[parameter.name]
         if parameter.name in node.parameter_values:
             # Check the internal parameter values
-            internal_value = node.get_parameter_value(parameter.name)
+            # Disabling read converters here because we want to serialize the raw value.
+            internal_value = node.get_parameter_value(parameter.name, run_read_converters=False)
         # We have a value. Attempt to get a hash for it to see if it matches one
         # we've already indexed.
         commands = []


### PR DESCRIPTION
# Problem

`StaticFilesManager().save_static_file` returns a presigned url that is then saved and serialized into the parameter value. After some time, this value expires.

# Solution

- Update `save_static_file` to return a non-presigned url.
- Create a new class of converter (`read_converter`) that is only executed when _getting_ the parameter value.
- Create a new Trait, `PresignedUrlGenerator`, that applies a read converter which generates a presigned url from a standard one.

Closes #1930