### PR TITLE
Add `settable` as a field for AddParameterToNode, GetParameterDetails, and AlterParameterDetails request types.

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -715,7 +715,7 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
 
     # "settable" here means whether it can be assigned to during regular business operation.
     # During save/load, this value IS still serialized to save its proper state.
-    settable: bool = True
+    _settable: bool = True
 
     # "serializable" controls whether parameter values should be serialized during save/load operations.
     # Set to False for parameters containing non-serializable types (ImageDrivers, PromptDrivers, file handles, etc.)
@@ -771,7 +771,7 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         self.tooltip_as_input = tooltip_as_input
         self.tooltip_as_property = tooltip_as_property
         self.tooltip_as_output = tooltip_as_output
-        self.settable = settable
+        self._settable = settable
         self.serializable = serializable
         self.user_defined = user_defined
         if allowed_modes is None:
@@ -911,6 +911,15 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
             self._changes["mode_allowed_input"] = ParameterMode.INPUT in value
             self._changes["mode_allowed_output"] = ParameterMode.OUTPUT in value
             self._changes["mode_allowed_property"] = ParameterMode.PROPERTY in value
+
+    @property
+    def settable(self) -> bool:
+        return self._settable
+
+    @settable.setter
+    @BaseNodeElement.emits_update_on_write
+    def settable(self, value: bool) -> None:
+        self._settable = value
 
     @property
     def ui_options(self) -> dict:

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -43,6 +43,7 @@ class AddParameterToNodeRequest(RequestPayload):
         is_user_defined: Whether this is a user-defined parameter (affects serialization)
         parent_container_name: Name of parent container if nested
         initial_setup: Skip setup work when loading from file
+        settable: Whether parameter can be set directly by the user or not
 
     Results: AddParameterToNodeResultSuccess (with parameter name) | AddParameterToNodeResultFailure
     """
@@ -63,6 +64,7 @@ class AddParameterToNodeRequest(RequestPayload):
     mode_allowed_property: bool = Field(default=True)
     mode_allowed_output: bool = Field(default=True)
     is_user_defined: bool = Field(default=True)
+    settable: bool = Field(default=True)
     parent_container_name: str | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
     initial_setup: bool = False
@@ -225,6 +227,7 @@ class GetParameterDetailsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
         tooltip_as_input/property/output: Mode-specific tooltips
         mode_allowed_input/property/output: Which modes are allowed
         is_user_defined: Whether this is a user-defined parameter
+        settable: Whether parameter can be set directly by the user or not (None for non-Parameters)
         ui_options: UI configuration options
     """
 
@@ -241,6 +244,7 @@ class GetParameterDetailsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
     mode_allowed_property: bool
     mode_allowed_output: bool
     is_user_defined: bool
+    settable: bool | None
     ui_options: dict | None
 
 
@@ -272,6 +276,7 @@ class AlterParameterDetailsRequest(RequestPayload):
         mode_allowed_input: Whether parameter can be used as input
         mode_allowed_property: Whether parameter can be used as property
         mode_allowed_output: Whether parameter can be used as output
+        settable: Whether parameter can be set directly by the user or not
         ui_options: New UI configuration options
         traits: Set of parameter traits
         initial_setup: Skip setup work when loading from file
@@ -293,6 +298,7 @@ class AlterParameterDetailsRequest(RequestPayload):
     mode_allowed_input: bool | None = None
     mode_allowed_property: bool | None = None
     mode_allowed_output: bool | None = None
+    settable: bool | None = None
     ui_options: dict | None = None
     traits: set[str] | None = None
     # initial_setup prevents unnecessary work when we are loading a workflow from a file.
@@ -330,6 +336,7 @@ class AlterParameterDetailsRequest(RequestPayload):
             "mode_allowed_input",
             "mode_allowed_property",
             "mode_allowed_output",
+            "settable",
             "ui_options",
             "traits",
         ]

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -964,6 +964,7 @@ class NodeManager:
             allowed_modes=allowed_modes,
             ui_options=request.ui_options,
             parent_container_name=request.parent_container_name,
+            settable=request.settable,
         )
         try:
             if request.parent_container_name and request.initial_setup:
@@ -1170,6 +1171,7 @@ class NodeManager:
             mode_allowed_property=allows_property,
             mode_allowed_output=allows_output,
             is_user_defined=getattr(element, "user_defined", False),
+            settable=getattr(element, "settable", None),
             ui_options=getattr(element, "ui_options", None),
         )
         return result
@@ -1259,7 +1261,7 @@ class NodeManager:
         if request.ui_options is not None and hasattr(parameter, "ui_options"):
             parameter.ui_options = request.ui_options  # type: ignore[attr-defined]
 
-    def modify_key_parameter_fields(self, request: AlterParameterDetailsRequest, parameter: Parameter) -> None:
+    def modify_key_parameter_fields(self, request: AlterParameterDetailsRequest, parameter: Parameter) -> None:  # noqa: C901, PLR0912
         if request.type is not None:
             parameter.type = request.type
         if request.input_types is not None:
@@ -1284,6 +1286,8 @@ class NodeManager:
                 parameter.allowed_modes.add(ParameterMode.OUTPUT)
             else:
                 parameter.allowed_modes.discard(ParameterMode.OUTPUT)
+        if request.settable is not None:
+            parameter.settable = request.settable
 
     def _validate_and_break_invalid_connections(
         self, node_name: str, parameter: Parameter, request: AlterParameterDetailsRequest

--- a/tests/unit/exe_types/test_core_types.py
+++ b/tests/unit/exe_types/test_core_types.py
@@ -305,3 +305,30 @@ class TestParameterGroup:
 class TestParameter:
     def test_init(self) -> None:
         assert Parameter(name="test", input_types=["str"], type="str", output_type="str", tooltip="test")
+
+    def test_settable_property(self) -> None:
+        """Test that settable property works correctly and is included in serialization."""
+        # Test default value
+        param = Parameter(name="test", input_types=["str"], type="str", output_type="str", tooltip="test")
+        assert param.settable is True
+
+        # Test setting to False
+        param_false = Parameter(
+            name="test", input_types=["str"], type="str", output_type="str", tooltip="test", settable=False
+        )
+        assert param_false.settable is False
+
+        # Test property setter
+        param.settable = False
+        assert param.settable is False
+        param.settable = True
+        assert param.settable is True
+
+        # Test serialization includes settable
+        param_dict = param.to_dict()
+        assert "settable" in param_dict
+        assert param_dict["settable"] is True
+
+        param_false_dict = param_false.to_dict()
+        assert "settable" in param_false_dict
+        assert param_false_dict["settable"] is False


### PR DESCRIPTION
Fixes #1966 
Fixes #1979 

Allows user to get, alter, and create parameters with `settable=True` or `False`

If a new (empty) node is connected, propagate None and empty values, too.