### PR TITLE
Don't propagate values to control params as they don't have any.

### DIFF
--- a/src/griptape_nodes/machines/node_resolution.py
+++ b/src/griptape_nodes/machines/node_resolution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
+from griptape_nodes.exe_types.core_types import ParameterType, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.exe_types.type_validator import TypeValidator
 from griptape_nodes.machines.fsm import FSM, State
@@ -219,16 +219,21 @@ class ExecuteNodeState(State):
                     output_value = upstream_node.get_parameter_value(upstream_parameter.name)
 
                 # Pass the value through using the same mechanism as normal resolution
-                GriptapeNodes.get_instance().handle_request(
-                    SetParameterValueRequest(
-                        parameter_name=parameter.name,
-                        node_name=current_node.name,
-                        value=output_value,
-                        data_type=upstream_parameter.output_type,
-                        incoming_connection_source_node_name=upstream_node.name,
-                        incoming_connection_source_parameter_name=upstream_parameter.name,
+                # Skip propagation for Control Parameters as they should not receive values
+                if (
+                    ParameterType.attempt_get_builtin(upstream_parameter.output_type)
+                    != ParameterTypeBuiltin.CONTROL_TYPE
+                ):
+                    GriptapeNodes.get_instance().handle_request(
+                        SetParameterValueRequest(
+                            parameter_name=parameter.name,
+                            node_name=current_node.name,
+                            value=output_value,
+                            data_type=upstream_parameter.output_type,
+                            incoming_connection_source_node_name=upstream_node.name,
+                            incoming_connection_source_parameter_name=upstream_parameter.name,
+                        )
                     )
-                )
 
     @staticmethod
     async def on_enter(context: ResolutionContext) -> type[State] | None:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -9,6 +9,7 @@ from griptape_nodes.exe_types.core_types import (
     Parameter,
     ParameterContainer,
     ParameterMode,
+    ParameterType,
     ParameterTypeBuiltin,
 )
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -852,7 +853,11 @@ class FlowManager:
             if isinstance(target_param, ParameterContainer):
                 target_node.kill_parameter_children(target_param)
         # Set the parameter value (including None/empty values) unless we're in initial setup
-        if request.initial_setup is False:
+        # Skip propagation for Control Parameters as they should not receive values
+        if (
+            request.initial_setup is False
+            and ParameterType.attempt_get_builtin(source_param.output_type) != ParameterTypeBuiltin.CONTROL_TYPE
+        ):
             # When creating a connection, pass the initial value from source to target parameter
             # Set incoming_connection_source fields to identify this as legitimate connection value passing
             # (not manual property setting) so it bypasses the INPUT+PROPERTY connection blocking logic

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -10,6 +10,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterContainer,
     ParameterGroup,
     ParameterMode,
+    ParameterType,
     ParameterTypeBuiltin,
 )
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -1638,16 +1639,18 @@ class NodeManager:
             # (not manual property setting) so it bypasses the INPUT+PROPERTY connection blocking logic
             conn_output_nodes = parent_flow.get_connected_output_parameters(node, parameter)
             for target_node, target_parameter in conn_output_nodes:
-                GriptapeNodes.handle_request(
-                    SetParameterValueRequest(
-                        parameter_name=target_parameter.name,
-                        node_name=target_node.name,
-                        value=finalized_value,
-                        data_type=object_type,  # Do type instead of output type, because it hasn't been processed.
-                        incoming_connection_source_node_name=node.name,
-                        incoming_connection_source_parameter_name=parameter.name,
+                # Skip propagation for Control Parameters as they should not receive values
+                if ParameterType.attempt_get_builtin(parameter.output_type) != ParameterTypeBuiltin.CONTROL_TYPE:
+                    GriptapeNodes.handle_request(
+                        SetParameterValueRequest(
+                            parameter_name=target_parameter.name,
+                            node_name=target_node.name,
+                            value=finalized_value,
+                            data_type=object_type,  # Do type instead of output type, because it hasn't been processed.
+                            incoming_connection_source_node_name=node.name,
+                            incoming_connection_source_parameter_name=parameter.name,
+                        )
                     )
-                )
 
         # Cool.
         details = f"Successfully set value on Node '{node_name}' Parameter '{request.parameter_name}'."


### PR DESCRIPTION
ControlParameters have settable=False on them and shouldn't be subject to propagation. Fixes an issue where connections would propagate and throw a SetValue error.