### PR TITLE
catchup adv lib ver to remote repo

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -28,7 +28,7 @@
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Advanced media generation and manipulation nodes for Griptape Nodes.",
-    "library_version": "0.66.3",
+    "library_version": "0.66.4",
     "engine_version": "0.67.0",
     "tags": [
       "Griptape",


### PR DESCRIPTION
My brain was not fully awake and I[ bumped the patch version](https://github.com/griptape-ai/griptape-nodes-library-advanced-media/actions/runs/21143864492) instead of publishing 0.66.3