### PR TITLE
Fix/revert flux memory optimizations

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -25,6 +25,7 @@ FLUX_PIPELINE_COMPONENT_NAMES = [
     "text_encoder",
     "text_encoder_2",
     "transformer",
+    "controlnet",
 ]
 
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cache
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
@@ -180,7 +181,7 @@ def _optimize_flux_pipeline(  # noqa: C901
     return
 
 
-def optimize_flux_pipeline(
+def new_optimize_flux_pipeline(
     pipe: diffusers.FluxPipeline | diffusers.FluxImg2ImgPipeline | diffusers.AmusedPipeline,
     pipe_params: FluxPipelineParameters | FluxFillPipelineParameters | DiptychFluxFillPipelineParameters,
 ) -> None:
@@ -203,3 +204,65 @@ def optimize_flux_pipeline(
             torch.backends.cuda.sdp_kernel()
     except Exception:
         logger.debug("sdp_kernel not supported, continuing without")
+
+
+@cache
+def optimize_flux_pipeline_memory_footprint(pipe: diffusers.FluxPipeline | diffusers.FluxImg2ImgPipeline) -> None:
+    """Optimize pipeline memory footprint."""
+    device = get_best_device()
+
+    if device == torch.device("cuda"):
+        # We specifically do not call pipe.to(device) for gpus
+        # because it would move ALL the models in the pipe to the
+        # gpus, potentially causing us to exhaust available VRAM,
+        # and essentially undo all of the following VRAM pressure
+        # reducing optimizations in vain.
+        #
+        # TL;DR - DONT CALL `pipe.to(device)` FOR GPUS!
+        # (unless you checked pipe is small enough!)
+
+        if hasattr(pipe, "transformer"):
+            # This fp8 layerwise caching is important for lower VRAM
+            # gpus (say 25GB or lower). Not important if not on a gpu.
+            # We only do this for the transformer, because its the biggest.
+            # TODO: https://github.com/griptape-ai/griptape-nodes/issues/846
+            logger.info("Enabling fp8 layerwise caching for transformer")
+            pipe.transformer.enable_layerwise_casting(
+                storage_dtype=torch.float8_e4m3fn,
+                compute_dtype=torch.bfloat16,
+            )
+        # Sequential cpu offload only makes sense for gpus (VRAM <-> RAM).
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/846
+        logger.info("Enabling sequential cpu offload")
+        pipe.enable_sequential_cpu_offload()
+    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/846
+    logger.info("Enabling attention slicing")
+    pipe.enable_attention_slicing()
+    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/846
+    if hasattr(pipe, "enable_vae_slicing"):
+        logger.info("Enabling vae slicing")
+        pipe.enable_vae_slicing()
+    elif hasattr(pipe, "vae"):
+        logger.info("Enabling vae slicing")
+        pipe.vae.enable_slicing()
+
+    logger.info("Final memory footprint:")
+    print_flux_pipeline_memory_footprint(pipe)
+
+    if device == torch.device("mps"):
+        # You must move the pipeline models to MPS if available to
+        # use it (otherwise you'll get the CPU).
+        logger.info("Transferring model to MPS/GPU - may take minutes")
+        pipe.to(device)
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/847
+
+    if device == torch.device("cuda"):
+        # We specifically do not call pipe.to(device) for gpus
+        # because it would move ALL the models in the pipe to the
+        # gpus, potentially causing us to exhaust available VRAM,
+        # and essentially undo all of the following VRAM pressure
+        # reducing optimizations in vain.
+        #
+        # TL;DR - DONT CALL `pipe.to(device)` FOR GPUS!
+        # (unless you checked pipe is small enough!)
+        pass

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -136,12 +136,12 @@ def _optimize_flux_pipeline(  # noqa: C901
                 pipe.to(device)
                 return
 
-            if hasattr(pipe, "enable_model_cpu_offload"):
-                logger.info("Insufficient memory. Enabling model cpu offload")
-                pipe.enable_model_cpu_offload()
+            if hasattr(pipe, "enable_sequential_cpu_offload"):
+                logger.info("Insufficient memory. Enabling sequential cpu offload")
+                pipe.enable_sequential_cpu_offload()
                 _log_memory_info(pipe, device)
                 if _check_cuda_memory_sufficient(pipe, device):
-                    logger.info("Sufficient memory after model cpu offload")
+                    logger.info("Sufficient memory after sequential cpu offload")
                     return
                 logger.info("Disabling model cpu offload, trying sequential cpu offload")
                 pipe.disable_model_cpu_offload()

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -143,16 +143,6 @@ def _optimize_flux_pipeline(  # noqa: C901
                 if _check_cuda_memory_sufficient(pipe, device):
                     logger.info("Sufficient memory after sequential cpu offload")
                     return
-                logger.info("Disabling model cpu offload, trying sequential cpu offload")
-                pipe.disable_model_cpu_offload()
-
-            if hasattr(pipe, "enable_sequential_cpu_offload"):
-                logger.info("Insufficient memory. Enabling sequential cpu offload")
-                pipe.enable_sequential_cpu_offload()
-                _log_memory_info(pipe, device)
-                if _check_cuda_memory_sufficient(pipe, device):
-                    logger.info("Sufficient memory after sequential cpu offload")
-                    return
 
         if hasattr(pipe, "enable_vae_slicing"):
             # Apply VAE slicing as final optimization

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -143,6 +143,16 @@ def _optimize_flux_pipeline(  # noqa: C901
                 if _check_cuda_memory_sufficient(pipe, device):
                     logger.info("Sufficient memory after model cpu offload")
                     return
+                logger.info("Disabling model cpu offload, trying sequential cpu offload")
+                pipe.disable_model_cpu_offload()
+
+            if hasattr(pipe, "enable_sequential_cpu_offload"):
+                logger.info("Insufficient memory. Enabling sequential cpu offload")
+                pipe.enable_sequential_cpu_offload()
+                _log_memory_info(pipe, device)
+                if _check_cuda_memory_sufficient(pipe, device):
+                    logger.info("Sufficient memory after sequential cpu offload")
+                    return
 
         if hasattr(pipe, "enable_vae_slicing"):
             # Apply VAE slicing as final optimization

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -118,9 +118,15 @@ def _optimize_flux_pipeline(  # noqa: C901
     if device.type == "cuda":
         _log_memory_info(pipe, device)
 
+        if hasattr(pipe, "enable_vae_slicing"):
+            logger.info("Enabling vae slicing")
+            pipe.enable_vae_slicing()
+        elif hasattr(pipe, "vae"):
+            logger.info("Enabling vae slicing")
+            pipe.vae.enable_slicing()
+
         if _check_cuda_memory_sufficient(pipe, device):
-            logger.info("Sufficient memory on %s for Pipeline.", device)
-            logger.info("Moving pipeline to %s", device)
+            logger.info("Sufficient memory. Moving pipeline to %s", device)
             pipe.to(device)
             return
 
@@ -143,12 +149,6 @@ def _optimize_flux_pipeline(  # noqa: C901
                 if _check_cuda_memory_sufficient(pipe, device):
                     logger.info("Sufficient memory after model cpu offload")
                     return
-
-        if hasattr(pipe, "enable_vae_slicing"):
-            # Apply VAE slicing as final optimization
-            logger.info("Insufficient memory. Enabling vae slicing")
-            pipe.enable_vae_slicing()
-            _log_memory_info(pipe, device)
 
         # Final check after all optimizations
         if not _check_cuda_memory_sufficient(pipe, device):

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -136,12 +136,12 @@ def _optimize_flux_pipeline(  # noqa: C901
                 pipe.to(device)
                 return
 
-            if hasattr(pipe, "enable_sequential_cpu_offload"):
-                logger.info("Insufficient memory. Enabling sequential cpu offload")
-                pipe.enable_sequential_cpu_offload()
+            if hasattr(pipe, "enable_model_cpu_offload"):
+                logger.info("Insufficient memory. Enabling model cpu offload")
+                pipe.enable_model_cpu_offload()
                 _log_memory_info(pipe, device)
                 if _check_cuda_memory_sufficient(pipe, device):
-                    logger.info("Sufficient memory after sequential cpu offload")
+                    logger.info("Sufficient memory after model cpu offload")
                     return
 
         if hasattr(pipe, "enable_vae_slicing"):


### PR DESCRIPTION
This reverts to the old style of memory optimization, which includes always fp8 casting the transformer