### PR TITLE
fix: handle HTTPS clone failures for public GitHub repos

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -187,7 +187,9 @@ from griptape_nodes.utils.git_utils import (
     get_git_remote,
     get_local_commit_sha,
     is_git_url,
+    normalize_github_url,
     parse_git_url_with_ref,
+    sparse_checkout_library_json,
     switch_branch_or_tag,
     update_library_git,
 )
@@ -3809,7 +3811,7 @@ class LibraryManager:
 
     async def download_library_request(self, request: DownloadLibraryRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, PLR0915, C901
         """Download a library from a git repository."""
-        git_url = request.git_url
+        git_url = normalize_github_url(request.git_url)
         branch_tag_commit = request.branch_tag_commit
         target_directory_name = request.target_directory_name
         download_directory = request.download_directory
@@ -4189,8 +4191,6 @@ class LibraryManager:
         ref = request.ref
 
         # Normalize GitHub shorthand to full URL
-        from griptape_nodes.utils.git_utils import normalize_github_url, sparse_checkout_library_json
-
         normalized_url = normalize_github_url(git_url)
         logger.info("Inspecting library metadata from '%s' (ref: %s)", normalized_url, ref)
 

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -16,6 +16,7 @@ from griptape_nodes.utils.git_utils import (
     GitRefError,
     GitRemoteError,
     GitRepositoryError,
+    _CredentialCallbacks,
     clone_repository,
     extract_repo_name_from_url,
     get_current_ref,
@@ -936,7 +937,9 @@ class TestCloneRepository:
 
             clone_repository("https://github.com/user/repo.git", target_path)
 
-            mock_clone.assert_called_once_with("https://github.com/user/repo.git", str(target_path), callbacks=None)
+            args, kwargs = mock_clone.call_args
+            assert args == ("https://github.com/user/repo.git", str(target_path))
+            assert isinstance(kwargs["callbacks"], _CredentialCallbacks)
 
     def test_clone_repository_raises_error_when_clone_returns_none(self, temp_dir: Path) -> None:
         """Test that GitCloneError is raised when clone returns None."""


### PR DESCRIPTION
Two root causes addressed:

1. Missing .git suffix: GitHub redirects HTTPS URLs without .git, which libgit2 misinterprets as an auth failure. normalize_github_url() is now called in download_library_request() (the startup download path) so the suffix is always present before cloning, matching the existing behavior in inspect_library_repo_request().

2. url.insteadOf SSH rewrite: users with a url.insteadOf git config rule that rewrites HTTPS to SSH caused libgit2 to request SSH credentials with no callback set. A new _CredentialCallbacks class inspects the allowed_types argument at credential-request time and supplies SSH key or agent credentials when SSH types are requested, and empty UserPass for plain public HTTPS repos.