### PR TITLE
Implement worker mode and session connection

### DIFF
--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -308,8 +308,12 @@ class EventRequest[P: Payload](BaseEvent):
         # Create and attach the request payload
         if payload_type:
             if is_dataclass(payload_type):
-                # Create dataclass instance
-                request_payload = payload_type(**request_data)
+                # Filter out fields that have init=False to avoid constructor errors
+                from dataclasses import fields
+
+                init_fields = {f.name for f in fields(payload_type) if f.init}
+                filtered_request_data = {k: v for k, v in request_data.items() if k in init_fields}
+                request_payload = payload_type(**filtered_request_data)
             elif issubclass(payload_type, BaseModel):
                 # Handle Pydantic models
                 request_payload = payload_type.model_validate(request_data)
@@ -405,7 +409,12 @@ class EventResult[P: RequestPayload, R: ResultPayload](BaseEvent, ABC):
         # Process request payload
         if req_payload_type:
             if is_dataclass(req_payload_type):
-                request_payload = req_payload_type(**request_data)
+                # Filter out fields that have init=False to avoid constructor errors
+                from dataclasses import fields
+
+                init_fields = {f.name for f in fields(req_payload_type) if f.init}
+                filtered_request_data = {k: v for k, v in request_data.items() if k in init_fields}
+                request_payload = req_payload_type(**filtered_request_data)
             elif issubclass(req_payload_type, BaseModel):
                 request_payload = req_payload_type.model_validate(request_data)
             else:
@@ -419,7 +428,12 @@ class EventResult[P: RequestPayload, R: ResultPayload](BaseEvent, ABC):
         # Process result payload
         if res_payload_type:
             if is_dataclass(res_payload_type):
-                result_payload = res_payload_type(**result_data)
+                # Filter out fields that have init=False to avoid constructor errors
+                from dataclasses import fields
+
+                init_fields = {f.name for f in fields(res_payload_type) if f.init}
+                filtered_result_data = {k: v for k, v in result_data.items() if k in init_fields}
+                result_payload = res_payload_type(**filtered_result_data)
             elif issubclass(res_payload_type, BaseModel):
                 result_payload = res_payload_type.model_validate(result_data)
             else:

--- a/src/griptape_nodes/retained_mode/events/session_events.py
+++ b/src/griptape_nodes/retained_mode/events/session_events.py
@@ -1,0 +1,40 @@
+"""Events for session management and client registration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+@dataclass
+@PayloadRegistry.register
+class RegisterSessionClientRequest(RequestPayload):
+    """Request registration of a new session client.
+
+    Results: RegisterSessionClientResultSuccess | RegisterSessionClientResultFailure
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class RegisterSessionClientResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Client ID assigned successfully.
+
+    Args:
+        client_id: Unique client identifier assigned by the orchestrator
+    """
+
+    client_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class RegisterSessionClientResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Client registration failed."""


### PR DESCRIPTION
This PR adds initial plumbing for a new `worker` mode for the engine. The current engine behavior can be considered an `orchestrator`, which has control of a Session. Workers can be added to a Session as clients. Eventually they can be used for handling Events such as node executions. This PR is the first step toward that.

* Implement worker mode and session connection
  * New `gtn worker` command to start a worker process for a session
  * Enable websocket connection to listen for EventResult type events, rather than just EventRequests
  * Add `RegisterSessionClientRequest` events

TODO
* Improve the data maintained for a registered client
* Refactor Library related functions to be fully Event style