### PR TITLE
fix: improve WebSocket connection error handling and messaging

### DIFF
--- a/src/griptape_nodes/api_client/client.py
+++ b/src/griptape_nodes/api_client/client.py
@@ -175,12 +175,7 @@ class Client:
             logger.debug("WebSocket client connected")
         except TimeoutError as e:
             logger.error("Failed to connect WebSocket client: timeout")
-            msg = (
-                "Connection timeout - failed to connect to Nodes API. "
-                "This may indicate an invalid or missing GT_CLOUD_API_KEY, "
-                "or an SSL certificate verification failure. "
-                "Please verify your API key is correct and that your system's CA certificates are up to date."
-            )
+            msg = "Connection timeout - failed to connect to Nodes API."
             raise ConnectionError(msg) from e
 
     async def disconnect(self) -> None:


### PR DESCRIPTION
- Catch `InvalidStatus` (401/403) in `_manage_connection` so a bad/missing API key surfaces immediately with a clear error instead of a 10-second timeout with a misleading message
- Catch `InvalidURI` for misconfigured `GRIPTAPE_NODES_API_BASE_URL`
- Catch `ssl.SSLError` for certificate verification failures on machines with outdated/missing CA certs
- Catch `OSError` for DNS and network-level failures
- Update timeout error message to mention SSL as a possible cause alongside API key issues
- Extract `_handle_websocket_session` helper to keep `_manage_connection` within cyclomatic complexity limits

May help #4013