### PR TITLE
refactor: remove unneeded active node check

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -350,16 +350,7 @@ async def _process_node_event(event: GriptapeNodeEvent) -> None:
 
 async def _process_execution_node_event(event: ExecutionGriptapeNodeEvent) -> None:
     """Process ExecutionGriptapeNodeEvents and send them to the API (async version)."""
-    result_event = event.wrapped_event
-    if type(result_event.payload).__name__ == "NodeStartProcessEvent":
-        griptape_nodes.EventManager().current_active_node = result_event.payload.node_name
-
-    if type(result_event.payload).__name__ == "NodeFinishProcessEvent":
-        if result_event.payload.node_name != griptape_nodes.EventManager().current_active_node:
-            msg = "Node start and finish do not match."
-            raise KeyError(msg) from None
-        griptape_nodes.EventManager().current_active_node = None
-    await __emit_message("execution_event", result_event.json())
+    await __emit_message("execution_event", event.wrapped_event.json())
 
 
 async def _process_progress_event(gt_event: ProgressEvent) -> None:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -45,7 +45,6 @@ class EventManager:
         self._request_type_to_manager: dict[type[RequestPayload], Callable] = defaultdict(list)  # pyright: ignore[reportAttributeAccessIssue]
         # Dictionary to store ALL SUBSCRIBERS to app events.
         self._app_event_listeners: dict[type[AppPayload], set[Callable]] = {}
-        self.current_active_node: str | None = None
         # Boolean that lets us know if there is currently a FlushParameterChangesRequest in the event queue.
         self._flush_in_queue: bool = False
         # Event queue for publishing events


### PR DESCRIPTION
Getting this error when starting a flow, cancelling, and then starting again.

I suspect the flow is not being fully cancelled so run 1's `NodeFinishProcessEvent` comes across as run 2 is starting.

Will create a followup task to investigate proper cancellation, but I don't see much value in having this error/state.