### PR TITLE
Added the question mark to the list of delimiters supported by Split Text 

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/lists/split_text.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/lists/split_text.py
@@ -46,6 +46,7 @@ class SplitText(ControlNode):
         "hash": "#",
         "ampersand": "&",
         "equals": "=",
+        "question mark": "?",
     }
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:


### PR DESCRIPTION
Fixes #3261 

<img width="1657" height="633" alt="Screenshot 2025-11-22 at 11 18 14 PM" src="https://github.com/user-attachments/assets/eeb3d66a-7b1f-448a-809e-8cfffa76a7c5" />
