### PR TITLE
refactor: replace 'if not result.succeeded()' with 'if result.failed()'

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/engine/engine_node.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/engine/engine_node.py
@@ -384,7 +384,7 @@ class EngineNode(SuccessFailureNode):
         for param_name in plan.to_remove:
             remove_request = RemoveParameterFromNodeRequest(parameter_name=param_name, node_name=self.name)
             result = GriptapeNodes.handle_request(remove_request)
-            if not result.succeeded():
+            if result.failed():
                 logger.error("Failed to remove parameter %s: %s", param_name, result.result_details)
 
         # Add new parameters for this group
@@ -460,7 +460,7 @@ class EngineNode(SuccessFailureNode):
             if self.get_parameter_by_name(param.name) is not None:
                 remove_request = RemoveParameterFromNodeRequest(parameter_name=param.name, node_name=self.name)
                 result = GriptapeNodes.handle_request(remove_request)
-                if not result.succeeded():
+                if result.failed():
                     logger.error("Failed to remove parameter %s: %s", param.name, result.result_details)
 
         # Reset static UI elements to explanatory content
@@ -644,7 +644,7 @@ class EngineNode(SuccessFailureNode):
         )
 
         result = GriptapeNodes.handle_request(add_request)
-        if not result.succeeded():
+        if result.failed():
             logger.error(
                 "Failed to create input parameter %s: %s",
                 param_name,
@@ -783,7 +783,7 @@ class EngineNode(SuccessFailureNode):
         )
 
         result = GriptapeNodes.handle_request(add_request)
-        if not result.succeeded():
+        if result.failed():
             logger.error(
                 "Failed to create output parameter %s: %s",
                 param_name,

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -588,7 +588,7 @@ class FlowManager:
             and self._global_control_flow_machine.context.flow_name == flow.name
         ):
             result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow.name))
-            if not result.succeeded():
+            if result.failed():
                 details = f"Attempted to delete flow '{flow_name}'. Failed because running flow could not cancel."
                 return DeleteFlowResultFailure(result_details=details)
 
@@ -2514,7 +2514,7 @@ class FlowManager:
             ValidateFlowDependenciesRequest(flow_name=flow_name, flow_node_name=start_node.name if start_node else None)
         )
         try:
-            if not result.succeeded():
+            if result.failed():
                 details = f"Couldn't start flow with name {flow_name}. Flow Validation Failed"
                 return StartFlowResultFailure(validation_exceptions=[], result_details=details)
             result = cast("ValidateFlowDependenciesResultSuccess", result)
@@ -2573,7 +2573,7 @@ class FlowManager:
             ValidateFlowDependenciesRequest(flow_name=flow_name, flow_node_name=start_node.name if start_node else None)
         )
         try:
-            if not result.succeeded():
+            if result.failed():
                 details = f"Couldn't start flow with name {flow_name}. Flow Validation Failed"
                 return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
             result = cast("ValidateFlowDependenciesResultSuccess", result)

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -833,7 +833,7 @@ class NodeManager:
                     if control_node in connected_nodes:
                         result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
                         cancelled = True
-                        if not result.succeeded():
+                        if result.failed():
                             details = f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
                             return DeleteNodeResultFailure(result_details=details)
             if resolving_node_names is not None and not cancelled:
@@ -841,7 +841,7 @@ class NodeManager:
                     resolving_node = GriptapeNodes.ObjectManager().get_object_by_name(resolving_node_name)
                     if resolving_node in connected_nodes:
                         result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
-                        if not result.succeeded():
+                        if result.failed():
                             details = f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
                             return DeleteNodeResultFailure(result_details=details)
                         break  # Only need to cancel once
@@ -2468,7 +2468,7 @@ class NodeManager:
         # Validate here.
         result = self.on_validate_node_dependencies_request(ValidateNodeDependenciesRequest(node_name=node_name))
         try:
-            if not result.succeeded():
+            if result.failed():
                 details = f"Failed to resolve node '{node_name}'. Flow Validation Failed"
                 return StartFlowResultFailure(validation_exceptions=[], result_details=details)
             result = cast("ValidateNodeDependenciesResultSuccess", result)
@@ -3018,7 +3018,7 @@ class NodeManager:
                 target_parameter_name=connection_command.target_parameter_name,
             )
             result = GriptapeNodes.handle_request(connection_request)
-            if not result.succeeded():
+            if result.failed():
                 details = f"Failed to create a connection between {connection_request.source_node_name} and {connection_request.target_node_name}"
                 logger.warning(details)
         return DeserializeSelectedNodesFromCommandsResultSuccess(
@@ -3030,7 +3030,7 @@ class NodeManager:
         result = GriptapeNodes.handle_request(
             SerializeSelectedNodesToCommandsRequest(nodes_to_serialize=request.nodes_to_duplicate)
         )
-        if not result.succeeded():
+        if result.failed():
             details = "Failed to serialized selected nodes."
             return DuplicateSelectedNodesResultFailure(result_details=details)
         result = GriptapeNodes.handle_request(DeserializeSelectedNodesFromCommandsRequest(positions=request.positions))

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -118,7 +118,7 @@ class ObjectManager:
         for flow_name in flows:
             if GriptapeNodes.FlowManager().check_for_existing_running_flow():
                 result = await GriptapeNodes.ahandle_request(CancelFlowRequest(flow_name=flow_name))
-                if not result.succeeded():
+                if result.failed():
                     details = f"Attempted to clear all object state and delete everything. Failed because running flow '{flow_name}' could not cancel."
                     logger.error(details)
                     return ClearAllObjectStateResultFailure(result_details=details)

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -928,7 +928,7 @@ class RetainedMode:
         )
         result = GriptapeNodes().handle_request(request)
 
-        if not result.succeeded():
+        if result.failed():
             return False, result
 
         # Navigate through indices
@@ -983,7 +983,7 @@ class RetainedMode:
         )
         result = GriptapeNodes().handle_request(request)
 
-        if not result.succeeded():
+        if result.failed():
             return result
 
         # Navigate to the proper location and set the value
@@ -1169,7 +1169,7 @@ class RetainedMode:
             )
             result = GriptapeNodes().handle_request(request)
 
-            if not result.succeeded():
+            if result.failed():
                 logger.error(
                     'set_value failed for "%s.%s", failed to get value for container "%s".',
                     node,


### PR DESCRIPTION
Replace all occurrences of the pattern 'if not result.succeeded()' with the more readable 'if result.failed()' throughout the codebase.

Fixes #363