### PR TITLE
fix: don't broadcast result of serialize commands

### DIFF
--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -266,6 +266,7 @@ class SerializeFlowToCommandsRequest(RequestPayload):
             Copy/paste can make use of this.
     """
 
+    broadcast_result: bool = False
     flow_name: str | None = None
     include_create_flow_command: bool = True
 

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -560,6 +560,7 @@ class SerializeNodeToCommandsRequest(RequestPayload):
     Results: SerializeNodeToCommandsResultSuccess (with commands) | SerializeNodeToCommandsResultFailure (serialization error)
     """
 
+    broadcast_result: bool = False
     node_name: str | None = None
     unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any] = field(
         default_factory=dict


### PR DESCRIPTION
```
[18:03:48] WARNING  Sending large WebSocket message: type=success_result (SerializeFlowToCommandsResultSuccess), size=109740 bytes. Large messages can   
                    saturate the send buffer and cause connected clients (e.g. the editor) to stall or disconnect.
```

```
15:57:08 | WARNING  Sending large WebSocket message: type=success_result
15:57:08 | (SerializeNodeToCommandsResultSuccess), size=222521 bytes.
15:57:08 | Large messages can saturate the send buffer and cause
15:57:08 | connected clients (e.g. the editor) to stall or disconnect.
```