### PR TITLE
fix: use get_config_value to support newly nested nested config key

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -60,12 +60,11 @@ class SecretsManager:
         """
         secret_names = set()
 
-        # Check root level for secrets_to_register
-        root_secrets = self.config_manager.merged_config.get(
-            "app_events.on_app_initialization_complete.secrets_to_register", []
+        secrets_to_register = self.config_manager.get_config_value(
+            "app_events.on_app_initialization_complete.secrets_to_register", default=[]
         )
-        if isinstance(root_secrets, list):
-            secret_names.update(root_secrets)
+
+        secret_names.update(secrets_to_register)
 
         # Register each secret (create blank entry if doesn't exist)
         for secret_name in secret_names:


### PR DESCRIPTION
Last minute changed `secrets_to_register` to be a nested key in https://github.com/griptape-ai/griptape-nodes/pull/2535. Apparently forgot to test.