### PR TITLE
fix: detect directory paths before attempting to write

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -665,6 +665,17 @@ class OSManager:
         # Get normalized path for file operations (handles Windows long paths)
         normalized_path = self._normalize_path_for_platform(file_path)
 
+        # Check if path is a directory (must check before attempting to write)
+        try:
+            if Path(normalized_path).is_dir():
+                msg = f"Path is a directory, not a file: {file_path}"
+                logger.error(msg)
+                return WriteFileResultFailure(failure_reason=FileIOFailureReason.IS_DIRECTORY, result_details=msg)
+        except OSError as e:
+            msg = f"Error checking if path is directory {file_path}: {e}"
+            logger.error(msg)
+            return WriteFileResultFailure(failure_reason=FileIOFailureReason.IO_ERROR, result_details=msg)
+
         # Check existing file policy (only if not appending)
         if not request.append and request.existing_file_policy == ExistingFilePolicy.FAIL:
             try:


### PR DESCRIPTION
Add platform-independent directory check in WriteFileRequest handling. When an empty string is passed as file_path, it resolves to a directory. Previously, this would raise different exceptions on different platforms:
- Unix/Linux/macOS: IsADirectoryError
- Windows: PermissionError (errno 13)

Now we check if the path is a directory before attempting to write, ensuring consistent IS_DIRECTORY failure across all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)