### PR TITLE
Migrated EngineNode to SuccessFailure node type

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/engine/engine_node.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/engine/engine_node.py
@@ -162,9 +162,8 @@ class EngineNode(SuccessFailureNode):
         self._create_status_parameters(
             result_details_tooltip="Details about the execution result",
             result_details_placeholder="Details on the request execution will be presented here.",
+            parameter_group_initially_collapsed=False,  # Show Status group expanded by default for EngineNode
         )
-        # Override to show Status group expanded by default for EngineNode
-        self.status_component.get_parameter_group().ui_options = {"collapsed": False}
 
         # Initial parameter creation will be deferred to validate_before_workflow_run
         # to ensure the node is properly registered first
@@ -566,14 +565,14 @@ class EngineNode(SuccessFailureNode):
         # Check if request type is usable
         if not new_request_info.has_results:
             # Set result_details to show the error instead of using error_message
-            self.status_component.set_execution_result(
+            self._set_status_results(
                 was_successful=False,
                 result_details=f"ERROR: Cannot use {clean_type}: {self._RESULT_CLASSES_NOT_FOUND_ERROR}",
             )
             return
 
         # Clear result_details for usable request types
-        self.status_component.set_execution_result(was_successful=False, result_details="")
+        self._set_status_results(was_successful=False, result_details="")
 
         # Systematic parameter transition approach
         if _old_type:

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1254,8 +1254,10 @@ class SuccessFailureNode(BaseNode):
 
     def _create_status_parameters(
         self,
+        *,
         result_details_tooltip: str = "Details about the operation result",
         result_details_placeholder: str = "Details on the operation will be presented here.",
+        parameter_group_initially_collapsed: bool = True,
     ) -> None:
         """Create and add standard status output parameters in a collapsible group.
 
@@ -1270,13 +1272,14 @@ class SuccessFailureNode(BaseNode):
         Args:
             result_details_tooltip: Custom tooltip for result_details parameter
             result_details_placeholder: Custom placeholder text for result_details parameter
+            parameter_group_initially_collapsed: Whether the Status group should start collapsed
         """
         # Create status component with OUTPUT modes for SuccessFailureNode
         self.status_component = ExecutionStatusComponent(
             self,
             was_successful_modes={ParameterMode.OUTPUT},
             result_details_modes={ParameterMode.OUTPUT},
-            parameter_group_initially_collapsed=True,
+            parameter_group_initially_collapsed=parameter_group_initially_collapsed,
             result_details_tooltip=result_details_tooltip,
             result_details_placeholder=result_details_placeholder,
         )


### PR DESCRIPTION
Engine Node was the progenitor of SuccessFailureNode, but never got the loving 😿 