### PR TITLE
update: replace gltf nodes with three_d 

### DIFF
--- a/docs/nodes/three_d/load_gltf.md
+++ b/docs/nodes/three_d/load_gltf.md
@@ -1,8 +1,8 @@
-# LoadGLTF
+# Load3D
 
 ## What is it?
 
-The LoadGLTF is a building block that lets you bring a GLTF file into your workflow. It allows you to load 3D models from various sources to be used and displayed within your project.
+The Load3D is a building block that lets you bring a GLTF file into your workflow. It allows you to load 3D models from various sources to be used and displayed within your project.
 
 ## When would I use it?
 
@@ -17,7 +17,7 @@ Use this node when you want to:
 
 ### Basic Setup
 
-1. Add the LoadGLTF node to your workflow
+1. Add the Load3D node to your workflow
 1. Connect it to a source of GLTF data (file browser, URL, or another node output)
 
 ### Parameters

--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -1694,6 +1694,15 @@
       }
     },
     {
+      "class_name": "LoadThreeD",
+      "file_path": "griptape_nodes_library/three_d/load_three_d.py",
+      "metadata": {
+        "category": "3D",
+        "description": "Loads a 3D file into your workflow",
+        "display_name": "Load 3D"
+      }
+    },
+    {
       "class_name": "ForLoopStartNode",
       "file_path": "griptape_nodes_library/execution/for_loop_start.py",
       "metadata": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library/three_d/load_three_d.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/three_d/load_three_d.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+from griptape.artifacts import ImageUrlArtifact
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes_library.utils.three_d_utils import dict_to_three_d_url_artifact
+
+
+class LoadThreeD(DataNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        # Need to define the category
+        self.category = "3D"
+        self.description = "Load a 3D file"
+        three_d_parameter = Parameter(
+            name="3d",
+            input_types=["ThreeDArtifact", "ThreeDUrlArtifact"],
+            type="ThreeDUrlArtifact",
+            output_type="ThreeDUrlArtifact",
+            default_value=None,
+            ui_options={"clickable_file_browser": True, "expander": True},
+            tooltip="The 3D file that has been loaded.",
+        )
+        self.add_parameter(three_d_parameter)
+
+        self.add_node_element(
+            ParameterMessage(
+                variant="none",
+                name="help_message",
+                value='To output an image of the model, click "Save Snapshot".',
+                ui_options={"text_align": "text-center"},
+            )
+        )
+        image_parameter = Parameter(
+            name="image",
+            type="ImageUrlArtifact",
+            default_value=None,
+            tooltip="The image of the 3D file.",
+            allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+        )
+        self.add_parameter(image_parameter)
+
+    def after_value_set(
+        self,
+        parameter: Parameter,
+        value: Any,
+    ) -> None:
+        if parameter.name == "3d":
+            image_url = value.get("metadata", {}).get("imageUrl")
+            if image_url:
+                image_artifact = ImageUrlArtifact(value=image_url)
+                self.set_parameter_value("image", image_artifact)
+                self.parameter_output_values["image"] = image_artifact
+                self.hide_message_by_name("help_message")
+            else:
+                self.show_message_by_name("help_message")
+
+        return super().after_value_set(parameter, value)
+
+    def process(self) -> None:
+        three_d = self.get_parameter_value("3d")
+        image = self.get_parameter_value("image")
+
+        if isinstance(three_d, dict):
+            three_d_artifact = dict_to_three_d_url_artifact(three_d)
+        else:
+            three_d_artifact = three_d
+
+        self.parameter_output_values["image"] = image
+        self.parameter_output_values["3d"] = three_d_artifact

--- a/libraries/griptape_nodes_library/griptape_nodes_library/three_d/three_d_artifact.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/three_d/three_d_artifact.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from griptape.artifacts import BaseArtifact
+from griptape.artifacts.url_artifact import UrlArtifact
+
+
+class ThreeDArtifact(BaseArtifact):
+    """A ThreeD file artifact."""
+
+    def __init__(self, value: bytes, meta: dict[str, Any] | None = None) -> None:
+        super().__init__(value=value, meta=meta or {})
+
+    def to_text(self) -> str:
+        """Convert the ThreeD file to text representation."""
+        return f"ThreeD file with {len(self.value)} bytes"
+
+
+class ThreeDUrlArtifact(UrlArtifact):
+    """A ThreeD file URL artifact."""
+
+    def __init__(self, value: str, meta: dict[str, Any] | None = None) -> None:
+        super().__init__(value=value, meta=meta or {})
+
+    def to_text(self) -> str:
+        """Convert the ThreeD URL to text representation."""
+        return f"ThreeD file URL: {self.value}"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/three_d_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/three_d_utils.py
@@ -1,0 +1,34 @@
+import base64
+import uuid
+
+from griptape_nodes_library.three_d.three_d_artifact import ThreeDUrlArtifact
+
+
+def dict_to_three_d_url_artifact(three_d_dict: dict, three_d_format: str | None = None) -> ThreeDUrlArtifact:
+    """Convert a dictionary representation of a 3D file to a ThreeDArtifact."""
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+    # Get the base64 encoded string
+    value = three_d_dict["value"]
+    if three_d_dict["type"] == "ThreeDUrlArtifact":
+        return ThreeDUrlArtifact(value)
+
+    # If the base64 string has a prefix like "data:model/gltf-binary;base64,", remove it
+    if "base64," in value:
+        value = value.split("base64,")[1]
+
+    # Decode the base64 string to bytes
+    three_d_bytes = base64.b64decode(value)
+
+    # Determine the format from the MIME type if not specified
+    if three_d_format is None:
+        if "type" in three_d_dict:
+            # Extract format from MIME type (e.g., 'model/gltf-binary' -> 'glb')
+            mime_format = three_d_dict["type"].split("/")[1] if "/" in three_d_dict["type"] else None
+            three_d_format = mime_format
+        else:
+            three_d_format = "glb"
+
+    url = GriptapeNodes.StaticFilesManager().save_static_file(three_d_bytes, f"{uuid.uuid4()}.{three_d_format}")
+
+    return ThreeDUrlArtifact(url)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,5 +208,5 @@ nav:
         - Start Flow: nodes/execution/start_flow.md
         - End Flow: nodes/execution/end_flow.md
     - 3D:
-        - Load GLTF: nodes/three_d/load_gltf.md
+        - Load 3D: nodes/three_d/load_gltf.md
   - Glossary: glossary.md


### PR DESCRIPTION
fixes: https://github.com/griptape-ai/griptape-nodes/issues/1710

Adding a three_d node instead of gltf node, but keeping the older gltf nodes around for backwards compatibility.

requires: https://github.com/griptape-ai/griptape-vsl-gui/pull/1241

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--2012.org.readthedocs.build/en/2012/

<!-- readthedocs-preview griptape-nodes end -->