### PR TITLE
Engine handles execute on publish

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/subprocess_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/subprocess_workflow_executor.py
@@ -16,11 +16,17 @@ from griptape_nodes.app.app import _create_websocket_connection, _send_subscribe
 from griptape_nodes.bootstrap.utils.python_subprocess_executor import PythonSubprocessExecutor
 from griptape_nodes.bootstrap.workflow_executors.local_session_workflow_executor import LocalSessionWorkflowExecutor
 from griptape_nodes.drivers.storage import StorageBackend
-from griptape_nodes.retained_mode.events.base_events import ExecutionEvent
-from griptape_nodes.retained_mode.events.execution_events import ControlFlowResolvedEvent
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
+    EventResultSuccess,
+    ExecutionEvent,
+    ResultPayload,
+)
+from griptape_nodes.retained_mode.events.execution_events import ControlFlowResolvedEvent, StartFlowRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from types import TracebackType
 
 logger = logging.getLogger(__name__)
@@ -31,9 +37,14 @@ class SubprocessWorkflowExecutorError(Exception):
 
 
 class SubprocessWorkflowExecutor(LocalSessionWorkflowExecutor, PythonSubprocessExecutor):
-    def __init__(self, workflow_path: str) -> None:
+    def __init__(
+        self,
+        workflow_path: str,
+        on_start_flow_result: Callable[[ResultPayload], None] | None = None,
+    ) -> None:
         PythonSubprocessExecutor.__init__(self)
         self._workflow_path = workflow_path
+        self._on_start_flow_result = on_start_flow_result
         # Generate a unique session ID for this execution
         self._session_id = uuid.uuid4().hex
         self._websocket_thread: threading.Thread | None = None
@@ -233,14 +244,21 @@ class SubprocessWorkflowExecutor(LocalSessionWorkflowExecutor, PythonSubprocessE
 
     async def _process_event(self, event: dict) -> None:
         """Process events received from the subprocess via WebSocket."""
+        event_type = event.get("type", "unknown")
+        if event_type == "execution_event":
+            await self._process_execution_event(event)
+        elif event_type in ["success_result", "failure_result"]:
+            await self._process_result_event(event)
+
+    async def _process_execution_event(self, event: dict) -> None:
         payload = event.get("payload", {})
         event_type = payload.get("event_type", "")
         payload_type_name = payload.get("payload_type", "")
         payload_type = PayloadRegistry.get_type(payload_type_name)
 
         # Focusing on ExecutionEvent types for the workflow executor
-        if event_type != "ExecutionEvent":
-            logger.debug("Ignoring non-ExecutionEvent type: %s", event_type)
+        if event_type not in ["ExecutionEvent", "EventResultSuccess", "EventResultFailure"]:
+            logger.debug("Ignoring event type: %s", event_type)
             return
 
         if payload_type is None:
@@ -252,3 +270,29 @@ class SubprocessWorkflowExecutor(LocalSessionWorkflowExecutor, PythonSubprocessE
         if isinstance(ex_event.payload, ControlFlowResolvedEvent):
             logger.info("Workflow execution completed successfully")
             self.output = {ex_event.payload.end_node_name: ex_event.payload.parameter_output_values}
+
+    async def _process_result_event(self, event: dict) -> None:
+        payload = event.get("payload", {})
+        request_type_name = payload.get("request_type", "")
+        response_type_name = payload.get("result_type", "")
+        request_payload_type = PayloadRegistry.get_type(request_type_name)
+        response_payload_type = PayloadRegistry.get_type(response_type_name)
+
+        if request_payload_type is None or response_payload_type is None:
+            logger.warning("Unknown payload types: %s, %s", request_type_name, response_type_name)
+            return
+        if payload.get("type", "unknown") == "success_result":
+            result_event = EventResultSuccess.from_dict(
+                data=payload, req_payload_type=request_payload_type, res_payload_type=response_payload_type
+            )
+        else:
+            result_event = EventResultFailure.from_dict(
+                data=payload, req_payload_type=request_payload_type, res_payload_type=response_payload_type
+            )
+
+        if isinstance(result_event.request, StartFlowRequest):
+            logger.info("Received StartFlowRequest result event")
+            if self._on_start_flow_result:
+                self._on_start_flow_result(result_event.result)
+        else:
+            logger.warning("Ignoring result event for request type: %s", request_type_name)

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -31,6 +31,7 @@ from griptape_nodes.retained_mode.events.app_events import (
 
 # Runtime imports for ResultDetails since it's used at runtime
 from griptape_nodes.retained_mode.events.base_events import ResultDetail, ResultDetails
+from griptape_nodes.retained_mode.events.execution_events import StartFlowResultFailure, StartFlowResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
     GetTopLevelFlowRequest,
@@ -3283,11 +3284,79 @@ class WorkflowManager:
             if isinstance(result, PublishWorkflowResultSuccess):
                 workflow_file = Path(result.published_workflow_file_path)
                 result = self._register_published_workflow_file(workflow_file, result)
+
+                if request.execute_on_publish:
+                    await self._handle_execute_on_publish(request, workflow_file)
+
             return result  # noqa: TRY300
         except Exception as e:
             details = f"Failed to publish workflow '{request.workflow_name}': {e!s}"
             logger.exception(details)
             return PublishWorkflowResultFailure(exception=e, result_details=details)
+
+    async def _handle_execute_on_publish(self, request: PublishWorkflowRequest, workflow_file: Path) -> None:
+        class ExecuteOnPublishError(Exception):
+            pass
+
+        # Create an event to track when we get a start workflow result
+        start_result_received = asyncio.Event()
+        exception: ExecuteOnPublishError | None = None
+
+        def invoke_done_callback(future: asyncio.Future) -> None:
+            nonlocal exception
+            try:
+                future.result()
+            except Exception as e:
+                msg = f"Error during invocation of published workflow '{request.workflow_name}': {e!s}"
+                logger.exception(msg)
+                exception = ExecuteOnPublishError(e)
+                start_result_received.set()
+
+        def on_start_flow_result(start_result: ResultPayload) -> None:
+            nonlocal exception
+            if isinstance(start_result, StartFlowResultSuccess):
+                msg = f"Successfully started published workflow '{request.workflow_name}'"
+                logger.info(msg)
+            elif isinstance(start_result, StartFlowResultFailure):
+                msg = f"Failed to invoke published workflow '{request.workflow_name}': {start_result.exception}"
+                logger.exception(msg)
+                exceptions = start_result.validation_exceptions
+                exceptions.append(start_result.exception) if start_result.exception else None
+                exception = ExecuteOnPublishError(exceptions)
+
+            start_result_received.set()
+
+        invoke_task = asyncio.create_task(
+            self._invoke_published_workflow(request.workflow_name, workflow_file, on_start_flow_result)
+        )
+        invoke_task.add_done_callback(invoke_done_callback)
+
+        # Wait for StartFlow result
+        try:
+            await asyncio.wait_for(start_result_received.wait(), timeout=10.0)
+            if exception is not None:
+                raise exception
+        except TimeoutError:
+            # Timeout occurred - don't block on subprocess workflow execution, just log a warning
+            msg = f"Timeout waiting for workflow '{request.workflow_name}' StartFlow result."
+            logger.warning(msg)
+
+    async def _invoke_published_workflow(
+        self, workflow_name: str, workflow_path: Path, on_start_flow_result: Callable[[ResultPayload], None]
+    ) -> None:
+        from griptape_nodes.bootstrap.workflow_executors.subprocess_workflow_executor import SubprocessWorkflowExecutor
+
+        subprocess_executor = SubprocessWorkflowExecutor(
+            workflow_path=str(workflow_path), on_start_flow_result=on_start_flow_result
+        )
+        storage_backend_value = GriptapeNodes.ConfigManager().get_config_value("storage_backend")
+
+        async with subprocess_executor as executor:
+            await executor.arun(
+                workflow_name=workflow_name,
+                flow_input={},
+                storage_backend=StorageBackend(value=storage_backend_value),
+            )
 
     def _register_published_workflow_file(
         self, workflow_file: Path, result: PublishWorkflowResultSuccess


### PR DESCRIPTION
* Engine handles execute on publish
  * Make use of the `SubprocessWorkflowExecutor`
  * Update the `SubprocessWorkflowExecutor` to listen for StartFlow results
  * Enable a failed StartFlow result from subprocess execution to trigger failure of a PublishWorkflowRequest
  * Fix EventResult from_dict method

Enables libraries to get rid of custom logic for executing a workflow on publish.

Closes #2304 