### PR TITLE
Node dependencies (node libraries, imports, files referenced, and workflows referenced) are aggregated when serializing.

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -99,30 +99,6 @@ class NodeDependencies:
         self.imports.update(other.imports)
         self.libraries.update(other.libraries)
 
-    def aggregate_from(self, other: "NodeDependencies") -> None:
-        """Aggregate dependencies from another NodeDependencies object into this one.
-
-        Args:
-            other: The NodeDependencies object to aggregate from
-        """
-        # Aggregate referenced workflows
-        if other.referenced_workflows:
-            if self.referenced_workflows is None:
-                self.referenced_workflows = set()
-            self.referenced_workflows.update(other.referenced_workflows)
-
-        # Aggregate static files
-        if other.static_files:
-            if self.static_files is None:
-                self.static_files = set()
-            self.static_files.update(other.static_files)
-
-        # Aggregate imports
-        if other.imports:
-            if self.imports is None:
-                self.imports = set()
-            self.imports.update(other.imports)
-
 
 class NodeResolutionState(StrEnum):
     """Possible states for a node during resolution."""

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -99,6 +99,30 @@ class NodeDependencies:
         self.imports.update(other.imports)
         self.libraries.update(other.libraries)
 
+    def aggregate_from(self, other: "NodeDependencies") -> None:
+        """Aggregate dependencies from another NodeDependencies object into this one.
+
+        Args:
+            other: The NodeDependencies object to aggregate from
+        """
+        # Aggregate referenced workflows
+        if other.referenced_workflows:
+            if self.referenced_workflows is None:
+                self.referenced_workflows = set()
+            self.referenced_workflows.update(other.referenced_workflows)
+
+        # Aggregate static files
+        if other.static_files:
+            if self.static_files is None:
+                self.static_files = set()
+            self.static_files.update(other.static_files)
+
+        # Aggregate imports
+        if other.imports:
+            if self.imports is None:
+                self.imports = set()
+            self.imports.update(other.imports)
+
 
 class NodeResolutionState(StrEnum):
     """Possible states for a node during resolution."""

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
+from griptape_nodes.exe_types.node_types import NodeDependencies
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 from griptape_nodes.node_library.workflow_registry import WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import (
@@ -200,8 +201,9 @@ class SerializedFlowCommands:
         set_parameter_value_commands (dict[SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]]): List of commands
             to set parameter values, keyed by node UUID, during deserialization.
         sub_flows_commands (list["SerializedFlowCommands"]): List of sub-flow commands. Cascades into sub-flows within this serialization.
-        referenced_workflows (set[str]): Set of workflow file paths that are referenced by this flow and its sub-flows.
-            Used for validation before deserialization to ensure all referenced workflows are available.
+        node_dependencies (NodeDependencies): Aggregated dependencies from all nodes in this flow and its sub-flows.
+            Includes referenced workflows, static files, and Python imports. Used for workflow packaging,
+            dependency resolution, and deployment planning.
     """
 
     @dataclass
@@ -232,7 +234,7 @@ class SerializedFlowCommands:
     ]
     set_lock_commands_per_node: dict[SerializedNodeCommands.NodeUUID, SetLockNodeStateRequest]
     sub_flows_commands: list["SerializedFlowCommands"]
-    referenced_workflows: set[str]
+    node_dependencies: NodeDependencies
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from griptape_nodes.exe_types.node_types import NodeDependencies
-from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 from griptape_nodes.node_library.workflow_registry import WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
@@ -187,8 +186,6 @@ class SerializedFlowCommands:
     Useful for save/load, copy/paste, etc.
 
     Attributes:
-        node_libraries_used (set[LibraryNameAndVersion]): Set of libraries and versions used by the nodes,
-            including those in child flows.
         flow_initialization_command (CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest | None): Command to initialize the flow that contains all of this.
             Can be CreateFlowRequest for standalone flows, ImportWorkflowAsReferencedSubFlowRequest for referenced workflows,
             or None to deserialize into whatever Flow is in the Current Context.
@@ -202,7 +199,7 @@ class SerializedFlowCommands:
             to set parameter values, keyed by node UUID, during deserialization.
         sub_flows_commands (list["SerializedFlowCommands"]): List of sub-flow commands. Cascades into sub-flows within this serialization.
         node_dependencies (NodeDependencies): Aggregated dependencies from all nodes in this flow and its sub-flows.
-            Includes referenced workflows, static files, and Python imports. Used for workflow packaging,
+            Includes referenced workflows, static files, Python imports, and libraries. Used for workflow packaging,
             dependency resolution, and deployment planning.
     """
 
@@ -224,7 +221,6 @@ class SerializedFlowCommands:
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
-    node_libraries_used: set[LibraryNameAndVersion]
     flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest | None
     serialized_node_commands: list[SerializedNodeCommands]
     serialized_connections: list[IndirectConnectionSerialization]

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -4,7 +4,7 @@ from typing import Any, NamedTuple, NewType
 from uuid import uuid4
 
 from griptape_nodes.exe_types.core_types import NodeMessagePayload
-from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.exe_types.node_types import NodeDependencies, NodeResolutionState
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
@@ -410,6 +410,7 @@ class SerializedNodeCommands:
         create_node_command (CreateNodeRequest): The command to create the node.
         element_modification_commands (list[RequestPayload]): A list of commands to create or modify the elements (including Parameters) of the node.
         node_library_details (LibraryNameAndVersion): Details of the library and version used by the node.
+        node_dependencies (NodeDependencies): Dependencies that this node has on external resources (workflows, files, imports).
         node_uuid (NodeUUID): The UUID of this particular node. During deserialization, this UUID will be used to correlate this node's instance
             with the connections and parameter values necessary. We cannot use node name because Griptape Nodes enforces unique names, and we cannot
             predict the name that will be selected upon instantiation. Similarly, the same serialized node may be deserialized multiple times, such
@@ -436,6 +437,7 @@ class SerializedNodeCommands:
     create_node_command: CreateNodeRequest
     element_modification_commands: list[RequestPayload]
     node_library_details: LibraryNameAndVersion
+    node_dependencies: NodeDependencies
     lock_node_command: SetLockNodeStateRequest | None = None
     node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(str(uuid4())))
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 from griptape_nodes.exe_types.core_types import NodeMessagePayload
 from griptape_nodes.exe_types.node_types import NodeDependencies, NodeResolutionState
-from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -409,8 +408,7 @@ class SerializedNodeCommands:
     Attributes:
         create_node_command (CreateNodeRequest): The command to create the node.
         element_modification_commands (list[RequestPayload]): A list of commands to create or modify the elements (including Parameters) of the node.
-        node_library_details (LibraryNameAndVersion): Details of the library and version used by the node.
-        node_dependencies (NodeDependencies): Dependencies that this node has on external resources (workflows, files, imports).
+        node_dependencies (NodeDependencies): Dependencies that this node has on external resources (workflows, files, imports, libraries).
         node_uuid (NodeUUID): The UUID of this particular node. During deserialization, this UUID will be used to correlate this node's instance
             with the connections and parameter values necessary. We cannot use node name because Griptape Nodes enforces unique names, and we cannot
             predict the name that will be selected upon instantiation. Similarly, the same serialized node may be deserialized multiple times, such
@@ -436,7 +434,6 @@ class SerializedNodeCommands:
 
     create_node_command: CreateNodeRequest
     element_modification_commands: list[RequestPayload]
-    node_library_details: LibraryNameAndVersion
     node_dependencies: NodeDependencies
     lock_node_command: SetLockNodeStateRequest | None = None
     node_uuid: NodeUUID = field(default_factory=lambda: SerializedNodeCommands.NodeUUID(str(uuid4())))

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -18,6 +18,7 @@ from griptape_nodes.exe_types.node_types import (
     BaseNode,
     EndLoopNode,
     ErrorProxyNode,
+    NodeDependencies,
     NodeResolutionState,
     StartLoopNode,
 )
@@ -2075,11 +2076,19 @@ class NodeManager:
             lock_command = SetLockNodeStateRequest(node_name=None, lock=True)
         else:
             lock_command = None
+
+        # Collect node dependencies
+        node_dependencies = node.get_node_dependencies()
+        if node_dependencies is None:
+            # Ensure we always have a NodeDependencies object, even if empty
+            node_dependencies = NodeDependencies()
+
         # Hooray
         serialized_node_commands = SerializedNodeCommands(
             create_node_command=create_node_request,
             element_modification_commands=element_modification_commands,
             node_library_details=library_details,
+            node_dependencies=node_dependencies,
             lock_node_command=lock_command,
         )
         details = f"Successfully serialized node '{node_name}' into commands."

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2083,11 +2083,13 @@ class NodeManager:
             # Ensure we always have a NodeDependencies object, even if empty
             node_dependencies = NodeDependencies()
 
+        # Add the library dependency to the node dependencies
+        node_dependencies.libraries.add(library_details)
+
         # Hooray
         serialized_node_commands = SerializedNodeCommands(
             create_node_command=create_node_request,
             element_modification_commands=element_modification_commands,
-            node_library_details=library_details,
             node_dependencies=node_dependencies,
             lock_node_command=lock_command,
         )

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1379,14 +1379,14 @@ class WorkflowManager:
 
         # Create the Workflow Metadata header
         workflows_referenced = None
-        if serialized_flow_commands.referenced_workflows:
-            workflows_referenced = list(serialized_flow_commands.referenced_workflows)
+        if serialized_flow_commands.node_dependencies.referenced_workflows:
+            workflows_referenced = list(serialized_flow_commands.node_dependencies.referenced_workflows)
 
         return WorkflowMetadata(
             name=str(file_name),
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
             engine_version_created_with=engine_version,
-            node_libraries_referenced=list(serialized_flow_commands.node_libraries_used),
+            node_libraries_referenced=list(serialized_flow_commands.node_dependencies.libraries),
             workflows_referenced=workflows_referenced,
             creation_date=creation_date,
             last_modified_date=datetime.now(tz=UTC),

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1395,7 +1395,7 @@ class WorkflowManager:
             image=image_path,
         )
 
-    def _generate_workflow_file_content(  # noqa: PLR0912, C901
+    def _generate_workflow_file_content(  # noqa: PLR0912, PLR0915, C901
         self,
         serialized_flow_commands: SerializedFlowCommands,
         workflow_metadata: WorkflowMetadata,
@@ -1409,6 +1409,13 @@ class WorkflowManager:
 
         import_recorder = ImportRecorder()
         import_recorder.add_from_import("griptape_nodes.retained_mode.griptape_nodes", "GriptapeNodes")
+
+        # Add imports from node dependencies
+        for import_dep in serialized_flow_commands.node_dependencies.imports:
+            if import_dep.class_name:
+                import_recorder.add_from_import(import_dep.module, import_dep.class_name)
+            else:
+                import_recorder.add_import(import_dep.module)
 
         ast_container = ASTContainer()
 


### PR DESCRIPTION
This is dependent on (built on) https://github.com/griptape-ai/griptape-nodes/pull/2389