### PR TITLE
fix: remove debug log

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -402,9 +402,7 @@ class NodeManager:
             )
         # modifying to exception to try to catch all possible issues with node creation.
         except Exception as err:
-            import traceback
-
-            traceback.print_exc()
+            logger.error(err)
             details = f"Could not create Node '{final_node_name}' of type '{request.node_type}': {err}"
 
             # Check if we should create an Error Proxy node instead of failing


### PR DESCRIPTION
Replaces ugly stack trace with pretty error log.
```
Traceback (most recent call last):
  File "/Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/retained_mode/managers/node_manager.py", line 397, in on_create_node_request
    node = LibraryRegistry.create_node(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/node_library/library_registry.py", line 281, in create_node
    dest_library = instance.get_library_for_node_type(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/node_library/library_registry.py", line 267, in get_library_for_node_type
    dest_library = instance.get_library(specific_library_name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/collindutter/Projects/griptape/griptape-nodes/src/griptape_nodes/node_library/library_registry.py", line 210, in get_library
    raise KeyError(msg)
KeyError: "Library 'Kling AI Library' not found"
```

```
           ERROR    "Library 'Kling AI Library' not found"
```