### PR TITLE
feature: Note node can use Markdown formatting

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/note.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/note.py
@@ -1,10 +1,7 @@
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import (
-    Parameter,
-    ParameterMode,
-)
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 
 
 class Note(BaseNode):
@@ -17,17 +14,16 @@ class Note(BaseNode):
         super().__init__(name, metadata)
 
         self.add_parameter(
-            Parameter(
+            ParameterString(
                 name="note",
                 default_value=value,
-                type="str",
-                allowed_modes={ParameterMode.PROPERTY},
-                ui_options={
-                    "multiline": True,
-                    "placeholder_text": "Enter your note here...",
-                    "is_full_width": True,
-                    "className": "text-xl",
-                },
+                allow_input=False,
+                allow_property=True,
+                allow_output=False,
+                multiline=True,
+                placeholder_text="Enter your note here...",
+                markdown=True,
+                is_full_width=True,
                 tooltip="A helpful note",
             )
         )

--- a/src/griptape_nodes/exe_types/param_types/parameter_string.py
+++ b/src/griptape_nodes/exe_types/param_types/parameter_string.py
@@ -44,6 +44,7 @@ class ParameterString(Parameter):
         markdown: bool = False,
         multiline: bool = False,
         placeholder_text: str | None = None,
+        is_full_width: bool = False,
         accept_any: bool = True,
         hide: bool = False,
         hide_label: bool = False,
@@ -78,6 +79,7 @@ class ParameterString(Parameter):
             markdown: Whether to enable markdown rendering
             multiline: Whether to use multiline input
             placeholder_text: Placeholder text for the input field
+            is_full_width: Whether the parameter should take full width in the UI
             accept_any: Whether to accept any input type and convert to string (default: True)
             hide: Whether to hide the entire parameter
             hide_label: Whether to hide the parameter label
@@ -105,6 +107,8 @@ class ParameterString(Parameter):
             ui_options["multiline"] = multiline
         if placeholder_text is not None:
             ui_options["placeholder_text"] = placeholder_text
+        if is_full_width:
+            ui_options["is_full_width"] = is_full_width
 
         # Set up string conversion based on accept_any setting
         if converters is None:
@@ -230,3 +234,26 @@ class ParameterString(Parameter):
             self.ui_options = ui_options
         else:
             self.update_ui_options_key("placeholder_text", value)
+
+    @property
+    def is_full_width(self) -> bool:
+        """Get whether the parameter should take full width in the UI.
+
+        Returns:
+            True if full width is enabled, False otherwise
+        """
+        return self.ui_options.get("is_full_width", False)
+
+    @is_full_width.setter
+    def is_full_width(self, value: bool) -> None:
+        """Set whether the parameter should take full width in the UI.
+
+        Args:
+            value: Whether to enable full width
+        """
+        if value:
+            self.update_ui_options_key("is_full_width", value)
+        else:
+            ui_options = self.ui_options.copy()
+            ui_options.pop("is_full_width", None)
+            self.ui_options = ui_options


### PR DESCRIPTION
requires: https://github.com/griptape-ai/griptape-vsl-gui/pull/1611

fixes: #3156

This allows the Note node to work with markdown now - so users can add images, bold text, etc to their notes.

<img width="793" height="726" alt="image" src="https://github.com/user-attachments/assets/1b81b2c3-fb41-43b9-ab8b-af2f83af6807" />
