### PR TITLE
Fix subprocess failing on Windows due to missing environment variables

### DIFF
--- a/src/griptape_nodes/bootstrap/utils/python_subprocess_executor.py
+++ b/src/griptape_nodes/bootstrap/utils/python_subprocess_executor.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 _INHERIT_ENV_VARS = [
     "PATH",
     "HOME",
+    "USERPROFILE",
     "TEMP",
     "TMP",
     "COMSPEC",


### PR DESCRIPTION
### Problem

On Windows, spawning subprocesses for workflow execution/publishing fails with:

```
OSError: [WinError 10106] The requested service provider could not be loaded or initialized
```

This occurs when importing asyncio because the _overlapped module requires SystemRoot to be set.

A subsequent error also occurs:
```
RuntimeError: Could not determine home directory.
```

### Cause

`PythonSubprocessExecutor.execute_python_script()` passes the env parameter directly to `asyncio.create_subprocess_exec()`. When env is provided, it completely replaces the 
parent's environment rather than merging with it. Callers were passing minimal env dicts like:

```python
env={"GTN_CONFIG_ENABLE_WORKSPACE_FILE_WATCHING": "false"}
```

This stripped essential system variables (SystemRoot, PATH, USERPROFILE, etc.) that Windows and Python require to function.

### Solution

Added an allowlist of essential environment variables that are inherited from the parent process, with caller-provided variables merged on top. This follows the same 
pattern used by [pyperf](https://github.com/psf/pyperf/blob/main/pyperf/_utils.py#L272).

Inherited variables:
- PATH, HOME, USERPROFILE - basic system paths
- TEMP, TMP - temp directories
- COMSPEC, SystemRoot, SystemDrive - Windows system variables
- PYTHONPATH - Python module resolution