### PR TITLE
Enable publishing libraries to register their start and end node types

### DIFF
--- a/libraries/griptape_cloud/griptape_cloud/griptape_cloud_library_advanced.py
+++ b/libraries/griptape_cloud/griptape_cloud/griptape_cloud_library_advanced.py
@@ -3,7 +3,10 @@ import logging
 from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
 from griptape_nodes.node_library.library_registry import Library, LibrarySchema
 from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
-from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
+from griptape_nodes.retained_mode.events.workflow_events import (
+    PublishWorkflowRegisteredEventData,
+    PublishWorkflowRequest,
+)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logging.basicConfig(level=logging.INFO)
@@ -38,4 +41,10 @@ class GriptapeCloudLibraryAdvanced(AdvancedNodeLibrary):
             request_type=PublishWorkflowRequest,
             handler=_publish_workflow_request_handler,
             library_data=library_data,
+            event_data=PublishWorkflowRegisteredEventData(
+                start_flow_node_type="GriptapeCloudStartFlow",
+                start_flow_node_library_name=library_data.name,
+                end_flow_node_type="GriptapeCloudEndFlow",
+                end_flow_node_library_name=library_data.name,
+            ),
         )

--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_publisher.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_publisher.py
@@ -448,6 +448,7 @@ class GriptapeCloudPublisher(GriptapeCloudApiMixin):
 
         asset_name = f"{structure_id}/{file_name}"
         self._upload_file_to_data_lake(name=asset_name, value=file_contents, bucket_id=self._gt_cloud_bucket_id)
+        Path(package_path).unlink(missing_ok=True)
 
         update_structure_request_content = UpdateStructureRequestContent(
             structure_config_file="structure_config.yaml",

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import logging
 import pickle
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -30,6 +31,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     DeleteWorkflowResultFailure,
     LoadWorkflowMetadata,
     LoadWorkflowMetadataResultSuccess,
+    PublishWorkflowRegisteredEventData,
     PublishWorkflowRequest,
     SaveWorkflowFileFromSerializedFlowRequest,
     SaveWorkflowFileFromSerializedFlowResultSuccess,
@@ -42,6 +44,14 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 logger = logging.getLogger("griptape_nodes")
+
+
+@dataclass
+class PublishWorkflowStartEndNodes:
+    start_flow_node_type: str
+    start_flow_node_library_name: str
+    end_flow_node_type: str
+    end_flow_node_library_name: str
 
 
 class PublishLocalWorkflowResult(NamedTuple):
@@ -221,6 +231,40 @@ class NodeExecutor:
                 published_filename = published_workflow_filename.stem
                 await self._delete_workflow(workflow_name=published_filename, workflow_path=published_workflow_filename)
 
+    async def _get_workflow_start_end_nodes(self, library: Library | None) -> PublishWorkflowStartEndNodes:
+        library_name = "Griptape Nodes Library"
+        start_node_type = "StartFlow"
+        end_node_type = "EndFlow"
+
+        if library is not None:
+            # Attempt to get start and end nodes from the registered handler
+            library_name = library.get_library_data().name
+            registered_event_handler = self.get_workflow_handler(library_name)
+            registered_event_data = registered_event_handler.event_data
+            if registered_event_data is not None and isinstance(
+                registered_event_data, PublishWorkflowRegisteredEventData
+            ):
+                return PublishWorkflowStartEndNodes(
+                    start_flow_node_type=registered_event_data.start_flow_node_type,
+                    start_flow_node_library_name=registered_event_data.start_flow_node_library_name,
+                    end_flow_node_type=registered_event_data.end_flow_node_type,
+                    end_flow_node_library_name=registered_event_data.end_flow_node_library_name,
+                )
+
+            start_nodes = library.get_nodes_by_base_type(StartNode)
+            end_nodes = library.get_nodes_by_base_type(EndNode)
+            if len(start_nodes) > 0 and len(end_nodes) > 0:
+                start_node_type = start_nodes[0]
+                end_node_type = end_nodes[0]
+                library_name = library.get_library_data().name
+
+        return PublishWorkflowStartEndNodes(
+            start_flow_node_type=start_node_type,
+            start_flow_node_library_name=library_name,
+            end_flow_node_type=end_node_type,
+            end_flow_node_library_name=library_name,
+        )
+
     async def _publish_local_workflow(
         self, node: BaseNode, library: Library | None = None
     ) -> PublishLocalWorkflowResult:
@@ -232,16 +276,9 @@ class NodeExecutor:
         sanitized_node_name = node.name.replace(" ", "_")
         output_parameter_prefix = f"{sanitized_node_name}_packaged_node_"
         # We have to make our defaults strings because the PackageNodesAsSerializedFlowRequest doesn't accept None types.
-        library_name = "Griptape Nodes Library"
-        start_node_type = "StartFlow"
-        end_node_type = "EndFlow"
-        if library is not None:
-            start_nodes = library.get_nodes_by_base_type(StartNode)
-            end_nodes = library.get_nodes_by_base_type(EndNode)
-            if len(start_nodes) > 0 and len(end_nodes) > 0:
-                start_node_type = start_nodes[0]
-                end_node_type = end_nodes[0]
-                library_name = library.get_library_data().name
+        library_name = library.get_library_data().name if library is not None else "Griptape Nodes Library"
+        workflow_start_end_nodes = await self._get_workflow_start_end_nodes(library)
+
         sanitized_library_name = library_name.replace(" ", "_")
         # If we are packaging a NodeGroupProxyNode, that means that we are packaging multiple nodes together, so we have to get the list of nodes from the proxy node.
         if isinstance(node, NodeGroupProxyNode):
@@ -255,9 +292,10 @@ class NodeExecutor:
 
         request = PackageNodesAsSerializedFlowRequest(
             node_names=node_names,
-            start_node_type=start_node_type,
-            end_node_type=end_node_type,
-            start_end_specific_library_name=library_name,
+            start_node_type=workflow_start_end_nodes.start_flow_node_type,
+            end_node_type=workflow_start_end_nodes.end_flow_node_type,
+            start_node_library_name=workflow_start_end_nodes.start_flow_node_library_name,
+            end_node_library_name=workflow_start_end_nodes.end_flow_node_library_name,
             output_parameter_prefix=output_parameter_prefix,
             entry_control_node_name=None,
             entry_control_parameter_name=None,

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -428,7 +428,8 @@ class PackageNodesAsSerializedFlowRequest(RequestPayload):
         node_names: List of node names to package as a flow (empty list will create StartFlow→EndFlow only with warning)
         start_node_type: Node type name for the artificial start node (None or omitted defaults to "StartFlow")
         end_node_type: Node type name for the artificial end node (None or omitted defaults to "EndFlow")
-        start_end_specific_library_name: Library name containing the start/end nodes (defaults to "Griptape Nodes Library")
+        start_node_library_name: Library name containing the start node (defaults to "Griptape Nodes Library")
+        end_node_library_name: Library name containing the end node (defaults to "Griptape Nodes Library")
         entry_control_node_name: Name of the node that should receive the control flow entry (required if entry_control_parameter_name specified)
         entry_control_parameter_name: Name of the control parameter on the entry node (None for auto-detection of first available control parameter)
         output_parameter_prefix: Prefix for parameter names on the generated end node to avoid collisions (defaults to "packaged_node_")
@@ -440,7 +441,8 @@ class PackageNodesAsSerializedFlowRequest(RequestPayload):
     node_names: list[str] = field(default_factory=list)
     start_node_type: str | None = None
     end_node_type: str | None = None
-    start_end_specific_library_name: str = "Griptape Nodes Library"
+    start_node_library_name: str = "Griptape Nodes Library"
+    end_node_library_name: str = "Griptape Nodes Library"
     entry_control_node_name: str | None = None
     entry_control_parameter_name: str | None = None
     output_parameter_prefix: str = "packaged_node_"

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -377,6 +377,16 @@ class LoadWorkflowMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
 
 
 @dataclass
+class PublishWorkflowRegisteredEventData:
+    """Data specific to registering a PublishWorkflowRequest event handler."""
+
+    start_flow_node_type: str
+    start_flow_node_library_name: str
+    end_flow_node_type: str
+    end_flow_node_library_name: str
+
+
+@dataclass
 @PayloadRegistry.register
 class PublishWorkflowRequest(RequestPayload):
     """Publish a workflow for distribution.

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1288,19 +1288,19 @@ class FlowManager:
         try:
             start_end_library = LibraryRegistry.get_library_for_node_type(
                 node_type=request.start_node_type,  # type: ignore[arg-type]  # Guaranteed non-None by handler
-                specific_library_name=request.start_end_specific_library_name,
+                specific_library_name=request.start_node_library_name,
             )
         except KeyError as err:
-            details = f"Attempted to package nodes with start node type '{request.start_node_type}' from library '{request.start_end_specific_library_name}'. Failed because start node type was not found in library. Error: {err}."
+            details = f"Attempted to package nodes with start node type '{request.start_node_type}' from library '{request.start_node_library_name}'. Failed because start node type was not found in library. Error: {err}."
             return PackageNodesAsSerializedFlowResultFailure(result_details=details)
 
         try:
             LibraryRegistry.get_library_for_node_type(
                 node_type=request.end_node_type,  # type: ignore[arg-type]  # Guaranteed non-None by handler
-                specific_library_name=request.start_end_specific_library_name,
+                specific_library_name=request.end_node_library_name,
             )
         except KeyError as err:
-            details = f"Attempted to package nodes with end node type '{request.end_node_type}' from library '{request.start_end_specific_library_name}'. Failed because end node type was not found in library. Error: {err}."
+            details = f"Attempted to package nodes with end node type '{request.end_node_type}' from library '{request.end_node_library_name}'. Failed because end node type was not found in library. Error: {err}."
             return PackageNodesAsSerializedFlowResultFailure(result_details=details)
 
         # Get the actual library version
@@ -1818,7 +1818,7 @@ class FlowManager:
         # Build end node CreateNodeRequest
         end_create_node_command = CreateNodeRequest(
             node_type=request.end_node_type,  # type: ignore[arg-type]  # Guaranteed non-None by handler
-            specific_library_name=request.start_end_specific_library_name,
+            specific_library_name=request.end_node_library_name,
             node_name=end_node_name,
             metadata={},
             initial_setup=True,
@@ -1827,7 +1827,7 @@ class FlowManager:
 
         # Create library details
         end_node_library_details = LibraryNameAndVersion(
-            library_name=request.start_end_specific_library_name,
+            library_name=request.end_node_library_name,
             library_version=library_version,
         )
 
@@ -2071,7 +2071,7 @@ class FlowManager:
         # Build start node CreateNodeRequest
         start_create_node_command = CreateNodeRequest(
             node_type=request.start_node_type,  # type: ignore[arg-type]  # Guaranteed non-None by handler
-            specific_library_name=request.start_end_specific_library_name,
+            specific_library_name=request.start_node_library_name,
             node_name=start_node_name,
             metadata={},
             initial_setup=True,
@@ -2080,7 +2080,7 @@ class FlowManager:
 
         # Create library details
         start_node_library_details = LibraryNameAndVersion(
-            library_name=request.start_end_specific_library_name,
+            library_name=request.start_node_library_name,
             library_version=library_version,
         )
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from importlib.resources import files
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from packaging.requirements import InvalidRequirement, Requirement
 from pydantic import ValidationError
@@ -145,6 +145,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger("griptape_nodes")
 console = Console()
 
+TRegisteredEventData = TypeVar("TRegisteredEventData")
+
 
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
@@ -166,11 +168,16 @@ class LibraryManager:
     _library_file_path_to_info: dict[str, LibraryInfo]
 
     @dataclass
-    class RegisteredEventHandler:
-        """Information regarding an event handler from a registered library."""
+    class RegisteredEventHandler(Generic[TRegisteredEventData]):
+        """Information regarding an event handler from a registered library.
+
+        The generic type parameter TRegisteredEventData allows each event type
+        to specify its own structured additional data.
+        """
 
         handler: Callable[[RequestPayload], ResultPayload]
         library_data: LibrarySchema
+        event_data: TRegisteredEventData | None = None
 
     # Stable module namespace mappings for workflow serialization
     # These mappings ensure that dynamically loaded modules can be reliably imported
@@ -196,7 +203,9 @@ class LibraryManager:
         self._dynamic_to_stable_module_mapping = {}
         self._stable_to_dynamic_module_mapping = {}
         self._library_to_stable_modules = {}
-        self._library_event_handler_mappings: dict[type[Payload], dict[str, LibraryManager.RegisteredEventHandler]] = {}
+        self._library_event_handler_mappings: dict[
+            type[Payload], dict[str, LibraryManager.RegisteredEventHandler[Any]]
+        ] = {}
         # LibraryDirectory owns the FSMs and manages library lifecycle
         self._library_directory = LibraryDirectory()
         self._libraries_loading_complete = asyncio.Event()
@@ -356,15 +365,23 @@ class LibraryManager:
         request_type: type[RequestPayload],
         handler: Callable[[RequestPayload], ResultPayload],
         library_data: LibrarySchema,
+        event_data: object | None = None,
     ) -> None:
-        """Register an event handler for a specific request type from a library."""
+        """Register an event handler for a specific request type from a library.
+
+        Args:
+            request_type: The type of request payload this handler processes
+            handler: The callable handler function
+            library_data: Schema data for the library registering this handler
+            event_data: Optional structured data specific to this event type
+        """
         if self._library_event_handler_mappings.get(request_type) is None:
             self._library_event_handler_mappings[request_type] = {}
         self._library_event_handler_mappings[request_type][library_data.name] = LibraryManager.RegisteredEventHandler(
-            handler=handler, library_data=library_data
+            handler=handler, library_data=library_data, event_data=event_data
         )
 
-    def get_registered_event_handlers(self, request_type: type[Payload]) -> dict[str, RegisteredEventHandler]:
+    def get_registered_event_handlers(self, request_type: type[Payload]) -> dict[str, RegisteredEventHandler[Any]]:
         """Get all registered event handlers for a specific request type."""
         return self._library_event_handler_mappings.get(request_type, {})
 


### PR DESCRIPTION
* Enable publishing libraries to register their start and end node types
  * Update GTC Library to do so 

Registration looks like:

```python
    def after_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:  # noqa: ARG002
        """Called after all nodes have been loaded from the library."""
        GriptapeNodes.LibraryManager().on_register_event_handler(
            request_type=PublishWorkflowRequest,
            handler=_publish_workflow_request_handler,
            library_data=library_data,
            event_data=PublishWorkflowRegisteredEventData(
                start_flow_node_type="DeadlineCloudStartFlow",
                end_flow_node_type="DeadlineCloudEndFlow",
                start_flow_node_library_name=library_data.name,
                end_flow_node_library_name=library_data.name,
            ),
        )
```

Closes #2573 