### PR TITLE
fix(image): handle near-opaque alpha masks

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/combine_masks.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/combine_masks.py
@@ -154,10 +154,7 @@ class CombineMasks(DataNode):
                 alpha_min, alpha_max = alpha_extrema
                 if isinstance(alpha_min, (int, float)) and isinstance(alpha_max, (int, float)):
                     alpha_range = alpha_max - alpha_min
-                    if (
-                        alpha_min >= self._ALPHA_NEAR_OPAQUE_MIN
-                        and alpha_range <= self._ALPHA_NEAR_OPAQUE_RANGE
-                    ):
+                    if alpha_min >= self._ALPHA_NEAR_OPAQUE_MIN and alpha_range <= self._ALPHA_NEAR_OPAQUE_RANGE:
                         use_alpha = False
             if use_alpha:
                 result = alpha


### PR DESCRIPTION
## Summary
- treat nearly-opaque RGBA/LA alpha as a signal to use RGB/L mask data
- prevent CombineMasks from producing fully masked results for PaintMask outputs
- keep true alpha masks unchanged

## Test plan
- not run (manual verification with provided mask samples)

Closes #3706.