### PR TITLE
refactor: replace watchdog with watchfiles for `make run/watch`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dev = [
   "pyright>=1.1.396",
   "ruff>=0.11.0",
   "typos>=1.30.2",
-  "watchdog>=6.0.0",
 ]
 docs = [
   "mkdocs-material>=9.6.9",

--- a/src/griptape_nodes/app/watch.py
+++ b/src/griptape_nodes/app/watch.py
@@ -2,85 +2,53 @@ from __future__ import annotations
 
 import subprocess
 import sys
-import time
-from typing import Any
 
-from watchdog.events import PatternMatchingEventHandler
-from watchdog.observers import Observer
+from watchfiles import DefaultFilter, watch
 
 from griptape_nodes.utils.uv_utils import find_uv_bin
 
 
-class ReloadHandler(PatternMatchingEventHandler):
-    def __init__(
-        self,
-        *,
-        patterns: list[str] | None = None,
-        ignore_patterns: list[str] | None = None,
-        ignore_directories: bool = False,
-        case_sensitive: bool = False,
-    ) -> None:
-        super().__init__(
-            patterns=patterns,
-            ignore_patterns=ignore_patterns,
-            ignore_directories=ignore_directories,
-            case_sensitive=case_sensitive,
-        )
-        self.process = None
-        self.start_process()
+def start_process() -> subprocess.Popen:
+    """Start the gtn process."""
+    uv_path = find_uv_bin()
+    return subprocess.Popen(  # noqa: S603
+        [uv_path, "run", "gtn"],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
 
-    def start_process(self) -> None:
-        if self.process:
-            self._terminate_process(self.process)
-        uv_path = find_uv_bin()
-        self.process = subprocess.Popen(  # noqa: S603
-            [uv_path, "run", "gtn"],
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
 
-    def _terminate_process(self, process: subprocess.Popen) -> None:
-        """Gracefully terminate a process with timeout."""
-        if process.poll() is not None:
-            return  # Process already terminated
+def terminate_process(process: subprocess.Popen) -> None:
+    """Gracefully terminate a process with timeout."""
+    if process.poll() is not None:
+        return  # Process already terminated
 
-        # First try graceful termination
-        process.terminate()
-        try:
-            # Wait up to 5 seconds for graceful shutdown
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            # Force kill if it doesn't shut down gracefully
-            process.kill()
-            process.wait()
-
-    def on_modified(self, event: Any) -> None:
-        """Called on any file event in the watched directory (create, modify, delete, move)."""
-        # Don't reload if the event is on a directory
-        if event.is_directory:
-            return
-
-        if str(event.src_path).endswith(__file__):
-            return
-
-        self.start_process()
+    # First try graceful termination
+    process.terminate()
+    try:
+        # Wait up to 5 seconds for graceful shutdown
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        # Force kill if it doesn't shut down gracefully
+        process.kill()
+        process.wait()
 
 
 if __name__ == "__main__":
-    event_handler = ReloadHandler(patterns=["*.py"], ignore_patterns=["*.pyc", "*.pyo"], ignore_directories=True)
+    # Configure filter to ignore .venv, __pycache__, and compiled Python files
+    watch_filter = DefaultFilter(
+        ignore_dirs=(".venv",),
+        ignore_entity_patterns=(r"\.pyc$", r"\.pyo$"),
+    )
 
-    observer = Observer()
-    observer.schedule(event_handler, path="src", recursive=True)
-    observer.schedule(event_handler, path="libraries", recursive=True)
-    observer.schedule(event_handler, path="tests", recursive=True)
-    observer.start()
+    process = start_process()
 
     try:
-        while True:
-            time.sleep(1)
+        # Watch for changes in src, libraries, and tests directories
+        for changes in watch("src", "libraries", "tests", watch_filter=watch_filter):
+            # Only restart on .py file changes
+            if any(str(path).endswith(".py") for _, path in changes):
+                terminate_process(process)
+                process = start_process()
     except KeyboardInterrupt:
-        if event_handler.process:
-            event_handler._terminate_process(event_handler.process)
-    finally:
-        observer.stop()
-        observer.join()
+        terminate_process(process)

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,6 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
     { name = "typos" },
-    { name = "watchdog" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -372,7 +371,6 @@ dev = [
     { name = "pyright", specifier = ">=1.1.396" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "typos", specifier = ">=1.30.2" },
-    { name = "watchdog", specifier = ">=6.0.0" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.5.2" },


### PR DESCRIPTION
Removes code, a dependency, and let's us properly ignore `.venv` directories.