### PR TITLE
fix: add type flexibility to KeyValuePair value parameter

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/dict/key_value_pair.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/dict/key_value_pair.py
@@ -24,7 +24,7 @@ class KeyValuePair(DataNode):
         self.add_parameter(
             Parameter(
                 name="value",
-                input_types=["str","int","float","bool"],
+                input_types=["str", "int", "float", "bool"],
                 default_value="",
                 type="str",
                 tooltip="Value for the dictionary",


### PR DESCRIPTION
This PR fixes the KeyValuePair node to accept multiple types for the value parameter, not just strings.

The value parameter now accepts: `str`, `int`, `float`, and `bool` types, making it more flexible for creating key-value pairs with different data types.

Closes #3184