### PR TITLE
deprecate Flux LoRA Training node

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -28,7 +28,7 @@
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Advanced media generation and manipulation nodes for Griptape Nodes.",
-    "library_version": "0.61.2",
+    "library_version": "0.62.1",
     "engine_version": "0.63.0",
     "tags": [
       "Griptape",


### PR DESCRIPTION
https://github.com/griptape-ai/griptape-nodes-lora-training-library is much better

paired with https://github.com/griptape-ai/griptape-nodes-library-advanced-media/pull/1