### PR TITLE
fix: properly handle requests that cross sync to async boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "semver>=3.0.4",
   "aiofiles>=25.1.0",
   "ruamel.yaml>=0.18.15",
+  "asyncio-thread-runner>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from dataclasses import fields
 from typing import TYPE_CHECKING, Any, cast
 
+from asyncio_thread_runner import ThreadRunner
 from typing_extensions import TypedDict, TypeVar
 
 from griptape_nodes.retained_mode.events.base_events import (
@@ -276,8 +277,8 @@ class EventManager:
         if inspect.iscoroutinefunction(callback):
             try:
                 asyncio.get_running_loop()
-                msg = "Async handler cannot be called with sync handle_request. Use ahandle_request instead."
-                raise ValueError(msg)
+                with ThreadRunner() as runner:
+                    result_payload: ResultPayload = runner.run(callback(request))
             except RuntimeError:
                 # No event loop running, safe to use asyncio.run
                 result_payload: ResultPayload = asyncio.run(callback(request))

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncio-thread-runner"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/fd/1b5b3452f9e7df89b0c9bd246d276e0ae3a6b6bd7304076e09f2df1bf9fb/asyncio_thread_runner-1.0.tar.gz", hash = "sha256:9b3f6c30d3ee8ae5cca1a243b6bb872404bdbcd88ec39fbbffa7984b96493182", size = 7630, upload-time = "2025-08-19T17:37:24.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/87/1fead469bb900643e2962aaf49b2b69f0e3222b652fd78d3a8df6fbb0e17/asyncio_thread_runner-1.0-py3-none-any.whl", hash = "sha256:d7cc3f8b2f8446ac9450132ae8372a4810734ea8399e20d4233cc43920d8c812", size = 5067, upload-time = "2025-08-19T17:37:23.037Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -326,6 +335,7 @@ version = "0.60.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "asyncio-thread-runner" },
     { name = "binaryornot" },
     { name = "fastapi" },
     { name = "griptape" },
@@ -385,6 +395,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "asyncio-thread-runner", specifier = ">=1.0" },
     { name = "austin-dist", marker = "extra == 'profiling'", specifier = ">=3.7.0" },
     { name = "binaryornot", specifier = ">=0.4.4" },
     { name = "fastapi", specifier = ">=0.115.12" },


### PR DESCRIPTION
https://death.andgravity.com/asyncio-bridge

>So, you're doing some sync stuff.
But you also need to do [some async stuff](https://death.andgravity.com/limit-concurrency), without making everything async.
Maybe the sync stuff is an existing application.
Maybe you still want to use [your favorite sync library](https://death.andgravity.com/output).
Or maybe you need just [a little async](https://twitter.com/_andgravity/status/1678431313332785152), without having to pay the full price.
Of course, you can run a coroutine with [asyncio.run()](https://docs.python.org/3/library/asyncio-runner.html#asyncio.run), and blocking sync code from a coroutine with [asyncio.to_thread()](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread), but the former isn't granular enough, and the latter doesn't solve async code being at the top.
As always, there must be a better way.


Massive shoutout to @lemon24 for making such an awesome package.