### PR TITLE
fix: use process over aprocess for builder/runtime nodes

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import json
 import logging
@@ -13,7 +12,7 @@ from diffusers_nodes_library.common.utils.huggingface_utils import model_cache
 from diffusers_nodes_library.common.utils.lora_utils import LorasParameter
 from diffusers_nodes_library.common.utils.pipeline_utils import optimize_diffusion_pipeline
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -133,7 +132,7 @@ class DiffusionPipelineBuilderNode(ControlNode):
     def preprocess(self) -> None:
         self.log_params.clear_logs()
 
-    async def aprocess(self) -> None:
+    def process(self) -> AsyncResult:
         self.preprocess()
         self.log_params.append_to_logs("Building pipeline...\n")
 
@@ -141,7 +140,7 @@ class DiffusionPipelineBuilderNode(ControlNode):
             return self._build_pipeline()
 
         with self.log_params.append_profile_to_logs("Pipeline building/caching"):
-            await asyncio.to_thread(model_cache.get_or_build_pipeline, self.get_parameter_value("pipeline"), builder)
+            yield lambda: model_cache.get_or_build_pipeline(self.get_parameter_value("pipeline"), builder)
 
         self.log_params.append_to_logs("Pipeline building complete.\n")
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_runtime_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_runtime_node.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Any, ClassVar
 
@@ -12,7 +11,7 @@ from diffusers_nodes_library.common.parameters.log_parameter import (  # type: i
 )
 from diffusers_nodes_library.common.utils.huggingface_utils import model_cache
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import BaseNode, ControlNode, NodeResolutionState
+from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode, NodeResolutionState
 
 logger = logging.getLogger("diffusers_nodes_library")
 
@@ -120,9 +119,9 @@ class DiffusionPipelineRuntimeNode(ControlNode):
         )
         return self.pipe_params.runtime_parameters.validate_before_node_run()
 
-    async def aprocess(self) -> None:
+    def process(self) -> AsyncResult:
         self.preprocess()
         self.pipe_params.runtime_parameters.publish_output_image_preview_placeholder()
         pipe = self._get_pipeline()
 
-        await asyncio.to_thread(self.pipe_params.runtime_parameters.process_pipeline, pipe)
+        yield lambda: (self.pipe_params.runtime_parameters.process_pipeline, pipe)


### PR DESCRIPTION
Alternatively could use `griptape_nodes.async_utils.to_thread` but I think this is a better mental model. Doesn't make sense to do CPU bound work in aprocess.


This makes it so that threads don't continue running when cancelled.