### PR TITLE
fix: skip gtn update in new model manager

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -451,7 +451,7 @@ class ModelManager:
         logger.info("Starting download for model: %s", model_id)
 
         # Build CLI command
-        cmd = [sys.executable, "-m", "griptape_nodes", "models", "download", download_params.model_id]
+        cmd = [sys.executable, "-m", "griptape_nodes", "--no-update", "models", "download", download_params.model_id]
 
         if download_params.local_dir:
             cmd.extend(["--local-dir", download_params.local_dir])


### PR DESCRIPTION
Ooops a71cc22d90e0 got reverted in f20f08d4a40c