### PR TITLE
BatchSetNodeMetadataRequest

### DIFF
--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -265,6 +265,50 @@ class SetNodeMetadataResultFailure(ResultPayloadFailure):
     """Metadata update failed. Common causes: node not found, no current context, invalid metadata format."""
 
 
+@dataclass
+@PayloadRegistry.register
+class BatchSetNodeMetadataRequest(RequestPayload):
+    """Update metadata for multiple nodes in a single request.
+
+    Use when: Updating positions for multiple nodes at once, applying bulk styling changes,
+    implementing multi-node selection operations, optimizing performance for UI updates.
+    Supports partial updates - only specified metadata fields are updated for each node.
+
+    Args:
+        node_metadata_updates: Dictionary mapping node names to their metadata updates.
+                              Each node's metadata is merged with existing metadata (partial update).
+                              If a node name is None, uses the current context node.
+
+    Results: BatchSetNodeMetadataResultSuccess | BatchSetNodeMetadataResultFailure (some nodes not found, update errors)
+    """
+
+    node_metadata_updates: dict[str | None, dict]
+
+
+@dataclass
+@PayloadRegistry.register
+class BatchSetNodeMetadataResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Batch node metadata update completed successfully.
+
+    Args:
+        updated_nodes: List of node names that were successfully updated
+        failed_nodes: Dictionary mapping failed node names to error descriptions (if any)
+    """
+
+    updated_nodes: list[str]
+    failed_nodes: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+@PayloadRegistry.register
+class BatchSetNodeMetadataResultFailure(ResultPayloadFailure):
+    """Batch metadata update failed.
+
+    Common causes: all nodes not found, no current context, invalid metadata format,
+    or other systemic errors preventing the batch operation.
+    """
+
+
 # Get all info via a "jumbo" node event. Batches multiple info requests for, say, a GUI.
 # ...jumbode?
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -282,7 +282,7 @@ class BatchSetNodeMetadataRequest(RequestPayload):
     Results: BatchSetNodeMetadataResultSuccess | BatchSetNodeMetadataResultFailure (some nodes not found, update errors)
     """
 
-    node_metadata_updates: dict[str | None, dict]
+    node_metadata_updates: dict[str | None, dict[str, Any]]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -676,20 +676,25 @@ class NodeManager:
         failed_nodes = {}
 
         for node_name, metadata_update in request.node_metadata_updates.items():
+            # Resolve node name and get node object
+            node = None
             if node_name is None:
-                current_node = GriptapeNodes.ContextManager().get_current_node()
-                if current_node is None:
+                # Get from current context
+                if not GriptapeNodes.ContextManager().has_current_node():
                     failed_nodes["current_context"] = "No current context node available"
                     continue
-                actual_node_name = current_node.name
+                node = GriptapeNodes.ContextManager().get_current_node()
+                actual_node_name = node.name
             else:
                 actual_node_name = node_name
 
-            obj_mgr = GriptapeNodes.ObjectManager()
-            node = obj_mgr.attempt_get_object_by_name_as_type(actual_node_name, BaseNode)
+            # Look up node if we don't have it yet
             if node is None:
-                failed_nodes[actual_node_name] = f"Node '{actual_node_name}' not found"
-                continue
+                obj_mgr = GriptapeNodes.ObjectManager()
+                node = obj_mgr.attempt_get_object_by_name_as_type(actual_node_name, BaseNode)
+                if node is None:
+                    failed_nodes[actual_node_name] = f"Node '{actual_node_name}' not found"
+                    continue
 
             single_request = SetNodeMetadataRequest(node_name=actual_node_name, metadata=metadata_update)
             result = self.on_set_node_metadata_request(single_request)

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -53,6 +53,9 @@ from griptape_nodes.retained_mode.events.library_events import (
     GetLibraryMetadataResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import (
+    BatchSetNodeMetadataRequest,
+    BatchSetNodeMetadataResultFailure,
+    BatchSetNodeMetadataResultSuccess,
     CreateNodeRequest,
     CreateNodeResultFailure,
     CreateNodeResultSuccess,
@@ -152,6 +155,7 @@ class NodeManager:
         )
         event_manager.assign_manager_to_request_type(GetNodeMetadataRequest, self.on_get_node_metadata_request)
         event_manager.assign_manager_to_request_type(SetNodeMetadataRequest, self.on_set_node_metadata_request)
+        event_manager.assign_manager_to_request_type(BatchSetNodeMetadataRequest, self.on_batch_set_node_metadata_request)
         event_manager.assign_manager_to_request_type(
             ListConnectionsForNodeRequest, self.on_list_connections_for_node_request
         )
@@ -664,6 +668,47 @@ class NodeManager:
 
         result = SetNodeMetadataResultSuccess()
         return result
+
+    def on_batch_set_node_metadata_request(self, request: BatchSetNodeMetadataRequest) -> ResultPayload:
+        """Handle batch metadata updates for multiple nodes."""
+        updated_nodes = []
+        failed_nodes = {}
+
+        for node_name, metadata_update in request.node_metadata_updates.items():
+            try:
+                # Create a single node metadata request for each node
+                single_request = SetNodeMetadataRequest(
+                    node_name=node_name,
+                    metadata=metadata_update
+                )
+                
+                # Process the single request
+                result = self.on_set_node_metadata_request(single_request)
+                
+                if isinstance(result, SetNodeMetadataResultSuccess):
+                    # Extract the actual node name that was updated
+                    actual_node_name = node_name if node_name is not None else GriptapeNodes.ContextManager().get_current_node().name
+                    updated_nodes.append(actual_node_name)
+                else:
+                    # Handle failure
+                    actual_node_name = node_name if node_name is not None else "current_context"
+                    failed_nodes[actual_node_name] = getattr(result, 'result_details', 'Unknown error')
+                    
+            except Exception as e:
+                # Handle any exceptions
+                actual_node_name = node_name if node_name is not None else "current_context"
+                failed_nodes[actual_node_name] = str(e)
+
+        # Return success if at least one node was updated, or if all nodes failed
+        if updated_nodes:
+            return BatchSetNodeMetadataResultSuccess(
+                updated_nodes=updated_nodes,
+                failed_nodes=failed_nodes
+            )
+        else:
+            return BatchSetNodeMetadataResultFailure(
+                result_details=f"Failed to update any nodes. Failed nodes: {failed_nodes}"
+            )
 
     def on_list_connections_for_node_request(self, request: ListConnectionsForNodeRequest) -> ResultPayload:
         node_name = request.node_name

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -672,7 +672,6 @@ class NodeManager:
         return result
 
     def on_batch_set_node_metadata_request(self, request: BatchSetNodeMetadataRequest) -> ResultPayload:
-        """Handle batch metadata updates for multiple nodes."""
         updated_nodes = []
         failed_nodes = {}
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -677,11 +677,11 @@ class NodeManager:
 
         for node_name, metadata_update in request.node_metadata_updates.items():
             # Resolve the actual node name once at the top of the loop
-            if node_name is not None:
-                actual_node_name = node_name
-            else:
+            if node_name is None:
                 current_node = GriptapeNodes.ContextManager().get_current_node()
                 actual_node_name = current_node.name if current_node else "unknown"
+            else:
+                actual_node_name = node_name
 
             try:
                 # Create a single node metadata request for each node

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -155,7 +155,9 @@ class NodeManager:
         )
         event_manager.assign_manager_to_request_type(GetNodeMetadataRequest, self.on_get_node_metadata_request)
         event_manager.assign_manager_to_request_type(SetNodeMetadataRequest, self.on_set_node_metadata_request)
-        event_manager.assign_manager_to_request_type(BatchSetNodeMetadataRequest, self.on_batch_set_node_metadata_request)
+        event_manager.assign_manager_to_request_type(
+            BatchSetNodeMetadataRequest, self.on_batch_set_node_metadata_request
+        )
         event_manager.assign_manager_to_request_type(
             ListConnectionsForNodeRequest, self.on_list_connections_for_node_request
         )
@@ -677,23 +679,22 @@ class NodeManager:
         for node_name, metadata_update in request.node_metadata_updates.items():
             try:
                 # Create a single node metadata request for each node
-                single_request = SetNodeMetadataRequest(
-                    node_name=node_name,
-                    metadata=metadata_update
-                )
-                
+                single_request = SetNodeMetadataRequest(node_name=node_name, metadata=metadata_update)
+
                 # Process the single request
                 result = self.on_set_node_metadata_request(single_request)
-                
+
                 if isinstance(result, SetNodeMetadataResultSuccess):
                     # Extract the actual node name that was updated
-                    actual_node_name = node_name if node_name is not None else GriptapeNodes.ContextManager().get_current_node().name
+                    actual_node_name = (
+                        node_name if node_name is not None else GriptapeNodes.ContextManager().get_current_node().name
+                    )
                     updated_nodes.append(actual_node_name)
                 else:
                     # Handle failure
                     actual_node_name = node_name if node_name is not None else "current_context"
-                    failed_nodes[actual_node_name] = getattr(result, 'result_details', 'Unknown error')
-                    
+                    failed_nodes[actual_node_name] = getattr(result, "result_details", "Unknown error")
+
             except Exception as e:
                 # Handle any exceptions
                 actual_node_name = node_name if node_name is not None else "current_context"
@@ -701,10 +702,7 @@ class NodeManager:
 
         # Return success if at least one node was updated, or if all nodes failed
         if updated_nodes:
-            return BatchSetNodeMetadataResultSuccess(
-                updated_nodes=updated_nodes,
-                failed_nodes=failed_nodes
-            )
+            return BatchSetNodeMetadataResultSuccess(updated_nodes=updated_nodes, failed_nodes=failed_nodes)
         else:
             return BatchSetNodeMetadataResultFailure(
                 result_details=f"Failed to update any nodes. Failed nodes: {failed_nodes}"

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -703,10 +703,10 @@ class NodeManager:
         # Return success if at least one node was updated, or if all nodes failed
         if updated_nodes:
             return BatchSetNodeMetadataResultSuccess(updated_nodes=updated_nodes, failed_nodes=failed_nodes)
-        else:
-            return BatchSetNodeMetadataResultFailure(
-                result_details=f"Failed to update any nodes. Failed nodes: {failed_nodes}"
-            )
+
+        return BatchSetNodeMetadataResultFailure(
+            result_details=f"Failed to update any nodes. Failed nodes: {failed_nodes}"
+        )
 
     def on_list_connections_for_node_request(self, request: ListConnectionsForNodeRequest) -> ResultPayload:
         node_name = request.node_name

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -43,7 +43,6 @@ from griptape_nodes.retained_mode.events.library_events import (
     ListRegisteredLibrariesRequest,
 )
 from griptape_nodes.retained_mode.events.node_events import (
-    BatchSetNodeMetadataRequest,
     CreateNodeRequest,
     DeleteNodeRequest,
     GetNodeMetadataRequest,

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -43,6 +43,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     ListRegisteredLibrariesRequest,
 )
 from griptape_nodes.retained_mode.events.node_events import (
+    BatchSetNodeMetadataRequest,
     CreateNodeRequest,
     DeleteNodeRequest,
     GetNodeMetadataRequest,


### PR DESCRIPTION
New `BatchSetNodeMetadata` event to help us process multiple node metadata updates at the same time

Closes #1952 

Needs to go in before https://github.com/griptape-ai/griptape-vsl-gui/pull/1210