### PR TITLE
refactor!: don't automatically look for libraries in workspace

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2058,9 +2058,4 @@ class LibraryManager:
             if library_path.exists():
                 process_path(library_path)
 
-        # Add from workspace - recursive discovery of library JSON files
-        workspace_path = config_mgr.workspace_path
-        if workspace_path.exists():
-            process_path(workspace_path)
-
         return list(discovered_libraries)


### PR DESCRIPTION
Users found this too magical. Users can still specifiy a directory if they want similar behavior.