### PR TITLE
Use hex for image grid color picker

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/display_image_grid.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/display_image_grid.py
@@ -119,7 +119,7 @@ class DisplayImageGrid(ControlNode):
             default_value="#000000",
             tooltip="Background color of the grid (hex color)",
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-            traits={ColorPicker(format="hexa")},
+            traits={ColorPicker(format="hex")},
         )
         self.add_parameter(self.background_color)
 


### PR DESCRIPTION
that was easy
<img width="1123" height="942" alt="Screenshot 2025-12-08 132243" src="https://github.com/user-attachments/assets/5487b705-96a9-428d-a265-b6786dab300b" />
