### PR TITLE
Update: LoadAudio is larger by default

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.60.3",
+    "library_version": "0.60.4",
     "engine_version": "0.71.0",
     "tags": [
       "Griptape",

--- a/libraries/griptape_nodes_library/griptape_nodes_library/audio/load_audio.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/audio/load_audio.py
@@ -58,6 +58,10 @@ class LoadAudio(DataNode):
             config=self._tethering_config,
         )
 
+        # TODO: Replace this with a method once: https://github.com/griptape-ai/griptape-nodes/pull/3779 is merged
+        if "size" not in self.metadata:
+            self.metadata["size"] = {"width": 400, "height": 320}
+
     def after_incoming_connection(
         self,
         source_node: BaseNode,


### PR DESCRIPTION
Currently the LoadAudio node doesn't display all the parameters when it's loaded.

This increases the size via metadata on load.

before:
<img width="635" height="279" alt="image" src="https://github.com/user-attachments/assets/7a58fcc1-cbcb-478b-9e57-c36d26636c7f" />

after:
<img width="506" height="285" alt="image" src="https://github.com/user-attachments/assets/2af73db8-91b6-424c-96b6-6890439ab11d" />
