### PR TITLE
refactor: run websocket connection on separate thread from engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.52.0"
+version = "0.52.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/src/griptape_nodes/app/api.py
+++ b/src/griptape_nodes/app/api.py
@@ -168,7 +168,7 @@ def _setup_app(static_directory: Path) -> None:
     )
 
 
-def start_api(static_directory: Path) -> None:
+def start_static_server(static_directory: Path) -> None:
     """Run uvicorn server synchronously using uvicorn.run."""
     # Setup the FastAPI app
     _setup_app(static_directory)

--- a/src/griptape_nodes/app/api.py
+++ b/src/griptape_nodes/app/api.py
@@ -141,17 +141,6 @@ async def _delete_static_file(file_path: str, static_directory: Annotated[Path, 
         return {"message": f"File {file_path} deleted successfully"}
 
 
-@app.post("/engines/request")
-async def _create_event(request: Request) -> None:
-    """Create event using centralized event utilities."""
-    from .app import _process_api_event
-
-    body = await request.json()
-
-    # Use centralized event processing
-    await _process_api_event(body)
-
-
 def _setup_app(static_directory: Path) -> None:
     """Setup FastAPI app with middleware and static files."""
     global static_dir  # noqa: PLW0603

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -18,7 +18,8 @@ from rich.panel import Panel
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
-from griptape_nodes.mcp_server.server import main_sync
+from griptape_nodes.app.api import start_static_server
+from griptape_nodes.mcp_server.server import start_mcp_server
 from griptape_nodes.retained_mode.events import app_events, execution_events
 
 # This import is necessary to register all events, even if not technically used
@@ -36,8 +37,6 @@ from griptape_nodes.retained_mode.events.base_events import (
 )
 from griptape_nodes.retained_mode.events.logger_events import LogHandlerEvent
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-from .api import start_api
 
 
 # WebSocket thread communication message types
@@ -138,12 +137,12 @@ async def astart_app() -> None:
 
     try:
         # Start MCP server in daemon thread
-        threading.Thread(target=main_sync, args=(api_key,), daemon=True, name="mcp-server").start()
+        threading.Thread(target=start_mcp_server, args=(api_key,), daemon=True, name="mcp-server").start()
 
         # Start static server in daemon thread if enabled
         if STATIC_SERVER_ENABLED:
             static_dir = _build_static_dir()
-            threading.Thread(target=start_api, args=(static_dir,), daemon=True, name="static-server").start()
+            threading.Thread(target=start_static_server, args=(static_dir,), daemon=True, name="static-server").start()
 
         # Start WebSocket tasks in daemon thread
         threading.Thread(

--- a/src/griptape_nodes/mcp_server/server.py
+++ b/src/griptape_nodes/mcp_server/server.py
@@ -69,7 +69,7 @@ mcp_server_logger.addHandler(RichHandler(show_time=True, show_path=False, markup
 mcp_server_logger.setLevel(logging.INFO)
 
 
-def main_sync(api_key: str) -> None:
+def start_mcp_server(api_key: str) -> None:
     """Synchronous version of main entry point for the Griptape Nodes MCP server."""
     mcp_server_logger.debug("Starting MCP GTN server...")
     # Give these a session ID

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from dotenv import load_dotenv
 
 # Signal the server to shutdown gracefully using the API module function
-from griptape_nodes.app.api import start_api
+from griptape_nodes.app.api import start_static_server
 from griptape_nodes.app.app import _build_static_dir
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
@@ -93,7 +93,7 @@ async def api_server() -> AsyncGenerator[None, None]:
 
     static_dir = _build_static_dir()
 
-    server_thread = threading.Thread(target=lambda: start_api(static_dir), daemon=True)
+    server_thread = threading.Thread(target=lambda: start_static_server(static_dir), daemon=True)
     server_thread.start()
 
     yield

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.52.0"
+version = "0.52.1"
 source = { editable = "." }
 dependencies = [
     { name = "binaryornot" },


### PR DESCRIPTION
This PR decouples the websocket connection from the engine to avoid any low-level connection issues while the engine is working. I'm hoping this will resolve errors like this:

```
ERROR:griptape_nodes_app:Error sending event to Nodes API: received 1011 (internal error) keepalive ping timeout; then sent 1011 (internal error) keepalive ping timeout
```

This is accomplished by spinning up the websocket connection in a daemon thread, and communicating with the engine via `EventManager`'s threadsafe operations.

The engine can send messages back to the websocket by putting messages into an outbound message queue using the threadsafe `loop.call_soon_threadsafe`.