### PR TITLE
feat: add granular initialization progress events

### DIFF
--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal
+from enum import StrEnum
 
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
@@ -10,6 +10,21 @@ from griptape_nodes.retained_mode.events.base_events import (
     WorkflowNotAlteredMixin,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+class InitializationPhase(StrEnum):
+    """Initialization phase types for engine startup."""
+
+    LIBRARIES = "libraries"
+    WORKFLOWS = "workflows"
+
+
+class InitializationStatus(StrEnum):
+    """Status types for initialization progress."""
+
+    LOADING = "loading"
+    COMPLETE = "complete"
+    FAILED = "failed"
 
 
 @dataclass
@@ -111,17 +126,17 @@ class EngineInitializationProgress(AppPayload):
     """Real-time progress updates during engine initialization (libraries and workflows loading).
 
     Args:
-        phase: Current initialization phase ('libraries' or 'workflows')
+        phase: Current initialization phase (libraries or workflows)
         item_name: Name of the library or workflow being loaded
-        status: Current status of the item ('loading', 'complete', or 'failed')
+        status: Current status of the item (loading, complete, or failed)
         current: Number of items completed so far
         total: Total number of items to load
-        error: Error message if status is 'failed', None otherwise
+        error: Error message if status is failed, None otherwise
     """
 
-    phase: Literal["libraries", "workflows"]
+    phase: InitializationPhase
     item_name: str
-    status: Literal["loading", "complete", "failed"]
+    status: InitializationStatus
     current: int
     total: int
     error: str | None = None

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -39,6 +39,8 @@ from griptape_nodes.retained_mode.events.app_events import (
     EngineInitializationProgress,
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
+    InitializationPhase,
+    InitializationStatus,
 )
 
 # Runtime imports for ResultDetails since it's used at runtime
@@ -1541,9 +1543,9 @@ class LibraryManager:
                 GriptapeNodes.EventManager().put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
-                            phase="libraries",
+                            phase=InitializationPhase.LIBRARIES,
                             item_name=library_name,
-                            status="loading",
+                            status=InitializationStatus.LOADING,
                             current=current_library_index,
                             total=total_libraries,
                         )
@@ -1560,9 +1562,9 @@ class LibraryManager:
                     GriptapeNodes.EventManager().put_event(
                         AppEvent(
                             payload=EngineInitializationProgress(
-                                phase="libraries",
+                                phase=InitializationPhase.LIBRARIES,
                                 item_name=library_name,
-                                status="complete",
+                                status=InitializationStatus.COMPLETE,
                                 current=current_library_index,
                                 total=total_libraries,
                             )
@@ -1587,9 +1589,9 @@ class LibraryManager:
                         GriptapeNodes.EventManager().put_event(
                             AppEvent(
                                 payload=EngineInitializationProgress(
-                                    phase="libraries",
+                                    phase=InitializationPhase.LIBRARIES,
                                     item_name=library_name,
-                                    status="failed",
+                                    status=InitializationStatus.FAILED,
                                     current=current_library_index,
                                     total=total_libraries,
                                     error=error_message,
@@ -1601,9 +1603,9 @@ class LibraryManager:
                         GriptapeNodes.EventManager().put_event(
                             AppEvent(
                                 payload=EngineInitializationProgress(
-                                    phase="libraries",
+                                    phase=InitializationPhase.LIBRARIES,
                                     item_name=library_name,
-                                    status="complete",
+                                    status=InitializationStatus.COMPLETE,
                                     current=current_library_index,
                                     total=total_libraries,
                                 )

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -35,6 +35,8 @@ from griptape_nodes.retained_mode.events.app_events import (
     EngineInitializationProgress,
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
+    InitializationPhase,
+    InitializationStatus,
 )
 
 # Runtime imports for ResultDetails since it's used at runtime
@@ -4150,9 +4152,9 @@ class WorkflowManager:
             GriptapeNodes.EventManager().put_event(
                 AppEvent(
                     payload=EngineInitializationProgress(
-                        phase="workflows",
+                        phase=InitializationPhase.WORKFLOWS,
                         item_name=workflow_name,
-                        status="loading",
+                        status=InitializationStatus.LOADING,
                         current=current_index,
                         total=total_workflows,
                     )
@@ -4167,9 +4169,9 @@ class WorkflowManager:
                 GriptapeNodes.EventManager().put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
-                            phase="workflows",
+                            phase=InitializationPhase.WORKFLOWS,
                             item_name=workflow_name,
-                            status="complete",
+                            status=InitializationStatus.COMPLETE,
                             current=current_index,
                             total=total_workflows,
                         )
@@ -4181,9 +4183,9 @@ class WorkflowManager:
                 GriptapeNodes.EventManager().put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
-                            phase="workflows",
+                            phase=InitializationPhase.WORKFLOWS,
                             item_name=workflow_name,
-                            status="failed",
+                            status=InitializationStatus.FAILED,
                             current=current_index,
                             total=total_workflows,
                             error="Failed to process workflow file",


### PR DESCRIPTION
Add EngineInitializationProgress events that provide real-time status updates during library and workflow loading. This enables the UI to display detailed initialization progress instead of showing a generic loading screen.

Changes:
- Add EngineInitializationProgress event type with phase, item name, status, and progress tracking
- Emit progress events during library loading (loading/complete/failed per library)
- Emit progress events during workflow loading (loading/complete/failed per workflow)
- Display progress as "X of Y" for both libraries and workflows

<img width="1493" height="850" alt="image" src="https://github.com/user-attachments/assets/efe10ef4-42dc-4054-9b41-73ce25581fe6" />

Closes https://github.com/griptape-ai/griptape-nodes/issues/2909
