### PR TITLE
Update Events for Proper Flow State tracking in the GUI

### DIFF
--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -261,18 +261,18 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
             # For control flow/sequential: emit all nodes in flow as involved
             flow_manager = GriptapeNodes.FlowManager()
             flow = flow_manager.get_flow_by_name(self._context.flow_name)
-            involved_nodes = list(flow.nodes.keys())
-            GriptapeNodes.EventManager().put_event(
-                ExecutionGriptapeNodeEvent(
-                    wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))
-                )
-            )
         self._context.current_nodes = current_nodes
         # Set entry control parameter for initial node (None for workflow start)
         for node in current_nodes:
             node.set_entry_control_parameter(None)
         # Set up to debug
         self._context.paused = debug_mode
+        involved_nodes = list(flow.nodes.keys())
+        GriptapeNodes.EventManager().put_event(
+                ExecutionGriptapeNodeEvent(
+                    wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))
+                )
+            )
         await self.start(ResolveNodeState)  # Begins the flow
 
     async def update(self) -> None:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -229,11 +229,6 @@ class CompleteState(State):
                     )
                 )
             )
-
-        # Emit empty involved nodes list to indicate execution complete
-        GriptapeNodes.EventManager().put_event(
-            ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=[])))
-        )
         logger.info("Flow is complete.")
         return None
 
@@ -269,10 +264,10 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         flow = flow_manager.get_flow_by_name(self._context.flow_name)
         involved_nodes = list(flow.nodes.keys())
         GriptapeNodes.EventManager().put_event(
-                ExecutionGriptapeNodeEvent(
-                    wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))
-                )
+            ExecutionGriptapeNodeEvent(
+                wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))
             )
+        )
         await self.start(ResolveNodeState)  # Begins the flow
 
     async def update(self) -> None:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -259,14 +259,14 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         else:
             current_nodes = [start_node]
             # For control flow/sequential: emit all nodes in flow as involved
-            flow_manager = GriptapeNodes.FlowManager()
-            flow = flow_manager.get_flow_by_name(self._context.flow_name)
         self._context.current_nodes = current_nodes
         # Set entry control parameter for initial node (None for workflow start)
         for node in current_nodes:
             node.set_entry_control_parameter(None)
         # Set up to debug
         self._context.paused = debug_mode
+        flow_manager = GriptapeNodes.FlowManager()
+        flow = flow_manager.get_flow_by_name(self._context.flow_name)
         involved_nodes = list(flow.nodes.keys())
         GriptapeNodes.EventManager().put_event(
                 ExecutionGriptapeNodeEvent(

--- a/src/griptape_nodes/machines/dag_builder.py
+++ b/src/griptape_nodes/machines/dag_builder.py
@@ -43,10 +43,12 @@ class DagBuilder:
 
     graphs: dict[str, DirectedGraph]  # Str is the name of the start node associated here.
     node_to_reference: dict[str, DagNode]
+    graph_to_nodes: dict[str, set[str]]  # Track which nodes belong to which graph
 
     def __init__(self) -> None:
         self.graphs = {}
         self.node_to_reference: dict[str, DagNode] = {}
+        self.graph_to_nodes = {}
 
     # Complex with the inner recursive method, but it needs connections and added_nodes.
     def add_node_with_dependencies(self, node: BaseNode, graph_name: str = "default") -> list[BaseNode]:  # noqa: C901
@@ -98,6 +100,12 @@ class DagBuilder:
             dag_node = DagNode(node_reference=current_node, node_state=NodeState.WAITING)
             self.node_to_reference[current_node.name] = dag_node
             graph.add_node(node_for_adding=current_node.name)
+
+            # Track which nodes belong to this graph
+            if graph_name not in self.graph_to_nodes:
+                self.graph_to_nodes[graph_name] = set()
+            self.graph_to_nodes[graph_name].add(current_node.name)
+
             # DON'T mark as resolved - that happens during actual execution
             added_nodes.append(current_node)
 
@@ -117,12 +125,19 @@ class DagBuilder:
             graph = DirectedGraph()
             self.graphs[graph_name] = graph
         graph.add_node(node_for_adding=node.name)
+
+        # Track which nodes belong to this graph
+        if graph_name not in self.graph_to_nodes:
+            self.graph_to_nodes[graph_name] = set()
+        self.graph_to_nodes[graph_name].add(node.name)
+
         return dag_node
 
     def clear(self) -> None:
         """Clear all nodes and references from the DAG builder."""
         self.graphs.clear()
         self.node_to_reference.clear()
+        self.graph_to_nodes.clear()
 
     def can_queue_control_node(self, node: DagNode) -> bool:
         if len(self.graphs) == 1:
@@ -205,3 +220,10 @@ class DagBuilder:
                                 return True
 
         return False
+
+    def cleanup_empty_graph_nodes(self, graph_name: str) -> None:
+        """Remove nodes from node_to_reference when their graph becomes empty (only in single node resolution)."""
+        if graph_name in self.graph_to_nodes:
+            for node_name in self.graph_to_nodes[graph_name]:
+                self.node_to_reference.pop(node_name, None)
+            self.graph_to_nodes.pop(graph_name, None)

--- a/src/griptape_nodes/machines/dag_builder.py
+++ b/src/griptape_nodes/machines/dag_builder.py
@@ -61,16 +61,15 @@ class DagBuilder:
         if graph is None:
             graph = DirectedGraph()
             self.graphs[graph_name] = graph
+            self.graph_to_nodes[graph_name] = set()
 
         def _add_node_recursive(current_node: BaseNode, visited: set[str], graph: DirectedGraph) -> None:
             if current_node.name in visited:
                 return
             visited.add(current_node.name)
-
             # Skip if already in DAG (use DAG membership, not resolved state)
             if current_node.name in self.node_to_reference:
                 return
-
             # Process dependencies first (depth-first)
             ignore_data_dependencies = False
             # This is specifically for output_selector. Overriding 'initialize_spotlight' doesn't work anymore.
@@ -102,8 +101,6 @@ class DagBuilder:
             graph.add_node(node_for_adding=current_node.name)
 
             # Track which nodes belong to this graph
-            if graph_name not in self.graph_to_nodes:
-                self.graph_to_nodes[graph_name] = set()
             self.graph_to_nodes[graph_name].add(current_node.name)
 
             # DON'T mark as resolved - that happens during actual execution

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -536,10 +536,6 @@ class ErrorState(State):
 class DagCompleteState(State):
     @staticmethod
     async def on_enter(context: ParallelResolutionContext) -> type[State] | None:
-        # Emit empty involved nodes list to indicate DAG execution complete
-        GriptapeNodes.EventManager().put_event(
-            ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=[])))
-        )
         # Clear the DAG builder so we don't have any leftover nodes in node_to_reference.
         if context.dag_builder is not None:
             context.dag_builder.clear()
@@ -565,7 +561,6 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         """Execute the DAG structure using the existing DagBuilder."""
         if self.context.dag_builder is None:
             self.context.dag_builder = GriptapeNodes.FlowManager().global_dag_builder
-        ExecuteDagState._emit_involved_nodes_update(self.context)
         await self.start(ExecuteDagState)
 
     def change_debug_mode(self, *, debug_mode: bool) -> None:

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -189,7 +189,7 @@ class ExecuteDagState(State):
         network_value = False
         if context.dag_builder is not None:
             network = context.dag_builder.graphs.get(network_name, None)
-            network_value = network is not None and len(network) == 0
+            network_value = network is not None and len(network) > 0
 
         if flow_manager.global_single_node_resolution:
             # Clean up nodes from emptied graphs in single node resolution mode

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -193,7 +193,7 @@ class ExecuteDagState(State):
 
         if flow_manager.global_single_node_resolution:
             # Clean up nodes from emptied graphs in single node resolution mode
-            if network_value and context.dag_builder is not None:
+            if not network_value and context.dag_builder is not None:
                 context.dag_builder.cleanup_empty_graph_nodes(network_name)
                 GriptapeNodes.handle_request(GetFlowStateRequest(flow_name=context.flow_name))
             return True

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -394,9 +394,6 @@ class ExecuteDagState(State):
 
         context.workflow_state = WorkflowState.NO_ERROR
 
-        # Emit initial involved nodes for DAG execution
-        ExecuteDagState._emit_involved_nodes_update(context)
-
         if not context.paused:
             return ExecuteDagState
         return None
@@ -568,6 +565,7 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         """Execute the DAG structure using the existing DagBuilder."""
         if self.context.dag_builder is None:
             self.context.dag_builder = GriptapeNodes.FlowManager().global_dag_builder
+        ExecuteDagState._emit_involved_nodes_update(self.context)
         await self.start(ExecuteDagState)
 
     def change_debug_mode(self, *, debug_mode: bool) -> None:

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -350,6 +350,18 @@ class NodeFinishProcessEvent(ExecutionPayload):
 
 @dataclass
 @PayloadRegistry.register
+class InvolvedNodesEvent(ExecutionPayload):
+    """Event indicating which nodes are involved in the current execution.
+
+    For parallel resolution: Dynamic list based on DAG builder state
+    For control flow/sequential: All nodes when started, empty when complete
+    """
+
+    involved_nodes: list[str]
+
+
+@dataclass
+@PayloadRegistry.register
 class GriptapeEvent(ExecutionPayload):
     node_name: str
     parameter_name: str

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -225,12 +225,10 @@ class GetFlowStateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     Args:
         control_node: Name of the current control node (if any)
         resolving_node: Name of the node currently being resolved (if any)
-        involved_nodes: Names of nodes that are queued to be executed or have been executed in the current run.
     """
 
     control_nodes: list[str] | None
     resolving_node: list[str] | None
-    involved_nodes: list[str] | None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1720,6 +1720,7 @@ class FlowManager:
         if self.check_for_existing_running_flow():
             # Now we know something is running, it's ParallelResolutionMachine, and that we are in single_node_resolution.
             self._global_dag_builder.add_node_with_dependencies(node, node.name)
+            GriptapeNodes.handle_request(GetFlowStateRequest(flow_name=flow.name))
         else:
             # Set that we are only working on one node right now!
             self._global_single_node_resolution = True

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1744,8 +1744,11 @@ class FlowManager:
             if isinstance(resolution_machine, ParallelResolutionMachine):
                 self._global_dag_builder.add_node_with_dependencies(node)
                 resolution_machine.context.dag_builder = self._global_dag_builder
-            # Send a GetFlowStateRequest
-            involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
+                involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
+            else:
+                involved_nodes = list(flow.nodes.keys())
+            # Send a InvolvedNodesRequest
+
             GriptapeNodes.EventManager().put_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1741,7 +1741,6 @@ class FlowManager:
                 if self.check_for_existing_running_flow():
                     self.cancel_flow_run()
                     raise RuntimeError(e) from e
-            GriptapeNodes.handle_request(GetFlowStateRequest(flow_name=flow.name))
             if resolution_machine.is_complete():
                 self._global_single_node_resolution = False
                 self._global_control_flow_machine.context.current_nodes = []
@@ -1817,10 +1816,7 @@ class FlowManager:
                 node.node_reference.name
                 for node in control_flow_context.resolution_machine.context.task_to_node.values()
             ]
-            involved_nodes = set()
-            for graph in self._global_dag_builder.graphs.values():
-                involved_nodes.update(graph.nodes())
-            involved_nodes = list(involved_nodes)
+            involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
             return current_control_nodes, current_resolving_nodes, involved_nodes if len(involved_nodes) != 0 else None
         if isinstance(control_flow_context.resolution_machine, SequentialResolutionMachine):
             focus_stack_for_node = control_flow_context.resolution_machine.context.focus_stack

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1803,9 +1803,6 @@ class FlowManager:
             node.set_entry_control_parameter(None)
 
     def flow_state(self, flow: ControlFlow) -> tuple[list[str] | None, list[str] | None, list[str] | None]:  # noqa: ARG002
-        if not self.check_for_existing_running_flow():
-            msg = "Flow hasn't started."
-            raise RuntimeError(msg)
         if self._global_control_flow_machine is None:
             return None, None, None
         control_flow_context = self._global_control_flow_machine.context

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1802,7 +1802,7 @@ class FlowManager:
             # Clear entry control parameter for new execution
             node.set_entry_control_parameter(None)
 
-    def flow_state(self, flow: ControlFlow) -> tuple[list[str] | None, list[str] | None, list[str] | None]:  # noqa: ARG002
+    def flow_state(self, flow: ControlFlow) -> tuple[list[str] | None, list[str] | None, list[str] | None]:
         if self._global_control_flow_machine is None:
             return None, None, None
         control_flow_context = self._global_control_flow_machine.context
@@ -1817,12 +1817,16 @@ class FlowManager:
                 node.node_reference.name
                 for node in control_flow_context.resolution_machine.context.task_to_node.values()
             ]
-            involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
+            if self._global_single_node_resolution:
+                involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
+            else:
+                involved_nodes = list(flow.nodes.keys())
             return current_control_nodes, current_resolving_nodes, involved_nodes if len(involved_nodes) != 0 else None
         if isinstance(control_flow_context.resolution_machine, SequentialResolutionMachine):
             focus_stack_for_node = control_flow_context.resolution_machine.context.focus_stack
             current_resolving_node = focus_stack_for_node[-1].node.name if len(focus_stack_for_node) else None
-            return current_control_nodes, [current_resolving_node] if current_resolving_node else None, None
+            involved_nodes = list(flow.nodes.keys())
+            return current_control_nodes, [current_resolving_node] if current_resolving_node else None, involved_nodes
         return current_control_nodes, None, None
 
     def get_start_node_from_node(self, flow: ControlFlow, node: BaseNode) -> BaseNode | None:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1733,12 +1733,15 @@ class FlowManager:
             if isinstance(resolution_machine, ParallelResolutionMachine):
                 self._global_dag_builder.add_node_with_dependencies(node)
                 resolution_machine.context.dag_builder = self._global_dag_builder
+            # Send a GetFlowStateRequest
+            GriptapeNodes.handle_request(GetFlowStateRequest(flow_name=flow.name))
             try:
                 await resolution_machine.resolve_node(node)
             except Exception as e:
                 if self.check_for_existing_running_flow():
                     self.cancel_flow_run()
                     raise RuntimeError(e) from e
+            GriptapeNodes.handle_request(GetFlowStateRequest(flow_name=flow.name))
             if resolution_machine.is_complete():
                 self._global_single_node_resolution = False
                 self._global_control_flow_machine.context.current_nodes = []
@@ -1817,7 +1820,10 @@ class FlowManager:
                 node.node_reference.name
                 for node in control_flow_context.resolution_machine.context.task_to_node.values()
             ]
-            involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
+            involved_nodes = set()
+            for graph in self._global_dag_builder.graphs.values():
+                involved_nodes.update(graph.nodes())
+            involved_nodes = list(involved_nodes)
             return current_control_nodes, current_resolving_nodes, involved_nodes if len(involved_nodes) != 0 else None
         if isinstance(control_flow_context.resolution_machine, SequentialResolutionMachine):
             focus_stack_for_node = control_flow_context.resolution_machine.context.focus_stack

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -446,7 +446,7 @@ class NodeManager:
             # get the current node executing / resolving
             # if it's in connected nodes, cancel flow.
             # otherwise, leave it.
-            control_node_names, resolving_node_names, _ = GriptapeNodes.FlowManager().flow_state(parent_flow)
+            control_node_names, resolving_node_names = GriptapeNodes.FlowManager().flow_state(parent_flow)
             connected_nodes = parent_flow.get_all_connected_nodes(node)
             cancelled = False
             if control_node_names is not None:


### PR DESCRIPTION
- adds a GetFlowStateRequest in several different places, so the UI can always be fully up to date on blocked nodes during single node resolution.
- updates tracking of graphs, so nodes can be popped once their graph is completely finished in single node resolution state. node_to_reference should still store the node in it when running a full control flow, this is unique to single node resolution.