### PR TITLE
Fix caching for param changes

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_flux_control_net_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_flux_control_net_pipeline.py
@@ -82,7 +82,7 @@ class UnionFluxControlNetPipeline(ControlNode):
             )
 
         with self.log_params.append_profile_to_logs("Loading model"), self.log_params.append_logs_to_logs(logger):
-            optimize_flux_pipeline(pipe=pipe, pipe_params=self.flux_params)
+            optimize_flux_pipeline(pipe=pipe)
 
         with (
             self.log_params.append_profile_to_logs("Configuring flux loras"),

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_pro_flux_control_net_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_pro_flux_control_net_pipeline.py
@@ -78,7 +78,7 @@ class UnionProFluxControlNetPipeline(ControlNode):
             )
 
         with self.log_params.append_profile_to_logs("Loading model"), self.log_params.append_logs_to_logs(logger):
-            optimize_flux_pipeline(pipe=pipe, pipe_params=self.flux_params)
+            optimize_flux_pipeline(pipe=pipe)
 
         with (
             self.log_params.append_profile_to_logs("Configuring flux loras"),

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_pro_two_flux_control_net_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/controlnet/union_pro_two_flux_control_net_pipeline.py
@@ -78,7 +78,7 @@ class UnionProTwoFluxControlNetPipeline(ControlNode):
             )
 
         with self.log_params.append_profile_to_logs("Loading model"), self.log_params.append_logs_to_logs(logger):
-            optimize_flux_pipeline(pipe=pipe, pipe_params=self.flux_params)
+            optimize_flux_pipeline(pipe=pipe)
 
         with (
             self.log_params.append_profile_to_logs("Configuring flux loras"),

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_fill_pipeline.py
@@ -72,7 +72,7 @@ class FluxFillPipeline(ControlNode):
             )
 
         with self.log_params.append_profile_to_logs("Loading model"), self.log_params.append_logs_to_logs(logger):
-            optimize_flux_pipeline(pipe=pipe, pipe_params=self.pipe_params)
+            optimize_flux_pipeline(pipe=pipe)
 
         with (
             self.log_params.append_profile_to_logs("Configuring flux loras"),

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline.py
@@ -61,7 +61,7 @@ class FluxPipeline(ControlNode):
             )
 
         with self.log_params.append_profile_to_logs("Loading model"), self.log_params.append_logs_to_logs(logger):
-            optimize_flux_pipeline(pipe=pipe, pipe_params=self.pipe_params)
+            optimize_flux_pipeline(pipe=pipe)
 
         with (
             self.log_params.append_profile_to_logs("Configuring flux loras"),

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/flux_pipeline_memory_footprint.py
@@ -209,12 +209,9 @@ def new_optimize_flux_pipeline(
 @cache
 def optimize_flux_pipeline(
     pipe: diffusers.FluxPipeline | diffusers.FluxImg2ImgPipeline | diffusers.AmusedPipeline,
-    pipe_params: FluxPipelineParameters | FluxFillPipelineParameters | DiptychFluxFillPipelineParameters,
 ) -> None:
     """Optimize pipeline memory footprint."""
     device = get_best_device()
-
-    logger.debug("Using legacy memory footprint optimization, ignoring pipe_params: %s", pipe_params)
 
     if device == torch.device("cuda"):
         # We specifically do not call pipe.to(device) for gpus

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/tiling_flux_img_2_img_pipeline.py
@@ -180,7 +180,7 @@ class TilingFluxImg2ImgPipeline(ControlNode):
             )
 
         with self.log_params.append_profile_to_logs("Loading model"), self.log_params.append_logs_to_logs(logger):
-            optimize_flux_pipeline(pipe=pipe, pipe_params=self.flux_params)
+            optimize_flux_pipeline(pipe=pipe)
 
         with (
             self.log_params.append_profile_to_logs("Configuring flux loras"),


### PR DESCRIPTION
For the rollback, we need to ignore pipe_params for the cached function