### PR TITLE
Fix GTC publishing for Windows

### DIFF
--- a/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_workflow_builder.py
+++ b/libraries/griptape_cloud/griptape_cloud/publish_workflow/griptape_cloud_workflow_builder.py
@@ -94,11 +94,11 @@ class GriptapeCloudWorkflowBuilder:
         for i, lib in enumerate(libraries):
             if lib.endswith(".json"):
                 script += f"""
-    request_{i!s} = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path="{lib}"))
+    request_{i!s} = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path={lib!r}))
 """
             else:
                 script += f"""
-    request_{i!s} = GriptapeNodes.handle_request(RegisterLibraryFromRequirementSpecifierRequest(requirement_specifier="{lib}"))
+    request_{i!s} = GriptapeNodes.handle_request(RegisterLibraryFromRequirementSpecifierRequest(requirement_specifier={lib!r}))
 """
         return script
 

--- a/libraries/griptape_cloud/griptape_nodes_library.json
+++ b/libraries/griptape_cloud/griptape_nodes_library.json
@@ -14,8 +14,8 @@
   "metadata": {
     "author": "Griptape",
     "description": "Collection of nodes for accessing Griptape Cloud APIs and services.",
-    "library_version": "0.67.0",
-    "engine_version": "0.67.0",
+    "library_version": "0.68.0",
+    "engine_version": "0.71.0",
     "tags": ["Griptape", "AI", "Cloud"],
     "dependencies": {
       "pip_dependencies": ["griptape-cloud-client==0.1.1"]


### PR DESCRIPTION
* Fix GTC publishing for Windows
  * Refactor to use engine defined operations for file/tree copying
  *  `_normalize_line_endings` for some extra Windows fun

Fixes Structure deployment when publishing was performed from a Windows machine:

```bash
/bin/sh: 1: ./pre_build_install_script.sh: not found

The command '/bin/sh -c chmod +x pre_build_install_script.sh && ./pre_build_install_script.sh' returned a non-zero code: 127
```

^ Result of Windows style line endings

Closes #3773 