### PR TITLE
chore: bump v0.59.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.59.2"
+version = "0.59.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.59.2"
+version = "0.59.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.59`.

Cherry-picked commit: fb6d91e21d74e4129add44a3d1b0b3be23418026