### PR TITLE
chore: bump v0.75.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.75.0"
+version = "0.75.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.75.0"
+version = "0.75.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.75`.

Cherry-picked commit: 8398a6b926741ece81a45d1a732b44ac8f772207