### PR TITLE
fix: ignore `.venv` in `workflow_manager.py`

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4099,7 +4099,7 @@ class WorkflowManager:
                 ),
             )
 
-    def _process_workflows_for_registration(self, workflows_to_register: list[str]) -> WorkflowRegistrationResult:
+    def _process_workflows_for_registration(self, workflows_to_register: list[str]) -> WorkflowRegistrationResult:  # noqa: C901
         """Process a list of workflow paths for registration.
 
         Returns:


### PR DESCRIPTION
`workflow_manager` was scanning `.venv` as part of it's process - this forces it to ignore it.

fixes: #2972 