### PR TITLE
fixes issue where flatten_list caused already-flat lists try and flatten

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.57.0",
+    "library_version": "0.57.1",
     "engine_version": "0.69.0",
     "tags": ["Griptape", "AI"],
     "dependencies": {

--- a/libraries/griptape_nodes_library/griptape_nodes_library/lists/base_create_list.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/lists/base_create_list.py
@@ -86,7 +86,17 @@ class BaseCreateListNode(ControlNode):
         remove_blank = self.get_parameter_value(self.remove_blank.name)
 
         if flatten_list:
-            list_values = [item for sublist in list_values for item in sublist]
+            # Check if list is already flat (no nested lists)
+            has_nested_lists = any(isinstance(item, list) for item in list_values)
+            if has_nested_lists:
+                # Flatten only if there are nested lists
+                flattened = []
+                for item in list_values:
+                    if isinstance(item, list):
+                        flattened.extend(item)
+                    else:
+                        flattened.append(item)
+                list_values = flattened
 
         if remove_duplicates:
             list_values = list(set(list_values))


### PR DESCRIPTION
fixes: #3676 

Lists like:

["hello", "there"] were being flattened to ["h", "e", "l", "l", "o", "t", "h", "e", "r", "e"] which was not the intent.

it should only flatten non-flat lists.