### PR TITLE
feat: show validation problems when loading project

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1139,10 +1139,17 @@ class ProjectManager:
         template = ProjectTemplate.merge(DEFAULT_PROJECT_TEMPLATE, overlay, validation)
 
         if not validation.is_usable():
+            problem_details = "; ".join(
+                f"{p.field_path} (line {p.line_number}): {p.message}"
+                if p.line_number is not None
+                else f"{p.field_path}: {p.message}"
+                for p in validation.problems
+            )
             logger.error(
-                "Attempted to load workspace project from '%s'. Failed because template is not usable (status: %s)",
+                "Attempted to load workspace project from '%s'. Failed because template is not usable (status: %s). Problems: %s",
                 workspace_project_path,
                 validation.status,
+                problem_details,
             )
             return
 


### PR DESCRIPTION
```
           ERROR    Attempted to load workspace project from
                    '/Users/collindutter/Projects/griptape/griptape-nodes/GriptapeNodes/griptape-nodes-project.yml'. Failed because template is not
                    usable (status: UNUSABLE). Problems: situations.save_static_file.policy.on_collision: Input should be 'create_new', 'overwrite',
                    'fail' or 'prompt'
```