### PR TITLE
fix: un-remove spandrel dependency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -116,7 +116,6 @@ The following Python package dependencies were removed from the Advanced Media L
 - `beautifulsoup4`
 - `protobuf` (duplicate entries consolidated)
 - `sentencepiece`
-- `spandrel`
 - `torchaudio`
 - `ftfy`
 

--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -47,6 +47,7 @@
         "peft>=0.17.0",
         "pillow>=11.2.1",
         "cmake==3.31.6",
+        "spandrel>=0.4.1",
         "torch>=2.7.0",
         "torchvision>=0.22.0",
         "transformers>=4.51.2",


### PR DESCRIPTION
Before:
<img width="1306" height="138" alt="Screenshot 2025-11-19 at 11 52 56 AM" src="https://github.com/user-attachments/assets/3dda437e-9cf7-4b76-8b23-b738313738dd" />


After:
<img width="1300" height="77" alt="Screenshot 2025-11-19 at 12 06 30 PM" src="https://github.com/user-attachments/assets/9565818b-dc7e-4fa2-b6cb-969c0bc1f442" />

