### PR TITLE
Migrate Seedream/Seedance to proxy base node

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/seedream_image_generation.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from copy import deepcopy
 from typing import Any
 
-from griptape.artifacts import ImageUrlArtifact, ImageArtifact
+from griptape.artifacts import ImageArtifact, ImageUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
@@ -17,8 +17,8 @@ from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_input, normalize_artifact_list
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes_library.utils.image_utils import (
     convert_image_value_to_base64_data_uri,
     read_image_from_file_path,

--- a/libraries/griptape_nodes_library/griptape_nodes_library/video/seedance_video_generation.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/video/seedance_video_generation.py
@@ -19,8 +19,8 @@ from griptape_nodes.exe_types.param_types.parameter_string import ParameterStrin
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_list
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
 
 logger = logging.getLogger("griptape_nodes")
 


### PR DESCRIPTION
Migrate the Seedream image generation node and the Seedance video generation node to use the base Griptape Proxy Node.