### PR TITLE
feat: set active project when loading a workflow

### DIFF
--- a/src/griptape_nodes/common/project_templates/__init__.py
+++ b/src/griptape_nodes/common/project_templates/__init__.py
@@ -28,6 +28,7 @@ from griptape_nodes.common.project_templates.validation import (
 
 __all__ = [
     "DEFAULT_PROJECT_TEMPLATE",
+    "PROJECT_FILE_NAME",
     "DirectoryDefinition",
     "ProjectOverlayData",
     "ProjectOverride",
@@ -47,3 +48,5 @@ __all__ = [
     "load_project_template_from_yaml",
     "load_yaml_with_line_tracking",
 ]
+
+PROJECT_FILE_NAME = "griptape-nodes-project.yml"

--- a/src/griptape_nodes/retained_mode/events/project_events.py
+++ b/src/griptape_nodes/retained_mode/events/project_events.py
@@ -537,3 +537,48 @@ class GetAllSituationsForProjectResultSuccess(WorkflowNotAlteredMixin, ResultPay
 @PayloadRegistry.register
 class GetAllSituationsForProjectResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Failure result when cannot get situations."""
+
+
+@dataclass
+@PayloadRegistry.register
+class FindProjectForPathRequest(RequestPayload):
+    """Find which project a file path belongs to, across all loaded projects.
+
+    Use when: A workflow is loaded and you need to detect which project it
+    belongs to so you can set the active project accordingly.
+
+    Skips the system default project and checks all user-defined loaded projects.
+    Returns the first matching project ID.
+
+    Args:
+        absolute_path: The absolute filesystem path to check
+
+    Results: FindProjectForPathResultSuccess | FindProjectForPathResultFailure
+    """
+
+    absolute_path: Path
+
+
+@dataclass
+@PayloadRegistry.register
+class FindProjectForPathResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Path was checked against all loaded projects.
+
+    Success means the check was performed (not necessarily that a match was found).
+    - project_id is NOT None: Path belongs to a specific project
+    - project_id is None: Path does not belong to any loaded project
+
+    Args:
+        project_id: The ID of the matching project, or None if no project matched
+    """
+
+    project_id: ProjectID | None
+
+
+@dataclass
+@PayloadRegistry.register
+class FindProjectForPathResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Path check could not be performed.
+
+    Returned when the operation cannot be performed (secrets manager unavailable).
+    """

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -35,6 +35,9 @@ from griptape_nodes.retained_mode.events.project_events import (
     AttemptMatchPathAgainstMacroRequest,
     AttemptMatchPathAgainstMacroResultFailure,
     AttemptMatchPathAgainstMacroResultSuccess,
+    FindProjectForPathRequest,
+    FindProjectForPathResultFailure,
+    FindProjectForPathResultSuccess,
     GetAllSituationsForProjectRequest,
     GetAllSituationsForProjectResultFailure,
     GetAllSituationsForProjectResultSuccess,
@@ -209,6 +212,9 @@ class ProjectManager:
             event_manager.assign_manager_to_request_type(
                 AttemptMapAbsolutePathToProjectRequest, self.on_attempt_map_absolute_path_to_project_request
             )
+            event_manager.assign_manager_to_request_type(
+                FindProjectForPathRequest, self.on_find_project_for_path_request
+            )
 
             # Register app initialization listener
             event_manager.add_listener_to_app_event(
@@ -269,9 +275,10 @@ class ProjectManager:
 
         if template is None:
             self._registered_template_status[request.project_path] = validation
+            parse_errors = "; ".join(p.message for p in validation.problems)
             return LoadProjectTemplateResultFailure(
                 validation=validation,
-                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because YAML could not be parsed",
+                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because YAML could not be parsed: {parse_errors}",
             )
 
         # Generate project_id from file path
@@ -795,6 +802,46 @@ class ProjectManager:
         return AttemptMapAbsolutePathToProjectResultSuccess(
             mapped_path=mapped_path,
             result_details=f"Successfully mapped absolute path to '{mapped_path}'",
+        )
+
+    def on_find_project_for_path_request(
+        self, request: FindProjectForPathRequest
+    ) -> FindProjectForPathResultSuccess | FindProjectForPathResultFailure:
+        """Find which project a file path belongs to across all loaded projects.
+
+        Checks all loaded non-default projects to find one whose directories
+        contain the given absolute path.
+
+        Args:
+            request: Request containing the absolute path to check
+
+        Returns:
+            Success with project_id if a project match is found, or None if no match
+            Failure if operation cannot be performed (secrets manager unavailable)
+        """
+        if self._secrets_manager is None:
+            return FindProjectForPathResultFailure(
+                result_details=f"Attempted to find project for path '{request.absolute_path}'. Failed because SecretsManager not available"
+            )
+
+        for project_id, project_info in self._successfully_loaded_project_templates.items():
+            if project_id == SYSTEM_DEFAULTS_KEY:
+                continue
+
+            try:
+                mapped_path = self._absolute_path_to_macro_path(request.absolute_path, project_info)
+            except (RuntimeError, NotImplementedError):
+                continue
+
+            if mapped_path is not None:
+                return FindProjectForPathResultSuccess(
+                    project_id=project_id,
+                    result_details=f"Successfully found project for path '{request.absolute_path}'. Project ID: '{project_id}'",
+                )
+
+        return FindProjectForPathResultSuccess(
+            project_id=None,
+            result_details=f"Attempted to find project for path '{request.absolute_path}'. Path does not belong to any loaded project",
         )
 
     # Helper methods (private)

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -23,6 +23,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from griptape_nodes.common.project_templates import PROJECT_FILE_NAME
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -72,6 +73,12 @@ from griptape_nodes.retained_mode.events.os_events import (
     GetFileInfoResultSuccess,
     WriteFileRequest,
     WriteFileResultFailure,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    FindProjectForPathRequest,
+    FindProjectForPathResultSuccess,
+    LoadProjectTemplateRequest,
+    SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
     BranchWorkflowRequest,
@@ -647,6 +654,50 @@ class WorkflowManager:
                 error_message = "Workflow execution completed but no current flow context could be established"
                 raise RuntimeError(error_message)
 
+    async def _set_project_for_workflow_path(self, complete_file_path: str) -> None:
+        """Detect which project a workflow file belongs to and set it as the active project.
+
+        Walks up from the workflow file's directory to find the nearest griptape-nodes-project.yml,
+        loads it, then sets that project as the current project. Stops at the workspace
+        root to avoid picking up unrelated project files. Logs but does not fail on errors.
+
+        Args:
+            complete_file_path: Absolute path to the workflow file
+        """
+        workflow_path = Path(complete_file_path)
+        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+
+        # Walk up from the workflow's directory looking for the nearest griptape-nodes-project.yml,
+        # stopping at the workspace root.
+        current = workflow_path.parent
+        while True:
+            project_yml = current / PROJECT_FILE_NAME
+            if project_yml.is_file():
+                load_request = LoadProjectTemplateRequest(project_path=project_yml)
+                await GriptapeNodes.ahandle_request(load_request)
+                break
+            if current == workspace_path or not current.is_relative_to(workspace_path):
+                break
+            current = current.parent
+
+        find_request = FindProjectForPathRequest(absolute_path=workflow_path)
+        find_result = await GriptapeNodes.ahandle_request(find_request)
+
+        if not isinstance(find_result, FindProjectForPathResultSuccess):
+            logger.debug(
+                "Could not determine project for workflow '%s': %s", complete_file_path, find_result.result_details
+            )
+            return
+
+        if find_result.project_id is None:
+            return
+
+        set_request = SetCurrentProjectRequest(project_id=find_result.project_id)
+        await GriptapeNodes.ahandle_request(set_request)
+        logger.info(
+            "Set active project to '%s' based on workflow path '%s'", find_result.project_id, complete_file_path
+        )
+
     async def run_workflow(self, relative_file_path: str) -> WorkflowExecutionResult:
         # Resolve path using utility function
         workspace_path = GriptapeNodes.ConfigManager().workspace_path
@@ -690,6 +741,9 @@ class WorkflowManager:
                 details = f"Failed to clear the existing object state when trying to run '{complete_file_path}'."
                 return RunWorkflowFromScratchResultFailure(result_details=details)
 
+            # Set the project before running so nodes are created with the correct project context.
+            await self._set_project_for_workflow_path(complete_file_path)
+
             # Run the file, goddamn it
             execution_result = await self.run_workflow(relative_file_path=relative_file_path)
             if execution_result.execution_successful:
@@ -706,6 +760,10 @@ class WorkflowManager:
         if not Path(complete_file_path).is_file():
             details = f"Failed to find file. Path '{complete_file_path}' doesn't exist."
             return RunWorkflowWithCurrentStateResultFailure(result_details=details)
+
+        # Set the project before running so nodes are created with the correct project context.
+        await self._set_project_for_workflow_path(complete_file_path)
+
         execution_result = await self.run_workflow(relative_file_path=relative_file_path)
 
         if execution_result.execution_successful:
@@ -730,6 +788,10 @@ class WorkflowManager:
 
         # get file_path from workflow
         relative_file_path = workflow.file_path
+        complete_file_path = WorkflowRegistry.get_complete_file_path(relative_file_path=relative_file_path)
+
+        # Set the project before running so nodes are created with the correct project context.
+        await self._set_project_for_workflow_path(complete_file_path)
 
         # Squelch any ResultPayloads that indicate the workflow was changed, because we are loading it.
         with WorkflowManager.WorkflowSquelchContext(self):

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1267,3 +1267,171 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
             result_message = str(result.result_details)
             assert "failed" in result_message.lower()
             assert "workflow" in result_message.lower() or "no current workflow" in result_message.lower()
+
+
+class TestProjectManagerFindProjectForPath:
+    """Test ProjectManager FindProjectForPath event handler."""
+
+    @pytest.fixture
+    def project_manager(self) -> ProjectManager:
+        """Create a ProjectManager instance for testing."""
+        mock_config = Mock()
+        mock_secrets = Mock()
+        mock_event_manager = Mock()
+        return ProjectManager(mock_event_manager, mock_config, mock_secrets)
+
+    def _register_project(self, project_manager: ProjectManager, project_id: str, project_base: Path) -> None:
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import (
+            DEFAULT_PROJECT_TEMPLATE,
+            ProjectValidationInfo,
+            ProjectValidationStatus,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+        directory_schemas = {
+            dir_name: ParsedMacro(dir_def.path_macro)
+            for dir_name, dir_def in DEFAULT_PROJECT_TEMPLATE.directories.items()
+        }
+
+        project_manager._successfully_loaded_project_templates[project_id] = ProjectInfo(
+            project_id=project_id,
+            project_file_path=project_base / "project.yml",
+            project_base_dir=project_base,
+            template=DEFAULT_PROJECT_TEMPLATE,
+            validation=ProjectValidationInfo(status=ProjectValidationStatus.GOOD),
+            parsed_situation_schemas={},
+            parsed_directory_schemas=directory_schemas,
+        )
+
+    def test_find_project_path_inside_loaded_project(self, project_manager: ProjectManager) -> None:
+        """Test that a path inside a loaded project returns that project's ID."""
+        from griptape_nodes.retained_mode.events.project_events import (
+            FindProjectForPathRequest,
+            FindProjectForPathResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        project_base = Path("/Users/test/myproject")
+        project_id = str(project_base / "project.yml")
+
+        self._register_project(project_manager, SYSTEM_DEFAULTS_KEY, Path("/Users/test/workspace"))
+        self._register_project(project_manager, project_id, project_base)
+        project_manager._secrets_manager = Mock()
+        project_manager._secrets_manager.resolve.return_value = "test_value"
+
+        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_config = Mock()
+            mock_config.get_config_value.return_value = str(project_base)
+            mock_gn.ConfigManager.return_value = mock_config
+
+            mock_context = Mock()
+            mock_context.has_current_workflow.return_value = False
+            mock_gn.ContextManager.return_value = mock_context
+
+            from griptape_nodes.retained_mode.managers.os_manager import OSManager
+
+            mock_os_manager = Mock(spec=OSManager)
+            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
+                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
+            )
+            mock_gn.OSManager.return_value = mock_os_manager
+
+            absolute_path = project_base / "outputs" / "file.png"
+            request = FindProjectForPathRequest(absolute_path=absolute_path)
+            result = project_manager.on_find_project_for_path_request(request)
+
+            assert isinstance(result, FindProjectForPathResultSuccess)
+            assert result.project_id == project_id
+
+    def test_find_project_path_outside_all_projects(self, project_manager: ProjectManager) -> None:
+        """Test that a path outside all loaded projects returns None."""
+        from griptape_nodes.retained_mode.events.project_events import (
+            FindProjectForPathRequest,
+            FindProjectForPathResultSuccess,
+        )
+
+        project_base = Path("/Users/test/myproject")
+        project_id = str(project_base / "project.yml")
+
+        self._register_project(project_manager, project_id, project_base)
+        project_manager._secrets_manager = Mock()
+        project_manager._secrets_manager.resolve.return_value = "test_value"
+
+        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_config = Mock()
+            mock_config.get_config_value.return_value = str(project_base)
+            mock_gn.ConfigManager.return_value = mock_config
+
+            mock_context = Mock()
+            mock_context.has_current_workflow.return_value = False
+            mock_gn.ContextManager.return_value = mock_context
+
+            from griptape_nodes.retained_mode.managers.os_manager import OSManager
+
+            mock_os_manager = Mock(spec=OSManager)
+            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
+                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
+            )
+            mock_gn.OSManager.return_value = mock_os_manager
+
+            absolute_path = Path("/Users/test/Downloads/file.png")
+            request = FindProjectForPathRequest(absolute_path=absolute_path)
+            result = project_manager.on_find_project_for_path_request(request)
+
+            assert isinstance(result, FindProjectForPathResultSuccess)
+            assert result.project_id is None
+
+    def test_find_project_skips_system_defaults(self, project_manager: ProjectManager) -> None:
+        """Test that the system defaults project is never returned as a match."""
+        from griptape_nodes.retained_mode.events.project_events import (
+            FindProjectForPathRequest,
+            FindProjectForPathResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        project_base = Path("/Users/test/workspace")
+
+        self._register_project(project_manager, SYSTEM_DEFAULTS_KEY, project_base)
+        project_manager._secrets_manager = Mock()
+        project_manager._secrets_manager.resolve.return_value = "test_value"
+
+        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_config = Mock()
+            mock_config.get_config_value.return_value = str(project_base)
+            mock_gn.ConfigManager.return_value = mock_config
+
+            mock_context = Mock()
+            mock_context.has_current_workflow.return_value = False
+            mock_gn.ContextManager.return_value = mock_context
+
+            from griptape_nodes.retained_mode.managers.os_manager import OSManager
+
+            mock_os_manager = Mock(spec=OSManager)
+            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
+                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
+            )
+            mock_gn.OSManager.return_value = mock_os_manager
+
+            # Path is inside workspace (system defaults base), but system defaults should be skipped
+            absolute_path = project_base / "outputs" / "file.png"
+            request = FindProjectForPathRequest(absolute_path=absolute_path)
+            result = project_manager.on_find_project_for_path_request(request)
+
+            assert isinstance(result, FindProjectForPathResultSuccess)
+            assert result.project_id is None
+
+    def test_find_project_no_secrets_manager(self, project_manager: ProjectManager) -> None:
+        """Test that missing secrets manager returns Failure."""
+        from griptape_nodes.retained_mode.events.project_events import (
+            FindProjectForPathRequest,
+            FindProjectForPathResultFailure,
+        )
+
+        project_manager._secrets_manager = None
+
+        request = FindProjectForPathRequest(absolute_path=Path("/Users/test/project/outputs/file.png"))
+        result = project_manager.on_find_project_for_path_request(request)
+
+        assert isinstance(result, FindProjectForPathResultFailure)
+        assert "SecretsManager not available" in str(result.result_details)


### PR DESCRIPTION
When a workflow is loaded, detect which project its file path belongs to and automatically set it as the active project.  Adds `FindProjectForPathRequest` event that searches all loaded non-default projects and returns the matching project ID. WorkflowManager calls this after each successful workflow load and sets the current project accordingly.


When tested against #4030 

<img width="397" height="354" alt="image" src="https://github.com/user-attachments/assets/b26e24a4-00f4-4d64-9357-96be41131f5d" />


Closes #4033