### PR TITLE
feat: add log for when websocket reconnects

### DIFF
--- a/src/griptape_nodes/api_client/client.py
+++ b/src/griptape_nodes/api_client/client.py
@@ -203,7 +203,10 @@ class Client:
             async for websocket in connect(self.url, additional_headers=self.headers):
                 self._websocket = websocket
                 self._connection_ready.set()
-                logger.debug("WebSocket connection established: %s", self.url)
+                if self._subscribed_topics:
+                    logger.info("WebSocket reconnected successfully")
+                else:
+                    logger.debug("WebSocket connection established: %s", self.url)
 
                 # Resubscribe to all topics after reconnection
                 if self._subscribed_topics:


### PR DESCRIPTION
Some log output of me reconnecting:
```
[09:25:09] INFO     connect failed; reconnecting in 5.0 seconds: socket.gaierror: [Errno 8] nodename nor servname provided, or not known
[09:30:37] INFO     WebSocket connection closed, reconnecting...
[10:07:07] INFO     connect failed;
                    reconnecting in 90.0
                    seconds: OSError: [Errno
                    51] Network is unreachable
           INFO     WebSocket connection
                    closed, reconnecting...
           INFO     connect failed;
                    reconnecting in 3.1
                    seconds: OSError: [Errno
                    51] Network is unreachable
[10:07:11] INFO     connect failed; reconnecting in 3.1 seconds: OSError: [Errno 51] Network is unreachable
[10:07:14] INFO     connect failed; reconnecting in 5.0 seconds: OSError: [Errno 51] Network is unreachable
[10:07:19] INFO     connect failed; reconnecting in 8.1 seconds: OSError: [Errno 51] Network is unreachable
[10:08:38] INFO     WebSocket reconnected successfully
```