### PR TITLE
Update: badge icon options

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -95,7 +95,7 @@ class PublicArtifactUrlParameter:
     def add_input_parameters(self) -> None:
         self._node.add_parameter(self._parameter)
         self._parameter.set_badge(
-            variant="warning",
+            variant="cloud-upload",
             title="Media Upload",
             message=self.get_help_message(),
             hide_clear_button=False,


### PR DESCRIPTION
Fixes: https://github.com/griptape-ai/griptape-nodes/issues/3942

Frontend PR: https://github.com/griptape-ai/griptape-vsl-gui/pull/1951

Adds a `cloud-upload` variant to `BadgeData`

Example:

```python
        self.add_parameter(
            ParameterString(
                name="cloud_upload_example",
                default_value="some content",
                badge=BadgeData(
                    variant="cloud-upload",
                    title="Cloud Upload Badge",
                    message="This is a cloud upload badge\n\nCheck it out - links to [docs](https://docs.griptape.ai)",
                ),
            )
        )
```

Also adds optional `icon` and `color` attributes to `BadgeData`.

If only `icon` is provided, it will use that icon and the color from `variant`. 

If only `color` is provided, it will use the icon specified in `variant`.

If both are provided, it will use both.

```python
        self.add_parameter(
            ParameterString(
                name="custom",
                default_value="some content",
                badge=BadgeData(
                    variant="warning",
                    title="Custom Badge",
                    icon="cloud-rain",
                    color="rgb(255, 0, 0)",
                    message="This badge has a custom color and icon",
                ),
            )
        )

```