### PR TITLE
Groups Bug

### DIFF
--- a/src/griptape_nodes/exe_types/node_groups/base_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_node_group.py
@@ -80,6 +80,9 @@ class BaseNodeGroup(BaseNode):
             if node.name in self.nodes:
                 del self.nodes[node.name]
 
+        node_names_in_group = set(self.nodes.keys())
+        self.metadata["node_names_in_group"] = list(node_names_in_group)
+
     def _add_nodes_to_group_dict(self, nodes: list[BaseNode]) -> None:
         """Add nodes to the group's node dictionary."""
         for node in nodes:


### PR DESCRIPTION
Update Node Group metadata when nodes are removed from a group, following the subflow pattern.

Bug repro:
- Create a node and a group (either create around the node, or separately and drag in/resize over)
- Remove the node from the group by dragging or resizing
- Refresh the page
- Buggy-ness