### PR TITLE
No longer strips control params on save so that output control flow can be preserved.

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -3168,7 +3168,7 @@ class WorkflowManager:
         for node in nodes:
             for param in node.parameters:
                 # Expose only the parameters that are relevant for workflow input and output.
-                param_info = self.extract_parameter_shape_info(param, include_control_params=False)
+                param_info = self.extract_parameter_shape_info(param, include_control_params=True)
                 if param_info is not None:
                     if node.name in workflow_shape[workflow_shape_type]:
                         cast("dict", workflow_shape[workflow_shape_type][node.name])[param.name] = param_info
@@ -3225,7 +3225,7 @@ class WorkflowManager:
         return workflow_shape
 
     def extract_parameter_shape_info(
-        self, parameter: Parameter, *, include_control_params: bool = False
+        self, parameter: Parameter, *, include_control_params: bool
     ) -> ParameterShapeInfo | None:
         """Extract shape information from a parameter for workflow shape building.
 


### PR DESCRIPTION
Fixes stubbed toes during publishing/execution.