### PR TITLE
Use model CPU offload instead of sequential

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -136,12 +136,12 @@ def _optimize_flux_pipeline(  # noqa: C901
                 pipe.to(device)
                 return
 
-            if hasattr(pipe, "enable_model_cpu_offload"):
-                logger.info("Insufficient memory. Enabling model cpu offload")
-                pipe.enable_model_cpu_offload()
+            if hasattr(pipe, "enable_sequential_cpu_offload"):
+                logger.info("Insufficient memory. Enabling sequential cpu offload")
+                pipe.enable_sequential_cpu_offload()
                 _log_memory_info(pipe, device)
                 if _check_cuda_memory_sufficient(pipe, device):
-                    logger.info("Sufficient memory after model cpu offload")
+                    logger.info("Sufficient memory after sequential cpu offload")
                     return
                 logger.info("Disabling model cpu offload, trying sequential cpu offload")
                 pipe.disable_model_cpu_offload()

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -143,16 +143,6 @@ def _optimize_flux_pipeline(  # noqa: C901
                 if _check_cuda_memory_sufficient(pipe, device):
                     logger.info("Sufficient memory after sequential cpu offload")
                     return
-                logger.info("Disabling model cpu offload, trying sequential cpu offload")
-                pipe.disable_model_cpu_offload()
-
-            if hasattr(pipe, "enable_sequential_cpu_offload"):
-                logger.info("Insufficient memory. Enabling sequential cpu offload")
-                pipe.enable_sequential_cpu_offload()
-                _log_memory_info(pipe, device)
-                if _check_cuda_memory_sufficient(pipe, device):
-                    logger.info("Sufficient memory after sequential cpu offload")
-                    return
 
         if hasattr(pipe, "enable_vae_slicing"):
             # Apply VAE slicing as final optimization

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -143,6 +143,16 @@ def _optimize_flux_pipeline(  # noqa: C901
                 if _check_cuda_memory_sufficient(pipe, device):
                     logger.info("Sufficient memory after model cpu offload")
                     return
+                logger.info("Disabling model cpu offload, trying sequential cpu offload")
+                pipe.disable_model_cpu_offload()
+
+            if hasattr(pipe, "enable_sequential_cpu_offload"):
+                logger.info("Insufficient memory. Enabling sequential cpu offload")
+                pipe.enable_sequential_cpu_offload()
+                _log_memory_info(pipe, device)
+                if _check_cuda_memory_sufficient(pipe, device):
+                    logger.info("Sufficient memory after sequential cpu offload")
+                    return
 
         if hasattr(pipe, "enable_vae_slicing"):
             # Apply VAE slicing as final optimization

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -136,12 +136,12 @@ def _optimize_flux_pipeline(  # noqa: C901
                 pipe.to(device)
                 return
 
-            if hasattr(pipe, "enable_sequential_cpu_offload"):
-                logger.info("Insufficient memory. Enabling sequential cpu offload")
-                pipe.enable_sequential_cpu_offload()
+            if hasattr(pipe, "enable_model_cpu_offload"):
+                logger.info("Insufficient memory. Enabling model cpu offload")
+                pipe.enable_model_cpu_offload()
                 _log_memory_info(pipe, device)
                 if _check_cuda_memory_sufficient(pipe, device):
-                    logger.info("Sufficient memory after sequential cpu offload")
+                    logger.info("Sufficient memory after model cpu offload")
                     return
 
         if hasattr(pipe, "enable_vae_slicing"):


### PR DESCRIPTION
In my research, I have discovered that [enable_model_cpu_offload](https://huggingface.co/docs/diffusers/v0.35.1/en/api/pipelines/overview#diffusers.DiffusionPipeline.enable_model_cpu_offload) has superior performance to enable_sequential_cpu_offload

plz ignore revert hell in commit history