### PR TITLE
refactor: change log level for logs either not important or redundant

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -173,7 +173,7 @@ async def _run_websocket_tasks(api_key: str, main_loop: asyncio.AbstractEventLoo
     initialized = False
 
     async for ws_connection in connection_stream:
-        logger.info("WebSocket connection established")
+        logger.debug("WebSocket connection established")
         try:
             # Emit initialization event only for the first connection
             if not initialized:
@@ -346,7 +346,7 @@ async def _send_unsubscribe_command(ws_connection: Any, topic: str) -> None:
 
 async def _process_event_queue() -> None:
     """Process events concurrently - runs on main thread."""
-    logger.info("Starting event queue processor on main thread")
+    logger.debug("Starting event queue processor on main thread")
     background_tasks = set()
 
     def _handle_task_result(task: asyncio.Task) -> None:
@@ -379,7 +379,7 @@ async def _process_event_queue() -> None:
             task.add_done_callback(_handle_task_result)
             event_queue.task_done()
     except asyncio.CancelledError:
-        logger.info("Event queue processor shutdown complete")
+        logger.debug("Event queue processor shutdown complete")
         raise
 
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -631,7 +631,8 @@ class WorkflowManager:
         return RegisterWorkflowResultSuccess(
             workflow_name=workflow.metadata.name,
             result_details=ResultDetails(
-                message=f"Successfully registered workflow: {workflow.metadata.name}", level="INFO"
+                message=f"Successfully registered workflow: {workflow.metadata.name}",
+                level="DEBUG",
             ),
         )
 


### PR DESCRIPTION
Would love to turn off `StreamableHTTP session manager started` but I couldn't find a way to shut it up.
Before:
```
❮ make run/watch
uv run src/griptape_nodes/app/watch.py
Checking for updates...
Starting Griptape Nodes engine...
[13:25:29] INFO     Starting event queue processor on main thread
           INFO     WebSocket connection established
           INFO     Installing dependencies for library 'Griptape Nodes Library' with pip in venv at /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/.venv
           INFO     Successfully loaded Library 'Griptape Nodes Library' from JSON file at /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/griptape_nodes_library.json
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library Name                                    │ Status       │ Version        │ File Path                                                                                                                                                                             │ Problems                             ┃ │
│ ┠─────────────────────────────────────────────────┼──────────────┼────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────┨ │
│ ┃ OK - Griptape Nodes Library                     │ GOOD         │ 0.50.0         │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/griptape_nodes_library.json                                                                          │ No problems detected.                ┃ │
│ ┠─────────────────────────────────────────────────┼──────────────┼────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────┨ │
│ ┃ OK - Sandbox Library                            │ GOOD         │ 0.53.0         │ /Users/collindutter/Projects/griptape/griptape-nodes/GriptapeNodes/sandbox_library                                                                                                    │ No problems detected.                ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
           INFO     Successfully registered workflow: prompt_an_image
           INFO     Successfully registered workflow: coordinating_agents
           INFO     Successfully registered workflow: compare_prompts
           INFO     Successfully registered workflow: photography_team
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Workflow Information ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Workflow Name           │ Status │ File Path                                                                                                 │ Problems                                                                                                   │ Dependencies                                       ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - prompt_an_image     │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/prom │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ pt_an_image.py                                                                                            │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ Workflow schema version 0.4.0 is older than version 0.7.0. The generated LocalExecutor code for the        │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow file is missing the `--json-input` argument, which may cause issues for Publish Workflow requests │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ when using certain Library targets. Consider updating the workflow by saving it again.                     │                                                    ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - coordinating_agents │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/coor │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ dinating_agents.py                                                                                        │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ Workflow schema version 0.4.0 is older than version 0.7.0. The generated LocalExecutor code for the        │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow file is missing the `--json-input` argument, which may cause issues for Publish Workflow requests │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ when using certain Library targets. Consider updating the workflow by saving it again.                     │                                                    ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - compare_prompts     │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/comp │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ are_prompts.py                                                                                            │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ Workflow schema version 0.6.1 is older than version 0.7.0. The generated LocalExecutor code for the        │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow file is missing the `--json-input` argument, which may cause issues for Publish Workflow requests │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ when using certain Library targets. Consider updating the workflow by saving it again.                     │                                                    ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - photography_team    │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/phot │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ ography_team.py                                                                                           │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Griptape Nodes Engine Started ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                                                                                                                                                    │
│                                                                                                                         Engine is ready to receive events                                                                                                                                                          │
│                                                                                                                         Return to: https://nodes.griptape.ai to access the Workflow Editor                                                                                                                         │
│                                                                                                                                                                                                                                                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── v0.53.0 (file) | Session: cdc8d1a7... ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
           INFO     StreamableHTTP session manager started
```

After:

```
❮ make run/watch
uv run src/griptape_nodes/app/watch.py
Checking for updates...
Starting Griptape Nodes engine...
[13:28:10] INFO     Installing dependencies for library 'Griptape Nodes Library' with pip in venv at /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/.venv
           INFO     StreamableHTTP session manager started
           INFO     Successfully loaded Library 'Griptape Nodes Library' from JSON file at /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/griptape_nodes_library.json
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library Name                                    │ Status       │ Version        │ File Path                                                                                                                                                                             │ Problems                             ┃ │
│ ┠─────────────────────────────────────────────────┼──────────────┼────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────┨ │
│ ┃ OK - Griptape Nodes Library                     │ GOOD         │ 0.50.0         │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/griptape_nodes_library.json                                                                          │ No problems detected.                ┃ │
│ ┠─────────────────────────────────────────────────┼──────────────┼────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────┨ │
│ ┃ OK - Sandbox Library                            │ GOOD         │ 0.53.0         │ /Users/collindutter/Projects/griptape/griptape-nodes/GriptapeNodes/sandbox_library                                                                                                    │ No problems detected.                ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Workflow Information ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Workflow Name           │ Status │ File Path                                                                                                 │ Problems                                                                                                   │ Dependencies                                       ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - prompt_an_image     │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/prom │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ pt_an_image.py                                                                                            │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ Workflow schema version 0.4.0 is older than version 0.7.0. The generated LocalExecutor code for the        │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow file is missing the `--json-input` argument, which may cause issues for Publish Workflow requests │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ when using certain Library targets. Consider updating the workflow by saving it again.                     │                                                    ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - coordinating_agents │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/coor │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ dinating_agents.py                                                                                        │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ Workflow schema version 0.4.0 is older than version 0.7.0. The generated LocalExecutor code for the        │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow file is missing the `--json-input` argument, which may cause issues for Publish Workflow requests │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ when using certain Library targets. Consider updating the workflow by saving it again.                     │                                                    ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - compare_prompts     │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/comp │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ are_prompts.py                                                                                            │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ Workflow schema version 0.6.1 is older than version 0.7.0. The generated LocalExecutor code for the        │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow file is missing the `--json-input` argument, which may cause issues for Publish Workflow requests │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ when using certain Library targets. Consider updating the workflow by saving it again.                     │                                                    ┃ │
│ ┠─────────────────────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┨ │
│ ┃ ! - photography_team    │ FLAWED │ /Users/collindutter/.local/share/griptape_nodes/libraries/griptape_nodes_library/workflows/templates/phot │ This workflow was built with library 'Griptape Nodes Library' v0.41.0, but you have v0.50.0. Minor         │ CAUTION - Griptape Nodes Library (0.41.0): CAUTION ┃ │
│ ┃                         │        │ ography_team.py                                                                                           │ differences are usually compatible. If you experience issues, you can update the library or save this      │                                                    ┃ │
│ ┃                         │        │                                                                                                           │ workflow to update it to your current library versions.                                                    │                                                    ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Griptape Nodes Engine Started ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                                                                                                                                                    │
│                                                                                                                         Engine is ready to receive events                                                                                                                                                          │
│                                                                                                                         Return to: https://nodes.griptape.ai to access the Workflow Editor                                                                                                                         │
│                                                                                                                                                                                                                                                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── v0.53.0 (file) | Session: cdc8d1a7... ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```