### PR TITLE
Fall back to Griptape Nodes Library for Start and End Flow Nodes when publishing to a library target in node_executor

### DIFF
--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -222,16 +222,16 @@ class NodeExecutor:
         output_parameter_prefix = f"{sanitized_node_name}_packaged_node_"
         # We have to make our defaults strings because the PackageNodeAsSerializedFlowRequest doesn't accept None types.
         library_name = "Griptape Nodes Library"
-        sanitized_library_name = ""
         start_node_type = "StartFlow"
-        end_node_type = "StartFlow"
+        end_node_type = "EndFlow"
         if library is not None:
-            library_name = library.get_library_data().name
-            sanitized_library_name = library_name.replace(" ", "_")
-            start_node_type = library.get_nodes_by_base_type(StartNode)
-            end_node_type = library.get_nodes_by_base_type(EndNode)
-            start_node_type = start_node_type[0] if len(start_node_type) > 0 else "StartFlow"
-            end_node_type = end_node_type[0] if len(end_node_type) > 0 else "EndFlow"
+            start_nodes = library.get_nodes_by_base_type(StartNode)
+            end_nodes = library.get_nodes_by_base_type(EndNode)
+            if len(start_nodes) > 0 and len(end_nodes) > 0:
+                start_node_type = start_nodes[0]
+                end_node_type = end_nodes[0]
+                library_name = library.get_library_data().name
+        sanitized_library_name = library_name.replace(" ", "_")
         request = PackageNodeAsSerializedFlowRequest(
             node_name=node.name,
             start_node_type=start_node_type,


### PR DESCRIPTION
* Fall back to Griptape Nodes Library for Start and End Flow Nodes when publishing to a library target in node_executor

Tested with GTC Library

<img width="1250" height="737" alt="GTC_execution" src="https://github.com/user-attachments/assets/9a55f3ce-7270-4525-a5b8-3e5dbb848f92" />
