### PR TITLE
perf: load nodes in a thread to avoid blocking event loop

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 import logging
@@ -895,7 +896,8 @@ class LibraryManager:
                         continue  # SKIP IT
 
         # Attempt to load nodes from the library.
-        library_load_results = self._attempt_load_nodes_from_library(
+        library_load_results = await asyncio.to_thread(
+            self._attempt_load_nodes_from_library,
             library_data=library_data,
             library=library,
             base_dir=base_dir,
@@ -1521,7 +1523,7 @@ class LibraryManager:
         for library_result in metadata_result.successful_libraries:
             if library_result.library_schema.name == LibraryManager.SANDBOX_LIBRARY_NAME:
                 # Handle sandbox library - use the schema we already have
-                self._attempt_generate_sandbox_library_from_schema(
+                await self._attempt_generate_sandbox_library_from_schema(
                     library_schema=library_result.library_schema, sandbox_directory=library_result.file_path
                 )
             else:
@@ -1853,7 +1855,7 @@ class LibraryManager:
             problems=problems,
         )
 
-    def _attempt_generate_sandbox_library_from_schema(
+    async def _attempt_generate_sandbox_library_from_schema(
         self, library_schema: LibrarySchema, sandbox_directory: str
     ) -> None:
         """Generate sandbox library using an existing schema, loading actual node classes."""
@@ -1945,7 +1947,8 @@ class LibraryManager:
             return
 
         # Load nodes into the library
-        library_load_results = self._attempt_load_nodes_from_library(
+        library_load_results = await asyncio.to_thread(
+            self._attempt_load_nodes_from_library,
             library_data=library_data,
             library=library,
             base_dir=sandbox_library_dir,


### PR DESCRIPTION
Pinned down from these logs:
```
[16:48:37] INFO     Successfully loaded Library 'Griptape Nodes Advanced Media Library' from JSON file at /Users/collindutter/Projects/griptape/griptape-nodes/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
           INFO     Installing dependencies for library 'Griptape Nodes Library' with pip in venv at /Users/collindutter/Projects/griptape/griptape-nodes/libraries/griptape_nodes_library/.venv
           WARNING  Executing <Task pending name='Task-13' coro=<call_function() running at /Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/utils/async_utils.py:30> wait_for=<Future pending cb=[Task.task_wakeup()] created at
                    /Users/collindutter/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/base_events.py:448> cb= created at /Users/collindutter/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/asyncio/tasks.py:420> took 2.523 seconds
           INFO     execute program '/Users/collindutter/Projects/griptape/griptape-nodes/.venv/bin/python3': <_UnixSubprocessTransport pid=21674 running stdout=<_UnixReadPipeTransport fd=24 polling> stderr=<_UnixReadPipeTransport fd=26 polling>>
           INFO     <_UnixReadPipeTransport fd=26 polling> was closed by peer
           INFO     <_UnixReadPipeTransport fd=24 polling> was closed by peer
           INFO     <_UnixSubprocessTransport pid=21674 running stdout=<_UnixReadPipeTransport closed fd=24 closed> stderr=<_UnixReadPipeTransport closed fd=26 closed>> exited with return code 0
           INFO     Successfully loaded Library 'Griptape Nodes Library' from JSON file at /Users/collindutter/Projects/griptape/griptape-nodes/libraries/griptape_nodes_library/griptape_nodes_library.json
```