### PR TITLE
fix: don't broadcast library loading when opening workflows

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -352,9 +352,11 @@ class RegisterLibraryFromFileResultSuccess(WorkflowAlteredMixin, ResultPayloadSu
 
     Args:
         library_name: Name of the registered library
+        was_already_loaded: True if the library was already loaded, False if it was loaded by this request
     """
 
     library_name: str
+    was_already_loaded: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Noticed a "Loading Libraries" indicator when switching between workflows. Libraries weren't actually being reloaded but it appeared as if they were.