### PR TITLE
feat: add GetFlowSnapshotRequest for complete flow state introspection

### DIFF
--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -516,7 +516,6 @@ class ConnectionState:
     """Represents the complete state of a connection.
 
     Attributes:
-        connection_id: Unique identifier for this connection
         source_node_name: Name of the source node
         source_parameter_name: Name of the source parameter
         source_parameter_type: Type of the source parameter
@@ -525,7 +524,6 @@ class ConnectionState:
         target_parameter_type: Type of the target parameter
     """
 
-    connection_id: str
     source_node_name: str
     source_parameter_name: str
     source_parameter_type: str

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -530,7 +530,6 @@ class FlowManager:
 
         for connection in flow_connections:
             connection_state = ConnectionState(
-                connection_id=str(id(connection)),
                 source_node_name=connection.source_node.name,
                 source_parameter_name=connection.source_parameter.name,
                 source_parameter_type=connection.source_parameter.type,


### PR DESCRIPTION
Add new GetFlowSnapshotRequest that returns a complete snapshot of a flow's runtime state including all nodes and connections using actual node names (not UUIDs).

- Add NodeState and ConnectionState dataclasses for clean data structure
- Implement on_get_flow_snapshot_request handler in FlowManager
- Returns comprehensive node info: name, type, library, metadata, lock state, resolution state, and all parameter values
- Returns complete connection info: node names, parameter names, and types
- Ideal for runtime introspection, monitoring, and flow visualization

This differs from the existing GetFlowStateRequest (in execution_events.py) which returns execution state (control/resolving nodes), not structural state.