### PR TITLE
chore: bump v0.66.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.66.2"
+version = "0.66.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.66.2"
+version = "0.66.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.66`.

Cherry-picked commit: 7fdeaaa57743cbddd978b59a497ab5f9c97b3771