### PR TITLE
fix(lists): fix GetFromList node not outputting item on creation

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/lists/get_from_list.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/lists/get_from_list.py
@@ -37,6 +37,7 @@ class GetFromList(ControlNode):
             tooltip="Index to get the item from",
             input_types=["int", "float"],
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            default_value=0,
         )
         self.add_parameter(self.index)
 
@@ -108,3 +109,4 @@ class GetFromList(ControlNode):
     def process(self) -> None:
         item = self._get_item()
         self.parameter_output_values["item"] = item
+        self.publish_update_to_parameter("item", item)


### PR DESCRIPTION
## Summary

- Fixes `GetFromList` node not outputting the item when the node is first created
- Adds `default_value=0` to the `index` parameter so it's not `None` on creation
- Adds `publish_update_to_parameter` call in `process()` to propagate the output value

## Test Plan

- [ ] Create a `GetFromList` node
- [ ] Connect a list to the `items` input
- [ ] Verify the `item` output is populated with the first item (index 0) without needing to change the index value

Fixes #3436