### PR TITLE
Fix: Not losing singular data nodes

### DIFF
--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -483,11 +483,14 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
                         correct_graph = flow_manager.is_node_connected(graph_start_node, node)
                         # This means this node is in the downstream connection of one of this graph.
                         if correct_graph:
+                            # Is the node connected to a graph?
                             disconnected = False
                             if node.name not in dag_builder.start_node_candidates:
                                 dag_builder.start_node_candidates[node.name] = set()
                             dag_builder.start_node_candidates[node.name].add(graph_start_node_name)
                     if disconnected:
+                        # If the node is not connected to any graph, we can add it as it's own graph here.
+                        # It will not cause any overlapping confusion with existing graphs.
                         dag_builder.add_node_with_dependencies(node_to_add, node_to_add.name)
                 flow_manager.global_flow_queue.queue.remove(item)
 


### PR DESCRIPTION
After the update to modify how we queue Dags, I found a bug where if we have a data node that's fully disconnected from the rest of the flow in parallel execution, it gets thrown away from the start node queue without being queued. 