### PR TITLE
Handle properties in minimum param dict

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -3006,7 +3006,8 @@ class WorkflowManager:
         set_parameter_value_asts.append(with_node_context)
         return set_parameter_value_asts
 
-    def _convert_parameter_to_minimal_dict(self, parameter: Parameter) -> dict[str, Any]:
+    @classmethod
+    def _convert_parameter_to_minimal_dict(cls, parameter: Parameter) -> dict[str, Any]:
         """Converts a parameter to a minimal dictionary for loading up a dynamic, black-box Node."""
         param_dict = parameter.to_dict()
         fields_to_include = [
@@ -3025,9 +3026,12 @@ class WorkflowManager:
             "traits",
             "ui_options",
             "settable",
-            "user_defined",
+            "is_user_defined",
         ]
         minimal_dict = {key: param_dict[key] for key in fields_to_include if key in param_dict}
+        minimal_dict["settable"] = bool(getattr(parameter, "settable", True))
+        minimal_dict["is_user_defined"] = bool(getattr(param_dict, "is_user_defined", True))
+
         return minimal_dict
 
     def _create_workflow_shape_from_nodes(

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1,0 +1,56 @@
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
+
+
+class TestWorkflowManager:
+    """Test WorkflowManager functionality including parameter serialization."""
+
+    def test_convert_parameter_to_minimal_dict_serializes_settable_correctly(self) -> None:
+        """Test that _convert_parameter_to_minimal_dict properly serializes settable as boolean."""
+        # Create a test parameter
+        param = Parameter(
+            name="test_param",
+            tooltip="Test parameter",
+            type="str",
+            default_value="test_value",
+            settable=True,
+            user_defined=False,
+        )
+
+        # Call the method under test
+        result = WorkflowManager._convert_parameter_to_minimal_dict(param)
+
+        # Assert that settable is properly serialized as a boolean
+        assert "settable" in result
+        assert isinstance(result["settable"], bool)
+        assert result["settable"] is True
+
+        # Assert that is_user_defined is properly serialized as a boolean
+        assert "is_user_defined" in result
+        assert isinstance(result["is_user_defined"], bool)
+
+        # Assert that other expected fields are present
+        assert result["name"] == "test_param"
+        assert result["tooltip"] == "Test parameter"
+        assert result["type"] == "str"
+        assert result["default_value"] == "test_value"
+
+    def test_convert_parameter_to_minimal_dict_handles_false_settable(self) -> None:
+        """Test that _convert_parameter_to_minimal_dict handles settable=False correctly."""
+        # Create a test parameter with settable=False
+        param = Parameter(
+            name="readonly_param", tooltip="Read-only parameter", type="int", settable=False, user_defined=True
+        )
+
+        # Call the method under test
+        result = WorkflowManager._convert_parameter_to_minimal_dict(param)
+
+        # Assert that settable is properly serialized as False
+        assert "settable" in result
+        assert isinstance(result["settable"], bool)
+        assert result["settable"] is False
+
+        # Assert that is_user_defined is properly serialized as True
+        assert "is_user_defined" in result
+        assert isinstance(result["is_user_defined"], bool)
+        assert result["is_user_defined"] is True


### PR DESCRIPTION
* Handle properties in minimum param dict
  * There's surely a better way to do this and we should probably figure it out, but this fix works and currently all of publishing is broken because of this issue
  
The issue presents in trying to serialize properties into a workflow file:

```
Traceback (most recent call last):
  File "C:\Users\Administrator\workspace\Griptape\griptape-nodes-library-deadline-cloud\griptape_nodes_library_deadline_cloud\publish\temp_executor_c07e621d42b44fa4a20a13351af22c8e.py", line 190, in <module>
    main()
  File "C:\Users\Administrator\workspace\Griptape\griptape-nodes-library-deadline-cloud\griptape_nodes_library_deadline_cloud\publish\temp_executor_c07e621d42b44fa4a20a13351af22c8e.py", line 48, in main
    "workflow_shape": {'input': {'Start Flow': {'prompt': {'name': 'prompt', 'tooltip': 'New parameter', 'type': 'str', 'input_types': ['str'], 'output_type': 'str', 'default_value': '', 'tooltip_as_input': None, 'tooltip_as_property': None, 'tooltip_as_output': None, 'ui_options': {'is_custom': True, 'is_user_added': True}, 'settable': FieldInfo(annotation=NoneType, required=False, default=True)}}}, 'output': {'End Flow': {'output_image': {'name': 'output_image', 'tooltip': 'New parameter', 'type': 'ImageArtifact', 'input_types': ['ImageArtifact'], 'output_type': 'ImageArtifact', 'default_value': '', 'tooltip_as_input': None, 'tooltip_as_property': None, 'tooltip_as_output': None, 'ui_options': {'is_custom': True, 'is_user_added': True}, 'settable': FieldInfo(annotation=NoneType, required=False, default=True)}}}},
                                                                                                                             
                                                                                                                             
                                                                                         ^^^^^^^^^
NameError: name 'FieldInfo' is not defined
```