### PR TITLE
Update Resolution to work with Control Flow

### DIFF
--- a/src/griptape_nodes/common/directed_graph.py
+++ b/src/griptape_nodes/common/directed_graph.py
@@ -38,6 +38,16 @@ class DirectedGraph:
             return 0
         return len(self._predecessors.get(node, set()))
 
+    def out_degree(self, node: str) -> int:
+        """Return the out-degree of a node (number of outgoing edges)."""
+        if node not in self._nodes:
+            return 0
+        count = 0
+        for predecessors in self._predecessors.values():
+            if node in predecessors:
+                count += 1
+        return count
+
     def remove_node(self, node: str) -> None:
         """Remove a node and all its edges from the graph."""
         if node not in self._nodes:

--- a/src/griptape_nodes/common/directed_graph.py
+++ b/src/griptape_nodes/common/directed_graph.py
@@ -12,6 +12,10 @@ class DirectedGraph:
         self._nodes: set[str] = set()
         self._predecessors: dict[str, set[str]] = {}
 
+    def __len__(self) -> int:
+        """Return the number of nodes in the graph."""
+        return len(self._nodes)
+
     def add_node(self, node_for_adding: str) -> None:
         """Add a node to the graph."""
         self._nodes.add(node_for_adding)

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -40,7 +40,7 @@ logger = logging.getLogger("griptape_nodes")
 # This is the control flow context. Owns the Resolution Machine
 class ControlFlowContext:
     flow: ControlFlow
-    current_node: BaseNode | None
+    current_nodes: list[BaseNode]
     resolution_machine: ParallelResolutionMachine | SequentialResolutionMachine
     selected_output: Parameter | None
     paused: bool = False
@@ -64,7 +64,7 @@ class ControlFlowContext:
             )
         else:
             self.resolution_machine = SequentialResolutionMachine()
-        self.current_node = None
+        self.current_nodes = []
 
     def get_next_node(self, output_parameter: Parameter) -> NextNodeInfo | None:
         """Get the next node and the target parameter that will receive the control flow.
@@ -72,7 +72,7 @@ class ControlFlowContext:
         Returns:
             NextNodeInfo | None: Information about the next node or None if no connection
         """
-        if self.current_node is not None:
+        if len(self.current_nodes) > 0:
             node_connection = (
                 GriptapeNodes.FlowManager().get_connections().get_connected_node(self.current_node, output_parameter)
             )
@@ -87,9 +87,10 @@ class ControlFlowContext:
         return None
 
     def reset(self, *, cancel: bool = False) -> None:
-        if self.current_node:
-            self.current_node.clear_node()
-        self.current_node = None
+        if self.current_nodes is not None:
+            for node in self.current_nodes:
+                node.clear_node()
+        self.current_nodes = []
         self.resolution_machine.reset_machine(cancel=cancel)
         self.selected_output = None
         self.paused = False
@@ -100,7 +101,7 @@ class ResolveNodeState(State):
     @staticmethod
     async def on_enter(context: ControlFlowContext) -> type[State] | None:
         # The state machine has started, but it hasn't began to execute yet.
-        if context.current_node is None:
+        if len(context.current_nodes) == 0:
             # We don't have anything else to do. Move back to Complete State so it has to restart.
             return CompleteState
 
@@ -225,12 +226,16 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
     async def start_flow(self, start_node: BaseNode, debug_mode: bool = False) -> None:  # noqa: FBT001, FBT002
         # If using DAG resolution, process data_nodes from queue first
         if isinstance(self._context.resolution_machine, ParallelResolutionMachine):
-            await self._process_data_nodes_for_dag(start_node)
-        self._context.current_node = start_node
+            current_nodes = await self._process_nodes_for_dag(start_node)
+        else:
+            current_nodes = [start_node]
+        self._context.current_nodes = current_nodes
         # Set entry control parameter for initial node (None for workflow start)
-        start_node.set_entry_control_parameter(None)
+        for node in current_nodes:
+            node.set_entry_control_parameter(None)
         # Set up to debug
         self._context.paused = debug_mode
+        await self._context.resolution_machine.resolve_node()
         await self.start(ResolveNodeState)  # Begins the flow
 
     async def update(self) -> None:
@@ -273,14 +278,14 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         ):
             await self.update()
 
-    async def _process_data_nodes_for_dag(self, start_node: BaseNode) -> None:
+    async def _process_nodes_for_dag(self, start_node: BaseNode) -> list[BaseNode]:
         """Process data_nodes from the global queue to build unified DAG.
 
         This method identifies data_nodes in the execution queue and processes
         their dependencies into the DAG resolution machine.
         """
         if not isinstance(self._context.resolution_machine, ParallelResolutionMachine):
-            return
+            return []
         # Get the global flow queue
         flow_manager = GriptapeNodes.FlowManager()
         dag_builder = flow_manager.global_dag_builder
@@ -290,17 +295,24 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         # Build with the first node:
         dag_builder.add_node_with_dependencies(start_node, start_node.name)
         queue_items = list(flow_manager.global_flow_queue.queue)
-
+        start_nodes = []
         # Find data_nodes and remove them from queue
         for item in queue_items:
             from griptape_nodes.retained_mode.managers.flow_manager import DagExecutionType
 
-            if item.dag_execution_type == DagExecutionType.DATA_NODE:
+            if item.dag_execution_type in (DagExecutionType.CONTROL_NODE, DagExecutionType.START_NODE):
+                node = item.node
+                node.state = NodeResolutionState.UNRESOLVED
+                dag_builder.add_node_with_dependencies(node, node.name)
+                flow_manager.global_flow_queue.queue.remove(item)
+                #start_nodes.append(node)
+            elif item.dag_execution_type == DagExecutionType.DATA_NODE:
                 node = item.node
                 node.state = NodeResolutionState.UNRESOLVED
                 # Build here.
                 dag_builder.add_node_with_dependencies(node, node.name)
                 flow_manager.global_flow_queue.queue.remove(item)
+        return start_nodes
 
     def reset_machine(self, *, cancel: bool = False) -> None:
         self._context.reset(cancel=cancel)

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -66,25 +66,41 @@ class ControlFlowContext:
             self.resolution_machine = SequentialResolutionMachine()
         self.current_nodes = []
 
-    def get_next_node(self, output_parameter: Parameter) -> NextNodeInfo | None:
-        """Get the next node and the target parameter that will receive the control flow.
+    def get_next_nodes(self, output_parameter: Parameter | None = None) -> list[NextNodeInfo]:
+        """Get all next nodes from the current nodes.
 
         Returns:
-            NextNodeInfo | None: Information about the next node or None if no connection
+            list[NextNodeInfo]: List of next nodes to process
         """
-        if len(self.current_nodes) > 0:
-            node_connection = (
-                GriptapeNodes.FlowManager().get_connections().get_connected_node(self.current_node, output_parameter)
-            )
-            if node_connection is not None:
-                node, entry_parameter = node_connection
-                return NextNodeInfo(node=node, entry_parameter=entry_parameter)
-            # Continue Execution to the next node that needs to be executed using global execution queue
-            # Get the next node in the execution queue, or None if queue is empty
+        next_nodes = []
+        
+        for current_node in self.current_nodes:
+            if output_parameter is not None:
+                # Get connected node from control flow
+                node_connection = (
+                    GriptapeNodes.FlowManager().get_connections().get_connected_node(current_node, output_parameter)
+                )
+                if node_connection is not None:
+                    node, entry_parameter = node_connection
+                    next_nodes.append(NextNodeInfo(node=node, entry_parameter=entry_parameter))
+            else:
+                # Get next control output for this node
+                next_output = current_node.get_next_control_output()
+                if next_output is not None:
+                    node_connection = (
+                        GriptapeNodes.FlowManager().get_connections().get_connected_node(current_node, next_output)
+                    )
+                    if node_connection is not None:
+                        node, entry_parameter = node_connection
+                        next_nodes.append(NextNodeInfo(node=node, entry_parameter=entry_parameter))
+        
+        # If no connections found, check execution queue
+        if not next_nodes:
             node = GriptapeNodes.FlowManager().get_next_node_from_execution_queue()
             if node is not None:
-                return NextNodeInfo(node=node, entry_parameter=None)
-        return None
+                next_nodes.append(NextNodeInfo(node=node, entry_parameter=None))
+        
+        return next_nodes
 
     def reset(self, *, cancel: bool = False) -> None:
         if self.current_nodes is not None:
@@ -105,20 +121,21 @@ class ResolveNodeState(State):
             # We don't have anything else to do. Move back to Complete State so it has to restart.
             return CompleteState
 
-        # Mark the node unresolved, and broadcast an event to the GUI.
-        if not context.current_node.lock:
-            context.current_node.make_node_unresolved(
-                current_states_to_trigger_change_event=set(
-                    {NodeResolutionState.UNRESOLVED, NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
+        # Mark all current nodes unresolved and broadcast events
+        for current_node in context.current_nodes:
+            if not current_node.lock:
+                current_node.make_node_unresolved(
+                    current_states_to_trigger_change_event=set(
+                        {NodeResolutionState.UNRESOLVED, NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
+                    )
+                )
+            # Now broadcast that we have a current control node.
+            GriptapeNodes.EventManager().put_event(
+                ExecutionGriptapeNodeEvent(
+                    wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name=current_node.name))
                 )
             )
-        # Now broadcast that we have a current control node.
-        GriptapeNodes.EventManager().put_event(
-            ExecutionGriptapeNodeEvent(
-                wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name=context.current_node.name))
-            )
-        )
-        logger.info("Resolving %s", context.current_node.name)
+            logger.info("Resolving %s", current_node.name)
         if not context.paused:
             # Call the update. Otherwise wait
             return ResolveNodeState
@@ -127,11 +144,13 @@ class ResolveNodeState(State):
     # This is necessary to transition to the next step.
     @staticmethod
     async def on_update(context: ControlFlowContext) -> type[State] | None:
-        # If node has not already been resolved!
-        if context.current_node is None:
+        # If no current nodes, we're done
+        if len(context.current_nodes) == 0:
             return CompleteState
-        if context.current_node.state != NodeResolutionState.RESOLVED:
-            await context.resolution_machine.resolve_node(context.current_node)
+        
+        # Resolve nodes - pass first node for sequential resolution
+        current_node = context.current_nodes[0] if context.current_nodes else None
+        await context.resolution_machine.resolve_node(current_node)
 
         if context.resolution_machine.is_complete():
             return NextNodeState
@@ -141,44 +160,49 @@ class ResolveNodeState(State):
 class NextNodeState(State):
     @staticmethod
     async def on_enter(context: ControlFlowContext) -> type[State] | None:
-        if context.current_node is None:
+        if len(context.current_nodes) == 0:
             return CompleteState
-        # I did define this on the ControlNode.
-        if context.current_node.stop_flow:
-            # We're done here.
-            context.current_node.stop_flow = False
+        
+        # Check for stop_flow on any current nodes
+        for current_node in context.current_nodes[:]:
+            if current_node.stop_flow:
+                current_node.stop_flow = False
+                context.current_nodes.remove(current_node)
+        
+        # If all nodes stopped flow, complete
+        if len(context.current_nodes) == 0:
             return CompleteState
-        next_output = context.current_node.get_next_control_output()
-        next_node_info = None
-
-        if next_output is not None:
-            context.selected_output = next_output
-            next_node_info = context.get_next_node(context.selected_output)
-            GriptapeNodes.EventManager().put_event(
-                ExecutionGriptapeNodeEvent(
-                    wrapped_event=ExecutionEvent(
-                        payload=SelectedControlOutputEvent(
-                            node_name=context.current_node.name,
-                            selected_output_parameter_name=next_output.name,
+        
+        # Get all next nodes from current nodes
+        next_node_infos = context.get_next_nodes()
+        
+        # Broadcast selected control output events for nodes with outputs
+        for current_node in context.current_nodes:
+            next_output = current_node.get_next_control_output()
+            if next_output is not None:
+                context.selected_output = next_output
+                GriptapeNodes.EventManager().put_event(
+                    ExecutionGriptapeNodeEvent(
+                        wrapped_event=ExecutionEvent(
+                            payload=SelectedControlOutputEvent(
+                                node_name=current_node.name,
+                                selected_output_parameter_name=next_output.name,
+                            )
                         )
                     )
                 )
-            )
-        else:
-            # Get the next node in the execution queue, or None if queue is empty
-            next_node = GriptapeNodes.FlowManager().get_next_node_from_execution_queue()
-            if next_node is not None:
-                next_node_info = NextNodeInfo(node=next_node, entry_parameter=None)
-
-        # The parameter that will be evaluated next
-        if next_node_info is None:
-            # If no node attached
+        
+        # If no next nodes, we're complete
+        if not next_node_infos:
             return CompleteState
 
-        # Always set the entry control parameter (None for execution queue nodes)
-        next_node_info.node.set_entry_control_parameter(next_node_info.entry_parameter)
-
-        context.current_node = next_node_info.node
+        # Set up next nodes as current nodes
+        next_nodes = []
+        for next_node_info in next_node_infos:
+            next_node_info.node.set_entry_control_parameter(next_node_info.entry_parameter)
+            next_nodes.append(next_node_info.node)
+        
+        context.current_nodes = next_nodes
         context.selected_output = None
         if not context.paused:
             return ResolveNodeState
@@ -192,14 +216,15 @@ class NextNodeState(State):
 class CompleteState(State):
     @staticmethod
     async def on_enter(context: ControlFlowContext) -> type[State] | None:
-        if context.current_node is not None:
+        # Broadcast completion events for any remaining current nodes
+        for current_node in context.current_nodes:
             GriptapeNodes.EventManager().put_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(
                         payload=ControlFlowResolvedEvent(
-                            end_node_name=context.current_node.name,
+                            end_node_name=current_node.name,
                             parameter_output_values=TypeValidator.safe_serialize(
-                                context.current_node.parameter_output_values
+                                current_node.parameter_output_values
                             ),
                         )
                     )
@@ -235,7 +260,6 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
             node.set_entry_control_parameter(None)
         # Set up to debug
         self._context.paused = debug_mode
-        await self._context.resolution_machine.resolve_node()
         await self.start(ResolveNodeState)  # Begins the flow
 
     async def update(self) -> None:
@@ -295,7 +319,7 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         # Build with the first node:
         dag_builder.add_node_with_dependencies(start_node, start_node.name)
         queue_items = list(flow_manager.global_flow_queue.queue)
-        start_nodes = []
+        start_nodes = [start_node]
         # Find data_nodes and remove them from queue
         for item in queue_items:
             from griptape_nodes.retained_mode.managers.flow_manager import DagExecutionType
@@ -305,7 +329,7 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
                 node.state = NodeResolutionState.UNRESOLVED
                 dag_builder.add_node_with_dependencies(node, node.name)
                 flow_manager.global_flow_queue.queue.remove(item)
-                #start_nodes.append(node)
+                start_nodes.append(node)
             elif item.dag_execution_type == DagExecutionType.DATA_NODE:
                 node = item.node
                 node.state = NodeResolutionState.UNRESOLVED

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from tracemalloc import start
 from typing import TYPE_CHECKING
 
 from griptape_nodes.exe_types.core_types import Parameter
@@ -287,7 +288,7 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
             msg = "DAG builder is not initialized."
             raise ValueError(msg)
         # Build with the first node:
-        dag_builder.add_node_with_dependencies(start_node)
+        dag_builder.add_node_with_dependencies(start_node, start_node.name)
         queue_items = list(flow_manager.global_flow_queue.queue)
 
         # Find data_nodes and remove them from queue
@@ -298,7 +299,7 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
                 node = item.node
                 node.state = NodeResolutionState.UNRESOLVED
                 # Build here.
-                dag_builder.add_node_with_dependencies(node)
+                dag_builder.add_node_with_dependencies(node, node.name)
                 flow_manager.global_flow_queue.queue.remove(item)
 
     def reset_machine(self, *, cancel: bool = False) -> None:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -73,7 +73,6 @@ class ControlFlowContext:
             list[NextNodeInfo]: List of next nodes to process
         """
         next_nodes = []
-        
         for current_node in self.current_nodes:
             if output_parameter is not None:
                 # Get connected node from control flow

--- a/src/griptape_nodes/machines/dag_builder.py
+++ b/src/griptape_nodes/machines/dag_builder.py
@@ -6,14 +6,13 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from griptape_nodes.common.directed_graph import DirectedGraph
-from griptape_nodes.exe_types.connections import Connections
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import NodeResolutionState
 
 if TYPE_CHECKING:
     import asyncio
-    from typing import Any
 
+    from griptape_nodes.exe_types.connections import Connections
     from griptape_nodes.exe_types.node_types import BaseNode
 
 logger = logging.getLogger("griptape_nodes")
@@ -52,7 +51,6 @@ class DagBuilder:
     def add_node_with_dependencies(self, node: BaseNode, graph_name: str = "default") -> list[BaseNode]:
         """Add node and all its dependencies to DAG. Returns list of added nodes."""
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
 
         connections = GriptapeNodes.FlowManager().get_connections()
         added_nodes = []
@@ -119,12 +117,12 @@ class DagBuilder:
         self.graphs.clear()
         self.node_to_reference.clear()
 
-
     def can_queue_control_node(self, node: DagNode, network_name: str) -> bool:  # noqa: ARG002
         if len(self.graphs) == 1:
             return True
 
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
         connections = GriptapeNodes.FlowManager().get_connections()
 
         if self.get_number_incoming_control_connections(node.node_reference, connections) <= 1:
@@ -167,7 +165,9 @@ class DagBuilder:
 
         return control_connection_count
 
-    def _is_node_in_forward_path(self, start_node: BaseNode, target_node: BaseNode, connections: Connections, visited: set[str] | None = None) -> bool:
+    def _is_node_in_forward_path(
+        self, start_node: BaseNode, target_node: BaseNode, connections: Connections, visited: set[str] | None = None
+    ) -> bool:
         """Check if target_node is reachable from start_node through control flow connections."""
         if visited is None:
             visited = set()

--- a/src/griptape_nodes/machines/dag_builder.py
+++ b/src/griptape_nodes/machines/dag_builder.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from griptape_nodes.common.directed_graph import DirectedGraph
+from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 
 if TYPE_CHECKING:
     import asyncio
@@ -37,19 +38,25 @@ class DagNode:
 
 class DagBuilder:
     """Handles DAG construction independently of execution state machine."""
+    graphs: dict[str, DirectedGraph] # Str is the name of the start node associated here.
+    node_to_reference: dict[str, DagNode]
 
     def __init__(self) -> None:
-        self.graph = DirectedGraph()
+        self.graphs = {}
         self.node_to_reference: dict[str, DagNode] = {}
 
-    def add_node_with_dependencies(self, node: BaseNode) -> list[BaseNode]:
+    def add_node_with_dependencies(self, node: BaseNode, graph_name: str = "default") -> list[BaseNode]:
         """Add node and all its dependencies to DAG. Returns list of added nodes."""
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         connections = GriptapeNodes.FlowManager().get_connections()
         added_nodes = []
+        graph = self.graphs.get(graph_name, None)
+        if graph is None:
+            graph = DirectedGraph()
+            self.graphs[graph_name] = graph
 
-        def _add_node_recursive(current_node: BaseNode, visited: set[str]) -> None:
+        def _add_node_recursive(current_node: BaseNode, visited: set[str], graph: DirectedGraph) -> None:
             if current_node.name in visited:
                 return
             visited.add(current_node.name)
@@ -60,40 +67,46 @@ class DagBuilder:
 
             # Process dependencies first (depth-first)
             for param in current_node.parameters:
+                if param.type == ParameterTypeBuiltin.CONTROL_TYPE:
+                    continue
                 upstream_connection = connections.get_connected_node(current_node, param)
                 if upstream_connection:
                     upstream_node, _ = upstream_connection
 
                     # If upstream is already in DAG, just add edge
                     if upstream_node.name in self.node_to_reference:
-                        self.graph.add_edge(upstream_node.name, current_node.name)
+                        graph.add_edge(upstream_node.name, current_node.name)
                     # Otherwise, add it to DAG first
                     else:
-                        _add_node_recursive(upstream_node, visited)
-                        self.graph.add_edge(upstream_node.name, current_node.name)
+                        _add_node_recursive(upstream_node, visited, graph)
+                        graph.add_edge(upstream_node.name, current_node.name)
 
             # Add current node to DAG (but keep original resolution state)
 
             dag_node = DagNode(node_reference=current_node, node_state=NodeState.WAITING)
             self.node_to_reference[current_node.name] = dag_node
-            self.graph.add_node(node_for_adding=current_node.name)
+            graph.add_node(node_for_adding=current_node.name)
             # DON'T mark as resolved - that happens during actual execution
             added_nodes.append(current_node)
 
-        _add_node_recursive(node, set())
+        _add_node_recursive(node, set(), graph)
         return added_nodes
 
-    def add_node(self, node: BaseNode) -> DagNode:
+    def add_node(self, node: BaseNode, graph_name: str = "default") -> DagNode:
         """Add just one node to DAG without dependencies (assumes dependencies already exist)."""
         if node.name in self.node_to_reference:
             return self.node_to_reference[node.name]
 
         dag_node = DagNode(node_reference=node, node_state=NodeState.WAITING)
         self.node_to_reference[node.name] = dag_node
-        self.graph.add_node(node_for_adding=node.name)
+        graph = self.graphs.get(graph_name, None)
+        if graph is None:
+            graph = DirectedGraph()
+            self.graphs[graph_name] = graph
+        graph.add_node(node_for_adding=node.name)
         return dag_node
 
     def clear(self) -> None:
         """Clear all nodes and references from the DAG builder."""
-        self.graph.clear()
+        self.graphs.clear()
         self.node_to_reference.clear()

--- a/src/griptape_nodes/machines/dag_builder.py
+++ b/src/griptape_nodes/machines/dag_builder.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from griptape_nodes.common.directed_graph import DirectedGraph
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
+from griptape_nodes.exe_types.node_types import NodeResolutionState
 
 if TYPE_CHECKING:
     import asyncio
@@ -72,7 +73,9 @@ class DagBuilder:
                 upstream_connection = connections.get_connected_node(current_node, param)
                 if upstream_connection:
                     upstream_node, _ = upstream_connection
-
+                    # Don't add nodes that have already been resolved.
+                    if upstream_node.state == NodeResolutionState.RESOLVED:
+                        continue
                     # If upstream is already in DAG, just add edge
                     if upstream_node.name in self.node_to_reference:
                         graph.add_edge(upstream_node.name, current_node.name)

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -159,6 +159,10 @@ class ExecuteDagState(State):
     @staticmethod
     def get_next_control_graph(context: ParallelResolutionContext, node: BaseNode, network_name: str) -> None:
         """Get next control flow nodes and add them to the DAG graph."""
+        if context.dag_builder is not None:
+            network = context.dag_builder.graphs.get(network_name, None)
+            if network is None or len(network) == 0:
+                return
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         # Check stop_flow first
         if node.stop_flow:
@@ -177,7 +181,7 @@ class ExecuteDagState(State):
                         {NodeResolutionState.UNRESOLVED, NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
                     )
             )
-                if context.dag_builder:
+                if context.dag_builder is not None:
                     context.dag_builder.add_node_with_dependencies(next_node, network_name)
 
     @staticmethod

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -165,13 +165,16 @@ class ExecuteDagState(State):
                 return
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         # Check stop_flow first
+        flow_manager = GriptapeNodes.FlowManager()
+        if flow_manager.global_single_node_resolution:
+            return
         if node.stop_flow:
             node.stop_flow = False
             return  # No more nodes to add
         next_output = node.get_next_control_output()
         if next_output is not None:
             # Get connected node from control flow
-            node_connection = GriptapeNodes.FlowManager().get_connections().get_connected_node(node, next_output)
+            node_connection = flow_manager.get_connections().get_connected_node(node, next_output)
             if node_connection is not None:
                 next_node, _ = node_connection
                 # Add the next control node to the DAG

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -161,7 +161,7 @@ class ExecuteDagState(State):
         """Get next control flow nodes and add them to the DAG graph."""
         if context.dag_builder is not None:
             network = context.dag_builder.graphs.get(network_name, None)
-            if network is None or len(network) == 0:
+            if network is not None and len(network) > 0:
                 return
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         # Check stop_flow first

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -227,7 +227,7 @@ class GetFlowStateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
         resolving_node: Name of the node currently being resolved (if any)
     """
 
-    control_node: str | None
+    control_nodes: list[str] | None
     resolving_node: list[str] | None
 
 

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -193,6 +193,11 @@ class FlowManager:
         self._global_single_node_resolution = False
         self._global_dag_builder = DagBuilder()
 
+
+    @property
+    def global_single_node_resolution(self) -> bool:
+        return self._global_single_node_resolution
+
     @property
     def global_flow_queue(self) -> Queue[QueueItem]:
         return self._global_flow_queue

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -193,7 +193,6 @@ class FlowManager:
         self._global_single_node_resolution = False
         self._global_dag_builder = DagBuilder()
 
-
     @property
     def global_single_node_resolution(self) -> bool:
         return self._global_single_node_resolution
@@ -1801,7 +1800,9 @@ class FlowManager:
             return None, None
         control_flow_context = self._global_control_flow_machine.context
         current_control_nodes = (
-            [control_flow_node.name for control_flow_node in control_flow_context.current_nodes] if control_flow_context.current_nodes is not None else None
+            [control_flow_node.name for control_flow_node in control_flow_context.current_nodes]
+            if control_flow_context.current_nodes is not None
+            else None
         )
         # focus_stack is no longer available in the new architecture
         if isinstance(control_flow_context.resolution_machine, ParallelResolutionMachine):

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1086,14 +1086,14 @@ class FlowManager:
             details = f"Could not get flow state. Error: {err}"
             return GetFlowStateResultFailure(result_details=details)
         try:
-            control_node, resolving_nodes = self.flow_state(flow)
+            control_nodes, resolving_nodes = self.flow_state(flow)
         except Exception as e:
             details = f"Failed to get flow state of flow with name {flow_name}. Exception occurred: {e} "
             logger.exception(details)
             return GetFlowStateResultFailure(result_details=details)
         details = f"Successfully got flow state for flow with name {flow_name}."
         return GetFlowStateResultSuccess(
-            control_node=control_node, resolving_node=resolving_nodes, result_details=details
+            control_nodes=control_nodes, resolving_node=resolving_nodes, result_details=details
         )
 
     def on_cancel_flow_request(self, request: CancelFlowRequest) -> ResultPayload:
@@ -1719,7 +1719,7 @@ class FlowManager:
 
         # Get or create machine
         self._global_control_flow_machine = ControlFlowMachine(flow.name)
-        self._global_control_flow_machine.context.current_node = node
+        self._global_control_flow_machine.context.current_nodes = [node]
         resolution_machine = self._global_control_flow_machine.resolution_machine
         resolution_machine.change_debug_mode(debug_mode=debug_mode)
         node.state = NodeResolutionState.UNRESOLVED
@@ -1730,7 +1730,7 @@ class FlowManager:
         await resolution_machine.resolve_node(node)
         if resolution_machine.is_complete():
             self._global_single_node_resolution = False
-            self._global_control_flow_machine.context.current_node = None
+            self._global_control_flow_machine.context.current_nodes = []
 
     async def single_execution_step(self, flow: ControlFlow, change_debug_mode: bool) -> None:  # noqa: FBT001
         # do a granular step
@@ -1788,15 +1788,15 @@ class FlowManager:
             # Clear entry control parameter for new execution
             node.set_entry_control_parameter(None)
 
-    def flow_state(self, flow: ControlFlow) -> tuple[str | None, list[str] | None]:  # noqa: ARG002
+    def flow_state(self, flow: ControlFlow) -> tuple[list[str] | None, list[str] | None]:  # noqa: ARG002
         if not self.check_for_existing_running_flow():
             msg = "Flow hasn't started."
             raise RuntimeError(msg)
         if self._global_control_flow_machine is None:
             return None, None
         control_flow_context = self._global_control_flow_machine.context
-        current_control_node = (
-            control_flow_context.current_node.name if control_flow_context.current_node is not None else None
+        current_control_nodes = (
+            [control_flow_node.name for control_flow_node in control_flow_context.current_nodes] if control_flow_context.current_nodes is not None else None
         )
         # focus_stack is no longer available in the new architecture
         if isinstance(control_flow_context.resolution_machine, ParallelResolutionMachine):
@@ -1804,12 +1804,12 @@ class FlowManager:
                 node.node_reference.name
                 for node in control_flow_context.resolution_machine.context.task_to_node.values()
             ]
-            return current_control_node, current_resolving_nodes
+            return current_control_nodes, current_resolving_nodes
         if isinstance(control_flow_context.resolution_machine, SequentialResolutionMachine):
             focus_stack_for_node = control_flow_context.resolution_machine.context.focus_stack
             current_resolving_node = focus_stack_for_node[-1].node.name if len(focus_stack_for_node) else None
-            return current_control_node, [current_resolving_node] if current_resolving_node else None
-        return current_control_node, None
+            return current_control_nodes, [current_resolving_node] if current_resolving_node else None
+        return current_control_nodes, None
 
     def get_start_node_from_node(self, flow: ControlFlow, node: BaseNode) -> BaseNode | None:
         # backwards chain in control outputs.

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -455,9 +455,7 @@ class NodeManager:
                         result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
                         cancelled = True
                         if not result.succeeded():
-                            details = (
-                                f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
-                            )
+                            details = f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
                             return DeleteNodeResultFailure(result_details=details)
             if resolving_node_names is not None and not cancelled:
                 for resolving_node_name in resolving_node_names:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -445,19 +445,20 @@ class NodeManager:
             # get the current node executing / resolving
             # if it's in connected nodes, cancel flow.
             # otherwise, leave it.
-            control_node_name, resolving_node_names = GriptapeNodes.FlowManager().flow_state(parent_flow)
+            control_node_names, resolving_node_names = GriptapeNodes.FlowManager().flow_state(parent_flow)
             connected_nodes = parent_flow.get_all_connected_nodes(node)
             cancelled = False
-            if control_node_name is not None:
-                control_node = GriptapeNodes.ObjectManager().get_object_by_name(control_node_name)
-                if control_node in connected_nodes:
-                    result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
-                    cancelled = True
-                    if not result.succeeded():
-                        details = (
-                            f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
-                        )
-                        return DeleteNodeResultFailure(result_details=details)
+            if control_node_names is not None:
+                for control_node_name in control_node_names:
+                    control_node = GriptapeNodes.ObjectManager().get_object_by_name(control_node_name)
+                    if control_node in connected_nodes:
+                        result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
+                        cancelled = True
+                        if not result.succeeded():
+                            details = (
+                                f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
+                            )
+                            return DeleteNodeResultFailure(result_details=details)
             if resolving_node_names is not None and not cancelled:
                 for resolving_node_name in resolving_node_names:
                     resolving_node = GriptapeNodes.ObjectManager().get_object_by_name(resolving_node_name)

--- a/tests/unit/machines/test_dag_builder.py
+++ b/tests/unit/machines/test_dag_builder.py
@@ -23,7 +23,7 @@ class TestDagBuilder:
         """Test that initialization creates an empty DAG builder."""
         dag_builder = DagBuilder()
 
-        assert dag_builder.graph.nodes() == set()
+        assert len(dag_builder.graphs) == 0
         assert dag_builder.node_to_reference == {}
 
     def test_add_node_creates_dag_node(self) -> None:
@@ -47,7 +47,9 @@ class TestDagBuilder:
 
         dag_builder.add_node(mock_node)
 
-        assert "test_node" in dag_builder.graph.nodes()
+        default_graph = dag_builder.graphs.get("default")
+        assert default_graph is not None
+        assert "test_node" in default_graph.nodes()
         assert "test_node" in dag_builder.node_to_reference
 
     def test_add_node_duplicate_returns_existing(self) -> None:
@@ -60,7 +62,9 @@ class TestDagBuilder:
         dag_node2 = dag_builder.add_node(mock_node)
 
         assert dag_node1 is dag_node2
-        assert len(dag_builder.graph.nodes()) == 1
+        default_graph = dag_builder.graphs.get("default")
+        assert default_graph is not None
+        assert len(default_graph.nodes()) == 1
         assert len(dag_builder.node_to_reference) == 1
 
     def test_add_node_with_dependencies_no_connections(self) -> None:
@@ -80,7 +84,9 @@ class TestDagBuilder:
 
             assert len(added_nodes) == 1
             assert added_nodes[0] is mock_node
-            assert "test_node" in dag_builder.graph.nodes()
+            default_graph = dag_builder.graphs.get("default")
+            assert default_graph is not None
+            assert "test_node" in default_graph.nodes()
 
     def test_add_node_with_dependencies_with_upstream_nodes(self) -> None:
         """Test adding a node with upstream dependencies."""
@@ -114,12 +120,14 @@ class TestDagBuilder:
             assert len(added_nodes) == 2
             assert upstream_node in added_nodes
             assert downstream_node in added_nodes
-            assert "upstream_node" in dag_builder.graph.nodes()
-            assert "downstream_node" in dag_builder.graph.nodes()
+            default_graph = dag_builder.graphs.get("default")
+            assert default_graph is not None
+            assert "upstream_node" in default_graph.nodes()
+            assert "downstream_node" in default_graph.nodes()
 
             # Check that edge was added
-            assert dag_builder.graph.in_degree("downstream_node") == 1
-            assert dag_builder.graph.in_degree("upstream_node") == 0
+            assert default_graph.in_degree("downstream_node") == 1
+            assert default_graph.in_degree("upstream_node") == 0
 
     def test_add_node_with_dependencies_existing_upstream_node(self) -> None:
         """Test adding a node when upstream dependency already exists in DAG."""
@@ -153,9 +161,11 @@ class TestDagBuilder:
             assert added_nodes[0] is downstream_node
 
             # Both nodes should be in the DAG with proper edge
-            assert len(dag_builder.graph.nodes()) == 2
-            assert dag_builder.graph.in_degree("downstream_node") == 1
-            assert dag_builder.graph.in_degree("upstream_node") == 0
+            default_graph = dag_builder.graphs.get("default")
+            assert default_graph is not None
+            assert len(default_graph.nodes()) == 2
+            assert default_graph.in_degree("downstream_node") == 1
+            assert default_graph.in_degree("upstream_node") == 0
 
     def test_add_node_with_dependencies_prevents_cycles(self) -> None:
         """Test that add_node_with_dependencies handles potential cycles using visited set."""
@@ -216,14 +226,16 @@ class TestDagBuilder:
         dag_builder.add_node(mock_node2)
 
         # Verify nodes were added
-        assert len(dag_builder.graph.nodes()) == 2
+        default_graph = dag_builder.graphs.get("default")
+        assert default_graph is not None
+        assert len(default_graph.nodes()) == 2
         assert len(dag_builder.node_to_reference) == 2
 
         # Clear the DAG builder
         dag_builder.clear()
 
         # Verify everything is cleared
-        assert dag_builder.graph.nodes() == set()
+        assert len(dag_builder.graphs) == 0
         assert dag_builder.node_to_reference == {}
 
     def test_clear_on_empty_dag_builder(self) -> None:
@@ -233,7 +245,7 @@ class TestDagBuilder:
         # Clear should not raise any errors
         dag_builder.clear()
 
-        assert dag_builder.graph.nodes() == set()
+        assert len(dag_builder.graphs) == 0
         assert dag_builder.node_to_reference == {}
 
     def test_clear_removes_edges(self) -> None:
@@ -264,13 +276,15 @@ class TestDagBuilder:
             dag_builder.add_node_with_dependencies(downstream_node)
 
             # Verify edge was created
-            assert dag_builder.graph.in_degree("downstream_node") == 1
+            default_graph = dag_builder.graphs.get("default")
+            assert default_graph is not None
+            assert default_graph.in_degree("downstream_node") == 1
 
             # Clear the DAG
             dag_builder.clear()
 
             # Verify everything is cleared including edges
-            assert dag_builder.graph.nodes() == set()
+            assert len(dag_builder.graphs) == 0
             assert dag_builder.node_to_reference == {}
 
     def test_node_state_preservation(self) -> None:


### PR DESCRIPTION
closes #2054 

Updates Parallel Execution to work with multiple control flows at once. 
Some key updates:
1. Sequential resolution remains unchanged. It'll create a control flow machine, and then a sequential resolution machine, and step through each one. 
2. Parallel execution is updated. Now, the function of Control Flow Machine is to initialize the Dag graphs (there is a list of graphs, instead of a singular graph). Leaf nodes are grabbed from the list of graphs, and once a graph is empty, the parallel_resolution machine does some of the work that was previously in Control Flow Machine, and steps to the next node, and adds it (with it's dependencies) to the graph. This has to happen at execution time, for nodes like 'if/else', where we don't know which flow we'll follow.  
3. As well, we've added a method to Dag Builder. this helps determine if there are multiple control flows that lead to the same node, like in the image attached: 
<img width="694" height="720" alt="image" src="https://github.com/user-attachments/assets/11511078-c229-4e73-81fc-1bc20a540a5e" />
In this case, we don't want to move onto the node until all three have finished. There are also more complex scenarios, like this screenshot: 
<img width="733" height="589" alt="Screenshot 2025-09-15 at 4 56 05 PM" src="https://github.com/user-attachments/assets/2b714700-fdc5-4ede-b847-5ed80a4e310e" />
where we don't necessarily have to wait for both paths to Merge Images to resolve before resolving it, depending on the path of IfElse. 