### PR TITLE
fix!: set output type of edge detection nodes to image url artifact

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
+++ b/libraries/griptape_nodes_advanced_media_library/controlnet_aux_nodes_library/anyline_detector.py
@@ -43,7 +43,7 @@ class AnylineDetector(ControlNode):
         self.add_parameter(
             Parameter(
                 name="output_image",
-                output_type="ImageArtifact",
+                output_type="ImageUrlArtifact",
                 tooltip="The output image",
                 allowed_modes={ParameterMode.OUTPUT},
             )

--- a/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
+++ b/libraries/griptape_nodes_advanced_media_library/opencv_nodes_library/canny_convert_image.py
@@ -72,7 +72,7 @@ class CannyConvertImage(ControlNode):
         self.add_parameter(
             Parameter(
                 name="output_image",
-                output_type="ImageArtifact",
+                output_type="ImageUrlArtifact",
                 tooltip="The output image",
                 allowed_modes={ParameterMode.OUTPUT},
             )


### PR DESCRIPTION
Nobody uses ImageArtifact anymore, should we update _everywhere_?