### PR TITLE
Support container parameters in workflow shape

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -3269,6 +3269,7 @@ class WorkflowManager:
             "ui_options",
             "settable",
             "is_user_defined",
+            "parent_container_name",
         ]
         minimal_dict = {key: param_dict[key] for key in fields_to_include if key in param_dict}
         minimal_dict["settable"] = bool(getattr(parameter, "settable", True))
@@ -3365,16 +3366,6 @@ class WorkflowManager:
         Returns:
             Parameter info dict if relevant for workflow shape, None if should be excluded
         """
-        # TODO (https://github.com/griptape-ai/griptape-nodes/issues/1090): This is a temporary solution until we know how to handle container types.
-        # Always exclude list types until container type handling is implemented
-        if parameter.type.startswith("list"):
-            logger.warning(
-                "Skipping list parameter '%s' of type '%s' in workflow shape - container types not yet supported",
-                parameter.name,
-                parameter.type,
-            )
-            return None
-
         # Conditionally exclude control types
         if not include_control_params and parameter.type == ParameterTypeBuiltin.CONTROL_TYPE.value:
             return None


### PR DESCRIPTION
### Details

This change enables ParameterList and general `list` type parameters to be included in the workflow shape.

Looking at the mentioned issue: https://github.com/griptape-ai/griptape-nodes/issues/1090
The context for that issue was that the original[ StartFlow and EndFlow nodes](https://github.com/griptape-ai/griptape-nodes/blob/21920d92af4f7bb51ff961cee13fc82aea0813d3/nodes/griptape_nodes_library/utils/start_flow.py) just had a selection of ParameterList type parameters such that a User could add an item to the list in order to expose the Parameters they desired for each type. 
I think that issue should now be resolved, since the new strategy for specifying custom Parameters on a Start/EndFlow node is to use the `Add Parameter` button in the GUI, which simply calls `AddParameterToNode`, so that Parameters are entirely dynamic.

This means that we no longer have to specifically filter out `list` types, since we're not trying to avoid those default ParameterList parameters from ye old Start/EndFlow nodes.

All this to say, I think it's ok for us to remove this specific `list` check, and allow workflow shapes to be generated with `list` or ParameterList parameters. Also adding `parent_container_name` to the minimal dict so that ParameterList children can be re-constructed with the proper parent Parameter.

Closes #2588 