### PR TITLE
chore: bump v0.59.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.59.1"
+version = "0.59.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.59.1"
+version = "0.59.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.59`.

Cherry-picked commit: 42e92f6ddae16daeb26411bf19bb7afc620356a3