### PR TITLE
Lock the workflow file while saving to eliminate concurrent writes stomping on each other.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "aioshutil>=1.5",
   "ruamel.yaml>=0.18.15",
   "asyncio-thread-runner>=1.0",
+  "portalocker>=2.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar, cast
 
 import aiofiles
+import portalocker
 import semver
 import tomlkit
 from rich.box import HEAVY_EDGE
@@ -1269,8 +1270,11 @@ class WorkflowManager:
         success: bool
         error_details: str
 
-    async def _write_workflow_file(self, file_path: Path, content: str, file_name: str) -> WriteWorkflowFileResult:
+    def _write_workflow_file(self, file_path: Path, content: str, file_name: str) -> WriteWorkflowFileResult:
         """Write workflow content to file with proper validation and error handling.
+
+        Uses portalocker for exclusive file locking to prevent concurrent writes.
+        First write wins - if another process is writing, this call fails immediately.
 
         Args:
             file_path: Path where to write the file
@@ -1295,13 +1299,34 @@ class WorkflowManager:
             details = f"Attempted to save workflow '{file_name}'. Failed when creating directory structure: {e}"
             return self.WriteWorkflowFileResult(success=False, error_details=details)
 
-        # Write the file content
+        # Write the file content with exclusive lock (non-blocking)
+        error_details = None
         try:
-            async with aiofiles.open(file_path, "w", encoding="utf-8") as file:
-                await file.write(content)
+            with portalocker.Lock(
+                file_path,
+                mode="w",
+                encoding="utf-8",
+                timeout=0,  # Non-blocking: fail immediately if locked
+                flags=portalocker.LockFlags.EXCLUSIVE,
+            ) as fh:
+                fh.write(content)
+        except portalocker.LockException:
+            error_details = (
+                f"Attempted to save workflow '{file_name}'. Another process is currently writing to this workflow file"
+            )
+        except PermissionError as e:
+            error_details = f"Attempted to save workflow '{file_name}'. Permission denied: {e}"
+        except IsADirectoryError:
+            error_details = f"Attempted to save workflow '{file_name}'. Path is a directory, not a file"
+        except UnicodeEncodeError as e:
+            error_details = f"Attempted to save workflow '{file_name}'. Content encoding error: {e}"
         except OSError as e:
-            details = f"Attempted to save workflow '{file_name}'. Failed when writing file content: {e}"
-            return self.WriteWorkflowFileResult(success=False, error_details=details)
+            error_details = f"Attempted to save workflow '{file_name}'. OS error: {e}"
+        except Exception as e:
+            error_details = f"Attempted to save workflow '{file_name}'. Unexpected error: {type(e).__name__}: {e}"
+
+        if error_details:
+            return self.WriteWorkflowFileResult(success=False, error_details=error_details)
 
         return self.WriteWorkflowFileResult(success=True, error_details="")
 
@@ -1546,7 +1571,10 @@ class WorkflowManager:
             return SaveWorkflowFileFromSerializedFlowResultFailure(result_details=details)
 
         # Write the workflow file
-        write_result = await self._write_workflow_file(file_path, final_code_output, request.file_name)
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/3169
+        # This is a synchronous call within an async context and may block the event loop.
+        # Consider using asyncio.to_thread() to run in a thread pool for better async performance.
+        write_result = self._write_workflow_file(file_path, final_code_output, request.file_name)
         if not write_result.success:
             return SaveWorkflowFileFromSerializedFlowResultFailure(result_details=write_result.error_details)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 3
-requires-python = "==3.12.*"
+revision = 2
+requires-python = ">=3.12.0, <3.13"
 
 [[package]]
 name = "aiofiles"
@@ -354,6 +354,7 @@ dependencies = [
     { name = "mcp", extra = ["ws"] },
     { name = "packaging" },
     { name = "pillow" },
+    { name = "portalocker" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -416,6 +417,7 @@ requires-dist = [
     { name = "mcp", extras = ["ws"], specifier = ">=1.10.1" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "pillow", specifier = ">=11.3.0" },
+    { name = "portalocker", specifier = ">=2.10.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -1098,6 +1100,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #3167 

We will extrapolate this logic for other writes (eventually making it into WriteFileRequest) in future tasks as part of https://github.com/griptape-ai/griptape-nodes/issues/3166