### PR TITLE
fix: fall back to workspace staticfiles when workflow is outside workspace

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -430,13 +430,16 @@ class StaticFilesManager:
             # Resolve both sides to ensure drive letters match on Windows (drive-relative vs absolute paths).
             workspace_relative_path = macro_result.absolute_path.resolve().relative_to(workspace_dir)
         except ValueError:
+            static_files_dir = self.config_manager.get_config_value("static_files_directory", default="staticfiles")
+            workspace_relative_path = Path(static_files_dir) / file_name
             logger.warning(
-                "Failed to resolve %s situation path: resolved path %s is outside workspace %s",
+                "Resolved %s situation path %s is outside workspace %s. "
+                "Falling back to workspace staticfiles directory: %s",
                 SAVE_STATIC_FILE_SITUATION,
                 macro_result.absolute_path,
                 workspace_dir,
+                workspace_relative_path,
             )
-            return None
 
         policy = self._map_situation_policy(situation.policy.on_collision)
         return ResolvedStaticFilePath(path=workspace_relative_path, policy=policy)

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -774,3 +774,64 @@ class TestStaticFilesManagerResolveStaticFilePath:
 
         assert result is None
         assert "save_static_file" in caplog.text
+
+    def test_resolve_falls_back_to_workspace_staticfiles_when_path_is_outside_workspace(
+        self, mock_static_files_manager: StaticFilesManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Falls back to workspace staticfiles directory when resolved path is outside workspace."""
+        import logging
+
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import (
+            GetPathForMacroResultSuccess,
+            GetSituationResultSuccess,
+        )
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        situation = SituationTemplate(
+            name="save_static_file",
+            macro="{workflow_dir?:/}staticfiles/{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+        )
+        workspace_dir = Path("/mock/workspace")
+        # Workflow is outside the workspace (e.g., saved in Downloads)
+        outside_path = Path("/Users/user/Downloads/staticfiles/output.png")
+
+        def handle_request(request: object) -> object:
+            from griptape_nodes.retained_mode.events.project_events import (
+                GetPathForMacroRequest,
+                GetSituationRequest,
+            )
+
+            if isinstance(request, GetSituationRequest):
+                return GetSituationResultSuccess(situation=situation, result_details="ok")
+            if isinstance(request, GetPathForMacroRequest):
+                return GetPathForMacroResultSuccess(
+                    resolved_path=outside_path,
+                    absolute_path=outside_path,
+                    result_details="ok",
+                )
+            msg = f"Unexpected request: {request}"
+            raise AssertionError(msg)
+
+        mock_config_manager = Mock()
+        mock_config_manager.get_config_value.side_effect = lambda key, **kwargs: (
+            str(workspace_dir) if key == "workspace_directory" else kwargs.get("default", "staticfiles")
+        )
+        mock_static_files_manager.config_manager = mock_config_manager
+
+        with (
+            patch.object(GriptapeNodes, "handle_request", side_effect=handle_request),
+            patch.object(GriptapeNodes, "ConfigManager", return_value=mock_config_manager),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+        ):
+            result = mock_static_files_manager._resolve_static_file_path("output.png")
+
+        assert result is not None
+        assert result.path == Path("staticfiles/output.png")
+        assert result.policy == ExistingFilePolicy.OVERWRITE
+        assert "outside workspace" in caplog.text


### PR DESCRIPTION
- Detects when the `save_static_file` situation macro resolves to a path outside the workspace (e.g., workflow saved in `~/Downloads/`)
- Falls back to saving in `staticfiles/<filename>` relative to the workspace root instead of failing
- Logs a clear warning explaining what happened and where the file was saved instead

Closes #4127