### PR TITLE
bump std lib to 0.60.5

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.60.4",
+    "library_version": "0.60.5",
     "engine_version": "0.71.0",
     "tags": [
       "Griptape",


### PR DESCRIPTION
Missed in https://github.com/griptape-ai/griptape-nodes/commit/a33044a8919b8e58718bc2f9d9a4ab025de6f0b3