### PR TITLE
docs: resolve developing nodes guide merge conflicts

### DIFF
--- a/docs/how_to/developing_nodes.md
+++ b/docs/how_to/developing_nodes.md
@@ -12,8 +12,8 @@ At a high level:
 - A **Node** is a Python class that defines **parameters** (inputs/outputs/properties) and a `process()` method.
 - A **Workflow (Flow)** is a graph of nodes connected by parameters.
 - Parameters are both:
-  - **UI elements** (what a user sees/edits/connects), and
-  - **type-checked connection points** (what can connect to what).
+    - **UI elements** (what a user sees/edits/connects), and
+    - **type-checked connection points** (what can connect to what).
 
 ### Choose the right base node type
 
@@ -91,9 +91,9 @@ class UppercaseText(DataNode):
 ### Test as you go
 
 - After adding/editing a node, run it in a simple flow and verify:
-  - the parameter UI looks correct (inputs, properties, outputs)
-  - output values update in the UI
-  - validation errors are actionable
+    - the parameter UI looks correct (inputs, properties, outputs)
+    - output values update in the UI
+    - validation errors are actionable
 
 ## Parameters: the practical model
 
@@ -124,8 +124,8 @@ If you need a quick reference, see the **Parameter helper constructs** section i
 ### Containers: `ParameterList` and `ParameterDictionary`
 
 - **`ParameterList`**: use when you want “many of the same thing” in a node UI.
-  - Retrieval: `get_parameter_list_value()` flattens nested iterables.
-  - Note: the current implementation drops falsey items (e.g. `0`, `False`). Preserve those by using `get_parameter_value()` and flattening manually.
+    - Retrieval: `get_parameter_list_value()` flattens nested iterables.
+    - Note: the current implementation drops falsey items (e.g. `0`, `False`). Preserve those by using `get_parameter_value()` and flattening manually.
 - **`ParameterDictionary`**: use when you want ordered key/value entries in the UI.
 
 ### Traits: UI behaviors and validation


### PR DESCRIPTION
### Summary
- Resolves merge conflicts in `docs/how_to/developing_nodes.md` and removes conflict markers.
- Keeps onboarding examples consistent with the engine’s `Parameter` API (`allowed_modes`, `output_type`).
- Fixes minor list indentation in the doc.

### Testing
- [x] Confirmed `docs/how_to/developing_nodes.md` contains **no** `<<<<<<<`, `=======`, or `>>>>>>>` markers.
- [x] Manual review of rendered Markdown structure (lists/code blocks).

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--3603.org.readthedocs.build/en/3603/

<!-- readthedocs-preview griptape-nodes end -->