### PR TITLE
ci: don't run workflow tests on PRs

### DIFF
--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -3,8 +3,6 @@ name: Workflow Tests
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
Too finicky and expensive. They'll continue to run on `main`.