### PR TITLE
update: group icon

### DIFF
--- a/libraries/griptape_nodes_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_library/griptape_nodes_library.json
@@ -27,7 +27,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.63.1",
+    "library_version": "0.63.2",
     "engine_version": "0.71.0",
     "tags": ["Griptape", "AI"],
     "dependencies": {
@@ -2040,7 +2040,7 @@
         "category": "misc",
         "description": "Create a group node to organize your workflow",
         "display_name": "Group",
-        "icon": "vault",
+        "icon": "group",
         "group": "create",
         "is_node_group": true
       }


### PR DESCRIPTION
Updates the group icon in the Add Group menu

fixes: https://github.com/griptape-ai/griptape-nodes/issues/3915

node header
<img width="637" height="117" alt="image" src="https://github.com/user-attachments/assets/ce316d3e-fb38-42ff-afe0-85d4fc7e7920" />

node toolbar
<img width="325" height="84" alt="image" src="https://github.com/user-attachments/assets/6aab1c56-eb43-4968-8544-a232cbf6c824" />

group toolbar
<img width="224" height="91" alt="image" src="https://github.com/user-attachments/assets/5883c538-c545-4d63-9016-4f021fc4d162" />


Add group menu (note - this is resolved via an engine PR - https://github.com/griptape-ai/griptape-nodes/pull/3916
<img width="491" height="175" alt="image" src="https://github.com/user-attachments/assets/1ff4ef5b-42f5-4c33-8149-4b3da38634d7" />


