### PR TITLE
Update generated workflow executor code for async changes

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -23,9 +23,6 @@ class LocalExecutorError(Exception):
 
 
 class LocalWorkflowExecutor(WorkflowExecutor):
-    def __init__(self) -> None:
-        self.output: dict | None = None
-
     def _load_flow_for_workflow(self) -> str:
         try:
             context_manager = GriptapeNodes.ContextManager()

--- a/src/griptape_nodes/bootstrap/workflow_executors/workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/workflow_executor.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from abc import abstractmethod
 from typing import Any
 
 from griptape_nodes.drivers.storage import StorageBackend
@@ -7,21 +9,23 @@ logger = logging.getLogger(__name__)
 
 
 class WorkflowExecutor:
-    async def run(
+    def __init__(self) -> None:
+        self.output: dict | None = None
+
+    def run(
         self,
         workflow_name: str,
         flow_input: Any,
         storage_backend: StorageBackend = StorageBackend.LOCAL,
         **kwargs: Any,
     ) -> None:
-        msg = "Subclasses must implement the run method"
-        raise NotImplementedError(msg)
+        return asyncio.run(self.arun(workflow_name, flow_input, storage_backend, **kwargs))
 
+    @abstractmethod
     async def arun(
         self,
         workflow_name: str,
         flow_input: Any,
         storage_backend: StorageBackend = StorageBackend.LOCAL,
         **kwargs: Any,
-    ) -> None:
-        await self.run(workflow_name, flow_input, storage_backend, **kwargs)
+    ) -> None: ...

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1515,6 +1515,7 @@ class WorkflowManager:
 
         # === imports ===
         import_recorder.add_import("argparse")
+        import_recorder.add_import("asyncio")
         import_recorder.add_import("json")
         import_recorder.add_from_import(
             "griptape_nodes.bootstrap.workflow_executors.local_workflow_executor", "LocalWorkflowExecutor"
@@ -1522,6 +1523,7 @@ class WorkflowManager:
         import_recorder.add_from_import(
             "griptape_nodes.bootstrap.workflow_executors.workflow_executor", "WorkflowExecutor"
         )
+        import_recorder.add_from_import("griptape_nodes.drivers.storage.storage_backend", "StorageBackend")
 
         # === 1) build the `def execute_workflow(input: dict, storage_backend: str = StorageBackend.LOCAL, workflow_executor: WorkflowExecutor | None = None) -> dict | None:` ===
         #   args
@@ -1554,6 +1556,16 @@ class WorkflowManager:
         # Generate the ensure flow context function call
         ensure_context_call = self._generate_ensure_flow_context_call()
 
+        # Convert string storage_backend to StorageBackend enum
+        storage_backend_convert = ast.Assign(
+            targets=[ast.Name(id="storage_backend_enum", ctx=ast.Store())],
+            value=ast.Call(
+                func=ast.Name(id="StorageBackend", ctx=ast.Load()),
+                args=[ast.Name(id="storage_backend", ctx=ast.Load())],
+                keywords=[],
+            ),
+        )
+
         # Create conditional logic: workflow_executor = workflow_executor or LocalWorkflowExecutor()
         executor_assign = ast.Assign(
             targets=[ast.Name(id="workflow_executor", ctx=ast.Store())],
@@ -1570,18 +1582,20 @@ class WorkflowManager:
             ),
         )
         run_call = ast.Expr(
-            value=ast.Call(
-                func=ast.Attribute(
-                    value=ast.Name(id="workflow_executor", ctx=ast.Load()),
-                    attr="run",
-                    ctx=ast.Load(),
-                ),
-                args=[],
-                keywords=[
-                    ast.keyword(arg="workflow_name", value=ast.Constant(flow_name)),
-                    ast.keyword(arg="flow_input", value=ast.Name(id="input", ctx=ast.Load())),
-                    ast.keyword(arg="storage_backend", value=ast.Name(id="storage_backend", ctx=ast.Load())),
-                ],
+            value=ast.Await(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="workflow_executor", ctx=ast.Load()),
+                        attr="arun",
+                        ctx=ast.Load(),
+                    ),
+                    args=[],
+                    keywords=[
+                        ast.keyword(arg="workflow_name", value=ast.Constant(flow_name)),
+                        ast.keyword(arg="flow_input", value=ast.Name(id="input", ctx=ast.Load())),
+                        ast.keyword(arg="storage_backend", value=ast.Name(id="storage_backend_enum", ctx=ast.Load())),
+                    ],
+                )
             )
         )
         return_stmt = ast.Return(
@@ -1592,15 +1606,53 @@ class WorkflowManager:
             )
         )
 
-        func_def = ast.FunctionDef(
-            name="execute_workflow",
+        # === Generate async aexecute_workflow function ===
+        async_func_def = ast.AsyncFunctionDef(
+            name="aexecute_workflow",
             args=args,
-            body=[ensure_context_call, executor_assign, run_call, return_stmt],
+            body=[ensure_context_call, storage_backend_convert, executor_assign, run_call, return_stmt],
             decorator_list=[],
             returns=return_annotation,
             type_params=[],
         )
-        ast.fix_missing_locations(func_def)
+        ast.fix_missing_locations(async_func_def)
+
+        # === Generate sync execute_workflow function (backward compatibility wrapper) ===
+        sync_func_def = ast.FunctionDef(
+            name="execute_workflow",
+            args=args,
+            body=[
+                ast.Return(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="asyncio", ctx=ast.Load()),
+                            attr="run",
+                            ctx=ast.Load(),
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id="aexecute_workflow", ctx=ast.Load()),
+                                args=[],
+                                keywords=[
+                                    ast.keyword(arg="input", value=ast.Name(id="input", ctx=ast.Load())),
+                                    ast.keyword(
+                                        arg="storage_backend", value=ast.Name(id="storage_backend", ctx=ast.Load())
+                                    ),
+                                    ast.keyword(
+                                        arg="workflow_executor", value=ast.Name(id="workflow_executor", ctx=ast.Load())
+                                    ),
+                                ],
+                            )
+                        ],
+                        keywords=[],
+                    )
+                )
+            ],
+            decorator_list=[],
+            returns=return_annotation,
+            type_params=[],
+        )
+        ast.fix_missing_locations(sync_func_def)
 
         # === 2) build the `if __name__ == "__main__":` block ===
         main_test = ast.Compare(
@@ -1890,7 +1942,7 @@ class WorkflowManager:
         # Generate the ensure flow context function
         ensure_context_func = self._generate_ensure_flow_context_function(import_recorder)
 
-        return [ensure_context_func, func_def, if_node]
+        return [ensure_context_func, sync_func_def, async_func_def, if_node]
 
     def _generate_ensure_flow_context_function(
         self,

--- a/tests/unit/bootstrap/__init__.py
+++ b/tests/unit/bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Bootstrap tests package."""

--- a/tests/unit/bootstrap/workflow_executors/__init__.py
+++ b/tests/unit/bootstrap/workflow_executors/__init__.py
@@ -1,0 +1,1 @@
+"""Workflow executors tests package."""

--- a/tests/unit/bootstrap/workflow_executors/test_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_workflow_executor.py
@@ -1,0 +1,200 @@
+"""Unit tests for WorkflowExecutor class."""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest  # type: ignore[reportMissingImports]
+
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.drivers.storage import StorageBackend
+
+
+class ConcreteWorkflowExecutor(WorkflowExecutor):
+    """Concrete implementation of WorkflowExecutor for testing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.arun_mock = AsyncMock()
+
+    async def arun(
+        self,
+        workflow_name: str,
+        flow_input: Any,
+        storage_backend: StorageBackend = StorageBackend.LOCAL,
+        **kwargs: Any,
+    ) -> None:
+        await self.arun_mock(workflow_name, flow_input, storage_backend, **kwargs)
+
+
+class TestWorkflowExecutor:
+    """Test suite for WorkflowExecutor class."""
+
+    def test_init(self) -> None:
+        """Test WorkflowExecutor initialization."""
+        executor = ConcreteWorkflowExecutor()
+        assert executor.output is None
+
+    def test_init_sets_output_to_none(self) -> None:
+        """Test that initialization sets output to None."""
+        executor = ConcreteWorkflowExecutor()
+        executor.output = {"test": "data"}
+
+        # Create a new executor
+        new_executor = ConcreteWorkflowExecutor()
+        assert new_executor.output is None
+
+    @pytest.mark.asyncio
+    async def test_arun_is_abstract(self) -> None:
+        """Test that arun method is properly defined in concrete implementation."""
+        executor = ConcreteWorkflowExecutor()
+
+        # Test that arun can be called with required parameters
+        await executor.arun("test_workflow", {"input": "data"})
+
+        # Verify the mock was called with correct arguments
+        executor.arun_mock.assert_called_once_with("test_workflow", {"input": "data"}, StorageBackend.LOCAL)
+
+    @pytest.mark.asyncio
+    async def test_arun_with_custom_storage_backend(self) -> None:
+        """Test arun method with custom storage backend."""
+        executor = ConcreteWorkflowExecutor()
+
+        await executor.arun("test_workflow", {"input": "data"}, StorageBackend.GTC)
+
+        executor.arun_mock.assert_called_once_with("test_workflow", {"input": "data"}, StorageBackend.GTC)
+
+    @pytest.mark.asyncio
+    async def test_arun_with_kwargs(self) -> None:
+        """Test arun method with additional keyword arguments."""
+        executor = ConcreteWorkflowExecutor()
+
+        await executor.arun(
+            "test_workflow", {"input": "data"}, StorageBackend.LOCAL, extra_param="test_value", another_param=42
+        )
+
+        executor.arun_mock.assert_called_once_with(
+            "test_workflow", {"input": "data"}, StorageBackend.LOCAL, extra_param="test_value", another_param=42
+        )
+
+    @patch("asyncio.run")
+    def test_run_calls_asyncio_run_with_arun(self, mock_asyncio_run: MagicMock) -> None:
+        """Test that run method calls asyncio.run with arun coroutine."""
+        executor = ConcreteWorkflowExecutor()
+
+        # Call the synchronous run method
+        executor.run("test_workflow", {"input": "data"})
+
+        # Verify asyncio.run was called once
+        mock_asyncio_run.assert_called_once()
+
+        # Get the coroutine that was passed to asyncio.run
+        call_args = mock_asyncio_run.call_args[0]
+        assert len(call_args) == 1
+        coroutine = call_args[0]
+
+        # Verify it's a coroutine
+        assert asyncio.iscoroutine(coroutine)
+
+        # Clean up the coroutine to avoid warnings
+        coroutine.close()
+
+    @patch("asyncio.run")
+    def test_run_with_custom_storage_backend(self, mock_asyncio_run: MagicMock) -> None:
+        """Test run method with custom storage backend."""
+        executor = ConcreteWorkflowExecutor()
+
+        executor.run("test_workflow", {"input": "data"}, StorageBackend.GTC)
+
+        mock_asyncio_run.assert_called_once()
+
+        # Clean up the coroutine
+        call_args = mock_asyncio_run.call_args[0]
+        coroutine = call_args[0]
+        coroutine.close()
+
+    @patch("asyncio.run")
+    def test_run_with_kwargs(self, mock_asyncio_run: MagicMock) -> None:
+        """Test run method with additional keyword arguments."""
+        executor = ConcreteWorkflowExecutor()
+
+        executor.run("test_workflow", {"input": "data"}, StorageBackend.LOCAL, extra_param="test_value")
+
+        mock_asyncio_run.assert_called_once()
+
+        # Clean up the coroutine
+        call_args = mock_asyncio_run.call_args[0]
+        coroutine = call_args[0]
+        coroutine.close()
+
+    def test_run_returns_none(self) -> None:
+        """Test that run method returns None."""
+        executor = ConcreteWorkflowExecutor()
+
+        with patch("asyncio.run") as mock_asyncio_run:
+            mock_asyncio_run.return_value = None
+            result = executor.run("test_workflow", {"input": "data"})
+            assert result is None
+
+    def test_output_property_can_be_set(self) -> None:
+        """Test that output property can be set and retrieved."""
+        executor = ConcreteWorkflowExecutor()
+
+        test_output = {"result": "success", "data": [1, 2, 3]}
+        executor.output = test_output
+
+        assert executor.output == test_output
+
+    def test_output_property_can_be_none(self) -> None:
+        """Test that output property can be set to None."""
+        executor = ConcreteWorkflowExecutor()
+        executor.output = {"some": "data"}
+
+        executor.output = None
+        assert executor.output is None
+
+    def test_abstract_method_enforcement(self) -> None:
+        """Test that WorkflowExecutor cannot be instantiated directly due to abstract method."""
+        # This test verifies that the arun method is properly marked as abstract
+        # We can't instantiate WorkflowExecutor directly, but we can verify the abstract method exists
+        assert hasattr(WorkflowExecutor, "arun")
+        assert getattr(WorkflowExecutor.arun, "__isabstractmethod__", False)
+
+
+class TestWorkflowExecutorIntegration:
+    """Integration tests for WorkflowExecutor functionality."""
+
+    @pytest.mark.asyncio
+    async def test_full_workflow_execution_cycle(self) -> None:
+        """Test a complete workflow execution cycle."""
+        executor = ConcreteWorkflowExecutor()
+
+        # Set up the mock to simulate setting output
+        async def mock_arun(*_args: Any, **_kwargs: Any) -> None:
+            executor.output = {"workflow_result": "completed"}
+
+        executor.arun_mock.side_effect = mock_arun
+
+        # Execute the workflow
+        await executor.arun("integration_test", {"test_input": "value"})
+
+        # Verify the workflow was called and output was set
+        executor.arun_mock.assert_called_once()
+        assert executor.output == {"workflow_result": "completed"}
+
+    def test_synchronous_wrapper_integration(self) -> None:
+        """Test the synchronous run method integration."""
+        executor = ConcreteWorkflowExecutor()
+
+        # Set up the mock to simulate setting output
+        async def mock_arun(*_args: Any, **_kwargs: Any) -> None:
+            executor.output = {"sync_result": "success"}
+
+        executor.arun_mock.side_effect = mock_arun
+
+        # Execute synchronously
+        result = executor.run("sync_test", {"input": "data"})
+
+        # Verify execution completed
+        assert result is None  # run method returns None
+        assert executor.output == {"sync_result": "success"}


### PR DESCRIPTION
* Update generated workflow executor code for async changes

Old executor code:

```python
def execute_workflow(input: dict, storage_backend: str='local', workflow_executor: WorkflowExecutor | None=None) -> dict | None:
    _ensure_workflow_context()
    workflow_executor = workflow_executor or LocalWorkflowExecutor()
    workflow_executor.run(workflow_name='ControlFlow_1', flow_input=input, storage_backend=storage_backend)
    return workflow_executor.output

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('--storage-backend', choices=['local', 'gtc'], default='local', help="Storage backend to use: 'local' for local filesystem or 'gtc' for Griptape Cloud")
    parser.add_argument('--json-input', default=None, help='JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.')
    parser.add_argument('--prompt', default=None, help='New parameter')
    args = parser.parse_args()
    flow_input = {}
    if args.json_input is not None:
        flow_input = json.loads(args.json_input)
    if args.json_input is None:
        if 'Start Flow' not in flow_input:
            flow_input['Start Flow'] = {}
        if args.prompt is not None:
            flow_input['Start Flow']['prompt'] = args.prompt
    workflow_output = execute_workflow(input=flow_input, storage_backend=args.storage_backend)
    print(workflow_output)

```

New executor code:

```python
def execute_workflow(input: dict, storage_backend: str='local', workflow_executor: WorkflowExecutor | None=None) -> dict | None:
    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, workflow_executor=workflow_executor))

async def aexecute_workflow(input: dict, storage_backend: str='local', workflow_executor: WorkflowExecutor | None=None) -> dict | None:
    _ensure_workflow_context()
    storage_backend_enum = StorageBackend(storage_backend)
    workflow_executor = workflow_executor or LocalWorkflowExecutor()
    await workflow_executor.arun(workflow_name='ControlFlow_1', flow_input=input, storage_backend=storage_backend_enum)
    return workflow_executor.output

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('--storage-backend', choices=['local', 'gtc'], default='local', help="Storage backend to use: 'local' for local filesystem or 'gtc' for Griptape Cloud")
    parser.add_argument('--json-input', default=None, help='JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.')
    parser.add_argument('--prompt', default=None, help='New parameter')
    args = parser.parse_args()
    flow_input = {}
    if args.json_input is not None:
        flow_input = json.loads(args.json_input)
    if args.json_input is None:
        if 'Start Flow' not in flow_input:
            flow_input['Start Flow'] = {}
        if args.prompt is not None:
            flow_input['Start Flow']['prompt'] = args.prompt
    workflow_output = execute_workflow(input=flow_input, storage_backend=args.storage_backend)
    print(workflow_output)
```