### PR TITLE
Add OSManager copy tree and copy file handlers

### DIFF
--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -379,7 +379,6 @@ class CopyTreeRequest(RequestPayload):
     Args:
         source_path: Path to the source directory to copy
         destination_path: Path where the directory tree should be copied
-        workspace_only: If True, constrain to workspace directory
         symlinks: If True, copy symbolic links as links (default: False)
         ignore_dangling_symlinks: If True, ignore dangling symlinks (default: False)
         dirs_exist_ok: If True, allow destination to exist (default: False)
@@ -390,7 +389,6 @@ class CopyTreeRequest(RequestPayload):
 
     source_path: str
     destination_path: str
-    workspace_only: bool | None = True
     symlinks: bool = False
     ignore_dangling_symlinks: bool = False
     dirs_exist_ok: bool = False
@@ -439,7 +437,6 @@ class CopyFileRequest(RequestPayload):
     Args:
         source_path: Path to the source file to copy
         destination_path: Path where the file should be copied
-        workspace_only: If True, constrain to workspace directory
         overwrite: If True, overwrite destination if it exists (default: False)
 
     Results: CopyFileResultSuccess | CopyFileResultFailure
@@ -447,7 +444,6 @@ class CopyFileRequest(RequestPayload):
 
     source_path: str
     destination_path: str
-    workspace_only: bool | None = True
     overwrite: bool = False
 
 

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1195,7 +1195,7 @@ class OSManager:
         """Handle a request to copy a single file."""
         # Resolve source path
         try:
-            source_path = self._resolve_file_path(request.source_path, workspace_only=request.workspace_only is True)
+            source_path = self._resolve_file_path(request.source_path, workspace_only=False)
             source_normalized = self._normalize_path_for_platform(source_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid source path: {e}"
@@ -1216,9 +1216,7 @@ class OSManager:
 
         # Resolve destination path
         try:
-            destination_path = self._resolve_file_path(
-                request.destination_path, workspace_only=request.workspace_only is True
-            )
+            destination_path = self._resolve_file_path(request.destination_path, workspace_only=False)
             dest_normalized = self._normalize_path_for_platform(destination_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid destination path: {e}"
@@ -1275,7 +1273,7 @@ class OSManager:
         )
 
     def _validate_copy_tree_paths(
-        self, source_str: str, dest_str: str, *, workspace_only: bool, dirs_exist_ok: bool
+        self, source_str: str, dest_str: str, *, dirs_exist_ok: bool
     ) -> CopyTreeValidationResult | CopyTreeResultFailure:
         """Validate and normalize source and destination paths for copy tree operation.
 
@@ -1284,7 +1282,7 @@ class OSManager:
         """
         # Resolve and normalize source path
         try:
-            source_path = self._resolve_file_path(source_str, workspace_only=workspace_only)
+            source_path = self._resolve_file_path(source_str, workspace_only=False)
             source_normalized = self._normalize_path_for_platform(source_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid source path: {e}"
@@ -1305,7 +1303,7 @@ class OSManager:
 
         # Resolve and normalize destination path
         try:
-            destination_path = self._resolve_file_path(dest_str, workspace_only=workspace_only)
+            destination_path = self._resolve_file_path(dest_str, workspace_only=False)
             dest_normalized = self._normalize_path_for_platform(destination_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid destination path: {e}"
@@ -1435,7 +1433,6 @@ class OSManager:
         validation_result = self._validate_copy_tree_paths(
             request.source_path,
             request.destination_path,
-            workspace_only=request.workspace_only is True,
             dirs_exist_ok=request.dirs_exist_ok,
         )
 


### PR DESCRIPTION
* Add OSManager copy tree and copy file handlers
  * The CopyTree and CopyFile requests make use of the engine's logic for handling platform specific scenarios (such as long file paths on Windows machines) 

Step toward resolving this: https://github.com/griptape-ai/griptape-nodes-library-deadline-cloud/issues/67

Tested on a remote Windows instance copying the Advanced Media Library to a long temporary path like:

```bash
C:\Users\Administrator\AppData\Local\Temp\2\dc_pipe_deadline_bundle_this-is-a-big-prefix_yv1yr520\assets\libraries\griptape_nodes_advanced_media_library\diffusers_nodes_library\pipelines\stable_diffusion_diffedit\stable_diffusion_diffedit_pipeline_memory_footprint.py
```