### PR TITLE
Update: `JsonExtractValue` extracts values correctly

### DIFF
--- a/docs/nodes/json/json_extract_value.md
+++ b/docs/nodes/json/json_extract_value.md
@@ -27,10 +27,9 @@ The JSON Extract Value node allows you to extract specific values from JSON data
 - **Dot Notation Paths**: Use simple dot notation to navigate JSON structure
 - **Array Indexing**: Access array elements using `[index]` syntax
 - **Wildcard Operations**: Extract all values from arrays using `[*]` syntax
-- **Automatic Quote Stripping**: Automatically removes outer quotes from simple string values for clean output (objects/arrays are unaffected)
+- **Native Python Types**: Returns raw Python values (strings, dicts, lists, etc.) - no JSON serialization needed
 - **Real-time Updates**: Automatically updates when input changes
-- **Safe Extraction**: Returns empty object `{}` if path doesn't exist
-- **JSON Output**: Returns properly formatted JSON strings
+- **Safe Extraction**: Returns empty dict `{}` if path doesn't exist
 
 ## JMESPath Syntax
 
@@ -77,7 +76,7 @@ path = "projects[*].tasks[*].assignee"  # Gets all assignees from all project ta
 ```python
 # Input JSON: {"user": {"name": "John", "age": 30}}
 # Path: "user.name"
-# Output: "John"  # Quotes automatically stripped from simple string values
+# Output: "John"  # Returns raw Python string value
 ```
 
 ### Array Element Extraction
@@ -85,7 +84,7 @@ path = "projects[*].tasks[*].assignee"  # Gets all assignees from all project ta
 ```python
 # Input JSON: {"items": [{"title": "Book", "price": 25}, {"title": "Magazine", "price": 10}]}
 # Path: "items[0].title"
-# Output: "Book"  # Quotes automatically stripped from simple string values
+# Output: "Book"  # Returns raw Python string value
 ```
 
 ### Nested Array Access
@@ -93,7 +92,7 @@ path = "projects[*].tasks[*].assignee"  # Gets all assignees from all project ta
 ```python
 # Input JSON: {"orders": [{"items": [{"name": "Product A"}, {"name": "Product B"}]}]}
 # Path: "orders[0].items[1].name"
-# Output: "Product B"  # Quotes automatically stripped from simple string values
+# Output: "Product B"  # Returns raw Python string value
 ```
 
 ### Non-existent Path
@@ -101,29 +100,36 @@ path = "projects[*].tasks[*].assignee"  # Gets all assignees from all project ta
 ```python
 # Input JSON: {"user": {"name": "John"}}
 # Path: "user.email"
-# Output: "{}"  # Empty object for non-existent paths
+# Output: {}  # Empty dict (Python dict object) for non-existent paths
 ```
 
-### Automatic Quote Stripping
+### Different Return Types
 
-The node automatically removes outer quotes from simple string values, making the output cleaner for use in other nodes:
+The node returns raw Python values directly from JMESPath, matching the extracted data type:
 
 ```python
+# String extraction
 # Input JSON: {"product": {"name": "Widget", "category": "Electronics"}}
 # Path: "product.name"
-# Output: "Widget"  # Quotes automatically stripped from simple string values
+# Output: "Widget"  # Python string
 
+# Object extraction
+# Input JSON: {"user": {"name": "John", "age": 30}}
+# Path: "user"
+# Output: {"name": "John", "age": 30}  # Python dict
+
+# Array extraction
 # Input JSON: {"items": [{"title": "Book"}, {"title": "Magazine"}]}
 # Path: "items"
-# Output: "[{\"title\":\"Book\"},{\"title\":\"Magazine\"}]"  # Objects/arrays are unchanged
+# Output: [{"title": "Book"}, {"title": "Magazine"}]  # Python list
 ```
 
 **Important Notes:**
 
-- Quote stripping automatically applies to simple string values (values that start and end with quotes)
-- Complex objects and arrays are never affected - they remain as valid JSON
-- This makes the output cleaner for text processing or concatenation with other nodes
-- The output is always valid JSON, with quotes only stripped from simple string values
+- The node returns native Python types (str, dict, list, int, bool, etc.) - no JSON serialization
+- This makes the output directly usable by other nodes without parsing
+- Consistent with other JSON nodes in the library (JsonInput, JsonReplace, etc.)
+- JMESPath handles all type conversions automatically
 
 ## Use Cases
 


### PR DESCRIPTION
`JsonExtractValue` node now extracts values correctly, ensuring we don't get extra quotes around values.

fixes: #2987

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--2990.org.readthedocs.build/en/2990/

<!-- readthedocs-preview griptape-nodes end -->