### PR TITLE
fix: skip update when syncing libraries immediately after update

### DIFF
--- a/src/griptape_nodes/updater/__init__.py
+++ b/src/griptape_nodes/updater/__init__.py
@@ -60,7 +60,7 @@ def _sync_libraries() -> None:
     console.print("[bold green]Syncing libraries...[/bold green]")
     try:
         subprocess.run(
-            ["griptape-nodes", "libraries", "sync"],  # noqa: S607
+            ["griptape-nodes", "--no-update", "libraries", "sync"],  # noqa: S607
             text=True,
             capture_output=True,
             check=True,


### PR DESCRIPTION
_In theory_ this should not trigger because we just updated. But there seems to be some race condition.