### PR TITLE
fix: update diffusers version to fix missing flux2 error

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -40,7 +40,7 @@
         "beautifulsoup4>=4.13.4",
         "controlnet-aux>=0.0.9",
         "static-ffmpeg>=2.8",
-        "diffusers @ https://github.com/huggingface/diffusers/archive/5ffb73d4aeac9eaef8366d7b21872d64009bd1c7.zip",
+        "diffusers @ https://github.com/huggingface/diffusers/archive/f48f9c250fe7f6027c7445f8be04bb4499583f58.zip",
         "imageio[ffmpeg]>=2.37.2",
         "ninja>=1.13.0",
         "numpy>=2.2.4",


### PR DESCRIPTION
To fix this error in latest:
<img width="398" height="300" alt="Screenshot 2025-12-03 at 8 58 31 AM" src="https://github.com/user-attachments/assets/d32d09b9-43f4-4651-aece-441ec6a643ab" />

logs:
```
Traceback (most recent call last):
  File "C:\Users\dev\griptape-nodes\src\griptape_nodes\retained_mode\managers\node_manager.py", line 379, in on_create_node_request
    node = LibraryRegistry.create_node(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\dev\griptape-nodes\src\griptape_nodes\node_library\library_registry.py", line 246, in create_node
    return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\dev\griptape-nodes\src\griptape_nodes\node_library\library_registry.py", line 338, in create_node
    raise KeyError(msg)
KeyError: "Node type 'DiffusionPipelineBuilderNode' not found in library 'Griptape Nodes Advanced Media Library'"
           WARNING  Created Error Proxy (placeholder) node 'Diffusion Pipeline Builder' to substitute for failed
                    'DiffusionPipelineBuilderNode'
           WARNING  Parameter 'attention_slicing' alteration recorded for ErrorProxyNode 'Diffusion Pipeline Builder'.
                    Original node 'DiffusionPipelineBuilderNode' had loading errors - preserving changes for correct
                    recreation when dependency 'Griptape Nodes Advanced Media Library' is resolved.
           WARNING  Parameter 'vae_slicing' alteration recorded for ErrorProxyNode 'Diffusion Pipeline Builder'.
                    Original node 'DiffusionPipelineBuilderNode' had loading errors - preserving changes for correct
                    recreation when dependency 'Griptape Nodes Advanced Media Library' is resolved.
           WARNING  Parameter 'transformer_layerwise_casting' alteration recorded for ErrorProxyNode 'Diffusion Pipeline
                    Builder'. Original node 'DiffusionPipelineBuilderNode' had loading errors - preserving changes for
                    correct recreation when dependency 'Griptape Nodes Advanced Media Library' is resolved.
           WARNING  Parameter 'cpu_offload_strategy' alteration recorded for ErrorProxyNode 'Diffusion Pipeline
                    Builder'. Original node 'DiffusionPipelineBuilderNode' had loading errors - preserving changes for
                    correct recreation when dependency 'Griptape Nodes Advanced Media Library' is resolved.
           WARNING  Parameter 'quantization_mode' alteration recorded for ErrorProxyNode 'Diffusion Pipeline Builder'.
                    Original node 'DiffusionPipelineBuilderNode' had loading errors - preserving changes for correct
                    recreation when dependency 'Griptape Nodes Advanced Media Library' is resolved.
Traceback (most recent call last):
  File "C:\Users\dev\griptape-nodes\src\griptape_nodes\retained_mode\managers\node_manager.py", line 379, in on_create_node_request
    node = LibraryRegistry.create_node(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\dev\griptape-nodes\src\griptape_nodes\node_library\library_registry.py", line 246, in create_node
    return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\dev\griptape-nodes\src\griptape_nodes\node_library\library_registry.py", line 338, in create_node
    raise KeyError(msg)
KeyError: "Node type 'DiffusionPipelineRuntimeNode' not found in library 'Griptape Nodes Advanced Media Library'"
           WARNING  Created Error Proxy (placeholder) node 'Generate Image (Diffusion Pipeline)' to substitute for
                    failed 'DiffusionPipelineRuntimeNode'
[08:16:30] INFO     Save workflow: scenario=first_save, file_name=workflow_1,
                    file_path=C:\Users\dev\Documents\GriptapeNodes\workflow_1.py, branched_from=None
UserWarning: timeout has no effect in blocking mode
           INFO     Successfully saved workflow to: C:\Users\dev\Documents\GriptapeNodes\workflow_1.py
[08:16:31] ERROR    Attempted to load node 'DiffusionPipelineBuilderNode' from
                    'C:\Users\dev\griptape-nodes\libraries\griptape_nodes_advanced_media_library\diffusers_nodes_library
                    \common\nodes\diffusion_pipeline_builder_node.py'. Failed because module could not be imported:
                    Attempted to load class 'DiffusionPipelineBuilderNode'. Error: Error reloading module
                    gtn_dynamic_module_diffusion_pipeline_builder_node_py_-1189608035407188221 from
                    C:\Users\dev\griptape-nodes\libraries\griptape_nodes_advanced_media_library\diffusers_nodes_library\
                    common\nodes\diffusion_pipeline_builder_node.py: module diffusers has no attribute Flux2Pipeline
           ERROR    Attempted to load node 'DiffusionPipelineRuntimeNode' from
                    'C:\Users\dev\griptape-nodes\libraries\griptape_nodes_advanced_media_library\diffusers_nodes_library
                    \common\nodes\diffusion_pipeline_runtime_node.py'. Failed because module could not be imported:
                    Attempted to load class 'DiffusionPipelineRuntimeNode'. Error: Error reloading module
                    gtn_dynamic_module_diffusion_pipeline_runtime_node_py_1789418205027004861 from
                    C:\Users\dev\griptape-nodes\libraries\griptape_nodes_advanced_media_library\diffusers_nodes_library\
                    common\nodes\diffusion_pipeline_runtime_node.py: module diffusers has no attribute Flux2Pipeline
```


Notes:
- When running from source, I needed to manually delete the `.venv` folder at `griptape-nodes\libraries\griptape_nodes_advanced_media_library\.venv` for it to reinstall dependencies after updating the dependencies in the griptape json file.
