### PR TITLE
fix: convert windows urls to posix when dealing with static files

### DIFF
--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -27,17 +27,6 @@ class BaseStorageDriver(ABC):
         """
         self.workspace_directory = workspace_directory
 
-    def _get_full_path(self, path: Path) -> Path:
-        """Get the full path by joining workspace directory with the given path.
-
-        Args:
-            path: The relative path to join with workspace directory.
-
-        Returns:
-            The full path as workspace_directory / path.
-        """
-        return self.workspace_directory / path
-
     @abstractmethod
     def create_signed_upload_url(self, path: Path) -> CreateSignedUploadUrlResponse:
         """Create a signed upload URL for the given path.

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -58,7 +58,7 @@ class LocalStorageDriver(BaseStorageDriver):
 
     def create_signed_download_url(self, path: Path) -> str:
         # The base_url already includes the /static path, so just append the path
-        url = f"{self.base_url}/{path}"
+        url = f"{self.base_url}/{path.as_posix()}"
         # Add a cache-busting query parameter to the URL so that the browser always reloads the file
         cache_busted_url = f"{url}?t={int(time.time())}"
         return cache_busted_url
@@ -70,7 +70,7 @@ class LocalStorageDriver(BaseStorageDriver):
             path: The path of the file to delete.
         """
         # Use the static server's delete endpoint
-        delete_url = urljoin(self.base_url, f"/static-files/{path}")
+        delete_url = urljoin(self.base_url, f"/static-files/{path.as_posix()}")
 
         try:
             response = httpx.delete(delete_url)

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -109,7 +109,7 @@ class StaticFilesManager:
 
         try:
             url = self.save_static_file(content_bytes, file_name)
-        except ValueError as e:
+        except Exception as e:
             msg = f"Failed to create static file for file {file_name}: {e}"
             logger.error(msg)
             return CreateStaticFileResultFailure(error=msg, result_details=msg)
@@ -135,7 +135,7 @@ class StaticFilesManager:
 
         try:
             response = self.storage_driver.create_signed_upload_url(full_file_path)
-        except ValueError as e:
+        except Exception as e:
             msg = f"Failed to create presigned URL for file {file_name}: {e}"
             logger.error(msg)
             return CreateStaticFileUploadUrlResultFailure(error=msg, result_details=msg)
@@ -166,7 +166,7 @@ class StaticFilesManager:
 
         try:
             url = self.storage_driver.create_signed_download_url(full_file_path)
-        except ValueError as e:
+        except Exception as e:
             msg = f"Failed to create presigned URL for file {file_name}: {e}"
             logger.error(msg)
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)


### PR DESCRIPTION
Fixes `\`s appearing in URLs on windows. Yes, I verified on Windows.