### PR TITLE
Removes errant error toasts on Save Image. Allows flows to continue if a failure control path exists instead of canceling the flow.

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
@@ -85,6 +85,7 @@ class SaveImage(ControlNode):
                 tooltip="Indicates whether it completed without errors.",
                 type="bool",
                 default_value=False,
+                settable=False,
                 allowed_modes={ParameterMode.OUTPUT},
             )
 
@@ -94,7 +95,7 @@ class SaveImage(ControlNode):
                 tooltip="Details about the image save operation result",
                 type="str",
                 default_value="",
-                allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+                allowed_modes={ParameterMode.OUTPUT},
                 settable=False,
                 ui_options={"multiline": True},
             )
@@ -105,7 +106,7 @@ class SaveImage(ControlNode):
         # Reset execution state and result details at the start of each run
         self._execution_succeeded = None
         self._assign_result_details("")
-        self.set_parameter_value(self.was_successful.name, False)
+        self.parameter_output_values[self.was_successful.name] = False
 
         image = self.get_parameter_value("image")
         output_file = self.get_parameter_value("output_path") or DEFAULT_FILENAME
@@ -230,7 +231,7 @@ class SaveImage(ControlNode):
         match status:
             case SaveImageStatus.FAILURE:
                 self._execution_succeeded = False
-                self.set_parameter_value(self.was_successful.name, False)
+                self.parameter_output_values[self.was_successful.name] = False
 
                 # Get detailed input info for failures (including dictionary preview)
                 detailed_input_info = self._get_input_info_for_failure(self.get_parameter_value("image"))
@@ -247,7 +248,7 @@ class SaveImage(ControlNode):
 
             case SaveImageStatus.WARNING:
                 self._execution_succeeded = True
-                self.set_parameter_value(self.was_successful.name, True)
+                self.parameter_output_values[self.was_successful.name] = True
 
                 result_details = (
                     f"No image to save (warning)\n"
@@ -260,7 +261,7 @@ class SaveImage(ControlNode):
 
             case SaveImageStatus.SUCCESS:
                 self._execution_succeeded = True
-                self.set_parameter_value(self.was_successful.name, True)
+                self.parameter_output_values[self.was_successful.name] = True
 
                 result_details = (
                     f"Image saved successfully\n"

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
@@ -92,10 +92,13 @@ class SaveImage(ControlNode):
                 name="result_details",
                 tooltip="Details about the image save operation result",
                 type="str",
-                default_value="The output of the operation will be presented here.",
+                default_value=None,
                 allowed_modes={ParameterMode.OUTPUT},
                 settable=False,
-                ui_options={"multiline": True},
+                ui_options={
+                    "multiline": True,
+                    "placeholder_text": "Details on the save attempt will be presented here.",
+                },
             )
 
         self.add_node_element(group)

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/save_image.py
@@ -12,7 +12,6 @@ from griptape_nodes.exe_types.core_types import (
 )
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
-from griptape_nodes.traits.button import Button
 from griptape_nodes_library.utils.image_utils import dict_to_image_url_artifact, load_image_from_url_artifact
 
 DEFAULT_FILENAME = "griptape_nodes.png"
@@ -68,7 +67,6 @@ class SaveImage(ControlNode):
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
                 default_value=DEFAULT_FILENAME,
                 tooltip="The output filename with extension (.png, .jpg, etc.)",
-                traits={Button(label="save")},
             )
         )
 
@@ -94,7 +92,7 @@ class SaveImage(ControlNode):
                 name="result_details",
                 tooltip="Details about the image save operation result",
                 type="str",
-                default_value="",
+                default_value="The output of the operation will be presented here.",
                 allowed_modes={ParameterMode.OUTPUT},
                 settable=False,
                 ui_options={"multiline": True},
@@ -102,7 +100,7 @@ class SaveImage(ControlNode):
 
         self.add_node_element(group)
 
-    def process(self) -> None:
+    def process(self) -> None:  # noqa: C901, PLR0912, PLR0915
         # Reset execution state and result details at the start of each run
         self._execution_succeeded = None
         self._assign_result_details("")
@@ -137,51 +135,71 @@ class SaveImage(ControlNode):
                 processed_image = load_image_from_url_artifact(image)
             except Exception as e:
                 error_details = f"Failed to load image from URL: {e!s}"
-                self._handle_execution_result(
-                    status=SaveImageStatus.FAILURE,
-                    saved_path="",
-                    input_info=input_info,
-                    output_file=output_file,
-                    details=error_details,
-                    exception=e,
-                )
-                raise ValueError(error_details) from e
-
-        # Convert to appropriate artifact type
-        try:
-            image_artifact = to_image_artifact(processed_image)
-        except Exception as e:
-            error_details = f"Failed to convert image to artifact: {e!s}"
-            self._handle_execution_result(
-                status=SaveImageStatus.FAILURE,
-                saved_path="",
-                input_info=input_info,
-                output_file=output_file,
-                details=error_details,
-                exception=e,
-            )
-            raise ValueError(error_details) from e
-
-        # Determine save method based on path type
-        output_path = Path(output_file)
-        if output_path.is_absolute():
-            # Full path: save directly to filesystem
-            saved_path = self._save_to_filesystem(image_artifact, output_path, input_info, output_file)
+                self._handle_error_with_graceful_exit(error_details, e, input_info, output_file)
+            else:
+                # Convert to appropriate artifact type
+                try:
+                    image_artifact = to_image_artifact(processed_image)
+                except Exception as e:
+                    error_details = f"Failed to convert image to artifact: {e!s}"
+                    self._handle_error_with_graceful_exit(error_details, e, input_info, output_file)
+                else:
+                    # Save image using appropriate method based on path type
+                    try:
+                        output_path = Path(output_file)
+                        if output_path.is_absolute():
+                            # Full path: save directly to filesystem
+                            saved_path = self._save_to_filesystem(image_artifact, output_path)
+                        else:
+                            # Relative path: use static file manager
+                            saved_path = self._save_to_static_storage(image_artifact, output_file)
+                    except Exception as e:
+                        error_details = f"Failed to save image: {e!s}"
+                        self._handle_error_with_graceful_exit(error_details, e, input_info, output_file)
+                    else:
+                        # Success case with path method info
+                        path_method = "filesystem" if output_path.is_absolute() else "static storage"
+                        success_details = f"Image saved successfully via {path_method}"
+                        self._handle_execution_result(
+                            status=SaveImageStatus.SUCCESS,
+                            saved_path=saved_path,
+                            input_info=input_info,
+                            output_file=output_file,
+                            details=success_details,
+                        )
+                        logger.info(f"Saved image: {saved_path}")
         else:
-            # Relative path: use static file manager
-            saved_path = self._save_to_static_storage(image_artifact, output_file, input_info, output_file)
-
-        # Success case with path method info
-        path_method = "filesystem" if output_path.is_absolute() else "static storage"
-        success_details = f"Image saved successfully via {path_method}"
-        self._handle_execution_result(
-            status=SaveImageStatus.SUCCESS,
-            saved_path=saved_path,
-            input_info=input_info,
-            output_file=output_file,
-            details=success_details,
-        )
-        logger.info(f"Saved image: {saved_path}")
+            # Convert to appropriate artifact type
+            try:
+                image_artifact = to_image_artifact(processed_image)
+            except Exception as e:
+                error_details = f"Failed to convert image to artifact: {e!s}"
+                self._handle_error_with_graceful_exit(error_details, e, input_info, output_file)
+            else:
+                # Save image using appropriate method based on path type
+                try:
+                    output_path = Path(output_file)
+                    if output_path.is_absolute():
+                        # Full path: save directly to filesystem
+                        saved_path = self._save_to_filesystem(image_artifact, output_path)
+                    else:
+                        # Relative path: use static file manager
+                        saved_path = self._save_to_static_storage(image_artifact, output_file)
+                except Exception as e:
+                    error_details = f"Failed to save image: {e!s}"
+                    self._handle_error_with_graceful_exit(error_details, e, input_info, output_file)
+                else:
+                    # Success case with path method info
+                    path_method = "filesystem" if output_path.is_absolute() else "static storage"
+                    success_details = f"Image saved successfully via {path_method}"
+                    self._handle_execution_result(
+                        status=SaveImageStatus.SUCCESS,
+                        saved_path=saved_path,
+                        input_info=input_info,
+                        output_file=output_file,
+                        details=success_details,
+                    )
+                    logger.info(f"Saved image: {saved_path}")
 
     def get_next_control_output(self) -> Parameter | None:
         """Determine which control output to follow based on execution result."""
@@ -272,21 +290,13 @@ class SaveImage(ControlNode):
 
                 self._assign_result_details(f"{status}: {result_details}")
 
-    def _save_to_filesystem(self, image_artifact: Any, output_path: Path, input_info: str, output_file: str) -> str:
+    def _save_to_filesystem(self, image_artifact: Any, output_path: Path) -> str:
         """Save image directly to filesystem at the specified absolute path."""
         # Ensure parent directory exists
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
         except Exception as e:
             error_details = f"Failed to create directory structure for path: {e!s}"
-            self._handle_execution_result(
-                status=SaveImageStatus.FAILURE,
-                saved_path="",
-                input_info=input_info,
-                output_file=output_file,
-                details=error_details,
-                exception=e,
-            )
             raise ValueError(error_details) from e
 
         # Convert image to bytes
@@ -294,14 +304,6 @@ class SaveImage(ControlNode):
             image_bytes = image_artifact.to_bytes()
         except Exception as e:
             error_details = f"Failed to convert image artifact to bytes: {e!s}"
-            self._handle_execution_result(
-                status=SaveImageStatus.FAILURE,
-                saved_path="",
-                input_info=input_info,
-                output_file=output_file,
-                details=error_details,
-                exception=e,
-            )
             raise ValueError(error_details) from e
 
         # Write image bytes directly to file
@@ -309,35 +311,17 @@ class SaveImage(ControlNode):
             output_path.write_bytes(image_bytes)
         except Exception as e:
             error_details = f"Failed to write image file to filesystem: {e!s}"
-            self._handle_execution_result(
-                status=SaveImageStatus.FAILURE,
-                saved_path="",
-                input_info=input_info,
-                output_file=output_file,
-                details=error_details,
-                exception=e,
-            )
             raise ValueError(error_details) from e
 
         return str(output_path)
 
-    def _save_to_static_storage(
-        self, image_artifact: Any, output_file: str, input_info: str, output_file_for_error: str
-    ) -> str:
+    def _save_to_static_storage(self, image_artifact: Any, output_file: str) -> str:
         """Save image using the static file manager (existing behavior)."""
         # Convert image to bytes
         try:
             image_bytes = image_artifact.to_bytes()
         except Exception as e:
             error_details = f"Failed to convert image artifact to bytes: {e!s}"
-            self._handle_execution_result(
-                status=SaveImageStatus.FAILURE,
-                saved_path="",
-                input_info=input_info,
-                output_file=output_file_for_error,
-                details=error_details,
-                exception=e,
-            )
             raise ValueError(error_details) from e
 
         # Save to static storage
@@ -345,17 +329,41 @@ class SaveImage(ControlNode):
             return GriptapeNodes.StaticFilesManager().save_static_file(image_bytes, output_file)
         except Exception as e:
             error_details = f"Failed to save image to static storage: {e!s}"
-            self._handle_execution_result(
-                status=SaveImageStatus.FAILURE,
-                saved_path="",
-                input_info=input_info,
-                output_file=output_file_for_error,
-                details=error_details,
-                exception=e,
-            )
             raise ValueError(error_details) from e
 
     def _assign_result_details(self, message: str) -> None:
         """Helper to assign result_details using publish_update_to_parameter."""
         self.parameter_output_values[self.result_details.name] = message
         self.publish_update_to_parameter(self.result_details.name, message)
+
+    def _handle_error_with_graceful_exit(
+        self, error_details: str, exception: Exception, input_info: str, output_file: str
+    ) -> None:
+        """Handle error with graceful exit if failure output is connected."""
+        self._handle_execution_result(
+            status=SaveImageStatus.FAILURE,
+            saved_path="",
+            input_info=input_info,
+            output_file=output_file,
+            details=error_details,
+            exception=exception,
+        )
+        # If user has connected something to Failed output, they want to handle errors gracefully
+        # in their workflow rather than crashing the entire process with an exception
+        if not self._has_outgoing_connections(self.failure_output):
+            raise ValueError(error_details) from exception
+
+    def _has_outgoing_connections(self, parameter: Parameter) -> bool:
+        """Check if a specific parameter has outgoing connections."""
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        connections = GriptapeNodes.FlowManager().get_connections()
+
+        # Check if node has any outgoing connections
+        node_connections = connections.outgoing_index.get(self.name)
+        if node_connections is None:
+            return False
+
+        # Check if this specific parameter has any outgoing connections
+        param_connections = node_connections.get(parameter.name, [])
+        return len(param_connections) > 0


### PR DESCRIPTION
If we're happy with this, I have further tasks to systematize this into components that any save or load to make this process easier on the node author.