### PR TITLE
chore: bump v0.66.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.66.0"
+version = "0.66.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.66.0"
+version = "0.66.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.66`.

Cherry-picked commit: afbdea51a9a6e70f02ad85d445280c620a0f66ba