### PR TITLE
Added new method to just save a serialized flow. Existing SaveWorkflowRequest now calls it. Necessary for packaged workflows to send off to distributed system.

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
-from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -653,6 +653,7 @@ class SaveWorkflowFileFromSerializedFlowRequest(RequestPayload):
         image_path: Optional path to workflow image/thumbnail
         execution_flow_name: Optional flow name to use for execution code (defaults to file_name if not provided)
         branched_from: Optional branched from information to preserve workflow lineage
+        workflow_shape: Optional workflow shape defining inputs and outputs for external callers
 
     Results: SaveWorkflowFileFromSerializedFlowResultSuccess (with file path) | SaveWorkflowFileFromSerializedFlowResultFailure (save error)
     """
@@ -663,6 +664,7 @@ class SaveWorkflowFileFromSerializedFlowRequest(RequestPayload):
     image_path: str | None = None
     execution_flow_name: str | None = None
     branched_from: str | None = None
+    workflow_shape: WorkflowShape | None = None
 
 
 @dataclass


### PR DESCRIPTION
Fixes #2296 

@zachgiordano I really need your eyes on the dead code that was removed (is it dead?) as well as how we're handling the execution flow name to run. Not feeling great about that just yet.

# Add `SaveWorkflowFileFromSerializedFlowRequest` for lightweight workflow file generation

## Summary

This PR introduces a new standalone workflow saving capability that allows generating workflow files directly from `SerializedFlowCommands` without the overhead of the existing `SaveWorkflowRequest` process, while refactoring the existing implementation to eliminate code duplication.

## Changes Made

### ✨ New Features

**`SaveWorkflowFileFromSerializedFlowRequest`** - New event request that generates workflow files from user-supplied `SerializedFlowCommands`:
- **Purpose**: Save arbitrary workflow subsets without registry operations, file resolution logic, or configuration persistence
- **Use cases**: Creating workflow files from partial workflows, exporting workflow segments, generating standalone workflow files
- **Parameters**:
  - `serialized_flow_commands`: The workflow structure to save
  - `file_name`: Target filename (without .py extension)
  - `creation_date`: Optional creation timestamp (defaults to current time)
  - `image_path`: Optional workflow thumbnail path
  - `execution_flow_name`: Optional flow name for execution code (defaults to file_name)
  - `branched_from`: Optional workflow lineage information

### 🔧 Refactoring & Architecture

**Eliminated Code Duplication**: The existing `SaveWorkflowRequest` now uses the new infrastructure internally:
- Extracted reusable `_generate_workflow_metadata_from_commands()` method
- Extracted reusable `_generate_workflow_file_content()` method
- Extracted reusable `_write_workflow_file()` method with `WriteWorkflowFileResult` NamedTuple

**Simplified Metadata Generation**: Removed unnecessary abstraction layers:
- Eliminated `_generate_workflow_metadata()` wrapper method (29 lines)
- Inlined `WorkflowMetadata` constructor in `_generate_workflow_metadata_from_commands()`
- Direct `branched_from` parameter handling instead of full `prior_workflow` object passing

### 🗑️ Dead Code Removal

**Major cleanup** identified and removed unused methods:
- **`_generate_workflow_file_contents_and_metadata()`** (~232 lines) - Never called anywhere
- **`_generate_workflow_metadata()`** (29 lines) - Only used as unnecessary wrapper
- **`_gather_workflow_imports()`** (14 lines) - Completely unused
- **Unused imports**: Removed `pkgutil` import

**Total lines removed**: ~275 lines of dead code

## New Logic

### **Execution Flow Name Handling**
- **Assumption**: `execution_flow_name` should always have a value (either from request or defaulted to `file_name`) @zachgiordano I could use insight here.
- **Logic**: Standalone handler changes an `execution_file_name` of `None` to `file_name`, `SaveWorkflowRequest` passes `top_level_flow_name`
- **Behavior**: Workflow execution code always generates (matching original behavior)

### **Metadata Generation**
- **Assumption**: All metadata can be derived from `SerializedFlowCommands` + basic parameters
- **Logic**: Engine version fetched dynamically, workflow shape extracted if available, creation/modification dates handled appropriately
- **Behavior**: Identical metadata structure to original implementation

### **File Path Resolution**
- **Assumption**: Standalone request works in workspace directory with simple filename.py pattern
- **Logic**: `SaveWorkflowRequest` continues complex path resolution (existing workflows, templates, absolute paths)
- **Behavior**: Clear separation of concerns between simple and complex use cases

## Compatibility & Testing

✅ **Backward Compatibility**: `SaveWorkflowRequest` maintains identical behavior
✅ **Branch/Merge Operations**: Workflow lineage preservation verified
✅ **Template Workflows**: Template handling logic unchanged
✅ **Registry Operations**: Configuration and registry updates preserved

## Files Changed

- **`workflow_events.py`**: Added new request/result classes (+49 lines)
- **`workflow_manager.py`**: Refactored implementation, removed dead code (+317, -247 lines)
