### PR TITLE
chore(library): update default library metadata

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -29,10 +29,7 @@
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.52.10",
     "engine_version": "0.65.0",
-    "tags": [
-      "Griptape",
-      "AI"
-    ],
+    "tags": ["Griptape", "AI"],
     "dependencies": {
       "pip_dependencies": [
         "griptape[drivers-prompt-amazon-bedrock,drivers-prompt-anthropic,drivers-prompt-cohere,drivers-prompt-ollama,drivers-web-scraper-trafilatura,drivers-web-search-duckduckgo,drivers-web-search-exa,loaders-image,loaders-pdf]>=1.8.12",
@@ -1464,7 +1461,7 @@
       "metadata": {
         "category": "image",
         "description": "Create an image with text rendered on it",
-        "display_name": "Add Text to Image",
+        "display_name": "Create Text Image",
         "group": "create",
         "icon": "Type"
       }


### PR DESCRIPTION
## Summary
- Normalize default library tag formatting.
- Rename the `AddTextToImage` node display name to **Create Text Image**.

## Test plan
- [ ] Open the node library and confirm tags render as expected.
- [ ] Confirm the node displays as **Create Text Image** in the UI.