### PR TITLE
fix: initialize _libraries_loading_complete event as set

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -345,6 +345,7 @@ class LibraryManager:
             type[Payload], dict[str, LibraryManager.RegisteredEventHandler[Any]]
         ] = {}
         self._libraries_loading_complete = asyncio.Event()
+        self._libraries_loading_complete.set()  # Not loading initially; load_all_libraries_from_config will clear/set this
 
         event_manager.assign_manager_to_request_type(
             ListRegisteredLibrariesRequest, self.on_list_registered_libraries_request


### PR DESCRIPTION
Closes #3991

## Summary

- `asyncio.Event()` initializes to the not-set (blocking) state
- After #3986, `on_list_registered_libraries_request` awaits `_libraries_loading_complete`, which is only set by `load_all_libraries_from_config()`
- In the CLI path (`gtn libraries sync`), app initialization never runs, so the event is never set and the command hangs indefinitely
- Fix: initialize the event as already set — the correct default is "no loading in progress, so proceed immediately"
- `load_all_libraries_from_config()` already clears/sets the event around its work, so the normal app startup flow is unaffected

## Test plan

- [x] Run `uv run gtn libraries sync` and confirm it completes without hanging
- [x] Start the full app and confirm library loading still works correctly (libraries listed only after loading completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)