### PR TITLE
adding button trait to ParameterMessage

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -8,6 +9,8 @@ from enum import Enum, StrEnum, auto
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, Self, TypeVar
 
 from pydantic import BaseModel
+
+logger = logging.getLogger("griptape_nodes")
 
 
 class NodeMessagePayload(BaseModel):
@@ -554,6 +557,7 @@ class ParameterMessage(BaseNodeElement, UIOptionsMixin):
         button_align: ButtonAlignType = "full-width",
         full_width: bool = False,
         ui_options: dict | None = None,
+        traits: set[Trait.__class__ | Trait] | None = None,
         **kwargs,
     ):
         super().__init__(element_type=ParameterMessage.__name__, **kwargs)
@@ -568,6 +572,17 @@ class ParameterMessage(BaseNodeElement, UIOptionsMixin):
         self._button_align = button_align
         self._full_width = full_width
         self._ui_options = ui_options or {}
+
+        # Handle traits if provided
+        if traits:
+            for trait in traits:
+                if isinstance(trait, type):
+                    # It's a trait class, instantiate it
+                    trait_instance = trait()
+                else:
+                    # It's already a trait instance
+                    trait_instance = trait
+                self.add_child(trait_instance)
 
     @property
     def variant(self) -> VariantType:
@@ -694,6 +709,13 @@ class ParameterMessage(BaseNodeElement, UIOptionsMixin):
         else:
             button_icon = self.button_icon
 
+        # Check if there are any Button traits with on_click callbacks
+        has_button_callback = False
+        for child in self.children:
+            if hasattr(child, "on_click_callback") and child.on_click_callback is not None:
+                has_button_callback = True
+                break
+
         # Merge the UI options with the message-specific options
         # Always include these fields, even if they're None or empty
         message_ui_options = {
@@ -705,6 +727,7 @@ class ParameterMessage(BaseNodeElement, UIOptionsMixin):
             "button_icon": button_icon,
             "button_variant": self.button_variant,
             "button_align": self.button_align,
+            "button_on_click": has_button_callback,
             "full_width": self.full_width,
         }
 

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -712,7 +712,10 @@ class ParameterMessage(BaseNodeElement, UIOptionsMixin):
         # Check if there are any Button traits with on_click callbacks
         has_button_callback = False
         for child in self.children:
-            if hasattr(child, "on_click_callback") and child.on_click_callback is not None:
+            # Import here to avoid circular imports
+            from griptape_nodes.traits.button import Button
+
+            if isinstance(child, Button) and child.on_click_callback is not None:
                 has_button_callback = True
                 break
 


### PR DESCRIPTION
Adds the ability to add a ButtonTrait to the ParameterMessage, giving it the ability to execute python methods.
https://www.loom.com/share/ad10d3da4b40473aa1b4bc21171ad3d6?sid=884f1704-15d1-444d-a28f-ffb9da8c715f
fixes: #2234
requires: https://github.com/griptape-ai/griptape-vsl-gui/pull/1332