### PR TITLE
feat: add individual item type detection for DisplayList

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/lists/display_list.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/lists/display_list.py
@@ -18,9 +18,17 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 class DisplayList(ControlNode):
     """DisplayList Node that takes a list and creates output parameters for each item in the list.
 
-    This node takes a list as input and creates a new output parameter for each item in the list,
-    with the type of the object in the list. This allows for dynamic output parameters based on
-    the content of the input list.
+    This node takes a list as input and creates a new output parameter for each item in the list.
+    Each output parameter is individually typed based on its specific item, allowing for mixed-type
+    lists where different items can have different types.
+
+    Features:
+    - Individual type detection: Each item's type is detected independently
+    - Automatic connection validation: Incompatible connections are removed when types change
+    - Type-specific UI options: Images get proper display, dicts get multiline, etc.
+    - Complete type information: Each parameter has type, output_type, and input_types set
+
+    Supported types: str, int, float, bool, dict, ImageUrlArtifact/ImageArtifact
     """
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:


### PR DESCRIPTION
## Summary
Adds individual type detection for each item in DisplayList and automatically validates/removes incompatible connections when types change.

Closes #3190

## Changes
- **Added type detection per item**: Each output parameter now detects and uses the type of its specific item, rather than all items using the type of the first item
- **Added connection validation**: When an item's type changes, incompatible connections are automatically removed
- **Improved type handling**: Follows the pattern from `DictGetValueByKey` for consistent type compatibility checking

## Implementation Details

### New Imports
- `logging` - for logger instance
- `ParameterType` - for type compatibility checks
- `DeleteConnectionRequest` - for removing incompatible connections
- `GriptapeNodes` - for flow manager access

### Modified Methods
- **`_update_display_list`**: Now detects type for each individual item and updates the output_type of each child parameter accordingly. Always validates connections to ensure compatibility.

### New Methods
- **`_validate_and_remove_incompatible_connections`**: Validates outgoing connections for a specific parameter and removes any that are incompatible with the new type. Follows the pattern from `get_dict_value.py`.

## Benefits
- More accurate type information for each list item
- Prevents invalid connections from persisting when types change
- Better user experience with automatic connection cleanup
- Consistent with existing type validation patterns in the codebase

## Testing
- No linter errors (only pre-existing complexity warnings)
- Follows established patterns from `DictGetValueByKey`
- Backward compatible with existing functionality

## Fixed Issues
- Connections are now always validated, not just when types change
- Validation also applies to newly created parameters