### PR TITLE
features/adding additional video nodes

### DIFF
--- a/ParameterButton_Implementation_Plan.md
+++ b/ParameterButton_Implementation_Plan.md
@@ -1,0 +1,410 @@
+# ParameterButton Implementation Plan
+
+## Overview
+
+This document outlines the implementation plan for adding interactive button functionality to Griptape Nodes. The plan includes `ParameterButton` for individual buttons and `ParameterButtonGroup` for grouping related buttons together.
+
+## Core Components
+
+### 1. ParameterButton
+
+A UI element that displays a button and executes a specified method in the node when clicked.
+
+#### Key Features
+
+- **Button Text**: Display text on the button
+- **Method Execution**: Execute node methods when clicked
+- **Button Types**: Primary, secondary, danger, success, warning, info
+- **Icons**: Support for button icons (Lucide-style)
+- **Tooltips**: Help text on hover
+- **States**: Disabled/enabled states
+- **Layout**: Full-width option
+
+#### Class Structure
+
+```python
+class ParameterButton(BaseNodeElement, UIOptionsMixin):
+    """Represents a UI button element that can execute node methods when clicked."""
+    
+    # Button types
+    DEFAULT_BUTTON_TYPES: ClassVar[dict[str, str]] = {
+        "primary": "Primary",
+        "secondary": "Secondary", 
+        "danger": "Danger",
+        "success": "Success",
+        "warning": "Warning",
+        "info": "Info",
+    }
+    
+    # Common button icons
+    DEFAULT_ICONS: ClassVar[dict[str, str]] = {
+        "refresh": "refresh-cw",
+        "download": "download",
+        "upload": "upload",
+        "delete": "trash-2",
+        "edit": "edit",
+        "add": "plus",
+        "save": "save",
+        "play": "play",
+        "stop": "square",
+        "pause": "pause",
+        "settings": "settings",
+        "help": "help-circle",
+        "info": "info",
+        "warning": "alert-triangle",
+        "error": "alert-circle",
+        "success": "check-circle",
+    }
+    
+    type ButtonType = Literal["primary", "secondary", "danger", "success", "warning", "info"]
+    
+    # Properties
+    _button_text: str
+    _button_type: ButtonType
+    _method_name: str
+    _icon: str | None
+    _tooltip: str | list[dict] | None
+    _disabled: bool
+    _full_width: bool
+    _in_group: bool
+    _group_position: str | None  # "first", "middle", "last", "only"
+```
+
+#### Constructor
+
+```python
+def __init__(
+    self,
+    button_text: str,
+    method_name: str,
+    *,
+    button_type: ButtonType = "primary",
+    icon: str | None = None,
+    tooltip: str | list[dict] | None = None,
+    disabled: bool = False,
+    full_width: bool = False,
+    ui_options: dict | None = None,
+    **kwargs,
+):
+```
+
+#### Convenience Methods
+
+```python
+@classmethod
+def create_refresh_button(cls, method_name: str, **kwargs) -> "ParameterButton":
+    """Create a refresh button with standard icon and tooltip."""
+
+@classmethod
+def create_download_button(cls, method_name: str, **kwargs) -> "ParameterButton":
+    """Create a download button with standard icon and tooltip."""
+
+@classmethod
+def create_delete_button(cls, method_name: str, **kwargs) -> "ParameterButton":
+    """Create a delete button with standard icon and tooltip."""
+
+@classmethod
+def create_save_button(cls, method_name: str, **kwargs) -> "ParameterButton":
+    """Create a save button with standard icon and tooltip."""
+```
+
+### 2. ParameterButtonGroup
+
+A container for grouping related buttons together with consistent styling and layout.
+
+#### Key Features
+
+- **Layout Options**: Horizontal, vertical, compact, stacked
+- **Group Management**: Add/remove buttons dynamically
+- **Position Awareness**: Buttons know their position in the group
+- **Responsive Design**: Adapts to different screen sizes
+
+#### Class Structure
+
+```python
+class ParameterButtonGroup(BaseNodeElement, UIOptionsMixin):
+    """UI element for grouping related buttons together."""
+    
+    # Layout options
+    DEFAULT_LAYOUTS: ClassVar[dict[str, str]] = {
+        "horizontal": "Horizontal",
+        "vertical": "Vertical",
+        "compact": "Compact",
+        "stacked": "Stacked",
+    }
+    
+    type LayoutType = Literal["horizontal", "vertical", "compact", "stacked"]
+    
+    # Properties
+    _layout: LayoutType
+    _full_width: bool
+```
+
+#### Convenience Methods
+
+```python
+@classmethod
+def create_crud_group(
+    cls, 
+    create_method: str, 
+    read_method: str, 
+    update_method: str, 
+    delete_method: str,
+    **kwargs
+) -> "ParameterButtonGroup":
+    """Create a standard CRUD button group."""
+
+@classmethod
+def create_file_actions_group(
+    cls,
+    save_method: str,
+    load_method: str,
+    export_method: str,
+    **kwargs
+) -> "ParameterButtonGroup":
+    """Create a file operations button group."""
+
+@classmethod
+def create_playback_group(
+    cls,
+    play_method: str,
+    pause_method: str,
+    stop_method: str,
+    **kwargs
+) -> "ParameterButtonGroup":
+    """Create a media playback button group."""
+```
+
+## Event System
+
+### Button Click Event
+
+```python
+@dataclass
+@PayloadRegistry.register
+class ButtonClickEvent(ExecutionPayload):
+    """Event fired when a ParameterButton is clicked."""
+    
+    element_id: str
+    node_name: str
+    method_name: str
+```
+
+### Node Integration
+
+```python
+class BaseNode(ABC):
+    # Add to existing BaseNode class
+    _button_handlers: dict[str, Callable] = field(default_factory=dict)
+    
+    def register_button_handler(self, method_name: str, handler: Callable) -> None:
+        """Register a method to be called when a button with this method_name is clicked."""
+    
+    def execute_button_handler(self, method_name: str) -> Any:
+        """Execute the registered button handler."""
+```
+
+## Usage Examples
+
+### Basic Button Usage
+
+```python
+# Simple button with icon and tooltip
+ParameterButton(
+    button_text="Generate Image",
+    method_name="generate_image",
+    button_type="primary",
+    icon="image",
+    tooltip="Generate a new image based on current settings"
+)
+
+# Using convenience methods
+ParameterButton.create_refresh_button("refresh_data")
+ParameterButton.create_download_button("download_result")
+ParameterButton.create_save_button("save_settings")
+```
+
+### Button Groups
+
+```python
+# Basic button group
+with ParameterButtonGroup("Actions", layout="horizontal"):
+    ParameterButton(
+        button_text="Save",
+        method_name="save_data",
+        button_type="primary",
+        icon="save"
+    )
+    ParameterButton(
+        button_text="Cancel",
+        method_name="cancel_operation",
+        button_type="secondary",
+        icon="x"
+    )
+
+# Using convenience methods
+crud_group = ParameterButtonGroup.create_crud_group(
+    create_method="create_item",
+    read_method="read_item", 
+    update_method="update_item",
+    delete_method="delete_item"
+)
+
+# Vertical layout
+with ParameterButtonGroup("Settings", layout="vertical", full_width=True):
+    ParameterButton(
+        button_text="General Settings",
+        method_name="open_general_settings",
+        button_type="secondary",
+        icon="settings"
+    )
+    ParameterButton(
+        button_text="Reset to Defaults",
+        method_name="reset_settings",
+        button_type="danger",
+        icon="refresh-cw"
+    )
+```
+
+### Complete Node Example
+
+```python
+class MyNode(BaseNode):
+    def __init__(self, name: str):
+        super().__init__(name)
+        
+        # Register button handlers
+        self.register_button_handler("refresh_data", self.refresh_data)
+        self.register_button_handler("clear_cache", self.clear_cache)
+        self.register_button_handler("save_settings", self.save_settings)
+        
+        # Create UI elements
+        with ParameterGroup("Data Management"):
+            # Individual buttons
+            ParameterButton(
+                button_text="Refresh Data",
+                method_name="refresh_data",
+                button_type="primary",
+                icon="refresh-cw",
+                tooltip="Refresh data from source"
+            )
+            
+            # Button group
+            with ParameterButtonGroup("Actions", layout="horizontal"):
+                ParameterButton(
+                    button_text="Save",
+                    method_name="save_settings",
+                    button_type="success",
+                    icon="save"
+                )
+                ParameterButton(
+                    button_text="Clear Cache",
+                    method_name="clear_cache",
+                    button_type="warning",
+                    icon="trash-2"
+                )
+    
+    def refresh_data(self):
+        # Implementation for refresh data
+        pass
+    
+    def clear_cache(self):
+        # Implementation for clear cache
+        pass
+    
+    def save_settings(self):
+        # Implementation for save settings
+        pass
+```
+
+## Frontend Integration
+
+### Button Rendering
+
+- **Icon Support**: Use Lucide React or similar icon library
+- **Tooltip Display**: Show tooltips on hover with support for structured content
+- **Button States**: Handle disabled, loading, and normal states
+- **Styling**: Apply different styles based on `button_type`
+
+### Button Group Rendering
+
+- **Layout Management**: Handle horizontal, vertical, compact, and stacked layouts
+- **Group Styling**: Rounded corners on outer edges, shared borders
+- **Responsive Design**: Adapt layout for different screen sizes
+- **Focus Management**: Proper keyboard navigation within groups
+
+### Event Handling
+
+- **Click Events**: Emit `ButtonClickEvent` when buttons are clicked
+- **Loading States**: Show loading indicators during method execution
+- **Error Handling**: Display errors if method execution fails
+
+## Implementation Steps
+
+### Phase 1: Core Button Implementation
+
+1. Create `ParameterButton` class in `core_types.py`
+1. Add button click event system
+1. Integrate with `BaseNode` for method execution
+1. Add convenience methods for common button types
+
+### Phase 2: Button Groups
+
+1. Create `ParameterButtonGroup` class
+1. Implement group management methods
+1. Add convenience methods for common group patterns
+1. Update `ParameterButton` to be group-aware
+
+### Phase 3: Frontend Integration
+
+1. Create button components
+1. Implement button group layouts
+1. Add event handling for button clicks
+1. Implement loading and error states
+
+### Phase 4: Testing and Documentation
+
+1. Unit tests for button functionality
+1. Integration tests for button groups
+1. Documentation and examples
+1. Frontend testing
+
+## Benefits
+
+### For Developers
+
+- **Consistency**: Follows existing Griptape Nodes patterns
+- **Flexibility**: Supports various button types and layouts
+- **Ease of Use**: Convenience methods reduce boilerplate
+- **Type Safety**: Proper typing for all components
+
+### For Users
+
+- **Visual Clarity**: Icons and tooltips improve usability
+- **Organization**: Button groups organize related actions
+- **Accessibility**: Proper tooltips and keyboard navigation
+- **Responsive Design**: Works well on different screen sizes
+
+### For the System
+
+- **Event-Driven**: Integrates with existing event system
+- **Extensible**: Easy to add new button types and features
+- **Maintainable**: Clear separation of concerns
+- **Performance**: Efficient event handling and rendering
+
+## Files to Modify/Create
+
+### New Files
+
+- `src/griptape_nodes/retained_mode/events/button_events.py` - Button click events
+
+### Modified Files
+
+- `src/griptape_nodes/exe_types/core_types.py` - Add ParameterButton and ParameterButtonGroup classes
+- `src/griptape_nodes/exe_types/node_types.py` - Add button handler methods to BaseNode
+- `src/griptape_nodes/retained_mode/managers/event_manager.py` - Register button events
+- Frontend components - Render buttons and handle interactions
+
+## Conclusion
+
+This implementation plan provides a comprehensive solution for adding interactive buttons to Griptape Nodes. The design follows existing patterns, provides flexibility for different use cases, and maintains consistency with the current architecture. The button system will enhance user experience by providing clear, organized ways to interact with node functionality.

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -13,4 +13,17 @@ nav:
       - Get List Length: nodes/lists/get_list_length.md
       - Remove From List: nodes/lists/remove_from_list.md
       - Replace In List: nodes/lists/replace_in_list.md
-      - Split List: nodes/lists/split_list.md 
+      - Split List: nodes/lists/split_list.md
+    - Video:
+      - Load Video: nodes/video/load_video.md
+      - Display Video: nodes/video/display_video.md
+      - Save Video: nodes/video/save_video.md
+      - Resize Video: nodes/video/resize_video.md
+      - Add Film Grain: nodes/video/add_film_grain.md
+      - Add RGB Shift: nodes/video/add_rgb_shift.md
+      - Add Vignette: nodes/video/add_vignette.md
+      - Split Video: nodes/video/split_video.md
+      - Adjust Video EQ: nodes/video/adjust_video_eq.md
+      - Hold Video Frames: nodes/video/hold_video_frames.md
+      - Reverse Video: nodes/video/reverse_video.md
+      - Flip Video: nodes/video/flip_video.md 

--- a/docs/nodes/video/add_color_curves.md
+++ b/docs/nodes/video/add_color_curves.md
@@ -1,0 +1,94 @@
+# AddColorCurves
+
+## What is it?
+
+The AddColorCurves node applies color grading effects to video using FFmpeg's `curves` filter. This filter allows for sophisticated color manipulation by adjusting the tonal curves of the video, providing both built-in presets and custom curve options for advanced color grading.
+
+## When would I use it?
+
+Use the AddColorCurves node when:
+
+- You want to apply cinematic color grading effects to your video
+- You need to match the color style of multiple video clips
+- You're creating content that requires a specific visual aesthetic
+- You want to enhance the mood and atmosphere of your video
+- You need professional color correction and grading
+- You're working on projects that require consistent color treatment
+
+## How to use it
+
+### Basic Setup
+
+1. Add an AddColorCurves node to your workflow
+1. Connect a video source to the "video" input
+1. Select a curve preset or define custom curves
+1. Run the workflow to apply the color grading
+
+### Parameters
+
+- **video**: The video content to apply color curves to (supports VideoArtifact and VideoUrlArtifact)
+
+- **curve_preset**: Built-in curve preset for color grading effects (default: "none")
+
+    - **none**: No curves applied
+    - **color_negative**: Color negative film look
+    - **cross_process**: Cross-processed film effect
+    - **darker**: Darker overall tone
+    - **increase_contrast**: Moderate contrast boost
+    - **lighter**: Lighter overall tone
+    - **linear_contrast**: Linear contrast adjustment
+    - **medium_contrast**: Medium contrast enhancement
+    - **negative**: Black and white negative effect
+    - **strong_contrast**: High contrast dramatic look
+    - **vintage**: Classic vintage film look
+
+
+
+### Outputs
+
+- **video**: The video with color curves applied, available as output to connect to other nodes
+
+## Examples
+
+### Example 1: Apply Vintage Effect
+
+1. Connect the video output from a LoadVideo node to the AddColorCurves's "video" input
+1. Set "curve_preset" to "vintage"
+1. Run the workflow - the video will have a classic vintage film look
+1. The output filename will be `{original_filename}_curves_vintage.{format}`
+
+### Example 2: Apply Strong Contrast
+
+1. Connect a video to the AddColorCurves node
+1. Set "curve_preset" to "strong_contrast"
+1. Run the workflow - the video will have dramatic contrast enhancement
+1. The output filename will be `{original_filename}_curves_strong_contrast.{format}`
+
+### Example 3: Apply Cross-Process Effect
+
+1. Connect a video to the AddColorCurves node
+1. Set "curve_preset" to "cross_process"
+1. Run the workflow - the video will have a cross-processed film look
+1. The output filename will be `{original_filename}_curves_cross_process.{format}`
+
+## Important Notes
+
+- The AddColorCurves node uses FFmpeg's curves filter for high-quality color grading
+- Built-in presets provide quick access to common color grading effects
+- Processing time depends on video length and resolution
+- Curves can significantly affect the visual mood and style of your video
+- For best results, apply curves after other color adjustments
+
+## Parameter Recommendations
+
+### For Cinematic Look
+- Use "vintage" or "cross_process" presets
+- Try "color_negative" for a unique film look
+
+### For High Contrast
+- Use "strong_contrast" or "negative"
+- Try "increase_contrast" for subtle enhancement
+
+
+
+

--- a/docs/nodes/video/add_color_curves.md
+++ b/docs/nodes/video/add_color_curves.md
@@ -42,7 +42,11 @@ Use the AddColorCurves node when:
     - **strong_contrast**: High contrast dramatic look
     - **vintage**: Classic vintage film look
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
 
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
 
 ### Outputs
 
@@ -82,13 +86,11 @@ Use the AddColorCurves node when:
 ## Parameter Recommendations
 
 ### For Cinematic Look
+
 - Use "vintage" or "cross_process" presets
 - Try "color_negative" for a unique film look
 
 ### For High Contrast
+
 - Use "strong_contrast" or "negative"
 - Try "increase_contrast" for subtle enhancement
-
-
-
-

--- a/docs/nodes/video/add_film_grain.md
+++ b/docs/nodes/video/add_film_grain.md
@@ -37,7 +37,7 @@ Use the AddFilmGrain node when:
 - **luminance_threshold**: Luminance level where grain is most visible (50-100, default: 75)
 
     - 50 = grain visible in darker areas
-    - 75 = grain visible in mid-tones (default, good for faces)
+    - 75 = grain visible in mid-tones (default, good for lighter areas)
     - 100 = grain visible in brighter areas
 
 - **grain_scale**: Grain scale factor (1.0-4.0, default: 2.0)
@@ -57,7 +57,7 @@ Imagine you want to add a subtle film grain to a digital video to give it a cine
 1. Add an AddFilmGrain node to your workflow
 1. Connect the video output from a LoadVideo node to the AddFilmGrain's "video" input
 1. Set the "grain_intensity" to 0.12 for subtle grain
-1. Set the "luminance_threshold" to 75 for optimal grain visibility on faces
+1. Set the "luminance_threshold" to 75 for optimal grain visibility on lighter areas
 1. Set the "grain_scale" to 2.0 for medium-sized grain particles
 1. Run the workflow - the video will have realistic film grain added
 1. The output filename will be `{original_filename}_grain_0.12.{format}`
@@ -76,7 +76,7 @@ Imagine you want to add a subtle film grain to a digital video to give it a cine
 - **For subtle film look**: Use grain_intensity 0.08-0.15, luminance_threshold 75
 - **For vintage/retro effect**: Use grain_intensity 0.3-0.6, grain_scale 2.5-3.0
 - **For heavy film grain**: Use grain_intensity 0.7-1.0, grain_scale 3.0-4.0
-- **For portraits**: Use luminance_threshold 70-80 for optimal grain on faces
+- **For portraits**: Use luminance_threshold 70-80 for optimal grain on lighter areas
 - **For landscapes**: Use luminance_threshold 60-70 for grain in mid-tones
 
 ## Common Issues

--- a/docs/nodes/video/add_film_grain.md
+++ b/docs/nodes/video/add_film_grain.md
@@ -1,0 +1,88 @@
+# AddFilmGrain
+
+## What is it?
+
+The AddFilmGrain node adds realistic film grain to video using sophisticated noise generation and luminance masking. It creates authentic film-like texture that varies based on the brightness of different areas in the video.
+
+## When would I use it?
+
+Use the AddFilmGrain node when:
+
+- You want to add a cinematic, film-like quality to digital video
+- You need to create vintage or retro video effects
+- You want to add texture and character to clean digital footage
+- You're creating content that needs to look like it was shot on film
+- You want to enhance the visual depth and atmosphere of your video
+
+## How to use it
+
+### Basic Setup
+
+1. Add an AddFilmGrain node to your workflow
+1. Connect a video source to the "video" input
+1. Adjust the grain intensity, luminance threshold, and grain scale parameters
+1. Run the workflow to add film grain to your video
+
+### Parameters
+
+- **video**: The video content to add film grain to (supports VideoArtifact and VideoUrlArtifact)
+
+- **grain_intensity**: Film grain intensity (0.05-1.0, default: 0.15)
+
+    - 0.05 = very subtle grain
+    - 0.15 = moderate grain (default)
+    - 0.5 = heavy grain
+    - 1.0 = maximum grain intensity
+
+- **luminance_threshold**: Luminance level where grain is most visible (50-100, default: 75)
+
+    - 50 = grain visible in darker areas
+    - 75 = grain visible in mid-tones (default, good for faces)
+    - 100 = grain visible in brighter areas
+
+- **grain_scale**: Grain scale factor (1.0-4.0, default: 2.0)
+
+    - 1.0 = fine grain particles
+    - 2.0 = medium grain (default)
+    - 4.0 = larger grain particles
+
+### Outputs
+
+- **video**: The video with film grain added, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to add a subtle film grain to a digital video to give it a cinematic look:
+
+1. Add an AddFilmGrain node to your workflow
+1. Connect the video output from a LoadVideo node to the AddFilmGrain's "video" input
+1. Set the "grain_intensity" to 0.12 for subtle grain
+1. Set the "luminance_threshold" to 75 for optimal grain visibility on faces
+1. Set the "grain_scale" to 2.0 for medium-sized grain particles
+1. Run the workflow - the video will have realistic film grain added
+1. The output filename will be `{original_filename}_grain_0.12.{format}`
+
+## Important Notes
+
+- The AddFilmGrain node uses FFmpeg with sophisticated noise generation algorithms
+- Grain intensity is automatically adjusted based on the luminance of each pixel
+- The effect creates temporal grain that changes between frames for realism
+- Processing time depends on video length and resolution
+- The original audio track is preserved
+- Logs are available for debugging processing issues
+
+## Parameter Recommendations
+
+- **For subtle film look**: Use grain_intensity 0.08-0.15, luminance_threshold 75
+- **For vintage/retro effect**: Use grain_intensity 0.3-0.6, grain_scale 2.5-3.0
+- **For heavy film grain**: Use grain_intensity 0.7-1.0, grain_scale 3.0-4.0
+- **For portraits**: Use luminance_threshold 70-80 for optimal grain on faces
+- **For landscapes**: Use luminance_threshold 60-70 for grain in mid-tones
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Too Much Grain**: Reduce grain_intensity if the effect is too strong
+- **Grain Not Visible**: Increase grain_intensity or adjust luminance_threshold
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/add_film_grain.md
+++ b/docs/nodes/video/add_film_grain.md
@@ -46,6 +46,12 @@ Use the AddFilmGrain node when:
     - 2.0 = medium grain (default)
     - 4.0 = larger grain particles
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The video with film grain added, available as output to connect to other nodes

--- a/docs/nodes/video/add_overlay.md
+++ b/docs/nodes/video/add_overlay.md
@@ -1,0 +1,100 @@
+# AddOverlay
+
+## What is it?
+
+The AddOverlay node composites two videos together by overlaying one video on top of another using FFmpeg's blend modes. It provides control over the blend mode, channel selection, and sizing of the overlay video. The node supports various blend modes that match industry-standard compositing software.
+
+## When would I use it?
+
+Use the AddOverlay node when:
+
+- You want to add film grain or noise effects to your video
+- You need to composite multiple video layers together
+- You're creating videos with watermarks or logos
+- You want to add visual effects that require layering
+- You're working on projects that need video compositing
+- You want to create vintage or textured video effects
+
+## How to use it
+
+### Basic Setup
+
+1. Add an AddOverlay node to your workflow
+1. Connect a base video to the "video" input
+1. Connect an overlay video to the "overlay_video" input
+1. Choose a blend mode and adjust the amount parameter
+1. Run the workflow to composite the videos
+
+### Parameters
+
+- **video**: The base video content (supports VideoArtifact and VideoUrlArtifact)
+
+- **overlay_video**: The video or image to overlay on top of the base video (supports VideoArtifact, VideoUrlArtifact, ImageArtifact, and ImageUrlArtifact)
+
+- **blend_mode**: How to blend the overlay with the base video (default: "overlay")
+
+    - **overlay**: Original overlay with alpha blending
+    - **screen**: Brighten (good for dust/scratches)
+    - **lighten**: Only brighten where overlay is brighter
+    - **softlight**: Natural blending for film grain
+    - **grainmerge**: Merge grain/noise (recommended for noise effects)
+    - **grainextract**: Extract grain/noise
+    - **glow**: Glow effect
+    - **hardlight**: Hard light blending
+
+- **amount**: Strength of the overlay effect (0.0-1.0, default: 0.5)
+
+    - 0.0 = no effect (original video unchanged)
+    - 0.5 = 50% effect strength (default)
+    - 1.0 = full effect strength
+
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
+### Outputs
+
+- **video**: The composited video with overlay applied, available as output to connect to other nodes
+
+## Examples
+
+### Example 1: Film Grain Overlay
+
+1. Connect a base video to the AddOverlay's "video" input
+1. Connect a film grain video to the "overlay_video" input
+1. Set "blend_mode" to "grainmerge" for noise effects
+1. Set "amount" to 0.3 for subtle grain effect
+1. Run the workflow - the video will have a film grain overlay
+1. The output filename will be `{original_filename}_overlay_grainmerge_amount0.30.{format}`
+
+### Example 2: Logo Overlay
+
+1. Connect a base video to the AddOverlay's "video" input
+1. Connect a PNG logo with transparency to the "overlay_video" input
+1. Set "blend_mode" to "overlay" for alpha blending
+1. Set "amount" to 0.8 for visible logo
+1. Run the workflow - the video will have a positioned logo
+
+### Example 3: Vintage Effect with Film Grain
+
+1. Use ChangeSpeed to speed up your video
+1. Use AddColorCurves with "vintage" preset
+1. Use AddOverlay to add film grain texture
+1. Set "blend_mode" to "grainmerge"
+1. Set "amount" to 0.4 for vintage grain effect
+1. Run the workflow for a complete vintage look
+
+## Important Notes
+
+- The overlay video will be automatically looped and trimmed to match the base video's duration
+- PNG images with transparency are supported as overlays
+- The node uses linear RGB blending for consistent results that match industry standards
+- For noise effects, use "grainmerge" blend mode with "luminance" channel
+- For logos with transparency, use "overlay" blend mode with "rgba" channel
+- The overlay is always centered on the base video for simplicity
+
+## Technical Details
+
+The node uses FFmpeg's blend modes and supports both overlay filter (for alpha blending) and blend filter (for other blend modes). It automatically converts to linear RGB space for consistent blending behavior that matches industry-standard compositing software.

--- a/docs/nodes/video/add_rgb_shift.md
+++ b/docs/nodes/video/add_rgb_shift.md
@@ -40,7 +40,9 @@ Use the AddRGBShift node when:
 #### Tear Effect Settings
 
 - **tear_enabled**: Enable tear effect (default: False)
+
 - **tear_position**: Vertical position of tear (0.0-1.0, where 0.5 is center, default: 0.5)
+
 - **tear_offset**: Horizontal offset amount for tear effect (-50 to 50 pixels, default: 10)
 
 - **processing_speed**: Balance between processing speed and output quality (default: "balanced")

--- a/docs/nodes/video/add_rgb_shift.md
+++ b/docs/nodes/video/add_rgb_shift.md
@@ -1,0 +1,103 @@
+# AddRGBShift
+
+## What is it?
+
+The AddRGBShift node adds RGB shift (chromatic aberration) effects to video, creating visual distortions where the red, green, and blue color channels are offset from each other. It can create both static and animated glitch effects with VHS-style artifacts.
+
+## When would I use it?
+
+Use the AddRGBShift node when:
+
+- You want to create glitch art or digital distortion effects
+- You need to simulate VHS tape artifacts and degradation
+- You're creating cyberpunk or retro-futuristic content
+- You want to add visual interest to otherwise clean footage
+- You need to create unsettling or disorienting visual effects
+- You're making content that mimics old video technology
+
+## How to use it
+
+### Basic Setup
+
+1. Add an AddRGBShift node to your workflow
+1. Connect a video source to the "video" input
+1. Choose between "static" or "animated" glitch mode
+1. Adjust the RGB shift parameters and visual effects
+1. Run the workflow to add the RGB shift effect
+
+### Parameters
+
+#### Glitched Visual Style
+
+- **red_horizontal**: Red channel horizontal shift (-20 to 20 pixels, default: -6)
+- **red_vertical**: Red channel vertical shift (-20 to 20 pixels, default: 0)
+- **green_horizontal**: Green channel horizontal shift (-20 to 20 pixels, default: 6)
+- **green_vertical**: Green channel vertical shift (-20 to 20 pixels, default: 0)
+- **blue_horizontal**: Blue channel horizontal shift (-20 to 20 pixels, default: 0)
+- **blue_vertical**: Blue channel vertical shift (-20 to 20 pixels, default: 0)
+- **intensity**: Overall intensity of the RGB shift effect (0.0-1.0, default: 1.0)
+
+#### Glitch Animation Settings
+
+- **glitch_frequency**: Number of glitches per second when animated (0.1-10.0, default: 2.0)
+- **glitch_duration**: Duration of each glitch in seconds (0.01-0.5, default: 0.1)
+- **glitch_intensity**: Intensity of glitch shifts when animated (0.0-1.0, default: 0.5)
+
+#### Tear Effects
+
+- **tear_offset_min**: Minimum horizontal offset for tear effect (-50 to 50 pixels, default: 5)
+- **tear_offset_max**: Maximum horizontal offset for tear effect (-50 to 50 pixels, default: 15)
+
+#### Random Seed Settings
+
+- **random_seed**: Random seed for glitch timing (default: 42, use -1 for random patterns)
+
+#### Non-Glitched Visual Style (VHS Base Effects)
+
+- **noise_strength**: Tape noise strength (0-50, default: 8)
+- **chroma_shift_horizontal**: Chroma shift horizontal (always active) (-10 to 10 pixels, default: 2)
+- **chroma_shift_vertical**: Chroma shift vertical (always active) (-10 to 10 pixels, default: -2)
+- **blur_strength**: Blur strength (0.0-3.0, default: 0.8)
+- **motion_trails**: Motion trail frames (1-5, default: 3)
+
+### Outputs
+
+- **video**: The video with RGB shift effects added, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to create a VHS-style glitch effect on a video:
+
+1. Add an AddRGBShift node to your workflow
+1. Connect the video output from a LoadVideo node to the AddRGBShift's "video" input
+1. Set glitch_mode to "animated" for dynamic effects
+1. Set red_horizontal to -8, green_horizontal to 8 for classic RGB separation
+1. Set glitch_frequency to 1.5 for moderate glitch timing
+1. Set noise_strength to 12 for visible tape noise
+1. Run the workflow - the video will have VHS-style glitch effects
+1. The output filename will include all the effect parameters
+
+## Important Notes
+
+- The AddRGBShift node uses FFmpeg with complex filter chains for realistic effects
+- Animated mode creates sporadic, unpredictable glitches with random timing
+- Static mode applies constant RGB shift throughout the video
+- Tear effects randomly occur during animated glitches
+- The original audio track is preserved
+- Processing time depends on video length and effect complexity
+
+## Effect Recommendations
+
+- **Subtle RGB shift**: Use small values (2-4 pixels) for red/green horizontal shifts
+- **Heavy glitch effect**: Use larger values (10-20 pixels) and animated mode
+- **VHS simulation**: Combine noise_strength 8-15, chroma_shift, and blur_strength 0.5-1.0
+- **Cyberpunk aesthetic**: Use animated mode with high glitch_frequency and tear effects
+- **Retro video look**: Use static mode with moderate RGB shifts and noise
+
+## Common Issues
+
+- **Processing Timeout**: Complex effects may take longer to process; the node has a 5-minute timeout
+- **Effect Too Strong**: Reduce intensity or RGB shift values if the effect is overwhelming
+- **No Glitches in Animated Mode**: Check glitch_frequency and ensure random_seed is set appropriately
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/add_rgb_shift.md
+++ b/docs/nodes/video/add_rgb_shift.md
@@ -43,6 +43,12 @@ Use the AddRGBShift node when:
 - **tear_position**: Vertical position of tear (0.0-1.0, where 0.5 is center, default: 0.5)
 - **tear_offset**: Horizontal offset amount for tear effect (-50 to 50 pixels, default: 10)
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The video with RGB shift effects added, available as output to connect to other nodes

--- a/docs/nodes/video/add_rgb_shift.md
+++ b/docs/nodes/video/add_rgb_shift.md
@@ -2,18 +2,18 @@
 
 ## What is it?
 
-The AddRGBShift node adds RGB shift (chromatic aberration) effects to video, creating visual distortions where the red, green, and blue color channels are offset from each other. It can create both static and animated glitch effects with VHS-style artifacts.
+The AddRGBShift node adds RGB shift (chromatic aberration) effects to video, creating visual distortions where the red, green, and blue color channels are offset from each other. It can also add a tear effect that splits the video horizontally and applies different RGB shifts to each part.
 
 ## When would I use it?
 
 Use the AddRGBShift node when:
 
 - You want to create glitch art or digital distortion effects
-- You need to simulate VHS tape artifacts and degradation
+- You need to simulate chromatic aberration or lens distortion
 - You're creating cyberpunk or retro-futuristic content
 - You want to add visual interest to otherwise clean footage
 - You need to create unsettling or disorienting visual effects
-- You're making content that mimics old video technology
+- You want to add a tear effect that splits the video horizontally
 
 ## How to use it
 
@@ -21,13 +21,13 @@ Use the AddRGBShift node when:
 
 1. Add an AddRGBShift node to your workflow
 1. Connect a video source to the "video" input
-1. Choose between "static" or "animated" glitch mode
-1. Adjust the RGB shift parameters and visual effects
+1. Adjust the RGB shift parameters for each color channel
+1. Optionally enable the tear effect and configure its position and offset
 1. Run the workflow to add the RGB shift effect
 
 ### Parameters
 
-#### Glitched Visual Style
+#### RGB Shift Settings
 
 - **red_horizontal**: Red channel horizontal shift (-20 to 20 pixels, default: -6)
 - **red_vertical**: Red channel vertical shift (-20 to 20 pixels, default: 0)
@@ -37,28 +37,11 @@ Use the AddRGBShift node when:
 - **blue_vertical**: Blue channel vertical shift (-20 to 20 pixels, default: 0)
 - **intensity**: Overall intensity of the RGB shift effect (0.0-1.0, default: 1.0)
 
-#### Glitch Animation Settings
+#### Tear Effect Settings
 
-- **glitch_frequency**: Number of glitches per second when animated (0.1-10.0, default: 2.0)
-- **glitch_duration**: Duration of each glitch in seconds (0.01-0.5, default: 0.1)
-- **glitch_intensity**: Intensity of glitch shifts when animated (0.0-1.0, default: 0.5)
-
-#### Tear Effects
-
-- **tear_offset_min**: Minimum horizontal offset for tear effect (-50 to 50 pixels, default: 5)
-- **tear_offset_max**: Maximum horizontal offset for tear effect (-50 to 50 pixels, default: 15)
-
-#### Random Seed Settings
-
-- **random_seed**: Random seed for glitch timing (default: 42, use -1 for random patterns)
-
-#### Non-Glitched Visual Style (VHS Base Effects)
-
-- **noise_strength**: Tape noise strength (0-50, default: 8)
-- **chroma_shift_horizontal**: Chroma shift horizontal (always active) (-10 to 10 pixels, default: 2)
-- **chroma_shift_vertical**: Chroma shift vertical (always active) (-10 to 10 pixels, default: -2)
-- **blur_strength**: Blur strength (0.0-3.0, default: 0.8)
-- **motion_trails**: Motion trail frames (1-5, default: 3)
+- **tear_enabled**: Enable tear effect (default: False)
+- **tear_position**: Vertical position of tear (0.0-1.0, where 0.5 is center, default: 0.5)
+- **tear_offset**: Horizontal offset amount for tear effect (-50 to 50 pixels, default: 10)
 
 ### Outputs
 
@@ -66,38 +49,34 @@ Use the AddRGBShift node when:
 
 ## Example
 
-Imagine you want to create a VHS-style glitch effect on a video:
+Imagine you want to create a glitch effect on a video:
 
 1. Add an AddRGBShift node to your workflow
 1. Connect the video output from a LoadVideo node to the AddRGBShift's "video" input
-1. Set glitch_mode to "animated" for dynamic effects
 1. Set red_horizontal to -8, green_horizontal to 8 for classic RGB separation
-1. Set glitch_frequency to 1.5 for moderate glitch timing
-1. Set noise_strength to 12 for visible tape noise
-1. Run the workflow - the video will have VHS-style glitch effects
+1. Set intensity to 0.8 for a moderate effect
+1. Enable tear_enabled and set tear_position to 0.6 and tear_offset to 15
+1. Run the workflow - the video will have RGB shift effects with a tear at 60% down the frame
 1. The output filename will include all the effect parameters
 
 ## Important Notes
 
-- The AddRGBShift node uses FFmpeg with complex filter chains for realistic effects
-- Animated mode creates sporadic, unpredictable glitches with random timing
-- Static mode applies constant RGB shift throughout the video
-- Tear effects randomly occur during animated glitches
+- The AddRGBShift node uses FFmpeg with the rgbashift filter for reliable effects
+- The tear effect splits the video horizontally and applies different RGB shifts to each part
 - The original audio track is preserved
 - Processing time depends on video length and effect complexity
 
 ## Effect Recommendations
 
 - **Subtle RGB shift**: Use small values (2-4 pixels) for red/green horizontal shifts
-- **Heavy glitch effect**: Use larger values (10-20 pixels) and animated mode
-- **VHS simulation**: Combine noise_strength 8-15, chroma_shift, and blur_strength 0.5-1.0
-- **Cyberpunk aesthetic**: Use animated mode with high glitch_frequency and tear effects
-- **Retro video look**: Use static mode with moderate RGB shifts and noise
+- **Heavy glitch effect**: Use larger values (10-20 pixels) for dramatic separation
+- **Tear effect**: Position the tear at 0.3-0.7 for best visual impact
+- **Cyberpunk aesthetic**: Combine red/green horizontal shifts with tear effects
+- **Retro video look**: Use moderate RGB shifts with intensity around 0.7-0.9
 
 ## Common Issues
 
 - **Processing Timeout**: Complex effects may take longer to process; the node has a 5-minute timeout
 - **Effect Too Strong**: Reduce intensity or RGB shift values if the effect is overwhelming
-- **No Glitches in Animated Mode**: Check glitch_frequency and ensure random_seed is set appropriately
 - **No Video Input**: Make sure a video source is connected to the "video" input
 - **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/add_vignette.md
+++ b/docs/nodes/video/add_vignette.md
@@ -59,7 +59,7 @@ Use the AddVignette node when:
     - "forward" = darken edges (traditional vignette)
     - "backward" = lighten edges (inverse vignette)
 
-- **dither**: Enable dithering for smoother vignette gradients (default: true)
+
 
 ### Outputs
 
@@ -75,7 +75,7 @@ Imagine you want to add a subtle vignette to a portrait video to draw attention 
 1. Keep "center_x" and "center_y" at 0.0 to center the vignette
 1. Set "aspect" to 1.0 for a circular vignette
 1. Choose "forward" mode to darken the edges
-1. Enable "dither" for smooth gradients
+
 1. Run the workflow - the video will have a subtle vignette effect
 1. The output filename will be `{original_filename}_vignette_a0.50_x0.00_y0.00_r1.00_forward.{format}`
 
@@ -83,7 +83,6 @@ Imagine you want to add a subtle vignette to a portrait video to draw attention 
 
 - The AddVignette node uses FFmpeg with high-quality vignette algorithms
 - The effect creates smooth, gradual transitions from center to edges
-- Dithering helps reduce banding artifacts in the vignette gradient
 - The original audio track is preserved
 - Processing time depends on video length and resolution
 - Logs are available for debugging processing issues
@@ -92,7 +91,7 @@ Imagine you want to add a subtle vignette to a portrait video to draw attention 
 
 - **For portraits**: Use angle 0.4-0.6, center at (0,0), aspect 1.0
 - **For landscapes**: Use angle 0.3-0.5, center at (0,0), aspect 1.5-2.0
-- **For cinematic look**: Use angle 0.5-0.8, forward mode with dither enabled
+- **For cinematic look**: Use angle 0.5-0.8, forward mode
 - **For subtle enhancement**: Use angle 0.8-1.2 for very gentle vignette
 - **For dramatic effect**: Use angle 2.0-3.0 for strong vignette
 - **For off-center subjects**: Adjust center_x and center_y to match subject position

--- a/docs/nodes/video/add_vignette.md
+++ b/docs/nodes/video/add_vignette.md
@@ -1,0 +1,106 @@
+# AddVignette
+
+## What is it?
+
+The AddVignette node adds a vignette effect to video, creating a gradual darkening or lightening around the edges of the frame. This effect can enhance the visual focus on the center of the frame and add a cinematic quality to your video.
+
+## When would I use it?
+
+Use the AddVignette node when:
+
+- You want to draw attention to the center of your video frame
+- You need to create a cinematic, film-like look
+- You want to add depth and atmosphere to your video
+- You're creating content that needs a professional, polished appearance
+- You want to simulate the natural light falloff of camera lenses
+- You need to enhance the mood or emotional impact of your video
+
+## How to use it
+
+### Basic Setup
+
+1. Add an AddVignette node to your workflow
+1. Connect a video source to the "video" input
+1. Adjust the vignette angle, center position, and aspect ratio
+1. Choose between "forward" (darken edges) or "backward" (lighten edges) mode
+1. Run the workflow to add the vignette effect
+
+### Parameters
+
+- **video**: The video content to add vignette to (supports VideoArtifact and VideoUrlArtifact)
+
+- **angle**: Lens angle for vignette effect (0.1-3.14, default: 0.628)
+
+    - Smaller values = less vignette effect
+    - 0.1 = very subtle vignette
+    - 0.628 = moderate vignette (default)
+    - 3.14 = very strong vignette
+
+- **center_x**: Center X offset (-1.0 to 1.0, default: 0.0)
+
+    - -1.0 = far left
+    - 0.0 = center (default)
+    - 1.0 = far right
+
+- **center_y**: Center Y offset (-1.0 to 1.0, default: 0.0)
+
+    - -1.0 = top
+    - 0.0 = center (default)
+    - 1.0 = bottom
+
+- **aspect**: Aspect ratio of vignette (0.1-10.0, default: 1.0)
+
+    - 0.1 = very wide vignette
+    - 1.0 = circular vignette (default)
+    - 10.0 = very tall vignette
+
+- **mode**: Vignette mode (default: "forward")
+
+    - "forward" = darken edges (traditional vignette)
+    - "backward" = lighten edges (inverse vignette)
+
+- **dither**: Enable dithering for smoother vignette gradients (default: true)
+
+### Outputs
+
+- **video**: The video with vignette effect added, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to add a subtle vignette to a portrait video to draw attention to the subject:
+
+1. Add an AddVignette node to your workflow
+1. Connect the video output from a LoadVideo node to the AddVignette's "video" input
+1. Set the "angle" to 0.5 for a moderate vignette effect
+1. Keep "center_x" and "center_y" at 0.0 to center the vignette
+1. Set "aspect" to 1.0 for a circular vignette
+1. Choose "forward" mode to darken the edges
+1. Enable "dither" for smooth gradients
+1. Run the workflow - the video will have a subtle vignette effect
+1. The output filename will be `{original_filename}_vignette_a0.50_x0.00_y0.00_r1.00_forward.{format}`
+
+## Important Notes
+
+- The AddVignette node uses FFmpeg with high-quality vignette algorithms
+- The effect creates smooth, gradual transitions from center to edges
+- Dithering helps reduce banding artifacts in the vignette gradient
+- The original audio track is preserved
+- Processing time depends on video length and resolution
+- Logs are available for debugging processing issues
+
+## Parameter Recommendations
+
+- **For portraits**: Use angle 0.4-0.6, center at (0,0), aspect 1.0
+- **For landscapes**: Use angle 0.3-0.5, center at (0,0), aspect 1.5-2.0
+- **For cinematic look**: Use angle 0.5-0.8, forward mode with dither enabled
+- **For subtle enhancement**: Use angle 0.8-1.2 for very gentle vignette
+- **For dramatic effect**: Use angle 2.0-3.0 for strong vignette
+- **For off-center subjects**: Adjust center_x and center_y to match subject position
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Vignette Too Strong**: Decrease the angle value to make the effect more subtle
+- **Vignette Not Visible**: Increase the angle value to make the effect stronger
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/add_vignette.md
+++ b/docs/nodes/video/add_vignette.md
@@ -59,7 +59,11 @@ Use the AddVignette node when:
     - "forward" = darken edges (traditional vignette)
     - "backward" = lighten edges (inverse vignette)
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
 
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
 
 ### Outputs
 
@@ -70,13 +74,19 @@ Use the AddVignette node when:
 Imagine you want to add a subtle vignette to a portrait video to draw attention to the subject:
 
 1. Add an AddVignette node to your workflow
+
 1. Connect the video output from a LoadVideo node to the AddVignette's "video" input
+
 1. Set the "angle" to 0.5 for a moderate vignette effect
+
 1. Keep "center_x" and "center_y" at 0.0 to center the vignette
+
 1. Set "aspect" to 1.0 for a circular vignette
+
 1. Choose "forward" mode to darken the edges
 
 1. Run the workflow - the video will have a subtle vignette effect
+
 1. The output filename will be `{original_filename}_vignette_a0.50_x0.00_y0.00_r1.00_forward.{format}`
 
 ## Important Notes

--- a/docs/nodes/video/adjust_video_eq.md
+++ b/docs/nodes/video/adjust_video_eq.md
@@ -52,6 +52,12 @@ Use the AdjustVideoEQ node when:
     - 1.0 = normal gamma (default)
     - 10.0 = very dark mid-tones
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The video with EQ adjustments applied, available as output to connect to other nodes

--- a/docs/nodes/video/adjust_video_eq.md
+++ b/docs/nodes/video/adjust_video_eq.md
@@ -1,0 +1,95 @@
+# AdjustVideoEQ
+
+## What is it?
+
+The AdjustVideoEQ node allows you to adjust video brightness, contrast, saturation, and gamma settings. It provides precise control over the visual appearance of your video content using FFmpeg's high-quality equalization filters.
+
+## When would I use it?
+
+Use the AdjustVideoEQ node when:
+
+- You need to correct exposure issues in your video
+- You want to enhance the visual quality of poorly lit footage
+- You need to adjust color saturation for artistic or technical reasons
+- You want to match the look of multiple video clips
+- You're creating content that needs specific visual adjustments
+- You want to improve the overall visual appeal of your video
+
+## How to use it
+
+### Basic Setup
+
+1. Add an AdjustVideoEQ node to your workflow
+1. Connect a video source to the "video" input
+1. Adjust the brightness, contrast, saturation, and gamma parameters
+1. Run the workflow to apply the EQ adjustments
+
+### Parameters
+
+- **video**: The video content to adjust (supports VideoArtifact and VideoUrlArtifact)
+
+- **brightness**: Brightness adjustment (-1.0 to 1.0, default: 0.0)
+
+    - -1.0 = very dark
+    - 0.0 = normal brightness (default)
+    - 1.0 = very bright
+
+- **contrast**: Contrast adjustment (0.0 to 3.0, default: 1.0)
+
+    - 0.0 = no contrast (flat image)
+    - 1.0 = normal contrast (default)
+    - 3.0 = very high contrast
+
+- **saturation**: Saturation adjustment (0.0 to 3.0, default: 1.0)
+
+    - 0.0 = black and white
+    - 1.0 = normal saturation (default)
+    - 3.0 = very saturated colors
+
+- **gamma**: Gamma adjustment (0.1 to 10.0, default: 1.0)
+
+    - 0.1 = very bright mid-tones
+    - 1.0 = normal gamma (default)
+    - 10.0 = very dark mid-tones
+
+### Outputs
+
+- **video**: The video with EQ adjustments applied, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to brighten a dark video and increase its saturation:
+
+1. Add an AdjustVideoEQ node to your workflow
+1. Connect the video output from a LoadVideo node to the AdjustVideoEQ's "video" input
+1. Set "brightness" to 0.3 to brighten the video
+1. Set "contrast" to 1.2 to enhance contrast
+1. Set "saturation" to 1.5 to make colors more vibrant
+1. Keep "gamma" at 1.0 for normal mid-tone response
+1. Run the workflow - the video will be brighter and more saturated
+1. The output filename will be `{original_filename}_eq_b0.30_c1.20_s1.50_g1.00.{format}`
+
+## Important Notes
+
+- The AdjustVideoEQ node uses FFmpeg with high-quality equalization algorithms
+- All parameters work together to create the final visual effect
+- The original audio track is preserved
+- Processing time depends on video length and resolution
+- Logs are available for debugging processing issues
+
+## Parameter Recommendations
+
+- **For dark footage**: Use brightness 0.2-0.5, contrast 1.1-1.3
+- **For overexposed footage**: Use brightness -0.2 to -0.5, contrast 0.8-0.9
+- **For flat footage**: Use contrast 1.2-1.5, saturation 1.1-1.3
+- **For vibrant colors**: Use saturation 1.3-1.8, gamma 0.9-1.1
+- **For cinematic look**: Use contrast 1.1-1.2, saturation 0.8-0.9, gamma 1.1-1.2
+- **For vintage effect**: Use saturation 0.7-0.8, gamma 1.2-1.4
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Too Bright/Dark**: Adjust brightness value - use negative values to darken, positive to brighten
+- **Colors Too Saturated**: Reduce saturation value below 1.0
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/change_speed.md
+++ b/docs/nodes/video/change_speed.md
@@ -1,0 +1,91 @@
+# ChangeSpeed
+
+## What is it?
+
+The ChangeSpeed node allows you to change the playback speed of a video. It uses FFmpeg's setpts filter to adjust video timing and automatically adjusts audio speed to match, creating smooth speed changes while maintaining audio-video synchronization.
+
+## When would I use it?
+
+Use the ChangeSpeed node when:
+
+- You want to create fast-motion effects (e.g., 2x, 3x faster)
+- You need to create slow-motion effects (e.g., 0.5x, 0.25x slower)
+- You want to speed up long videos for quick review
+- You need to slow down fast action for analysis
+- You're creating time-lapse or slow-motion content
+- You want to adjust video pacing for different audiences
+
+## How to use it
+
+### Basic Setup
+
+1. Add a ChangeSpeed node to your workflow
+1. Connect a video source to the "video" input
+1. Set your desired speed multiplier
+1. Run the workflow to change the video's playback speed
+
+### Parameters
+
+- **video**: The video content to change speed (supports VideoArtifact and VideoUrlArtifact)
+
+- **speed**: Playback speed multiplier (0.1-10.0x, default: 1.0)
+
+    - 0.1 = 10x slower (very slow motion)
+    - 0.5 = 2x slower (slow motion)
+    - 1.0 = normal speed (default)
+    - 2.0 = 2x faster (fast motion)
+    - 5.0 = 5x faster (very fast motion)
+    - 10.0 = 10x faster (maximum speed)
+
+- **include_audio**: When enabled, includes audio in the output file (default: true)
+
+    - When enabled: Audio is speed-adjusted to match video speed
+    - When disabled: Creates a silent video (no audio track)
+
+### Outputs
+
+- **video**: The video with changed playback speed, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to create a fast-motion effect by speeding up a video 3x:
+
+1. Add a ChangeSpeed node to your workflow
+1. Connect the video output from a LoadVideo node to the ChangeSpeed's "video" input
+1. Set "speed" to 3.0 for 3x faster playback
+1. Keep "include_audio" enabled (default) to include speed-adjusted audio
+1. Run the workflow - the video will play 3x faster with audio adjusted to match
+1. The output filename will be `{original_filename}_speed3.0.{format}`
+
+## Important Notes
+
+- The ChangeSpeed node uses FFmpeg's setpts filter for high-quality speed changes
+- Audio is automatically speed-adjusted using the atempo filter to maintain synchronization (when include_audio is enabled)
+- Speed changes affect both video and audio simultaneously
+- Processing time depends on video length and resolution
+- Extreme speed changes (very fast or very slow) may affect audio quality
+- When include_audio is disabled, the output video will be silent
+
+## Parameter Recommendations
+
+- **For fast motion**: Use 2.0-5.0 for sped-up effects
+- **For slow motion**: Use 0.25-0.75 for slow-motion effects
+- **For time-lapse**: Use 5.0-10.0 for very fast playback
+- **For analysis**: Use 0.5-0.75 to slow down fast action
+- **For quick review**: Use 2.0-3.0 to speed up long content
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Audio Quality**: Extreme speed changes may affect audio clarity
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails
+
+## Speed Examples
+
+- **0.25x**: 4x slower - Good for analyzing fast action
+- **0.5x**: 2x slower - Classic slow motion
+- **1.0x**: Normal speed - No change
+- **2.0x**: 2x faster - Fast motion
+- **3.0x**: 3x faster - Very fast motion
+- **5.0x**: 5x faster - Time-lapse effect

--- a/docs/nodes/video/change_speed.md
+++ b/docs/nodes/video/change_speed.md
@@ -42,6 +42,12 @@ Use the ChangeSpeed node when:
     - When enabled: Audio is speed-adjusted to match video speed
     - When disabled: Creates a silent video (no audio track)
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The video with changed playback speed, available as output to connect to other nodes

--- a/docs/nodes/video/flip_video.md
+++ b/docs/nodes/video/flip_video.md
@@ -1,0 +1,73 @@
+# FlipVideo
+
+## What is it?
+
+The FlipVideo node flips your video horizontally, vertically, or both directions. This creates a mirror effect that can be useful for correcting orientation or creating artistic effects.
+
+## When would I use it?
+
+Use the FlipVideo node when:
+
+- You need to correct video that was recorded upside down or backwards
+- You want to create mirror effects for artistic purposes
+- You need to flip footage to match other video clips
+- You're creating content that requires flipped orientation
+- You want to create symmetrical video effects
+- You need to correct camera orientation issues
+
+## How to use it
+
+### Basic Setup
+
+1. Add a FlipVideo node to your workflow
+1. Connect a video source to the "video" input
+1. Choose the flip direction (horizontal, vertical, or both)
+1. Run the workflow to flip the video
+
+### Parameters
+
+- **video**: The video content to flip (supports VideoArtifact and VideoUrlArtifact)
+
+- **direction**: Flip direction (default: "horizontal")
+
+    - "horizontal" = flip left to right (mirror effect)
+    - "vertical" = flip top to bottom (upside down)
+    - "both" = flip both horizontally and vertically
+
+### Outputs
+
+- **video**: The flipped video, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to create a mirror effect on a video:
+
+1. Add a FlipVideo node to your workflow
+1. Connect the video output from a LoadVideo node to the FlipVideo's "video" input
+1. Set "direction" to "horizontal" to create a mirror effect
+1. Run the workflow - the video will be flipped horizontally
+1. The output filename will be `{original_filename}_flipped_horizontal.{format}`
+
+## Important Notes
+
+- The FlipVideo node uses FFmpeg with high-quality flip processing
+- Horizontal flip creates a mirror effect (left becomes right)
+- Vertical flip turns the video upside down
+- Both directions flip the video in both axes
+- The original audio track is preserved
+- Processing time depends on video length and resolution
+- Logs are available for debugging processing issues
+
+## Direction Recommendations
+
+- **For mirror effects**: Use "horizontal" - creates left-to-right mirror
+- **For upside down correction**: Use "vertical" - flips top to bottom
+- **For complete rotation**: Use "both" - flips in both directions
+- **For camera correction**: Use appropriate direction based on how the camera was oriented
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Wrong Direction**: Make sure you've selected the correct flip direction for your needs
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/flip_video.md
+++ b/docs/nodes/video/flip_video.md
@@ -34,6 +34,12 @@ Use the FlipVideo node when:
     - "vertical" = flip top to bottom (upside down)
     - "both" = flip both horizontally and vertically
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The flipped video, available as output to connect to other nodes

--- a/docs/nodes/video/hold_video_frames.md
+++ b/docs/nodes/video/hold_video_frames.md
@@ -35,6 +35,12 @@ Use the HoldVideoFrames node when:
     - 5 = each frame held for 5 frames (much slower playback)
     - 10 = each frame held for 10 frames (very slow playback)
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The video with frame holding effect applied, available as output to connect to other nodes

--- a/docs/nodes/video/hold_video_frames.md
+++ b/docs/nodes/video/hold_video_frames.md
@@ -1,0 +1,73 @@
+# HoldVideoFrames
+
+## What is it?
+
+The HoldVideoFrames node creates a stepped video effect by holding each frame for a specified number of frames. This creates a stop-motion or frame-stepping effect that can add artistic interest to your video content.
+
+## When would I use it?
+
+Use the HoldVideoFrames node when:
+
+- You want to create a stop-motion animation effect
+- You need to slow down fast-moving content for better visibility
+- You're creating artistic video effects with frame manipulation
+- You want to add a retro or vintage feel to your video
+- You need to create dramatic slow-motion effects
+- You're making content that requires frame-by-frame analysis
+
+## How to use it
+
+### Basic Setup
+
+1. Add a HoldVideoFrames node to your workflow
+1. Connect a video source to the "video" input
+1. Set the "hold_frames" parameter to specify how many frames to hold
+1. Run the workflow to create the frame-holding effect
+
+### Parameters
+
+- **video**: The video content to apply frame holding to (supports VideoArtifact and VideoUrlArtifact)
+
+- **hold_frames**: Number of frames to hold (1-10, default: 2)
+
+    - 1 = no effect (normal playback)
+    - 2 = each frame held for 2 frames (slower playback)
+    - 5 = each frame held for 5 frames (much slower playback)
+    - 10 = each frame held for 10 frames (very slow playback)
+
+### Outputs
+
+- **video**: The video with frame holding effect applied, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to create a stop-motion effect on a video:
+
+1. Add a HoldVideoFrames node to your workflow
+1. Connect the video output from a LoadVideo node to the HoldVideoFrames's "video" input
+1. Set "hold_frames" to 3 to hold each frame for 3 frames
+1. Run the workflow - the video will have a stepped, stop-motion effect
+1. The output filename will be `{original_filename}_hold_3_frames.{format}`
+
+## Important Notes
+
+- The HoldVideoFrames node uses FFmpeg with high-quality frame processing
+- The effect reduces the effective frame rate by the hold_frames value
+- The original audio track is preserved but may not sync perfectly with the visual effect
+- Processing time depends on video length and hold_frames value
+- Logs are available for debugging processing issues
+
+## Effect Recommendations
+
+- **Subtle slow motion**: Use hold_frames 2-3 for gentle frame holding
+- **Stop-motion effect**: Use hold_frames 4-6 for noticeable stepping
+- **Dramatic slow motion**: Use hold_frames 7-10 for very slow playback
+- **Frame analysis**: Use hold_frames 2-3 to slow down fast content for review
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Effect Too Strong**: Reduce hold_frames value if the effect is too dramatic
+- **Audio Sync Issues**: The frame holding may affect audio synchronization
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/reverse_video.md
+++ b/docs/nodes/video/reverse_video.md
@@ -34,6 +34,12 @@ Use the ReverseVideo node when:
     - "mute" = reverse video only, no audio
     - "keep" = reverse video, keep original audio (not recommended)
 
+- **processing_speed**: Balance between processing speed and output quality (default: "balanced")
+
+    - **fast**: Fastest processing, lower quality (ultrafast preset, CRF 30)
+    - **balanced**: Good balance of speed and quality (medium preset, CRF 23)
+    - **quality**: Highest quality, slower processing (slow preset, CRF 18)
+
 ### Outputs
 
 - **video**: The reversed video, available as output to connect to other nodes

--- a/docs/nodes/video/reverse_video.md
+++ b/docs/nodes/video/reverse_video.md
@@ -62,6 +62,8 @@ Imagine you want to create a backwards playback effect:
 - The "keep" option may create audio sync issues
 - Processing time depends on video length
 - Logs are available for debugging processing issues
+- The node automatically detects if the video has audio and handles it appropriately
+- Videos without audio will be processed correctly without errors
 
 ## Audio Handling Recommendations
 

--- a/docs/nodes/video/reverse_video.md
+++ b/docs/nodes/video/reverse_video.md
@@ -1,0 +1,72 @@
+# ReverseVideo
+
+## What is it?
+
+The ReverseVideo node reverses the playback direction of your video, making it play backwards. It can also handle audio reversal or muting depending on your needs.
+
+## When would I use it?
+
+Use the ReverseVideo node when:
+
+- You want to create backwards playback effects
+- You need to reverse footage for artistic or creative purposes
+- You're creating special effects that require reverse motion
+- You want to add surreal or dreamlike qualities to your video
+- You need to reverse specific segments for editing purposes
+- You're making content that requires backwards motion analysis
+
+## How to use it
+
+### Basic Setup
+
+1. Add a ReverseVideo node to your workflow
+1. Connect a video source to the "video" input
+1. Choose how to handle audio (reverse, mute, or keep original)
+1. Run the workflow to reverse the video
+
+### Parameters
+
+- **video**: The video content to reverse (supports VideoArtifact and VideoUrlArtifact)
+
+- **audio_handling**: How to handle audio (default: "reverse")
+
+    - "reverse" = reverse both video and audio (recommended)
+    - "mute" = reverse video only, no audio
+    - "keep" = reverse video, keep original audio (not recommended)
+
+### Outputs
+
+- **video**: The reversed video, available as output to connect to other nodes
+
+## Example
+
+Imagine you want to create a backwards playback effect:
+
+1. Add a ReverseVideo node to your workflow
+1. Connect the video output from a LoadVideo node to the ReverseVideo's "video" input
+1. Set "audio_handling" to "reverse" to reverse both video and audio
+1. Run the workflow - the video will play backwards
+1. The output filename will be `{original_filename}_reversed_reverse.{format}`
+
+## Important Notes
+
+- The ReverseVideo node uses FFmpeg with high-quality reverse processing
+- Reversing both video and audio creates the most natural backwards effect
+- Muting audio is recommended if you want to avoid strange backwards audio
+- The "keep" option may create audio sync issues
+- Processing time depends on video length
+- Logs are available for debugging processing issues
+
+## Audio Handling Recommendations
+
+- **For natural backwards effect**: Use "reverse" - both video and audio play backwards
+- **For silent backwards effect**: Use "mute" - video plays backwards with no audio
+- **For custom audio**: Use "mute" and add your own audio track separately
+
+## Common Issues
+
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **Strange Audio**: If audio sounds odd, try using "mute" instead of "reverse"
+- **Audio Sync Issues**: The "keep" option may cause audio/video synchronization problems
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/nodes/video/split_video.md
+++ b/docs/nodes/video/split_video.md
@@ -31,20 +31,23 @@ Use the SplitVideo node when:
 - **timecodes**: Timecodes to split the video at (required)
 
     Supports various formats:
-    
+
     **Simple timecode ranges:**
+
     ```
     00:00:00:00-00:01:00:00
     00:01:00:00-00:02:30:00
     ```
-    
+
     **Timecodes with titles:**
+
     ```
     00:00:00:00-00:00:04:07|Segment 1: Introduction
     00:00:04:08-00:00:08:15|Segment 2: Main Content
     ```
-    
+
     **JSON format:**
+
     ```json
     [
       {"start": "00:00:00:00", "end": "00:01:00:00", "title": "Intro"},
@@ -64,11 +67,11 @@ Imagine you want to split a 10-minute video into three segments:
 1. Add a SplitVideo node to your workflow
 1. Connect the video output from a LoadVideo node to the SplitVideo's "video" input
 1. Enter timecodes in the "timecodes" parameter:
-   ```
-   00:00:00:00-00:02:30:00|Segment 1: Introduction
-   00:02:30:00-00:07:30:00|Segment 2: Main Content
-   00:07:30:00-00:10:00:00|Segment 3: Conclusion
-   ```
+    ```
+    00:00:00:00-00:02:30:00|Segment 1: Introduction
+    00:02:30:00-00:07:30:00|Segment 2: Main Content
+    00:07:30:00-00:10:00:00|Segment 3: Conclusion
+    ```
 1. Run the workflow - the video will be split into three separate files
 1. Each segment will be available as a separate output in the split_videos list
 

--- a/docs/nodes/video/split_video.md
+++ b/docs/nodes/video/split_video.md
@@ -1,0 +1,100 @@
+# SplitVideo
+
+## What is it?
+
+The SplitVideo node allows you to split a video into multiple segments using timecodes. It uses AI-powered parsing to understand various timecode formats and creates separate video files for each segment while maintaining high quality.
+
+## When would I use it?
+
+Use the SplitVideo node when:
+
+- You need to break a long video into smaller, manageable segments
+- You want to extract specific scenes or sections from a video
+- You're creating video clips for social media or different platforms
+- You need to separate different parts of a recording (intro, main content, outro)
+- You want to create highlight reels from longer footage
+- You're preparing video content for different audiences or purposes
+
+## How to use it
+
+### Basic Setup
+
+1. Add a SplitVideo node to your workflow
+1. Connect a video source to the "video" input
+1. Enter timecodes in the "timecodes" parameter
+1. Run the workflow to split the video into segments
+
+### Parameters
+
+- **video**: The video to split (supports VideoArtifact and VideoUrlArtifact)
+
+- **timecodes**: Timecodes to split the video at (required)
+
+    Supports various formats:
+    
+    **Simple timecode ranges:**
+    ```
+    00:00:00:00-00:01:00:00
+    00:01:00:00-00:02:30:00
+    ```
+    
+    **Timecodes with titles:**
+    ```
+    00:00:00:00-00:00:04:07|Segment 1: Introduction
+    00:00:04:08-00:00:08:15|Segment 2: Main Content
+    ```
+    
+    **JSON format:**
+    ```json
+    [
+      {"start": "00:00:00:00", "end": "00:01:00:00", "title": "Intro"},
+      {"start": "00:01:00:00", "end": "00:02:30:00", "title": "Main Content"}
+    ]
+    ```
+
+### Outputs
+
+- **split_videos**: List of split video segments (VideoUrlArtifact array)
+- **logs**: Processing logs and detailed events
+
+## Example
+
+Imagine you want to split a 10-minute video into three segments:
+
+1. Add a SplitVideo node to your workflow
+1. Connect the video output from a LoadVideo node to the SplitVideo's "video" input
+1. Enter timecodes in the "timecodes" parameter:
+   ```
+   00:00:00:00-00:02:30:00|Segment 1: Introduction
+   00:02:30:00-00:07:30:00|Segment 2: Main Content
+   00:07:30:00-00:10:00:00|Segment 3: Conclusion
+   ```
+1. Run the workflow - the video will be split into three separate files
+1. Each segment will be available as a separate output in the split_videos list
+
+## Important Notes
+
+- The SplitVideo node uses AI-powered parsing to understand various timecode formats
+- Timecodes should be in SMPTE format (HH:MM:SS:FF) where FF represents frames
+- The node automatically detects video frame rate and drop frame settings
+- Each segment maintains the original video quality and audio
+- Processing time depends on video length and number of segments
+- The node uses FFmpeg for high-quality video processing
+- Logs provide detailed information about the splitting process
+
+## Timecode Format Guidelines
+
+- **Frame rates**: The node automatically detects 24fps, 25fps, 29.97fps, 30fps, 50fps, 59.94fps, and 60fps
+- **Drop frame**: Automatically detected for 29.97fps and 59.94fps videos
+- **Frame numbers**: Use 00-23 for 24fps, 00-24 for 25fps, 00-29 for 30fps, etc.
+- **Separators**: Use hyphens (-) between start and end times, pipes (|) for titles
+- **Titles**: Optional but recommended for better organization
+
+## Common Issues
+
+- **Invalid Timecodes**: Make sure timecodes are in correct SMPTE format (HH:MM:SS:FF)
+- **Overlapping Segments**: Ensure segments don't overlap in time
+- **Processing Timeout**: Large videos may take longer to process; the node has a 5-minute timeout
+- **No Video Input**: Make sure a video source is connected to the "video" input
+- **Empty Segments**: Check that start time is before end time for each segment
+- **FFmpeg Errors**: Check the logs parameter for detailed error information if processing fails

--- a/docs/video_expression_system_design.md
+++ b/docs/video_expression_system_design.md
@@ -1,0 +1,215 @@
+# Video Expression System Design
+
+## Overview
+
+We were designing a system to allow video processing nodes to accept **animated expressions** for their parameters, enabling dynamic effects that change over time during video playback.
+
+## Goals
+
+### Primary Objectives
+
+- Allow numeric parameters in video nodes to accept either **static values** or **FFmpeg expressions**
+- Enable real-time animation of video effects (vignette intensity, grain strength, color shifts, etc.)
+- Provide a consistent interface across all video processing nodes
+- Support the `{duration}` placeholder to automatically use actual video duration
+
+### Use Cases
+
+- **Vignette intensity** that increases over time: `t/{duration}`
+- **Center position** that moves in patterns: `sin(t/{duration}*3.14159)`
+- **Grain strength** that pulses: `0.5 + 0.5*sin(t/{duration}*6.28318)`
+- **Color shifts** that oscillate: `cos(t/{duration}*3.14159)`
+
+## Technical Implementation
+
+### 1. Parameter Type System
+
+```python
+# Parameters accept multiple input types
+Parameter(
+    name="angle",
+    type="float",
+    input_types=["int", "float", "str"],  # Allow expressions as strings
+    tooltip="Can be static value or expression like 't/{duration}'"
+)
+```
+
+### 2. {duration} Placeholder System
+
+```python
+def _process_expression_parameter(self, expression: str, duration: float) -> str:
+    """Replace {duration} with actual video duration and wrap in quotes."""
+    if not isinstance(expression, str):
+        return expression
+        
+    # Replace {duration} placeholder with actual duration
+    processed_expression = expression.replace("{duration}", str(duration))
+    
+    # Wrap in single quotes for FFmpeg if it contains expressions
+    if any(char in processed_expression for char in ['t', 'w', 'h', 'n', 'sin', 'cos', 'random']):
+        processed_expression = f"'{processed_expression}'"
+        
+    return processed_expression
+```
+
+### 3. Dynamic UI Management
+
+```python
+def after_incoming_connection(self, source_node, source_parameter, target_parameter):
+    # Remove slider when expression is connected
+    if target_parameter.name in expression_params and type(source_node.get_parameter_value(source_parameter.name)) is str:
+        slider_traits = target_parameter.find_elements_by_type(Slider)
+        if slider_traits:
+            target_parameter.remove_trait(trait_type=slider_traits[0])
+        target_parameter.type = "str"  # Change type to string
+
+def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter):
+    # Restore slider when expression is disconnected
+    if target_parameter.name in expression_params:
+        target_parameter.type = "float"  # Change type back to float
+```
+
+### 4. FFmpeg Expression Processing
+
+```python
+# Convert expressions to proper FFmpeg syntax
+if isinstance(center_x, (int, float)):
+    x0 = f"w/2+{center_x}*w/2"  # Static pixel position
+else:
+    x0 = f"w/2+({center_x_expr})*w/2"  # Animated pixel position
+```
+
+## Example Expressions
+
+### Time-Based Animations
+
+```bash
+t/{duration}                    # Linear ramp 0 to 1
+0.1 + (t/{duration})*0.8       # Linear ramp 0.1 to 0.9
+(t/{duration})^2               # Ease-in ramp
+1 - (1 - t/{duration})^2       # Ease-out ramp
+```
+
+### Oscillating Effects
+
+```bash
+sin(t/{duration}*3.14159)      # Sine wave (1 cycle)
+cos(t/{duration}*6.28318)      # Cosine wave (2 cycles)
+0.5 + 0.5*sin(t/{duration}*3.14159)  # Sine wave 0 to 1
+```
+
+### Random Effects
+
+```bash
+0.1 + 0.8*random(0)           # Static random value
+0.1 + 0.8*random(t*100)       # Animated random noise
+```
+
+## Challenges Encountered
+
+### 1. UI Complexity
+
+- **Dynamic trait management**: Adding/removing sliders based on connection state
+- **Type switching**: Changing parameter types between float and string
+- **Default value restoration**: Resetting parameters when expressions are disconnected
+
+### 2. FFmpeg Integration
+
+- **Expression syntax**: Proper quoting and escaping for FFmpeg filters
+- **Coordinate conversion**: Converting normalized expressions to pixel positions
+- **Parameter validation**: Skipping validation for expression strings
+
+### 3. Error Handling
+
+- **Expression parsing**: Handling malformed FFmpeg expressions
+- **Type mismatches**: Managing mixed static/expression parameters
+- **Fallback behavior**: Graceful degradation when expressions fail
+
+## Base Class Design
+
+### BaseVideoProcessor Enhancements
+
+```python
+class BaseVideoProcessor(ControlNode, ABC):
+    def _process_expression_parameter(self, expression: str, duration: float) -> str:
+        """Process expressions and replace placeholders."""
+        
+    def _detect_video_properties(self, input_url: str, ffprobe_path: str) -> tuple[float, tuple[int, int], float]:
+        """Detect duration, resolution, framerate for expression processing."""
+        
+    def _process_video(self, input_url: str, output_path: str, **kwargs) -> None:
+        """Add video properties to kwargs for expression processing."""
+```
+
+## Node Integration Pattern
+
+### Standard Implementation
+
+```python
+class AddVignette(BaseVideoProcessor):
+    def _setup_custom_parameters(self):
+        # Define parameters with expression support
+        angle_parameter = Parameter(
+            name="angle",
+            input_types=["int", "float", "str"],
+            tooltip="Can be expression like 't/{duration}'"
+        )
+        
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs):
+        # Process expressions for all parameters
+        duration = kwargs.get("duration", 0.0)
+        angle_expr = self._process_expression_parameter(angle, duration)
+        
+        # Build filter with processed expressions
+        filter_complex = f"vignette=angle={angle_expr}:..."
+```
+
+## Benefits vs Complexity Trade-off
+
+### Benefits
+
+- **Rich animation capabilities**: Complex time-based effects
+- **Consistent interface**: Same pattern across all video nodes
+- **FFmpeg integration**: Leverages powerful expression system
+- **User flexibility**: Mix static and animated parameters
+
+### Complexity Costs
+
+- **UI management**: Dynamic trait addition/removal
+- **Type handling**: Switching between float and string types
+- **Error handling**: Expression validation and fallbacks
+- **Maintenance**: More complex codebase with edge cases
+
+## Alternative Approaches
+
+### 1. Dedicated Animation Nodes
+
+Create separate "curve" or "animation" nodes that output expression strings:
+
+```python
+class SineWaveNode(DataNode):
+    def process(self):
+        # Output: "sin(t/4.51*3.14159)"
+        self.parameter_output_values["expression"] = f"sin(t/{duration}*{frequency})"
+```
+
+### 2. Timeline-Based Animation
+
+Use a timeline interface where users can set keyframes and interpolate between values.
+
+### 3. Preset Animation Patterns
+
+Provide predefined animation patterns (fade in, pulse, oscillate) as dropdown options.
+
+## Conclusion
+
+The expression system provides powerful animation capabilities but significantly increases complexity. For a cleaner, more maintainable codebase, we've decided to revert to static parameters and explore simpler animation approaches in the future.
+
+## Future Considerations
+
+If animation is needed later, consider:
+
+1. **Dedicated animation nodes** that output expression strings
+1. **Preset animation patterns** as parameter options
+1. **Timeline-based keyframe system** for complex animations
+1. **Separate animation layer** that doesn't complicate core video processing

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -716,6 +716,17 @@
       }
     },
     {
+      "class_name": "AddOverlay",
+      "file_path": "griptape_nodes_library/video/add_overlay.py",
+      "metadata": {
+        "category": "video",
+        "description": "Add an overlay video on top of a base video using FFmpeg's overlay filter with alpha channel control",
+        "display_name": "Add Overlay",
+        "icon": "layers",
+        "group": "edit"
+      }
+    },
+    {
       "class_name": "ToBool",
       "file_path": "griptape_nodes_library/convert/to_bool.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -705,6 +705,17 @@
       }
     },
     {
+      "class_name": "AddColorCurves",
+      "file_path": "griptape_nodes_library/video/add_color_curves.py",
+      "metadata": {
+        "category": "video",
+        "description": "Add color curves (color grading) effect to video using FFmpeg's curves filter with presets and custom curve options",
+        "display_name": "Add Color Curves",
+        "icon": "palette",
+        "group": "edit"
+      }
+    },
+    {
       "class_name": "ToBool",
       "file_path": "griptape_nodes_library/convert/to_bool.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -617,6 +617,83 @@
       }
     },
     {
+      "class_name": "HoldVideoFrames",
+      "file_path": "griptape_nodes_library/video/hold_video_frames.py",
+      "metadata": {
+        "category": "video",
+        "description": "Hold video frames for a specified number of frames, creating a stepped video effect",
+        "display_name": "Hold Video Frames",
+        "icon": "pause-circle",
+        "group": "edit"
+      }
+    },
+    {
+      "class_name": "AddFilmGrain",
+      "file_path": "griptape_nodes_library/video/add_film_grain.py",
+      "metadata": {
+        "category": "video",
+        "description": "Add realistic film grain to video using sophisticated noise generation and luminance masking",
+        "display_name": "Add Film Grain",
+        "icon": "film",
+        "group": "edit"
+      }
+    },
+    {
+      "class_name": "AddVignette",
+      "file_path": "griptape_nodes_library/video/add_vignette.py",
+      "metadata": {
+        "category": "video",
+        "description": "Add a vignette effect to video with adjustable lens angle, center position, and aspect ratio",
+        "display_name": "Add Vignette",
+        "icon": "circle-dot",
+        "group": "edit"
+      }
+    },
+    {
+      "class_name": "ReverseVideo",
+      "file_path": "griptape_nodes_library/video/reverse_video.py",
+      "metadata": {
+        "category": "video",
+        "description": "Reverse video playback with options to reverse, mute, or keep original audio",
+        "display_name": "Reverse Video",
+        "icon": "rewind",
+        "group": "edit"
+      }
+    },
+    {
+      "class_name": "FlipVideo",
+      "file_path": "griptape_nodes_library/video/flip_video.py",
+      "metadata": {
+        "category": "video",
+        "description": "Flip video horizontally, vertically, or both directions",
+        "display_name": "Flip Video",
+        "icon": "flip-horizontal",
+        "group": "edit"
+      }
+    },
+    {
+      "class_name": "AdjustVideoEQ",
+      "file_path": "griptape_nodes_library/video/adjust_video_eq.py",
+      "metadata": {
+        "category": "video",
+        "description": "Adjust video brightness, contrast, saturation, and gamma with precise controls",
+        "display_name": "Adjust Video EQ",
+        "icon": "sliders",
+        "group": "edit"
+      }
+    },
+    {
+      "class_name": "AddRGBShift",
+      "file_path": "griptape_nodes_library/video/add_rgb_shift.py",
+      "metadata": {
+        "category": "video",
+        "description": "Add RGB shift (chromatic aberration) effect with individual channel control, static or animated glitches, and VHS-style base effects with configurable noise, chroma shift, blur, and motion trails",
+        "display_name": "Add RGB Shift",
+        "icon": "palette",
+        "group": "edit"
+      }
+    },
+    {
       "class_name": "ToBool",
       "file_path": "griptape_nodes_library/convert/to_bool.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -13,7 +13,8 @@
     "dependencies": {
       "pip_dependencies": [
         "griptape[drivers-prompt-amazon-bedrock,drivers-prompt-anthropic,drivers-prompt-cohere,drivers-prompt-ollama,drivers-web-scraper-trafilatura,drivers-web-search-duckduckgo,drivers-web-search-exa,loaders-image,loaders-pdf]>=1.7.1",
-        "json-repair>=0.46.1"
+        "json-repair>=0.46.1",
+        "static-ffmpeg>=2.8"
       ]
     }
   },
@@ -602,6 +603,17 @@
         "display_name": "Save Video",
         "icon": "file-down",
         "group": "general"
+      }
+    },
+    {
+      "class_name": "SplitVideo",
+      "file_path": "griptape_nodes_library/video/split_video.py",
+      "metadata": {
+        "category": "video",
+        "description": "Split a video into multiple parts using ffmpeg with timecode support",
+        "display_name": "Split Video",
+        "icon": "scissors",
+        "group": "edit"
       }
     },
     {

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -694,6 +694,17 @@
       }
     },
     {
+      "class_name": "ChangeSpeed",
+      "file_path": "griptape_nodes_library/video/change_speed.py",
+      "metadata": {
+        "category": "video",
+        "description": "Change the playback speed of a video using FFmpeg's setpts filter with automatic audio speed adjustment",
+        "display_name": "Change Speed",
+        "icon": "zap",
+        "group": "edit"
+      }
+    },
+    {
       "class_name": "ToBool",
       "file_path": "griptape_nodes_library/convert/to_bool.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/video_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/video_utils.py
@@ -107,11 +107,11 @@ def validate_url(url: str) -> bool:
 
 def smpte_to_seconds(tc: str, rate: float, *, drop_frame: bool | None = None) -> float:
     """Convert SMPTE timecode to seconds.
-    
+
     Drop-frame timecode is used for NTSC video (29.97/59.94 fps) to keep timecode
     synchronized with real time. It drops frames at specific intervals to compensate
     for the slight difference between nominal and actual frame rates.
-    
+
     Examples:
     - Non-drop: "01:23:45:12" (standard timecode)
     - Drop-frame: "01:23:45;12" (NTSC drop-frame timecode)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_color_curves.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_color_curves.py
@@ -1,0 +1,100 @@
+from typing import Any, ClassVar
+
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.traits.options import Options
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class AddColorCurves(BaseVideoProcessor):
+    """Add color curves (color grading) effect to video using FFmpeg's curves filter."""
+
+    # Available curve presets (from FFmpeg curves filter)
+    CURVE_PRESETS: ClassVar[list[str]] = [
+        "none",
+        "color_negative",
+        "cross_process",
+        "darker",
+        "increase_contrast",
+        "lighter",
+        "linear_contrast",
+        "medium_contrast",
+        "negative",
+        "strong_contrast",
+        "vintage",
+    ]
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup color curves parameters."""
+        self.add_parameter(
+            Parameter(
+                name="curve_preset",
+                type="str",
+                default_value="none",
+                tooltip="Built-in curve preset for color grading effects",
+                traits={Options(choices=self.CURVE_PRESETS)},
+            )
+        )
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "color curves"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for color curves."""
+        curve_preset = kwargs.get("curve_preset", "none")
+
+        # Build curves filter
+        if curve_preset != "none":
+            filter_complex = f"curves=preset={curve_preset}"
+        else:
+            # No curves applied
+            filter_complex = "null"
+
+        return [
+            "ffmpeg",
+            "-i",
+            input_url,
+            "-vf",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "12",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate color curves parameters."""
+        exceptions = []
+
+        curve_preset = self.get_parameter_value("curve_preset")
+        if curve_preset is not None and curve_preset not in self.CURVE_PRESETS:
+            msg = f"{self.name} - Curve preset must be one of the available presets, got {curve_preset}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get color curves parameters."""
+        return {
+            "curve_preset": self.get_parameter_value("curve_preset"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        curve_preset = kwargs.get("curve_preset", "none")
+
+        if curve_preset != "none":
+            return f"_curves_{curve_preset}"
+        return ""

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_color_curves.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_color_curves.py
@@ -38,16 +38,19 @@ class AddColorCurves(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "color curves"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build FFmpeg command for color curves."""
         curve_preset = kwargs.get("curve_preset", "none")
 
         # Build curves filter
         if curve_preset != "none":
-            filter_complex = f"curves=preset={curve_preset}"
+            custom_filter = f"curves=preset={curve_preset}"
         else:
             # No curves applied
-            filter_complex = "null"
+            custom_filter = "null"
+
+        # Combine with frame rate filter if needed
+        filter_complex = self._combine_video_filters(custom_filter, input_frame_rate)
 
         # Get processing speed settings
         preset, pix_fmt, crf = self._get_processing_speed_settings()

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_color_curves.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_color_curves.py
@@ -25,15 +25,14 @@ class AddColorCurves(BaseVideoProcessor):
 
     def _setup_custom_parameters(self) -> None:
         """Setup color curves parameters."""
-        self.add_parameter(
-            Parameter(
-                name="curve_preset",
-                type="str",
-                default_value="none",
-                tooltip="Built-in curve preset for color grading effects",
-                traits={Options(choices=self.CURVE_PRESETS)},
-            )
+        parameter = Parameter(
+            name="curve_preset",
+            type="str",
+            default_value="none",
+            tooltip="Built-in curve preset for color grading effects",
         )
+        parameter.add_trait(Options(choices=self.CURVE_PRESETS))
+        self.add_parameter(parameter)
 
     def _get_processing_description(self) -> str:
         """Get description of what this processor does."""
@@ -50,6 +49,9 @@ class AddColorCurves(BaseVideoProcessor):
             # No curves applied
             filter_complex = "null"
 
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
         return [
             "ffmpeg",
             "-i",
@@ -59,11 +61,11 @@ class AddColorCurves(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "12",
+            str(crf),
             "-pix_fmt",
-            "yuv420p",
+            pix_fmt,
             "-movflags",
             "+faststart",
             "-c:a",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_film_grain.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_film_grain.py
@@ -1,0 +1,167 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class AddFilmGrain(BaseVideoProcessor):
+    """Add realistic film grain to video using sophisticated noise generation and luminance masking."""
+
+    # Grain intensity constants
+    MIN_GRAIN_INTENSITY = 0.05
+    MAX_GRAIN_INTENSITY = 1.0
+    DEFAULT_GRAIN_INTENSITY = 0.15
+
+    # Luminance threshold constants
+    MIN_LUMINANCE_THRESHOLD = 50
+    MAX_LUMINANCE_THRESHOLD = 100
+    DEFAULT_LUMINANCE_THRESHOLD = 75
+
+    # Grain scale constants
+    MIN_GRAIN_SCALE = 1.0
+    MAX_GRAIN_SCALE = 4.0
+    DEFAULT_GRAIN_SCALE = 2.0
+    """Add realistic film grain to video using sophisticated noise generation and luminance masking."""
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup custom parameters for film grain."""
+        # Add grain intensity parameter
+        grain_intensity_parameter = Parameter(
+            name="grain_intensity",
+            type="float",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            default_value=self.DEFAULT_GRAIN_INTENSITY,
+            tooltip=f"Film grain intensity ({self.MIN_GRAIN_INTENSITY} = subtle, {self.MAX_GRAIN_INTENSITY} = heavy grain)",
+        )
+        self.add_parameter(grain_intensity_parameter)
+        grain_intensity_parameter.add_trait(Slider(min_val=self.MIN_GRAIN_INTENSITY, max_val=self.MAX_GRAIN_INTENSITY))
+
+        # Add luminance threshold parameter
+        luminance_threshold_parameter = Parameter(
+            name="luminance_threshold",
+            type="int",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            default_value=self.DEFAULT_LUMINANCE_THRESHOLD,
+            tooltip=f"Luminance level where grain is most visible (typically {self.DEFAULT_LUMINANCE_THRESHOLD} for faces)",
+        )
+        self.add_parameter(luminance_threshold_parameter)
+        luminance_threshold_parameter.add_trait(
+            Slider(min_val=self.MIN_LUMINANCE_THRESHOLD, max_val=self.MAX_LUMINANCE_THRESHOLD)
+        )
+
+        # Add grain scale parameter
+        grain_scale_parameter = Parameter(
+            name="grain_scale",
+            type="float",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            default_value=self.DEFAULT_GRAIN_SCALE,
+            tooltip="Grain scale factor (higher = larger grain particles)",
+        )
+        self.add_parameter(grain_scale_parameter)
+        grain_scale_parameter.add_trait(Slider(min_val=self.MIN_GRAIN_SCALE, max_val=self.MAX_GRAIN_SCALE))
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "film grain addition"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build the FFmpeg command for film grain addition."""
+        grain_intensity = kwargs.get("grain_intensity", self.DEFAULT_GRAIN_INTENSITY)
+        luminance_threshold = kwargs.get("luminance_threshold", self.DEFAULT_LUMINANCE_THRESHOLD)
+        grain_scale = kwargs.get("grain_scale", self.DEFAULT_GRAIN_SCALE)
+
+        # Get FFmpeg paths and video properties
+        ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
+        frame_rate, (width, height), duration = self._detect_video_properties(input_url, ffprobe_path)
+
+        # Scale dimensions for grain generation (smaller = faster processing)
+        scaled_width = int(width / grain_scale)
+        scaled_height = int(height / grain_scale)
+
+        # Log the detected framerate for debugging
+        self.append_value_to_parameter("logs", f"Using detected framerate: {frame_rate} fps\n")
+
+        # Build the complex filter for realistic film grain
+        # Based on: https://gist.github.com/logiclrd/287140934c12bed1fd4be75e8624c118
+        # The original uses two inputs and creates a sophisticated grain overlay
+
+        # Use temporal grain (changes between frames) for realistic film grain effect
+        random_expr = "random(1)*256"
+        self.append_value_to_parameter("logs", "Temporal grain enabled: grain pattern changes between frames\n")
+
+        filter_complex = f"""
+        color=black:d={duration}:s={scaled_width}x{scaled_height}:r={frame_rate},
+        geq=lum_expr={random_expr}:cb=128:cr=128,
+        deflate=threshold0=15,
+        dilation=threshold0=10,
+        eq=contrast=3,
+        scale={width}x{height} [n];
+        [0] eq=saturation=0,geq=lum='{grain_intensity}*(182-abs({luminance_threshold}-lum(X,Y)))':cb=128:cr=128 [o];
+        [n][o] blend=c0_mode=multiply,negate [a];
+        color=c=black:d={duration}:s={width}x{height}:r={frame_rate} [b];
+        [1][a] alphamerge [c];
+        [b][c] overlay
+        """.replace("\n", "").replace(" ", "")
+
+        # Build FFmpeg command with high-quality settings (matching the gist)
+        cmd = [
+            ffmpeg_path,
+            "-y",
+            "-i",
+            input_url,
+            "-i",
+            input_url,  # Second input as per the original gist
+            "-filter_complex",
+            filter_complex,
+            "-c:a",
+            "copy",
+            "-c:v",
+            "libx264",
+            "-tune",
+            "grain",
+            "-preset",
+            "veryslow",  # Original uses veryslow for quality
+            "-crf",
+            "12",  # Original uses crf 12 for high quality
+            output_path,
+        ]
+
+        return cmd
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate custom parameters."""
+        exceptions = []
+
+        # Validate grain intensity
+        grain_intensity = self.parameter_values.get("grain_intensity", self.DEFAULT_GRAIN_INTENSITY)
+        if grain_intensity < self.MIN_GRAIN_INTENSITY or grain_intensity > self.MAX_GRAIN_INTENSITY:
+            msg = f"{self.name}: Grain intensity must be between {self.MIN_GRAIN_INTENSITY} and {self.MAX_GRAIN_INTENSITY}"
+            exceptions.append(ValueError(msg))
+
+        # Validate luminance threshold
+        luminance_threshold = self.parameter_values.get("luminance_threshold", self.DEFAULT_LUMINANCE_THRESHOLD)
+        if luminance_threshold < self.MIN_LUMINANCE_THRESHOLD or luminance_threshold > self.MAX_LUMINANCE_THRESHOLD:
+            msg = f"{self.name}: Luminance threshold must be between {self.MIN_LUMINANCE_THRESHOLD} and {self.MAX_LUMINANCE_THRESHOLD}"
+            exceptions.append(ValueError(msg))
+
+        # Validate grain scale
+        grain_scale = self.parameter_values.get("grain_scale", self.DEFAULT_GRAIN_SCALE)
+        if grain_scale < self.MIN_GRAIN_SCALE or grain_scale > self.MAX_GRAIN_SCALE:
+            msg = f"{self.name}: Grain scale must be between {self.MIN_GRAIN_SCALE} and {self.MAX_GRAIN_SCALE}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get custom parameters for processing."""
+        return {
+            "grain_intensity": self.parameter_values.get("grain_intensity", self.DEFAULT_GRAIN_INTENSITY),
+            "luminance_threshold": self.parameter_values.get("luminance_threshold", self.DEFAULT_LUMINANCE_THRESHOLD),
+            "grain_scale": self.parameter_values.get("grain_scale", self.DEFAULT_GRAIN_SCALE),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get the output filename suffix."""
+        grain_intensity = kwargs.get("grain_intensity", self.DEFAULT_GRAIN_INTENSITY)
+        return f"_grain_{grain_intensity:.2f}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_film_grain.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_film_grain.py
@@ -43,7 +43,7 @@ class AddFilmGrain(BaseVideoProcessor):
             type="int",
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
             default_value=self.DEFAULT_LUMINANCE_THRESHOLD,
-            tooltip=f"Luminance level where grain is most visible (typically {self.DEFAULT_LUMINANCE_THRESHOLD} for faces)",
+            tooltip=f"Luminance level where grain is most visible (typically {self.DEFAULT_LUMINANCE_THRESHOLD} for lighter areas)",
         )
         self.add_parameter(luminance_threshold_parameter)
         luminance_threshold_parameter.add_trait(

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_film_grain.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_film_grain.py
@@ -104,7 +104,10 @@ class AddFilmGrain(BaseVideoProcessor):
         [b][c] overlay
         """.replace("\n", "").replace(" ", "")
 
-        # Build FFmpeg command with high-quality settings (matching the gist)
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
+        # Build FFmpeg command with processing speed settings
         cmd = [
             ffmpeg_path,
             "-y",
@@ -121,9 +124,13 @@ class AddFilmGrain(BaseVideoProcessor):
             "-tune",
             "grain",
             "-preset",
-            "veryslow",  # Original uses veryslow for quality
+            preset,
             "-crf",
-            "12",  # Original uses crf 12 for high quality
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             output_path,
         ]
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_overlay.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_overlay.py
@@ -98,6 +98,9 @@ class AddOverlay(BaseVideoProcessor):
         amount = kwargs.get("amount", self.DEFAULT_AMOUNT)
 
         if not overlay_video:
+            # Get processing speed settings
+            preset, pix_fmt, crf = self._get_processing_speed_settings()
+
             # No overlay video provided, just copy the input
             return [
                 "ffmpeg",
@@ -106,11 +109,11 @@ class AddOverlay(BaseVideoProcessor):
                 "-c:v",
                 "libx264",
                 "-preset",
-                "veryslow",
+                preset,
                 "-crf",
-                "12",
+                str(crf),
                 "-pix_fmt",
-                "yuv420p",
+                pix_fmt,
                 "-movflags",
                 "+faststart",
                 "-c:a",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_overlay.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_overlay.py
@@ -96,7 +96,6 @@ class AddOverlay(BaseVideoProcessor):
         overlay_video = kwargs.get("overlay_video")
         blend_mode = kwargs.get("blend_mode", "overlay")
         amount = kwargs.get("amount", self.DEFAULT_AMOUNT)
-        sizing = kwargs.get("sizing", "Scale to cover")
 
         if not overlay_video:
             # No overlay video provided, just copy the input
@@ -143,9 +142,6 @@ class AddOverlay(BaseVideoProcessor):
         else:
             # Use blend filter for other blend modes - blend all components
             filter_complex = f"[0]loop=loop=-1,trim=duration={base_duration}[fg];[1][fg]blend=all_mode={blend_mode}:all_opacity={amount}[out]"
-
-        # Debug: print the filter complex
-        print(f"Filter complex: {filter_complex}")
 
         # Get processing speed settings
         preset, pix_fmt, crf = self._get_processing_speed_settings()

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_overlay.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_overlay.py
@@ -1,0 +1,218 @@
+from typing import Any, ClassVar
+
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class AddOverlay(BaseVideoProcessor):
+    """Add an overlay video or image on top of a base video using FFmpeg's blend modes.
+
+    This node supports various blend modes that match industry-standard compositing software.
+    It can overlay videos, images (PNG with transparency), and supports different channels
+    and positioning options.
+
+    Key Features:
+    - Multiple blend modes (overlay, screen, grainmerge, etc.)
+    - Channel selection (luminance, RGB, alpha, rgba)
+    - Flexible positioning (9 directions + custom)
+    - Sizing options (as-is, scale to cover/fit)
+    - Linear RGB blending for consistent results
+
+    Common Use Cases:
+    - Adding film grain/noise effects
+    - Overlaying logos or watermarks
+    - Adding dust/scratch effects
+    - Compositing multiple video layers
+    """
+
+    # Blend mode constants - matching Nuke's standard blend modes
+    BLEND_MODES: ClassVar[list[str]] = [
+        "overlay",  # Original overlay with alpha blending
+        "screen",  # Brighten (good for dust/scratches)
+        "lighten",  # Only brighten where overlay is brighter
+        "softlight",  # Natural blending for film grain
+        "grainmerge",  # Merge grain/noise (recommended for noise effects)
+        "grainextract",  # Extract grain/noise
+        "glow",  # Glow effect
+        "hardlight",  # Hard light blending
+    ]
+
+    # Amount constants
+    MIN_AMOUNT = 0.0
+    MAX_AMOUNT = 1.0
+    DEFAULT_AMOUNT = 0.5
+
+    # Sizing options
+    SIZING_OPTIONS: ClassVar[list[str]] = [
+        "Scale to cover",  # Scale to cover (maintains aspect ratio)
+        "Scale to fit",  # Scale to fit (doesn't maintain aspect ratio)
+    ]
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup overlay parameters."""
+        overlay_param = Parameter(
+            name="overlay_video",
+            input_types=["VideoArtifact", "VideoUrlArtifact", "ImageArtifact", "ImageUrlArtifact"],
+            type="VideoUrlArtifact",
+            tooltip="The video or image to overlay on top of the base video (PNG with transparency supported)",
+        )
+        self.add_parameter(overlay_param)
+
+        blend_mode_param = Parameter(
+            name="blend_mode",
+            type="str",
+            default_value="overlay",
+            tooltip="Blend mode for combining the overlay with the base video",
+        )
+        blend_mode_param.add_trait(Options(choices=self.BLEND_MODES))
+        self.add_parameter(blend_mode_param)
+
+        amount_param = Parameter(
+            name="amount",
+            type="float",
+            default_value=self.DEFAULT_AMOUNT,
+            tooltip=f"Strength of the overlay effect ({self.MIN_AMOUNT}-{self.MAX_AMOUNT})",
+        )
+        amount_param.add_trait(Slider(min_val=self.MIN_AMOUNT, max_val=self.MAX_AMOUNT))
+        self.add_parameter(amount_param)
+
+        sizing_param = Parameter(
+            name="sizing",
+            type="str",
+            default_value="Scale to cover",
+            tooltip="How to size the overlay: Scale to cover (maintains aspect), Scale to fit (stretches)",
+        )
+        sizing_param.add_trait(Options(choices=self.SIZING_OPTIONS))
+        self.add_parameter(sizing_param)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "video overlay"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for video overlay."""
+        overlay_video = kwargs.get("overlay_video")
+        blend_mode = kwargs.get("blend_mode", "overlay")
+        amount = kwargs.get("amount", self.DEFAULT_AMOUNT)
+        sizing = kwargs.get("sizing", "Scale to cover")
+
+        if not overlay_video:
+            # No overlay video provided, just copy the input
+            return [
+                "ffmpeg",
+                "-i",
+                input_url,
+                "-c:v",
+                "libx264",
+                "-preset",
+                "veryslow",
+                "-crf",
+                "12",
+                "-pix_fmt",
+                "yuv420p",
+                "-movflags",
+                "+faststart",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "192k",
+                "-y",
+                output_path,
+            ]
+
+        # Get the overlay URL
+        overlay_url = overlay_video.url if hasattr(overlay_video, "url") else str(overlay_video)
+
+        # Get base video duration for proper trimming
+        ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
+        _, _, base_duration = self._detect_video_properties(input_url, ffprobe_path)
+
+        # For now, skip scaling for "Scale to cover" and "Scale to fit" to get basic overlay working
+        # Always center the overlay for simplicity
+        overlay_position = "(W-w)/2:(H-h)/2"
+
+        # Build overlay filter complex based on blend mode and channel selection
+        # [0] = overlay video/image, [1] = base video
+        # Process: loop overlay, trim to base duration, apply channel filter, then blend
+
+        if blend_mode == "overlay":
+            # Use overlay filter for alpha blending
+            filter_complex = f"[0]loop=loop=-1,trim=duration={base_duration},format=rgba,colorchannelmixer=aa={amount}[fg];[1][fg]overlay={overlay_position}[out]"
+        else:
+            # Use blend filter for other blend modes - blend all components
+            filter_complex = f"[0]loop=loop=-1,trim=duration={base_duration}[fg];[1][fg]blend=all_mode={blend_mode}:all_opacity={amount}[out]"
+
+        # Debug: print the filter complex
+        print(f"Filter complex: {filter_complex}")
+
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
+        return [
+            "ffmpeg",
+            "-i",
+            overlay_url,  # Overlay video (film grain) - [0]
+            "-i",
+            input_url,  # Base video (main content) - [1]
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[out]",
+            "-shortest",  # End when shortest stream ends
+            "-c:v",
+            "libx264",
+            "-preset",
+            preset,
+            "-crf",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate overlay parameters."""
+        exceptions = []
+
+        blend_mode = self.get_parameter_value("blend_mode")
+        if blend_mode is not None and blend_mode not in self.BLEND_MODES:
+            msg = f"{self.name} - Blend mode must be one of {self.BLEND_MODES}, got {blend_mode}"
+            exceptions.append(ValueError(msg))
+
+        amount = self.get_parameter_value("amount")
+        if amount is not None and (amount < self.MIN_AMOUNT or amount > self.MAX_AMOUNT):
+            msg = f"{self.name} - Amount must be between {self.MIN_AMOUNT} and {self.MAX_AMOUNT}, got {amount}"
+            exceptions.append(ValueError(msg))
+
+        sizing = self.get_parameter_value("sizing")
+        if sizing is not None and sizing not in self.SIZING_OPTIONS:
+            msg = f"{self.name} - Sizing must be one of {self.SIZING_OPTIONS}, got {sizing}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get overlay parameters."""
+        return {
+            "overlay_video": self.get_parameter_value("overlay_video"),
+            "blend_mode": self.get_parameter_value("blend_mode"),
+            "amount": self.get_parameter_value("amount"),
+            "sizing": self.get_parameter_value("sizing"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        blend_mode = kwargs.get("blend_mode", "overlay")
+        amount = kwargs.get("amount", self.DEFAULT_AMOUNT)
+        sizing = kwargs.get("sizing", "Scale to cover")
+
+        return f"_overlay_{sizing.replace(' ', '_')}_{blend_mode}_amount{amount:.2f}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
@@ -9,8 +9,8 @@ class AddRGBShift(BaseVideoProcessor):
     """Add RGB shift (chromatic aberration) effect to video."""
 
     # RGB shift constants
-    MIN_SHIFT = -20
-    MAX_SHIFT = 20
+    MIN_SHIFT = -50
+    MAX_SHIFT = 50
     DEFAULT_SHIFT = 6
 
     # RGB shift intensity constants
@@ -128,13 +128,13 @@ class AddRGBShift(BaseVideoProcessor):
         tear_position = kwargs.get("tear_position", 0.5)
         tear_offset = kwargs.get("tear_offset", 10)
 
-        # Apply intensity scaling to all shifts
-        red_h_scaled = int(red_h * intensity)
-        red_v_scaled = int(red_v * intensity)
-        green_h_scaled = int(green_h * intensity)
-        green_v_scaled = int(green_v * intensity)
-        blue_h_scaled = int(blue_h * intensity)
-        blue_v_scaled = int(blue_v * intensity)
+        # Apply intensity scaling to all shifts and clamp to FFmpeg's valid range (-255 to 255)
+        red_h_scaled = max(-255, min(255, int(red_h * intensity)))
+        red_v_scaled = max(-255, min(255, int(red_v * intensity)))
+        green_h_scaled = max(-255, min(255, int(green_h * intensity)))
+        green_v_scaled = max(-255, min(255, int(green_v * intensity)))
+        blue_h_scaled = max(-255, min(255, int(blue_h * intensity)))
+        blue_v_scaled = max(-255, min(255, int(blue_v * intensity)))
 
         if tear_enabled:
             # Create tear effect by splitting the video and applying different RGB shifts

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
@@ -1,8 +1,6 @@
-import random
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
-from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
 
@@ -20,86 +18,20 @@ class AddRGBShift(BaseVideoProcessor):
     MAX_INTENSITY = 1.0
     DEFAULT_INTENSITY = 1.0
 
-    # Animated glitch timing constants
-    MIN_GLITCH_FREQUENCY = 0.1
-    MAX_GLITCH_FREQUENCY = 10.0
-    DEFAULT_GLITCH_FREQUENCY = 2.0
-
-    MIN_GLITCH_INTENSITY = 0.0
-    MAX_GLITCH_INTENSITY = 1.0
-    DEFAULT_GLITCH_INTENSITY = 0.5
-
-    MIN_GLITCH_DURATION = 0.01
-    MAX_GLITCH_DURATION = 0.5
-    DEFAULT_GLITCH_DURATION = 0.1
-
-    # Visual effect constants
-    MIN_NOISE_STRENGTH = 0
-    MAX_NOISE_STRENGTH = 50
-    DEFAULT_NOISE_STRENGTH = 8
-
-    MIN_CHROMA_SHIFT = -10
-    MAX_CHROMA_SHIFT = 10
-    DEFAULT_CHROMA_SHIFT_H = 2
-    DEFAULT_CHROMA_SHIFT_V = -2
-
-    MIN_BLUR_STRENGTH = 0.0
-    MAX_BLUR_STRENGTH = 3.0
-    DEFAULT_BLUR_STRENGTH = 0.8
-
-    MIN_MOTION_TRAILS = 1
-    MAX_MOTION_TRAILS = 5
-    DEFAULT_MOTION_TRAILS = 3
-
-    # Glitch timing variation constants
-    GLITCH_DURATION_VARIATION_MIN = 0.8
-    GLITCH_DURATION_VARIATION_MAX = 1.2
-    GLITCH_INTERVAL_VARIATION_MIN = 0.5
-    GLITCH_INTERVAL_VARIATION_MAX = 2.0
-
-    # Burst glitch timing constants
-    BURST_GAP_MIN = 0.05
-    BURST_GAP_MAX = 0.15
-
-    # Tear position constants
-    TEAR_POSITION_MIN = 0.1
-    TEAR_POSITION_MAX = 0.9
-
-    # Glitch burst constants
-    GLITCH_BURST_PROBABILITY = 0.3
-    GLITCH_BURST_COUNT_MIN = 2
-    GLITCH_BURST_COUNT_MAX = 3
-
-    # Glitch timing constants
-    GLITCH_START_DELAY_MIN = 0.5
-    GLITCH_START_DELAY_MAX = 2.0
-    GLITCH_TIME_LIMIT = 10.0
-    GLITCH_MIN_COUNT = 20
-
     # Tear effect constants
     MIN_TEAR_OFFSET = -50
     MAX_TEAR_OFFSET = 50
-    DEFAULT_TEAR_OFFSET_MIN = 5
-    DEFAULT_TEAR_OFFSET_MAX = 15
 
     def _setup_custom_parameters(self) -> None:
         """Setup RGB shift-specific parameters."""
-        # Glitch mode (at the top level)
-        glitch_mode_parameter = Parameter(
-            name="glitch_mode",
-            type="str",
-            default_value="static",
-            tooltip="Glitch animation: static (constant RGB shift) or animated (intermittent RGB shift with timing and tear effects)",
-        )
-        self.add_parameter(glitch_mode_parameter)
-        glitch_mode_parameter.add_trait(Options(choices=["static", "animated"]))
-        with ParameterGroup(name="glitched_visual_style", ui_options={"collapsed": False}) as glitched_group:
+        # RGB shift parameters
+        with ParameterGroup(name="rgb_shift_settings", ui_options={"collapsed": False}) as rgb_group:
             # Red channel horizontal shift
             Parameter(
                 name="red_horizontal",
                 type="int",
                 default_value=-self.DEFAULT_SHIFT,
-                tooltip=f"Red channel horizontal shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+                tooltip=f"Red channel horizontal shift ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
             ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
 
             # Red channel vertical shift
@@ -107,7 +39,7 @@ class AddRGBShift(BaseVideoProcessor):
                 name="red_vertical",
                 type="int",
                 default_value=0,
-                tooltip=f"Red channel vertical shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+                tooltip=f"Red channel vertical shift ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
             ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
 
             # Green channel horizontal shift
@@ -115,7 +47,7 @@ class AddRGBShift(BaseVideoProcessor):
                 name="green_horizontal",
                 type="int",
                 default_value=self.DEFAULT_SHIFT,
-                tooltip=f"Green channel horizontal shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+                tooltip=f"Green channel horizontal shift ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
             ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
 
             # Green channel vertical shift
@@ -123,7 +55,7 @@ class AddRGBShift(BaseVideoProcessor):
                 name="green_vertical",
                 type="int",
                 default_value=0,
-                tooltip=f"Green channel vertical shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+                tooltip=f"Green channel vertical shift ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
             ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
 
             # Blue channel horizontal shift
@@ -131,7 +63,7 @@ class AddRGBShift(BaseVideoProcessor):
                 name="blue_horizontal",
                 type="int",
                 default_value=0,
-                tooltip=f"Blue channel horizontal shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+                tooltip=f"Blue channel horizontal shift ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
             ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
 
             # Blue channel vertical shift
@@ -139,7 +71,7 @@ class AddRGBShift(BaseVideoProcessor):
                 name="blue_vertical",
                 type="int",
                 default_value=0,
-                tooltip=f"Blue channel vertical shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+                tooltip=f"Blue channel vertical shift ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
             ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
 
             # Overall intensity
@@ -147,109 +79,41 @@ class AddRGBShift(BaseVideoProcessor):
                 name="intensity",
                 type="float",
                 default_value=self.DEFAULT_INTENSITY,
-                tooltip=f"Overall intensity of the RGB shift effect during glitches ({self.MIN_INTENSITY}-{self.MAX_INTENSITY})",
+                tooltip=f"Overall intensity of the RGB shift effect ({self.MIN_INTENSITY}-{self.MAX_INTENSITY})",
             ).add_trait(Slider(min_val=self.MIN_INTENSITY, max_val=self.MAX_INTENSITY))
 
-        self.add_node_element(glitched_group)
+        self.add_node_element(rgb_group)
 
-        # Glitch animation settings (timing and frequency)
-        with ParameterGroup(name="glitch_animation_settings", ui_options={"collapsed": True}) as animation_group:
+        # Tear effect parameters
+        with ParameterGroup(name="tear_effect_settings", ui_options={"collapsed": True}) as tear_group:
             Parameter(
-                name="glitch_frequency",
+                name="tear_enabled",
+                type="bool",
+                default_value=False,
+                tooltip="Enable tear effect",
+            )
+
+            Parameter(
+                name="tear_position",
                 type="float",
-                default_value=self.DEFAULT_GLITCH_FREQUENCY,
-                tooltip=f"Number of glitches per second when animated ({self.MIN_GLITCH_FREQUENCY}-{self.MAX_GLITCH_FREQUENCY})",
-            ).add_trait(Slider(min_val=self.MIN_GLITCH_FREQUENCY, max_val=self.MAX_GLITCH_FREQUENCY))
+                default_value=0.5,
+                tooltip="Vertical position of tear (0.0-1.0, where 0.5 is center)",
+            ).add_trait(Slider(min_val=0.0, max_val=1.0))
 
             Parameter(
-                name="glitch_duration",
-                type="float",
-                default_value=self.DEFAULT_GLITCH_DURATION,
-                tooltip=f"Duration of each glitch in seconds when animated ({self.MIN_GLITCH_DURATION}-{self.MAX_GLITCH_DURATION})",
-            ).add_trait(Slider(min_val=self.MIN_GLITCH_DURATION, max_val=self.MAX_GLITCH_DURATION))
-
-            Parameter(
-                name="glitch_intensity",
-                type="float",
-                default_value=self.DEFAULT_GLITCH_INTENSITY,
-                tooltip=f"Intensity of glitch shifts when animated ({self.MIN_GLITCH_INTENSITY}-{self.MAX_GLITCH_INTENSITY})",
-            ).add_trait(Slider(min_val=self.MIN_GLITCH_INTENSITY, max_val=self.MAX_GLITCH_INTENSITY))
-
-        self.add_node_element(animation_group)
-
-        # Tear effects (randomly occur during animated glitches)
-        with ParameterGroup(name="tear_effects", ui_options={"collapsed": True}) as tear_group:
-            Parameter(
-                name="tear_offset_min",
+                name="tear_offset",
                 type="int",
-                default_value=self.DEFAULT_TEAR_OFFSET_MIN,
-                tooltip=f"Minimum horizontal offset for tear effect - randomly occurs during glitches ({self.MIN_TEAR_OFFSET} to {self.MAX_TEAR_OFFSET} pixels)",
-            ).add_trait(Slider(min_val=self.MIN_TEAR_OFFSET, max_val=self.MAX_TEAR_OFFSET))
-
-            Parameter(
-                name="tear_offset_max",
-                type="int",
-                default_value=self.DEFAULT_TEAR_OFFSET_MAX,
-                tooltip=f"Maximum horizontal offset for tear effect - randomly occurs during glitches ({self.MIN_TEAR_OFFSET} to {self.MAX_TEAR_OFFSET} pixels)",
+                default_value=10,
+                tooltip=f"Horizontal offset amount for tear effect ({self.MIN_TEAR_OFFSET} to {self.MAX_TEAR_OFFSET} pixels)",
             ).add_trait(Slider(min_val=self.MIN_TEAR_OFFSET, max_val=self.MAX_TEAR_OFFSET))
 
         self.add_node_element(tear_group)
-
-        # Random seed for glitch reproducibility
-        with ParameterGroup(name="random_seed_settings", ui_options={"collapsed": True}) as seed_group:
-            Parameter(
-                name="random_seed",
-                type="int",
-                default_value=42,
-                tooltip="Random seed for glitch timing. Use -1 for truly random patterns each time, or any positive number for reproducible patterns.",
-            )
-
-        self.add_node_element(seed_group)
-
-        # Non-glitched visual style (VHS base effects)
-        with ParameterGroup(name="non_glitched_visual_style", ui_options={"collapsed": True}) as vhs_group:
-            Parameter(
-                name="noise_strength",
-                type="int",
-                default_value=self.DEFAULT_NOISE_STRENGTH,
-                tooltip=f"Tape noise strength - always active ({self.MIN_NOISE_STRENGTH}-{self.MAX_NOISE_STRENGTH})",
-            ).add_trait(Slider(min_val=self.MIN_NOISE_STRENGTH, max_val=self.MAX_NOISE_STRENGTH))
-
-            Parameter(
-                name="chroma_shift_horizontal",
-                type="int",
-                default_value=self.DEFAULT_CHROMA_SHIFT_H,
-                tooltip=f"Chroma shift horizontal - always active ({self.MIN_CHROMA_SHIFT}-{self.MAX_CHROMA_SHIFT} pixels)",
-            ).add_trait(Slider(min_val=self.MIN_CHROMA_SHIFT, max_val=self.MAX_CHROMA_SHIFT))
-
-            Parameter(
-                name="chroma_shift_vertical",
-                type="int",
-                default_value=self.DEFAULT_CHROMA_SHIFT_V,
-                tooltip=f"Chroma shift vertical - always active ({self.MIN_CHROMA_SHIFT}-{self.MAX_CHROMA_SHIFT} pixels)",
-            ).add_trait(Slider(min_val=self.MIN_CHROMA_SHIFT, max_val=self.MAX_CHROMA_SHIFT))
-
-            Parameter(
-                name="blur_strength",
-                type="float",
-                default_value=self.DEFAULT_BLUR_STRENGTH,
-                tooltip=f"Blur strength - always active ({self.MIN_BLUR_STRENGTH}-{self.MAX_BLUR_STRENGTH})",
-            ).add_trait(Slider(min_val=self.MIN_BLUR_STRENGTH, max_val=self.MAX_BLUR_STRENGTH))
-
-            Parameter(
-                name="motion_trails",
-                type="int",
-                default_value=self.DEFAULT_MOTION_TRAILS,
-                tooltip=f"Motion trail frames - always active ({self.MIN_MOTION_TRAILS}-{self.MAX_MOTION_TRAILS})",
-            ).add_trait(Slider(min_val=self.MIN_MOTION_TRAILS, max_val=self.MAX_MOTION_TRAILS))
-
-        self.add_node_element(vhs_group)
 
     def _get_processing_description(self) -> str:
         """Get description of what this processor does."""
         return "RGB shift (chromatic aberration) addition"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:  # noqa: PLR0915
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
         """Build FFmpeg command for RGB shift effect."""
         red_h = kwargs.get("red_horizontal", -self.DEFAULT_SHIFT)
         red_v = kwargs.get("red_vertical", 0)
@@ -259,141 +123,39 @@ class AddRGBShift(BaseVideoProcessor):
         blue_v = kwargs.get("blue_vertical", 0)
         intensity = kwargs.get("intensity", self.DEFAULT_INTENSITY)
 
-        # Animated glitch parameters
-        glitch_mode = kwargs.get("glitch_mode", "static")
-        glitch_freq = kwargs.get("glitch_frequency", self.DEFAULT_GLITCH_FREQUENCY)
-        glitch_duration = kwargs.get("glitch_duration", self.DEFAULT_GLITCH_DURATION)
-
-        # Visual effect parameters
-        noise_strength = kwargs.get("noise_strength", self.DEFAULT_NOISE_STRENGTH)
-        chroma_shift_h = kwargs.get("chroma_shift_horizontal", self.DEFAULT_CHROMA_SHIFT_H)
-        chroma_shift_v = kwargs.get("chroma_shift_vertical", self.DEFAULT_CHROMA_SHIFT_V)
-        blur_strength = kwargs.get("blur_strength", self.DEFAULT_BLUR_STRENGTH)
-        motion_trails = kwargs.get("motion_trails", self.DEFAULT_MOTION_TRAILS)
-
         # Tear effect parameters
-        tear_offset_min = kwargs.get("tear_offset_min", self.DEFAULT_TEAR_OFFSET_MIN)
-        tear_offset_max = kwargs.get("tear_offset_max", self.DEFAULT_TEAR_OFFSET_MAX)
+        tear_enabled = kwargs.get("tear_enabled", False)
+        tear_position = kwargs.get("tear_position", 0.5)
+        tear_offset = kwargs.get("tear_offset", 10)
 
-        if glitch_mode == "animated":
-            # Animated glitch with multiple effects
-            # Calculate base shift amounts
-            red_h_scaled = int(red_h * intensity)
-            red_v_scaled = int(red_v * intensity)
-            green_h_scaled = int(green_h * intensity)
-            green_v_scaled = int(green_v * intensity)
-            blue_h_scaled = int(blue_h * intensity)
-            blue_v_scaled = int(blue_v * intensity)
+        # Apply intensity scaling to all shifts
+        red_h_scaled = int(red_h * intensity)
+        red_v_scaled = int(red_v * intensity)
+        green_h_scaled = int(green_h * intensity)
+        green_v_scaled = int(green_v * intensity)
+        blue_h_scaled = int(blue_h * intensity)
+        blue_v_scaled = int(blue_v * intensity)
 
-            # Create timeline enable expression for periodic glitches
-            # Stack multiple between() functions to create glitches throughout the video
-
-            # Create realistic VHS glitch pattern with random timing
-            # This creates sporadic, unpredictable glitches instead of regular pulses
-
-            # Set seed for reproducible but random glitches
-            random_seed = kwargs.get("random_seed", 42)
-            if random_seed >= 0:
-                random.seed(random_seed)  # Fixed seed for consistent results
-
-            # Calculate base timing
-            avg_interval = 1.0 / glitch_freq  # Average time between glitches
-
-            # Create glitches with random timing and varying durations
-            enable_expr = ""
-            # Start with a delay to avoid glitches at the very beginning
-            current_time = random.uniform(  # noqa: S311
-                self.GLITCH_START_DELAY_MIN, self.GLITCH_START_DELAY_MAX
-            )  # Random delay between 0.5-2 seconds
-            glitch_count = 0
-            max_glitches = max(self.GLITCH_MIN_COUNT, int(glitch_freq * 15))  # More glitches for better coverage
-
-            while current_time < self.GLITCH_TIME_LIMIT and glitch_count < max_glitches:  # Cover first 10 seconds
-                # Random interval with some clustering (glitches sometimes come in bursts)
-                if random.uniform(0, 1) < self.GLITCH_BURST_PROBABILITY:  # 30% chance of glitch burst  # noqa: S311
-                    # Create 2-3 glitches in quick succession
-                    burst_count = random.randint(self.GLITCH_BURST_COUNT_MIN, self.GLITCH_BURST_COUNT_MAX)  # noqa: S311
-                    for _ in range(burst_count):
-                        if glitch_count > 0:
-                            enable_expr += "+"
-
-                            # Vary the duration slightly for more realism
-                    actual_duration = glitch_duration * random.uniform(  # noqa: S311
-                        self.GLITCH_DURATION_VARIATION_MIN, self.GLITCH_DURATION_VARIATION_MAX
-                    )
-                    enable_expr += f"between(t,{current_time},{current_time + actual_duration})"
-
-                    current_time += random.uniform(  # noqa: S311
-                        self.BURST_GAP_MIN, self.BURST_GAP_MAX
-                    )  # Short gaps between burst glitches
-                    glitch_count += 1
-
-                    if current_time >= self.GLITCH_TIME_LIMIT or glitch_count >= max_glitches:
-                        break
-            else:
-                # Single glitch with random timing
-                if glitch_count > 0:
-                    enable_expr += "+"
-
-                # Vary the duration slightly for more realism
-                actual_duration = glitch_duration * random.uniform(  # noqa: S311
-                    self.GLITCH_DURATION_VARIATION_MIN, self.GLITCH_DURATION_VARIATION_MAX
-                )
-                enable_expr += f"between(t,{current_time},{current_time + actual_duration})"
-
-                glitch_count += 1
-
-                # Random interval to next glitch (sometimes longer, sometimes shorter)
-                interval_variation = random.uniform(  # noqa: S311
-                    self.GLITCH_INTERVAL_VARIATION_MIN, self.GLITCH_INTERVAL_VARIATION_MAX
-                )  # 50% to 200% of average
-                current_time += avg_interval * interval_variation
-
-            # Advanced filter complex with multiple effects
-            # Includes chroma shift, noise, rgbashift, and tear effects with timeline enables
-            # Random tear position and offset for each glitch
-
-            # Generate completely random tear position and offset
-            tear_position_random = random.uniform(  # noqa: S311
-                self.TEAR_POSITION_MIN, self.TEAR_POSITION_MAX
-            )  # Random between 10% and 90% of frame
-            tear_y_random = f"ih*{tear_position_random}"
-            tear_offset_random = random.randint(tear_offset_min, tear_offset_max)  # noqa: S311
+        if tear_enabled:
+            # Create tear effect by splitting the video and applying different RGB shifts
+            tear_y = f"ih*{tear_position}"
 
             filter_complex = (
-                f"scale=720:-2:flags=bicubic,format=yuv420p,"
-                f"eq=saturation=0.82:contrast=1.04:gamma=0.98,"
-                f"chromashift=cbh={chroma_shift_h}:crh={chroma_shift_v}:edge=smear,"
-                f"gblur=sigma={blur_strength},"
-                f"tmix=frames={motion_trails}:weights='1 2 1',"
-                f"noise=alls={noise_strength}:allf=t+u,"  # spellchecker:disable-line
                 f"split=3[main][tear_top][tear_bottom];"
                 f"[main]rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
                 f"gh={green_h_scaled}:gv={green_v_scaled}:"
-                f"bh={blue_h_scaled}:bv={blue_v_scaled}:"
-                f"enable='{enable_expr}'[rgb_shifted];"
-                f"[tear_top]crop=iw:{tear_y_random}:0:0,rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
+                f"bh={blue_h_scaled}:bv={blue_v_scaled}[rgb_shifted];"
+                f"[tear_top]crop=iw:{tear_y}:0:0,rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
                 f"gh={green_h_scaled}:gv={green_v_scaled}:"
-                f"bh={blue_h_scaled}:bv={blue_v_scaled}:"
-                f"enable='{enable_expr}'[top_shifted];"
-                f"[tear_bottom]crop=iw:ih-{tear_y_random}:0:{tear_y_random},rgbashift=rh={red_h_scaled + tear_offset_random}:rv={red_v_scaled}:"
-                f"gh={green_h_scaled + tear_offset_random}:gv={green_v_scaled}:"
-                f"bh={blue_h_scaled + tear_offset_random}:bv={blue_v_scaled}:"
-                f"enable='{enable_expr}'[bottom_shifted];"
+                f"bh={blue_h_scaled}:bv={blue_v_scaled}[top_shifted];"
+                f"[tear_bottom]crop=iw:ih-{tear_y}:0:{tear_y},rgbashift=rh={red_h_scaled + tear_offset}:rv={red_v_scaled}:"
+                f"gh={green_h_scaled + tear_offset}:gv={green_v_scaled}:"
+                f"bh={blue_h_scaled + tear_offset}:bv={blue_v_scaled}[bottom_shifted];"
                 f"[top_shifted][bottom_shifted]vstack[tear_effect];"
-                f"[rgb_shifted][tear_effect]overlay=0:0:enable='{enable_expr}'[out]"
+                f"[rgb_shifted][tear_effect]overlay=0:0[out]"
             )
-
         else:
-            # Static mode - apply intensity scaling to all shifts
-            red_h_scaled = int(red_h * intensity)
-            red_v_scaled = int(red_v * intensity)
-            green_h_scaled = int(green_h * intensity)
-            green_v_scaled = int(green_v * intensity)
-            blue_h_scaled = int(blue_h * intensity)
-            blue_v_scaled = int(blue_v * intensity)
-
-            # Build RGB shift filter
+            # Simple RGB shift without tear effect
             filter_complex = (
                 f"rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
                 f"gh={green_h_scaled}:gv={green_v_scaled}:"
@@ -420,7 +182,7 @@ class AddRGBShift(BaseVideoProcessor):
             output_path,
         ]
 
-    def _validate_custom_parameters(self) -> list[Exception] | None:  # noqa: C901, PLR0912
+    def _validate_custom_parameters(self) -> list[Exception] | None:
         """Validate RGB shift parameters."""
         exceptions = []
 
@@ -444,77 +206,15 @@ class AddRGBShift(BaseVideoProcessor):
             msg = f"{self.name} - Intensity must be between {self.MIN_INTENSITY} and {self.MAX_INTENSITY}, got {intensity}"
             exceptions.append(ValueError(msg))
 
-        # Validate glitch parameters
-        glitch_freq = self.get_parameter_value("glitch_frequency")
-        if glitch_freq is not None and (
-            glitch_freq < self.MIN_GLITCH_FREQUENCY or glitch_freq > self.MAX_GLITCH_FREQUENCY
-        ):
-            msg = f"{self.name} - Glitch frequency must be between {self.MIN_GLITCH_FREQUENCY} and {self.MAX_GLITCH_FREQUENCY}, got {glitch_freq}"
-            exceptions.append(ValueError(msg))
-
-        glitch_intensity = self.get_parameter_value("glitch_intensity")
-        if glitch_intensity is not None and (
-            glitch_intensity < self.MIN_GLITCH_INTENSITY or glitch_intensity > self.MAX_GLITCH_INTENSITY
-        ):
-            msg = f"{self.name} - Glitch intensity must be between {self.MIN_GLITCH_INTENSITY} and {self.MAX_GLITCH_INTENSITY}, got {glitch_intensity}"
-            exceptions.append(ValueError(msg))
-
-        glitch_duration = self.get_parameter_value("glitch_duration")
-        if glitch_duration is not None and (
-            glitch_duration < self.MIN_GLITCH_DURATION or glitch_duration > self.MAX_GLITCH_DURATION
-        ):
-            msg = f"{self.name} - Glitch duration must be between {self.MIN_GLITCH_DURATION} and {self.MAX_GLITCH_DURATION}, got {glitch_duration}"
-            exceptions.append(ValueError(msg))
-
-        # Validate VHS effect parameters
-        noise_strength = self.get_parameter_value("noise_strength")
-        if noise_strength is not None and (
-            noise_strength < self.MIN_NOISE_STRENGTH or noise_strength > self.MAX_NOISE_STRENGTH
-        ):
-            msg = f"{self.name} - Noise strength must be between {self.MIN_NOISE_STRENGTH} and {self.MAX_NOISE_STRENGTH}, got {noise_strength}"
-            exceptions.append(ValueError(msg))
-
-        chroma_shift_h = self.get_parameter_value("chroma_shift_horizontal")
-        if chroma_shift_h is not None and (
-            chroma_shift_h < self.MIN_CHROMA_SHIFT or chroma_shift_h > self.MAX_CHROMA_SHIFT
-        ):
-            msg = f"{self.name} - Chroma shift horizontal must be between {self.MIN_CHROMA_SHIFT} and {self.MAX_CHROMA_SHIFT}, got {chroma_shift_h}"
-            exceptions.append(ValueError(msg))
-
-        chroma_shift_v = self.get_parameter_value("chroma_shift_vertical")
-        if chroma_shift_v is not None and (
-            chroma_shift_v < self.MIN_CHROMA_SHIFT or chroma_shift_v > self.MAX_CHROMA_SHIFT
-        ):
-            msg = f"{self.name} - Chroma shift vertical must be between {self.MIN_CHROMA_SHIFT} and {self.MAX_CHROMA_SHIFT}, got {chroma_shift_v}"
-            exceptions.append(ValueError(msg))
-
-        blur_strength = self.get_parameter_value("blur_strength")
-        if blur_strength is not None and (
-            blur_strength < self.MIN_BLUR_STRENGTH or blur_strength > self.MAX_BLUR_STRENGTH
-        ):
-            msg = f"{self.name} - Blur strength must be between {self.MIN_BLUR_STRENGTH} and {self.MAX_BLUR_STRENGTH}, got {blur_strength}"
-            exceptions.append(ValueError(msg))
-
-        motion_trails = self.get_parameter_value("motion_trails")
-        if motion_trails is not None and (
-            motion_trails < self.MIN_MOTION_TRAILS or motion_trails > self.MAX_MOTION_TRAILS
-        ):
-            msg = f"{self.name} - Motion trails must be between {self.MIN_MOTION_TRAILS} and {self.MAX_MOTION_TRAILS}, got {motion_trails}"
-            exceptions.append(ValueError(msg))
-
         # Validate tear effect parameters
-        tear_offset_min = self.get_parameter_value("tear_offset_min")
-        if tear_offset_min is not None and (
-            tear_offset_min < self.MIN_TEAR_OFFSET or tear_offset_min > self.MAX_TEAR_OFFSET
-        ):
-            msg = f"{self.name} - Tear offset min must be between {self.MIN_TEAR_OFFSET} and {self.MAX_TEAR_OFFSET}, got {tear_offset_min}"
+        tear_position = self.get_parameter_value("tear_position")
+        if tear_position is not None and (tear_position < 0.0 or tear_position > 1.0):
+            msg = f"{self.name} - Tear position must be between 0.0 and 1.0, got {tear_position}"
             exceptions.append(ValueError(msg))
 
-        tear_offset_max = self.get_parameter_value("tear_offset_max")
-        if tear_offset_max is not None and (
-            tear_offset_max < self.MIN_TEAR_OFFSET or tear_offset_max > self.MAX_TEAR_OFFSET
-        ):
-            msg = f"{self.name} - Tear offset max must be between {self.MIN_TEAR_OFFSET} and {self.MAX_TEAR_OFFSET}, got {tear_offset_max}"
+        tear_offset = self.get_parameter_value("tear_offset")
+        if tear_offset is not None and (tear_offset < self.MIN_TEAR_OFFSET or tear_offset > self.MAX_TEAR_OFFSET):
+            msg = f"{self.name} - Tear offset must be between {self.MIN_TEAR_OFFSET} and {self.MAX_TEAR_OFFSET}, got {tear_offset}"
             exceptions.append(ValueError(msg))
 
         return exceptions if exceptions else None
@@ -529,18 +229,9 @@ class AddRGBShift(BaseVideoProcessor):
             "blue_horizontal": self.get_parameter_value("blue_horizontal"),
             "blue_vertical": self.get_parameter_value("blue_vertical"),
             "intensity": self.get_parameter_value("intensity"),
-            "glitch_mode": self.get_parameter_value("glitch_mode"),
-            "glitch_frequency": self.get_parameter_value("glitch_frequency"),
-            "glitch_intensity": self.get_parameter_value("glitch_intensity"),
-            "glitch_duration": self.get_parameter_value("glitch_duration"),
-            "noise_strength": self.get_parameter_value("noise_strength"),
-            "chroma_shift_horizontal": self.get_parameter_value("chroma_shift_horizontal"),
-            "chroma_shift_vertical": self.get_parameter_value("chroma_shift_vertical"),
-            "blur_strength": self.get_parameter_value("blur_strength"),
-            "motion_trails": self.get_parameter_value("motion_trails"),
-            "tear_offset_min": self.get_parameter_value("tear_offset_min"),
-            "tear_offset_max": self.get_parameter_value("tear_offset_max"),
-            "random_seed": self.get_parameter_value("random_seed"),
+            "tear_enabled": self.get_parameter_value("tear_enabled"),
+            "tear_position": self.get_parameter_value("tear_position"),
+            "tear_offset": self.get_parameter_value("tear_offset"),
         }
 
     def _get_output_suffix(self, **kwargs) -> str:
@@ -552,20 +243,13 @@ class AddRGBShift(BaseVideoProcessor):
         blue_h = kwargs.get("blue_horizontal", 0)
         blue_v = kwargs.get("blue_vertical", 0)
         intensity = kwargs.get("intensity", self.DEFAULT_INTENSITY)
-        glitch_mode = kwargs.get("glitch_mode", "static")
+        tear_enabled = kwargs.get("tear_enabled", False)
 
         suffix = f"_rgbshift_rh{red_h}_rv{red_v}_gh{green_h}_gv{green_v}_bh{blue_h}_bv{blue_v}_i{intensity:.2f}"
 
-        if glitch_mode == "animated":
-            glitch_freq = kwargs.get("glitch_frequency", self.DEFAULT_GLITCH_FREQUENCY)
-            glitch_intensity = kwargs.get("glitch_intensity", self.DEFAULT_GLITCH_INTENSITY)
-            noise_strength = kwargs.get("noise_strength", self.DEFAULT_NOISE_STRENGTH)
-            chroma_shift_h = kwargs.get("chroma_shift_horizontal", self.DEFAULT_CHROMA_SHIFT_H)
-            chroma_shift_v = kwargs.get("chroma_shift_vertical", self.DEFAULT_CHROMA_SHIFT_V)
-            blur_strength = kwargs.get("blur_strength", self.DEFAULT_BLUR_STRENGTH)
-            motion_trails = kwargs.get("motion_trails", self.DEFAULT_MOTION_TRAILS)
-            tear_offset_min = kwargs.get("tear_offset_min", self.DEFAULT_TEAR_OFFSET_MIN)
-            tear_offset_max = kwargs.get("tear_offset_max", self.DEFAULT_TEAR_OFFSET_MAX)
-            suffix += f"_animated_f{glitch_freq:.1f}_i{glitch_intensity:.2f}_n{noise_strength}_c{chroma_shift_h}{chroma_shift_v}_b{blur_strength:.1f}_m{motion_trails}_t{tear_offset_min}-{tear_offset_max}"
+        if tear_enabled:
+            tear_position = kwargs.get("tear_position", 0.5)
+            tear_offset = kwargs.get("tear_offset", 10)
+            suffix += f"_tear_p{tear_position:.2f}_o{tear_offset}"
 
         return suffix

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
@@ -366,7 +366,7 @@ class AddRGBShift(BaseVideoProcessor):
                 f"chromashift=cbh={chroma_shift_h}:crh={chroma_shift_v}:edge=smear,"
                 f"gblur=sigma={blur_strength},"
                 f"tmix=frames={motion_trails}:weights='1 2 1',"
-                f"noise=alls={noise_strength}:allf=t+u,"
+                f"noise=alls={noise_strength}:allf=t+u,"  # typos: disable-line
                 f"split=3[main][tear_top][tear_bottom];"
                 f"[main]rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
                 f"gh={green_h_scaled}:gv={green_v_scaled}:"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
@@ -366,7 +366,7 @@ class AddRGBShift(BaseVideoProcessor):
                 f"chromashift=cbh={chroma_shift_h}:crh={chroma_shift_v}:edge=smear,"
                 f"gblur=sigma={blur_strength},"
                 f"tmix=frames={motion_trails}:weights='1 2 1',"
-                f"noise=alls={noise_strength}:allf=t+u,"  # typos: disable-line
+                f"noise=alls={noise_strength}:allf=t+u,"  # spellchecker:disable-line
                 f"split=3[main][tear_top][tear_bottom];"
                 f"[main]rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
                 f"gh={green_h_scaled}:gv={green_v_scaled}:"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
@@ -1,0 +1,571 @@
+import random
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class AddRGBShift(BaseVideoProcessor):
+    """Add RGB shift (chromatic aberration) effect to video."""
+
+    # RGB shift constants
+    MIN_SHIFT = -20
+    MAX_SHIFT = 20
+    DEFAULT_SHIFT = 6
+
+    # RGB shift intensity constants
+    MIN_INTENSITY = 0.0
+    MAX_INTENSITY = 1.0
+    DEFAULT_INTENSITY = 1.0
+
+    # Animated glitch timing constants
+    MIN_GLITCH_FREQUENCY = 0.1
+    MAX_GLITCH_FREQUENCY = 10.0
+    DEFAULT_GLITCH_FREQUENCY = 2.0
+
+    MIN_GLITCH_INTENSITY = 0.0
+    MAX_GLITCH_INTENSITY = 1.0
+    DEFAULT_GLITCH_INTENSITY = 0.5
+
+    MIN_GLITCH_DURATION = 0.01
+    MAX_GLITCH_DURATION = 0.5
+    DEFAULT_GLITCH_DURATION = 0.1
+
+    # Visual effect constants
+    MIN_NOISE_STRENGTH = 0
+    MAX_NOISE_STRENGTH = 50
+    DEFAULT_NOISE_STRENGTH = 8
+
+    MIN_CHROMA_SHIFT = -10
+    MAX_CHROMA_SHIFT = 10
+    DEFAULT_CHROMA_SHIFT_H = 2
+    DEFAULT_CHROMA_SHIFT_V = -2
+
+    MIN_BLUR_STRENGTH = 0.0
+    MAX_BLUR_STRENGTH = 3.0
+    DEFAULT_BLUR_STRENGTH = 0.8
+
+    MIN_MOTION_TRAILS = 1
+    MAX_MOTION_TRAILS = 5
+    DEFAULT_MOTION_TRAILS = 3
+
+    # Glitch timing variation constants
+    GLITCH_DURATION_VARIATION_MIN = 0.8
+    GLITCH_DURATION_VARIATION_MAX = 1.2
+    GLITCH_INTERVAL_VARIATION_MIN = 0.5
+    GLITCH_INTERVAL_VARIATION_MAX = 2.0
+
+    # Burst glitch timing constants
+    BURST_GAP_MIN = 0.05
+    BURST_GAP_MAX = 0.15
+
+    # Tear position constants
+    TEAR_POSITION_MIN = 0.1
+    TEAR_POSITION_MAX = 0.9
+
+    # Glitch burst constants
+    GLITCH_BURST_PROBABILITY = 0.3
+    GLITCH_BURST_COUNT_MIN = 2
+    GLITCH_BURST_COUNT_MAX = 3
+
+    # Glitch timing constants
+    GLITCH_START_DELAY_MIN = 0.5
+    GLITCH_START_DELAY_MAX = 2.0
+    GLITCH_TIME_LIMIT = 10.0
+    GLITCH_MIN_COUNT = 20
+
+    # Tear effect constants
+    MIN_TEAR_OFFSET = -50
+    MAX_TEAR_OFFSET = 50
+    DEFAULT_TEAR_OFFSET_MIN = 5
+    DEFAULT_TEAR_OFFSET_MAX = 15
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup RGB shift-specific parameters."""
+        # Glitch mode (at the top level)
+        glitch_mode_parameter = Parameter(
+            name="glitch_mode",
+            type="str",
+            default_value="static",
+            tooltip="Glitch animation: static (constant RGB shift) or animated (intermittent RGB shift with timing and tear effects)",
+        )
+        self.add_parameter(glitch_mode_parameter)
+        glitch_mode_parameter.add_trait(Options(choices=["static", "animated"]))
+        with ParameterGroup(name="glitched_visual_style", ui_options={"collapsed": False}) as glitched_group:
+            # Red channel horizontal shift
+            Parameter(
+                name="red_horizontal",
+                type="int",
+                default_value=-self.DEFAULT_SHIFT,
+                tooltip=f"Red channel horizontal shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
+
+            # Red channel vertical shift
+            Parameter(
+                name="red_vertical",
+                type="int",
+                default_value=0,
+                tooltip=f"Red channel vertical shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
+
+            # Green channel horizontal shift
+            Parameter(
+                name="green_horizontal",
+                type="int",
+                default_value=self.DEFAULT_SHIFT,
+                tooltip=f"Green channel horizontal shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
+
+            # Green channel vertical shift
+            Parameter(
+                name="green_vertical",
+                type="int",
+                default_value=0,
+                tooltip=f"Green channel vertical shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
+
+            # Blue channel horizontal shift
+            Parameter(
+                name="blue_horizontal",
+                type="int",
+                default_value=0,
+                tooltip=f"Blue channel horizontal shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
+
+            # Blue channel vertical shift
+            Parameter(
+                name="blue_vertical",
+                type="int",
+                default_value=0,
+                tooltip=f"Blue channel vertical shift during glitches ({self.MIN_SHIFT} to {self.MAX_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_SHIFT, max_val=self.MAX_SHIFT))
+
+            # Overall intensity
+            Parameter(
+                name="intensity",
+                type="float",
+                default_value=self.DEFAULT_INTENSITY,
+                tooltip=f"Overall intensity of the RGB shift effect during glitches ({self.MIN_INTENSITY}-{self.MAX_INTENSITY})",
+            ).add_trait(Slider(min_val=self.MIN_INTENSITY, max_val=self.MAX_INTENSITY))
+
+        self.add_node_element(glitched_group)
+
+        # Glitch animation settings (timing and frequency)
+        with ParameterGroup(name="glitch_animation_settings", ui_options={"collapsed": True}) as animation_group:
+            Parameter(
+                name="glitch_frequency",
+                type="float",
+                default_value=self.DEFAULT_GLITCH_FREQUENCY,
+                tooltip=f"Number of glitches per second when animated ({self.MIN_GLITCH_FREQUENCY}-{self.MAX_GLITCH_FREQUENCY})",
+            ).add_trait(Slider(min_val=self.MIN_GLITCH_FREQUENCY, max_val=self.MAX_GLITCH_FREQUENCY))
+
+            Parameter(
+                name="glitch_duration",
+                type="float",
+                default_value=self.DEFAULT_GLITCH_DURATION,
+                tooltip=f"Duration of each glitch in seconds when animated ({self.MIN_GLITCH_DURATION}-{self.MAX_GLITCH_DURATION})",
+            ).add_trait(Slider(min_val=self.MIN_GLITCH_DURATION, max_val=self.MAX_GLITCH_DURATION))
+
+            Parameter(
+                name="glitch_intensity",
+                type="float",
+                default_value=self.DEFAULT_GLITCH_INTENSITY,
+                tooltip=f"Intensity of glitch shifts when animated ({self.MIN_GLITCH_INTENSITY}-{self.MAX_GLITCH_INTENSITY})",
+            ).add_trait(Slider(min_val=self.MIN_GLITCH_INTENSITY, max_val=self.MAX_GLITCH_INTENSITY))
+
+        self.add_node_element(animation_group)
+
+        # Tear effects (randomly occur during animated glitches)
+        with ParameterGroup(name="tear_effects", ui_options={"collapsed": True}) as tear_group:
+            Parameter(
+                name="tear_offset_min",
+                type="int",
+                default_value=self.DEFAULT_TEAR_OFFSET_MIN,
+                tooltip=f"Minimum horizontal offset for tear effect - randomly occurs during glitches ({self.MIN_TEAR_OFFSET} to {self.MAX_TEAR_OFFSET} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_TEAR_OFFSET, max_val=self.MAX_TEAR_OFFSET))
+
+            Parameter(
+                name="tear_offset_max",
+                type="int",
+                default_value=self.DEFAULT_TEAR_OFFSET_MAX,
+                tooltip=f"Maximum horizontal offset for tear effect - randomly occurs during glitches ({self.MIN_TEAR_OFFSET} to {self.MAX_TEAR_OFFSET} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_TEAR_OFFSET, max_val=self.MAX_TEAR_OFFSET))
+
+        self.add_node_element(tear_group)
+
+        # Random seed for glitch reproducibility
+        with ParameterGroup(name="random_seed_settings", ui_options={"collapsed": True}) as seed_group:
+            Parameter(
+                name="random_seed",
+                type="int",
+                default_value=42,
+                tooltip="Random seed for glitch timing. Use -1 for truly random patterns each time, or any positive number for reproducible patterns.",
+            )
+
+        self.add_node_element(seed_group)
+
+        # Non-glitched visual style (VHS base effects)
+        with ParameterGroup(name="non_glitched_visual_style", ui_options={"collapsed": True}) as vhs_group:
+            Parameter(
+                name="noise_strength",
+                type="int",
+                default_value=self.DEFAULT_NOISE_STRENGTH,
+                tooltip=f"Tape noise strength - always active ({self.MIN_NOISE_STRENGTH}-{self.MAX_NOISE_STRENGTH})",
+            ).add_trait(Slider(min_val=self.MIN_NOISE_STRENGTH, max_val=self.MAX_NOISE_STRENGTH))
+
+            Parameter(
+                name="chroma_shift_horizontal",
+                type="int",
+                default_value=self.DEFAULT_CHROMA_SHIFT_H,
+                tooltip=f"Chroma shift horizontal - always active ({self.MIN_CHROMA_SHIFT}-{self.MAX_CHROMA_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_CHROMA_SHIFT, max_val=self.MAX_CHROMA_SHIFT))
+
+            Parameter(
+                name="chroma_shift_vertical",
+                type="int",
+                default_value=self.DEFAULT_CHROMA_SHIFT_V,
+                tooltip=f"Chroma shift vertical - always active ({self.MIN_CHROMA_SHIFT}-{self.MAX_CHROMA_SHIFT} pixels)",
+            ).add_trait(Slider(min_val=self.MIN_CHROMA_SHIFT, max_val=self.MAX_CHROMA_SHIFT))
+
+            Parameter(
+                name="blur_strength",
+                type="float",
+                default_value=self.DEFAULT_BLUR_STRENGTH,
+                tooltip=f"Blur strength - always active ({self.MIN_BLUR_STRENGTH}-{self.MAX_BLUR_STRENGTH})",
+            ).add_trait(Slider(min_val=self.MIN_BLUR_STRENGTH, max_val=self.MAX_BLUR_STRENGTH))
+
+            Parameter(
+                name="motion_trails",
+                type="int",
+                default_value=self.DEFAULT_MOTION_TRAILS,
+                tooltip=f"Motion trail frames - always active ({self.MIN_MOTION_TRAILS}-{self.MAX_MOTION_TRAILS})",
+            ).add_trait(Slider(min_val=self.MIN_MOTION_TRAILS, max_val=self.MAX_MOTION_TRAILS))
+
+        self.add_node_element(vhs_group)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "RGB shift (chromatic aberration) addition"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:  # noqa: PLR0915
+        """Build FFmpeg command for RGB shift effect."""
+        red_h = kwargs.get("red_horizontal", -self.DEFAULT_SHIFT)
+        red_v = kwargs.get("red_vertical", 0)
+        green_h = kwargs.get("green_horizontal", self.DEFAULT_SHIFT)
+        green_v = kwargs.get("green_vertical", 0)
+        blue_h = kwargs.get("blue_horizontal", 0)
+        blue_v = kwargs.get("blue_vertical", 0)
+        intensity = kwargs.get("intensity", self.DEFAULT_INTENSITY)
+
+        # Animated glitch parameters
+        glitch_mode = kwargs.get("glitch_mode", "static")
+        glitch_freq = kwargs.get("glitch_frequency", self.DEFAULT_GLITCH_FREQUENCY)
+        glitch_duration = kwargs.get("glitch_duration", self.DEFAULT_GLITCH_DURATION)
+
+        # Visual effect parameters
+        noise_strength = kwargs.get("noise_strength", self.DEFAULT_NOISE_STRENGTH)
+        chroma_shift_h = kwargs.get("chroma_shift_horizontal", self.DEFAULT_CHROMA_SHIFT_H)
+        chroma_shift_v = kwargs.get("chroma_shift_vertical", self.DEFAULT_CHROMA_SHIFT_V)
+        blur_strength = kwargs.get("blur_strength", self.DEFAULT_BLUR_STRENGTH)
+        motion_trails = kwargs.get("motion_trails", self.DEFAULT_MOTION_TRAILS)
+
+        # Tear effect parameters
+        tear_offset_min = kwargs.get("tear_offset_min", self.DEFAULT_TEAR_OFFSET_MIN)
+        tear_offset_max = kwargs.get("tear_offset_max", self.DEFAULT_TEAR_OFFSET_MAX)
+
+        if glitch_mode == "animated":
+            # Animated glitch with multiple effects
+            # Calculate base shift amounts
+            red_h_scaled = int(red_h * intensity)
+            red_v_scaled = int(red_v * intensity)
+            green_h_scaled = int(green_h * intensity)
+            green_v_scaled = int(green_v * intensity)
+            blue_h_scaled = int(blue_h * intensity)
+            blue_v_scaled = int(blue_v * intensity)
+
+            # Create timeline enable expression for periodic glitches
+            # Stack multiple between() functions to create glitches throughout the video
+
+            # Create realistic VHS glitch pattern with random timing
+            # This creates sporadic, unpredictable glitches instead of regular pulses
+
+            # Set seed for reproducible but random glitches
+            random_seed = kwargs.get("random_seed", 42)
+            if random_seed >= 0:
+                random.seed(random_seed)  # Fixed seed for consistent results
+
+            # Calculate base timing
+            avg_interval = 1.0 / glitch_freq  # Average time between glitches
+
+            # Create glitches with random timing and varying durations
+            enable_expr = ""
+            # Start with a delay to avoid glitches at the very beginning
+            current_time = random.uniform(  # noqa: S311
+                self.GLITCH_START_DELAY_MIN, self.GLITCH_START_DELAY_MAX
+            )  # Random delay between 0.5-2 seconds
+            glitch_count = 0
+            max_glitches = max(self.GLITCH_MIN_COUNT, int(glitch_freq * 15))  # More glitches for better coverage
+
+            while current_time < self.GLITCH_TIME_LIMIT and glitch_count < max_glitches:  # Cover first 10 seconds
+                # Random interval with some clustering (glitches sometimes come in bursts)
+                if random.uniform(0, 1) < self.GLITCH_BURST_PROBABILITY:  # 30% chance of glitch burst  # noqa: S311
+                    # Create 2-3 glitches in quick succession
+                    burst_count = random.randint(self.GLITCH_BURST_COUNT_MIN, self.GLITCH_BURST_COUNT_MAX)  # noqa: S311
+                    for _ in range(burst_count):
+                        if glitch_count > 0:
+                            enable_expr += "+"
+
+                            # Vary the duration slightly for more realism
+                    actual_duration = glitch_duration * random.uniform(  # noqa: S311
+                        self.GLITCH_DURATION_VARIATION_MIN, self.GLITCH_DURATION_VARIATION_MAX
+                    )
+                    enable_expr += f"between(t,{current_time},{current_time + actual_duration})"
+
+                    current_time += random.uniform(  # noqa: S311
+                        self.BURST_GAP_MIN, self.BURST_GAP_MAX
+                    )  # Short gaps between burst glitches
+                    glitch_count += 1
+
+                    if current_time >= self.GLITCH_TIME_LIMIT or glitch_count >= max_glitches:
+                        break
+            else:
+                # Single glitch with random timing
+                if glitch_count > 0:
+                    enable_expr += "+"
+
+                # Vary the duration slightly for more realism
+                actual_duration = glitch_duration * random.uniform(  # noqa: S311
+                    self.GLITCH_DURATION_VARIATION_MIN, self.GLITCH_DURATION_VARIATION_MAX
+                )
+                enable_expr += f"between(t,{current_time},{current_time + actual_duration})"
+
+                glitch_count += 1
+
+                # Random interval to next glitch (sometimes longer, sometimes shorter)
+                interval_variation = random.uniform(  # noqa: S311
+                    self.GLITCH_INTERVAL_VARIATION_MIN, self.GLITCH_INTERVAL_VARIATION_MAX
+                )  # 50% to 200% of average
+                current_time += avg_interval * interval_variation
+
+            # Advanced filter complex with multiple effects
+            # Includes chroma shift, noise, rgbashift, and tear effects with timeline enables
+            # Random tear position and offset for each glitch
+
+            # Generate completely random tear position and offset
+            tear_position_random = random.uniform(  # noqa: S311
+                self.TEAR_POSITION_MIN, self.TEAR_POSITION_MAX
+            )  # Random between 10% and 90% of frame
+            tear_y_random = f"ih*{tear_position_random}"
+            tear_offset_random = random.randint(tear_offset_min, tear_offset_max)  # noqa: S311
+
+            filter_complex = (
+                f"scale=720:-2:flags=bicubic,format=yuv420p,"
+                f"eq=saturation=0.82:contrast=1.04:gamma=0.98,"
+                f"chromashift=cbh={chroma_shift_h}:crh={chroma_shift_v}:edge=smear,"
+                f"gblur=sigma={blur_strength},"
+                f"tmix=frames={motion_trails}:weights='1 2 1',"
+                f"noise=alls={noise_strength}:allf=t+u,"
+                f"split=3[main][tear_top][tear_bottom];"
+                f"[main]rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
+                f"gh={green_h_scaled}:gv={green_v_scaled}:"
+                f"bh={blue_h_scaled}:bv={blue_v_scaled}:"
+                f"enable='{enable_expr}'[rgb_shifted];"
+                f"[tear_top]crop=iw:{tear_y_random}:0:0,rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
+                f"gh={green_h_scaled}:gv={green_v_scaled}:"
+                f"bh={blue_h_scaled}:bv={blue_v_scaled}:"
+                f"enable='{enable_expr}'[top_shifted];"
+                f"[tear_bottom]crop=iw:ih-{tear_y_random}:0:{tear_y_random},rgbashift=rh={red_h_scaled + tear_offset_random}:rv={red_v_scaled}:"
+                f"gh={green_h_scaled + tear_offset_random}:gv={green_v_scaled}:"
+                f"bh={blue_h_scaled + tear_offset_random}:bv={blue_v_scaled}:"
+                f"enable='{enable_expr}'[bottom_shifted];"
+                f"[top_shifted][bottom_shifted]vstack[tear_effect];"
+                f"[rgb_shifted][tear_effect]overlay=0:0:enable='{enable_expr}'[out]"
+            )
+
+        else:
+            # Static mode - apply intensity scaling to all shifts
+            red_h_scaled = int(red_h * intensity)
+            red_v_scaled = int(red_v * intensity)
+            green_h_scaled = int(green_h * intensity)
+            green_v_scaled = int(green_v * intensity)
+            blue_h_scaled = int(blue_h * intensity)
+            blue_v_scaled = int(blue_v * intensity)
+
+            # Build RGB shift filter
+            filter_complex = (
+                f"rgbashift=rh={red_h_scaled}:rv={red_v_scaled}:"
+                f"gh={green_h_scaled}:gv={green_v_scaled}:"
+                f"bh={blue_h_scaled}:bv={blue_v_scaled}"
+            )
+
+        return [
+            "ffmpeg",
+            "-i",
+            input_url,
+            "-vf",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "12",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "copy",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:  # noqa: C901, PLR0912
+        """Validate RGB shift parameters."""
+        exceptions = []
+
+        # Validate shift values
+        for param_name in [
+            "red_horizontal",
+            "red_vertical",
+            "green_horizontal",
+            "green_vertical",
+            "blue_horizontal",
+            "blue_vertical",
+        ]:
+            value = self.get_parameter_value(param_name)
+            if value is not None and (value < self.MIN_SHIFT or value > self.MAX_SHIFT):
+                msg = f"{self.name} - {param_name} must be between {self.MIN_SHIFT} and {self.MAX_SHIFT}, got {value}"
+                exceptions.append(ValueError(msg))
+
+        # Validate intensity
+        intensity = self.get_parameter_value("intensity")
+        if intensity is not None and (intensity < self.MIN_INTENSITY or intensity > self.MAX_INTENSITY):
+            msg = f"{self.name} - Intensity must be between {self.MIN_INTENSITY} and {self.MAX_INTENSITY}, got {intensity}"
+            exceptions.append(ValueError(msg))
+
+        # Validate glitch parameters
+        glitch_freq = self.get_parameter_value("glitch_frequency")
+        if glitch_freq is not None and (
+            glitch_freq < self.MIN_GLITCH_FREQUENCY or glitch_freq > self.MAX_GLITCH_FREQUENCY
+        ):
+            msg = f"{self.name} - Glitch frequency must be between {self.MIN_GLITCH_FREQUENCY} and {self.MAX_GLITCH_FREQUENCY}, got {glitch_freq}"
+            exceptions.append(ValueError(msg))
+
+        glitch_intensity = self.get_parameter_value("glitch_intensity")
+        if glitch_intensity is not None and (
+            glitch_intensity < self.MIN_GLITCH_INTENSITY or glitch_intensity > self.MAX_GLITCH_INTENSITY
+        ):
+            msg = f"{self.name} - Glitch intensity must be between {self.MIN_GLITCH_INTENSITY} and {self.MAX_GLITCH_INTENSITY}, got {glitch_intensity}"
+            exceptions.append(ValueError(msg))
+
+        glitch_duration = self.get_parameter_value("glitch_duration")
+        if glitch_duration is not None and (
+            glitch_duration < self.MIN_GLITCH_DURATION or glitch_duration > self.MAX_GLITCH_DURATION
+        ):
+            msg = f"{self.name} - Glitch duration must be between {self.MIN_GLITCH_DURATION} and {self.MAX_GLITCH_DURATION}, got {glitch_duration}"
+            exceptions.append(ValueError(msg))
+
+        # Validate VHS effect parameters
+        noise_strength = self.get_parameter_value("noise_strength")
+        if noise_strength is not None and (
+            noise_strength < self.MIN_NOISE_STRENGTH or noise_strength > self.MAX_NOISE_STRENGTH
+        ):
+            msg = f"{self.name} - Noise strength must be between {self.MIN_NOISE_STRENGTH} and {self.MAX_NOISE_STRENGTH}, got {noise_strength}"
+            exceptions.append(ValueError(msg))
+
+        chroma_shift_h = self.get_parameter_value("chroma_shift_horizontal")
+        if chroma_shift_h is not None and (
+            chroma_shift_h < self.MIN_CHROMA_SHIFT or chroma_shift_h > self.MAX_CHROMA_SHIFT
+        ):
+            msg = f"{self.name} - Chroma shift horizontal must be between {self.MIN_CHROMA_SHIFT} and {self.MAX_CHROMA_SHIFT}, got {chroma_shift_h}"
+            exceptions.append(ValueError(msg))
+
+        chroma_shift_v = self.get_parameter_value("chroma_shift_vertical")
+        if chroma_shift_v is not None and (
+            chroma_shift_v < self.MIN_CHROMA_SHIFT or chroma_shift_v > self.MAX_CHROMA_SHIFT
+        ):
+            msg = f"{self.name} - Chroma shift vertical must be between {self.MIN_CHROMA_SHIFT} and {self.MAX_CHROMA_SHIFT}, got {chroma_shift_v}"
+            exceptions.append(ValueError(msg))
+
+        blur_strength = self.get_parameter_value("blur_strength")
+        if blur_strength is not None and (
+            blur_strength < self.MIN_BLUR_STRENGTH or blur_strength > self.MAX_BLUR_STRENGTH
+        ):
+            msg = f"{self.name} - Blur strength must be between {self.MIN_BLUR_STRENGTH} and {self.MAX_BLUR_STRENGTH}, got {blur_strength}"
+            exceptions.append(ValueError(msg))
+
+        motion_trails = self.get_parameter_value("motion_trails")
+        if motion_trails is not None and (
+            motion_trails < self.MIN_MOTION_TRAILS or motion_trails > self.MAX_MOTION_TRAILS
+        ):
+            msg = f"{self.name} - Motion trails must be between {self.MIN_MOTION_TRAILS} and {self.MAX_MOTION_TRAILS}, got {motion_trails}"
+            exceptions.append(ValueError(msg))
+
+        # Validate tear effect parameters
+        tear_offset_min = self.get_parameter_value("tear_offset_min")
+        if tear_offset_min is not None and (
+            tear_offset_min < self.MIN_TEAR_OFFSET or tear_offset_min > self.MAX_TEAR_OFFSET
+        ):
+            msg = f"{self.name} - Tear offset min must be between {self.MIN_TEAR_OFFSET} and {self.MAX_TEAR_OFFSET}, got {tear_offset_min}"
+            exceptions.append(ValueError(msg))
+
+        tear_offset_max = self.get_parameter_value("tear_offset_max")
+        if tear_offset_max is not None and (
+            tear_offset_max < self.MIN_TEAR_OFFSET or tear_offset_max > self.MAX_TEAR_OFFSET
+        ):
+            msg = f"{self.name} - Tear offset max must be between {self.MIN_TEAR_OFFSET} and {self.MAX_TEAR_OFFSET}, got {tear_offset_max}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get RGB shift parameters."""
+        return {
+            "red_horizontal": self.get_parameter_value("red_horizontal"),
+            "red_vertical": self.get_parameter_value("red_vertical"),
+            "green_horizontal": self.get_parameter_value("green_horizontal"),
+            "green_vertical": self.get_parameter_value("green_vertical"),
+            "blue_horizontal": self.get_parameter_value("blue_horizontal"),
+            "blue_vertical": self.get_parameter_value("blue_vertical"),
+            "intensity": self.get_parameter_value("intensity"),
+            "glitch_mode": self.get_parameter_value("glitch_mode"),
+            "glitch_frequency": self.get_parameter_value("glitch_frequency"),
+            "glitch_intensity": self.get_parameter_value("glitch_intensity"),
+            "glitch_duration": self.get_parameter_value("glitch_duration"),
+            "noise_strength": self.get_parameter_value("noise_strength"),
+            "chroma_shift_horizontal": self.get_parameter_value("chroma_shift_horizontal"),
+            "chroma_shift_vertical": self.get_parameter_value("chroma_shift_vertical"),
+            "blur_strength": self.get_parameter_value("blur_strength"),
+            "motion_trails": self.get_parameter_value("motion_trails"),
+            "tear_offset_min": self.get_parameter_value("tear_offset_min"),
+            "tear_offset_max": self.get_parameter_value("tear_offset_max"),
+            "random_seed": self.get_parameter_value("random_seed"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        red_h = kwargs.get("red_horizontal", -self.DEFAULT_SHIFT)
+        red_v = kwargs.get("red_vertical", 0)
+        green_h = kwargs.get("green_horizontal", self.DEFAULT_SHIFT)
+        green_v = kwargs.get("green_vertical", 0)
+        blue_h = kwargs.get("blue_horizontal", 0)
+        blue_v = kwargs.get("blue_vertical", 0)
+        intensity = kwargs.get("intensity", self.DEFAULT_INTENSITY)
+        glitch_mode = kwargs.get("glitch_mode", "static")
+
+        suffix = f"_rgbshift_rh{red_h}_rv{red_v}_gh{green_h}_gv{green_v}_bh{blue_h}_bv{blue_v}_i{intensity:.2f}"
+
+        if glitch_mode == "animated":
+            glitch_freq = kwargs.get("glitch_frequency", self.DEFAULT_GLITCH_FREQUENCY)
+            glitch_intensity = kwargs.get("glitch_intensity", self.DEFAULT_GLITCH_INTENSITY)
+            noise_strength = kwargs.get("noise_strength", self.DEFAULT_NOISE_STRENGTH)
+            chroma_shift_h = kwargs.get("chroma_shift_horizontal", self.DEFAULT_CHROMA_SHIFT_H)
+            chroma_shift_v = kwargs.get("chroma_shift_vertical", self.DEFAULT_CHROMA_SHIFT_V)
+            blur_strength = kwargs.get("blur_strength", self.DEFAULT_BLUR_STRENGTH)
+            motion_trails = kwargs.get("motion_trails", self.DEFAULT_MOTION_TRAILS)
+            tear_offset_min = kwargs.get("tear_offset_min", self.DEFAULT_TEAR_OFFSET_MIN)
+            tear_offset_max = kwargs.get("tear_offset_max", self.DEFAULT_TEAR_OFFSET_MAX)
+            suffix += f"_animated_f{glitch_freq:.1f}_i{glitch_intensity:.2f}_n{noise_strength}_c{chroma_shift_h}{chroma_shift_v}_b{blur_strength:.1f}_m{motion_trails}_t{tear_offset_min}-{tear_offset_max}"
+
+        return suffix

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_rgb_shift.py
@@ -162,6 +162,9 @@ class AddRGBShift(BaseVideoProcessor):
                 f"bh={blue_h_scaled}:bv={blue_v_scaled}"
             )
 
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
         return [
             "ffmpeg",
             "-i",
@@ -171,11 +174,13 @@ class AddRGBShift(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "12",
+            str(crf),
             "-pix_fmt",
-            "yuv420p",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             "-c:a",
             "copy",
             "-y",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
@@ -1,0 +1,197 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class AddVignette(BaseVideoProcessor):
+    """Add a vignette effect to video."""
+
+    # Vignette angle constants (lens angle) - this controls intensity
+    MIN_ANGLE = 0.1
+    MAX_ANGLE = 3.14
+    DEFAULT_ANGLE = 0.628  # PI/5
+
+    # Vignette center position constants
+    MIN_CENTER_OFFSET = -1.0
+    MAX_CENTER_OFFSET = 1.0
+    DEFAULT_CENTER_OFFSET = 0.0
+
+    # Vignette aspect ratio constants
+    MIN_ASPECT = 0.1
+    MAX_ASPECT = 10.0
+    DEFAULT_ASPECT = 1.0
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup vignette-specific parameters."""
+        with ParameterGroup(name="vignette_settings", ui_options={"collapsed": False}) as vignette_group:
+            # Vignette angle parameter (lens angle) - controls intensity
+            angle_parameter = Parameter(
+                name="angle",
+                type="float",
+                default_value=self.DEFAULT_ANGLE,
+                tooltip=f"Lens angle for vignette effect - smaller values = stronger effect ({self.MIN_ANGLE}-{self.MAX_ANGLE})",
+            )
+            self.add_parameter(angle_parameter)
+            angle_parameter.add_trait(Slider(min_val=self.MIN_ANGLE, max_val=self.MAX_ANGLE))
+
+            # Vignette center X offset parameter
+            center_x_parameter = Parameter(
+                name="center_x",
+                type="float",
+                default_value=self.DEFAULT_CENTER_OFFSET,
+                tooltip="Center X offset (-1.0 to 1.0, 0 = center)",
+            )
+            self.add_parameter(center_x_parameter)
+            center_x_parameter.add_trait(Slider(min_val=self.MIN_CENTER_OFFSET, max_val=self.MAX_CENTER_OFFSET))
+
+            # Vignette center Y offset parameter
+            center_y_parameter = Parameter(
+                name="center_y",
+                type="float",
+                default_value=self.DEFAULT_CENTER_OFFSET,
+                tooltip="Center Y offset (-1.0 to 1.0, 0 = center)",
+            )
+            self.add_parameter(center_y_parameter)
+            center_y_parameter.add_trait(Slider(min_val=self.MIN_CENTER_OFFSET, max_val=self.MAX_CENTER_OFFSET))
+
+            # Vignette aspect ratio parameter
+            aspect_parameter = Parameter(
+                name="aspect",
+                type="float",
+                default_value=self.DEFAULT_ASPECT,
+                tooltip=f"Aspect ratio of vignette ({self.MIN_ASPECT}-{self.MAX_ASPECT})",
+            )
+            self.add_parameter(aspect_parameter)
+            aspect_parameter.add_trait(Slider(min_val=self.MIN_ASPECT, max_val=self.MAX_ASPECT))
+
+            # Vignette mode parameter
+            mode_parameter = Parameter(
+                name="mode",
+                type="str",
+                default_value="forward",
+                tooltip="Vignette mode: forward (darken edges) or backward (lighten edges)",
+            )
+            self.add_parameter(mode_parameter)
+            mode_parameter.add_trait(Options(choices=["forward", "backward"]))
+
+            # Dither parameter
+            dither_parameter = Parameter(
+                name="dither",
+                type="bool",
+                default_value=True,
+                tooltip="Enable dithering for smoother vignette gradients",
+            )
+            self.add_parameter(dither_parameter)
+
+        self.add_node_element(vignette_group)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "vignette effect addition"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for vignette effect."""
+        angle = kwargs.get("angle", self.DEFAULT_ANGLE)
+        center_x = kwargs.get("center_x", self.DEFAULT_CENTER_OFFSET)
+        center_y = kwargs.get("center_y", self.DEFAULT_CENTER_OFFSET)
+        aspect = kwargs.get("aspect", self.DEFAULT_ASPECT)
+        mode = kwargs.get("mode", "forward")
+        dither = kwargs.get("dither", True)
+
+        # Calculate center position based on offset
+        if center_x == 0:
+            x0 = "w/2"
+        elif center_x > 0:
+            x0 = f"w/2+{center_x}*w/2"
+        else:
+            x0 = f"w/2{center_x}*w/2"  # center_x is negative, so this becomes w/2-0.01*w/2
+
+        if center_y == 0:
+            y0 = "h/2"
+        elif center_y > 0:
+            y0 = f"h/2+{center_y}*h/2"
+        else:
+            y0 = f"h/2{center_y}*h/2"  # center_y is negative, so this becomes h/2-0.01*h/2
+
+        # Determine mode value
+        mode_value = "1" if mode == "backward" else "0"
+
+        # Build vignette filter with all parameters
+        dither_value = "true" if dither else "false"
+        filter_complex = (
+            f"vignette=angle={angle}:x0={x0}:y0={y0}:aspect={aspect}:mode={mode_value}:dither={dither_value}"
+        )
+
+        return [
+            "ffmpeg",
+            "-i",
+            input_url,
+            "-vf",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "12",
+            "-c:a",
+            "copy",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate vignette parameters."""
+        exceptions = []
+
+        angle = self.get_parameter_value("angle")
+        if angle is not None and (angle < self.MIN_ANGLE or angle > self.MAX_ANGLE):
+            msg = f"{self.name} - Angle must be between {self.MIN_ANGLE} and {self.MAX_ANGLE}, got {angle}"
+            exceptions.append(ValueError(msg))
+
+        center_x = self.get_parameter_value("center_x")
+        if center_x is not None and (center_x < self.MIN_CENTER_OFFSET or center_x > self.MAX_CENTER_OFFSET):
+            msg = f"{self.name} - Center X must be between {self.MIN_CENTER_OFFSET} and {self.MAX_CENTER_OFFSET}, got {center_x}"
+            exceptions.append(ValueError(msg))
+
+        center_y = self.get_parameter_value("center_y")
+        if center_y is not None and (center_y < self.MIN_CENTER_OFFSET or center_y > self.MAX_CENTER_OFFSET):
+            msg = f"{self.name} - Center Y must be between {self.MIN_CENTER_OFFSET} and {self.MAX_CENTER_OFFSET}, got {center_y}"
+            exceptions.append(ValueError(msg))
+
+        aspect = self.get_parameter_value("aspect")
+        if aspect is not None and (aspect < self.MIN_ASPECT or aspect > self.MAX_ASPECT):
+            msg = f"{self.name} - Aspect must be between {self.MIN_ASPECT} and {self.MAX_ASPECT}, got {aspect}"
+            exceptions.append(ValueError(msg))
+
+        mode = self.get_parameter_value("mode")
+        valid_modes = ["forward", "backward"]
+        if mode is not None and mode not in valid_modes:
+            msg = f"{self.name} - Mode must be one of {valid_modes}, got {mode}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get vignette parameters."""
+        return {
+            "angle": self.get_parameter_value("angle"),
+            "center_x": self.get_parameter_value("center_x"),
+            "center_y": self.get_parameter_value("center_y"),
+            "aspect": self.get_parameter_value("aspect"),
+            "mode": self.get_parameter_value("mode"),
+            "dither": self.get_parameter_value("dither"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        angle = kwargs.get("angle", self.DEFAULT_ANGLE)
+        center_x = kwargs.get("center_x", self.DEFAULT_CENTER_OFFSET)
+        center_y = kwargs.get("center_y", self.DEFAULT_CENTER_OFFSET)
+        aspect = kwargs.get("aspect", self.DEFAULT_ASPECT)
+        mode = kwargs.get("mode", "forward")
+
+        return f"_vignette_a{angle:.2f}_x{center_x:.2f}_y{center_y:.2f}_r{aspect:.2f}_{mode}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
@@ -11,8 +12,8 @@ class AddVignette(BaseVideoProcessor):
 
     # Vignette angle constants (lens angle) - this controls intensity
     MIN_ANGLE = 0.1
-    MAX_ANGLE = 3.14
-    DEFAULT_ANGLE = 0.628  # PI/5
+    MAX_ANGLE = math.pi
+    DEFAULT_ANGLE = math.pi / 5
 
     # Vignette center position constants
     MIN_CENTER_OFFSET = -1.0

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
@@ -112,6 +112,9 @@ class AddVignette(BaseVideoProcessor):
         # Build vignette filter with all parameters
         filter_complex = f"vignette=angle={angle}:x0={x0}:y0={y0}:aspect={aspect}:mode={mode_value}:dither=false"
 
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
         return [
             "ffmpeg",
             "-i",
@@ -121,9 +124,13 @@ class AddVignette(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "12",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             "-c:a",
             "copy",
             "-y",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
@@ -84,7 +84,7 @@ class AddVignette(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "vignette effect addition"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build FFmpeg command for vignette effect."""
         angle = kwargs.get("angle", self.DEFAULT_ANGLE)
         center_x = kwargs.get("center_x", self.DEFAULT_CENTER_OFFSET)
@@ -111,7 +111,10 @@ class AddVignette(BaseVideoProcessor):
         mode_value = "1" if mode == "backward" else "0"
 
         # Build vignette filter with all parameters
-        filter_complex = f"vignette=angle={angle}:x0={x0}:y0={y0}:aspect={aspect}:mode={mode_value}:dither=false"
+        custom_filter = f"vignette=angle={angle}:x0={x0}:y0={y0}:aspect={aspect}:mode={mode_value}:dither=false"
+
+        # Combine with frame rate filter if needed
+        filter_complex = self._combine_video_filters(custom_filter, input_frame_rate)
 
         # Get processing speed settings
         preset, pix_fmt, crf = self._get_processing_speed_settings()

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/add_vignette.py
@@ -77,15 +77,6 @@ class AddVignette(BaseVideoProcessor):
             self.add_parameter(mode_parameter)
             mode_parameter.add_trait(Options(choices=["forward", "backward"]))
 
-            # Dither parameter
-            dither_parameter = Parameter(
-                name="dither",
-                type="bool",
-                default_value=True,
-                tooltip="Enable dithering for smoother vignette gradients",
-            )
-            self.add_parameter(dither_parameter)
-
         self.add_node_element(vignette_group)
 
     def _get_processing_description(self) -> str:
@@ -99,7 +90,6 @@ class AddVignette(BaseVideoProcessor):
         center_y = kwargs.get("center_y", self.DEFAULT_CENTER_OFFSET)
         aspect = kwargs.get("aspect", self.DEFAULT_ASPECT)
         mode = kwargs.get("mode", "forward")
-        dither = kwargs.get("dither", True)
 
         # Calculate center position based on offset
         if center_x == 0:
@@ -120,10 +110,7 @@ class AddVignette(BaseVideoProcessor):
         mode_value = "1" if mode == "backward" else "0"
 
         # Build vignette filter with all parameters
-        dither_value = "true" if dither else "false"
-        filter_complex = (
-            f"vignette=angle={angle}:x0={x0}:y0={y0}:aspect={aspect}:mode={mode_value}:dither={dither_value}"
-        )
+        filter_complex = f"vignette=angle={angle}:x0={x0}:y0={y0}:aspect={aspect}:mode={mode_value}:dither=false"
 
         return [
             "ffmpeg",
@@ -183,7 +170,6 @@ class AddVignette(BaseVideoProcessor):
             "center_y": self.get_parameter_value("center_y"),
             "aspect": self.get_parameter_value("aspect"),
             "mode": self.get_parameter_value("mode"),
-            "dither": self.get_parameter_value("dither"),
         }
 
     def _get_output_suffix(self, **kwargs) -> str:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/adjust_video_eq.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/adjust_video_eq.py
@@ -77,7 +77,7 @@ class AdjustVideoEQ(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "video EQ adjustment"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build FFmpeg command for video EQ adjustment."""
         brightness = kwargs.get("brightness", self.DEFAULT_BRIGHTNESS)
         contrast = kwargs.get("contrast", self.DEFAULT_CONTRAST)
@@ -85,7 +85,10 @@ class AdjustVideoEQ(BaseVideoProcessor):
         gamma = kwargs.get("gamma", self.DEFAULT_GAMMA)
 
         # EQ filter: brightness, contrast, saturation, gamma
-        filter_complex = f"eq=brightness={brightness}:contrast={contrast}:saturation={saturation}:gamma={gamma}"
+        custom_filter = f"eq=brightness={brightness}:contrast={contrast}:saturation={saturation}:gamma={gamma}"
+
+        # Combine with frame rate filter if needed
+        filter_complex = self._combine_video_filters(custom_filter, input_frame_rate)
 
         # Get processing speed settings
         preset, pix_fmt, crf = self._get_processing_speed_settings()

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/adjust_video_eq.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/adjust_video_eq.py
@@ -1,0 +1,149 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class AdjustVideoEQ(BaseVideoProcessor):
+    """Adjust video brightness, contrast, saturation, and gamma."""
+
+    # Brightness constants
+    MIN_BRIGHTNESS = -1.0
+    MAX_BRIGHTNESS = 1.0
+    DEFAULT_BRIGHTNESS = 0.0
+
+    # Contrast constants
+    MIN_CONTRAST = 0.0
+    MAX_CONTRAST = 3.0
+    DEFAULT_CONTRAST = 1.0
+
+    # Saturation constants
+    MIN_SATURATION = 0.0
+    MAX_SATURATION = 3.0
+    DEFAULT_SATURATION = 1.0
+
+    # Gamma constants
+    MIN_GAMMA = 0.1
+    MAX_GAMMA = 10.0
+    DEFAULT_GAMMA = 1.0
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup EQ-specific parameters."""
+        with ParameterGroup(name="eq_settings", ui_options={"collapsed": False}) as eq_group:
+            # Brightness parameter
+            brightness_parameter = Parameter(
+                name="brightness",
+                type="float",
+                default_value=self.DEFAULT_BRIGHTNESS,
+                tooltip=f"Brightness adjustment ({self.MIN_BRIGHTNESS}-{self.MAX_BRIGHTNESS})",
+            )
+            self.add_parameter(brightness_parameter)
+            brightness_parameter.add_trait(Slider(min_val=self.MIN_BRIGHTNESS, max_val=self.MAX_BRIGHTNESS))
+
+            # Contrast parameter
+            contrast_parameter = Parameter(
+                name="contrast",
+                type="float",
+                default_value=self.DEFAULT_CONTRAST,
+                tooltip=f"Contrast adjustment ({self.MIN_CONTRAST}-{self.MAX_CONTRAST})",
+            )
+            self.add_parameter(contrast_parameter)
+            contrast_parameter.add_trait(Slider(min_val=self.MIN_CONTRAST, max_val=self.MAX_CONTRAST))
+
+            # Saturation parameter
+            saturation_parameter = Parameter(
+                name="saturation",
+                type="float",
+                default_value=self.DEFAULT_SATURATION,
+                tooltip=f"Saturation adjustment ({self.MIN_SATURATION}-{self.MAX_SATURATION})",
+            )
+            self.add_parameter(saturation_parameter)
+            saturation_parameter.add_trait(Slider(min_val=self.MIN_SATURATION, max_val=self.MAX_SATURATION))
+
+            # Gamma parameter
+            gamma_parameter = Parameter(
+                name="gamma",
+                type="float",
+                default_value=self.DEFAULT_GAMMA,
+                tooltip=f"Gamma adjustment ({self.MIN_GAMMA}-{self.MAX_GAMMA})",
+            )
+            self.add_parameter(gamma_parameter)
+            gamma_parameter.add_trait(Slider(min_val=self.MIN_GAMMA, max_val=self.MAX_GAMMA))
+
+        self.add_node_element(eq_group)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "video EQ adjustment"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for video EQ adjustment."""
+        brightness = kwargs.get("brightness", self.DEFAULT_BRIGHTNESS)
+        contrast = kwargs.get("contrast", self.DEFAULT_CONTRAST)
+        saturation = kwargs.get("saturation", self.DEFAULT_SATURATION)
+        gamma = kwargs.get("gamma", self.DEFAULT_GAMMA)
+
+        # EQ filter: brightness, contrast, saturation, gamma
+        filter_complex = f"eq=brightness={brightness}:contrast={contrast}:saturation={saturation}:gamma={gamma}"
+
+        return [
+            "ffmpeg",
+            "-i",
+            input_url,
+            "-vf",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "12",
+            "-c:a",
+            "copy",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate EQ parameters."""
+        exceptions = []
+
+        brightness = self.get_parameter_value("brightness")
+        if brightness is not None and (brightness < self.MIN_BRIGHTNESS or brightness > self.MAX_BRIGHTNESS):
+            msg = f"{self.name} - Brightness must be between {self.MIN_BRIGHTNESS} and {self.MAX_BRIGHTNESS}, got {brightness}"
+            exceptions.append(ValueError(msg))
+
+        contrast = self.get_parameter_value("contrast")
+        if contrast is not None and (contrast < self.MIN_CONTRAST or contrast > self.MAX_CONTRAST):
+            msg = f"{self.name} - Contrast must be between {self.MIN_CONTRAST} and {self.MAX_CONTRAST}, got {contrast}"
+            exceptions.append(ValueError(msg))
+
+        saturation = self.get_parameter_value("saturation")
+        if saturation is not None and (saturation < self.MIN_SATURATION or saturation > self.MAX_SATURATION):
+            msg = f"{self.name} - Saturation must be between {self.MIN_SATURATION} and {self.MAX_SATURATION}, got {saturation}"
+            exceptions.append(ValueError(msg))
+
+        gamma = self.get_parameter_value("gamma")
+        if gamma is not None and (gamma < self.MIN_GAMMA or gamma > self.MAX_GAMMA):
+            msg = f"{self.name} - Gamma must be between {self.MIN_GAMMA} and {self.MAX_GAMMA}, got {gamma}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get EQ parameters."""
+        return {
+            "brightness": self.get_parameter_value("brightness"),
+            "contrast": self.get_parameter_value("contrast"),
+            "saturation": self.get_parameter_value("saturation"),
+            "gamma": self.get_parameter_value("gamma"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        brightness = kwargs.get("brightness", self.DEFAULT_BRIGHTNESS)
+        contrast = kwargs.get("contrast", self.DEFAULT_CONTRAST)
+        saturation = kwargs.get("saturation", self.DEFAULT_SATURATION)
+        gamma = kwargs.get("gamma", self.DEFAULT_GAMMA)
+        return f"_eq_b{brightness:.2f}_c{contrast:.2f}_s{saturation:.2f}_g{gamma:.2f}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/adjust_video_eq.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/adjust_video_eq.py
@@ -87,6 +87,9 @@ class AdjustVideoEQ(BaseVideoProcessor):
         # EQ filter: brightness, contrast, saturation, gamma
         filter_complex = f"eq=brightness={brightness}:contrast={contrast}:saturation={saturation}:gamma={gamma}"
 
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
         return [
             "ffmpeg",
             "-i",
@@ -96,9 +99,13 @@ class AdjustVideoEQ(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "12",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             "-c:a",
             "copy",
             "-y",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/base_video_processor.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/base_video_processor.py
@@ -1,0 +1,360 @@
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+import static_ffmpeg.run
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes_library.utils.video_utils import detect_video_format, to_video_artifact, validate_url
+from griptape_nodes_library.video.video_url_artifact import VideoUrlArtifact
+
+
+class BaseVideoProcessor(ControlNode, ABC):
+    """Base class for video processing nodes with common functionality."""
+
+    # Default video properties constants
+    DEFAULT_FRAME_RATE = 30.0
+    DEFAULT_WIDTH = 1920
+    DEFAULT_HEIGHT = 1080
+    DEFAULT_DURATION = 0.0
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="video",
+                input_types=["VideoArtifact", "VideoUrlArtifact"],
+                type="VideoUrlArtifact",
+                tooltip="The video to process",
+                ui_options={
+                    "clickable_file_browser": True,
+                    "expander": True,
+                    "display_name": "Video or Path to Video",
+                },
+            )
+        )
+
+        self._setup_custom_parameters()
+
+        self.add_parameter(
+            Parameter(
+                name="output",
+                output_type="VideoUrlArtifact",
+                allowed_modes={ParameterMode.OUTPUT},
+                tooltip="The processed video",
+                ui_options={"pulse_on_run": True, "expander": True},
+            )
+        )
+
+        self._setup_logging_group()
+
+    @abstractmethod
+    def _setup_custom_parameters(self) -> None:
+        """Setup custom parameters specific to this video processor. Override in subclasses."""
+
+    @abstractmethod
+    def _get_processing_description(self) -> str:
+        """Get a description of what this processor does. Override in subclasses."""
+
+    @abstractmethod
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build the FFmpeg command for this processor. Override in subclasses."""
+
+    def _setup_logging_group(self) -> None:
+        """Setup the common logging parameter group."""
+        with ParameterGroup(name="Logs") as logs_group:
+            Parameter(
+                name="logs",
+                type="str",
+                tooltip="Displays processing logs and detailed events if enabled.",
+                ui_options={"multiline": True, "placeholder_text": "Logs"},
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        logs_group.ui_options = {"hide": True}  # Hide the logs group by default
+        self.add_node_element(logs_group)
+
+    def _get_ffmpeg_paths(self) -> tuple[str, str]:
+        """Get FFmpeg and FFprobe executable paths."""
+        try:
+            ffmpeg_path, ffprobe_path = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
+            return ffmpeg_path, ffprobe_path  # noqa: TRY300
+        except Exception as e:
+            error_msg = f"FFmpeg not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
+            raise ValueError(error_msg) from e
+
+    def _detect_video_properties(self, input_url: str, ffprobe_path: str) -> tuple[float, tuple[int, int], float]:
+        """Detect video frame rate, resolution, and duration."""
+        try:
+            cmd = [
+                ffprobe_path,
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_streams",
+                "-select_streams",
+                "v:0",
+                input_url,
+            ]
+
+            # URL is validated via _validate_url_safety() before this call
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
+            import json
+
+            streams_data = json.loads(result.stdout)
+
+            if streams_data.get("streams") and len(streams_data["streams"]) > 0:
+                video_stream = streams_data["streams"][0]
+
+                # Get frame rate
+                fps_str = video_stream.get("r_frame_rate", "30/1")
+                if "/" in fps_str:
+                    num, den = map(int, fps_str.split("/"))
+                    frame_rate = num / den
+                else:
+                    frame_rate = float(fps_str)
+
+                # Get resolution
+                width = int(video_stream.get("width", self.DEFAULT_WIDTH))
+                height = int(video_stream.get("height", self.DEFAULT_HEIGHT))
+
+                # Get duration
+                duration_str = video_stream.get("duration", "0")
+                duration = float(duration_str) if duration_str != "N/A" else self.DEFAULT_DURATION
+
+                return frame_rate, (width, height), duration
+            return self.DEFAULT_FRAME_RATE, (self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT), self.DEFAULT_DURATION  # noqa: TRY300
+
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: Could not detect video properties, using defaults: {e}\n")
+            return self.DEFAULT_FRAME_RATE, (self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT), self.DEFAULT_DURATION
+
+    def _validate_video_input(self) -> list[Exception] | None:
+        """Common video input validation."""
+        exceptions = []
+
+        # Validate that we have a video
+        video = self.parameter_values.get("video")
+        if not video:
+            msg = f"{self.name}: Video parameter is required"
+            exceptions.append(ValueError(msg))
+
+        # Make sure it's a video artifact
+        if not isinstance(video, VideoUrlArtifact):
+            msg = f"{self.name}: Video parameter must be a VideoUrlArtifact"
+            exceptions.append(ValueError(msg))
+
+        # Make sure it has a value
+        if hasattr(video, "value") and not video.value:  # type: ignore  # noqa: PGH003
+            msg = f"{self.name}: Video parameter must have a value"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _validate_url_safety(self, url: str) -> None:
+        """Validate that the URL is safe for ffmpeg processing."""
+        if not validate_url(url):
+            msg = f"{self.name}: Invalid or unsafe URL provided: {url}"
+            raise ValueError(msg)
+
+    def _get_video_input_data(self) -> tuple[str, str]:
+        """Get video input URL and detected format."""
+        video = self.parameter_values.get("video")
+        video_artifact = to_video_artifact(video)
+        input_url = video_artifact.value
+
+        detected_format = detect_video_format(video)
+        if not detected_format:
+            detected_format = "mp4"  # default fallback
+
+        return input_url, detected_format
+
+    def _create_temp_output_file(self, format_extension: str) -> tuple[str, Path]:
+        """Create a temporary output file and return path."""
+        with tempfile.NamedTemporaryFile(suffix=f".{format_extension}", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        return str(output_path), output_path
+
+    def _save_video_artifact(self, video_bytes: bytes, format_extension: str, suffix: str = "") -> VideoUrlArtifact:
+        """Save video bytes to static file and return VideoUrlArtifact."""
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        # Generate meaningful filename based on workflow and node
+        filename = self._generate_filename(suffix, format_extension)
+        url = GriptapeNodes.StaticFilesManager().save_static_file(video_bytes, filename)
+        return VideoUrlArtifact(url)
+
+    def _run_ffmpeg_command(self, cmd: list[str], timeout: int = 300) -> None:
+        """Run FFmpeg command with common error handling."""
+        self.append_value_to_parameter("logs", f"Running ffmpeg command: {' '.join(cmd)}\n")
+
+        try:
+            result = subprocess.run(  # noqa: S603
+                cmd, capture_output=True, text=True, check=True, timeout=timeout
+            )
+            self.append_value_to_parameter("logs", f"FFmpeg stdout: {result.stdout}\n")
+        except subprocess.TimeoutExpired as e:
+            error_msg = f"FFmpeg process timed out after {timeout} seconds"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+        except subprocess.CalledProcessError as e:
+            error_msg = f"FFmpeg error: {e.stderr}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+
+    def _cleanup_temp_file(self, file_path: Path) -> None:
+        """Clean up temporary file with error handling."""
+        try:
+            file_path.unlink(missing_ok=True)
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: Failed to clean up temporary file: {e}\n")
+
+    def _log_video_properties(self, frame_rate: float, resolution: tuple[int, int], duration: float) -> None:
+        """Log detected video properties."""
+        self.append_value_to_parameter(
+            "logs", f"Detected video: {resolution[0]}x{resolution[1]} @ {frame_rate}fps, duration: {duration}s\n"
+        )
+
+    def _log_format_detection(self, detected_format: str) -> None:
+        """Log detected video format."""
+        self.append_value_to_parameter("logs", f"Detected video format: {detected_format}\n")
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Common video input validation."""
+        exceptions = []
+
+        # Use base class validation for video input
+        base_exceptions = self._validate_video_input()
+        if base_exceptions:
+            exceptions.extend(base_exceptions)
+
+        # Add custom validation from subclasses
+        custom_exceptions = self._validate_custom_parameters()
+        if custom_exceptions:
+            exceptions.extend(custom_exceptions)
+
+        return exceptions if exceptions else None
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate custom parameters. Override in subclasses if needed."""
+        return None
+
+    def _process_video(self, input_url: str, output_path: str, **kwargs) -> None:
+        """Process video using the custom FFmpeg command from subclasses."""
+        try:
+            # Validate URL before using in subprocess
+            self._validate_url_safety(input_url)
+
+            # Get FFmpeg paths
+            ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
+
+            # Build the FFmpeg command using the subclass implementation
+            cmd = self._build_ffmpeg_command(input_url, output_path, **kwargs)
+
+            # Use base class method to run FFmpeg command
+            self._run_ffmpeg_command(cmd, timeout=300)
+
+        except Exception as e:
+            error_msg = f"Error during video processing: {e!s}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+
+    def _process(self, input_url: str, detected_format: str, **kwargs) -> None:
+        """Common processing wrapper."""
+        # Create temporary output file using base class method
+        output_path, output_path_obj = self._create_temp_output_file(detected_format)
+
+        try:
+            self.append_value_to_parameter("logs", f"{self._get_processing_description()}\n")
+
+            # Process video using the custom implementation
+            self._process_video(input_url, output_path, **kwargs)
+
+            # Read processed video
+            with output_path_obj.open("rb") as f:
+                output_bytes = f.read()
+
+            # Get output suffix from subclass
+            suffix = self._get_output_suffix(**kwargs)
+
+            # Use base class method to save video artifact
+            output_artifact = self._save_video_artifact(output_bytes, detected_format, suffix)
+
+            self.append_value_to_parameter(
+                "logs", f"Successfully processed video with suffix: {suffix}.{detected_format}\n"
+            )
+
+            # Save to parameter
+            self.parameter_output_values["output"] = output_artifact
+        except Exception as e:
+            error_message = str(e)
+            msg = f"{self.name}: Error processing video: {error_message}"
+            self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
+            raise ValueError(msg) from e
+        finally:
+            # Clean up temporary file using base class method
+            self._cleanup_temp_file(output_path_obj)
+
+    def _get_output_suffix(self, **kwargs) -> str:  # noqa: ARG002
+        """Get the output filename suffix. Override in subclasses if needed."""
+        return ""
+
+    def process(self) -> AsyncResult[None]:
+        """Common async processing entry point."""
+        # Get video input data
+        input_url, detected_format = self._get_video_input_data()
+        self._log_format_detection(detected_format)
+
+        # Get custom parameters from subclasses
+        custom_params = self._get_custom_parameters()
+
+        # Initialize logs
+        self.append_value_to_parameter("logs", f"[Processing {self._get_processing_description()}..]\n")
+
+        try:
+            # Run the video processing asynchronously
+            self.append_value_to_parameter("logs", "[Started video processing..]\n")
+            yield lambda: self._process(input_url, detected_format, **custom_params)
+            self.append_value_to_parameter("logs", "[Finished video processing.]\n")
+
+        except Exception as e:
+            error_message = str(e)
+            msg = f"{self.name}: Error processing video: {error_message}"
+            self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
+            raise ValueError(msg) from e
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get custom parameters for processing. Override in subclasses if needed."""
+        return {}
+
+    def _generate_filename(self, suffix: str = "", extension: str = "mp4") -> str:
+        """Generate a meaningful filename based on workflow and node information."""
+        from datetime import UTC, datetime
+
+        # Get workflow and node context
+        workflow_name = "unknown_workflow"
+        node_name = self.name
+
+        # Try to get workflow name from context
+        try:
+            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+            context_manager = GriptapeNodes.ContextManager()
+            workflow_name = context_manager.get_current_workflow_name()
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: Error getting workflow name: {e}\n")
+
+        # Clean up names for filename use
+        workflow_name = "".join(c for c in workflow_name if c.isalnum() or c in ("-", "_")).rstrip()
+        node_name = "".join(c for c in node_name if c.isalnum() or c in ("-", "_")).rstrip()
+
+        # Get current timestamp for cache busting
+        timestamp = int(datetime.now(UTC).timestamp())
+
+        # Create filename with meaningful structure and timestamp as query parameter
+        filename = f"{workflow_name}_{node_name}{suffix}.{extension}?t={timestamp}"
+
+        return filename

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/base_video_processor.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/base_video_processor.py
@@ -2,7 +2,7 @@ import subprocess
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import static_ffmpeg.run
 
@@ -23,7 +23,7 @@ class BaseVideoProcessor(ControlNode, ABC):
     DEFAULT_DURATION = 0.0
 
     # Common frame rate options for different platforms
-    FRAME_RATE_OPTIONS = {
+    FRAME_RATE_OPTIONS: ClassVar[dict[str, str]] = {
         "auto": "Auto (use input frame rate)",
         "24": "24 fps (Film)",
         "25": "25 fps (PAL)",
@@ -33,6 +33,9 @@ class BaseVideoProcessor(ControlNode, ABC):
         "59.94": "59.94 fps (NTSC HD)",
         "60": "60 fps (YouTube, Web HD)",
     }
+
+    # Frame rate tolerance for comparison (in fps)
+    FRAME_RATE_TOLERANCE: ClassVar[float] = 0.01
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
@@ -140,7 +143,7 @@ class BaseVideoProcessor(ControlNode, ABC):
         target_fps = float(output_frame_rate)
 
         # If target is same as input (within tolerance), no conversion needed
-        if abs(target_fps - input_frame_rate) < 0.01:
+        if abs(target_fps - input_frame_rate) < self.FRAME_RATE_TOLERANCE:
             return ""
 
         # Return fps filter for frame rate conversion

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/change_speed.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/change_speed.py
@@ -42,7 +42,7 @@ class ChangeSpeed(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "speed change"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build FFmpeg command for speed change."""
         speed = kwargs.get("speed", self.DEFAULT_SPEED)
         include_audio = kwargs.get("include_audio", True)
@@ -50,7 +50,10 @@ class ChangeSpeed(BaseVideoProcessor):
         # Use setpts filter to change video speed
         # PTS (Presentation Time Stamp) controls when each frame is displayed
         # Dividing by speed makes the video play faster/slower
-        filter_complex = f"setpts=PTS/{speed}"
+        custom_filter = f"setpts=PTS/{speed}"
+
+        # Combine with frame rate filter if needed
+        filter_complex = self._combine_video_filters(custom_filter, input_frame_rate)
 
         if include_audio:
             # Audio needs to be speed-adjusted to match the video speed change

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/change_speed.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/change_speed.py
@@ -1,0 +1,134 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class ChangeSpeed(BaseVideoProcessor):
+    """Change the playback speed of a video."""
+
+    # Speed constants
+    MIN_SPEED = 0.1
+    MAX_SPEED = 10.0
+    DEFAULT_SPEED = 1.0
+
+    # Audio filter constants
+    ATEMPO_MIN_SPEED = 0.5
+    ATEMPO_MAX_SPEED = 2.0
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup speed change parameters."""
+        with ParameterGroup(name="speed_settings", ui_options={"collapsed": False}) as speed_group:
+            # Speed multiplier parameter
+            Parameter(
+                name="speed",
+                type="float",
+                default_value=self.DEFAULT_SPEED,
+                tooltip=f"Playback speed multiplier ({self.MIN_SPEED}-{self.MAX_SPEED}x, 1.0 = normal speed)",
+            ).add_trait(Slider(min_val=self.MIN_SPEED, max_val=self.MAX_SPEED))
+
+            # Include audio parameter
+            Parameter(
+                name="include_audio",
+                type="bool",
+                default_value=True,
+                tooltip="When enabled, includes audio in the output file. When disabled, creates a silent video.",
+            )
+
+        self.add_node_element(speed_group)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "speed change"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for speed change."""
+        speed = kwargs.get("speed", self.DEFAULT_SPEED)
+        include_audio = kwargs.get("include_audio", True)
+
+        # Use setpts filter to change video speed
+        # PTS (Presentation Time Stamp) controls when each frame is displayed
+        # Dividing by speed makes the video play faster/slower
+        filter_complex = f"setpts=PTS/{speed}"
+
+        if include_audio:
+            # Audio needs to be speed-adjusted to match the video speed change
+            # Use atempo filter with speed ratio calculation
+            # Note: atempo has limits (0.5x to 2.0x), so we may need to chain multiple filters
+            if speed >= self.ATEMPO_MIN_SPEED and speed <= self.ATEMPO_MAX_SPEED:
+                audio_filter = f"atempo={speed}"
+            else:
+                # For extreme speed changes, we'll need to chain atempo filters
+                # This is a simplified approach - in practice, you might want more sophisticated handling
+                audio_filter = (
+                    f"atempo={self.ATEMPO_MAX_SPEED},atempo={self.ATEMPO_MAX_SPEED}"
+                    if speed > self.ATEMPO_MAX_SPEED
+                    else f"atempo={self.ATEMPO_MIN_SPEED},atempo={self.ATEMPO_MIN_SPEED}"
+                )
+
+            # Build the command with audio speed adjustment
+            return [
+                "ffmpeg",
+                "-i",
+                input_url,
+                "-vf",
+                filter_complex,
+                "-af",
+                audio_filter,
+                "-c:v",
+                "libx264",
+                "-preset",
+                "veryslow",
+                "-crf",
+                "12",
+                "-y",
+                output_path,
+            ]
+        # Build the command without audio (silent video)
+        return [
+            "ffmpeg",
+            "-i",
+            input_url,
+            "-vf",
+            filter_complex,
+            "-an",  # No audio
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "12",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate speed parameters."""
+        exceptions = []
+
+        speed = self.get_parameter_value("speed")
+        if speed is not None and (speed < self.MIN_SPEED or speed > self.MAX_SPEED):
+            msg = f"{self.name} - Speed must be between {self.MIN_SPEED} and {self.MAX_SPEED}, got {speed}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get speed change parameters."""
+        return {
+            "speed": self.get_parameter_value("speed"),
+            "include_audio": self.get_parameter_value("include_audio"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        speed = kwargs.get("speed", self.DEFAULT_SPEED)
+        include_audio = kwargs.get("include_audio", True)
+
+        suffix = f"_speed{speed:.1f}"
+
+        if not include_audio:
+            suffix += "_noaudio"
+
+        return suffix

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/change_speed.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/change_speed.py
@@ -67,6 +67,9 @@ class ChangeSpeed(BaseVideoProcessor):
                     else f"atempo={self.ATEMPO_MIN_SPEED},atempo={self.ATEMPO_MIN_SPEED}"
                 )
 
+            # Get processing speed settings
+            preset, pix_fmt, crf = self._get_processing_speed_settings()
+
             # Build the command with audio speed adjustment
             return [
                 "ffmpeg",
@@ -79,12 +82,23 @@ class ChangeSpeed(BaseVideoProcessor):
                 "-c:v",
                 "libx264",
                 "-preset",
-                "veryslow",
+                preset,
                 "-crf",
-                "12",
+                str(crf),
+                "-pix_fmt",
+                pix_fmt,
+                "-movflags",
+                "+faststart",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "192k",
                 "-y",
                 output_path,
             ]
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
         # Build the command without audio (silent video)
         return [
             "ffmpeg",
@@ -96,9 +110,13 @@ class ChangeSpeed(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "12",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             "-y",
             output_path,
         ]

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/display_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/display_video.py
@@ -21,9 +21,9 @@ class DisplayVideo(DataNode):
             Parameter(
                 name="video",
                 default_value=value,
-                input_types=["VideoArtifact", "VideoUrlArtifact"],
-                output_type="VideoArtifact",
-                type="VideoArtifact",
+                input_types=["VideoUrlArtifact", "VideoArtifact"],
+                output_type="VideoUrlArtifact",
+                type="VideoUrlArtifact",
                 tooltip="The video to display",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT, ParameterMode.PROPERTY},
             )

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/flip_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/flip_video.py
@@ -1,0 +1,79 @@
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.traits.options import Options
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class FlipVideo(BaseVideoProcessor):
+    """Flip video horizontally or vertically."""
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup flip-specific parameters."""
+        with ParameterGroup(name="flip_settings", ui_options={"collapsed": False}) as flip_group:
+            # Flip direction parameter
+            direction_parameter = Parameter(
+                name="direction",
+                type="str",
+                default_value="horizontal",
+                tooltip="Flip direction: horizontal or vertical",
+            )
+            self.add_parameter(direction_parameter)
+            direction_parameter.add_trait(Options(choices=["horizontal", "vertical", "both"]))
+
+        self.add_node_element(flip_group)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "video flipping"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for video flipping."""
+        direction = kwargs.get("direction", "horizontal")
+
+        # Determine flip filter based on direction
+        if direction == "horizontal":
+            filter_complex = "hflip"
+        elif direction == "vertical":
+            filter_complex = "vflip"
+        else:  # "both"
+            filter_complex = "hflip,vflip"
+
+        return [
+            "ffmpeg",
+            "-i",
+            input_url,
+            "-vf",
+            filter_complex,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "12",
+            "-c:a",
+            "copy",
+            "-y",
+            output_path,
+        ]
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate flip parameters."""
+        exceptions = []
+
+        direction = self.get_parameter_value("direction")
+        valid_choices = ["horizontal", "vertical", "both"]
+        if direction is not None and direction not in valid_choices:
+            msg = f"{self.name} - Direction must be one of {valid_choices}, got {direction}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, str]:
+        """Get flip parameters."""
+        return {
+            "direction": self.get_parameter_value("direction"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        direction = kwargs.get("direction", "horizontal")
+        return f"_flipped_{direction}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/flip_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/flip_video.py
@@ -37,6 +37,9 @@ class FlipVideo(BaseVideoProcessor):
         else:  # "both"
             filter_complex = "hflip,vflip"
 
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
         return [
             "ffmpeg",
             "-i",
@@ -46,9 +49,13 @@ class FlipVideo(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "12",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             "-c:a",
             "copy",
             "-y",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/flip_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/flip_video.py
@@ -25,17 +25,20 @@ class FlipVideo(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "video flipping"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build FFmpeg command for video flipping."""
         direction = kwargs.get("direction", "horizontal")
 
         # Determine flip filter based on direction
         if direction == "horizontal":
-            filter_complex = "hflip"
+            custom_filter = "hflip"
         elif direction == "vertical":
-            filter_complex = "vflip"
+            custom_filter = "vflip"
         else:  # "both"
-            filter_complex = "hflip,vflip"
+            custom_filter = "hflip,vflip"
+
+        # Combine with frame rate filter if needed
+        filter_complex = self._combine_video_filters(custom_filter, input_frame_rate)
 
         # Get processing speed settings
         preset, pix_fmt, crf = self._get_processing_speed_settings()

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
@@ -29,7 +29,7 @@ class HoldVideoFrames(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "video frame holding"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:  # noqa: ARG002
         """Build the FFmpeg command for frame holding."""
         hold_frames = kwargs.get("hold_frames", 2)
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
@@ -43,7 +43,10 @@ class HoldVideoFrames(BaseVideoProcessor):
         self.append_value_to_parameter("logs", f"Reduced frame rate for holding: {reduced_fps} fps\n")
         base_filter = f"fps=fps={reduced_fps},fps=fps={original_fps}"
 
-        # Build ffmpeg command using filter with high-quality settings
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+
+        # Build ffmpeg command using filter with processing speed settings
         cmd = [
             ffmpeg_path,
             "-y",
@@ -56,11 +59,13 @@ class HoldVideoFrames(BaseVideoProcessor):
             "-c:v",
             "libx264",
             "-preset",
-            "veryslow",
+            preset,
             "-crf",
-            "16",
-            "-x264-params",
-            "ref=6:deblock=-1,-1:me=umh:subme=9:chroma-qp-offset=-2:bframes=16:b-adapt=2:direct=auto:rc-lookahead=90",
+            str(crf),
+            "-pix_fmt",
+            pix_fmt,
+            "-movflags",
+            "+faststart",
             output_path,
         ]
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
@@ -29,7 +29,7 @@ class HoldVideoFrames(BaseVideoProcessor):
         """Get description of what this processor does."""
         return "video frame holding"
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build the FFmpeg command for frame holding."""
         hold_frames = kwargs.get("hold_frames", 2)
 
@@ -42,6 +42,11 @@ class HoldVideoFrames(BaseVideoProcessor):
         reduced_fps = original_fps / hold_frames
         self.append_value_to_parameter("logs", f"Reduced frame rate for holding: {reduced_fps} fps\n")
         base_filter = f"fps=fps={reduced_fps},fps=fps={original_fps}"
+
+        # Add output frame rate filter if needed (after the hold effect)
+        frame_rate_filter = self._get_frame_rate_filter(original_fps)
+        if frame_rate_filter:
+            base_filter = f"{base_filter},{frame_rate_filter}"
 
         # Get processing speed settings
         preset, pix_fmt, crf = self._get_processing_speed_settings()

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/hold_video_frames.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.traits.slider import Slider
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class HoldVideoFrames(BaseVideoProcessor):
+    """Hold video frames for a specified number of frames, creating a stepped video effect."""
+
+    MAX_HOLD_FRAMES = 10
+    MIN_HOLD_FRAMES = 1
+    DEFAULT_HOLD_FRAMES = 2
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup custom parameters for frame holding."""
+        # Add hold frames parameter
+        hold_frames_parameter = Parameter(
+            name="hold_frames",
+            type="int",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            default_value=self.DEFAULT_HOLD_FRAMES,
+            tooltip="Number of frames to hold (e.g., 2 = video updates every 2 frames)",
+        )
+        self.add_parameter(hold_frames_parameter)
+        hold_frames_parameter.add_trait(Slider(min_val=self.MIN_HOLD_FRAMES, max_val=self.MAX_HOLD_FRAMES))
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "video frame holding"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build the FFmpeg command for frame holding."""
+        hold_frames = kwargs.get("hold_frames", 2)
+
+        # Get the original frame rate from the input video
+        ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
+        frame_rate, resolution, duration = self._detect_video_properties(input_url, ffprobe_path)
+        original_fps = frame_rate
+
+        # Create frame holding effect by reducing frame rate and then duplicating frames
+        reduced_fps = original_fps / hold_frames
+        self.append_value_to_parameter("logs", f"Reduced frame rate for holding: {reduced_fps} fps\n")
+        base_filter = f"fps=fps={reduced_fps},fps=fps={original_fps}"
+
+        # Build ffmpeg command using filter with high-quality settings
+        cmd = [
+            ffmpeg_path,
+            "-y",
+            "-i",
+            input_url,
+            "-vf",
+            base_filter,
+            "-c:a",
+            "copy",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryslow",
+            "-crf",
+            "16",
+            "-x264-params",
+            "ref=6:deblock=-1,-1:me=umh:subme=9:chroma-qp-offset=-2:bframes=16:b-adapt=2:direct=auto:rc-lookahead=90",
+            output_path,
+        ]
+
+        return cmd
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate custom parameters."""
+        exceptions = []
+
+        # Validate hold_frames
+        hold_frames = self.parameter_values.get("hold_frames", self.DEFAULT_HOLD_FRAMES)
+        if hold_frames < self.MIN_HOLD_FRAMES or hold_frames > self.MAX_HOLD_FRAMES:
+            msg = f"{self.name}: Hold frames must be between {self.MIN_HOLD_FRAMES} and {self.MAX_HOLD_FRAMES}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        """Get custom parameters for processing."""
+        return {"hold_frames": self.parameter_values.get("hold_frames", self.DEFAULT_HOLD_FRAMES)}
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get the output filename suffix."""
+        hold_frames = kwargs.get("hold_frames", self.DEFAULT_HOLD_FRAMES)
+        return f"_hold_{hold_frames}_frames"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/resize_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/resize_video.py
@@ -2,7 +2,6 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import imageio_ffmpeg
 
@@ -11,24 +10,12 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
-from griptape_nodes_library.utils.video_utils import detect_video_format, dict_to_video_url_artifact
+from griptape_nodes_library.utils.video_utils import (
+    detect_video_format,
+    to_video_artifact,
+    validate_url,
+)
 from griptape_nodes_library.video.video_url_artifact import VideoUrlArtifact
-
-
-def to_video_artifact(video: Any | dict) -> Any:
-    """Convert a video or a dictionary to a VideoArtifact."""
-    if isinstance(video, dict):
-        return dict_to_video_url_artifact(video)
-    return video
-
-
-def validate_url(url: str) -> bool:
-    """Validate that the URL is safe for ffmpeg processing."""
-    try:
-        parsed = urlparse(url)
-        return bool(parsed.scheme in ("http", "https", "file") and parsed.netloc)
-    except Exception:
-        return False
 
 
 class ResizeVideo(ControlNode):

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/reverse_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/reverse_video.py
@@ -1,0 +1,76 @@
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.traits.options import Options
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class ReverseVideo(BaseVideoProcessor):
+    """Reverse video playback."""
+
+    def _setup_custom_parameters(self) -> None:
+        """Setup reverse-specific parameters."""
+        with ParameterGroup(name="reverse_settings", ui_options={"collapsed": False}) as reverse_group:
+            # Audio handling parameter
+            audio_parameter = Parameter(
+                name="audio_handling",
+                type="str",
+                default_value="reverse",
+                tooltip="How to handle audio: reverse, mute, or keep original",
+            )
+            self.add_parameter(audio_parameter)
+            audio_parameter.add_trait(Options(choices=["reverse", "mute", "keep"]))
+
+        self.add_node_element(reverse_group)
+
+    def _get_processing_description(self) -> str:
+        """Get description of what this processor does."""
+        return "video reversal"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, **kwargs) -> list[str]:
+        """Build FFmpeg command for video reversal."""
+        audio_handling = kwargs.get("audio_handling", "reverse")
+
+        # Base command
+        cmd = ["ffmpeg", "-i", input_url]
+
+        # Handle video reversal
+        video_filter = "reverse"
+
+        # Handle audio based on setting
+        if audio_handling == "reverse":
+            # Reverse both video and audio
+            filter_complex = "[0:v]reverse[v];[0:a]areverse[a]"
+            cmd.extend(["-filter_complex", filter_complex, "-map", "[v]", "-map", "[a]"])
+        elif audio_handling == "mute":
+            # Reverse video only, no audio
+            cmd.extend(["-vf", video_filter, "-an"])
+        else:  # "keep"
+            # Reverse video, keep original audio (not recommended but possible)
+            cmd.extend(["-vf", video_filter, "-c:a", "copy"])
+
+        # Add encoding settings
+        cmd.extend(["-c:v", "libx264", "-preset", "veryslow", "-crf", "12", "-y", output_path])
+
+        return cmd
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Validate reverse parameters."""
+        exceptions = []
+
+        audio_handling = self.get_parameter_value("audio_handling")
+        valid_choices = ["reverse", "mute", "keep"]
+        if audio_handling is not None and audio_handling not in valid_choices:
+            msg = f"{self.name} - Audio handling must be one of {valid_choices}, got {audio_handling}"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _get_custom_parameters(self) -> dict[str, str]:
+        """Get reverse parameters."""
+        return {
+            "audio_handling": self.get_parameter_value("audio_handling"),
+        }
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        """Get output filename suffix."""
+        audio_handling = kwargs.get("audio_handling", "reverse")
+        return f"_reversed_{audio_handling}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/reverse_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/reverse_video.py
@@ -48,7 +48,24 @@ class ReverseVideo(BaseVideoProcessor):
             cmd.extend(["-vf", video_filter, "-c:a", "copy"])
 
         # Add encoding settings
-        cmd.extend(["-c:v", "libx264", "-preset", "veryslow", "-crf", "12", "-y", output_path])
+        # Get processing speed settings
+        preset, pix_fmt, crf = self._get_processing_speed_settings()
+        cmd.extend(
+            [
+                "-c:v",
+                "libx264",
+                "-preset",
+                preset,
+                "-crf",
+                str(crf),
+                "-pix_fmt",
+                pix_fmt,
+                "-movflags",
+                "+faststart",
+                "-y",
+                output_path,
+            ]
+        )
 
         return cmd
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/save_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/save_video.py
@@ -7,17 +7,10 @@ from griptape_nodes.exe_types.core_types import (
 )
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
-from griptape_nodes_library.utils.video_utils import detect_video_format, dict_to_video_url_artifact
+from griptape_nodes_library.utils.video_utils import detect_video_format, to_video_artifact
 from griptape_nodes_library.video.video_url_artifact import VideoUrlArtifact
 
 DEFAULT_FILENAME = "griptape_nodes.mp4"
-
-
-def to_video_artifact(video: Any | dict) -> Any:
-    """Convert a video or a dictionary to a VideoArtifact."""
-    if isinstance(video, dict):
-        return dict_to_video_url_artifact(video)
-    return video
 
 
 def auto_determine_filename(base_filename: str, detected_format: str | None) -> str:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/split_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/split_video.py
@@ -1,0 +1,607 @@
+import json
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import static_ffmpeg.run
+from griptape.drivers.prompt.griptape_cloud_prompt_driver import GriptapeCloudPromptDriver
+from griptape.structures import Agent as GriptapeAgent
+from griptape.tasks import PromptTask
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterList, ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes_library.utils.video_utils import detect_video_format, dict_to_video_url_artifact
+from griptape_nodes_library.video.video_url_artifact import VideoUrlArtifact
+
+API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
+SERVICE = "Griptape"
+MODEL = "gpt-4.1-mini"
+
+
+def to_video_artifact(video: Any | dict) -> Any:
+    """Convert a video or a dictionary to a VideoArtifact."""
+    if isinstance(video, dict):
+        return dict_to_video_url_artifact(video)
+    return video
+
+
+def validate_url(url: str) -> bool:
+    """Validate that the URL is safe for ffmpeg processing."""
+    try:
+        parsed = urlparse(url)
+        return bool(parsed.scheme in ("http", "https", "file") and parsed.netloc)
+    except Exception:
+        return False
+
+
+# ----------------------------
+# Timecode utilities
+# ----------------------------
+
+# Constants for frame rates
+NOMINAL_30_FPS = 30
+NOMINAL_60_FPS = 60
+
+
+def _approx(v: float, target: float, tol: float = 0.02) -> bool:
+    return abs(v - target) <= tol
+
+
+def smpte_to_seconds(tc: str, rate: float, *, drop_frame: bool | None = None) -> float:
+    """Convert SMPTE timecode to seconds.
+
+    Accepts 'HH:MM:SS:FF' (non-DF) or 'HH:MM:SS;FF' (DF).
+    If drop_frame is None, semicolon implies DF; otherwise obey drop_frame flag.
+    DF supported for ~29.97 (30000/1001) and ~59.94 (60000/1001).
+    """
+    if not re.match(r"^\d{2}:\d{2}:\d{2}[:;]\d{2}$", tc):
+        error_msg = f"Bad SMPTE format: {tc!r}"
+        raise ValueError(error_msg)
+    sep = ";" if ";" in tc else ":"
+    hh, mm, ss, ff = map(int, re.split(r"[:;]", tc))
+    is_df = (sep == ";") if drop_frame is None else bool(drop_frame)
+
+    # Non-drop: straightforward
+    if not is_df:
+        return (hh * 3600) + (mm * 60) + ss + (ff / rate)
+
+    # Drop-frame: only valid for 29.97 and 59.94
+    nominal = NOMINAL_30_FPS if _approx(rate, 29.97) else NOMINAL_60_FPS if _approx(rate, 59.94) else None
+    if nominal is None:
+        # Fallback (treat as non-drop rather than guessing)
+        return (hh * 3600) + (mm * 60) + ss + (ff / rate)
+
+    drop_per_min = 2 if nominal == NOMINAL_30_FPS else 4
+    total_minutes = hh * 60 + mm
+    # Drop every minute except every 10th minute
+    dropped = drop_per_min * (total_minutes - total_minutes // 10)
+    frame_number = (hh * 3600 + mm * 60 + ss) * nominal + ff - dropped
+    actual_rate = 30000 / 1001 if nominal == NOMINAL_30_FPS else 60000 / 1001
+    return frame_number / actual_rate
+
+
+def frames_to_seconds(frames: int, rate: float) -> float:
+    """Convert frame number to seconds based on frame rate."""
+    return frames / rate
+
+
+def seconds_to_ts(sec: float) -> str:
+    """Return HH:MM:SS.mmm for ffmpeg."""
+    sec = max(sec, 0)
+    whole = int(sec)
+    ms = round((sec - whole) * 1000)
+    h = whole // 3600
+    m = (whole % 3600) // 60
+    s = whole % 60
+    return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
+
+
+def sanitize_filename(name: str) -> str:
+    """Sanitize filename by removing invalid characters and replacing spaces with underscores."""
+    name = re.sub(r"[^\w\s\-.]+", "_", name.strip())
+    name = re.sub(r"\s+", "_", name)
+    return name or "segment"
+
+
+# ----------------------------
+# Input parsing
+# ----------------------------
+
+
+@dataclass
+class Segment:
+    start_sec: float
+    end_sec: float
+    title: str
+    raw_id: str | None = None
+
+
+# ----------------------------
+# Command generation / execution
+# ----------------------------
+
+
+@dataclass
+class FfmpegConfig:
+    """Configuration for FFmpeg command generation."""
+
+    stream_copy: bool = True
+    accurate_seek: bool = True
+    keep_all_streams: bool = True
+
+
+def build_ffmpeg_cmd(
+    input_path: str,
+    seg: Segment,
+    outdir: str,
+    config: FfmpegConfig,
+) -> list[str]:
+    """Return a single ffmpeg command as a list (safe for subprocess).
+
+    - stream_copy=True uses -c copy (fast, keyframe-aligned)
+    - accurate_seek=True places -ss/-to AFTER -i (decode-based seek, more accurate)
+    - keep_all_streams=True adds -map 0 to keep audio/subs/timecode.
+    """
+    Path(outdir).mkdir(parents=True, exist_ok=True)
+    base = sanitize_filename(seg.title)
+    out_path = Path(outdir) / f"{base}.mp4"
+
+    ss = seconds_to_ts(seg.start_sec)
+    to = seconds_to_ts(seg.end_sec)
+
+    cmd = ["ffmpeg", "-hide_banner", "-y"]
+    # accurate seek puts -ss/-to after -i; fast seek places before
+    if not config.accurate_seek:
+        cmd += ["-ss", ss, "-to", to, "-i", input_path]
+    else:
+        cmd += ["-i", input_path, "-ss", ss, "-to", to]
+
+    if config.keep_all_streams:
+        cmd += ["-map", "0"]
+
+    if config.stream_copy:
+        cmd += ["-c", "copy"]
+    else:
+        # Re-encode path (example: H.264 video, copy audio)
+        cmd += ["-c:v", "libx264", "-crf", "18", "-preset", "medium", "-c:a", "aac", "-b:a", "192k"]
+
+    cmd += ["-movflags", "+faststart", str(out_path)]
+    return cmd
+
+
+class SplitVideo(ControlNode):
+    """Split a video into multiple parts using ffmpeg."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        # Add video input parameter
+        self.add_parameter(
+            Parameter(
+                name="video",
+                input_types=["VideoUrlArtifact", "VideoArtifact"],
+                type="VideoUrlArtifact",
+                allowed_modes={ParameterMode.INPUT},
+                tooltip="The video to split",
+            )
+        )
+
+        # Add timecodes parameter
+        timecodes_parameter = Parameter(
+            name="timecodes",
+            input_types=["str", "json"],
+            type="str",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            default_value="00:00:00:00-00:01:00:00",
+            tooltip="Timecodes to split the video at. Can be JSON format or simple timecode ranges.",
+            ui_options={"multiline": True, "placeholder_text": "Enter timecodes or JSON..."},
+        )
+        self.add_parameter(timecodes_parameter)
+
+        # Add output videos parameter list
+        self.split_videos_list = ParameterList(
+            name="split_videos",
+            type="VideoUrlArtifact",
+            allowed_modes={ParameterMode.OUTPUT},
+            tooltip="The split video segments",
+        )
+        self.add_parameter(self.split_videos_list)
+        # Group for logging information
+        with ParameterGroup(name="Logs") as logs_group:
+            Parameter(
+                name="logs",
+                type="str",
+                tooltip="Displays processing logs and detailed events if enabled.",
+                ui_options={"multiline": True, "placeholder_text": "Logs"},
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        logs_group.ui_options = {"hide": True}  # Hide the logs group by default
+
+        self.add_node_element(logs_group)
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        exceptions = []
+
+        # Validate that we have a video
+        video = self.parameter_values.get("video")
+        if not video:
+            msg = f"{self.name}: Video parameter is required"
+            exceptions.append(ValueError(msg))
+
+        # Make sure it's a video artifact
+        if not isinstance(video, VideoUrlArtifact):
+            msg = f"{self.name}: Video parameter must be a VideoUrlArtifact"
+            exceptions.append(ValueError(msg))
+
+        # Make sure it has a value
+        if hasattr(video, "value") and not video.value:  # type: ignore  # noqa: PGH003
+            msg = f"{self.name}: Video parameter must have a value"
+            exceptions.append(ValueError(msg))
+
+        # Validate timecodes
+        timecodes = self.parameter_values.get("timecodes")
+        if not timecodes:
+            msg = f"{self.name}: Timecodes parameter is required"
+            exceptions.append(ValueError(msg))
+
+        return exceptions if exceptions else None
+
+    def _clear_list(self) -> None:
+        """Clear the parameter list."""
+        self.split_videos_list.clear_list()
+
+    def _parse_timecodes_with_agent(self, timecodes_str: str) -> str:
+        api_key = self.get_config_value(SERVICE, API_KEY_ENV_VAR)
+        if not api_key:
+            error_msg = f"No API key found for {SERVICE}. Please set {API_KEY_ENV_VAR} environment variable."
+            raise ValueError(error_msg)
+
+        prompt_driver = GriptapeCloudPromptDriver(
+            model=MODEL, api_key=api_key, stream=True, structured_output_strategy="tool"
+        )
+        agent = GriptapeAgent()
+        agent.add_task(PromptTask(prompt_driver=prompt_driver))
+        msg = f"""
+Please parse the timecodes from the following string:
+{timecodes_str}
+and return ONLY the exact segments provided, with no additional segments or gap-filling. Return in this format with no commentary or other text:
+
+00:00:00:00-00:00:04:07|Segment 1: <title if exists>
+00:00:04:08-00:00:08:15|Segment 2: <title if exists>
+"""
+        try:
+            response = agent.run(msg)
+            self.append_value_to_parameter("logs", f"Agent response: {response}\n")
+            self.append_value_to_parameter("logs", f"Agent output: {agent.output}\n")
+
+            # The agent.output should contain the actual response text
+            if hasattr(agent, "output") and agent.output:
+                return str(agent.output)
+            if hasattr(response, "output") and hasattr(response.output, "value"):
+                return response.output.value
+            error_msg = f"Unexpected agent response format: {response}"
+            raise ValueError(error_msg)
+
+        except Exception as e:
+            error_msg = f"Agent failed to parse timecodes: {e!s}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+
+    def _parse_agent_response(self, agent_response: str, frame_rate: float, *, drop_frame: bool) -> list[Segment]:
+        """Parse the agent's response string into segments."""
+        self.append_value_to_parameter("logs", f"Parsing agent response: '{agent_response}'\n")
+        segments = []
+        for line_raw in agent_response.strip().split("\n"):
+            line = line_raw.strip()
+            if not line:
+                continue
+
+            self.append_value_to_parameter("logs", f"Processing line: '{line}'\n")
+
+            # Parse format: HH:MM:SS:FF-HH:MM:SS:FF|Title
+            parts = line.split("|", 1)
+            if len(parts) != 2:
+                self.append_value_to_parameter("logs", f"Skipping line - no pipe separator: '{line}'\n")
+                continue
+
+            time_range, title = parts
+
+            # Parse time range: HH:MM:SS:FF-HH:MM:SS:FF
+            time_parts = time_range.split("-")
+            if len(time_parts) != 2:
+                self.append_value_to_parameter("logs", f"Skipping line - no dash separator: '{line}'\n")
+                continue
+
+            start_tc, end_tc = time_parts
+
+            try:
+                start_sec = smpte_to_seconds(start_tc, frame_rate, drop_frame=drop_frame)
+                end_sec = smpte_to_seconds(end_tc, frame_rate, drop_frame=drop_frame)
+
+                if end_sec > start_sec:
+                    segments.append(Segment(start_sec, end_sec, title.strip()))
+                    self.append_value_to_parameter(
+                        "logs", f"Added segment: {start_sec}s to {end_sec}s - '{title.strip()}'\n"
+                    )
+                else:
+                    self.append_value_to_parameter(
+                        "logs", f"Skipping segment - end time <= start time: {start_sec}s to {end_sec}s\n"
+                    )
+            except Exception as e:
+                self.append_value_to_parameter("logs", f"Warning: Could not parse line '{line}': {e}\n")
+                continue
+
+        self.append_value_to_parameter("logs", f"Total segments parsed: {len(segments)}\n")
+        return segments
+
+    def _parse_timecodes(self, timecodes_str: str, frame_rate: float, *, drop_frame: bool) -> list[Segment]:
+        """Parse timecodes using agent-based parsing."""
+        try:
+            # Use agent to parse timecodes
+            agent_response = self._parse_timecodes_with_agent(timecodes_str)
+            self.append_value_to_parameter("logs", f"Agent response: {agent_response}\n")
+
+            # Parse agent response into segments
+            segments = self._parse_agent_response(agent_response, frame_rate, drop_frame=drop_frame)
+
+            if not segments:
+                error_msg = "No valid segments found in agent response"
+                raise ValueError(error_msg)
+            return segments
+
+        except Exception as e:
+            error_msg = f"Error parsing timecodes with agent: {e!s}"
+            raise ValueError(error_msg) from e
+
+    def _validate_ffmpeg_paths(self) -> tuple[str, str]:
+        """Validate and return FFmpeg and FFprobe paths."""
+        try:
+            ffmpeg_path, ffprobe_path = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
+            return ffmpeg_path, ffprobe_path
+        except Exception as e:
+            error_msg = f"FFmpeg not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
+            raise ValueError(error_msg) from e
+
+    def _detect_video_properties(self, input_url: str, ffprobe_path: str) -> tuple[float, bool]:
+        """Detect frame rate and drop frame from video using ffprobe."""
+        try:
+            cmd = [
+                ffprobe_path,
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_streams",
+                "-select_streams",
+                "v:0",  # Select first video stream
+                input_url,
+            ]
+
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+            data = json.loads(result.stdout)
+
+            if not data.get("streams"):
+                return 24.0, False  # Default fallback
+
+            stream = data["streams"][0]
+            r_frame_rate = stream.get("r_frame_rate", "24/1")
+
+            # Parse frame rate (e.g., "30000/1001" -> 29.97)
+            if "/" in r_frame_rate:
+                num, den = map(int, r_frame_rate.split("/"))
+                frame_rate = num / den
+            else:
+                frame_rate = float(r_frame_rate)
+
+            # Determine if drop frame based on frame rate
+            drop_frame = abs(frame_rate - 29.97) < 0.1 or abs(frame_rate - 59.94) < 0.1
+
+            return frame_rate, drop_frame
+
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: Could not detect video properties, using defaults: {e}\n")
+            return 24.0, False  # Default fallback
+
+    def _process_segment(
+        self, segment: Segment, input_url: str, temp_dir: str, ffmpeg_path: str, config: FfmpegConfig
+    ) -> str:
+        """Process a single video segment."""
+        self.append_value_to_parameter("logs", f"Processing segment: {segment.title}\n")
+
+        # Build ffmpeg command
+        cmd = build_ffmpeg_cmd(input_url, segment, temp_dir, config)
+
+        # Replace ffmpeg with actual path
+        cmd[0] = ffmpeg_path
+
+        self.append_value_to_parameter("logs", f"Running ffmpeg command: {' '.join(cmd)}\n")
+
+        # Run ffmpeg with timeout
+        try:
+            result = subprocess.run(  # noqa: S603
+                cmd, capture_output=True, text=True, check=True, timeout=300
+            )
+            self.append_value_to_parameter("logs", f"FFmpeg stdout: {result.stdout}\n")
+        except subprocess.TimeoutExpired as e:
+            error_msg = f"FFmpeg process timed out after 5 minutes for segment {segment.title}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+        except subprocess.CalledProcessError as e:
+            error_msg = f"FFmpeg error for segment {segment.title}: {e.stderr}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+
+        # Find the output file
+        base = sanitize_filename(segment.title)
+        output_path = Path(temp_dir) / f"{base}.mp4"
+
+        if output_path.exists():
+            self.append_value_to_parameter("logs", f"Successfully created segment: {output_path}\n")
+            return str(output_path)
+
+        error_msg = f"Expected output file not found: {output_path}"
+        raise ValueError(error_msg)
+
+    def _split_video_with_ffmpeg(
+        self,
+        input_url: str,
+        segments: list[Segment],
+        *,
+        stream_copy: bool = True,
+        accurate_seek: bool = True,
+    ) -> list[bytes]:
+        """Split video using static_ffmpeg and ffmpeg."""
+
+        def _validate_and_raise_if_invalid(url: str) -> None:
+            if not validate_url(url):
+                msg = f"{self.name}: Invalid or unsafe URL provided: {url}"
+                raise ValueError(msg)
+
+        try:
+            # Validate URL before using in subprocess
+            _validate_and_raise_if_invalid(input_url)
+
+            # Get ffmpeg executable paths
+            ffmpeg_path, ffprobe_path = self._validate_ffmpeg_paths()
+
+            # Create temporary directory for output files
+            with tempfile.TemporaryDirectory() as temp_dir:
+                output_files = []
+                config = FfmpegConfig(stream_copy=stream_copy, accurate_seek=accurate_seek)
+
+                for i, segment in enumerate(segments):
+                    self.append_value_to_parameter(
+                        "logs", f"Processing segment {i + 1}/{len(segments)}: {segment.title}\n"
+                    )
+
+                    output_file = self._process_segment(segment, input_url, temp_dir, ffmpeg_path, config)
+
+                    # Read the file content before the temp directory is cleaned up
+                    with Path(output_file).open("rb") as f:
+                        video_bytes = f.read()
+                    output_files.append(video_bytes)
+
+                return output_files
+
+        except Exception as e:
+            error_msg = f"Error during video splitting: {e!s}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+
+    def _process(
+        self,
+        input_url: str,
+        segments: list[Segment],
+        *,
+        stream_copy: bool,
+        accurate_seek: bool,
+        detected_format: str,
+    ) -> None:
+        """Performs the synchronous video splitting operation."""
+        # First clear the parameter list
+        self._clear_list()
+
+        try:
+            self.append_value_to_parameter("logs", f"Splitting video into {len(segments)} segments\n")
+
+            # Split video using ffmpeg
+            output_files = self._split_video_with_ffmpeg(
+                input_url, segments, stream_copy=stream_copy, accurate_seek=accurate_seek
+            )
+
+            # Convert output files to artifacts
+            split_video_artifacts = []
+            original_filename = Path(input_url).stem  # Get filename without extension
+
+            for i, video_bytes in enumerate(output_files):
+                # Create filename for the split segment
+                segment = segments[i]
+                filename = (
+                    f"{original_filename}_segment_{i + 1:03d}_{sanitize_filename(segment.title)}.{detected_format}"
+                )
+
+                # Save to static files
+                url = GriptapeNodes.StaticFilesManager().save_static_file(video_bytes, filename)
+
+                # Create output artifact
+                video_artifact = VideoUrlArtifact(url)
+                split_video_artifacts.append(video_artifact)
+
+                self.append_value_to_parameter("logs", f"Saved segment {i + 1}: {filename}\n")
+
+            # Save all artifacts to parameter list
+            logger.info(f"Saving {len(split_video_artifacts)} split video artifacts")
+            for i, item in enumerate(split_video_artifacts):
+                if i < len(self.split_videos_list):
+                    current_parameter = self.split_videos_list[i]
+                    self.set_parameter_value(current_parameter.name, item)
+                    # Using to ensure updates are being propagated
+                    self.publish_update_to_parameter(current_parameter.name, item)
+                    self.parameter_output_values[current_parameter.name] = item
+                    continue
+                new_child = self.split_videos_list.add_child_parameter()
+                # Set the parameter value
+                self.set_parameter_value(new_child.name, item)
+
+        except Exception as e:
+            error_message = str(e)
+            msg = f"{self.name}: Error splitting video: {error_message}"
+            self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
+            raise ValueError(msg) from e
+
+    def process(self) -> AsyncResult[None]:
+        """Executes the main logic of the node asynchronously."""
+        video = self.parameter_values.get("video")
+        timecodes = self.parameter_values.get("timecodes", "")
+
+        # Initialize logs
+        self.append_value_to_parameter("logs", "[Processing video split..]\n")
+
+        try:
+            # Convert to video artifact
+            video_artifact = to_video_artifact(video)
+
+            # Get the video URL directly
+            input_url = video_artifact.value
+
+            # Always detect video properties for best results
+            self.append_value_to_parameter("logs", "Detecting video properties...\n")
+            ffmpeg_path, ffprobe_path = self._validate_ffmpeg_paths()
+            frame_rate, drop_frame = self._detect_video_properties(input_url, ffprobe_path)
+
+            self.append_value_to_parameter("logs", f"Detected frame rate: {frame_rate} fps\n")
+            self.append_value_to_parameter("logs", f"Detected drop frame: {drop_frame}\n")
+
+            # Parse timecodes
+            self.append_value_to_parameter("logs", "Parsing timecodes...\n")
+            segments = self._parse_timecodes(timecodes, frame_rate, drop_frame=drop_frame)
+            self.append_value_to_parameter("logs", f"Parsed {len(segments)} segments\n")
+
+            # Detect video format for output filename
+            detected_format = detect_video_format(video)
+            if not detected_format:
+                detected_format = "mp4"  # default fallback
+
+            self.append_value_to_parameter("logs", f"Detected video format: {detected_format}\n")
+
+            # Run the video processing asynchronously
+            self.append_value_to_parameter("logs", "[Started video processing..]\n")
+            yield lambda: self._process(
+                input_url,
+                segments,
+                stream_copy=True,  # Always use best quality
+                accurate_seek=True,  # Always use best quality
+                detected_format=detected_format,
+            )
+            self.append_value_to_parameter("logs", "[Finished video processing.]\n")
+
+        except Exception as e:
+            error_message = str(e)
+            msg = f"{self.name}: Error splitting video: {error_message}"
+            self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
+            raise ValueError(msg) from e

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
         - Display Video: nodes/video/display_video.md
         - Resize Video: nodes/video/resize_video.md
         - Save Video: nodes/video/save_video.md
+        - Change Speed: nodes/video/change_speed.md
     - Tools:
         - Calculator: nodes/tools/calculator_tool.md
         - Date Time: nodes/tools/date_time_tool.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
         - Resize Video: nodes/video/resize_video.md
         - Save Video: nodes/video/save_video.md
         - Change Speed: nodes/video/change_speed.md
+        - Add Color Curves: nodes/video/add_color_curves.md
     - Tools:
         - Calculator: nodes/tools/calculator_tool.md
         - Date Time: nodes/tools/date_time_tool.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
         - Save Video: nodes/video/save_video.md
         - Change Speed: nodes/video/change_speed.md
         - Add Color Curves: nodes/video/add_color_curves.md
+        - Add Overlay: nodes/video/add_overlay.md
     - Tools:
         - Calculator: nodes/tools/calculator_tool.md
         - Date Time: nodes/tools/date_time_tool.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,14 @@ mypy-init-return = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.typos]
+default.extend-ignore-re = [
+  # Ignore any line that ends with this comment:
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  # Or: ignore the *next* line after this comment:
+  "(?m)(#|//)\\s*spellchecker:ignore-next-line\\n.*"
+]
+
 [tool.pyright]
 venvPath = "."
 venv = ".venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "binaryornot>=0.4.4",
   "pillow>=11.3.0",
   "watchfiles>=1.1.0",
+  "static-ffmpeg>=2.8",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 3
-requires-python = "==3.12.*"
+revision = 2
+requires-python = ">=3.12.0, <3.13"
 
 [[package]]
 name = "annotated-types"
@@ -96,6 +96,24 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
+]
+
+[[package]]
 name = "chardet"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -148,12 +166,50 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "45.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz", hash = "sha256:5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719", size = 744949, upload-time = "2025-08-05T23:59:27.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/b6/cabd07410f222f32c8d55486c464f432808abaa1f12af9afcbe8f2f19030/cryptography-45.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44647c5d796f5fc042bbc6d61307d04bf29bccb74d188f18051b635f20a9c75f", size = 4206483, upload-time = "2025-08-05T23:58:27.132Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/f9c7d36a38b1cfeb1cc74849aabe9bf817990f7603ff6eb485e0d70e0b27/cryptography-45.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e40b80ecf35ec265c452eea0ba94c9587ca763e739b8e559c128d23bff7ebbbf", size = 4429679, upload-time = "2025-08-05T23:58:29.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2a/4434c17eb32ef30b254b9e8b9830cee4e516f08b47fdd291c5b1255b8101/cryptography-45.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:00e8724bdad672d75e6f069b27970883179bd472cd24a63f6e620ca7e41cc0c5", size = 4210553, upload-time = "2025-08-05T23:58:30.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/1d/09a5df8e0c4b7970f5d1f3aff1b640df6d4be28a64cae970d56c6cf1c772/cryptography-45.0.6-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7a3085d1b319d35296176af31c90338eeb2ddac8104661df79f80e1d9787b8b2", size = 3894499, upload-time = "2025-08-05T23:58:32.03Z" },
+    { url = "https://files.pythonhosted.org/packages/79/62/120842ab20d9150a9d3a6bdc07fe2870384e82f5266d41c53b08a3a96b34/cryptography-45.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1b7fa6a1c1188c7ee32e47590d16a5a0646270921f8020efc9a511648e1b2e08", size = 4458484, upload-time = "2025-08-05T23:58:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/1bc3634d45ddfed0871bfba52cf8f1ad724761662a0c792b97a951fb1b30/cryptography-45.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:275ba5cc0d9e320cd70f8e7b96d9e59903c815ca579ab96c1e37278d231fc402", size = 4210281, upload-time = "2025-08-05T23:58:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/ffb12c2d83d0ee625f124880a1f023b5878f79da92e64c37962bbbe35f3f/cryptography-45.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f4028f29a9f38a2025abedb2e409973709c660d44319c61762202206ed577c42", size = 4456890, upload-time = "2025-08-05T23:58:36.923Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8e/b3f3fe0dc82c77a0deb5f493b23311e09193f2268b77196ec0f7a36e3f3e/cryptography-45.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ee411a1b977f40bd075392c80c10b58025ee5c6b47a822a33c1198598a7a5f05", size = 4333247, upload-time = "2025-08-05T23:58:38.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a6/c3ef2ab9e334da27a1d7b56af4a2417d77e7806b2e0f90d6267ce120d2e4/cryptography-45.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2a21a8eda2d86bb604934b6b37691585bd095c1f788530c1fcefc53a82b3453", size = 4565045, upload-time = "2025-08-05T23:58:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c6/ea5173689e014f1a8470899cd5beeb358e22bb3cf5a876060f9d1ca78af4/cryptography-45.0.6-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d9ef57b6768d9fa58e92f4947cea96ade1233c0e236db22ba44748ffedca394", size = 4198169, upload-time = "2025-08-05T23:58:47.121Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/73/b12995edc0c7e2311ffb57ebd3b351f6b268fed37d93bfc6f9856e01c473/cryptography-45.0.6-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea3c42f2016a5bbf71825537c2ad753f2870191134933196bee408aac397b3d9", size = 4421273, upload-time = "2025-08-05T23:58:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6e/286894f6f71926bc0da67408c853dd9ba953f662dcb70993a59fd499f111/cryptography-45.0.6-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:20ae4906a13716139d6d762ceb3e0e7e110f7955f3bc3876e3a07f5daadec5f3", size = 4199211, upload-time = "2025-08-05T23:58:50.139Z" },
+    { url = "https://files.pythonhosted.org/packages/de/34/a7f55e39b9623c5cb571d77a6a90387fe557908ffc44f6872f26ca8ae270/cryptography-45.0.6-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dac5ec199038b8e131365e2324c03d20e97fe214af051d20c49db129844e8b3", size = 3883732, upload-time = "2025-08-05T23:58:52.253Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b9/c6d32edbcba0cd9f5df90f29ed46a65c4631c4fbe11187feb9169c6ff506/cryptography-45.0.6-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:18f878a34b90d688982e43f4b700408b478102dd58b3e39de21b5ebf6509c301", size = 4450655, upload-time = "2025-08-05T23:58:53.848Z" },
+    { url = "https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5", size = 4198956, upload-time = "2025-08-05T23:58:55.209Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/061ec6689207d54effdff535bbdf85cc380d32dd5377173085812565cf38/cryptography-45.0.6-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:eccddbd986e43014263eda489abbddfbc287af5cddfd690477993dbb31e31016", size = 4449859, upload-time = "2025-08-05T23:58:56.639Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ff/e7d5a2ad2d035e5a2af116e1a3adb4d8fcd0be92a18032917a089c6e5028/cryptography-45.0.6-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:550ae02148206beb722cfe4ef0933f9352bab26b087af00e48fdfb9ade35c5b3", size = 4320254, upload-time = "2025-08-05T23:58:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/82/27/092d311af22095d288f4db89fcaebadfb2f28944f3d790a4cf51fe5ddaeb/cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9", size = 4554815, upload-time = "2025-08-05T23:59:00.283Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/5b41c32ecedcfdb4c77b28b6cb14234f252075f8cdb254531727a35547dd/docutils-0.22.tar.gz", hash = "sha256:ba9d57750e92331ebe7c08a1bbf7a7f8143b86c476acd51528b042216a6aad0f", size = 2277984, upload-time = "2025-07-29T15:20:31.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/57/8db39bc5f98f042e0153b1de9fb88e1a409a33cda4dd7f723c2ed71e01f6/docutils-0.22-py3-none-any.whl", hash = "sha256:4ed966a0e96a0477d852f7af31bdcb3adc049fbb35ccba358c2ea8a03287615e", size = 630709, upload-time = "2025-07-29T15:20:28.335Z" },
 ]
 
 [[package]]
@@ -177,6 +233,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/d7/6c8b3bfe33eeffa208183ec037fee0cce9f7f024089ab1c5d12ef04bd27c/fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143", size = 296485, upload-time = "2025-07-11T16:22:32.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565", size = 95631, upload-time = "2025-07-11T16:22:30.485Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
 ]
 
 [[package]]
@@ -253,6 +318,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "static-ffmpeg" },
     { name = "tomlkit" },
     { name = "uv" },
     { name = "uvicorn" },
@@ -304,6 +370,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "static-ffmpeg", specifier = ">=2.8" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "uv", specifier = ">=0.6.16" },
     { name = "uvicorn", specifier = ">=0.34.2" },
@@ -383,6 +450,18 @@ wheels = [
 ]
 
 [[package]]
+name = "id"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/11/102da08f88412d875fa2f1a9a469ff7ad4c874b0ca6fed0048fe385bdb3d/id-1.5.0.tar.gz", hash = "sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d", size = 15237, upload-time = "2024-12-04T19:53:05.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl", hash = "sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658", size = 13611, upload-time = "2024-12-04T19:53:03.02Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +491,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload-time = "2024-08-20T03:39:27.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload-time = "2024-08-20T03:39:25.966Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/1aa2d585304ec07262e1a83a9889880701079dde796ac7b1d1826f40c63d/jaraco_functools-4.3.0.tar.gz", hash = "sha256:cfd13ad0dd2c47a3600b439ef72d8615d482cedcff1632930d6f28924d92f294", size = 19755, upload-time = "2025-08-18T20:05:09.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/09/726f168acad366b11e420df31bf1c702a54d373a83f968d94141a8c3fde0/jaraco_functools-4.3.0-py3-none-any.whl", hash = "sha256:227ff8ed6f7b8f62c56deff101545fa7543cf2c8e7b82a7c2116e672f29c26e8", size = 10408, upload-time = "2025-08-18T20:05:08.69Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -480,6 +601,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085, upload-time = "2024-12-25T15:26:44.377Z" },
 ]
 
 [[package]]
@@ -813,6 +951,29 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/96cff0977357f60f06ec4368c4c7a7a26cccfe7c9fcd54f5378bf0428fd3/nh3-0.3.0.tar.gz", hash = "sha256:d8ba24cb31525492ea71b6aac11a4adac91d828aadeff7c4586541bf5dc34d2f", size = 19655, upload-time = "2025-07-17T14:43:37.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/e0/cf1543e798ba86d838952e8be4cb8d18e22999be2a24b112a671f1c04fd6/nh3-0.3.0-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ec6cfdd2e0399cb79ba4dcffb2332b94d9696c52272ff9d48a630c5dca5e325a", size = 1442218, upload-time = "2025-07-17T14:43:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/86/a96b1453c107b815f9ab8fac5412407c33cc5c7580a4daf57aabeb41b774/nh3-0.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5e7185599f89b0e391e2f29cc12dc2e206167380cea49b33beda4891be2fe1", size = 823791, upload-time = "2025-07-17T14:43:19.721Z" },
+    { url = "https://files.pythonhosted.org/packages/97/33/11e7273b663839626f714cb68f6eb49899da5a0d9b6bc47b41fe870259c2/nh3-0.3.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:389d93d59b8214d51c400fb5b07866c2a4f79e4e14b071ad66c92184fec3a392", size = 811143, upload-time = "2025-07-17T14:43:20.779Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1b/b15bd1ce201a1a610aeb44afd478d55ac018b4475920a3118ffd806e2483/nh3-0.3.0-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e9e6a7e4d38f7e8dda9edd1433af5170c597336c1a74b4693c5cb75ab2b30f2a", size = 1064661, upload-time = "2025-07-17T14:43:21.839Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/14/079670fb2e848c4ba2476c5a7a2d1319826053f4f0368f61fca9bb4227ae/nh3-0.3.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7852f038a054e0096dac12b8141191e02e93e0b4608c4b993ec7d4ffafea4e49", size = 997061, upload-time = "2025-07-17T14:43:23.179Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e5/ac7fc565f5d8bce7f979d1afd68e8cb415020d62fa6507133281c7d49f91/nh3-0.3.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af5aa8127f62bbf03d68f67a956627b1bd0469703a35b3dad28d0c1195e6c7fb", size = 924761, upload-time = "2025-07-17T14:43:24.23Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2c/6394301428b2017a9d5644af25f487fa557d06bc8a491769accec7524d9a/nh3-0.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f416c35efee3e6a6c9ab7716d9e57aa0a49981be915963a82697952cba1353e1", size = 803959, upload-time = "2025-07-17T14:43:26.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9a/344b9f9c4bd1c2413a397f38ee6a3d5db30f1a507d4976e046226f12b297/nh3-0.3.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37d3003d98dedca6cd762bf88f2e70b67f05100f6b949ffe540e189cc06887f9", size = 844073, upload-time = "2025-07-17T14:43:27.375Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/cd37f76c8ca277b02a84aa20d7bd60fbac85b4e2cbdae77cb759b22de58b/nh3-0.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:634e34e6162e0408e14fb61d5e69dbaea32f59e847cfcfa41b66100a6b796f62", size = 1000680, upload-time = "2025-07-17T14:43:28.452Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/db/7aa11b44bae4e7474feb1201d8dee04fabe5651c7cb51409ebda94a4ed67/nh3-0.3.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:b0612ccf5de8a480cf08f047b08f9d3fecc12e63d2ee91769cb19d7290614c23", size = 1076613, upload-time = "2025-07-17T14:43:30.031Z" },
+    { url = "https://files.pythonhosted.org/packages/97/03/03f79f7e5178eb1ad5083af84faff471e866801beb980cc72943a4397368/nh3-0.3.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:c7a32a7f0d89f7d30cb8f4a84bdbd56d1eb88b78a2434534f62c71dac538c450", size = 1001418, upload-time = "2025-07-17T14:43:31.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/55/1974bcc16884a397ee699cebd3914e1f59be64ab305533347ca2d983756f/nh3-0.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3f1b4f8a264a0c86ea01da0d0c390fe295ea0bcacc52c2103aca286f6884f518", size = 986499, upload-time = "2025-07-17T14:43:32.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/76936ec021fe1f3270c03278b8af5f2079038116b5d0bfe8538ffe699d69/nh3-0.3.0-cp38-abi3-win32.whl", hash = "sha256:6d68fa277b4a3cf04e5c4b84dd0c6149ff7d56c12b3e3fab304c525b850f613d", size = 599000, upload-time = "2025-07-17T14:43:33.852Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ae/324b165d904dc1672eee5f5661c0a68d4bab5b59fbb07afb6d8d19a30b45/nh3-0.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:bae63772408fd63ad836ec569a7c8f444dd32863d0c67f6e0b25ebbd606afa95", size = 604530, upload-time = "2025-07-17T14:43:34.95Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/76/3165e84e5266d146d967a6cc784ff2fbf6ddd00985a55ec006b72bc39d5d/nh3-0.3.0-cp38-abi3-win_arm64.whl", hash = "sha256:d97d3efd61404af7e5721a0e74d81cdbfc6e5f97e11e731bb6d090e30a7b62b2", size = 585971, upload-time = "2025-07-17T14:43:35.936Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -930,6 +1091,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "progress"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/26/3b086f0c5d6c1c18c2430d6fac3a99d79553884ca6cdf759cf256dd43b7d/progress-1.6.1.tar.gz", hash = "sha256:c1ba719f862ce885232a759eab47971fe74dfc7bb76ab8a51ef5940bad35086c", size = 7164, upload-time = "2025-07-01T05:50:43.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/59/123aee44a039b212cfb8d90be1adf06496a99b313ee1683aadf90b3d9799/progress-1.6.1-py3-none-any.whl", hash = "sha256:5239f22f305c12fdc8ce6e0e47f70f21622a935e16eafc4535617112e7c7ea0b", size = 9761, upload-time = "2025-07-01T05:50:40.963Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
 ]
 
 [[package]]
@@ -1103,6 +1282,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,6 +1317,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "readme-renderer"
+version = "44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
 ]
 
 [[package]]
@@ -1181,6 +1383,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
 ]
 
 [[package]]
@@ -1282,6 +1505,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1322,6 +1558,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+]
+
+[[package]]
+name = "static-ffmpeg"
+version = "2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "progress" },
+    { name = "requests" },
+    { name = "twine" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/39/1a5d0603280dd681ec52a2a6717c05dab530190dff7887b7603740a1741b/static_ffmpeg-2.13-py3-none-any.whl", hash = "sha256:3bed55a7979f9de9d1eec1126b98774a1d41c2e323811f59973d54b9c94d6dac", size = 7586, upload-time = "2025-03-30T23:34:20.646Z" },
 ]
 
 [[package]]
@@ -1370,6 +1620,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "twine"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "id" },
+    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/a2/6df94fc5c8e2170d21d7134a565c3a8fb84f9797c1dd65a5976aaf714418/twine-6.1.0.tar.gz", hash = "sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd", size = 168404, upload-time = "2025-01-21T18:45:26.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/b6/74e927715a285743351233f33ea3c684528a0d374d2e43ff9ce9585b73fe/twine-6.1.0-py3-none-any.whl", hash = "sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384", size = 40791, upload-time = "2025-01-21T18:45:24.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
adds the following video editing nodes:

`AddFilmGrain` - Adds realistic film grain with luminance-based masking
`AddOverlay` - allows for some simple overlay video control
`AddColorCurve` - Adds control for basic ffmpeg color curves
`AddRGBShift` - Creates glitch/VHS effects with static or animated RGB channel separation
`AddVignette` - Adds cinematic vignette effects (darkening/lightening around edges)
`ChangeSpeed` - Lets the user speed up or slow down the video
`SplitVideo` - Splits videos into segments using AI-powered timecode parsing
`AdjustVideoEQ` - Adjusts brightness, contrast, saturation, and gamma
`HoldVideoFrames` - Creates stop-motion effects by holding frames
`ReverseVideo` - Reverses video playback with audio handling options
`FlipVideo` - Flips video horizontally, vertically, or both directions

All nodes use FFmpeg for high-quality processing and maintain audio tracks where appropriate, and are based off a BaseVideoProcessor node that has all the main methods they use. This makes it easier to implement new video nodes.


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--1958.org.readthedocs.build/en/1958/

<!-- readthedocs-preview griptape-nodes end -->