### PR TITLE
fix: avoid direct on_read_file_request call to avoid async issues

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -612,7 +612,7 @@ class ConfigManager:
             encoding="utf-8",
             workspace_only=False,
         )
-        read_result = os_manager.on_read_file_request(read_request)
+        read_result = GriptapeNodes.handle_request(read_request)
 
         # Handle read failures
         if isinstance(read_result, ReadFileResultFailure):


### PR DESCRIPTION
`GriptapeNodes.handle_request` handles the `async` -> `sync` conversion.

Some open ended questions:
1. Should users ever call handler methods directly? e.g. `on_read_file_request`. I didn't touch `os_manager.on_rename_file_request` in this PR.
2. I think calling `GriptapeNodes.handle_request` will publish the results on the event bus. This could be a problem for requests like `ReadFile` which may include large results. Probably fine here for config file?
3. Should `on_read_file_request` be reverted to be sync?


Fixes https://github.com/griptape-ai/griptape-nodes/issues/3962