### PR TITLE
fix: filter out empty library paths from configuration

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1993,24 +1993,6 @@ class LibraryManager:
                     ret_val.append(file_path)
         return ret_val
 
-    def _load_libraries_from_config_category(self, config_category: str, *, load_as_default_library: bool) -> None:
-        config_mgr = GriptapeNodes.ConfigManager()
-        libraries_to_register_category: list[str] = config_mgr.get_config_value(config_category)
-
-        if libraries_to_register_category is not None:
-            for library_to_register in libraries_to_register_category:
-                if library_to_register:
-                    if library_to_register.endswith(".json"):
-                        library_load_request = RegisterLibraryFromFileRequest(
-                            file_path=library_to_register,
-                            load_as_default_library=load_as_default_library,
-                        )
-                    else:
-                        library_load_request = RegisterLibraryFromRequirementSpecifierRequest(
-                            requirement_specifier=library_to_register
-                        )
-                    GriptapeNodes.handle_request(library_load_request)
-
     def _remove_missing_libraries_from_config(self, config_category: str) -> None:
         # Now remove all libraries that were missing from the user's config.
         config_mgr = GriptapeNodes.ConfigManager()


### PR DESCRIPTION
Empty strings in libraries_to_register configuration were causing the engine to search the user's home directory, resulting in duplicate library errors. Now filters and warns about empty entries.

Fixes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)