### PR TITLE
fix: prevent type collision in workflow serialization value hashing

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2599,7 +2599,7 @@ class NodeManager:
     ) -> SerializedNodeCommands.IndirectSetParameterValueCommand | None:
         try:
             hash(value)
-            value_id = value
+            value_id = (type(value), value)
         except TypeError:
             # Couldn't get a hash. Use the object's ID
             value_id = id(value)


### PR DESCRIPTION
Closes #1983 

Fixed bug where numeric values (e.g., LoRA weight 1.0) were being saved as boolean True due to Python's equality semantics treating 1 == True and 0 == False as equal when used as dictionary keys.

Changed value_id from using the raw value to a tuple of (type, value) to ensure different types with equal values are treated as distinct keys in the serialization tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)