### PR TITLE
chore: bump v0.58.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.58.0"
+version = "0.58.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -280,7 +280,7 @@ wheels = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.58.0"
+version = "0.58.1"
 source = { editable = "." }
 dependencies = [
     { name = "binaryornot" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.58`.

Cherry-picked commit: d1362ce2bfb4aa7bfed295d1025f28f6310f33de