### PR TITLE
Actually use the provided encoders

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/flux_pipeline_type_flux_pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/flux_pipeline_type_flux_pipeline_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.diffusion_pipeline_type_pipeline_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -79,10 +80,28 @@ class FluxPipelineTypeFluxPipelineParameters(DiffusionPipelineTypePipelineParame
 
     def build_pipeline(self) -> diffusers.FluxPipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
-        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/2322
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        text_encoder_2_repo_id, text_encoder_2_revision = self._text_encoder_2_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.CLIPTextModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        text_encoder_2 = transformers.T5EncoderModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_2_repo_id,
+            revision=text_encoder_2_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
         return diffusers.FluxPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )

--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -513,7 +513,7 @@
       "class_name": "DiffusionPipelineBuilderNode",
       "file_path": "diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py",
       "metadata": {
-        "category": "",
+        "category": "misc",
         "description": "Build and cache 🤗 Diffuser Pipelines for reuse across multiple execution nodes.",
         "display_name": "Diffusion Pipeline Builder",
         "group": "diffusion"


### PR DESCRIPTION
Turns out we never actually used the provided encoders before, just the defaults (also, you can't set cat to blank, needs to be misc)