### PR TITLE
fix: Disable Seedream read timeout

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
@@ -410,7 +410,7 @@ class SeedreamImageGeneration(SuccessFailureNode):
         self._log_request(payload)
 
         try:
-            response = requests.post(proxy_url, json=payload, headers=headers, timeout=None)
+            response = requests.post(proxy_url, json=payload, headers=headers, timeout=None)  # noqa: S113
             response.raise_for_status()
             response_json = response.json()
             self._log("Request submitted successfully")


### PR DESCRIPTION
unblocks the case of super long generations/large inputs