### PR TITLE
fix: save_video validate before node run

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/save_video.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/save_video.py
@@ -109,7 +109,7 @@ class SaveVideo(ControlNode):
 
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
-    def validate_before_workflow_run(self) -> list[Exception] | None:
+    def validate_before_node_run(self) -> list[Exception] | None:
         exceptions = []
 
         # Validate that we have a video.


### PR DESCRIPTION
`save_video` was validating before workflow run, but should be validated before _node_ run instead.
fixes: #2092 