### PR TITLE
update: adds `max_subtasks` to `mcp_task`

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/tasks/mcp_task.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/tasks/mcp_task.py
@@ -250,7 +250,7 @@ class MCPTaskNode(SuccessFailureNode):
             return None, None, [], []
         return agent, driver, tools, rulesets
 
-    def _add_task_to_agent(
+    def _add_task_to_agent(  # noqa: PLR0913
         self, agent: Agent, tool: MCPTool, driver: Any, tools: list, rulesets: list, max_subtasks: int
     ) -> bool:
         """Add task to agent."""


### PR DESCRIPTION
fixes: #2980 
Property `max_subtasks` is now added to the `mcp_task` node.

By default it's a hidden property, so the user needs to display it in the Property Panel.

Default is 20.