### PR TITLE
feature: adding search to options trait

### DIFF
--- a/src/griptape_nodes/traits/multi_options.py
+++ b/src/griptape_nodes/traits/multi_options.py
@@ -29,15 +29,17 @@ class MultiOptions(Trait):
     placeholder: str = field(default="Select options...")
     max_selected_display: int = field(default=3)
     show_search: bool = field(default=True)
+    search_filter: str = field(default="")
     icon_size: str = field(default="small")
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         choices: list | None = None,
         placeholder: str = "Select options...",
         max_selected_display: int = 3,
         show_search: bool = True,
+        search_filter: str = "",
         icon_size: str = "small",
     ) -> None:
         super().__init__()
@@ -48,6 +50,7 @@ class MultiOptions(Trait):
         self.placeholder = placeholder
         self.max_selected_display = max_selected_display
         self.show_search = show_search
+        self.search_filter = search_filter
 
         # Validate icon_size
         if icon_size not in ["small", "large"]:
@@ -183,6 +186,7 @@ class MultiOptions(Trait):
                 "placeholder": self.placeholder,
                 "max_selected_display": self.max_selected_display,
                 "show_search": self.show_search,
+                "search_filter": self.search_filter,
                 "icon_size": self.icon_size,
             }
         }

--- a/src/griptape_nodes/traits/options.py
+++ b/src/griptape_nodes/traits/options.py
@@ -26,12 +26,16 @@ class Options(Trait):
 
     _choices: list = field(default_factory=lambda: ["choice 1", "choice 2", "choice 3"])
     element_id: str = field(default_factory=lambda: "Options")
+    show_search: bool = field(default=True)
+    search_filter: str = field(default="")
 
-    def __init__(self, *, choices: list | None = None) -> None:
+    def __init__(self, *, choices: list | None = None, show_search: bool = True, search_filter: str = "") -> None:
         super().__init__()
         # Set choices through property to ensure dual sync from the start
         if choices is not None:
             self.choices = choices
+        self.show_search = show_search
+        self.search_filter = search_filter
 
     @property
     def choices(self) -> list:
@@ -122,4 +126,8 @@ class Options(Trait):
         Using _choices directly breaks this cycle while still providing the correct
         initial choices for UI rendering. The property-based sync handles runtime updates.
         """
-        return {"simple_dropdown": self._choices}
+        return {
+            "simple_dropdown": self._choices,
+            "show_search": self.show_search,
+            "search_filter": self.search_filter,
+        }


### PR DESCRIPTION
Adds ability for users to search with the Options trait. Default is true. Also provides functionality to pre-fill the trait with the `search_filter` parameter.

fixes: #2213
UI pr: https://github.com/griptape-ai/griptape-vsl-gui/pull/1329