### PR TITLE
Pass skip_metadata_injection through storage drivers

### DIFF
--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -94,7 +94,12 @@ class BaseStorageDriver(ABC):
 
     @abstractmethod
     def save_file(
-        self, path: Path, file_content: bytes, existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE
+        self,
+        path: Path,
+        file_content: bytes,
+        existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
+        *,
+        skip_metadata_injection: bool = False,
     ) -> str:
         """Save a file to storage.
 
@@ -102,6 +107,7 @@ class BaseStorageDriver(ABC):
             path: Workspace-relative path of the file (e.g., ``outputs/image.png``).
             file_content: The file content as bytes.
             existing_file_policy: How to handle existing files. Defaults to OVERWRITE.
+            skip_metadata_injection: If True, skip automatic workflow metadata injection.
 
         Returns:
             The absolute file path where the file was saved.

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -151,7 +151,12 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
         return response_data["url"]
 
     def save_file(
-        self, path: Path, file_content: bytes, existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE
+        self,
+        path: Path,
+        file_content: bytes,
+        existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
+        *,
+        skip_metadata_injection: bool = False,  # noqa: ARG002
     ) -> str:
         """Save a file to cloud storage via HTTP upload.
 
@@ -159,6 +164,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             path: The path of the file to save.
             file_content: The file content as bytes.
             existing_file_policy: How to handle existing files. Defaults to OVERWRITE.
+            skip_metadata_injection: Unused; cloud storage does not perform metadata injection.
 
         Returns:
             The full asset URL for the saved file.

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -96,7 +96,12 @@ class LocalStorageDriver(BaseStorageDriver):
         }
 
     def save_file(
-        self, path: Path, file_content: bytes, existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE
+        self,
+        path: Path,
+        file_content: bytes,
+        existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
+        *,
+        skip_metadata_injection: bool = False,
     ) -> str:
         """Save a file to local storage by writing directly to disk.
 
@@ -104,6 +109,7 @@ class LocalStorageDriver(BaseStorageDriver):
             path: The path of the file to save.
             file_content: The file content as bytes.
             existing_file_policy: How to handle existing files. Defaults to OVERWRITE.
+            skip_metadata_injection: If True, skip automatic workflow metadata injection.
 
         Returns:
             The absolute file path where the file was saved.
@@ -119,6 +125,7 @@ class LocalStorageDriver(BaseStorageDriver):
                 file_path=str(absolute_path),
                 content=file_content,
                 existing_file_policy=existing_file_policy,
+                skip_metadata_injection=skip_metadata_injection,
             )
         )
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -305,6 +305,8 @@ class StaticFilesManager:
         data: bytes,
         file_name: str,
         existing_file_policy: ExistingFilePolicy | None = None,
+        *,
+        skip_metadata_injection: bool = False,
     ) -> str:
         """Saves a static file to the workspace directory.
 
@@ -318,6 +320,7 @@ class StaticFilesManager:
                 - OVERWRITE: Replace existing file content
                 - CREATE_NEW: Auto-generate unique filename (e.g., file_1.txt, file_2.txt)
                 - FAIL: Raise FileExistsError if file exists
+            skip_metadata_injection: If True, skip automatic workflow metadata injection.
 
         Returns:
             The URL of the saved file for UI display (with cache-busting). Note: the actual filename
@@ -340,7 +343,9 @@ class StaticFilesManager:
             effective_policy = existing_file_policy
 
         try:
-            saved_path = self.storage_driver.save_file(file_path, data, effective_policy)
+            saved_path = self.storage_driver.save_file(
+                file_path, data, effective_policy, skip_metadata_injection=skip_metadata_injection
+            )
         except FileExistsError:
             raise
         except Exception as e:


### PR DESCRIPTION
This fixes:
```
[11:05:21] INFO     Resolving Write Image Metadata                                                                                                       
           WARNING  Write Image Metadata: Failed to save image: StaticFilesManager.save_static_file() got an unexpected keyword argument                 
                    'skip_metadata_injection'                                                                                                            
           ERROR    Error processing node 'Write Image Metadata'                                                                                         
                    NoneType: None                                                                                                                       
           INFO     Flow is complete.                                                                                                                    
           ERROR    Node 'Write Image Metadata' failed: Node 'Write Image Metadata' encountered a problem: StaticFilesManager.save_static_file() got an  
                    unexpected keyword argument 'skip_metadata_injection'                                                                                
           ERROR    Failed to resolve "Write Image Metadata".  Error: Node 'Write Image Metadata' encountered a problem:                                 
                    StaticFilesManager.save_static_file() got an unexpected keyword argument 'skip_metadata_injection'
                    ```