### PR TITLE
chore: bump v0.77.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.77.0"
+version = "0.77.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.77.0"
+version = "0.77.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.77`.

Cherry-picked commit: c8f9026a51616ffdd48b8c40f625305762e57d3e