### PR TITLE
Apply mask to all channels

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.53.0",
+    "library_version": "0.53.1",
     "engine_version": "0.65.0",
     "tags": [
       "Griptape",


### PR DESCRIPTION
The previous mask did not replace RGB channels, resulting in some models that disregard Alpha to ignore the 'masking' and use the original RGB data of the photo