### PR TITLE
Implement node deprecation flag

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -52,6 +52,7 @@ class IconVariant(BaseModel):
 
 class NodeDeprecationMetadata(BaseModel):
     """Metadata about a deprecated node."""
+
     is_deprecated: bool = False
     deprecation_message: str | None = None
     removal_version: str | None = None

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -53,7 +53,6 @@ class IconVariant(BaseModel):
 class NodeDeprecationMetadata(BaseModel):
     """Metadata about a deprecated node."""
 
-    is_deprecated: bool = False
     deprecation_message: str | None = None
     removal_version: str | None = None
 
@@ -68,7 +67,7 @@ class NodeMetadata(BaseModel):
     icon: str | IconVariant | None = None
     color: str | None = None
     group: str | None = None
-    deprecation: NodeDeprecationMetadata = NodeDeprecationMetadata()
+    deprecation: NodeDeprecationMetadata | None = None
 
 
 class CategoryDefinition(BaseModel):

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -50,6 +50,13 @@ class IconVariant(BaseModel):
     dark: str
 
 
+class NodeDeprecationMetadata(BaseModel):
+    """Metadata about a deprecated node."""
+    is_deprecated: bool = False
+    deprecation_message: str | None = None
+    removal_version: str | None = None
+
+
 class NodeMetadata(BaseModel):
     """Metadata about each node within the library, which informs where in the hierarchy it sits, details on usage, and tags to assist search."""
 
@@ -60,7 +67,7 @@ class NodeMetadata(BaseModel):
     icon: str | IconVariant | None = None
     color: str | None = None
     group: str | None = None
-    deprecation_message: str | None = None
+    deprecation: NodeDeprecationMetadata = NodeDeprecationMetadata()
 
 
 class CategoryDefinition(BaseModel):

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -60,6 +60,7 @@ class NodeMetadata(BaseModel):
     icon: str | IconVariant | None = None
     color: str | None = None
     group: str | None = None
+    deprecated: bool = False
 
 
 class CategoryDefinition(BaseModel):

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -60,7 +60,7 @@ class NodeMetadata(BaseModel):
     icon: str | IconVariant | None = None
     color: str | None = None
     group: str | None = None
-    deprecated: bool = False
+    deprecation_message: str | None = None
 
 
 class CategoryDefinition(BaseModel):
@@ -100,7 +100,7 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.2.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.3.0"
 
     name: str
     library_schema_version: str

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -151,14 +151,14 @@ class VersionCompatibilityManager:
                     self._workflow_compatibility_checks.append(check_instance)
                     logger.debug("Registered workflow version compatibility check: %s", attr_name)
 
-    def _check_for_deprecated_nodes(self, nodes: list[NodeDefinition]) -> list[LibraryVersionCompatibilityIssue]:
-        """Check for deprecated nodes."""
+    def _check_library_for_deprecated_nodes(self, library_data: LibrarySchema) -> list[LibraryVersionCompatibilityIssue]:
+        """Check a library for deprecated nodes."""
         return [
             LibraryVersionCompatibilityIssue(
                 message=f"Node '{node.metadata.display_name}' (class: {node.class_name}) is deprecated and may be removed in future versions. {node.metadata.deprecation_message}",
                 severity=LibraryStatus.FLAWED,
             )
-            for node in nodes
+            for node in library_data.nodes
             if node.metadata.deprecation_message
         ] or []
 
@@ -174,7 +174,7 @@ class VersionCompatibilityManager:
                 issues = check_instance.check_library(library_data)
                 version_issues.extend(issues)
 
-        version_issues.extend(self._check_for_deprecated_nodes(library_data.nodes))
+        version_issues.extend(self._check_library_for_deprecated_nodes(library_data))
 
         return version_issues
 

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -11,13 +11,13 @@ from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, Version
-from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
+from griptape_nodes.retained_mode.managers.library_lifecycle.library_status import LibraryStatus
 
 if TYPE_CHECKING:
     from griptape_nodes.node_library.library_registry import LibrarySchema, NodeDefinition
     from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
-    from griptape_nodes.retained_mode.managers.library_lifecycle.library_status import LibraryStatus
+    from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -155,11 +155,11 @@ class VersionCompatibilityManager:
         """Check a library for deprecated nodes."""
         return [
             LibraryVersionCompatibilityIssue(
-                message=f"Node '{node.metadata.display_name}' (class: {node.class_name}) is deprecated and may be removed in future versions. {node.metadata.deprecation_message}",
+                message=f"Node '{node.metadata.display_name}' (class: {node.class_name}) is deprecated and {'will be removed in version ' + node.metadata.deprecation.removal_version if node.metadata.deprecation.removal_version else 'may be removed in future versions'}. {node.metadata.deprecation.deprecation_message or ''}".strip(),
                 severity=LibraryStatus.FLAWED,
             )
             for node in library_data.nodes
-            if node.metadata.deprecation_message
+            if node.metadata.deprecation.is_deprecated
         ] or []
 
     def check_library_version_compatibility(

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -151,12 +151,12 @@ class VersionCompatibilityManager:
                     self._workflow_compatibility_checks.append(check_instance)
                     logger.debug("Registered workflow version compatibility check: %s", attr_name)
 
-    def _check_for_deprecated_nodes(self, nodes: list[NodeDefinition]) -> list[WorkflowVersionCompatibilityIssue]:
-        """Check a workflow for deprecated nodes."""
+    def _check_for_deprecated_nodes(self, nodes: list[NodeDefinition]) -> list[LibraryVersionCompatibilityIssue]:
+        """Check for deprecated nodes."""
         return [
-            WorkflowVersionCompatibilityIssue(
+            LibraryVersionCompatibilityIssue(
                 message=f"Node '{node.metadata.display_name}' (class: {node.class_name}) is deprecated and may be removed in future versions. {node.metadata.deprecation_message}",
-                severity=WorkflowManager.WorkflowStatus.FLAWED,
+                severity=LibraryStatus.FLAWED,
             )
             for node in nodes
             if node.metadata.deprecation_message
@@ -166,7 +166,7 @@ class VersionCompatibilityManager:
         self, library_data: LibrarySchema
     ) -> list[LibraryVersionCompatibilityIssue]:
         """Check a library for version compatibility issues."""
-        version_issues = []
+        version_issues: list[LibraryVersionCompatibilityIssue] = []
 
         # Run all discovered compatibility checks
         for check_instance in self._compatibility_checks:
@@ -182,7 +182,7 @@ class VersionCompatibilityManager:
         self, workflow_metadata: WorkflowMetadata
     ) -> list[WorkflowVersionCompatibilityIssue]:
         """Check a workflow for version compatibility issues."""
-        version_issues = []
+        version_issues: list[WorkflowVersionCompatibilityIssue] = []
 
         # Run all discovered workflow compatibility checks
         for check_instance in self._workflow_compatibility_checks:

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -161,7 +161,7 @@ class VersionCompatibilityManager:
                 severity=LibraryStatus.FLAWED,
             )
             for node in library_data.nodes
-            if node.metadata.deprecation.is_deprecated
+            if node.metadata.deprecation is not None
         ] or []
 
     def check_library_version_compatibility(

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -157,10 +157,10 @@ class VersionCompatibilityManager:
         issues = []
 
         for node in nodes:
-            if node.metadata.deprecated:
+            if node.metadata.deprecation_message:
                 issues.append(
                     WorkflowVersionCompatibilityIssue(
-                        message=f"Node '{node.metadata.display_name}' (class: {node.class_name}) is deprecated and may be removed in future versions. Please consider replacing it with a supported alternative.",
+                        message=f"Node '{node.metadata.display_name}' (class: {node.class_name}) is deprecated and may be removed in future versions. {node.metadata.deprecation_message}",
                         severity=WorkflowManager.WorkflowStatus.FLAWED,
                     )
                 )


### PR DESCRIPTION
Provides the ability to message to the user that nodes in a library are deprecated and may be removed in future versions.

Example Logs:
<img width="1400" height="325" alt="Screenshot 2025-10-07 114002" src="https://github.com/user-attachments/assets/6dbaca98-880f-4e0b-a711-40e1f323d2c6" />


Example JSON:
```
    {
      "class_name": "FluxPipeline",
      "file_path": "diffusers_nodes_library/pipelines/flux/flux_pipeline.py",
      "metadata": {
        "category": "image/flux",
        "description": "Generate an Image with Flux via 🤗 Diffusers.",
        "display_name": "Flux",
        "deprecation": {
          "is_deprecated": true,
          "deprecation_message": "Use 'Diffusion Pipeline Builder' and 'Generate Image (Diffusion Pipeline)' nodes instead.",
          "removal_version": "0.59.0"
        }
      }
    },
```