### PR TITLE
Fix video encoding for DepthCrafter

### DIFF
--- a/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/depthcrafter/depthcrafter_pipeline.py
+++ b/libraries/griptape_nodes_advanced_media_library/diffusers_nodes_library/common/parameters/diffusion/depthcrafter/depthcrafter_pipeline.py
@@ -14,6 +14,9 @@ from diffusers.utils.torch_utils import randn_tensor  # pyright: ignore[reportMi
 
 logger = logging.getLogger("diffusers_nodes_library")
 
+# Maximum elements a single CUDA tensor can have before 32-bit kernel indexing fails.
+MAX_CUDA_TENSOR_ELEMENTS = 2**31 - 1
+
 
 class DepthCrafterVideoDiffusionPipeline(diffusers.StableVideoDiffusionPipeline):
     """Inspired by: https://github.com/Tencent/DepthCrafter/blob/main/depthcrafter/depth_crafter_ppl.py."""
@@ -38,8 +41,15 @@ class DepthCrafterVideoDiffusionPipeline(diffusers.StableVideoDiffusionPipeline)
         :param chunk_size: the chunk size to encode video
         :return: image_embeddings in shape of [b, 1024]
         """
-        video_224 = _resize_with_antialiasing(video.float(), (224, 224))
-        video_224 = (video_224 + 1.0) / 2.0  # [-1, 1] -> [0, 1]
+        # Chunk the resize to avoid exceeding 32-bit index limits on high-res, long videos.
+        elements_per_frame = video.shape[1] * video.shape[2] * video.shape[3]
+        resize_chunk_size = max(1, MAX_CUDA_TENSOR_ELEMENTS // elements_per_frame)
+
+        resized_chunks = []
+        for i in range(0, video.shape[0], resize_chunk_size):
+            chunk_224 = _resize_with_antialiasing(video[i : i + resize_chunk_size].float(), (224, 224))
+            resized_chunks.append((chunk_224 + 1.0) / 2.0)
+        video_224 = torch.cat(resized_chunks, dim=0)  # [t, 3, 224, 224]
 
         embeddings = []
         for i in range(0, video_224.shape[0], chunk_size):
@@ -159,7 +169,15 @@ class DepthCrafterVideoDiffusionPipeline(diffusers.StableVideoDiffusionPipeline)
         else:
             assert isinstance(video, torch.Tensor)  # noqa: S101
         video = video.to(device=device, dtype=self.dtype)  # pyright: ignore[reportAttributeAccessIssue]
-        video = video * 2.0 - 1.0  # [0,1] -> [-1,1], in [t, c, h, w]
+
+        # Compute max frames per chunk to keep CUDA kernel operations under the
+        # 32-bit index limit (2^31 - 1 elements per tensor).
+        elements_per_frame = video.shape[1] * video.shape[2] * video.shape[3]
+        safe_chunk_frames = max(1, MAX_CUDA_TENSOR_ELEMENTS // elements_per_frame)
+
+        # Normalize [0,1] -> [-1,1] in chunks.
+        for i in range(0, num_frames, safe_chunk_frames):
+            video[i : i + safe_chunk_frames] = video[i : i + safe_chunk_frames] * 2.0 - 1.0
 
         # Initialize timing events
         start_event = None
@@ -176,9 +194,11 @@ class DepthCrafterVideoDiffusionPipeline(diffusers.StableVideoDiffusionPipeline)
 
         video_embeddings = self.encode_video(video, chunk_size=decode_chunk_size).unsqueeze(0)  # [1, t, 1024]
         torch.cuda.empty_cache()
-        # 4. Encode input image using VAE
-        noise = randn_tensor(video.shape, generator=generator, device=device, dtype=video.dtype)
-        video = video + noise_aug_strength * noise  # in [t, c, h, w]
+        # 4. Add noise augmentation in chunks.
+        for i in range(0, num_frames, safe_chunk_frames):
+            chunk = video[i : i + safe_chunk_frames]
+            noise = randn_tensor(chunk.shape, generator=generator, device=device, dtype=video.dtype)
+            video[i : i + safe_chunk_frames] = chunk + noise_aug_strength * noise
 
         # pdb.set_trace()  # noqa: ERA001
         needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast

--- a/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
+++ b/libraries/griptape_nodes_advanced_media_library/griptape_nodes_library.json
@@ -28,12 +28,9 @@
   "metadata": {
     "author": "Griptape, Inc.",
     "description": "Advanced media generation and manipulation nodes for Griptape Nodes.",
-    "library_version": "0.66.6",
+    "library_version": "0.66.7",
     "engine_version": "0.67.0",
-    "tags": [
-      "Griptape",
-      "AI"
-    ],
+    "tags": ["Griptape", "AI"],
     "dependencies": {
       "pip_dependencies": [
         "accelerate>=1.6.0",
@@ -67,10 +64,7 @@
         "supervision>=0.27.0",
         "griptape[drivers-prompt-amazon-bedrock,drivers-prompt-anthropic,drivers-prompt-cohere,drivers-prompt-ollama,drivers-web-scraper-trafilatura,drivers-web-search-duckduckgo,drivers-web-search-exa,loaders-image]>=1.8.12"
       ],
-      "pip_install_flags": [
-        "--preview",
-        "--torch-backend=auto"
-      ]
+      "pip_install_flags": ["--preview", "--torch-backend=auto"]
     },
     "resources": {
       "required": {
@@ -346,7 +340,5 @@
       }
     }
   ],
-  "workflows": [
-    "workflows/templates/qwen_edit_2509_camera_control.py"
-  ]
+  "workflows": ["workflows/templates/qwen_edit_2509_camera_control.py"]
 }


### PR DESCRIPTION
Fix video encoding for DepthCrafter

* Chunk pre-processing operations in the DepthCrafter pipeline to avoid exceeding PyTorch's 32-bit CUDA kernel index limit (2^31 - 1 elements per tensor)                                    
* Affects three operations that previously allocated full-video-sized tensors: frame resize in encode_video, [0,1]→[-1,1] normalization, and noise augmentation
* No impact on videos that already fit within the limit (loops execute once)

Fixes the following issue:

<img width="769" height="193" alt="image" src="https://github.com/user-attachments/assets/89cd12b4-b6fb-4f13-a5e0-3787ae27c722" />

Closes the DepthCrafter portion of: https://github.com/griptape-ai/griptape-nodes-library-sam3/issues/8