### PR TITLE
feat: remove old XDG library paths from libraries_to_register

### DIFF
--- a/src/griptape_nodes/cli/commands/init.py
+++ b/src/griptape_nodes/cli/commands/init.py
@@ -9,6 +9,7 @@ from rich.box import HEAVY_EDGE
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
+from xdg_base_dirs import xdg_data_home
 
 from griptape_nodes.cli.shared import (
     CONFIG_DIR,
@@ -527,6 +528,18 @@ def _build_libraries_list(
 
     new_downloads = current_downloads.copy()
     new_register = current_register.copy()
+
+    # Remove old XDG data home library paths from libraries_to_register
+    xdg_libraries_base = str(xdg_data_home() / "griptape_nodes" / "libraries")
+    old_library_names = [
+        "griptape_nodes_library",
+        "griptape_nodes_advanced_media_library",
+        "griptape_cloud",
+    ]
+
+    for lib_name in old_library_names:
+        old_path_prefix = f"{xdg_libraries_base}/{lib_name}/"
+        new_register = [path for path in new_register if not path.startswith(old_path_prefix)]
 
     # Create a set of current download identifiers for fast lookup
     current_download_identifiers = {extract_repo_name_from_url(lib) for lib in current_downloads}


### PR DESCRIPTION
Filter out old library paths from libraries_to_register config during `gtn init` to prevent using stale XDG data home locations. The libraries will be re-added automatically via the libraries_to_download mechanism.

- Add xdg_data_home import from xdg_base_dirs
- Filter out paths starting with {xdg_data_home}/griptape_nodes/libraries/
  for griptape_nodes_library, griptape_nodes_advanced_media_library, and griptape_cloud
