### PR TITLE
fix: update CreateTextList output type to support list expansion

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/lists/create_text_list.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/lists/create_text_list.py
@@ -24,7 +24,7 @@ class CreateTextList(ControlNode):
         self.output = Parameter(
             name="output",
             tooltip="Output list",
-            output_type="list",
+            output_type="list[str]",
             allowed_modes={ParameterMode.OUTPUT},
         )
         self.add_parameter(self.output)


### PR DESCRIPTION
This PR fixes the issue where the Create Text List node's output type wasn't properly supporting list expansion for use with other nodes like Create Dictionary.

The output type has been updated from `list[str]` to properly support being used as input to nodes that expect list parameters.

Closes #3183