### PR TITLE
feat: add QwenImageControlNetPipeline support

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/pipeline_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/pipeline_parameters.py
@@ -40,6 +40,9 @@ from diffusers_nodes_library.common.parameters.diffusion.flux.runtime_parameters
 from diffusers_nodes_library.common.parameters.diffusion.flux.upscale_runtime_parameters import (
     FluxUpscalePipelineRuntimeParameters,
 )
+from diffusers_nodes_library.common.parameters.diffusion.qwen.controlnet_runtime_parameters import (
+    QwenImageControlNetPipelineRuntimeParameters,
+)
 from diffusers_nodes_library.common.parameters.diffusion.qwen.edit_plus_runtime_parameters import (
     QwenImageEditPlusPipelineRuntimeParameters,
 )
@@ -145,6 +148,8 @@ class DiffusionPipelineParameters:
                 self._runtime_parameters = QwenImageEditPlusPipelineRuntimeParameters(self._node)
             case "QwenImageUpscalePipeline":
                 self._runtime_parameters = QwenUpscalePipelineRuntimeParameters(self._node)
+            case "QwenImageControlNetPipeline":
+                self._runtime_parameters = QwenImageControlNetPipelineRuntimeParameters(self._node)
             case "StableDiffusionPipeline":
                 self._runtime_parameters = StableDiffusionPipelineRuntimeParameters(self._node)
             case "StableDiffusion3Pipeline":

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/controlnet_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/controlnet_parameters.py
@@ -1,0 +1,123 @@
+import logging
+
+import diffusers  # type: ignore[reportMissingImports]
+import torch  # type: ignore[reportMissingImports]
+import transformers  # type: ignore[reportMissingImports]
+
+from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
+    DiffusionPipelineTypePipelineParameters,
+)
+from diffusers_nodes_library.common.parameters.diffusion.scheduler_parameters import SchedulerParameters
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.param_components.huggingface.huggingface_repo_parameter import HuggingFaceRepoParameter
+
+logger = logging.getLogger("diffusers_nodes_library")
+
+
+class QwenImageControlNetPipelineParameters(DiffusionPipelineTypePipelineParameters):
+    def __init__(self, node: BaseNode, *, list_all_models: bool = False):
+        super().__init__(node)
+        self._model_repo_parameter = HuggingFaceRepoParameter(
+            node,
+            repo_ids=[
+                "Qwen/Qwen-Image",
+            ],
+            parameter_name="model",
+            list_all_models=list_all_models,
+        )
+
+        self._text_encoder_repo_parameter = HuggingFaceRepoParameter(
+            node,
+            repo_ids=[
+                "Qwen/Qwen2.5-VL-7B-Instruct",
+            ],
+            parameter_name="text_encoder",
+            list_all_models=list_all_models,
+        )
+
+        self._controlnet_repo_parameter = HuggingFaceRepoParameter(
+            node,
+            repo_ids=[
+                "InstantX/Qwen-Image-ControlNet-Union",
+            ],
+            parameter_name="controlnet_model",
+            list_all_models=list_all_models,
+        )
+
+        self._scheduler_parameters = SchedulerParameters(
+            node, scheduler_types=[diffusers.FlowMatchEulerDiscreteScheduler]
+        )
+
+    def add_input_parameters(self) -> None:
+        self._model_repo_parameter.add_input_parameters()
+        self._text_encoder_repo_parameter.add_input_parameters()
+        self._controlnet_repo_parameter.add_input_parameters()
+        self._scheduler_parameters.add_input_parameters()
+
+    def remove_input_parameters(self) -> None:
+        self._model_repo_parameter.remove_input_parameters()
+        self._text_encoder_repo_parameter.remove_input_parameters()
+        self._controlnet_repo_parameter.remove_input_parameters()
+        self._scheduler_parameters.remove_input_parameters()
+
+    def get_config_kwargs(self) -> dict:
+        return {
+            "controlnet_model": self._node.get_parameter_value("controlnet_model"),
+            "model": self._node.get_parameter_value("model"),
+            "text_encoder": self._node.get_parameter_value("text_encoder"),
+            **self._scheduler_parameters.get_config_kwargs(),
+        }
+
+    @property
+    def pipeline_class(self) -> type:
+        return diffusers.QwenImageControlNetPipeline
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        errors = []
+        model_errors = self._model_repo_parameter.validate_before_node_run()
+        if model_errors:
+            errors.extend(model_errors)
+
+        text_encoder_errors = self._text_encoder_repo_parameter.validate_before_node_run()
+        if text_encoder_errors:
+            errors.extend(text_encoder_errors)
+
+        controlnet_errors = self._controlnet_repo_parameter.validate_before_node_run()
+        if controlnet_errors:
+            errors.extend(controlnet_errors)
+
+        scheduler_errors = self._scheduler_parameters.validate_before_node_run()
+        if scheduler_errors:
+            errors.extend(scheduler_errors)
+
+        return errors or None
+
+    def build_pipeline(self) -> diffusers.QwenImageControlNetPipeline:
+        base_repo_id, base_revision = self._model_repo_parameter.get_repo_revision()
+        text_encoder_repo_id, text_encoder_revision = self._text_encoder_repo_parameter.get_repo_revision()
+        controlnet_repo_id, controlnet_revision = self._controlnet_repo_parameter.get_repo_revision()
+
+        text_encoder = transformers.Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            pretrained_model_name_or_path=text_encoder_repo_id,
+            revision=text_encoder_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        # Load ControlNet model
+        controlnet = diffusers.QwenImageControlNetModel.from_pretrained(
+            pretrained_model_name_or_path=controlnet_repo_id,
+            revision=controlnet_revision,
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )
+
+        return diffusers.QwenImageControlNetPipeline.from_pretrained(
+            pretrained_model_name_or_path=base_repo_id,
+            revision=base_revision,
+            text_encoder=text_encoder,
+            controlnet=controlnet,
+            scheduler=self._scheduler_parameters.get_scheduler(),
+            torch_dtype=torch.bfloat16,
+            local_files_only=True,
+        )

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/controlnet_runtime_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/controlnet_runtime_parameters.py
@@ -1,0 +1,134 @@
+import logging
+from typing import Any
+
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline  # type: ignore[reportMissingImports]
+from griptape.artifacts import ImageUrlArtifact
+from PIL.Image import Image
+from pillow_nodes_library.utils import (  # type: ignore[reportMissingImports]
+    image_artifact_to_pil,
+)
+from utils.image_utils import load_image_from_url_artifact
+
+from diffusers_nodes_library.common.parameters.diffusion.qwen.common import qwen_latents_to_image_pil
+from diffusers_nodes_library.common.parameters.diffusion.runtime_parameters import (
+    DiffusionPipelineRuntimeParameters,
+)
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import BaseNode
+
+logger = logging.getLogger("diffusers_nodes_library")
+
+
+class QwenImageControlNetPipelineRuntimeParameters(DiffusionPipelineRuntimeParameters):
+    def __init__(self, node: BaseNode):
+        super().__init__(node)
+
+    def _add_input_parameters(self) -> None:
+        self._node.add_parameter(
+            Parameter(
+                name="control_image",
+                input_types=["ImageArtifact", "ImageUrlArtifact"],
+                type="ImageArtifact",
+                tooltip="The ControlNet input condition to provide guidance to the model for generation.",
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="prompt",
+                default_value="",
+                type="str",
+                tooltip="The prompt or prompts to guide the image generation.",
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="negative_prompt",
+                default_value="",
+                type="str",
+                tooltip="The prompt or prompts not to guide the image generation.",
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="controlnet_conditioning_scale",
+                default_value=1.0,
+                input_types=["float"],
+                type="float",
+                tooltip="Multiplied with the outputs of the ControlNet before they are added to the residual in the original model.",
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="control_guidance_start",
+                default_value=0.0,
+                input_types=["float"],
+                type="float",
+                tooltip="The percentage of total steps at which the ControlNet starts applying.",
+                ui_options={"slider": {"min_val": 0.0, "max_val": 1.0}, "step": 0.01},
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="control_guidance_end",
+                default_value=1.0,
+                input_types=["float"],
+                type="float",
+                tooltip="The percentage of total steps at which the ControlNet stops applying.",
+                ui_options={"slider": {"min_val": 0.0, "max_val": 1.0}, "step": 0.01},
+            )
+        )
+        # Default is not 1.0 like other qwen pipelines because of https://github.com/griptape-ai/griptape-nodes/pull/3275#discussion_r2555019559
+        self._node.add_parameter(
+            Parameter(
+                name="true_cfg_scale",
+                default_value=4.0,
+                type="float",
+                tooltip="True classifier-free guidance (guidance scale) is enabled when true_cfg_scale > 1 and negative_prompt is provided.",
+            )
+        )
+        self._node.add_parameter(
+            Parameter(
+                name="guidance_scale",
+                default_value=3.5,
+                type="float",
+                tooltip="A guidance scale value for guidance distilled models. Leave empty to use true_cfg_scale instead.",
+            )
+        )
+
+    def _remove_input_parameters(self) -> None:
+        self._node.remove_parameter_element_by_name("prompt")
+        self._node.remove_parameter_element_by_name("negative_prompt")
+        self._node.remove_parameter_element_by_name("true_cfg_scale")
+        self._node.remove_parameter_element_by_name("guidance_scale")
+        self._node.remove_parameter_element_by_name("controlnet_conditioning_scale")
+        self._node.remove_parameter_element_by_name("control_guidance_start")
+        self._node.remove_parameter_element_by_name("control_guidance_end")
+        self._node.remove_parameter_element_by_name("control_image")
+
+    def _get_pipe_kwargs(self) -> dict:
+        kwargs = {
+            "prompt": self._node.get_parameter_value("prompt"),
+            "negative_prompt": self._node.get_parameter_value("negative_prompt"),
+            "true_cfg_scale": self._node.get_parameter_value("true_cfg_scale"),
+            "control_image": self.get_control_image_pil(),
+            "controlnet_conditioning_scale": self._node.get_parameter_value("controlnet_conditioning_scale"),
+            "control_guidance_start": self._node.get_parameter_value("control_guidance_start"),
+            "control_guidance_end": self._node.get_parameter_value("control_guidance_end"),
+        }
+
+        # Only add guidance_scale if it's not None (pipeline supports it optionally)
+        guidance_scale = self._node.get_parameter_value("guidance_scale")
+        if guidance_scale is not None:
+            kwargs["guidance_scale"] = guidance_scale
+
+        return kwargs
+
+    def get_control_image_pil(self) -> Image:
+        control_image_artifact = self._node.get_parameter_value("control_image")
+        if isinstance(control_image_artifact, ImageUrlArtifact):
+            control_image_artifact = load_image_from_url_artifact(control_image_artifact)
+        control_image_pil = image_artifact_to_pil(control_image_artifact)
+        return control_image_pil.convert("RGB")
+
+    def latents_to_image_pil(self, pipe: DiffusionPipeline, latents: Any) -> Image:
+        return qwen_latents_to_image_pil(pipe, latents, self.get_height(), self.get_width())

--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/pipeline_type_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/qwen/pipeline_type_parameters.py
@@ -6,6 +6,9 @@ from diffusers_nodes_library.common.parameters.diffusion.diffusion_pipeline_type
 from diffusers_nodes_library.common.parameters.diffusion.pipeline_type_parameters import (
     DiffusionPipelineTypePipelineParameters,
 )
+from diffusers_nodes_library.common.parameters.diffusion.qwen.controlnet_parameters import (
+    QwenImageControlNetPipelineParameters,
+)
 from diffusers_nodes_library.common.parameters.diffusion.qwen.edit_parameters import (
     QwenEditPipelineParameters,
 )
@@ -31,6 +34,7 @@ QwenPipelineTypeDict: dict[str, type[DiffusionPipelineTypePipelineParameters]] =
     "QwenImageEditPipeline": QwenEditPipelineParameters,
     "QwenImageEditPlusPipeline": QwenImageEditPlusPipelineParameters,
     "QwenImageUpscalePipeline": QwenUpscalePipelineParameters,
+    "QwenImageControlNetPipeline": QwenImageControlNetPipelineParameters,
 }
 
 


### PR DESCRIPTION
Includes the [InstantX/Qwen-Image-ControlNet-Union](https://huggingface.co/InstantX/Qwen-Image-ControlNet-Union) control net model, which supports these control image types: Canny, Soft Edge, Depth, Pose.

Below is an example of using a pose control image:

<img width="2408" height="923" alt="Screenshot 2025-11-24 at 8 55 56 AM" src="https://github.com/user-attachments/assets/2c902ed0-afc0-4a56-9324-dc3f2cbf03b7" />

resolves #3257 
