### PR TITLE
fix: add supervision dependency

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -59,6 +59,7 @@
         "sam2>=1.1.0",
         "scipy>=1.10.0",
         "matplotlib>=3.10.3",
+        "supervision>=0.27.0",
         "griptape[drivers-prompt-amazon-bedrock,drivers-prompt-anthropic,drivers-prompt-cohere,drivers-prompt-ollama,drivers-web-scraper-trafilatura,drivers-web-search-duckduckgo,drivers-web-search-exa,loaders-image]>=1.8.12"
       ],
       "pip_install_flags": [


### PR DESCRIPTION
Before:
<img width="1300" height="77" alt="Screenshot 2025-11-19 at 12 06 30 PM" src="https://github.com/user-attachments/assets/e5debcab-e12d-4627-9923-7987a4cf6d25" />


After:
<img width="1065" height="78" alt="Screenshot 2025-11-19 at 3 02 58 PM" src="https://github.com/user-attachments/assets/721a60fc-9ee4-40b6-b445-427d563ce364" />

resolves: https://github.com/griptape-ai/griptape-nodes/issues/3204


