### PR TITLE
chore: bump v0.65.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.65.2"
+version = "0.65.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.65.2"
+version = "0.65.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.65`.

Cherry-picked commit: a283e54c8a4659705a1079abd259f3ca9984dc2e