### PR TITLE
fix: properly remove qwen parameters

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/allegro/allegro_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/allegro/allegro_parameters.py
@@ -30,8 +30,7 @@ class AllegroPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._model_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/amused/amused_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/amused/amused_parameters.py
@@ -30,8 +30,7 @@ class AmusedPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._model_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/amused/img2img_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/amused/img2img_parameters.py
@@ -40,8 +40,7 @@ class AmusedImg2ImgPipelineParameters(DiffusionPipelineTypePipelineParameters):
         )
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
         self._node.remove_parameter_element_by_name("input_image")
 
     def get_config_kwargs(self) -> dict:

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/amused/inpaint_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/amused/inpaint_parameters.py
@@ -50,8 +50,7 @@ class AmusedInpaintPipelineParameters(DiffusionPipelineTypePipelineParameters):
         )
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
         self._node.remove_parameter_element_by_name("input_image")
         self._node.remove_parameter_element_by_name("mask_image")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/audioldm/audioldm_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/audioldm/audioldm_parameters.py
@@ -30,8 +30,7 @@ class AudioldmPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._model_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/controlnet_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/controlnet_parameters.py
@@ -58,14 +58,10 @@ class FluxControlNetPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._controlnet_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder_2")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_controlnet_model")
-        self._node.remove_parameter_element_by_name("text_encoder")
-        self._node.remove_parameter_element_by_name("text_encoder_2")
-        self._node.remove_parameter_element_by_name("controlnet_model")
+        self._model_repo_parameter.remove_input_parameters()
+        self._text_encoder_repo_parameter.remove_input_parameters()
+        self._text_encoder_2_repo_parameter.remove_input_parameters()
+        self._controlnet_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/fill_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/fill_parameters.py
@@ -45,12 +45,9 @@ class FluxFillPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._text_encoder_2_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder_2")
-        self._node.remove_parameter_element_by_name("text_encoder")
-        self._node.remove_parameter_element_by_name("text_encoder_2")
+        self._model_repo_parameter.remove_input_parameters()
+        self._text_encoder_repo_parameter.remove_input_parameters()
+        self._text_encoder_2_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/img2img_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/img2img_parameters.py
@@ -47,12 +47,9 @@ class FluxImg2ImgPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._text_encoder_2_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder_2")
-        self._node.remove_parameter_element_by_name("text_encoder")
-        self._node.remove_parameter_element_by_name("text_encoder_2")
+        self._model_repo_parameter.remove_input_parameters()
+        self._text_encoder_repo_parameter.remove_input_parameters()
+        self._text_encoder_2_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/kontext_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/kontext_parameters.py
@@ -45,12 +45,9 @@ class FluxKontextPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._text_encoder_2_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder_2")
-        self._node.remove_parameter_element_by_name("text_encoder")
-        self._node.remove_parameter_element_by_name("text_encoder_2")
+        self._model_repo_parameter.remove_input_parameters()
+        self._text_encoder_repo_parameter.remove_input_parameters()
+        self._text_encoder_2_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/img2img_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/img2img_parameters.py
@@ -36,10 +36,7 @@ class QwenImg2ImgPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._text_encoder_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_text_encoder")
-        self._node.remove_parameter_element_by_name("text_encoder")
+        self._model_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/qwen_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/qwen_parameters.py
@@ -36,8 +36,8 @@ class QwenPipelineParameters(DiffusionPipelineTypePipelineParameters):
         self._text_encoder_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("text_encoder")
+        self._model_repo_parameter.remove_input_parameters()
+        self._text_encoder_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/attend_excite_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/attend_excite_parameters.py
@@ -31,8 +31,7 @@ class StableDiffusionAttendAndExcitePipelineParameters(DiffusionPipelineTypePipe
         self._huggingface_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._huggingface_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/diff_edit_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/diff_edit_parameters.py
@@ -31,8 +31,7 @@ class StableDiffusionDiffEditPipelineParameters(DiffusionPipelineTypePipelinePar
         self._huggingface_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._huggingface_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/sd3_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/sd3_parameters.py
@@ -29,8 +29,7 @@ class StableDiffusion3PipelineParameters(DiffusionPipelineTypePipelineParameters
         self._huggingface_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._huggingface_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/sd_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/stable_diffusion/sd_parameters.py
@@ -31,8 +31,7 @@ class StableDiffusionPipelineParameters(DiffusionPipelineTypePipelineParameters)
         self._huggingface_repo_parameter.add_input_parameters()
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._huggingface_repo_parameter.remove_input_parameters()
 
     def get_config_kwargs(self) -> dict:
         return {

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/img2vid_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/img2vid_parameters.py
@@ -62,8 +62,7 @@ class WanImageToVideoPipelineParameters(DiffusionPipelineTypePipelineParameters)
         )
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
         self._node.remove_parameter_element_by_name("input_image")
         self._node.remove_parameter_element_by_name("width")
         self._node.remove_parameter_element_by_name("height")

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/vace_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/vace_parameters.py
@@ -80,8 +80,7 @@ class WanVacePipelineParameters(DiffusionPipelineTypePipelineParameters):
         )
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
         self._node.remove_parameter_element_by_name("input_video")
         self._node.remove_parameter_element_by_name("mask")
         self._node.remove_parameter_element_by_name("reference_frames")

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/vid2vid_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/vid2vid_parameters.py
@@ -61,8 +61,7 @@ class WanVideoToVideoPipelineParameters(DiffusionPipelineTypePipelineParameters)
         )
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
         self._node.remove_parameter_element_by_name("input_video")
         self._node.remove_parameter_element_by_name("width")
         self._node.remove_parameter_element_by_name("height")

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/wan_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/wan/wan_parameters.py
@@ -54,8 +54,7 @@ class WanPipelineParameters(DiffusionPipelineTypePipelineParameters):
         )
 
     def remove_input_parameters(self) -> None:
-        self._node.remove_parameter_element_by_name("model")
-        self._node.remove_parameter_element_by_name("huggingface_repo_parameter_message_model")
+        self._model_repo_parameter.remove_input_parameters()
         self._node.remove_parameter_element_by_name("width")
         self._node.remove_parameter_element_by_name("height")
 


### PR DESCRIPTION
Closes #2419 
Closes #2420


~We will certainly be bit by this again. I think the huggingface parameter should just operate on a single parameter name.~ `remove_input_parameters` saved the day.