### PR TITLE
fix: run model download with no update

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -417,7 +417,7 @@ class ModelManager:
         logger.info("Starting download for model: %s", model_id)
 
         # Build CLI command
-        cmd = [sys.executable, "-m", "griptape_nodes", "models", "download", download_params.model_id]
+        cmd = [sys.executable, "-m", "griptape_nodes", "--no-update", "models", "download", download_params.model_id]
 
         if download_params.local_dir:
             cmd.extend(["--local-dir", download_params.local_dir])


### PR DESCRIPTION
If there's an update for the engine, the model doesn't download.

Progress is still kind of borked, will follow up in separate PR.