### PR TITLE
chore: bump v0.60.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.60.0"
+version = "0.60.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.60.0"
+version = "0.60.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.60`.

Cherry-picked commit: c653570cd6f3b17d581241c7ad3e9dfd9e14b6de