### PR TITLE
fix: sync libraries from both config keys and eliminate code duplication

### DIFF
--- a/src/griptape_nodes/cli/commands/libraries.py
+++ b/src/griptape_nodes/cli/commands/libraries.py
@@ -8,7 +8,6 @@ from griptape_nodes.cli.shared import console
 from griptape_nodes.retained_mode.events.library_events import (
     DownloadLibraryRequest,
     DownloadLibraryResultSuccess,
-    LoadLibrariesRequest,
     SyncLibrariesRequest,
     SyncLibrariesResultSuccess,
 )
@@ -29,15 +28,6 @@ def sync(
 
 async def _sync_libraries(*, install_dependencies: bool, overwrite_existing: bool) -> None:
     """Sync all libraries by checking for updates and installing dependencies."""
-    console.print("[bold cyan]Loading libraries...[/bold cyan]")
-
-    # First, load libraries from configuration
-    load_request = LoadLibrariesRequest()
-    load_result = await GriptapeNodes.ahandle_request(load_request)
-    if not load_result.succeeded():
-        console.print(f"[red]Failed to load libraries: {load_result.result_details}[/red]")
-        return
-
     console.print("[bold cyan]Syncing libraries...[/bold cyan]")
 
     # Create sync request with provided parameters


### PR DESCRIPTION
Refactor library synchronization to handle both LIBRARIES_TO_DOWNLOAD_KEY and LIBRARIES_TO_REGISTER_KEY, fixing incomplete sync operations when libraries are specified in either config key.

Extract duplicate download logic into shared _download_libraries_from_git_urls method that both _ensure_libraries_from_config and sync_libraries_request use.

Changes:
- Add _download_libraries_from_git_urls method for concurrent library downloads
- Refactor _ensure_libraries_from_config to use shared download method
- Update sync_libraries_request to:
  - Collect git URLs from both LIBRARIES_TO_DOWNLOAD_KEY and LIBRARIES_TO_REGISTER_KEY
  - Use shared download method instead of nested function
  - Add Phase 2 to load newly downloaded libraries before updating
- Simplify CLI _sync_libraries by removing redundant LoadLibrariesRequest call
- Remove LoadLibrariesRequest import from CLI (now unused)