### PR TITLE
feat: add ability to map file to macro

### DIFF
--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -197,7 +197,7 @@ class File:
         else:
             self._file_path = file_path
 
-    def resolve_path(self) -> str:
+    def resolve(self) -> str:
         """Resolve and return the absolute path string for this file.
 
         Useful when a caller needs the path for writing (not reading). Macro
@@ -216,6 +216,25 @@ class File:
                 result_details="Cannot resolve path: file_path is None",
             )
         return resolved
+
+    @property
+    def location(self) -> str:
+        """Return the most portable string representation of this file's location.
+
+        Returns the macro template (e.g. ``"{outputs}/image.png"``) when the file
+        holds a macro path, otherwise the plain path string.  No I/O is performed.
+        """
+        if isinstance(self._file_path, MacroPath):
+            return self._file_path.parsed_macro.template
+        return self._file_path
+
+    @property
+    def name(self) -> str:
+        """Return the filename component of this file's location.
+
+        For example, a File holding ``"{outputs}/image.png"`` returns ``"image.png"``.
+        """
+        return Path(self.location).name
 
     def write_bytes(
         self,
@@ -667,7 +686,7 @@ class FileDestination:
         self._append = append
         self._create_parents = create_parents
 
-    def resolve_path(self) -> str:
+    def resolve(self) -> str:
         """Resolve and return the absolute path string for this destination.
 
         Returns:
@@ -676,47 +695,49 @@ class FileDestination:
         Raises:
             FileLoadError: If macro resolution fails (e.g. no project loaded).
         """
-        return self._file.resolve_path()
+        return self._file.resolve()
 
-    def write_bytes(self, content: bytes) -> Path:
+    def write_bytes(self, content: bytes) -> File:
         """Write bytes to the file using the configured write policy.
 
         Args:
             content: The bytes to write.
 
         Returns:
-            The actual path where the file was written.
+            A File referencing the path where the content was written.
 
         Raises:
             FileWriteError: If the file cannot be written.
         """
-        return self._file.write_bytes(
+        path = self._file.write_bytes(
             content,
             existing_file_policy=self._existing_file_policy,
             append=self._append,
             create_parents=self._create_parents,
         )
+        return File(str(path))
 
-    async def awrite_bytes(self, content: bytes) -> Path:
+    async def awrite_bytes(self, content: bytes) -> File:
         """Async version of write_bytes().
 
         Args:
             content: The bytes to write.
 
         Returns:
-            The actual path where the file was written.
+            A File referencing the path where the content was written.
 
         Raises:
             FileWriteError: If the file cannot be written.
         """
-        return await self._file.awrite_bytes(
+        path = await self._file.awrite_bytes(
             content,
             existing_file_policy=self._existing_file_policy,
             append=self._append,
             create_parents=self._create_parents,
         )
+        return File(str(path))
 
-    def write_text(self, content: str, encoding: str = "utf-8") -> Path:
+    def write_text(self, content: str, encoding: str = "utf-8") -> File:
         """Write text to the file using the configured write policy.
 
         Args:
@@ -724,20 +745,21 @@ class FileDestination:
             encoding: Text encoding to use when writing.
 
         Returns:
-            The actual path where the file was written.
+            A File referencing the path where the content was written.
 
         Raises:
             FileWriteError: If the file cannot be written.
         """
-        return self._file.write_text(
+        path = self._file.write_text(
             content,
             encoding,
             existing_file_policy=self._existing_file_policy,
             append=self._append,
             create_parents=self._create_parents,
         )
+        return File(str(path))
 
-    async def awrite_text(self, content: str, encoding: str = "utf-8") -> Path:
+    async def awrite_text(self, content: str, encoding: str = "utf-8") -> File:
         """Async version of write_text().
 
         Args:
@@ -745,18 +767,19 @@ class FileDestination:
             encoding: Text encoding to use when writing.
 
         Returns:
-            The actual path where the file was written.
+            A File referencing the path where the content was written.
 
         Raises:
             FileWriteError: If the file cannot be written.
         """
-        return await self._file.awrite_text(
+        path = await self._file.awrite_text(
             content,
             encoding,
             existing_file_policy=self._existing_file_policy,
             append=self._append,
             create_parents=self._create_parents,
         )
+        return File(str(path))
 
 
 @runtime_checkable

--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -1,13 +1,16 @@
 """ProjectFileDestination - project-aware FileDestination built from a situation template."""
 
 import logging
+from pathlib import Path
 
 from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.common.project_templates.situation import SituationFilePolicy
-from griptape_nodes.files.file import FileDestination
+from griptape_nodes.files.file import File, FileDestination
 from griptape_nodes.files.path_utils import FilenameParts
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
+    AttemptMapAbsolutePathToProjectResultSuccess,
     GetSituationRequest,
     GetSituationResultSuccess,
     MacroPath,
@@ -75,3 +78,30 @@ class ProjectFileDestination(FileDestination):
             existing_file_policy=existing_file_policy,
             create_parents=create_dirs,
         )
+
+    def write_bytes(self, content: bytes) -> File:
+        return self._map_to_macro_file(super().write_bytes(content))
+
+    async def awrite_bytes(self, content: bytes) -> File:
+        return self._map_to_macro_file(await super().awrite_bytes(content))
+
+    def write_text(self, content: str, encoding: str = "utf-8") -> File:
+        return self._map_to_macro_file(super().write_text(content, encoding))
+
+    async def awrite_text(self, content: str, encoding: str = "utf-8") -> File:
+        return self._map_to_macro_file(await super().awrite_text(content, encoding))
+
+    def _map_to_macro_file(self, result_file: File) -> File:
+        """Attempt to convert the written path to its portable macro form.
+
+        Returns a File holding the macro template (e.g. ``{outputs}/image.png``)
+        when the path is inside a project directory, so callers can store a
+        portable reference via ``file.as_macro()``.  Falls back to the original
+        File (absolute path) if mapping is not possible.
+        """
+        map_result = GriptapeNodes.handle_request(
+            AttemptMapAbsolutePathToProjectRequest(absolute_path=Path(result_file.resolve()))
+        )
+        if isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess) and map_result.mapped_path is not None:
+            return File(map_result.mapped_path)
+        return result_file

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1283,7 +1283,7 @@ class OSManager:
             directory_path_str: str | None
             if request.directory_path is not None:
                 try:
-                    directory_path_str = File(request.directory_path).resolve_path()
+                    directory_path_str = File(request.directory_path).resolve()
                 except FileLoadError as e:
                     return ListDirectoryResultFailure(
                         failure_reason=e.failure_reason,

--- a/tests/unit/files/test_file_loader.py
+++ b/tests/unit/files/test_file_loader.py
@@ -794,9 +794,9 @@ class TestFileDestinationWrite:
         )
         dest = FileDestination("workspace/output.png", existing_file_policy=ExistingFilePolicy.CREATE_NEW)
         with patch(HANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
-            path = dest.write_bytes(b"\x89PNG")
+            result = dest.write_bytes(b"\x89PNG")
 
-        assert path == Path("/workspace/output_1.png")
+        assert Path(result.resolve()) == Path("/workspace/output_1.png")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.CREATE_NEW
 
@@ -833,9 +833,9 @@ class TestFileDestinationWrite:
         )
         dest = FileDestination("workspace/output.txt", existing_file_policy=ExistingFilePolicy.FAIL)
         with patch(HANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
-            path = dest.write_text("hello")
+            result = dest.write_text("hello")
 
-        assert path == Path("/workspace/output.txt")
+        assert Path(result.resolve()) == Path("/workspace/output.txt")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.FAIL
 
@@ -852,10 +852,10 @@ class TestFileDestinationWrite:
         request = mock_handle.call_args.args[0]
         assert request.encoding == "latin-1"
 
-    def test_resolve_path_returns_path_string(self) -> None:
+    def test_resolve_returns_path_string(self) -> None:
         dest = FileDestination("workspace/output.png")
 
-        assert dest.resolve_path() == "workspace/output.png"
+        assert dest.resolve() == "workspace/output.png"
 
 
 class TestFileDestinationAsync:
@@ -870,9 +870,9 @@ class TestFileDestinationAsync:
         )
         dest = FileDestination("workspace/output.png", existing_file_policy=ExistingFilePolicy.CREATE_NEW)
         with patch(AHANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
-            path = await dest.awrite_bytes(b"\x89PNG")
+            result = await dest.awrite_bytes(b"\x89PNG")
 
-        assert path == Path("/workspace/output_1.png")
+        assert Path(result.resolve()) == Path("/workspace/output_1.png")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.CREATE_NEW
 
@@ -895,9 +895,9 @@ class TestFileDestinationAsync:
         )
         dest = FileDestination("workspace/output.txt", existing_file_policy=ExistingFilePolicy.FAIL)
         with patch(AHANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
-            path = await dest.awrite_text("hello")
+            result = await dest.awrite_text("hello")
 
-        assert path == Path("/workspace/output.txt")
+        assert Path(result.resolve()) == Path("/workspace/output.txt")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.FAIL
 
@@ -914,3 +914,80 @@ class TestFileDestinationAsync:
 
         request = mock_handle.call_args.args[0]
         assert request.encoding == "latin-1"
+
+
+class TestFileLocation:
+    """Tests for File.location property."""
+
+    def test_location_plain_string(self) -> None:
+        f = File("workspace/outputs/image.png")
+        assert f.location == "workspace/outputs/image.png"
+
+    def test_location_macro_path_returns_template(self) -> None:
+        f = File("{outputs}/image.png")
+        assert f.location == "{outputs}/image.png"
+
+    def test_location_macro_path_object_returns_template(self) -> None:
+        macro_path = MacroPath(ParsedMacro("{outputs}/file.txt"), {"outputs": "/resolved"})
+        f = File(macro_path)
+        assert f.location == "{outputs}/file.txt"
+
+    def test_location_no_io_performed(self) -> None:
+        with patch(HANDLE_REQUEST_PATH) as mock_handle:
+            f = File("{outputs}/image.png")
+            _ = f.location
+        mock_handle.assert_not_called()
+
+
+class TestFileName:
+    """Tests for File.name property."""
+
+    def test_name_plain_string(self) -> None:
+        f = File("workspace/outputs/image.png")
+        assert f.name == "image.png"
+
+    def test_name_macro_path_returns_filename_from_template(self) -> None:
+        f = File("{outputs}/image.png")
+        assert f.name == "image.png"
+
+    def test_name_macro_path_object(self) -> None:
+        macro_path = MacroPath(ParsedMacro("{outputs}/subdir/file.txt"), {"outputs": "/resolved"})
+        f = File(macro_path)
+        assert f.name == "file.txt"
+
+    def test_name_delegates_to_location(self) -> None:
+        """Name is always Path(location).name."""
+        from pathlib import Path as _Path
+
+        f = File("{outputs}/report.csv")
+        assert f.name == _Path(f.location).name
+
+
+class TestFileResolve:
+    """Tests for File.resolve() method."""
+
+    def test_resolve_plain_string(self) -> None:
+        f = File("/absolute/path/image.png")
+        assert Path(f.resolve()) == Path("/absolute/path/image.png")
+
+    def test_resolve_macro_path_calls_handle_request(self) -> None:
+        resolve_result = GetPathForMacroResultSuccess(
+            result_details="OK",
+            resolved_path=Path("outputs/image.png"),
+            absolute_path=Path("/workspace/outputs/image.png"),
+        )
+        with patch(HANDLE_REQUEST_PATH, return_value=resolve_result):
+            result = File("{outputs}/image.png").resolve()
+
+        assert Path(result) == Path("/workspace/outputs/image.png")
+
+    def test_resolve_macro_path_failure_raises_file_load_error(self) -> None:
+        resolve_failure = GetPathForMacroResultFailure(
+            result_details="Missing variables: outputs",
+            failure_reason=PathResolutionFailureReason.MISSING_REQUIRED_VARIABLES,
+            missing_variables={"outputs"},
+        )
+        with patch(HANDLE_REQUEST_PATH, return_value=resolve_failure), pytest.raises(FileLoadError) as exc_info:
+            File("{outputs}/image.png").resolve()
+
+        assert exc_info.value.failure_reason == FileIOFailureReason.MISSING_MACRO_VARIABLES


### PR DESCRIPTION
Needed by some upcoming node library refactors to store the macro path rather than the resolved path:
e.g.
```
            # Resolve output path from ProjectFileParameter and write to project directory.
            # Pass _index for multi-image responses so each image gets a unique numbered path;
            # the first image (index=0) omits the index for a clean single-image filename.
            extra = {"_index": index} if index > 0 else {}
            output_file = self._output_file_param.build_file(**extra)
            try:
                result_file = await output_file.awrite_bytes(png_bytes)
            except FileWriteError as e:
                self._log(f"Failed to write image {index}: {e}")
                return ImageUrlArtifact(value=image_url)
            self._log(f"Saved image {index} to {result_file.resolve()}")

            return ImageUrlArtifact(value=result_file.location, name=result_file.name)
```