### PR TITLE
refactor: consolidate app_events config key strings into constants

### DIFF
--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/structure.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/structure.py
@@ -26,7 +26,7 @@ os.environ["GTN_ENABLE_WORKSPACE_FILE_WATCHING"] = "false"
 
 def _set_libraries(libraries: list[str]) -> None:
     from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-    from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER
+    from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
 
     config_manager = GriptapeNodes.ConfigManager()
     config_manager.set_config_value(
@@ -34,7 +34,7 @@ def _set_libraries(libraries: list[str]) -> None:
         value=False,
     )
     config_manager.set_config_value(
-        key=LIBRARIES_TO_REGISTER,
+        key=LIBRARIES_TO_REGISTER_KEY,
         value=libraries,
     )
     config_manager.set_config_value(

--- a/src/griptape_nodes/cli/commands/init.py
+++ b/src/griptape_nodes/cli/commands/init.py
@@ -22,7 +22,7 @@ from griptape_nodes.cli.shared import (
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_DOWNLOAD, LIBRARIES_TO_REGISTER
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_DOWNLOAD_KEY, LIBRARIES_TO_REGISTER_KEY
 from griptape_nodes.utils.git_utils import extract_repo_name_from_url
 from griptape_nodes.utils.library_utils import filter_old_xdg_library_paths
 
@@ -236,11 +236,11 @@ def _handle_additional_library_config(config: InitConfig) -> bool | None:
             register_griptape_cloud_library=register_griptape_cloud_library,
         )
         config_manager.set_config_value(
-            LIBRARIES_TO_DOWNLOAD,
+            LIBRARIES_TO_DOWNLOAD_KEY,
             libraries_config.libraries_to_download,
         )
         config_manager.set_config_value(
-            LIBRARIES_TO_REGISTER,
+            LIBRARIES_TO_REGISTER_KEY,
             libraries_config.libraries_to_register,
         )
         console.print(
@@ -513,8 +513,8 @@ def _build_libraries_list(
 ) -> LibrariesConfig:
     """Builds the lists of libraries to download and register based on library settings."""
     # Get current configuration for both lists
-    download_key = LIBRARIES_TO_DOWNLOAD
-    register_key = LIBRARIES_TO_REGISTER
+    download_key = LIBRARIES_TO_DOWNLOAD_KEY
+    register_key = LIBRARIES_TO_REGISTER_KEY
 
     current_downloads = config_manager.get_config_value(
         download_key,

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -33,7 +33,7 @@ from griptape_nodes.retained_mode.events.config_events import (
     SetConfigValueResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER, Settings
+from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER_KEY, Settings
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
 
 logger = logging.getLogger("griptape_nodes")
@@ -210,7 +210,7 @@ class ConfigManager:
         An exception is made for `workflows_to_register` since resetting it gives the appearance of the user losing their workflows.
         """
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/1241 need a better way to annotate fields to ignore.
-        workflows_to_register = self.get_config_value(WORKFLOWS_TO_REGISTER)
+        workflows_to_register = self.get_config_value(WORKFLOWS_TO_REGISTER_KEY)
         USER_CONFIG_PATH.write_text(
             json.dumps(
                 {
@@ -226,7 +226,7 @@ class ConfigManager:
         self.load_configs()
 
     def save_user_workflow_json(self, workflow_file_name: str) -> None:
-        config_loc = WORKFLOWS_TO_REGISTER
+        config_loc = WORKFLOWS_TO_REGISTER_KEY
         existing_workflows = self.get_config_value(config_loc)
         if not existing_workflows:
             existing_workflows = []
@@ -234,14 +234,14 @@ class ConfigManager:
         self.set_config_value(config_loc, existing_workflows)
 
     def delete_user_workflow(self, workflow_file_name: str) -> None:
-        default_workflows = self.get_config_value(WORKFLOWS_TO_REGISTER)
+        default_workflows = self.get_config_value(WORKFLOWS_TO_REGISTER_KEY)
         if default_workflows:
             default_workflows = [
                 saved_workflow
                 for saved_workflow in default_workflows
                 if (saved_workflow.lower() != workflow_file_name.lower())
             ]
-            self.set_config_value(WORKFLOWS_TO_REGISTER, default_workflows)
+            self.set_config_value(WORKFLOWS_TO_REGISTER_KEY, default_workflows)
 
     def get_full_path(self, relative_path: str) -> Path:
         """Get a full path by combining the base path with a relative path.

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -153,7 +153,7 @@ from griptape_nodes.retained_mode.managers.library_lifecycle.library_provenance.
 )
 from griptape_nodes.retained_mode.managers.library_lifecycle.library_status import LibraryStatus
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
-from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_DOWNLOAD, LIBRARIES_TO_REGISTER
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_DOWNLOAD_KEY, LIBRARIES_TO_REGISTER_KEY
 from griptape_nodes.utils.async_utils import subprocess_run
 from griptape_nodes.utils.dict_utils import merge_dicts
 from griptape_nodes.utils.file_utils import find_file_in_directory
@@ -1711,7 +1711,7 @@ class LibraryManager:
             self.print_library_load_status()
 
             # Remove any missing libraries AFTER we've printed them for the user.
-            user_libraries_section = LIBRARIES_TO_REGISTER
+            user_libraries_section = LIBRARIES_TO_REGISTER_KEY
             self._remove_missing_libraries_from_config(config_category=user_libraries_section)
         finally:
             self._libraries_loading_complete.set()
@@ -1728,7 +1728,7 @@ class LibraryManager:
         Supports URL format with @ref suffix (e.g., "https://github.com/user/repo@stable").
         """
         config_mgr = GriptapeNodes.ConfigManager()
-        user_libraries_section = LIBRARIES_TO_DOWNLOAD
+        user_libraries_section = LIBRARIES_TO_DOWNLOAD_KEY
         config_libraries = config_mgr.get_config_value(user_libraries_section, default=[])
 
         # Get libraries directory
@@ -1868,7 +1868,7 @@ class LibraryManager:
         config_mgr = GriptapeNodes.ConfigManager()
 
         # Get the current libraries_to_register list
-        user_libraries_section = LIBRARIES_TO_REGISTER
+        user_libraries_section = LIBRARIES_TO_REGISTER_KEY
         libraries_to_register: list[str] = config_mgr.get_config_value(user_libraries_section)
 
         # Filter out empty or whitespace-only entries
@@ -2294,8 +2294,8 @@ class LibraryManager:
         config_mgr = GriptapeNodes.ConfigManager()
 
         # Get both config lists
-        register_key = LIBRARIES_TO_REGISTER
-        download_key = LIBRARIES_TO_DOWNLOAD
+        register_key = LIBRARIES_TO_REGISTER_KEY
+        download_key = LIBRARIES_TO_DOWNLOAD_KEY
 
         libraries_to_register = config_mgr.get_config_value(register_key)
         libraries_to_download = config_mgr.get_config_value(download_key) or []
@@ -2422,7 +2422,7 @@ class LibraryManager:
             List of library file paths found
         """
         config_mgr = GriptapeNodes.ConfigManager()
-        user_libraries_section = LIBRARIES_TO_REGISTER
+        user_libraries_section = LIBRARIES_TO_REGISTER_KEY
 
         discovered_libraries = set()
 
@@ -2923,11 +2923,11 @@ class LibraryManager:
                 logger.info("Library '%s' registered successfully", library_name)
 
         # Add library JSON file path to config so it's registered on future startups
-        libraries_to_register = config_mgr.get_config_value(LIBRARIES_TO_REGISTER, default=[])
+        libraries_to_register = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
         library_json_str = str(library_json_path)
         if library_json_str not in libraries_to_register:
             libraries_to_register.append(library_json_str)
-            config_mgr.set_config_value(LIBRARIES_TO_REGISTER, libraries_to_register)
+            config_mgr.set_config_value(LIBRARIES_TO_REGISTER_KEY, libraries_to_register)
             logger.info("Added library '%s' to config for auto-registration on startup", library_name)
 
         if skip_clone:
@@ -3025,7 +3025,7 @@ class LibraryManager:
 
         # Phase 1: Download missing libraries from config
         config_mgr = GriptapeNodes.ConfigManager()
-        user_libraries_section = LIBRARIES_TO_REGISTER
+        user_libraries_section = LIBRARIES_TO_REGISTER_KEY
         config_libraries = config_mgr.get_config_value(user_libraries_section, default=[])
 
         libraries_dir_setting = config_mgr.get_config_value("libraries_directory")

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -41,7 +41,7 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD
+from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD_KEY
 from griptape_nodes.utils.async_utils import cancel_subprocess
 
 if TYPE_CHECKING:
@@ -676,7 +676,7 @@ class ModelManager:
         """
         # Get models to download from configuration
         config_manager = GriptapeNodes.ConfigManager()
-        models_to_download = config_manager.get_config_value(MODELS_TO_DOWNLOAD, default=[])
+        models_to_download = config_manager.get_config_value(MODELS_TO_DOWNLOAD_KEY, default=[])
 
         # Find unfinished downloads to resume
         unfinished_models = await asyncio.to_thread(self._find_unfinished_downloads)

--- a/src/griptape_nodes/retained_mode/managers/operation_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/operation_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Self
 
-from griptape_nodes.retained_mode.managers.settings import EVENTS_TO_ECHO
+from griptape_nodes.retained_mode.managers.settings import EVENTS_TO_ECHO_KEY
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -440,7 +440,7 @@ class OperationDepthManager:
         self.payload_converter = PayloadConverter()
 
         # Ask the config manager for the list of events we want echoed.
-        config_events = config_mgr.get_config_value(EVENTS_TO_ECHO)
+        config_events = config_mgr.get_config_value(EVENTS_TO_ECHO_KEY)
         self.events_to_echo = set(config_events)
 
     def __enter__(self) -> Self:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -23,7 +23,7 @@ from griptape_nodes.retained_mode.events.secrets_events import (
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.settings import SECRETS_TO_REGISTER
+from griptape_nodes.retained_mode.managers.settings import SECRETS_TO_REGISTER_KEY
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -61,7 +61,7 @@ class SecretsManager:
         """
         secret_names = set()
 
-        secrets_to_register = self.config_manager.get_config_value(SECRETS_TO_REGISTER, default=[])
+        secrets_to_register = self.config_manager.get_config_value(SECRETS_TO_REGISTER_KEY, default=[])
 
         secret_names.update(secrets_to_register)
 

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -6,13 +6,13 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, field_validator
 from pydantic import Field as PydanticField
 
-LIBRARIES_TO_REGISTER = "app_events.on_app_initialization_complete.libraries_to_register"
-LIBRARIES_TO_DOWNLOAD = "app_events.on_app_initialization_complete.libraries_to_download"
-WORKFLOWS_TO_REGISTER = "app_events.on_app_initialization_complete.workflows_to_register"
-SECRETS_TO_REGISTER = "app_events.on_app_initialization_complete.secrets_to_register"
-MODELS_TO_DOWNLOAD = "app_events.on_app_initialization_complete.models_to_download"
-PROJECTS_TO_REGISTER = "app_events.on_app_initialization_complete.projects_to_register"
-EVENTS_TO_ECHO = "app_events.events_to_echo_as_retained_mode"
+LIBRARIES_TO_REGISTER_KEY = "app_events.on_app_initialization_complete.libraries_to_register"
+LIBRARIES_TO_DOWNLOAD_KEY = "app_events.on_app_initialization_complete.libraries_to_download"
+WORKFLOWS_TO_REGISTER_KEY = "app_events.on_app_initialization_complete.workflows_to_register"
+SECRETS_TO_REGISTER_KEY = "app_events.on_app_initialization_complete.secrets_to_register"
+MODELS_TO_DOWNLOAD_KEY = "app_events.on_app_initialization_complete.models_to_download"
+PROJECTS_TO_REGISTER_KEY = "app_events.on_app_initialization_complete.projects_to_register"
+EVENTS_TO_ECHO_KEY = "app_events.events_to_echo_as_retained_mode"
 
 
 class Category(BaseModel):

--- a/src/griptape_nodes/retained_mode/managers/sync_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/sync_manager.py
@@ -25,7 +25,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     RegisterWorkflowsFromConfigResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER
+from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER_KEY
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
@@ -491,7 +491,7 @@ class SyncManager:
         if synced_workflows:
             logger.info("Registering %d synced workflows from configuration", len(synced_workflows))
             try:
-                register_request = RegisterWorkflowsFromConfigRequest(config_section=WORKFLOWS_TO_REGISTER)
+                register_request = RegisterWorkflowsFromConfigRequest(config_section=WORKFLOWS_TO_REGISTER_KEY)
                 register_result = GriptapeNodes.handle_request(register_request)
 
                 if isinstance(register_result, RegisterWorkflowsFromConfigResultSuccess):

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -70,12 +70,12 @@ async def setup_test_libraries(griptape_nodes: GriptapeNodes) -> AsyncGenerator[
     config_manager = griptape_nodes.ConfigManager()
 
     # Save the original libraries state
-    original_libraries = config_manager.get_config_value(key=LIBRARIES_TO_REGISTER, default=[])
+    original_libraries = config_manager.get_config_value(key=LIBRARIES_TO_REGISTER_KEY, default=[])
 
     # Set the test libraries
     test_libraries = [str(lib) for lib in get_libraries()]
     config_manager.set_config_value(
-        key=LIBRARIES_TO_REGISTER,
+        key=LIBRARIES_TO_REGISTER_KEY,
         value=test_libraries,
     )
 
@@ -83,7 +83,7 @@ async def setup_test_libraries(griptape_nodes: GriptapeNodes) -> AsyncGenerator[
 
     # Restore original libraries state
     config_manager.set_config_value(
-        key=LIBRARIES_TO_REGISTER,
+        key=LIBRARIES_TO_REGISTER_KEY,
         value=original_libraries,
     )
 


### PR DESCRIPTION
Create config key constants in settings.py for app_events configuration keys to eliminate string duplication across the codebase. This improves maintainability and reduces the risk of typos when accessing config values.

Changes:
- Add 7 config key constants to settings.py:
  - LIBRARIES_TO_REGISTER
  - LIBRARIES_TO_DOWNLOAD
  - WORKFLOWS_TO_REGISTER
  - SECRETS_TO_REGISTER
  - MODELS_TO_DOWNLOAD
  - PROJECTS_TO_REGISTER
  - EVENTS_TO_ECHO


Closes https://github.com/griptape-ai/griptape-nodes/issues/3351
