### PR TITLE
refactor: move --no-update from gtn engine to gtn

### DIFF
--- a/src/griptape_nodes/cli/commands/engine.py
+++ b/src/griptape_nodes/cli/commands/engine.py
@@ -1,6 +1,5 @@
 """Engine command for Griptape Nodes CLI."""
 
-import typer
 from rich.prompt import Confirm
 
 from griptape_nodes.app import start_app
@@ -21,19 +20,13 @@ from griptape_nodes.cli.shared import (
 from griptape_nodes.utils.version_utils import get_current_version, get_install_source
 
 
-def engine_command(
-    no_update: bool = typer.Option(False, "--no-update", help="Skip the auto-update check."),  # noqa: FBT001
-) -> None:
+def engine_command() -> None:
     """Run the Griptape Nodes engine."""
-    _start_engine(no_update=no_update)
+    _start_engine()
 
 
-def _start_engine(*, no_update: bool = False) -> None:
-    """Starts the Griptape Nodes engine.
-
-    Args:
-        no_update (bool): If True, skips the auto-update check.
-    """
+def _start_engine() -> None:
+    """Starts the Griptape Nodes engine."""
     if not CONFIG_DIR.exists():
         # Default init flow if there is no config directory
         console.print("[bold green]Config directory not found. Initializing...[/bold green]")
@@ -50,10 +43,6 @@ def _start_engine(*, no_update: bool = False) -> None:
                 bucket_name=ENV_GTN_BUCKET_NAME,
             )
         )
-
-    # Confusing double negation -- If `no_update` is set, we want to skip the update
-    if not no_update:
-        _auto_update_self()
 
     console.print("[bold green]Starting Griptape Nodes engine...[/bold green]")
     start_app()

--- a/src/griptape_nodes/cli/main.py
+++ b/src/griptape_nodes/cli/main.py
@@ -10,6 +10,7 @@ from rich.console import Console
 sys.path.append(str(Path.cwd()))
 
 from griptape_nodes.cli.commands import config, engine, init, libraries, models, self
+from griptape_nodes.cli.commands.engine import _auto_update_self
 from griptape_nodes.utils.version_utils import get_complete_version_string
 
 console = Console()
@@ -47,9 +48,13 @@ def main(
         console.print(f"[bold green]{version_string}[/bold green]")
         raise typer.Exit
 
+    # Run auto-update check for any command (unless disabled)
+    if not no_update:
+        _auto_update_self()
+
     if ctx.invoked_subcommand is None:
         # Default to engine command when no subcommand is specified
-        engine.engine_command(no_update=no_update)
+        engine.engine_command()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`--no-update` is flag of `gtn engine` not `gtn`. This is confusing.

Closes #2315 