### PR TITLE
chore: bump v0.59.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.59.0"
+version = "0.59.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.59.0"
+version = "0.59.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.59`.

Cherry-picked commit: 548f17a419670c638e3314965a055d0970c8566c