### PR TITLE
fix: restore ui_options after adding back parameters

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/nodes/diffusion_pipeline_builder_node.py
@@ -25,6 +25,7 @@ UNION_PRO_2_CONFIG_HASH_POSTFIX = 1  # 0001
 class DiffusionPipelineBuilderNode(ControlNode):
     def __init__(self, **kwargs) -> None:
         self._initializing = True
+        self._ui_options_cache: dict[str, dict] = {}
         super().__init__(**kwargs)
         self.params = DiffusionPipelineBuilderParameters(self)
         self.huggingface_pipeline_params = HuggingFacePipelineParameter(self)
@@ -113,6 +114,10 @@ class DiffusionPipelineBuilderNode(ControlNode):
             parameter.user_defined = True
             super().add_parameter(parameter)
 
+            # Restore cached ui_options if available
+            if parameter.name in self._ui_options_cache:
+                parameter.ui_options = self._ui_options_cache[parameter.name]
+
     def set_parameter_value(
         self,
         param_name: str,
@@ -145,6 +150,13 @@ class DiffusionPipelineBuilderNode(ControlNode):
 
     def preprocess(self) -> None:
         self.log_params.clear_logs()
+
+    def _save_ui_options(self) -> None:
+        """Save ui_options for all current parameters to cache."""
+        for element in self.root_ui_element.children:
+            parameter = self.get_parameter_by_name(element.name)
+            if parameter is not None and parameter.ui_options:
+                self._ui_options_cache[parameter.name] = parameter.ui_options.copy()
 
     def process(self) -> AsyncResult:
         self.preprocess()

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/builder_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/builder_parameters.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from diffusers_nodes_library.common.parameters.diffusion.allegro.pipeline_type_parameters import (
     AllegroPipelineTypeParameters,
@@ -12,9 +14,6 @@ from diffusers_nodes_library.common.parameters.diffusion.audioldm.pipeline_type_
 )
 from diffusers_nodes_library.common.parameters.diffusion.custom.pipeline_type_parameters import (
     CustomPipelineTypeParameters,
-)
-from diffusers_nodes_library.common.parameters.diffusion.diffusion_pipeline_type_parameters import (
-    DiffusionPipelineTypeParameters,
 )
 from diffusers_nodes_library.common.parameters.diffusion.flux.pipeline_type_parameters import (
     FluxPipelineTypeParameters,
@@ -32,14 +31,19 @@ from diffusers_nodes_library.common.parameters.diffusion.wuerstchen.pipeline_typ
     WuerstchenPipelineTypeParameters,
 )
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.traits.options import Options
+
+if TYPE_CHECKING:
+    from diffusers_nodes_library.common.nodes.diffusion_pipeline_builder_node import DiffusionPipelineBuilderNode
+    from diffusers_nodes_library.common.parameters.diffusion.diffusion_pipeline_type_parameters import (
+        DiffusionPipelineTypeParameters,
+    )
 
 logger = logging.getLogger("diffusers_nodes_library")
 
 
 class DiffusionPipelineBuilderParameters:
-    def __init__(self, node: BaseNode):
+    def __init__(self, node: DiffusionPipelineBuilderNode):
         self.provider_choices = [
             "Flux",
             "Allegro",
@@ -116,6 +120,8 @@ class DiffusionPipelineBuilderParameters:
         self.pipeline_type_parameters.after_value_set(parameter, value)
 
     def regenerate_pipeline_type_parameters_for_provider(self, provider: str) -> None:
+        self._node._save_ui_options()
+
         self.pipeline_type_parameters.remove_input_parameters()
         self.set_pipeline_type_parameters(provider)
         self.pipeline_type_parameters.add_input_parameters()

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/diffusion_pipeline_type_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/diffusion_pipeline_type_parameters.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
-    DiffusionPipelineTypePipelineParameters,
-)
 from diffusers_nodes_library.common.parameters.huggingface_pipeline_parameter import HuggingFacePipelineParameter
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.traits.options import Options
+
+if TYPE_CHECKING:
+    from diffusers_nodes_library.common.nodes.diffusion_pipeline_builder_node import DiffusionPipelineBuilderNode
+    from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
+        DiffusionPipelineTypePipelineParameters,
+    )
 
 logger = logging.getLogger("diffusers_nodes_library")
 
@@ -17,8 +21,8 @@ class DiffusionPipelineTypeParameters(ABC):
     START_PARAMS: ClassVar = ["pipeline", "provider", "pipeline_type"]
     END_PARAMS: ClassVar = ["loras", "logs"]
 
-    def __init__(self, node: BaseNode):
-        self._node: BaseNode = node
+    def __init__(self, node: DiffusionPipelineBuilderNode):
+        self._node = node
         self.did_pipeline_type_change = False
         self._pipeline_type_pipeline_params: DiffusionPipelineTypePipelineParameters
         self.set_pipeline_type_pipeline_params(self.pipeline_types[0])
@@ -73,6 +77,8 @@ class DiffusionPipelineTypeParameters(ABC):
             self.regenerate_elements_for_pipeline_type(value)
 
     def regenerate_elements_for_pipeline_type(self, pipeline_type: str) -> None:
+        self._node._save_ui_options()
+
         self.pipeline_type_pipeline_params.remove_input_parameters()
         self.set_pipeline_type_pipeline_params(pipeline_type)
         self.pipeline_type_pipeline_params.add_input_parameters()


### PR DESCRIPTION
Ugly but similar strategy to connections for runtime node.
1. Save ui parameters
2. Kill parameters.
3. Add back parameters.
4. Sprinkle in saved ui parameters.


Closes #2545 