### PR TITLE
chore: bump v0.57.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.57.0"
+version = "0.57.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -280,7 +280,7 @@ wheels = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.57.0"
+version = "0.57.1"
 source = { editable = "." }
 dependencies = [
     { name = "binaryornot" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.57`.

Cherry-picked commit: d67e99a67398fb8e44460ef8dca0593f04edafe7