### PR TITLE
Aded back peft

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -28,7 +28,7 @@
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Advanced media generation and manipulation nodes for Griptape Nodes.",
-    "library_version": "0.66.4",
+    "library_version": "0.66.5",
     "engine_version": "0.67.0",
     "tags": [
       "Griptape",
@@ -45,6 +45,7 @@
         "ninja>=1.13.0",
         "numpy>=2.2.4",
         "opencv-python>=4.11.0.86",
+        "peft>=0.17.0",
         "pillow>=11.2.1",
         "sentencepiece>=0.2.0",
         "cmake==3.31.6",


### PR DESCRIPTION
During v66 migration this got removed as deprecation of LoRA training node. That was a mistake, but existing Library install environments retained peft and the issue was not noticed