### PR TITLE
feat: add support for registering libraries from git remote

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "aioshutil>=1.5",
   "ruamel.yaml>=0.18.15",
   "asyncio-thread-runner>=1.0",
+  "pygit2>=1.18.2",
 ]
 
 [project.optional-dependencies]

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -227,6 +227,11 @@ class Settings(BaseModel):
         default=True,
         description="Enable file watching for synced workflows directory",
     )
+    libraries_directory: str = Field(
+        category=FILE_SYSTEM,
+        default="libraries",
+        description="Path to the libraries directory where git repositories are cloned, relative to the workspace directory.",
+    )
     mcp_servers: list[MCPServerConfig] = Field(
         category=MCP_SERVERS,
         default_factory=list,

--- a/src/griptape_nodes/utils/file_utils.py
+++ b/src/griptape_nodes/utils/file_utils.py
@@ -1,0 +1,42 @@
+"""Utilities for file and directory operations."""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger("griptape_nodes")
+
+
+def find_file_in_directory(directory: Path, filename: str) -> Path | None:
+    """Search directory recursively for a file with the exact filename.
+
+    Args:
+        directory: Directory to search in
+        filename: Exact filename to search for (e.g., 'library.json')
+
+    Returns:
+        Path to the first matching file if found, None otherwise
+
+    Examples:
+        >>> find_file_in_directory(Path("/workspace"), "config.json")
+        Path("/workspace/subdir/config.json")
+        >>> find_file_in_directory(Path("/empty"), "missing.txt")
+        None
+    """
+    if not directory.exists():
+        logger.debug("Directory does not exist: %s", directory)
+        return None
+
+    if not directory.is_dir():
+        logger.debug("Path is not a directory: %s", directory)
+        return None
+
+    for root, _, files_found in os.walk(directory):
+        for file in files_found:
+            if file == filename:
+                found_path = Path(root) / file
+                logger.debug("Found file '%s' at: %s", filename, found_path)
+                return found_path
+
+    logger.debug("File '%s' not found in directory: %s", filename, directory)
+    return None

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -1,0 +1,216 @@
+"""Utilities for working with git repositories."""
+
+import logging
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pygit2
+
+logger = logging.getLogger("griptape_nodes")
+
+
+def is_git_url(url: str) -> bool:
+    """Check if a string is a git URL.
+
+    Args:
+        url: String to check
+
+    Returns:
+        True if the string appears to be a git URL, False otherwise
+
+    Examples:
+        >>> is_git_url("https://github.com/user/repo.git")
+        True
+        >>> is_git_url("git@github.com:user/repo.git")
+        True
+        >>> is_git_url("/path/to/local/file.json")
+        False
+    """
+    if not url:
+        return False
+
+    # Check for common git URL patterns
+    # HTTPS/HTTP URLs, SSH URLs, and file:// URLs for local git repos
+    return url.startswith(("https://", "http://", "git://", "git@", "ssh://", "file://"))
+
+
+def get_repo_name_from_url(url: str) -> str:
+    """Extract a sanitized repository name from a git URL.
+
+    Args:
+        url: Git URL to extract name from
+
+    Returns:
+        Sanitized name suitable for use as a directory name
+
+    Examples:
+        >>> get_repo_name_from_url("https://github.com/user/my-repo.git")
+        'my-repo'
+        >>> get_repo_name_from_url("git@gitlab.com:org/project.git")
+        'project'
+    """
+    # Handle SSH URLs (git@host:path)
+    if url.startswith("git@"):
+        # Extract path after the colon
+        if ":" in url:
+            path = url.split(":", 1)[1]
+        else:
+            path = url
+    else:
+        # Use urlparse for standard URLs
+        parsed = urlparse(url)
+        path = parsed.path
+
+    # Remove leading/trailing slashes and .git extension
+    path = path.strip("/")
+    path = path.removesuffix(".git")
+
+    # Get just the repository name (last part of path)
+    repo_name = path.split("/")[-1]
+
+    # Sanitize: replace problematic characters with underscores
+    repo_name = re.sub(r"[^\w\-.]", "_", repo_name)
+
+    return repo_name
+
+
+def clone_or_update_git_library(url: str, target_dir: Path, ref: str | None = None) -> Path:
+    """Clone a git repository or update it if it already exists.
+
+    Args:
+        url: Git repository URL to clone
+        target_dir: Directory to clone into (will be created if it doesn't exist)
+        ref: Optional branch, tag, or commit to checkout (defaults to default branch)
+
+    Returns:
+        Path to the cloned repository directory
+
+    Raises:
+        RuntimeError: If cloning or updating fails
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    if (target_dir / ".git").exists():
+        return _update_existing_repository(target_dir, ref)
+    return _clone_new_repository(url, target_dir, ref)
+
+
+def _checkout_ref(repo: pygit2.Repository, ref: str) -> None:
+    """Check out a specific ref (branch, tag, or commit) in a repository.
+
+    Args:
+        repo: The git repository
+        ref: Branch, tag, or commit to checkout
+
+    Raises:
+        KeyError: If the ref cannot be found
+    """
+    # Try to find the ref (branch, tag, or commit)
+    commit = repo.revparse_single(ref)
+    repo.checkout_tree(commit)
+    # Update HEAD
+    if repo.references.get(f"refs/heads/{ref}"):
+        repo.set_head(f"refs/heads/{ref}")
+    else:
+        repo.set_head(commit.id)
+
+
+def _update_to_latest(repo: pygit2.Repository) -> None:
+    """Update repository to latest commit on default branch.
+
+    Args:
+        repo: The git repository to update
+    """
+    # Get the default branch
+    default_branch = repo.head.shorthand
+    # Fast-forward merge with remote
+    remote_ref = repo.references.get(f"refs/remotes/origin/{default_branch}")
+    if remote_ref:
+        # Get the commit object from the remote reference
+        remote_commit = repo[remote_ref.target].peel(pygit2.Commit)
+        # Checkout the tree from the remote reference
+        repo.checkout_tree(remote_commit)
+        # Update or create the local branch reference
+        local_ref = repo.references.get(f"refs/heads/{default_branch}")
+        if local_ref:
+            local_ref.set_target(remote_ref.target)
+        else:
+            # Create local branch if it doesn't exist
+            repo.create_branch(default_branch, remote_commit)
+        # Set HEAD to the local branch
+        repo.set_head(f"refs/heads/{default_branch}")
+
+
+def _update_existing_repository(target_dir: Path, ref: str | None) -> Path:
+    """Update an existing git repository.
+
+    Args:
+        target_dir: Directory containing the existing repository
+        ref: Optional branch, tag, or commit to checkout
+
+    Returns:
+        Path to the repository directory
+
+    Raises:
+        RuntimeError: If updating fails
+    """
+    logger.debug("Repository already exists at %s, fetching updates", target_dir)
+    try:
+        repo = pygit2.Repository(str(target_dir))
+
+        # Fetch updates from remote
+        remote = repo.remotes["origin"]
+        remote.fetch()
+
+        # Checkout the specified ref if provided
+        if ref:
+            try:
+                _checkout_ref(repo, ref)
+            except KeyError as e:
+                logger.warning("Could not find ref '%s' in repository, using default branch: %s", ref, e)
+        else:
+            _update_to_latest(repo)
+
+        logger.info("Updated git repository at %s", target_dir)
+        return target_dir  # noqa: TRY300
+
+    except Exception as e:
+        error_msg = f"Failed to update git repository at {target_dir}: {e}"
+        logger.error(error_msg)
+        raise RuntimeError(error_msg) from e
+
+
+def _clone_new_repository(url: str, target_dir: Path, ref: str | None) -> Path:
+    """Clone a new git repository.
+
+    Args:
+        url: Git repository URL to clone
+        target_dir: Directory to clone into
+        ref: Optional branch, tag, or commit to checkout
+
+    Returns:
+        Path to the cloned repository directory
+
+    Raises:
+        RuntimeError: If cloning fails
+    """
+    logger.info("Cloning git repository from %s to %s", url, target_dir)
+    try:
+        # Clone the repository
+        repo = pygit2.clone_repository(url, str(target_dir))
+
+        # Checkout the specified ref if provided
+        if ref:
+            try:
+                _checkout_ref(repo, ref)
+            except KeyError as e:
+                logger.warning("Could not find ref '%s' in repository, using default branch: %s", ref, e)
+
+        logger.info("Successfully cloned git repository to %s", target_dir)
+        return target_dir  # noqa: TRY300
+
+    except Exception as e:
+        error_msg = f"Failed to clone git repository from {url}: {e}"
+        logger.error(error_msg)
+        raise RuntimeError(error_msg) from e

--- a/uv.lock
+++ b/uv.lock
@@ -135,6 +135,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+]
+
+[[package]]
 name = "chardet"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +378,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pillow" },
     { name = "pydantic" },
+    { name = "pygit2" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rich" },
@@ -417,6 +441,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pygit2", specifier = ">=1.18.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "rich", specifier = ">=14.1.0" },
@@ -1114,6 +1139,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1169,6 +1203,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/d6/887a1ff844e64aa823fb4905978d882a633cfe295c32eacad582b78a7d8b/pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c", size = 48608, upload-time = "2025-09-24T14:19:10.015Z" },
+]
+
+[[package]]
+name = "pygit2"
+version = "1.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/ea/762d00f6f518423cd889e39b12028844cc95f91a6413cf7136e184864821/pygit2-1.18.2.tar.gz", hash = "sha256:eca87e0662c965715b7f13491d5e858df2c0908341dee9bde2bc03268e460f55", size = 797200, upload-time = "2025-08-16T13:52:36.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/bf/469ec748d9d7989e5494eb5210f0752be4fb6b6bf892f9608cd2a1154dda/pygit2-1.18.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5eaf2855d78c5ad2a6c2ebf840f8717a8980c93567a91fbc0fc91650747454a4", size = 5504679, upload-time = "2025-08-16T13:39:17.017Z" },
+    { url = "https://files.pythonhosted.org/packages/40/95/da254224e3d60a0b5992e0fe8dee3cadfd959ee771375eb0ee921f77e636/pygit2-1.18.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee5dd227e4516577d9edc2b476462db9f0428d3cc1ad5de32e184458f25046ee", size = 5769675, upload-time = "2025-08-16T13:39:18.691Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/cd/722e71b832b9c0d28482e15547d6993868e64e15becee5d172b51d4a6fed/pygit2-1.18.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07e5c39ed67e07dac4eb99bfc33d7ccc105cd7c4e09916751155e7da3e07b6bc", size = 4605744, upload-time = "2025-08-16T13:39:20.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/50/70f38159f6783b54abcd74f47617478618f98a7f68370492777c9db42156/pygit2-1.18.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12ae4ed05b48bb9f08690c3bb9f96a37a193ed44e1a9a993509a6f1711bb22ae", size = 5504072, upload-time = "2025-08-16T13:39:21.834Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/79/5648354eeefb85782e7b66c28ac27c1d6de51fd71b716fa59956fd7d6e30/pygit2-1.18.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:00919a2eafd975a63025d211e1c1a521bf593f6c822bc61f18c1bc661cbffd42", size = 5768382, upload-time = "2025-08-21T13:36:33.4Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/a679120119e92dcdbeb8add6655043db3bc7746d469b7dfc744667ebcd33/pygit2-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f96a168bafb99e99b95f59b0090171396ad2fb07713e5505ad3e4c16a41d56a", size = 5472093, upload-time = "2025-08-16T13:39:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/54/e8c616a8fe12f80af64cfb9a7cba5f9455ca19c8ce68e5ef1d11d6a61d85/pygit2-1.18.2-cp312-cp312-win32.whl", hash = "sha256:ff1c99f2f342c3a3ec1847182d236088f1eb32bc6c4f93fbb5cb2514ccbe29f3", size = 1239180, upload-time = "2025-08-16T13:28:53.788Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/02/f4e51309c709f53575ceec53d74917cd2be536751d4d53f345a6b5427ad4/pygit2-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:507b5ea151cb963b77995af0c4fb51333f02f15a05c0b36c33cd3f5518134ceb", size = 1324567, upload-time = "2025-08-16T13:33:51.181Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Allows users to register a library by specifying the repo like this: `https://github.com/griptape-ai/griptape-nodes-library-kling`.

Verified on a windows machine WITHOUT GIT.