### PR TITLE
fix: don't call register during library download

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2782,18 +2782,6 @@ class LibraryManager:
                     install_deps_result.result_details,
                 )
 
-        # Automatically register the downloaded library
-        register_request = RegisterLibraryFromFileRequest(file_path=str(library_json_path))
-        register_result = await GriptapeNodes.ahandle_request(register_request)
-        if not register_result.succeeded():
-            logger.warning(
-                "Library '%s' was downloaded but registration failed: %s",
-                library_name,
-                register_result.result_details,
-            )
-        else:
-            logger.info("Library '%s' registered successfully", library_name)
-
         # Add library JSON file path to config so it's registered on future startups
         libraries_to_register = config_mgr.get_config_value(
             "app_events.on_app_initialization_complete.libraries_to_register", default=[]


### PR DESCRIPTION
Downloaded libraries are added to `libraries_to_register` which means they will be registered from that mechanism. Registering here is redundant and dangerous (because we error on duplicate registrations).