### PR TITLE
fix: properly handle connections when removing dynamic connections

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
@@ -139,7 +139,7 @@ class DiffusionPipelineBuilderNode(ControlNode):
         self.log_params.clear_logs()
 
     def remove_parameter_element_by_name(self, element_name: str) -> None:
-        # HACK: `node.remove_parameter_element_by_name` does not remove connections so we need to use the retained mode request which does.
+        # HACK: `node.remove_parameter_element_by_name` does not remove connections so we need to use the retained mode request which does.  # noqa: FIX004
         # To avoid updating a ton of callers, we just override this method here.
         # Long term, all nodes should probably use retained mode rather than direct node methods.
         if self.does_name_exist(element_name):

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
@@ -13,10 +13,7 @@ from diffusers_nodes_library.common.utils.lora_utils import LorasParameter
 from diffusers_nodes_library.common.utils.pipeline_utils import optimize_diffusion_pipeline
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode, NodeResolutionState
-from griptape_nodes.retained_mode.events.parameter_events import (
-    RemoveParameterFromNodeRequest,
-    SetParameterValueRequest,
-)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logger = logging.getLogger("diffusers_nodes_library")
@@ -137,15 +134,6 @@ class DiffusionPipelineBuilderNode(ControlNode):
 
     def preprocess(self) -> None:
         self.log_params.clear_logs()
-
-    def remove_parameter_element_by_name(self, element_name: str) -> None:
-        # HACK: `node.remove_parameter_element_by_name` does not remove connections so we need to use the retained mode request which does.  # noqa: FIX004
-        # To avoid updating a ton of callers, we just override this method here.
-        # Long term, all nodes should probably use retained mode rather than direct node methods.
-        if self.does_name_exist(element_name):
-            GriptapeNodes.handle_request(
-                RemoveParameterFromNodeRequest(parameter_name=element_name, node_name=self.name)
-            )
 
     def process(self) -> AsyncResult:
         self.preprocess()

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_runtime_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_runtime_node.py
@@ -12,6 +12,13 @@ from diffusers_nodes_library.common.parameters.log_parameter import (  # type: i
 from diffusers_nodes_library.common.utils.huggingface_utils import model_cache
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    IncomingConnection,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+    OutgoingConnection,
+)
 from griptape_nodes.retained_mode.events.parameter_events import RemoveParameterFromNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -31,6 +38,41 @@ class DiffusionPipelineRuntimeNode(ControlNode):
         self.log_params = LogParameter(self)
         self.log_params.add_output_parameters()
         self._initializing = False
+
+    def _save_connections(self) -> tuple[list[IncomingConnection], list[OutgoingConnection]]:
+        """Save all incoming and outgoing connections for this node, excluding pipeline parameter."""
+        result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self.name))
+        if isinstance(result, ListConnectionsForNodeResultSuccess):
+            # Exclude pipeline parameter since it never gets removed
+            incoming = [conn for conn in result.incoming_connections if conn.target_parameter_name != "pipeline"]
+            return incoming, result.outgoing_connections
+        return [], []
+
+    def _restore_connections(
+        self, saved_incoming: list[IncomingConnection], saved_outgoing: list[OutgoingConnection]
+    ) -> None:
+        """Restore connections for parameters that still exist after parameter changes."""
+        for conn in saved_incoming:
+            if self.does_name_exist(conn.target_parameter_name):
+                GriptapeNodes.handle_request(
+                    CreateConnectionRequest(
+                        source_node_name=conn.source_node_name,
+                        source_parameter_name=conn.source_parameter_name,
+                        target_node_name=self.name,
+                        target_parameter_name=conn.target_parameter_name,
+                    )
+                )
+
+        for conn in saved_outgoing:
+            if self.does_name_exist(conn.source_parameter_name):
+                GriptapeNodes.handle_request(
+                    CreateConnectionRequest(
+                        source_node_name=self.name,
+                        source_parameter_name=conn.source_parameter_name,
+                        target_node_name=conn.target_node_name,
+                        target_parameter_name=conn.target_parameter_name,
+                    )
+                )
 
     def set_parameter_value(
         self,
@@ -59,7 +101,10 @@ class DiffusionPipelineRuntimeNode(ControlNode):
             skip_before_value_set=skip_before_value_set,
         )
 
+        saved_incoming = []
+        saved_outgoing = []
         if did_pipeline_change:
+            saved_incoming, saved_outgoing = self._save_connections()
             self.pipe_params.runtime_parameters.remove_input_parameters()
             self.pipe_params.runtime_parameters.remove_output_parameters()
 
@@ -78,6 +123,9 @@ class DiffusionPipelineRuntimeNode(ControlNode):
             self.reorder_elements(sorted_parameters)
 
         self.pipe_params.runtime_parameters.after_value_set(parameter, value)
+
+        if did_pipeline_change:
+            self._restore_connections(saved_incoming, saved_outgoing)
 
     def add_parameter(self, parameter: Parameter) -> None:
         """Add a parameter to the node.

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_runtime_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_runtime_node.py
@@ -43,7 +43,7 @@ class DiffusionPipelineRuntimeNode(ControlNode):
         """Save all incoming and outgoing connections for this node, excluding pipeline parameter."""
         result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self.name))
         if isinstance(result, ListConnectionsForNodeResultSuccess):
-            # Exclude pipeline parameter since it never gets removed
+            # Exclude pipeline parameter since restoring it will trigger a cascade of changes
             incoming = [conn for conn in result.incoming_connections if conn.target_parameter_name != "pipeline"]
             return incoming, result.outgoing_connections
         return [], []
@@ -169,7 +169,7 @@ class DiffusionPipelineRuntimeNode(ControlNode):
         return self.pipe_params.runtime_parameters.validate_before_node_run()
 
     def remove_parameter_element_by_name(self, element_name: str) -> None:
-        # HACK: `node.remove_parameter_element_by_name` does not remove connections so we need to use the retained mode request which does.
+        # HACK: `node.remove_parameter_element_by_name` does not remove connections so we need to use the retained mode request which does.  # noqa: FIX004
         # To avoid updating a ton of callers, we just override this method here.
         # Long term, all nodes should probably use retained mode rather than direct node methods.
         if self.does_name_exist(element_name):

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1027,7 +1027,10 @@ class BaseNode(ABC):
 
         # Verify we have all elements
         if len(ordered_elements) != len(current_elements):
-            msg = "Element order must include all elements exactly once"
+            ordered_names = {e.name for e in ordered_elements}
+            current_names = {e.name for e in current_elements}
+            diff = current_names - ordered_names
+            msg = f"Element order must include all elements exactly once. Missing from new order: {diff}"
             raise ValueError(msg)
 
         # Remove all elements from root_ui_element

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -9,6 +9,7 @@ from griptape_nodes.exe_types.core_types import (
     Parameter,
     ParameterContainer,
     ParameterGroup,
+    ParameterMessage,
     ParameterMode,
     ParameterType,
     ParameterTypeBuiltin,
@@ -995,10 +996,17 @@ class NodeManager:
         if isinstance(element, ParameterGroup):
             for child in element.find_elements_by_type(Parameter):
                 GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(child.name, node_name))
-            node.remove_parameter_element_by_name(request.parameter_name)
+            node.remove_node_element(element)
 
             return RemoveParameterFromNodeResultSuccess(
                 result_details=f"Successfully removed parameter group '{request.parameter_name}' and all its children from node '{node_name}'."
+            )
+
+        if isinstance(element, ParameterMessage):
+            node.remove_node_element(element)
+
+            return RemoveParameterFromNodeResultSuccess(
+                result_details=f"Successfully removed parameter message '{request.parameter_name}' from node '{node_name}'."
             )
 
         # No tricky stuff, users!


### PR DESCRIPTION
1. Take a snapshot of connections.
2. Remove all parameters.
  2a. Now using `RemoveParameterFromNodeRequest` which properly removes connections. 
4. Add back all parameters.
5. Add back all connections.