### PR TITLE
Update/agent_mcp_server_capabilities

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -397,6 +397,33 @@ class AgentManager:
                         Rule("Only set generated_image_urls with images generated with your tools."),
                     ],
                 ),
+                # Note: Griptape's MCPTool automatically wraps arguments in a 'values' key, but our MCP server
+                # expects arguments directly. This ruleset instructs the agent to provide arguments without
+                # the 'values' wrapper to avoid validation errors. If MCPTool behavior changes in the future,
+                # this ruleset may need to be updated or removed.
+                Ruleset(
+                    name="mcp_tool_usage",
+                    rules=[
+                        Rule(
+                            "When calling MCP tools (mcpGriptapeNodes), provide arguments directly without wrapping them in a 'values' key. "
+                            "For example, use {'node_type': 'FluxImageGeneration', 'node_name': 'MyNode'} not {'values': {'node_type': 'FluxImageGeneration'}}."
+                        ),
+                    ],
+                ),
+                Ruleset(
+                    name="node_rulesets",
+                    rules=[
+                        Rule(
+                            "When asked to create a node, use ListNodeTypesInLibraryRequest or GetAllInfoForAllLibrariesRequest to check available node types and find the appropriate node."
+                        ),
+                        Rule(
+                            "When matching user requests to node types, account for variations: users may include spaces (e.g., 'Image Generation' vs 'ImageGeneration') or reorder words (e.g., 'Generate Image' vs 'Image Generation'). Match based on the words present, not exact spelling."
+                        ),
+                        Rule(
+                            "If you cannot determine the correct node type or node creation fails, ask the user for clarification."
+                        ),
+                    ],
+                ),
             ],
         )
 

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -29,6 +29,11 @@ from griptape_nodes.retained_mode.events.execution_events import (
     StartFlowRequest,
 )
 from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest
+from griptape_nodes.retained_mode.events.library_events import (
+    ListCategoriesInLibraryRequest,
+    ListNodeTypesInLibraryRequest,
+    ListRegisteredLibrariesRequest,
+)
 from griptape_nodes.retained_mode.events.node_events import (
     CreateNodeRequest,
     DeleteNodeRequest,
@@ -53,6 +58,10 @@ from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     # Workflows
     "RunWorkflowWithCurrentStateRequest": RunWorkflowWithCurrentStateRequest,
+    # Libraries
+    "ListRegisteredLibrariesRequest": ListRegisteredLibrariesRequest,
+    "ListNodeTypesInLibraryRequest": ListNodeTypesInLibraryRequest,
+    "ListCategoriesInLibraryRequest": ListCategoriesInLibraryRequest,
     # Execution
     "ResolveNodeRequest": ResolveNodeRequest,
     "StartFlowRequest": StartFlowRequest,


### PR DESCRIPTION
Added a bunch of new capabilities to the agent, and also added some rules to make it work better.

Now users can say things like:

```
Okay ,create an Agent node, give it a prompt that tells it to come up with a good image generation prompt for a capybara, then create a Flux Image Generation node and connect the output from the agent to the prompt for that node
```
and it will work