### PR TITLE
fix: specify griptape nodes module when syncing library after update

### DIFF
--- a/src/griptape_nodes/updater/__init__.py
+++ b/src/griptape_nodes/updater/__init__.py
@@ -61,7 +61,7 @@ def _sync_libraries() -> None:
     console.print("[bold green]Syncing libraries...[/bold green]")
     try:
         subprocess.run(  # noqa: S603
-            [sys.executable, "--no-update", "libraries", "sync"],
+            [sys.executable, "-m", "griptape_nodes", "--no-update", "libraries", "sync"],
             text=True,
             capture_output=True,
             check=True,


### PR DESCRIPTION
Fixes #3232

Oopsie from 87aaac47e0c6