### PR TITLE
Increase Seedream image generation API timeout

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
@@ -400,7 +400,7 @@ class SeedreamImageGeneration(SuccessFailureNode):
         self._log_request(payload)
 
         try:
-            response = requests.post(proxy_url, json=payload, headers=headers, timeout=60)
+            response = requests.post(proxy_url, json=payload, headers=headers, timeout=120)
             response.raise_for_status()
             response_json = response.json()
             self._log("Request submitted successfully")


### PR DESCRIPTION
p90+ image generation latencies will exceed the existing timeout and running into one of these really sucks for the user. double the timeout because waiting another 10-20 seconds is much better than having to restart the generation.