### PR TITLE
Success/Failure nodes now clear result details when a workflow is about to be run, reducing confusion from previous executions.

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1343,6 +1343,22 @@ class SuccessFailureNode(BaseNode):
             # No graceful handling, raise the exception to crash the flow
             raise exception
 
+    def validate_before_workflow_run(self) -> list[Exception] | None:
+        """Clear result details before workflow runs to avoid confusion from previous sessions."""
+        self._set_status_results(
+            was_successful=False,
+            result_details="<Results will appear when the node executes>"
+        )
+        return super().validate_before_workflow_run()
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Clear result details before node runs to avoid confusion from previous sessions."""
+        self._set_status_results(
+            was_successful=False,
+            result_details="<Results will appear when the node executes>"
+        )
+        return super().validate_before_node_run()
+
 
 class StartNode(BaseNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:


### PR DESCRIPTION
Fixes #2208 