### PR TITLE
chore: bump griptape_nodes_library to v0.54.0

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.53.3",
+    "library_version": "0.54.0",
     "engine_version": "0.65.0",
     "tags": ["Griptape", "AI"],
     "dependencies": {


### PR DESCRIPTION
never too many PRs