### PR TITLE
fix: improve handling during model download failure

### DIFF
--- a/src/griptape_nodes/cli/commands/models.py
+++ b/src/griptape_nodes/cli/commands/models.py
@@ -1,6 +1,7 @@
 """Models command for managing AI models."""
 
 import asyncio
+import sys
 from typing import TYPE_CHECKING
 
 import typer
@@ -130,6 +131,7 @@ async def _download_model(
     except Exception as e:
         console.print("[bold red]Model download failed:[/bold red]")
         console.print(f"[red]{e}[/red]")
+        sys.exit(1)
 
 
 async def _list_models() -> None:


### PR DESCRIPTION
Refactors the download model handler to wait for the model download to complete. This way we can convey error details back to the UI. Thanks to the power of async this is ok.

```
[15:46:16] ERROR    Failed to download model 'black-forest-labs/FLUX.1-dev': Downloading model: black-forest-labs/FLUX.1-dev
                    Model download failed:
                    401 Client Error. (Request ID: Root=1-68cddd38-517b610204cd4494523332dd;592e71f4-70ea-4816-a6f0-68a475fdb482)

                    Cannot access gated repo for url
                    https://huggingface.co/black-forest-labs/FLUX.1-dev/resolve/3de623fc3c33e44ffbe2bad470d0f45bccf2eb21/.gitattributes
                    .
                    Access to model black-forest-labs/FLUX.1-dev is restricted. You must have access to it and be authenticated to
                    access it. Please log
                    in.
           INFO     Completed automatic model downloads: 0 successful, 1 failed

```
Sister PR: https://github.com/griptape-ai/griptape-vsl-gui/pull/1298
<img width="969" height="464" alt="image" src="https://github.com/user-attachments/assets/a4a6f809-9311-4a9b-b047-c0dcc4472709" />


Towards #2270. Will add explicit auth instructions/requests in another PR.