### PR TITLE
fix: check for vae_slicing in automatic mode

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/utils/pipeline_utils.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/utils/pipeline_utils.py
@@ -185,8 +185,8 @@ def _automatic_optimize_diffusion_pipeline(  # noqa: C901 PLR0912 PLR0915
             return
 
         logger.warning("Insufficient memory on %s for Pipeline.", device)
-        logger.info("Enabling vae slicing")
         if hasattr(pipe, "enable_vae_slicing"):
+            logger.info("Enabling vae slicing")
             pipe.enable_vae_slicing()
 
         # Final check after VAE slicing


### PR DESCRIPTION
We check for it everywhere else. Ran into this on my mac.