### PR TITLE
Validate parameter config fields to use for AddParameterToNodeRequest during publish workflow creation

### DIFF
--- a/libraries/griptape_cloud/griptape_nodes_library.json
+++ b/libraries/griptape_cloud/griptape_nodes_library.json
@@ -14,17 +14,11 @@
   "metadata": {
     "author": "Griptape",
     "description": "Collection of nodes for accessing Griptape Cloud APIs and services.",
-    "library_version": "0.61.3",
-    "engine_version": "0.60.2",
-    "tags": [
-      "Griptape",
-      "AI",
-      "Cloud"
-    ],
+    "library_version": "0.67.0",
+    "engine_version": "0.67.0",
+    "tags": ["Griptape", "AI", "Cloud"],
     "dependencies": {
-      "pip_dependencies": [
-        "griptape-cloud-client==0.1.1"
-      ]
+      "pip_dependencies": ["griptape-cloud-client==0.1.1"]
     }
   },
   "categories": [


### PR DESCRIPTION
* Validate parameter config fields to use for AddParameterToNodeRequest during publish workflow creation
  * Some fields on a Parameter are not supported to be set in the  AddParameterToNodeRequest, so this change filters those out