### PR TITLE
chore: bump v0.74.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.74.3"
+version = "0.74.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.74.3"
+version = "0.74.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.74`.

Cherry-picked commit: c05de746449c362694bf115c846b0c571fd82e3e