### PR TITLE
Fix output value save

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2498,7 +2498,7 @@ class NodeManager:
         """
         output_value = None
         internal_value = None
-        if parameter.name in node.parameter_output_values and node.state == NodeResolutionState.RESOLVED:
+        if parameter.name in node.parameter_output_values:
             # Output values are more important.
             output_value = node.parameter_output_values[parameter.name]
         if parameter.name in node.parameter_values:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2048,11 +2048,10 @@ class NodeManager:
                     node=node,
                     unique_parameter_uuid_to_values=request.unique_parameter_uuid_to_values,
                     serialized_parameter_value_tracker=request.serialized_parameter_value_tracker,
+                    create_node_request=create_node_request,
                 )
                 if set_param_value_requests is not None:
                     set_value_commands.extend(set_param_value_requests)
-                else:
-                    create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
         # now check if locked
         if node.lock:
             lock_command = SetLockNodeStateRequest(node_name=None, lock=True)
@@ -2470,6 +2469,7 @@ class NodeManager:
         node: BaseNode,
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
         serialized_parameter_value_tracker: SerializedParameterValueTracker,
+        create_node_request: CreateNodeRequest,
     ) -> list[SerializedNodeCommands.IndirectSetParameterValueCommand] | None:
         """Generates code to save a parameter value for a node in a Griptape workflow.
 
@@ -2486,6 +2486,7 @@ class NodeManager:
             node (BaseNode): The node object that contains the parameter
             unique_parameter_uuid_to_values (dict[SerializedNodeCommands.UniqueParameterValueUUID, Any]): Dictionary mapping unique value UUIDs to values
             serialized_parameter_value_tracker (SerializedParameterValueTracker): Object mapping maintaining value hashes to unique value UUIDs, and non-serializable values
+            create_node_request (CreateNodeRequest): The node creation request that will be modified if serialization fails
 
         Returns:
             None (if no value to be serialized) or an IndirectSetParameterValueCommand linking the value to the unique value map
@@ -2520,6 +2521,8 @@ class NodeManager:
             if internal_command is None:
                 details = f"Attempted to serialize set value for parameter '{parameter.name}' on node '{node.name}'. The set value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
                 logger.warning(details)
+                # Set node to unresolved when serialization fails
+                create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
             else:
                 commands.append(internal_command)
         if output_value is not None:
@@ -2535,6 +2538,8 @@ class NodeManager:
             if output_command is None:
                 details = f"Attempted to serialize output value for parameter '{parameter.name}' on node '{node.name}'. The output value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
                 logger.warning(details)
+                # Set node to unresolved when serialization fails
+                create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
             else:
                 commands.append(output_command)
         return commands if commands else None


### PR DESCRIPTION
closes #1945 

Saves output values even when unresolved, and prevents unessecary unresolving when a node doesn't have a parameter value set. 