### PR TITLE
chore: bump v0.54.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.54.0"
+version = "0.54.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -278,7 +278,7 @@ wheels = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.54.0"
+version = "0.54.1"
 source = { editable = "." }
 dependencies = [
     { name = "binaryornot" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.54`.

Cherry-picked commit: 83db4077942c3a0ac3c9de412b437a762856096d