### PR TITLE
fix: wait for workflows to finish loading before listing/running them

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -256,6 +256,7 @@ class WorkflowManager:
         self._workflow_file_path_to_info = {}
         self._squelch_workflow_altered_count = 0
         self._referenced_workflow_stack = []
+        self._workflows_loading_complete = asyncio.Event()
 
         event_manager.assign_manager_to_request_type(
             RunWorkflowFromScratchRequest, self.on_run_workflow_from_scratch_request
@@ -346,6 +347,7 @@ class WorkflowManager:
     def on_libraries_initialization_complete(self) -> None:
         # All of the libraries have loaded, and any workflows they came with have been registered.
         # Discover workflows from both config and workspace.
+        self._workflows_loading_complete.clear()
         default_workflow_section = "app_events.on_app_initialization_complete.workflows_to_register"
         config_mgr = GriptapeNodes.ConfigManager()
 
@@ -379,6 +381,8 @@ class WorkflowManager:
                     workflow for workflow in workflows_to_register if workflow.lower() not in paths_to_remove
                 ]
                 config_mgr.set_config_value(default_workflow_section, workflows_to_register)
+
+        self._workflows_loading_complete.set()
 
     def get_workflow_metadata(self, workflow_file_path: Path, block_name: str) -> list[re.Match[str]]:
         """Get the workflow metadata for a given workflow file path.
@@ -600,7 +604,9 @@ class WorkflowManager:
         logger.error(execution_result.execution_details)
         return RunWorkflowWithCurrentStateResultFailure(result_details=execution_result.execution_details)
 
-    def on_run_workflow_from_registry_request(self, request: RunWorkflowFromRegistryRequest) -> ResultPayload:
+    async def on_run_workflow_from_registry_request(self, request: RunWorkflowFromRegistryRequest) -> ResultPayload:
+        await self._workflows_loading_complete.wait()
+
         # get workflow from registry
         try:
             workflow = WorkflowRegistry.get_workflow_by_name(request.workflow_name)
@@ -708,7 +714,9 @@ class WorkflowManager:
             ),
         )
 
-    def on_list_all_workflows_request(self, _request: ListAllWorkflowsRequest) -> ResultPayload:
+    async def on_list_all_workflows_request(self, _request: ListAllWorkflowsRequest) -> ResultPayload:
+        await self._workflows_loading_complete.wait()
+
         try:
             workflows = WorkflowRegistry.list_workflows()
         except Exception:


### PR DESCRIPTION
Also adding this to `on_run_workflow_from_registry_request` so that the editor doesn't kick you to the list workflows screen during boot.

Closes #2530