### PR TITLE
chore: version bump engine and node libraries in templates

### DIFF
--- a/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
+++ b/libraries/griptape_nodes_library/workflows/templates/compare_prompts.py
@@ -3,9 +3,9 @@
 #
 # [tool.griptape-nodes]
 # name = "compare_prompts"
-# schema_version = "0.11.0"
-# engine_version_created_with = "0.60.0"
-# node_libraries_referenced = [["Griptape Nodes Library", "0.50.0"]]
+# schema_version = "0.13.0"
+# engine_version_created_with = "0.64.1"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.51.1"]]
 # node_types_used = [["Griptape Nodes Library", "Agent"], ["Griptape Nodes Library", "GenerateImage"], ["Griptape Nodes Library", "MergeTexts"], ["Griptape Nodes Library", "Note"], ["Griptape Nodes Library", "TextInput"]]
 # description = "See how 3 different approaches to prompts affect image generation."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_compare_prompts.webp"

--- a/libraries/griptape_nodes_library/workflows/templates/coordinating_agents.py
+++ b/libraries/griptape_nodes_library/workflows/templates/coordinating_agents.py
@@ -3,9 +3,9 @@
 #
 # [tool.griptape-nodes]
 # name = "coordinating_agents"
-# schema_version = "0.11.0"
-# engine_version_created_with = "0.60.0"
-# node_libraries_referenced = [["Griptape Nodes Library", "0.50.0"]]
+# schema_version = "0.13.0"
+# engine_version_created_with = "0.64.1"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.51.1"]]
 # node_types_used = [["Griptape Nodes Library", "Agent"], ["Griptape Nodes Library", "DisplayText"], ["Griptape Nodes Library", "MergeTexts"], ["Griptape Nodes Library", "Note"]]
 # description = "Multiple agents with different jobs."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_coordinating_agents.webp"

--- a/libraries/griptape_nodes_library/workflows/templates/fill_in_the_story.py
+++ b/libraries/griptape_nodes_library/workflows/templates/fill_in_the_story.py
@@ -3,9 +3,9 @@
 # 
 # [tool.griptape-nodes]
 # name = "fill_in_the_story"
-# schema_version = "0.11.0"
-# engine_version_created_with = "0.60.2"
-# node_libraries_referenced = [["Griptape Nodes Library", "0.50.0"]]
+# schema_version = "0.13.0"
+# engine_version_created_with = "0.64.1"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.51.1"]]
 # node_types_used = [["Griptape Nodes Library", "Agent"], ["Griptape Nodes Library", "AudioDetails"], ["Griptape Nodes Library", "CombineAudio"], ["Griptape Nodes Library", "DisplayText"], ["Griptape Nodes Library", "ElevenLabsMusicGeneration"], ["Griptape Nodes Library", "ElevenLabsTextToSpeechGeneration"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ExecutePython"], ["Griptape Nodes Library", "KeyValuePair"], ["Griptape Nodes Library", "ListToDictKeys"], ["Griptape Nodes Library", "Math"], ["Griptape Nodes Library", "MergeKeyValuePairs"], ["Griptape Nodes Library", "MergeTexts"], ["Griptape Nodes Library", "Note"], ["Griptape Nodes Library", "Ruleset"], ["Griptape Nodes Library", "SeedreamImageGeneration"], ["Griptape Nodes Library", "SplitText"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "TextInput"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = true
 # description = "Create vocal and music tracks with a fill-in-the-blank story workflow."

--- a/libraries/griptape_nodes_library/workflows/templates/photography_team.py
+++ b/libraries/griptape_nodes_library/workflows/templates/photography_team.py
@@ -3,9 +3,9 @@
 #
 # [tool.griptape-nodes]
 # name = "photography_team"
-# schema_version = "0.11.0"
-# engine_version_created_with = "0.60.0"
-# node_libraries_referenced = [["Griptape Nodes Library", "0.50.0"]]
+# schema_version = "0.13.0"
+# engine_version_created_with = "0.64.1"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.51.1"]]
 # node_types_used = [["Griptape Nodes Library", "Agent"], ["Griptape Nodes Library", "AgentToTool"], ["Griptape Nodes Library", "GenerateImage"], ["Griptape Nodes Library", "Note"], ["Griptape Nodes Library", "Ruleset"], ["Griptape Nodes Library", "ToolList"]]
 # description = "A team of experts develop a prompt."
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_photography_team.webp"

--- a/libraries/griptape_nodes_library/workflows/templates/prompt_an_image.py
+++ b/libraries/griptape_nodes_library/workflows/templates/prompt_an_image.py
@@ -3,9 +3,9 @@
 #
 # [tool.griptape-nodes]
 # name = "prompt_an_image"
-# schema_version = "0.11.0"
-# engine_version_created_with = "0.60.0"
-# node_libraries_referenced = [["Griptape Nodes Library", "0.50.0"]]
+# schema_version = "0.13.0"
+# engine_version_created_with = "0.64.1"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.51.1"]]
 # node_types_used = [["Griptape Nodes Library", "GenerateImage"], ["Griptape Nodes Library", "Note"]]
 # image = "https://raw.githubusercontent.com/griptape-ai/griptape-nodes/refs/heads/main/libraries/griptape_nodes_library/workflows/templates/thumbnail_prompt_an_image.webp"
 # description = "The simplest image generation workflow."


### PR DESCRIPTION
## Description
Bumped version metadata in all template workflow files to reflect current engine and node library versions.

## Changes
Updated the following metadata fields in all template files:
- `schema_version`: `0.11.0` → `0.13.0`
- `engine_version_created_with`: `0.60.0`/`0.60.2` → `0.64.1`
- `node_libraries_referenced`: `[["Griptape Nodes Library", "0.50.0"]]` → `[["Griptape Nodes Library", "0.51.1"]]`

## Files Changed
- `compare_prompts.py`
- `coordinating_agents.py`
- `fill_in_the_story.py`
- `photography_team.py`
- `prompt_an_image.py`

## Testing
- [x] Verified only version metadata lines were changed
- [x] No formatting or code changes
- [x] Clean diff with 15 insertions, 15 deletions

@shhlife - Ready for review