### PR TITLE
refactor(extract_key_colors): use SuccessFailureNode with static color params

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library/image/extract_key_colors.py
+++ b/libraries/griptape_nodes_library/griptape_nodes_library/image/extract_key_colors.py
@@ -117,6 +117,18 @@ class ExtractKeyColors(SuccessFailureNode):
                 )
             )
 
+        # Add list output parameter for programmatic use
+        self.add_parameter(
+            Parameter(
+                name="colors",
+                tooltip="List of extracted colors in hex format",
+                type="list",
+                output_type="list",
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=[],
+            )
+        )
+
         # Add status parameters for success/failure reporting
         self._create_status_parameters(
             result_details_tooltip="Details about the color extraction result",
@@ -490,10 +502,12 @@ class ExtractKeyColors(SuccessFailureNode):
 
             logger.debug("Extracted %d colors ordered by prominence", selected_count)
 
-            # Update existing color parameters with extracted values
+            # Build list of hex colors and update individual color parameters
+            hex_colors = []
             for i, color in enumerate(selected_colors, 1):
                 r, g, b = color
                 hex_color = f"#{r:02x}{g:02x}{b:02x}"
+                hex_colors.append(hex_color)
                 logger.debug("  Color %d: RGB(%3d, %3d, %3d) | Hex: %s", i, r, g, b, hex_color)
 
                 param_name = f"color_{i}"
@@ -505,6 +519,10 @@ class ExtractKeyColors(SuccessFailureNode):
                 param_name = f"color_{i}"
                 self.set_parameter_value(param_name, "")
                 self.publish_update_to_parameter(param_name, "")
+
+            # Set the colors list output
+            self.set_parameter_value("colors", hex_colors)
+            self.publish_update_to_parameter("colors", hex_colors)
 
             # Build success details
             color_summary = ", ".join(f"#{r:02x}{g:02x}{b:02x}" for r, g, b in selected_colors)


### PR DESCRIPTION
## Summary

- Refactor ExtractKeyColors to use `SuccessFailureNode` base class for non-terminal failures
- Replace dynamic color parameter creation with 12 static parameters that show/hide based on `num_colors` setting
- Convert synchronous `process()` to async `aprocess()` with proper error handling pattern

## Changes

- **Base class**: Changed from `DataNode` to `SuccessFailureNode` - failures now route through the failure output instead of being terminal
- **Static color parameters**: Created `color_1` through `color_12` upfront in `__init__` instead of dynamically creating them during processing
- **Dynamic visibility**: Added `after_value_set()` to show/hide color parameters when `num_colors` changes (default shows 3)
- **Async processing**: Implemented `aprocess()` with `_clear_execution_status()`, `_set_status_results()`, and `_handle_failure_exception()` pattern
- **Removed**: `_clear_color_picker_parameters()` method and `number_of_color_params` instance variable

## Test plan

- [ ] Verify node shows 3 color parameters by default
- [ ] Change num_colors slider and verify correct parameters show/hide
- [ ] Run with valid image and verify colors are extracted correctly
- [ ] Test failure case (no image) with failure output connected - should route to failure path
- [ ] Test failure case with failure output disconnected - should raise exception as before