### PR TITLE
fix: Prevent ParameterGroup ui_options inheritance from causing trait leakage

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1077,11 +1077,6 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         for trait in traits:
             ui_options = ui_options | trait.ui_options_for_trait()
         ui_options = ui_options | self._ui_options
-        if self._parent is not None and isinstance(self._parent, ParameterGroup):
-            # Access the field value directly for ParameterGroup
-            parent_ui_options = getattr(self._parent, "ui_options", {})
-            if isinstance(parent_ui_options, dict):
-                ui_options = ui_options | parent_ui_options
         return ui_options
 
     @ui_options.setter


### PR DESCRIPTION
fixed: #2269

# Fix: Prevent ParameterGroup ui_options inheritance from causing trait leakage

## Problem

When adding traits (like `Options`) to parameters within a `ParameterGroup`, the trait's ui_options were leaking to all other parameters in the same group. This caused unintended UI elements (like dropdowns) to appear on parameters that didn't have the corresponding traits.

## Root Cause

The `Parameter.ui_options` property was inheriting ui_options from its parent `ParameterGroup`:

```python
if self._parent is not None and isinstance(self._parent, ParameterGroup):
    parent_ui_options = getattr(self._parent, "ui_options", {})
    if isinstance(parent_ui_options, dict):
        ui_options = ui_options | parent_ui_options
```

This inheritance mechanism was causing trait-generated ui_options to be shared across all parameters in the same group, even though traits should be parameter-specific.

## Solution

Removed the ParameterGroup ui_options inheritance from the `Parameter.ui_options` property:

```python
@property
def ui_options(self) -> dict:
    ui_options = {}
    traits = self.find_elements_by_type(Trait)
    for trait in traits:
        ui_options = ui_options | trait.ui_options_for_trait()
    ui_options = ui_options | self._ui_options
    return ui_options
```

## Impact

- ✅ **Fixed**: Traits are now properly isolated to individual parameters
- ✅ **Preserved**: ParameterGroup ui_options still work for group-level behavior (collapsed, hide, etc.)
- ✅ **Preserved**: Individual parameter ui_options continue to work correctly
- ✅ **No breaking changes**: All existing functionality remains intact

## Example

**Before**: Adding `Options` trait to `canvas_size` parameter caused all parameters in the `canvas_details_group` to show dropdown UI elements.

**After**: Only the `canvas_size` parameter shows the dropdown UI element.