### PR TITLE
Reject SetParameterValueRequests on parameters with an incoming connection (except for the value from the connection, of course!)

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/text/create_multiline_text.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/text/create_multiline_text.py
@@ -22,7 +22,7 @@ class TextInput(DataNode):
                 output_type="str",
                 type="str",
                 allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
-                tooltip="The text content to save to file",
+                tooltip="The text content to pass to another node.",
                 ui_options={"multiline": True},
             ),
         )

--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -235,8 +235,8 @@ class ExecuteNodeState(State):
                         node_name=current_node.name,
                         value=output_value,
                         data_type=upstream_parameter.output_type,
-                        upstream_connection_node_name=upstream_node.name,
-                        upstream_connection_parameter_name=upstream_parameter.name,
+                        incoming_connection_source_node_name=upstream_node.name,
+                        incoming_connection_source_parameter_name=upstream_parameter.name,
                     )
                 )
 

--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -235,6 +235,8 @@ class ExecuteNodeState(State):
                         node_name=current_node.name,
                         value=output_value,
                         data_type=upstream_parameter.output_type,
+                        upstream_connection_node_name=upstream_node.name,
+                        upstream_connection_parameter_name=upstream_parameter.name,
                     )
                 )
 

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -160,10 +160,10 @@ class SetParameterValueRequest(RequestPayload):
     initial_setup: bool = False
     # is_output is true when the value being saved is from an output value. Used when loading a workflow from a file.
     is_output: bool = False
-    # upstream_connection fields identify when this request comes from upstream node value passing during resolution
-    # Both must be None (manual/user request) or both must be set (upstream connection request)
-    upstream_connection_node_name: str | None = None
-    upstream_connection_parameter_name: str | None = None
+    # incoming_connection_source fields identify when this request comes from upstream node value passing during resolution
+    # Both must be None (manual/user request) or both must be set (incoming connection source request)
+    incoming_connection_source_node_name: str | None = None
+    incoming_connection_source_parameter_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -160,6 +160,10 @@ class SetParameterValueRequest(RequestPayload):
     initial_setup: bool = False
     # is_output is true when the value being saved is from an output value. Used when loading a workflow from a file.
     is_output: bool = False
+    # upstream_connection fields identify when this request comes from upstream node value passing during resolution
+    # Both must be None (manual/user request) or both must be set (upstream connection request)
+    upstream_connection_node_name: str | None = None
+    upstream_connection_parameter_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -855,12 +855,17 @@ class FlowManager:
                 target_node.kill_parameter_children(target_param)
         # if it existed somewhere and actually has a value - Set the parameter!
         if value and request.initial_setup is False:
+            # When creating a connection, pass the initial value from source to target parameter
+            # Set incoming_connection_source fields to identify this as legitimate connection value passing
+            # (not manual property setting) so it bypasses the INPUT+PROPERTY connection blocking logic
             GriptapeNodes.handle_request(
                 SetParameterValueRequest(
                     parameter_name=target_param.name,
                     node_name=target_node.name,
                     value=value,
                     data_type=source_param.type,
+                    incoming_connection_source_node_name=source_node.name,
+                    incoming_connection_source_parameter_name=source_param.name,
                 )
             )
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1580,8 +1580,9 @@ class NodeManager:
             # Mark node as unresolved, broadcast an event
             node.make_node_unresolved(current_states_to_trigger_change_event=set({NodeResolutionState.RESOLVED}))
             # Get the flow
-            # Pass the value through!
-            # Optional data_type parameter for internal handling!
+            # Pass the value through to connected downstream parameters!
+            # Set incoming_connection_source fields to identify this as legitimate upstream value propagation
+            # (not manual property setting) so it bypasses the INPUT+PROPERTY connection blocking logic
             conn_output_nodes = parent_flow.get_connected_output_parameters(node, parameter)
             for target_node, target_parameter in conn_output_nodes:
                 GriptapeNodes.handle_request(
@@ -1590,6 +1591,8 @@ class NodeManager:
                         node_name=target_node.name,
                         value=finalized_value,
                         data_type=object_type,  # Do type instead of output type, because it hasn't been processed.
+                        incoming_connection_source_node_name=node.name,
+                        incoming_connection_source_parameter_name=parameter.name,
                     )
                 )
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1502,11 +1502,11 @@ class NodeManager:
             result = SetParameterValueResultFailure(result_details=details)
             return result
 
-        # Validate upstream connection fields consistency
-        upstream_node_set = request.upstream_connection_node_name is not None
-        upstream_param_set = request.upstream_connection_parameter_name is not None
-        if upstream_node_set != upstream_param_set:
-            details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because upstream connection fields must both be None or both be set. Got upstream_connection_node_name={request.upstream_connection_node_name}, upstream_connection_parameter_name={request.upstream_connection_parameter_name}."
+        # Validate incoming connection source fields consistency
+        incoming_node_set = request.incoming_connection_source_node_name is not None
+        incoming_param_set = request.incoming_connection_source_parameter_name is not None
+        if incoming_node_set != incoming_param_set:
+            details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because incoming connection source fields must both be None or both be set. Got incoming_connection_source_node_name={request.incoming_connection_source_node_name}, incoming_connection_source_parameter_name={request.incoming_connection_source_parameter_name}."
             logger.error(details)
             result = SetParameterValueResultFailure(result_details=details)
             return result
@@ -1519,12 +1519,12 @@ class NodeManager:
             return result
 
         # Prevent manual property setting on parameters that have both INPUT and PROPERTY modes when they have incoming connections
-        # When a parameter can accept both input connections AND manual property values, having an active connection should 
+        # When a parameter can accept both input connections AND manual property values, having an active connection should
         # make the parameter non-settable as a property to avoid conflicts between connected values and manual values
-        # Skip this check if: initial_setup (workflow loading), or upstream_connection fields are set (system passing upstream values)
+        # Skip this check if: initial_setup (workflow loading), or incoming_connection_source fields are set (system passing upstream values)
         if (
             not request.initial_setup
-            and not upstream_node_set  # If upstream fields are set, this is a legitimate upstream value pass
+            and not incoming_node_set  # If incoming connection source fields are set, this is a legitimate upstream value pass
             and ParameterMode.INPUT in parameter.allowed_modes
             and ParameterMode.PROPERTY in parameter.allowed_modes
         ):
@@ -1534,7 +1534,7 @@ class NodeManager:
             if target_connections is not None:
                 param_connections = target_connections.get(request.parameter_name)
                 if param_connections:  # Has incoming connections
-                    # TODO: Consider emitting UI events when parameters become settable/unsettable due to connection changes
+                    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/1965 Consider emitting UI events when parameters become settable/unsettable due to connection changes
                     details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because this parameter has incoming connections and cannot be set as a property while connected."
                     logger.error(details)
                     result = SetParameterValueResultFailure(result_details=details)


### PR DESCRIPTION
Fixes #1959 

If a customer supplies an incoming connection to a Parameter that supports the INPUT and PROPERTY, we should reject calls to set the property value directly. It should be listening directly to the incoming connection. Once the incoming connection is removed, we can again accept set value requests.

Note that this approach does NOT modify the `settable` member var on the Parameter, so we're not juggling state.