### PR TITLE
fixes status by checking for placeholder

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/execution_status_component.py
+++ b/src/griptape_nodes/exe_types/param_components/execution_status_component.py
@@ -105,6 +105,7 @@ class ExecutionStatusComponent:
         self._update_parameter_value(self._result_details, result_details)
         # Update display label: show warning emoji only on actual failure (not placeholder/initialization messages)
         # While string matching is not the best practice, it's currently the only way to check for placeholder messages.
+        # TODO: use a better approach to check for placeholder messages. https://github.com/griptape-ai/griptape-nodes/issues/3686
         is_placeholder = result_details in (
             "<Results will appear when the node executes>",
             "Beginning execution...",


### PR DESCRIPTION
fixes #3666 

Previously the status message on a node  would get a warning message when they weren't actually causing errors. This was due to the node's status being reset during the `validate_before_workflow_run` and `validate_before_node_run` methods in `node_types.py`

```python
    def validate_before_workflow_run(self) -> list[Exception] | None:
        """Clear result details before workflow runs to avoid confusion from previous sessions."""
        self._set_status_results(was_successful=False, result_details="<Results will appear when the node executes>")
        return super().validate_before_workflow_run()

    def validate_before_node_run(self) -> list[Exception] | None:
        """Clear result details before node runs to avoid confusion from previous sessions."""
        self._set_status_results(was_successful=False, result_details="<Results will appear when the node executes>")
        return super().validate_before_node_run()
```

Initially I just set `was_successful=True`, but that's not right because the node hasn't successfully run yet, so instead  we're using string matching. 

it's probably not the most robust way to solve it, but it does fix this issue.

