### PR TITLE
fix: add fail_on_exists parameter to handle CLI vs startup downloads

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -711,6 +711,8 @@ class DownloadLibraryRequest(RequestPayload):
         install_dependencies: If True, automatically install dependencies after downloading (default: True)
         overwrite_existing: If True, delete existing directory before cloning (default: False)
         auto_register: If True, automatically register library after download (default: True)
+        fail_on_exists: If True, fail with retryable error when directory exists and overwrite_existing=False.
+                       If False, skip clone and register existing library (idempotent). (default: True)
 
     Results: DownloadLibraryResultSuccess (with library info) | DownloadLibraryResultFailure (clone error, directory exists)
     """
@@ -722,6 +724,7 @@ class DownloadLibraryRequest(RequestPayload):
     install_dependencies: bool = True
     overwrite_existing: bool = False
     auto_register: bool = True
+    fail_on_exists: bool = True
 
 
 @dataclass


### PR DESCRIPTION
Commit 6efefb0bd made library downloads idempotent (skip clone + register if directory exists), which fixed automatic startup behavior but broke the interactive UI retry pattern where users expect explicit conflict errors with guidance to use --overwrite.

Solution:
Add fail_on_exists boolean parameter to DownloadLibraryRequest that controls behavior when directory exists and overwrite_existing=False. Defaults to True (fail on conflict) for safer, more explicit behavior.

Changes:
- Add fail_on_exists parameter to DownloadLibraryRequest (default: True)
- Update download_library_request handler to check fail_on_exists flag when directory exists and overwrite_existing=False
- Set fail_on_exists=False in startup downloads for idempotent behavior
- Set fail_on_exists=False in sync downloads for consistency
- UI uses default True for explicit conflict errors

<img width="814" height="657" alt="image" src="https://github.com/user-attachments/assets/440e0e4e-6a1d-44e0-a628-e40eaa5a511b" />


Behavior after changes:

| Scenario                      | fail_on_exists | overwrite | Dir Exists? | Result                              |
|-------------------------------|----------------|-----------|-------------|-------------------------------------|
| UI first download            | True (default) | False     | No          | Success - downloads library         |
| UI retry without --overwrite | True (default) | False     | Yes         | Failure - retryable conflict error  |
| UI retry with --overwrite    | True (default) | True      | Yes         | Success - deletes and re-downloads  |
| Startup first run             | False          | False     | No          | Success - downloads library         |
| Startup subsequent runs       | False          | False     | Yes         | Success - skips clone, registers    |

Fixes the regression introduced in 6efefb0bdc4b while maintaining the desired idempotent behavior for automatic/startup downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)