### PR TITLE
refactor: have the local executor broadcast app initialization complete

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -4,6 +4,7 @@ from typing import Any
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.base_events import (
     EventRequest,
     ExecutionGriptapeNodeEvent,
@@ -155,6 +156,8 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         flow_name = self._load_flow_for_workflow()
         # Now let's set the input to the flow
         await self._set_input_for_flow(flow_name=flow_name, flow_input=flow_input)
+
+        await GriptapeNodes.EventManager().broadcast_app_event(AppInitializationComplete())
 
         # Now send the run command to actually execute it
         start_flow_request = StartFlowRequest(flow_name=flow_name)

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -9,7 +9,6 @@ from dotenv import load_dotenv
 
 # Signal the server to shutdown gracefully using the API module function
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -73,7 +72,6 @@ async def setup_test_libraries(griptape_nodes: GriptapeNodes) -> AsyncGenerator[
         key="app_events.on_app_initialization_complete.libraries_to_register",
         value=test_libraries,
     )
-    await griptape_nodes.EventManager().broadcast_app_event(AppInitializationComplete())
 
     yield  # Run all tests
 


### PR DESCRIPTION
Else the servers (https://github.com/griptape-ai/griptape-nodes/pull/2141) won't get booted. I think it's a reasonable mental model to think of the executor as spinning up its own little app.