### PR TITLE
fix: wait for library loading before listing registered libraries

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -258,8 +258,7 @@ class VersionCompatibilityManager:
         issues: list[WorkflowVersionCompatibilityIssue] = []
 
         # Get list of registered libraries once (silent check - no error logging)
-        list_request = ListRegisteredLibrariesRequest()
-        list_result = GriptapeNodes.LibraryManager().on_list_registered_libraries_request(list_request)
+        list_result = GriptapeNodes.handle_request(ListRegisteredLibrariesRequest())
 
         if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
             # Should not happen, but handle gracefully - return empty issues

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1280,10 +1280,7 @@ class WorkflowManager:
             problems.append(MissingLastModifiedDateProblem(default_date=str(WorkflowManager.EPOCH_START)))
 
         # Get list of registered libraries once (silent check - no error logging)
-        list_libraries_request = ListRegisteredLibrariesRequest()
-        list_libraries_result = GriptapeNodes.LibraryManager().on_list_registered_libraries_request(
-            list_libraries_request
-        )
+        list_libraries_result = GriptapeNodes.handle_request(ListRegisteredLibrariesRequest())
 
         if not isinstance(list_libraries_result, ListRegisteredLibrariesResultSuccess):
             # Should not happen, but handle gracefully - treat as no libraries registered


### PR DESCRIPTION
## Summary
- Makes `on_list_registered_libraries_request` async and awaits `_libraries_loading_complete` before returning, so callers always get the full list of libraries rather than a partial/empty one
- Replaces direct calls to the handler in `get_all_info_for_all_libraries_request`, `workflow_manager.py`, and `version_compatibility_manager.py` with `GriptapeNodes.handle_request` / `GriptapeNodes.ahandle_request` as appropriate

Closes #3985