### PR TITLE
fix: connection error for create image list

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/lists/create_image_list.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/lists/create_image_list.py
@@ -10,7 +10,7 @@ class CreateImageList(BaseCreateListNode):
         super().__init__(
             name,
             metadata,
-            input_types=["ImageUrlArtifact"],
+            input_types=["ImageUrlArtifact", "str"],
             output_type="list",
             default_value=None,
             items_tooltip="List of image items to add to",


### PR DESCRIPTION
This fixes a connection error for Create Image List that would happen if you're conecting an image to the ImageList w/out clicking first to create an input.

Previously we would get this error when trying to connect a LoadImage node to the list:

```
[04:46:30] ERROR    Connection failed on type mismatch "Load Image.path" type(str) to "Create Image List.items_ParameterListUniqueParamID_93235c180c5a47dc9fec988fcf97238f"      
                    types(['ImageUrlArtifact'])                                                                                                                                  
```

Now images will connect properly.

<img width="1055" height="783" alt="image" src="https://github.com/user-attachments/assets/f130eaad-81db-4a69-8761-e79f607db62c" />
