### PR TITLE
Payloads over 1mb will be outright denied/error

### DIFF
--- a/src/griptape_nodes/api_client/client.py
+++ b/src/griptape_nodes/api_client/client.py
@@ -274,16 +274,15 @@ class Client:
             )
             logger.error(msg)
             return
-
+        if len(serialized) > LARGE_PAYLOAD_WARNING_THRESHOLD:
+            logger.warning(
+                "Sending large WebSocket message: type=%s (%s), size=%d bytes. "
+                "Large messages can saturate the send buffer and cause connected clients (e.g. the editor) to stall or disconnect.",
+                message.get("type"),
+                message.get("payload", {}).get("result_type"),
+                len(serialized),
+            )
         try:
-            if len(serialized) > LARGE_PAYLOAD_WARNING_THRESHOLD:
-                logger.warning(
-                    "Sending large WebSocket message: type=%s (%s), size=%d bytes. "
-                    "Large messages can saturate the send buffer and cause connected clients (e.g. the editor) to stall or disconnect.",
-                    message.get("type"),
-                    message.get("payload", {}).get("result_type"),
-                    len(serialized),
-                )
             await self._websocket.send(serialized)
             logger.debug("Sent message type: %s", message.get("type"))
         except Exception as e:


### PR DESCRIPTION
### I guess you guys aren't ready for that yet. But your kids are gonna love it.

Current largest known event is loading the standard library (~150kb):
```
Sending large WebSocket message: type=success_result (GetAllInfoForAllLibrariesResultSuccess), size=147080 bytes. Large messages can saturate the send buffer and cause connected clients (e.g. the editor) to stall or disconnect.
```