### PR TITLE
Re-assign workspace path in config manager after env var config is loaded

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -200,6 +200,9 @@ class ConfigManager:
             merged_config = merge_dicts(merged_config, self.env_config)
             logger.debug("Merged config from environment variables: %s", list(self.env_config.keys()))
 
+        # Re-assign workspace path in case env var overrides it
+        self.workspace_path = merged_config["workspace_directory"]
+
         # Validate the full config against the Settings model.
         try:
             Settings.model_validate(merged_config)

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -98,3 +98,27 @@ class TestConfigManager:
             manager = ConfigManager()
             env_config = manager._load_config_from_env_vars()
             assert env_config == {"bar": "should_be_loaded"}
+
+    def test_workspace_path_reassigned_after_env_var_override(self) -> None:
+        """Test that workspace path is reassigned after environment variable config is loaded."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create initial workspace directory
+            initial_workspace = Path(temp_dir) / "initial_workspace"
+            initial_workspace.mkdir()
+
+            # Create override workspace directory
+            override_workspace = Path(temp_dir) / "override_workspace"
+            override_workspace.mkdir()
+
+            # Set environment variable to override workspace directory
+            with patch.dict(os.environ, {"GTN_CONFIG_WORKSPACE_DIRECTORY": str(override_workspace)}, clear=True):
+                manager = ConfigManager()
+                # Initially set workspace to the initial directory
+                manager.workspace_path = initial_workspace
+
+                # Load configs which should reassign workspace path from env var
+                manager.load_configs()
+
+                # Verify workspace path was reassigned to the env var value
+                assert manager.workspace_path == override_workspace.resolve()
+                assert manager.get_config_value("workspace_directory") == str(override_workspace)


### PR DESCRIPTION
* Re-assign workspace path in config manager after env var config is loaded