### PR TITLE
Revert "Remove explicit text_encoders (#2414)"

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/controlnet_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/controlnet_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -100,8 +101,24 @@ class FluxControlNetPipelineParameters(DiffusionPipelineTypePipelineParameters):
         return errors or None
 
     def build_pipeline(self) -> diffusers.FluxControlNetPipeline:
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        text_encoder_2_repo_id, text_encoder_2_revision = self._text_encoder_2_repo_parameter.get_repo_revision()
         controlnet_repo_id, controlnet_revision = self._controlnet_repo_parameter.get_repo_revision()
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.CLIPTextModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        text_encoder_2 = transformers.T5EncoderModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_2_repo_id,
+            revision=text_encoder_2_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         # Load ControlNet model first
         controlnet = diffusers.FluxControlNetModel.from_pretrained(
@@ -115,6 +132,8 @@ class FluxControlNetPipelineParameters(DiffusionPipelineTypePipelineParameters):
         return diffusers.FluxControlNetPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
             controlnet=controlnet,
             torch_dtype=torch.bfloat16,
             local_files_only=True,

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/fill_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/fill_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -81,10 +82,28 @@ class FluxFillPipelineParameters(DiffusionPipelineTypePipelineParameters):
 
     def build_pipeline(self) -> diffusers.FluxFillPipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        text_encoder_2_repo_id, text_encoder_2_revision = self._text_encoder_2_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.CLIPTextModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        text_encoder_2 = transformers.T5EncoderModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_2_repo_id,
+            revision=text_encoder_2_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         return diffusers.FluxFillPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/flux_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/flux_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -80,10 +81,28 @@ class FluxPipelineParameters(DiffusionPipelineTypePipelineParameters):
 
     def build_pipeline(self) -> diffusers.FluxPipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        text_encoder_2_repo_id, text_encoder_2_revision = self._text_encoder_2_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.CLIPTextModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        text_encoder_2 = transformers.T5EncoderModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_2_repo_id,
+            revision=text_encoder_2_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         return diffusers.FluxPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/img2img_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/img2img_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -83,10 +84,28 @@ class FluxImg2ImgPipelineParameters(DiffusionPipelineTypePipelineParameters):
 
     def build_pipeline(self) -> diffusers.FluxImg2ImgPipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        text_encoder_2_repo_id, text_encoder_2_revision = self._text_encoder_2_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.CLIPTextModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        text_encoder_2 = transformers.T5EncoderModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_2_repo_id,
+            revision=text_encoder_2_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         return diffusers.FluxImg2ImgPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/kontext_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/kontext_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -81,10 +82,28 @@ class FluxKontextPipelineParameters(DiffusionPipelineTypePipelineParameters):
 
     def build_pipeline(self) -> diffusers.FluxKontextPipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        text_encoder_2_repo_id, text_encoder_2_revision = self._text_encoder_2_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.CLIPTextModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        text_encoder_2 = transformers.T5EncoderModel.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_2_repo_id,
+            revision=text_encoder_2_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         return diffusers.FluxKontextPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/img2img_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/img2img_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -65,10 +66,19 @@ class QwenImg2ImgPipelineParameters(DiffusionPipelineTypePipelineParameters):
 
     def build_pipeline(self) -> diffusers.QwenImageImg2ImgPipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         return diffusers.QwenImageImg2ImgPipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/qwen_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/qwen_parameters.py
@@ -2,6 +2,7 @@ import logging
 
 import diffusers  # type: ignore[reportMissingImports]
 import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
 
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
@@ -63,10 +64,19 @@ class QwenPipelineParameters(DiffusionPipelineTypePipelineParameters):
 
     def build_pipeline(self) -> diffusers.QwenImagePipeline:
         base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
 
         return diffusers.QwenImagePipeline.from_pretrained(
             pretrained_model_name_or_path=base_repo_id,
             revision=base_revision,
+            text_encoder=text_encoder,
             torch_dtype=torch.bfloat16,
             local_files_only=True,
         )


### PR DESCRIPTION
This reverts commit ef07ba24cc28af989c7eea0083d0a436ab7a71d7.

After reinstalling the erroneous T5 Text Encoder, I am no longer seeing the reported HF cache errors. 