### PR TITLE
Add FAL's FLUX.2-Turbo model

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux2/flux2_parameters.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/flux2/flux2_parameters.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("diffusers_nodes_library")
 
 QUANTIZED_FLUX_2_REPO_IDS = ["diffusers/FLUX.2-dev-bnb-4bit"]
 
-FLUX_2_REPO_IDS = [*QUANTIZED_FLUX_2_REPO_IDS, "black-forest-labs/FLUX.2-dev"]
+FLUX_2_REPO_IDS = [*QUANTIZED_FLUX_2_REPO_IDS, "black-forest-labs/FLUX.2-dev", "fal/FLUX.2-dev-Turbo"]
 
 
 class Flux2PipelineParameters(DiffusionPipelineTypePipelineParameters):

--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -28,7 +28,7 @@
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Advanced media generation and manipulation nodes for Griptape Nodes.",
-    "library_version": "0.63.2",
+    "library_version": "0.63.3",
     "engine_version": "0.65.2",
     "tags": [
       "Griptape",


### PR DESCRIPTION
While not a 1st party model, FAL meets the bar to be added as a supported model: https://huggingface.co/fal/FLUX.2-dev-Turbo