### PR TITLE
feat: add cooperative cancellation

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import logging
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Iterable
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
@@ -41,6 +40,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
 )
 from griptape_nodes.traits.options import Options
+from griptape_nodes.utils import async_utils
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import NodeMessagePayload
@@ -142,6 +142,7 @@ class BaseNode(ABC):
         None  # The control input parameter used to enter this node during execution
     )
     lock: bool = False  # When lock is true, the node is locked and can't be modified. When lock is false, the node is unlocked and can be modified.
+    _cancellation_requested: threading.Event  # Event indicating if cancellation has been requested for this node
 
     @property
     def parameters(self) -> list[Parameter]:
@@ -169,6 +170,7 @@ class BaseNode(ABC):
         self.root_ui_element._node_context = self
         self.process_generator = None
         self._tracked_parameters = []
+        self._cancellation_requested = threading.Event()
         self.set_entry_control_parameter(None)
         self.execution_environment = Parameter(
             name="execution_environment",
@@ -209,6 +211,27 @@ class BaseNode(ABC):
             parameter: The control input parameter that triggered this node's execution, or None to clear
         """
         self._entry_control_parameter = parameter
+
+    @property
+    def is_cancellation_requested(self) -> bool:
+        """Check if cancellation has been requested for this node.
+
+        Returns:
+            True if cancellation has been requested, False otherwise
+        """
+        return self._cancellation_requested.is_set()
+
+    def request_cancellation(self) -> None:
+        """Request cancellation of this node's execution.
+
+        Sets a flag that the node can check during long-running operations
+        to cooperatively cancel execution.
+        """
+        self._cancellation_requested.set()
+
+    def clear_cancellation(self) -> None:
+        """Clear the cancellation request flag."""
+        self._cancellation_requested.clear()
 
     def emit_parameter_changes(self) -> None:
         if self._tracked_parameters:
@@ -816,20 +839,14 @@ class BaseNode(ABC):
             return
 
         if isinstance(result, Generator):
-            # Handle generator pattern asynchronously using the same logic as before
-            loop = asyncio.get_running_loop()
-
             try:
                 # Start the generator
                 func = next(result)
 
                 while True:
-                    # Run callable in thread pool (preserving existing behavior)
-                    with ThreadPoolExecutor() as executor:
-                        future_result = await loop.run_in_executor(executor, func)
-
                     # Send result back and get next callable
-                    func = result.send(future_result)
+                    func_result = await async_utils.to_thread(func)
+                    func = result.send(func_result)
 
             except StopIteration:
                 # Generator is done
@@ -884,6 +901,8 @@ class BaseNode(ABC):
         self.state = NodeResolutionState.UNRESOLVED
         # delete all output values potentially generated
         self.parameter_output_values.clear()
+        # Clear cancellation flag
+        self.clear_cancellation()
         # Clear the spotlight linked list
         # First, clear all next/prev pointers to break the linked list
         current = self.current_spotlight_parameter

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -346,6 +346,10 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
                 flow_manager.global_flow_queue.queue.remove(item)
         return start_nodes
 
+    async def cancel_flow(self) -> None:
+        """Cancel all nodes in the flow by delegating to the resolution machine."""
+        await self.resolution_machine.cancel_all_nodes()
+
     def reset_machine(self, *, cancel: bool = False) -> None:
         self._context.reset(cancel=cancel)
         self._current_state = None

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -476,7 +476,7 @@ class ExecuteDagState(State):
                     # Task was cancelled - this is expected during flow cancellation
                     context.task_to_node.pop(task)
                     logger.info("Task execution was cancelled.")
-                    return DagCompleteState
+                    return ErrorState
                 if task.exception():
                     # Get the actual exception and re-raise it
                     exc = task.exception()

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -472,6 +472,11 @@ class ExecuteDagState(State):
             done, _ = await asyncio.wait(context.task_to_node.keys(), return_when=asyncio.FIRST_COMPLETED)
             # Check for task exceptions and handle them properly
             for task in done:
+                if task.cancelled():
+                    # Task was cancelled - this is expected during flow cancellation
+                    context.task_to_node.pop(task)
+                    logger.info("Task execution was cancelled.")
+                    return DagCompleteState
                 if task.exception():
                     # Get the actual exception and re-raise it
                     exc = task.exception()
@@ -562,6 +567,21 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         if self.context.dag_builder is None:
             self.context.dag_builder = GriptapeNodes.FlowManager().global_dag_builder
         await self.start(ExecuteDagState)
+
+    async def cancel_all_nodes(self) -> None:
+        """Cancel all executing tasks and set cancellation flags on all nodes."""
+        # Set cancellation flag on all nodes being tracked
+        for dag_node in self.context.node_to_reference.values():
+            dag_node.node_reference.request_cancellation()
+
+        # Cancel all running tasks
+        tasks = list(self.context.task_to_node.keys())
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+        # Wait for all tasks to complete
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     def change_debug_mode(self, *, debug_mode: bool) -> None:
         self._context.paused = debug_mode


### PR DESCRIPTION
whew, Closes #2376

Nodes cannot be safely cancelled mid-execution. This problem has two aspects, depending on whether nodes implement `def process` or `async def aprocess`.

## Asynchronous Nodes
The asynchronous path is more straightforward since async tasks can be cancelled mid-execution. We create a task from the `aprocess` coroutine and call `task.cancel()`. If the `aprocess` performs purely IO-bound work, the task cancels immediately.

## The Threading Challenge
However, complications arise when nodes offload long-running work to threads. When we cancel a task that contains `asyncio.to_thread`, the task appears to complete, but the underlying thread continues running in the background. This is problematic because:

- It creates confusing behavior (the task appears cancelled but isn't truly stopped)
- Background threads continue consuming resources (particularly in diffusers)

## Solution: Two-Part Approach
1. **Fix `asyncio.to_thread` behavior**
We need `asyncio.to_thread` to wait for threads to finish when cancelled. This utility handles that:
https://github.com/griptape-ai/griptape-nodes/blob/e3fc20a940646a3131aace5c71296ad2aafbb6a6/src/griptape_nodes/utils/async_utils.py?plain=1#L58-L65
2. **Implement cooperative cancellation**
Since threads cannot be forcibly cancelled once started, we must use cooperative cancellation. When a user requests cancellation, we set a signal that the node checks during execution. The implementation varies by node type:
    - Agent nodes check during streaming
    - Diffusers nodes check after each diffusion step
    
    This ensures cancellation waits for threads to complete gracefully rather than leaving them running in the background.

## Misc: 
- The UI needs to be updated because cancellation is no longer immediate. https://github.com/griptape-ai/griptape-vsl-gui/pull/1338
- Cancellation is no longer immediate -- this may surprise users if they're using nodes that don't implement some form of cancellation.
- Nodes will need to be updated to take advantage of this new behavior. Separate PR to come.