### PR TITLE
fix: respect user config log_level for griptape_nodes logger

### DIFF
--- a/libraries/griptape_cloud/griptape_cloud/assets/create_asset_url.py
+++ b/libraries/griptape_cloud/griptape_cloud/assets/create_asset_url.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from griptape_cloud_client.models.bucket_detail import BucketDetail
 
 logger = logging.getLogger("griptape_nodes")
-logger.setLevel(logging.INFO)
 
 
 class CreateAssetUrl(BaseGriptapeCloudNode, ControlNode):

--- a/libraries/griptape_cloud/griptape_cloud/assets/upload_asset.py
+++ b/libraries/griptape_cloud/griptape_cloud/assets/upload_asset.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     from griptape_cloud_client.models.bucket_detail import BucketDetail
 
 logger = logging.getLogger("griptape_nodes")
-logger.setLevel(logging.INFO)
 
 
 class UploadAsset(BaseGriptapeCloudNode, ControlNode):

--- a/libraries/griptape_cloud/griptape_cloud/base/base_griptape_cloud_node.py
+++ b/libraries/griptape_cloud/griptape_cloud/base/base_griptape_cloud_node.py
@@ -13,9 +13,7 @@ DEFAULT_GRIPTAPE_CLOUD_ENDPOINT = urljoin(base=DEFAULT_GRIPTAPE_CLOUD_URL, url="
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("griptape_nodes")
-logger.setLevel(logging.INFO)
 
 
 class BaseGriptapeCloudNode(BaseNode, GriptapeCloudApiMixin):

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -94,9 +94,13 @@ class EventLogHandler(logging.Handler):
 # Logger for this module. Important that this is not the same as the griptape_nodes logger or else we'll have infinite log events.
 logger = logging.getLogger("griptape_nodes_app")
 
+# Get configured log level from config
+log_level_str = config_manager.get_config_value("log_level").upper()
+log_level = logging.getLevelNamesMapping()[log_level_str]
+
 griptape_nodes_logger = logging.getLogger("griptape_nodes")
 griptape_nodes_logger.addHandler(EventLogHandler())
-griptape_nodes_logger.setLevel(logging.INFO)
+griptape_nodes_logger.setLevel(log_level)
 
 # Root logger only gets RichHandler for console output
 logging.basicConfig(

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -528,7 +528,9 @@ class ConfigManager:
             level: The log level to set (e.g., 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL').
         """
         try:
-            logger.setLevel(level.upper())
-        except ValueError:
+            level_upper = level.upper()
+            log_level = getattr(logging, level_upper)
+            logger.setLevel(log_level)
+        except (ValueError, AttributeError):
             logger.error("Invalid log level %s. Defaulting to INFO.", level)
             logger.setLevel(logging.INFO)


### PR DESCRIPTION
Remove hardcoded logging.INFO from griptape_nodes logger initialization and instead use the log_level value from user config.