### PR TITLE
fix: don't put cache buster in file name

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/utils/file_utils.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/utils/file_utils.py
@@ -1,7 +1,5 @@
 """File utility functions for generating filenames and managing file operations."""
 
-from datetime import UTC, datetime
-
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
@@ -44,11 +42,8 @@ def generate_filename(
     workflow_name = "".join(c for c in workflow_name if c.isalnum() or c in ("-", "_")).rstrip()
     node_name = "".join(c for c in node_name if c.isalnum() or c in ("-", "_")).rstrip()
 
-    # Get current timestamp for cache busting
-    timestamp = int(datetime.now(UTC).timestamp())
-
-    # Create filename with meaningful structure and timestamp as query parameter
-    filename = f"{workflow_name}_{node_name}{suffix}.{extension}?t={timestamp}"
+    # Create filename with meaningful structure
+    filename = f"{workflow_name}_{node_name}{suffix}.{extension}"
 
     return filename
 

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -46,7 +46,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             response = httpx.post(url, json={"operation": "PUT"}, headers=self.headers)
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
-            msg = f"Failed to create presigned URL for file {path}: {e}"
+            msg = f"Failed to create presigned upload URL for file {path}: {e}"
             logger.error(msg)
             raise RuntimeError(msg) from e
 
@@ -60,7 +60,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             response = httpx.post(url, json={"method": "GET"}, headers=self.headers)
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
-            msg = f"Failed to create presigned URL for file {path}: {e}"
+            msg = f"Failed to create presigned download URL for file {path}: {e}"
             logger.error(msg)
             raise RuntimeError(msg) from e
 

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -43,14 +43,14 @@ class LocalStorageDriver(BaseStorageDriver):
             response = httpx.post(static_url, json={"file_path": str(path)})
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
-            msg = f"Failed to create presigned URL for file {path}: {e}"
+            msg = f"Failed to create upload URL for file {path}: {e}"
             logger.error(msg)
             raise RuntimeError(msg) from e
 
         response_data = response.json()
         url = response_data.get("url")
         if url is None:
-            msg = f"Failed to create presigned URL for file {path}: {response_data}"
+            msg = f"Failed to get upload URL for file {path}: {response_data}"
             logger.error(msg)
             raise ValueError(msg)
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -104,14 +104,12 @@ class StaticFilesManager:
             content_bytes = base64.b64decode(request.content)
         except (binascii.Error, ValueError) as e:
             msg = f"Failed to decode base64 content for file {file_name}: {e}"
-            logger.error(msg)
             return CreateStaticFileResultFailure(error=msg, result_details=msg)
 
         try:
             url = self.save_static_file(content_bytes, file_name)
         except Exception as e:
             msg = f"Failed to create static file for file {file_name}: {e}"
-            logger.error(msg)
             return CreateStaticFileResultFailure(error=msg, result_details=msg)
 
         return CreateStaticFileResultSuccess(url=url, result_details=f"Successfully created static file: {url}")
@@ -137,7 +135,6 @@ class StaticFilesManager:
             response = self.storage_driver.create_signed_upload_url(full_file_path)
         except Exception as e:
             msg = f"Failed to create presigned URL for file {file_name}: {e}"
-            logger.error(msg)
             return CreateStaticFileUploadUrlResultFailure(error=msg, result_details=msg)
 
         return CreateStaticFileUploadUrlResultSuccess(
@@ -168,7 +165,6 @@ class StaticFilesManager:
             url = self.storage_driver.create_signed_download_url(full_file_path)
         except Exception as e:
             msg = f"Failed to create presigned URL for file {file_name}: {e}"
-            logger.error(msg)
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
         return CreateStaticFileDownloadUrlResultSuccess(
@@ -177,7 +173,7 @@ class StaticFilesManager:
 
     def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         # Start static server in daemon thread if enabled
-        if self.storage_backend == StorageBackend.LOCAL:
+        if isinstance(self.storage_driver, LocalStorageDriver):
             threading.Thread(target=start_static_server, daemon=True, name="static-server").start()
 
     def save_static_file(self, data: bytes, file_name: str) -> str:


### PR DESCRIPTION
This is the role of the storage driver:
https://github.com/griptape-ai/griptape-nodes/blob/de42f2fb7da4e78ce13cfa9bbfba59b017896f22/src/griptape_nodes/drivers/storage/local_storage_driver.py?plain=1#L63

Closes #3025