### PR TITLE
fix: make event flushing a non-request to avoid network noise

### DIFF
--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -653,19 +653,3 @@ class ProgressEvent:
     value: Any = field()
     node_name: str = field()
     parameter_name: str = field()
-
-
-# Special internal request for flushing parameter changes
-@dataclass(kw_only=True)
-class FlushParameterChangesRequest(RequestPayload, WorkflowNotAlteredMixin):
-    pass
-
-
-@dataclass
-class FlushParameterChangesResultSuccess(ResultPayloadSuccess):
-    pass
-
-
-@dataclass
-class FlushParameterChangesResultFailure(ResultPayloadFailure):
-    pass

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -10,13 +10,11 @@ from typing import TYPE_CHECKING, Any, cast
 from asyncio_thread_runner import ThreadRunner
 from typing_extensions import TypedDict, TypeVar
 
+from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
-    EventRequest,
     EventResultFailure,
     EventResultSuccess,
-    FlushParameterChangesRequest,
-    FlushParameterChangesResultSuccess,
     RequestPayload,
     ResultPayload,
 )
@@ -31,15 +29,9 @@ AP = TypeVar("AP", bound=AppPayload, default=AppPayload)
 
 # Result types that should NOT trigger a flush request.
 #
-# After most requests complete, we queue a FlushParameterChangesRequest to flush any tracked
-# parameter changes to the UI. However, when the FlushParameterChangesRequest itself completes,
-# it returns a FlushParameterChangesResultSuccess. If we don't exclude this result type, it would
-# trigger another FlushParameterChangesRequest, which would return another FlushParameterChangesResultSuccess,
-# creating an infinite loop of flush requests.
-#
 # Add result types to this set if they should never trigger a flush (typically because they ARE
 # the flush operation itself, or other internal operations that don't modify workflow state).
-RESULT_TYPES_THAT_SKIP_FLUSH = {FlushParameterChangesResultSuccess}
+RESULT_TYPES_THAT_SKIP_FLUSH = {}
 
 
 class ResultContext(TypedDict, total=False):
@@ -249,7 +241,7 @@ class EventManager:
         # Queue flush request for async context (unless result type should skip flush)
         with operation_depth_mgr:
             if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
-                await self.aput_event(EventRequest(request=FlushParameterChangesRequest()))
+                self._flush_tracked_parameter_changes()
 
         return self._handle_request_core(
             request,
@@ -297,7 +289,7 @@ class EventManager:
         # Queue flush request for sync context (unless result type should skip flush)
         with operation_depth_mgr:
             if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
-                self.put_event(EventRequest(request=FlushParameterChangesRequest()))
+                self._flush_tracked_parameter_changes()
 
         return self._handle_request_core(
             request,
@@ -329,3 +321,14 @@ class EventManager:
             async with asyncio.TaskGroup() as tg:
                 for listener_callback in listener_set:
                     tg.create_task(call_function(listener_callback, app_event))
+
+    def _flush_tracked_parameter_changes(self) -> None:
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        obj_manager = GriptapeNodes.ObjectManager()
+        # Get all flows and their nodes
+        nodes = obj_manager.get_filtered_subset(type=BaseNode)
+        for node in nodes.values():
+            # Only flush if there are actually tracked parameters
+            if node._tracked_parameters:
+                node.emit_parameter_changes()


### PR DESCRIPTION
https://github.com/griptape-ai/griptape-nodes/pull/3145 made it so flush results went out a ton more. This is better than flush results being missed, but it's kind of noisy.

Flushing should not be a user-level request, it's part of the internal machinery.