### PR TITLE
chore: bump v0.52.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.51.0"
+version = "0.52.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.51.0"
+version = "0.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "binaryornot" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.52`.

Cherry-picked commit: da4b23e6564435ad75be57f116bf404b4dc08892