### PR TITLE
fix: surface errors that occur during app event broadcast

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -318,10 +318,6 @@ class EventManager:
         if app_event_type in self._app_event_listeners:
             listener_set = self._app_event_listeners[app_event_type]
 
-            await asyncio.gather(
-                *[
-                    asyncio.create_task(call_function(listener_callback, app_event))
-                    for listener_callback in listener_set
-                ],
-                return_exceptions=True,
-            )
+            async with asyncio.TaskGroup() as tg:
+                for listener_callback in listener_set:
+                    tg.create_task(call_function(listener_callback, app_event))


### PR DESCRIPTION
[TaskGroup](https://docs.python.org/3/library/asyncio-task.html#asyncio.TaskGroup)s are the more modern way of running tasks concurrently. They also handle exceptions more naturally.


Explosion not included.
```
                    ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)

                    ╭─────────────────────────────────────────── Sub-exception #1 ───────────────────────────────────────────╮
                    │ ╭──────────────────────────────── Traceback (most recent call last) ─────────────────────────────────╮ │
                    │ │ /Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/utils/async_utils.py:30 in │ │
                    │ │ call_function                                                                                      │ │
                    │ │                                                                                                    │ │
                    │ │    27 │   │   The result of the function call                                                      │ │
                    │ │    28 │   """                                                                                      │ │
                    │ │    29 │   if inspect.iscoroutinefunction(func):                                                    │ │
                    │ │ ❱  30 │   │   return await func(*args, **kwargs)                                                   │ │
                    │ │    31 │   return func(*args, **kwargs)                                                             │ │
                    │ │    32                                                                                              │ │
                    │ │    33                                                                                              │ │
                    │ │                                                                                                    │ │
                    │ │ /Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/retained_mode/managers/lib │ │
                    │ │ rary_manager.py:1562 in on_app_initialization_complete                                             │ │
                    │ │                                                                                                    │ │
                    │ │   1559 │   async def on_app_initialization_complete(self, _payload: AppInitializationComplete)     │ │
                    │ │        -> None:                                                                                    │ │
                    │ │   1560 │   │   # App just got init'd. See if there are library JSONs to load!                      │ │
                    │ │   1561 │   │   await self.load_all_libraries_from_config()                                         │ │
                    │ │ ❱ 1562 │   │   raise ValueError("I EXPLODED")                                                      │ │
                    │ │   1563 │   │                                                                                       │ │
                    │ │   1564 │   │   # Register all secrets now that libraries are loaded and settings are merged        │ │
                    │ │   1565 │   │   GriptapeNodes.SecretsManager().register_all_secrets()                               │ │
                    │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
                    │ ValueError: I EXPLODED                                                                                 │
                    ╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```