### PR TITLE
update: Rescale Image node: adding width and height resize mode

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/rescale_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/rescale_image.py
@@ -52,13 +52,20 @@ class RescaleImage(BaseImageProcessor):
                 self.show_parameter_by_name("target_width")
                 self.show_parameter_by_name("target_height")
                 self.show_parameter_by_name("fit_mode")
-                self.show_parameter_by_name("background_color")
+                # Background color visibility will be controlled by fit_mode
+                self.hide_parameter_by_name("background_color")
             else:
                 self.hide_parameter_by_name("percentage_scale")
                 self.show_parameter_by_name("target_size")
                 self.hide_parameter_by_name("target_width")
                 self.hide_parameter_by_name("target_height")
                 self.hide_parameter_by_name("fit_mode")
+                self.hide_parameter_by_name("background_color")
+        elif parameter.name == "fit_mode":
+            # Show background color only for fit mode
+            if value == self.FIT_MODE_FIT:
+                self.show_parameter_by_name("background_color")
+            else:
                 self.hide_parameter_by_name("background_color")
         return super().after_value_set(parameter, value)
 


### PR DESCRIPTION
fixes #2801

Adds a `width and height` option to the Rescale Image node with the following options:

`fit_mode`:
- `fit`: Scale to fit within the width/height, may letterbox/matte
- `fill`: Fills the target, possibly crop to maintain aspect ratio
- `stretch`: Ignore aspect ratio

when in `fill` mode it adds a `background_color` parameter.
