### PR TITLE
fix: centralize Windows PyTorch DLL pre-loading via advanced library

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/__init__.py
+++ b/libraries/griptape_nodes_advanced_media_library/__init__.py
@@ -1,0 +1,1 @@
+"""Griptape Nodes Advanced Media Library."""

--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_advanced_media_library_advanced.py
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_advanced_media_library_advanced.py
@@ -1,0 +1,45 @@
+import logging
+
+from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+from griptape_nodes.node_library.library_registry import Library, LibrarySchema
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("griptape_nodes")
+
+
+class AdvancedMediaLibrary(AdvancedNodeLibrary):
+    """Advanced library implementation for the Griptape Nodes Advanced Media Library.
+
+    Handles Windows-specific PyTorch DLL pre-loading before any nodes are loaded.
+    """
+
+    def before_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:  # noqa: ARG002
+        """Called before any nodes are loaded from the library.
+
+        On Windows, pre-loads PyTorch DLLs to avoid initialization errors.
+        See: https://github.com/pytorch/pytorch/issues/166628#issuecomment-3479375122
+        """
+        msg = f"Starting to load nodes for '{library_data.name}' library..."
+        logger.info(msg)
+
+        # Windows-specific fix: Pre-load PyTorch DLLs to avoid initialization errors
+        import contextlib
+        import platform
+        from pathlib import Path
+
+        if platform.system() == "Windows":
+            import ctypes
+            import site
+
+            for site_path in site.getsitepackages():
+                torch_lib_path = Path(site_path) / "torch" / "lib"
+                if torch_lib_path.exists():
+                    for dll in ["c10.dll", "torch_cpu.dll", "torch_python.dll"]:
+                        dll_path = torch_lib_path / dll
+                        if dll_path.exists():
+                            with contextlib.suppress(Exception):
+                                ctypes.CDLL(str(dll_path))
+                    break
+
+    def after_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:
+        """Called after all nodes have been loaded from the library."""

--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -1,6 +1,7 @@
 {
   "name": "Griptape Nodes Advanced Media Library",
   "library_schema_version": "0.3.0",
+  "advanced_library_path": "griptape_nodes_advanced_media_library_advanced.py",
   "settings": [
     {
       "description": "Configuration settings for the Advanced Media Library temporary file storage",


### PR DESCRIPTION
Centralizes the Windows DLL initialization workaround into a single advanced library module instead of duplicating across multiple node files.

Changes:
- Create AdvancedMediaLibrary class with before_library_nodes_loaded hook
- Pre-load PyTorch DLLs (c10.dll, torch_cpu.dll, torch_python.dll) on Windows
- Add advanced_library_path to library JSON configuration
- Remove duplicated Windows DLL pre-loading code from node files:
  - OpenPose (image and video detection)
  - DINO SAM2 (image and video detection)
- Add __init__.py to satisfy linter requirements

This addresses Windows DLL initialization errors:
"[WinError 1114] A dynamic link library (DLL) initialization routine failed"

See:
https://github.com/pytorch/pytorch/issues/166628#issuecomment-3479375122

🤖 Generated with [Claude Code](https://claude.com/claude-code)