### PR TITLE
Duplicate params

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_one_flux_control_net_model.py
@@ -5,7 +5,7 @@ from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
 from utils.image_utils import load_image_from_url_artifact
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.traits.options import Options
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_two_flux_control_net_parameters.py
@@ -3,9 +3,8 @@ from PIL.Image import Image
 from pillow_nodes_library.utils import image_artifact_to_pil
 from utils.image_utils import load_image_from_url_artifact
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
-from griptape_nodes.traits.options import Options
 
 
 class UnionTwoFluxControlNetParameters:


### PR DESCRIPTION
These pipelines already use FluxPipelineParameters and do not need their own quantization_mode and skip_memory_check params. This was known for FluxControlNetParameters but missed for these two

Closes https://github.com/griptape-ai/griptape-nodes/issues/2231