### PR TITLE
fix: strip trailing slash from base URL to prevent double slashes

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -57,7 +57,8 @@ class StaticFilesManager:
         from griptape_nodes.servers.static import STATIC_SERVER_URL
 
         base_url_config = config_manager.get_config_value("static_server_base_url")
-        base_url = f"{base_url_config}{STATIC_SERVER_URL}"
+        # Strip trailing slash to avoid double slashes when concatenating with STATIC_SERVER_URL
+        base_url = f"{base_url_config.rstrip('/')}{STATIC_SERVER_URL}"
 
         match self.storage_backend:
             case StorageBackend.GTC:


### PR DESCRIPTION
## Summary

Fix double slashes in static file URLs when `static_server_base_url` is configured with a trailing slash.

## Problem

When `static_server_base_url` ends with `/` and `STATIC_SERVER_URL` starts with `/`, the concatenation creates `//` in the URL path:

```
https://example.com//workspace/staticfiles/image.jpeg
```

Instead of:

```
https://example.com/workspace/staticfiles/image.jpeg
```

## Solution

Strip trailing slash from `base_url_config` before concatenating with `STATIC_SERVER_URL`:

```python
base_url = f"{base_url_config.rstrip('/')}{STATIC_SERVER_URL}"
```

## Changes

- `src/griptape_nodes/retained_mode/managers/static_files_manager.py`: Add `.rstrip('/')` to prevent double slashes

Fixes #3424