### PR TITLE
Allowlist additional Griptape domains for static file server

### DIFF
--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -182,7 +182,10 @@ def start_static_server() -> None:
         os.getenv("GRIPTAPE_NODES_UI_BASE_URL", "https://app.nodes.griptape.ai"),
         "https://app.nodes-staging.griptape.ai",
         "https://app-nightly.nodes.griptape.ai",
+        "https://editor.nodes.griptape.ai",
+        "https://editor-nightly.nodes.griptape.ai",
         "http://localhost:5173",
+        "http://localhost:5174",
         GriptapeNodes.ConfigManager().get_config_value("static_server_base_url"),
     ]
 


### PR DESCRIPTION
The allowlist is necessary for editors hosted on the new domains to be able to upload images/static files