### PR TITLE
feat: add import workflow request

### DIFF
--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -69,6 +69,11 @@ class WorkflowRegistry(metaclass=SingletonMeta):
     def get_complete_file_path(cls, relative_file_path: str) -> str:
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+        # If the path is already absolute, return it as-is
+        if Path(relative_file_path).is_absolute():
+            return relative_file_path
+
+        # Otherwise, resolve it relative to the workspace
         config_mgr = GriptapeNodes.ConfigManager()
         workspace_path = config_mgr.workspace_path
         complete_file_path = workspace_path / relative_file_path

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -140,6 +140,41 @@ class RegisterWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailur
 
 @dataclass
 @PayloadRegistry.register
+class ImportWorkflowRequest(RequestPayload):
+    """Import and register a workflow from a file.
+
+    Use when: Importing workflows from external sources, batch workflow imports,
+    command-line workflow registration, loading workflows from shared locations.
+
+    Args:
+        file_path: Path to the workflow file to import and register
+
+    Results: ImportWorkflowResultSuccess (with workflow name) | ImportWorkflowResultFailure (import error)
+    """
+
+    file_path: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ImportWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Workflow imported and registered successfully.
+
+    Args:
+        workflow_name: Name of the imported workflow
+    """
+
+    workflow_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ImportWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Workflow import failed. Common causes: file not found, invalid workflow format, metadata extraction error, registration error."""
+
+
+@dataclass
+@PayloadRegistry.register
 class ListAllWorkflowsRequest(RequestPayload):
     """List all workflows in the registry.
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -58,6 +58,9 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultFailure,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
+    ImportWorkflowRequest,
+    ImportWorkflowResultFailure,
+    ImportWorkflowResultSuccess,
     ListAllWorkflowsRequest,
     ListAllWorkflowsResultFailure,
     ListAllWorkflowsResultSuccess,
@@ -271,6 +274,10 @@ class WorkflowManager:
         event_manager.assign_manager_to_request_type(
             ImportWorkflowAsReferencedSubFlowRequest,
             self.on_import_workflow_as_referenced_sub_flow_request,
+        )
+        event_manager.assign_manager_to_request_type(
+            ImportWorkflowRequest,
+            self.on_import_workflow_request,
         )
         event_manager.assign_manager_to_request_type(
             BranchWorkflowRequest,
@@ -621,6 +628,36 @@ class WorkflowManager:
             logger.error(details)
             return RegisterWorkflowResultFailure(result_details=details)
         return RegisterWorkflowResultSuccess(workflow_name=workflow.metadata.name)
+
+    def on_import_workflow_request(self, request: ImportWorkflowRequest) -> ResultPayload:
+        # First, attempt to load metadata from the file
+        load_metadata_request = LoadWorkflowMetadata(file_name=request.file_path)
+        load_metadata_result = self.on_load_workflow_metadata_request(load_metadata_request)
+
+        if not isinstance(load_metadata_result, LoadWorkflowMetadataResultSuccess):
+            details = f"Failed to extract metadata from workflow file '{request.file_path}'"
+            logger.error(details)
+            return ImportWorkflowResultFailure(result_details=details)
+
+        # Now register the workflow with the extracted metadata
+        register_request = RegisterWorkflowRequest(metadata=load_metadata_result.metadata, file_name=request.file_path)
+        register_result = self.on_register_workflow_request(register_request)
+
+        if not isinstance(register_result, RegisterWorkflowResultSuccess):
+            details = f"Unexpected result when registering workflow from file '{request.file_path}'"
+            logger.error(details)
+            return ImportWorkflowResultFailure(result_details=details)
+
+        # Add the workflow to the user configuration
+        try:
+            full_path = WorkflowRegistry.get_complete_file_path(request.file_path)
+            GriptapeNodes.ConfigManager().save_user_workflow_json(full_path)
+        except Exception as e:
+            details = f"Failed to add workflow '{register_result.workflow_name}' to user configuration: {e}"
+
+            return ImportWorkflowResultFailure(result_details=details)
+
+        return ImportWorkflowResultSuccess(workflow_name=register_result.workflow_name)
 
     def on_list_all_workflows_request(self, _request: ListAllWorkflowsRequest) -> ResultPayload:
         try:
@@ -1359,10 +1396,20 @@ class WorkflowManager:
                     file_name = new_file_name
 
         # Get file name stuff prepped.
-        if not file_name:
-            file_name = datetime.now(tz=UTC).strftime("%d.%m_%H.%M")
-        relative_file_path = f"{file_name}.py"
-        file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_file_path)
+        # Use the existing registered file path if this is an existing workflow (not a template)
+        if prior_workflow and not prior_workflow.metadata.is_template:
+            # Use the existing registered file path
+            relative_file_path = prior_workflow.file_path
+            file_path = Path(WorkflowRegistry.get_complete_file_path(relative_file_path))
+            # Extract file name from the path for metadata generation
+            if not file_name:
+                file_name = prior_workflow.metadata.name
+        else:
+            # Create new path in workspace for new workflows or templates
+            if not file_name:
+                file_name = datetime.now(tz=UTC).strftime("%d.%m_%H.%M")
+            relative_file_path = f"{file_name}.py"
+            file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_file_path)
 
         # Generate the workflow file contents
         try:
@@ -1385,20 +1432,17 @@ class WorkflowManager:
             logger.error(details)
             return SaveWorkflowResultFailure(result_details=details)
 
-        relative_serialized_file_path = f"{file_name}.py"
-        serialized_file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_serialized_file_path)
-
         # Check disk space before writing
         config_manager = GriptapeNodes.ConfigManager()
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_workflows")
-        if not OSManager.check_available_disk_space(serialized_file_path.parent, min_space_gb):
-            error_msg = OSManager.format_disk_space_error(serialized_file_path.parent)
+        if not OSManager.check_available_disk_space(file_path.parent, min_space_gb):
+            error_msg = OSManager.format_disk_space_error(file_path.parent)
             details = f"Attempted to save workflow '{file_name}' (requires {min_space_gb:.1f} GB). Failed: {error_msg}"
             logger.error(details)
             return SaveWorkflowResultFailure(result_details=details)
 
         try:
-            with serialized_file_path.open("w", encoding="utf-8") as file:
+            with file_path.open("w", encoding="utf-8") as file:
                 file.write(final_code_output)
         except OSError as e:
             details = f"Attempted to save workflow '{file_name}'. Failed when writing file: {e}"
@@ -1408,19 +1452,21 @@ class WorkflowManager:
         # save the created workflow as an entry in the JSON config file.
         registered_workflows = WorkflowRegistry.list_workflows()
         if file_name not in registered_workflows:
-            try:
-                GriptapeNodes.ConfigManager().save_user_workflow_json(str(file_path))
-            except OSError as e:
-                details = f"Attempted to save workflow '{file_name}'. Failed when saving configuration: {e}"
-                logger.error(details)
-                return SaveWorkflowResultFailure(result_details=details)
+            # Only add to config if it's in the workspace directory (not an external file)
+            if not Path(relative_file_path).is_absolute():
+                try:
+                    GriptapeNodes.ConfigManager().save_user_workflow_json(str(file_path))
+                except OSError as e:
+                    details = f"Attempted to save workflow '{file_name}'. Failed when saving configuration: {e}"
+                    logger.error(details)
+                    return SaveWorkflowResultFailure(result_details=details)
             WorkflowRegistry.generate_new_workflow(metadata=workflow_metadata, file_path=relative_file_path)
         # Update existing workflow's metadata in the registry
         existing_workflow = WorkflowRegistry.get_workflow_by_name(file_name)
         existing_workflow.metadata = workflow_metadata
-        details = f"Successfully saved workflow to: {serialized_file_path}"
+        details = f"Successfully saved workflow to: {file_path}"
         logger.info(details)
-        return SaveWorkflowResultSuccess(file_path=str(serialized_file_path))
+        return SaveWorkflowResultSuccess(file_path=str(file_path))
 
     def _generate_workflow_metadata(  # noqa: PLR0913
         self,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,12 @@
+"""Shared fixtures for unit tests."""
+
+import pytest
+
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+@pytest.fixture
+def griptape_nodes() -> GriptapeNodes:
+    """Provide a properly initialized GriptapeNodes instance for testing."""
+    # Initialize GriptapeNodes (it's a singleton, so this returns the existing instance)
+    return GriptapeNodes()

--- a/tests/unit/node_library/__init__.py
+++ b/tests/unit/node_library/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for node_library module."""

--- a/tests/unit/node_library/test_workflow_registry.py
+++ b/tests/unit/node_library/test_workflow_registry.py
@@ -1,0 +1,112 @@
+"""Tests for WorkflowRegistry functionality."""
+
+import os
+import platform
+from pathlib import Path
+
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class TestWorkflowRegistry:
+    """Test suite for WorkflowRegistry functionality."""
+
+    def test_get_complete_file_path_with_absolute_path(self) -> None:
+        """Test that get_complete_file_path returns absolute paths as-is."""
+        # Use a platform-appropriate absolute path
+        if os.name == "nt":  # Windows
+            absolute_path = "C:\\absolute\\path\\to\\workflow.py"
+        else:  # Unix-like
+            absolute_path = "/absolute/path/to/workflow.py"
+
+        result = WorkflowRegistry.get_complete_file_path(absolute_path)
+
+        # On Windows, paths starting with / are not considered absolute
+        # so they get treated as relative paths
+        if os.name == "nt" and absolute_path.startswith("/"):
+            # On Windows, Unix-style paths are relative
+            assert Path(result).is_absolute()
+        else:
+            assert result == absolute_path
+
+    def test_get_complete_file_path_with_unix_style_on_windows(self) -> None:
+        """Test Unix-style paths on Windows (treated as relative)."""
+        unix_style_path = "/absolute/path/to/workflow.py"
+        result = WorkflowRegistry.get_complete_file_path(unix_style_path)
+
+        if os.name == "nt":  # Windows
+            # Unix-style paths are treated as relative on Windows
+            # The result should be the workspace path + the Unix path
+            assert result.endswith("\\absolute\\path\\to\\workflow.py")
+            # Verify it's been made absolute
+            assert Path(result).is_absolute()
+        else:
+            # On Unix, this is an absolute path
+            assert result == unix_style_path
+
+    def test_get_complete_file_path_with_absolute_windows_path(self) -> None:
+        """Test that get_complete_file_path handles Windows absolute paths."""
+        windows_path = "C:\\Users\\test\\workflow.py"
+
+        result = WorkflowRegistry.get_complete_file_path(windows_path)
+
+        # On Windows, it should be returned as-is
+        # On Unix systems, Path.is_absolute() returns False for Windows paths,
+        # so it will be treated as relative
+        if platform.system() == "Windows":
+            assert result == windows_path
+        else:
+            # On Unix, Windows paths are treated as relative
+            assert result.endswith("C:\\Users\\test\\workflow.py")
+
+    def test_get_complete_file_path_with_relative_path(self, griptape_nodes: GriptapeNodes) -> None:
+        """Test that get_complete_file_path resolves relative paths to workspace."""
+        relative_path = "workflows/my_workflow.py"
+
+        # Get the actual workspace path from the config manager
+        workspace_path = griptape_nodes.ConfigManager().workspace_path
+
+        result = WorkflowRegistry.get_complete_file_path(relative_path)
+
+        expected = str(workspace_path / relative_path)
+        assert result == expected
+
+    def test_get_complete_file_path_with_home_expansion(self) -> None:
+        """Test that get_complete_file_path handles paths with home directory expansion."""
+        home_path = "~/workflows/my_workflow.py"
+
+        # Home paths starting with ~ are NOT considered absolute by Path.is_absolute()
+        # so they will be treated as relative paths
+        result = WorkflowRegistry.get_complete_file_path(home_path)
+
+        # Should be treated as relative and appended to workspace
+        if os.name == "nt":  # Windows
+            # On Windows, ~ is just a regular character in the path
+            assert result.endswith("~\\workflows\\my_workflow.py")
+        else:
+            # On Unix, ~ is also treated as relative (not expanded)
+            assert result.endswith("~/workflows/my_workflow.py")
+
+    def test_get_complete_file_path_with_current_dir_relative(self, griptape_nodes: GriptapeNodes) -> None:
+        """Test that get_complete_file_path handles current directory relative paths."""
+        current_dir_path = "./my_workflow.py"
+
+        # Get the actual workspace path from the config manager
+        workspace_path = griptape_nodes.ConfigManager().workspace_path
+
+        result = WorkflowRegistry.get_complete_file_path(current_dir_path)
+
+        expected = str(workspace_path / current_dir_path)
+        assert result == expected
+
+    def test_get_complete_file_path_with_parent_dir_relative(self, griptape_nodes: GriptapeNodes) -> None:
+        """Test that get_complete_file_path handles parent directory relative paths."""
+        parent_dir_path = "../external/my_workflow.py"
+
+        # Get the actual workspace path from the config manager
+        workspace_path = griptape_nodes.ConfigManager().workspace_path
+
+        result = WorkflowRegistry.get_complete_file_path(parent_dir_path)
+
+        expected = str(workspace_path / parent_dir_path)
+        assert result == expected


### PR DESCRIPTION
Importing a workflow will register the workflow wherever it currently lives on disk. This is useful if you want to editor workflows that may live outside the workspace.

This PR also changed save workflow request to not blindly save workflows into the workspace and instead respect their current location.