### PR TITLE
fix: initialize app in threadsafe way

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -177,7 +177,9 @@ async def _run_websocket_tasks(api_key: str, main_loop: asyncio.AbstractEventLoo
         try:
             # Emit initialization event only for the first connection
             if not initialized:
-                griptape_nodes.EventManager().put_event(AppEvent(payload=app_events.AppInitializationComplete()))
+                griptape_nodes.EventManager().put_event_threadsafe(
+                    main_loop, AppEvent(payload=app_events.AppInitializationComplete())
+                )
                 initialized = True
 
             # Emit connection established event for every connection


### PR DESCRIPTION
Caught by running asyncio in debug mode ([TIL](https://docs.python.org/3/library/asyncio-dev.html)).