### PR TITLE
fix: properly handle long paths during libraries sync

### DIFF
--- a/src/griptape_nodes/cli/commands/libraries.py
+++ b/src/griptape_nodes/cli/commands/libraries.py
@@ -108,7 +108,7 @@ def _remove_readonly(func, path, excinfo) -> None:  # noqa: ANN001, ARG001
     long_path = GriptapeNodes.OSManager().normalize_path_for_platform(Path(path))
 
     try:
-        Path.chmod(Path(long_path), stat.S_IWRITE)
+        Path(long_path).chmod(stat.S_IWRITE)
         func(long_path)
     except Exception as e:
         console.print(f"[red]Error removing read-only file: {path}[/red]")

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -223,7 +223,7 @@ class OSManager:
         Returns:
             String representation of path, with Windows long path prefix if needed
         """
-        path_str = str(Path.resolve(path))
+        path_str = str(path.resolve())
 
         # Windows long path handling (paths > WINDOWS_MAX_PATH chars need \\?\ prefix)
         if self.is_windows() and len(path_str) > WINDOWS_MAX_PATH and not path_str.startswith("\\\\?\\"):


### PR DESCRIPTION
[Last minute refactors](https://github.com/griptape-ai/griptape-nodes/pull/2850#discussion_r2461535697) broke the original PR functionality. Verified this time.