### PR TITLE
ReadFileRequest now uses the same sanitization methods for difficult paths that artifact tethering uses

### DIFF
--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -162,6 +162,8 @@ class ReadFileRequest(RequestPayload):
         workspace_only: If True, constrain to workspace directory. If False, allow system-wide access.
                         If None, workspace constraints don't apply (e.g., cloud environments).
                         TODO: Remove workspace_only parameter - see https://github.com/griptape-ai/griptape-nodes/issues/2753
+        should_transform_image_content_to_thumbnail: If True, convert image files to thumbnail data URLs.
+                        If False, return raw image bytes. Default True for backwards compatibility.
 
     Results: ReadFileResultSuccess (with content) | ReadFileResultFailure (file not found, permission denied)
     """
@@ -170,6 +172,7 @@ class ReadFileRequest(RequestPayload):
     file_entry: FileSystemEntry | None = None
     encoding: str = "utf-8"
     workspace_only: bool | None = True  # TODO: Remove - see https://github.com/griptape-ai/griptape-nodes/issues/2753
+    should_transform_image_content_to_thumbnail: bool = True
 
 
 @dataclass


### PR DESCRIPTION
1. Transplanted the sanitization from artifact tethering to ReadFileRequest
2. Made the "transform image into a webp thumbnail for file picker previews" an OPTION on ReadFileRequest for back compat (we should revisit or remove this behavior later)
3. Had artifact tethering call ReadFileRequest now instead of doing its bespokery in just that one place