### PR TITLE
chore: bump v0.72.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.72.0"
+version = "0.72.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.72.0"
+version = "0.72.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v72`.

Cherry-picked commit: a8727f38ab587d93361bfdd009888f7b3e846b41