### PR TITLE
fix: RescaleImage node had a ParameterGroup missing

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/rescale_image.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/rescale_image.py
@@ -168,7 +168,7 @@ class RescaleImage(BaseImageProcessor):
 
         self.add_node_element(rescale_group)
 
-        # Hide the appropropriate parameters
+        # Hide the correct parameters
         self.hide_parameter_by_name("target_size")
         self.hide_parameter_by_name("target_width")
         self.hide_parameter_by_name("target_height")


### PR DESCRIPTION
Fixed missing parameter group in RescaleImage node
<img width="468" height="590" alt="image" src="https://github.com/user-attachments/assets/59a9a66f-c793-40a5-9cb8-4cd0f994c508" />

fixes: #3163
