### PR TITLE
feat(nodes): make Math node a ControlNode for use in For loops

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/number/math.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/number/math.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.traits.options import Options
 
 operations = [
@@ -24,7 +24,13 @@ operations = [
 CHOICES = [f"{op} [{expr}]" for op, expr in operations]
 
 
-class Math(BaseNode):
+class Math(ControlNode):
+    """Math node for performing mathematical operations.
+
+    Extends ControlNode to support control flow, enabling use in For loops
+    and other control flow constructs.
+    """
+
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
         self.add_parameter(
@@ -74,6 +80,7 @@ class Math(BaseNode):
         if parameter.name in ["operation", "A", "B"]:
             result = self.calculate_operation()
             self.parameter_output_values["result"] = result
+            self.publish_update_to_parameter("result", result)
 
             # Update B parameter visibility based on operation
             if parameter.name == "operation":


### PR DESCRIPTION
## Summary

Makes the Math node usable within For loops and other control flow constructs by converting it to a ControlNode.

Closes #3335

## Changes

- Changed `Math` class to extend `ControlNode` instead of `BaseNode`
- This adds control input ("Flow In") and output ("Flow Out") parameters to the node
- Added `publish_update_to_parameter` call to ensure UI updates when values change
- Added docstring explaining the node's purpose

## Why

The Math node was previously a `BaseNode` which lacks control input/output parameters. This meant it couldn't be executed within a For loop where control flow connections are required. By making it a `ControlNode`, users can now connect it into control flow chains and use it within loops.

## Testing

The node retains all existing mathematical functionality while gaining the ability to participate in control flow.