### PR TITLE
fix: use appropriate storage driver for cloud vs local URLs

### DIFF
--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -518,6 +518,49 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             return None
 
     @staticmethod
+    def extract_bucket_id_from_url(url_str: str) -> str | None:
+        """Extract bucket_id from a Griptape Cloud asset URL.
+
+        Static version for use without driver instance.
+        Parses URLs like: https://cloud.griptape.ai/buckets/{bucket_id}/assets/{workspace_path}
+        or /buckets/{bucket_id}/assets/{workspace_path}
+        Returns just the {bucket_id} portion.
+
+        Args:
+            url_str: Cloud asset URL or path string
+
+        Returns:
+            Bucket ID if URL matches cloud asset pattern, None otherwise
+        """
+        if not url_str:
+            return None
+
+        # Parse URL to extract path component
+        parsed = urlparse(url_str)
+        path = parsed.path if parsed.path else url_str
+
+        # Check for required patterns
+        if "/buckets/" not in path or "/assets/" not in path:
+            return None
+
+        # Extract bucket_id from: /buckets/{bucket_id}/assets/{workspace_path}
+        expected_parts = 2
+        try:
+            parts = path.split("/buckets/", 1)
+            if len(parts) != expected_parts:
+                return None
+
+            bucket_part = parts[1]
+            bucket_id = bucket_part.split("/assets/")[0]
+
+            if not bucket_id:
+                return None
+        except (IndexError, AttributeError):
+            return None
+        else:
+            return bucket_id
+
+    @staticmethod
     def create_signed_download_url_from_asset_url(
         asset_url: str,
         bucket_id: str | None = None,

--- a/tests/unit/drivers/storage/test_griptape_cloud_storage_driver.py
+++ b/tests/unit/drivers/storage/test_griptape_cloud_storage_driver.py
@@ -266,3 +266,102 @@ class TestGriptapeCloudStorageDriverUploadTimeout:
             assert mock_request.call_count == 1
             _, call_kwargs = mock_request.call_args
             assert call_kwargs["timeout"] == REQUEST_TIMEOUT_SECONDS
+
+
+class TestGriptapeCloudStorageDriverExtractBucketId:
+    """Test GriptapeCloudStorageDriver.extract_bucket_id_from_url() static method."""
+
+    def test_extract_bucket_id_from_full_https_url(self) -> None:
+        """Extract bucket_id from full HTTPS URL."""
+        url = "https://cloud.griptape.ai/buckets/test-bucket-123/assets/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "test-bucket-123"
+
+    def test_extract_bucket_id_from_full_http_url(self) -> None:
+        """Extract bucket_id from full HTTP URL."""
+        url = "http://cloud.griptape.ai/buckets/my-bucket/assets/path/to/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "my-bucket"
+
+    def test_extract_bucket_id_from_path_only(self) -> None:
+        """Extract bucket_id from path-only format (no domain)."""
+        url = "/buckets/bucket-456/assets/nested/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "bucket-456"
+
+    def test_extract_bucket_id_with_uuid_format(self) -> None:
+        """Extract bucket_id that uses UUID format."""
+        url = "https://cloud.griptape.ai/buckets/9ff5bda9-8f55-409f-a1dd-d1aba54fa233/assets/file.zip"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "9ff5bda9-8f55-409f-a1dd-d1aba54fa233"
+
+    def test_extract_bucket_id_with_nested_asset_path(self) -> None:
+        """Extract bucket_id when asset path has multiple nested directories."""
+        url = "https://cloud.griptape.ai/buckets/my-bucket/assets/deeply/nested/path/to/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "my-bucket"
+
+    def test_extract_bucket_id_returns_none_for_empty_string(self) -> None:
+        """Return None for empty string input."""
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url("")
+        assert result is None
+
+    def test_extract_bucket_id_returns_none_for_non_cloud_url(self) -> None:
+        """Return None for regular HTTP URL without cloud pattern."""
+        url = "https://example.com/some/path/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result is None
+
+    def test_extract_bucket_id_returns_none_for_missing_buckets(self) -> None:
+        """Return None when /buckets/ pattern is missing."""
+        url = "https://cloud.griptape.ai/assets/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result is None
+
+    def test_extract_bucket_id_returns_none_for_missing_assets(self) -> None:
+        """Return None when /assets/ pattern is missing."""
+        url = "https://cloud.griptape.ai/buckets/my-bucket/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result is None
+
+    def test_extract_bucket_id_returns_none_for_local_file_path(self) -> None:
+        """Return None for local file paths."""
+        url = "/home/user/documents/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result is None
+
+    def test_extract_bucket_id_returns_none_for_file_uri(self) -> None:
+        """Return None for file:// URIs."""
+        url = "file:///home/user/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result is None
+
+    def test_extract_bucket_id_returns_none_when_bucket_id_empty(self) -> None:
+        """Return None when bucket_id portion is empty."""
+        url = "https://cloud.griptape.ai/buckets//assets/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result is None
+
+    def test_extract_bucket_id_with_query_parameters(self) -> None:
+        """Extract bucket_id from URL with query parameters."""
+        url = "https://cloud.griptape.ai/buckets/my-bucket/assets/file.txt?version=1&cache=false"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "my-bucket"
+
+    def test_extract_bucket_id_with_url_fragment(self) -> None:
+        """Extract bucket_id from URL with fragment."""
+        url = "https://cloud.griptape.ai/buckets/my-bucket/assets/file.txt#section"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "my-bucket"
+
+    def test_extract_bucket_id_with_port_number(self) -> None:
+        """Extract bucket_id from URL with port number."""
+        url = "https://cloud.griptape.ai:8443/buckets/my-bucket/assets/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "my-bucket"
+
+    def test_extract_bucket_id_with_special_characters(self) -> None:
+        """Extract bucket_id containing special characters (hyphens, underscores)."""
+        url = "https://cloud.griptape.ai/buckets/my-bucket_test-123/assets/file.txt"
+        result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
+        assert result == "my-bucket_test-123"


### PR DESCRIPTION
Resolves #3739 by detecting Griptape Cloud URLs and routing them to GriptapeCloudStorageDriver instead of always using the configured driver. This ensures cloud asset URLs receive presigned URLs instead of localhost URLs.