### PR TITLE
Fix single node resolution

### DIFF
--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -399,9 +399,10 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
 
     async def resolve_node(self, node: BaseNode | None = None) -> None:  # noqa: ARG002
         """Execute the DAG structure using the existing DagBuilder."""
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
         if self.context.dag_builder is None:
-            msg = "DagBuilder is not initialized"
-            raise ValueError(msg)
+            self.context.dag_builder = GriptapeNodes.FlowManager().global_dag_builder
         await self.start(ExecuteDagState)
 
     def change_debug_mode(self, *, debug_mode: bool) -> None:

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -399,6 +399,9 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
 
     async def resolve_node(self, node: BaseNode | None = None) -> None:  # noqa: ARG002
         """Execute the DAG structure using the existing DagBuilder."""
+        if self.context.dag_builder is None:
+            msg = "DagBuilder is not initialized"
+            raise ValueError(msg)
         await self.start(ExecuteDagState)
 
     def change_debug_mode(self, *, debug_mode: bool) -> None:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1725,9 +1725,11 @@ class FlowManager:
         resolution_machine.change_debug_mode(debug_mode=debug_mode)
         node.state = NodeResolutionState.UNRESOLVED
         # Build the DAG for the node
-        if self._global_dag_builder is None:
-            self._global_dag_builder = DagBuilder()
-        self._global_dag_builder.add_node_with_dependencies(node)
+        if isinstance(resolution_machine, ParallelResolutionMachine):
+            if self._global_dag_builder is None:
+                self._global_dag_builder = DagBuilder()
+            self._global_dag_builder.add_node_with_dependencies(node)
+            resolution_machine.context.dag_builder = self._global_dag_builder
         await resolution_machine.resolve_node(node)
         if resolution_machine.is_complete():
             self._global_single_node_resolution = False

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -147,7 +147,7 @@ class FlowManager:
     _global_flow_queue: Queue[QueueItem]
     _global_control_flow_machine: ControlFlowMachine | None
     _global_single_node_resolution: bool
-    _global_dag_builder: DagBuilder | None
+    _global_dag_builder: DagBuilder
 
     def __init__(self, event_manager: EventManager) -> None:
         event_manager.assign_manager_to_request_type(CreateFlowRequest, self.on_create_flow_request)
@@ -191,14 +191,14 @@ class FlowManager:
         self._global_flow_queue = Queue[QueueItem]()
         self._global_control_flow_machine = None  # Track the current control flow machine
         self._global_single_node_resolution = False
-        self._global_dag_builder = None
+        self._global_dag_builder = DagBuilder()
 
     @property
     def global_flow_queue(self) -> Queue[QueueItem]:
         return self._global_flow_queue
 
     @property
-    def global_dag_builder(self) -> DagBuilder | None:
+    def global_dag_builder(self) -> DagBuilder:
         return self._global_dag_builder
 
     def get_connections(self) -> Connections:
@@ -522,7 +522,7 @@ class FlowManager:
 
             # Clean up ControlFlowMachine and DAG orchestrator for this flow
             self._global_control_flow_machine = None
-            self._global_dag_builder = None
+            self._global_dag_builder.clear()
 
         details = f"Successfully deleted Flow '{flow_name}'."
         result = DeleteFlowResultSuccess(result_details=details)
@@ -1600,7 +1600,6 @@ class FlowManager:
 
         # Initialize global control flow machine and DAG builder
 
-        self._global_dag_builder = DagBuilder()
         self._global_control_flow_machine = ControlFlowMachine(flow.name)
         try:
             await self._global_control_flow_machine.start_flow(start_node, debug_mode)
@@ -1630,7 +1629,7 @@ class FlowManager:
         if self._global_control_flow_machine is not None:
             self._global_control_flow_machine.reset_machine(cancel=True)
         self._global_single_node_resolution = False
-        self._global_dag_builder = None
+        self._global_dag_builder.clear()
         logger.debug("Cancelling flow run")
 
         GriptapeNodes.EventManager().put_event(
@@ -1726,8 +1725,6 @@ class FlowManager:
         node.state = NodeResolutionState.UNRESOLVED
         # Build the DAG for the node
         if isinstance(resolution_machine, ParallelResolutionMachine):
-            if self._global_dag_builder is None:
-                self._global_dag_builder = DagBuilder()
             self._global_dag_builder.add_node_with_dependencies(node)
             resolution_machine.context.dag_builder = self._global_dag_builder
         await resolution_machine.resolve_node(node)

--- a/tests/unit/machines/test_parallel_flow_execution.py
+++ b/tests/unit/machines/test_parallel_flow_execution.py
@@ -251,8 +251,8 @@ class TestFlowManagerDagBuilderIntegration:
             assert flow_manager._global_dag_builder is initial_dag_builder
 
             # Test that it can be cleared and reset
-            flow_manager._global_dag_builder = None
-            assert flow_manager._global_dag_builder is None
+            flow_manager._global_dag_builder.clear()
+            assert flow_manager._global_dag_builder is not None
 
         except Exception:  # noqa: S110
             # If FlowManager requires complex setup, skip this test


### PR DESCRIPTION
Bug with new parallel in single node resolution - the dag builder doesn't always get properly initialized. This fixes the bug that @aodhanroche was running into where it says "DagBuilder is not initialized" and still fails to cancel the flow. 