### PR TITLE
Feat/config hash postfix

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
@@ -19,7 +19,9 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logger = logging.getLogger("diffusers_nodes_library")
 
-UNION_PRO_2_CONFIG_HASH_POSTFIX = 1 # 0001
+# Additional postfix bits must be powers of two (1, 2, 4, 8, etc.) to ensure unique combinations
+UNION_PRO_2_CONFIG_HASH_POSTFIX = 1  # 0001
+
 
 class DiffusionPipelineBuilderNode(ControlNode):
     def __init__(self, **kwargs) -> None:
@@ -51,7 +53,7 @@ class DiffusionPipelineBuilderNode(ControlNode):
     def optimization_kwargs(self) -> dict[str, Any]:
         """Get optimization settings for the pipeline."""
         return self.huggingface_pipeline_params.get_hf_pipeline_parameters()
-    
+
     def _get_config_hash_postfix(self) -> int:
         config_bits = 0
         controlnet_model = self.get_parameter_value("controlnet_model")
@@ -78,7 +80,7 @@ class DiffusionPipelineBuilderNode(ControlNode):
             + "-"
             + hashlib.sha256(json.dumps(config_data, sort_keys=True).encode()).hexdigest()
         )
-        # Append postfix bits to config hash as hex
+        # Convert to hex and append postfix bits
         config_hash += f"-{self._get_config_hash_postfix():x}"
         return config_hash
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/controlnet_runtime_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux/controlnet_runtime_parameters.py
@@ -12,7 +12,6 @@ from diffusers_nodes_library.common.nodes.diffusion_pipeline_builder_node import
 from diffusers_nodes_library.common.parameters.diffusion.runtime_parameters import (
     DiffusionPipelineRuntimeParameters,
 )
-from diffusers_nodes_library.common.utils.huggingface_utils import model_cache
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.traits.options import Options


### PR DESCRIPTION
We need to pass info to the runtime node on specific param conditions. In this case, we need to know if the union-pro-2 controlnet model is selected b/c it doesn't have a control_mode param.

I am postfixing the config_hash with a hexadecimal value that represents the specific param conditions. In this case, bit 0 reflects if union-pro-2 is in use. bit 1 may reflect something else in the future, we don't have another param like that (yet)

Originally I was just going to postfix with 'union-pro-2' but then I was like "What if we need to convey that we are using union-pro-2 and some other param value?

Closes https://github.com/griptape-ai/griptape-nodes/issues/2334