### PR TITLE
chore: bump griptape_nodes_library to v0.53.3

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.53.2",
+    "library_version": "0.53.3",
     "engine_version": "0.65.0",
     "tags": ["Griptape", "AI"],
     "dependencies": {


### PR DESCRIPTION
standard repo and this repo got out of sync with [0.53.2](https://github.com/griptape-ai/griptape-nodes-library-standard/releases/tag/v0.53.2)