### PR TITLE
fix: update libraries logger name so logs propagate to UI

### DIFF
--- a/libraries/griptape_cloud/griptape_cloud/assets/create_asset_url.py
+++ b/libraries/griptape_cloud/griptape_cloud/assets/create_asset_url.py
@@ -11,7 +11,7 @@ from griptape_nodes.traits.options import Options
 if TYPE_CHECKING:
     from griptape_cloud_client.models.bucket_detail import BucketDetail
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/assets/upload_asset.py
+++ b/libraries/griptape_cloud/griptape_cloud/assets/upload_asset.py
@@ -12,7 +12,7 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 if TYPE_CHECKING:
     from griptape_cloud_client.models.bucket_detail import BucketDetail
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/assistants/assistant_options.py
+++ b/libraries/griptape_cloud/griptape_cloud/assistants/assistant_options.py
@@ -8,7 +8,7 @@ from griptape_cloud_client.models.assistant_detail import AssistantDetail
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/assistants/get_assistant.py
+++ b/libraries/griptape_cloud/griptape_cloud/assistants/get_assistant.py
@@ -6,7 +6,7 @@ from griptape_cloud.base.base_griptape_cloud_node import BaseGriptapeCloudNode
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/assistants/run_assistant.py
+++ b/libraries/griptape_cloud/griptape_cloud/assistants/run_assistant.py
@@ -10,7 +10,7 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 if TYPE_CHECKING:
     from griptape_cloud_client.models.assistant_detail import AssistantDetail
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/base/base_griptape_cloud_node.py
+++ b/libraries/griptape_cloud/griptape_cloud/base/base_griptape_cloud_node.py
@@ -13,7 +13,7 @@ API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/buckets/bucket_options.py
+++ b/libraries/griptape_cloud/griptape_cloud/buckets/bucket_options.py
@@ -8,7 +8,7 @@ from griptape_cloud_client.models.bucket_detail import BucketDetail
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/buckets/get_bucket.py
+++ b/libraries/griptape_cloud/griptape_cloud/buckets/get_bucket.py
@@ -6,7 +6,7 @@ from griptape_cloud.buckets.bucket_options import BucketOptions
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/griptape_cloud_library_advanced.py
+++ b/libraries/griptape_cloud/griptape_cloud/griptape_cloud_library_advanced.py
@@ -7,7 +7,7 @@ from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowR
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 def _publish_workflow_request_handler(request: RequestPayload) -> ResultPayload:

--- a/libraries/griptape_cloud/griptape_cloud/mixins/griptape_cloud_api_mixin.py
+++ b/libraries/griptape_cloud/griptape_cloud/mixins/griptape_cloud_api_mixin.py
@@ -73,7 +73,7 @@ from griptape_cloud_client.types import UNSET
 if TYPE_CHECKING:
     from griptape_cloud_client.client import AuthenticatedClient
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 class GriptapeCloudApiMixin:

--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_published_workflow.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_published_workflow.py
@@ -12,7 +12,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, Param
 from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode
 from griptape_nodes.exe_types.param_components.execution_status_component import ExecutionStatusComponent
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_workflow_builder.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_workflow_builder.py
@@ -18,7 +18,7 @@ from typing import Any
 from griptape_cloud.publish_workflow.griptape_cloud_published_workflow import GriptapeCloudPublishedWorkflow
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 @dataclass

--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/register_libraries_script.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/register_libraries_script.py
@@ -9,7 +9,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 logging.basicConfig(
     level=logging.INFO,
 )
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 PATHS = ["REPLACE_LIBRARY_PATHS"]
 

--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/structure.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/structure.py
@@ -13,7 +13,7 @@ PICKLE_DEFAULT = "REPLACE_PICKLE_DEFAULT"
 logging.basicConfig(
     level=logging.INFO,
 )
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 load_dotenv()

--- a/libraries/griptape_cloud/griptape_cloud/structures/get_structure.py
+++ b/libraries/griptape_cloud/griptape_cloud/structures/get_structure.py
@@ -6,7 +6,7 @@ from griptape_cloud.structures.structure_options import StructureOptions
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/structures/run_structure.py
+++ b/libraries/griptape_cloud/griptape_cloud/structures/run_structure.py
@@ -10,7 +10,7 @@ from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 if TYPE_CHECKING:
     from griptape_cloud_client.models.structure_detail import StructureDetail
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_cloud/griptape_cloud/structures/structure_options.py
+++ b/libraries/griptape_cloud/griptape_cloud/structures/structure_options.py
@@ -8,7 +8,7 @@ from griptape_cloud_client.models.structure_detail import StructureDetail
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 logger.setLevel(logging.INFO)
 
 

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/peft/training/utils/dreambooth_dataset.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/peft/training/utils/dreambooth_dataset.py
@@ -11,7 +11,7 @@ from torch.utils.data import Dataset  # type: ignore[reportMissingImports]
 from torchvision import transforms  # type: ignore[reportMissingImports]
 from torchvision.transforms.functional import crop  # type: ignore[reportMissingImports]
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 def collate_fn(examples: list[dict[str, Any]], *, with_prior_preservation: bool = False) -> dict[str, Any]:

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/peft/training/utils/optimizer.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/pipelines/flux/peft/training/utils/optimizer.py
@@ -6,7 +6,7 @@ from accelerate import Accelerator  # type: ignore[reportMissingImports]
 from accelerate.utils.deepspeed import DummyOptim  # type: ignore[reportMissingImports]
 from torch.optim import Optimizer  # type: ignore[reportMissingImports]
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 def create_optimizer(accelerator: Accelerator, args: argparse.Namespace, params_to_optimize: list[dict]) -> Optimizer:

--- a/libraries/griptape_nodes_advanced_media_library/utils/directory_utils.py
+++ b/libraries/griptape_nodes_advanced_media_library/utils/directory_utils.py
@@ -4,7 +4,7 @@ import logging
 
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 def check_cleanup_intermediates_directory() -> None:

--- a/libraries/griptape_nodes_library/griptape_nodes_library/audio/eleven_music_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/audio/eleven_music_generation.py
@@ -16,7 +16,7 @@ from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["ElevenMusicGeneration"]
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/engine/engine_node.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/engine/engine_node.py
@@ -27,7 +27,7 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 class ParamType(Enum):

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/flux_image_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/flux_image_generation.py
@@ -18,7 +18,7 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["FluxImageGeneration"]
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
@@ -17,7 +17,7 @@ from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["SeedreamImageGeneration"]
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/tools/vector_store_tool.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/tools/vector_store_tool.py
@@ -7,7 +7,7 @@ from griptape.tools import VectorStoreTool as GtVectorStoreTool
 
 from griptape_nodes_library.tools.base_tool import BaseTool
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 
 class VectorStore(BaseTool):

--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/image_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/image_utils.py
@@ -18,7 +18,7 @@ from requests.exceptions import RequestException
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes_library.utils.color_utils import NAMED_COLORS
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 # Constants for placeholder images
 DEFAULT_PLACEHOLDER_WIDTH = 400

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/seedance_video_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/seedance_video_generation.py
@@ -19,7 +19,7 @@ from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["SeedanceVideoGeneration"]
 

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/sora_video_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/sora_video_generation.py
@@ -20,7 +20,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes_library.utils.image_utils import dict_to_image_url_artifact, load_pil_from_url
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["SoraVideoGeneration"]
 


### PR DESCRIPTION
Only the `griptape_nodes` logger logs propagate to the UI. 

Closes https://github.com/griptape-ai/griptape-nodes/issues/2689