### PR TITLE
Update: helper method to set node size

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -831,7 +831,9 @@ class BaseNode(ABC):
                         emit_change=False,
                     )
 
-    def set_node_size(self, width: int = NODE_DEFAULT_SIZE["width"], height: int = NODE_DEFAULT_SIZE["height"]) -> None:
+    def set_initial_node_size(
+        self, width: int = NODE_DEFAULT_SIZE["width"], height: int = NODE_DEFAULT_SIZE["height"]
+    ) -> None:
         """Set the node's UI size. Node authors can call this to give the node a default or custom size.
 
         Args:


### PR DESCRIPTION
Node authors may want to set a specific node size when creating nodes.

They can currently do this by setting the metadata:

```python
self.metadata["size"] = {"width": 400, "height": 360}
```

but they may not be aware of this.

This method makes it easier, so in a node definition they just do:

```python
self.set_node_size(height=360)
```

where either height or width are optional.