### PR TITLE
chore: bump workflow schema version to 0.11.0

### DIFF
--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -45,7 +45,7 @@ class WorkflowShape(BaseModel):
 
 
 class WorkflowMetadata(BaseModel):
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.10.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.11.0"
 
     name: str
     schema_version: str


### PR DESCRIPTION
Forgot to do in https://github.com/griptape-ai/griptape-nodes/pull/2787