### PR TITLE
feat: expose workflow fitness info via API

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING, Literal
 
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowShape
@@ -750,6 +751,26 @@ class GetWorkflowMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFai
     """Workflow metadata retrieval failed. Common causes: workflow not found, registry error, file load error."""
 
 
+class WorkflowStatus(StrEnum):
+    """The status of a workflow that was attempted to be loaded."""
+
+    GOOD = "GOOD"
+    FLAWED = "FLAWED"
+    UNUSABLE = "UNUSABLE"
+    MISSING = "MISSING"
+
+
+class WorkflowDependencyStatus(StrEnum):
+    """The status of a single library dependency for a workflow."""
+
+    PERFECT = "PERFECT"
+    GOOD = "GOOD"
+    CAUTION = "CAUTION"
+    BAD = "BAD"
+    MISSING = "MISSING"
+    UNKNOWN = "UNKNOWN"
+
+
 @dataclass
 class WorkflowDependencyInfo:
     """Information about a single library dependency for a workflow.
@@ -758,13 +779,13 @@ class WorkflowDependencyInfo:
         library_name: Name of the library
         version_requested: Version of the library required by the workflow
         version_present: Version of the library currently installed, or None if not found
-        status: Dependency status (PERFECT, GOOD, CAUTION, BAD, MISSING, or UNKNOWN)
+        status: Dependency status
     """
 
     library_name: str
     version_requested: str
     version_present: str | None
-    status: str
+    status: WorkflowDependencyStatus
 
 
 @dataclass
@@ -775,17 +796,13 @@ class GetWorkflowInfoRequest(RequestPayload):
     Use when: Displaying workflow health warnings in the UI, checking whether a workflow
     has compatibility issues before loading it, showing dependency status.
 
-    Provide workflow_name (registry key) or workflow_file_path, but not both.
-
     Args:
-        workflow_name: Registry key for the workflow (optional if workflow_file_path provided)
-        workflow_file_path: Absolute file path to the workflow file (optional if workflow_name provided)
+        workflow_name: Registry key for the workflow.
 
-    Results: GetWorkflowInfoResultSuccess (with status and details) | GetWorkflowInfoResultFailure (not found, ambiguous args)
+    Results: GetWorkflowInfoResultSuccess (with status and details) | GetWorkflowInfoResultFailure (not found)
     """
 
-    workflow_name: str | None = None
-    workflow_file_path: str | None = None
+    workflow_name: str
 
 
 @dataclass
@@ -801,7 +818,7 @@ class GetWorkflowInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess
         workflow_dependencies: List of library dependency details
     """
 
-    status: str
+    status: WorkflowStatus
     workflow_name: str | None
     workflow_path: str
     problems: list[str]
@@ -812,6 +829,25 @@ class GetWorkflowInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess
 @PayloadRegistry.register
 class GetWorkflowInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Workflow info retrieval failed. Common causes: workflow not found, neither or both identifiers provided."""
+
+
+@dataclass
+class WorkflowInfoSummary:
+    """Serializable summary of a workflow's fitness/health information.
+
+    Args:
+        status: Overall fitness status
+        workflow_name: Display name of the workflow, or None if unavailable
+        workflow_path: Absolute file path to the workflow file
+        problems: List of human-readable problem descriptions, one entry per problem group
+        workflow_dependencies: List of library dependency details
+    """
+
+    status: WorkflowStatus
+    workflow_name: str | None
+    workflow_path: str
+    problems: list[str]
+    workflow_dependencies: list[WorkflowDependencyInfo]
 
 
 @dataclass
@@ -832,12 +868,11 @@ class ListAllWorkflowInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
     """Workflow info for all registered workflows retrieved successfully.
 
     Args:
-        workflow_infos: Dict mapping registry key to a dict containing status,
-            workflow_name, workflow_path, problems, and workflow_dependencies.
+        workflow_infos: Dict mapping registry key to workflow info summary.
             Workflows with no info entry are omitted.
     """
 
-    workflow_infos: dict
+    workflow_infos: dict[str, WorkflowInfoSummary]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -22,6 +22,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     ListRegisteredLibrariesRequest,
     ListRegisteredLibrariesResultSuccess,
 )
+from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries.deprecated_node_warning_problem import (
     DeprecatedNodeWarningProblem,
@@ -45,7 +46,6 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
     from griptape_nodes.retained_mode.managers.fitness_problems.workflows.workflow_problem import WorkflowProblem
-    from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -73,7 +73,7 @@ class WorkflowVersionCompatibilityIssue(NamedTuple):
     """Represents a workflow version compatibility issue found in a workflow."""
 
     problem: WorkflowProblem
-    severity: WorkflowManager.WorkflowStatus
+    severity: WorkflowStatus
 
 
 class WorkflowVersionCompatibilityCheck(ABC):
@@ -314,7 +314,7 @@ class VersionCompatibilityManager:
                             current_library_version=current_library_version,
                             workflow_library_version=workflow_library_version,
                         ),
-                        severity=GriptapeNodes.WorkflowManager().WorkflowStatus.FLAWED,
+                        severity=WorkflowStatus.FLAWED,
                     )
                 )
                 continue
@@ -348,7 +348,7 @@ class VersionCompatibilityManager:
                         removal_version=deprecation.removal_version,
                         deprecation_message=deprecation.deprecation_message,
                     ),
-                    severity=GriptapeNodes.WorkflowManager().WorkflowStatus.FLAWED,
+                    severity=WorkflowStatus.FLAWED,
                 )
             )
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import asyncio
-import dataclasses
 import logging
 import pickle
 import re
@@ -150,9 +149,10 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     SetWorkflowMetadataRequest,
     SetWorkflowMetadataResultFailure,
     SetWorkflowMetadataResultSuccess,
-)
-from griptape_nodes.retained_mode.events.workflow_events import (
-    WorkflowDependencyInfo as WorkflowDependencyInfoPayload,
+    WorkflowDependencyInfo,
+    WorkflowDependencyStatus,
+    WorkflowInfoSummary,
+    WorkflowStatus,
 )
 from griptape_nodes.retained_mode.griptape_nodes import (
     GriptapeNodes,
@@ -211,52 +211,19 @@ class WorkflowManager:
     )
     EPOCH_START = datetime(tzinfo=UTC, year=1970, month=1, day=1)
 
-    class WorkflowStatus(StrEnum):
-        """The status of a workflow that was attempted to be loaded."""
-
-        GOOD = "GOOD"  # No errors detected during loading. Registered.
-        FLAWED = "FLAWED"  # Some errors detected, but recoverable. Registered.
-        UNUSABLE = "UNUSABLE"  # Errors detected and not recoverable. Not registered.
-        MISSING = "MISSING"  # File not found. Not registered.
-
-    class WorkflowDependencyStatus(StrEnum):
-        """Records the status of each dependency for a workflow that was attempted to be loaded."""
-
-        PERFECT = "PERFECT"  # Same major, minor, and patch version
-        GOOD = "GOOD"  # Same major, minor version
-        CAUTION = "CAUTION"  # Dependency is ahead within maximum minor revisions
-        BAD = "BAD"  # Different major, or dependency ahead by more than maximum minor revisions
-        MISSING = "MISSING"  # Not found
-        UNKNOWN = "UNKNOWN"  # May not have been able to evaluate due to other errors.
-
-    @dataclass
-    class WorkflowDependencyInfo:
-        """Information about each dependency in a workflow that was attempted to be loaded."""
-
-        library_name: str
-        version_requested: str
-        version_present: str | None
-        status: WorkflowManager.WorkflowDependencyStatus
+    WorkflowStatus = WorkflowStatus
+    WorkflowDependencyStatus = WorkflowDependencyStatus
+    WorkflowDependencyInfo = WorkflowDependencyInfo
 
     @dataclass
     class WorkflowInfo:
         """Information about a workflow that was attempted to be loaded."""
 
-        status: WorkflowManager.WorkflowStatus
+        status: WorkflowStatus
         workflow_path: str
         workflow_name: str | None = None
-        workflow_dependencies: list[WorkflowManager.WorkflowDependencyInfo] = field(default_factory=list)
+        workflow_dependencies: list[WorkflowDependencyInfo] = field(default_factory=list)
         problems: list[WorkflowProblem] = field(default_factory=list)
-
-    @dataclass
-    class WorkflowInfoPayload:
-        """Serializable representation of WorkflowInfo for API responses."""
-
-        status: str
-        workflow_name: str | None
-        workflow_path: str
-        problems: list[str]
-        workflow_dependencies: list
 
     _workflow_file_path_to_info: dict[str, WorkflowInfo]
 
@@ -951,8 +918,8 @@ class WorkflowManager:
         """
         return str(GriptapeNodes.ConfigManager().workspace_path.joinpath(file_path))
 
-    def _build_workflow_info_payload(self, wf_info: WorkflowInfo) -> WorkflowInfoPayload:
-        """Convert a WorkflowInfo into a serializable payload for API responses."""
+    def _build_workflow_info_payload(self, wf_info: WorkflowInfo) -> WorkflowInfoSummary:
+        """Build a WorkflowInfoSummary from a WorkflowInfo, collating problems for display."""
         problems_by_type: dict[type, list] = defaultdict(list)
         for problem in wf_info.problems:
             problems_by_type[type(problem)].append(problem)
@@ -960,41 +927,22 @@ class WorkflowManager:
             problem_class.collate_problems_for_display(instances)
             for problem_class, instances in problems_by_type.items()
         ]
-        dependency_payloads = [
-            WorkflowDependencyInfoPayload(
-                library_name=dep.library_name,
-                version_requested=dep.version_requested,
-                version_present=dep.version_present,
-                status=dep.status.value,
-            )
-            for dep in wf_info.workflow_dependencies
-        ]
-        return WorkflowManager.WorkflowInfoPayload(
-            status=wf_info.status.value,
+        return WorkflowInfoSummary(
+            status=wf_info.status,
             workflow_name=wf_info.workflow_name,
             workflow_path=str(wf_info.workflow_path),
             problems=collated_problems,
-            workflow_dependencies=dependency_payloads,
+            workflow_dependencies=wf_info.workflow_dependencies,
         )
 
     def on_get_workflow_info_request(self, request: GetWorkflowInfoRequest) -> ResultPayload:
-        if request.workflow_name is None and request.workflow_file_path is None:
-            details = "Attempted to get workflow info. Failed because neither workflow_name nor workflow_file_path was provided."
+        try:
+            workflow = WorkflowRegistry.get_workflow_by_name(request.workflow_name)
+        except KeyError:
+            details = f"Attempted to get workflow info. Failed because workflow '{request.workflow_name}' was not found in the registry."
             return GetWorkflowInfoResultFailure(result_details=details)
 
-        if request.workflow_name is not None and request.workflow_file_path is not None:
-            details = "Attempted to get workflow info. Failed because both workflow_name and workflow_file_path were provided. Provide only one."
-            return GetWorkflowInfoResultFailure(result_details=details)
-
-        if request.workflow_name is not None:
-            try:
-                workflow = WorkflowRegistry.get_workflow_by_name(request.workflow_name)
-            except KeyError:
-                details = f"Attempted to get workflow info. Failed because workflow '{request.workflow_name}' was not found in the registry."
-                return GetWorkflowInfoResultFailure(result_details=details)
-            workflow_file_path = self._build_workflow_info_key(workflow.file_path)
-        else:
-            workflow_file_path = request.workflow_file_path
+        workflow_file_path = self._build_workflow_info_key(workflow.file_path)
 
         if workflow_file_path not in self._workflow_file_path_to_info:
             details = (
@@ -1020,7 +968,7 @@ class WorkflowManager:
             details = f"Attempted to list all workflow info. Failed to list workflows: {e}"
             return ListAllWorkflowInfoResultFailure(result_details=details)
 
-        workflow_infos: dict[str, dict] = {}
+        workflow_infos: dict[str, WorkflowInfoSummary] = {}
         for registry_key in registry_keys:
             try:
                 workflow = WorkflowRegistry.get_workflow_by_name(registry_key)
@@ -1030,7 +978,7 @@ class WorkflowManager:
             wf_info = self._workflow_file_path_to_info.get(workflow_file_path)
             if wf_info is None:
                 continue
-            workflow_infos[registry_key] = dataclasses.asdict(self._build_workflow_info_payload(wf_info))
+            workflow_infos[registry_key] = self._build_workflow_info_payload(wf_info)
 
         return ListAllWorkflowInfoResultSuccess(
             workflow_infos=workflow_infos,

--- a/src/griptape_nodes/version_compatibility/versions/v0_7_0/local_executor_argument_addition.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_7_0/local_executor_argument_addition.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import semver
 
+from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows.workflow_schema_version_problem import (
     WorkflowSchemaVersionProblem,
 )
@@ -13,7 +14,6 @@ from griptape_nodes.retained_mode.managers.version_compatibility_manager import 
     WorkflowVersionCompatibilityCheck,
     WorkflowVersionCompatibilityIssue,
 )
-from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
 if TYPE_CHECKING:
     from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -45,7 +45,7 @@ class LocalExecutorArgumentAddition(WorkflowVersionCompatibilityCheck):
                     problem=WorkflowSchemaVersionProblem(
                         description=f"Schema version {workflow_metadata.schema_version} older than 0.7.0. This workflow may not publish or execute properly. Re-save workflow to update."
                     ),
-                    severity=WorkflowManager.WorkflowStatus.FLAWED,
+                    severity=WorkflowStatus.FLAWED,
                 )
             )
 

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -32,6 +32,10 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     RegisterWorkflowResultSuccess,
     SetWorkflowMetadataRequest,
     SetWorkflowMetadataResultSuccess,
+    WorkflowDependencyInfo,
+    WorkflowDependencyStatus,
+    WorkflowInfoSummary,
+    WorkflowStatus,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
@@ -571,14 +575,14 @@ class TestWorkflowManager:
 
         workflow_manager = griptape_nodes.WorkflowManager()
         wf_info = WorkflowManager.WorkflowInfo(
-            status=WorkflowManager.WorkflowStatus.GOOD,
+            status=WorkflowStatus.GOOD,
             workflow_path="/workspace/workflows/my_workflow.py",
             workflow_name="my_workflow",
         )
 
         payload = workflow_manager._build_workflow_info_payload(wf_info)
 
-        assert isinstance(payload, WorkflowManager.WorkflowInfoPayload)
+        assert isinstance(payload, WorkflowInfoSummary)
         assert payload.status == "GOOD"
         assert payload.workflow_name == "my_workflow"
         assert payload.workflow_path == "/workspace/workflows/my_workflow.py"
@@ -594,7 +598,7 @@ class TestWorkflowManager:
 
         workflow_manager = griptape_nodes.WorkflowManager()
         wf_info = WorkflowManager.WorkflowInfo(
-            status=WorkflowManager.WorkflowStatus.UNUSABLE,
+            status=WorkflowStatus.UNUSABLE,
             workflow_path="/workspace/workflows/broken.py",
             workflow_name="broken",
             problems=[
@@ -610,23 +614,20 @@ class TestWorkflowManager:
         assert "lib-b" in payload.problems[0]
 
     def test_build_workflow_info_payload_includes_dependencies(self, griptape_nodes: GriptapeNodes) -> None:
-        """_build_workflow_info_payload converts WorkflowDependencyInfo to WorkflowDependencyInfoPayload instances."""
-        from griptape_nodes.retained_mode.events.workflow_events import (
-            WorkflowDependencyInfo as WorkflowDependencyInfoPayload,
-        )
+        """_build_workflow_info_payload passes WorkflowDependencyInfo instances through directly."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
         workflow_manager = griptape_nodes.WorkflowManager()
         wf_info = WorkflowManager.WorkflowInfo(
-            status=WorkflowManager.WorkflowStatus.FLAWED,
+            status=WorkflowStatus.FLAWED,
             workflow_path="/workspace/workflows/flawed.py",
             workflow_name="flawed",
             workflow_dependencies=[
-                WorkflowManager.WorkflowDependencyInfo(
+                WorkflowDependencyInfo(
                     library_name="my-lib",
                     version_requested="1.0.0",
                     version_present="1.1.0",
-                    status=WorkflowManager.WorkflowDependencyStatus.CAUTION,
+                    status=WorkflowDependencyStatus.CAUTION,
                 )
             ],
         )
@@ -635,31 +636,13 @@ class TestWorkflowManager:
 
         assert len(payload.workflow_dependencies) == 1
         dep = payload.workflow_dependencies[0]
-        assert isinstance(dep, WorkflowDependencyInfoPayload)
+        assert isinstance(dep, WorkflowDependencyInfo)
         assert dep.library_name == "my-lib"
         assert dep.version_requested == "1.0.0"
         assert dep.version_present == "1.1.0"
         assert dep.status == "CAUTION"
 
     # --- GetWorkflowInfoRequest ---
-
-    def test_on_get_workflow_info_request_neither_arg_fails(self, griptape_nodes: GriptapeNodes) -> None:
-        """GetWorkflowInfoRequest with neither workflow_name nor workflow_file_path returns failure."""
-        workflow_manager = griptape_nodes.WorkflowManager()
-        request = GetWorkflowInfoRequest()
-
-        result = workflow_manager.on_get_workflow_info_request(request)
-
-        assert isinstance(result, GetWorkflowInfoResultFailure)
-
-    def test_on_get_workflow_info_request_both_args_fails(self, griptape_nodes: GriptapeNodes) -> None:
-        """GetWorkflowInfoRequest with both workflow_name and workflow_file_path returns failure."""
-        workflow_manager = griptape_nodes.WorkflowManager()
-        request = GetWorkflowInfoRequest(workflow_name="my_workflow", workflow_file_path="/path/to/my_workflow.py")
-
-        result = workflow_manager.on_get_workflow_info_request(request)
-
-        assert isinstance(result, GetWorkflowInfoResultFailure)
 
     def test_on_get_workflow_info_request_workflow_not_in_registry_fails(self, griptape_nodes: GriptapeNodes) -> None:
         """GetWorkflowInfoRequest with unknown workflow_name returns failure."""
@@ -686,7 +669,7 @@ class TestWorkflowManager:
 
         assert isinstance(result, GetWorkflowInfoResultFailure)
 
-    def test_on_get_workflow_info_request_success_by_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_get_workflow_info_request_success(self, griptape_nodes: GriptapeNodes) -> None:
         """GetWorkflowInfoRequest succeeds when WorkflowInfo exists for the workflow."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
@@ -699,7 +682,7 @@ class TestWorkflowManager:
         workspace = griptape_nodes.ConfigManager().workspace_path
         info_key = str(workspace / "workflows/my_workflow.py")
         wf_info = WorkflowManager.WorkflowInfo(
-            status=WorkflowManager.WorkflowStatus.GOOD,
+            status=WorkflowStatus.GOOD,
             workflow_path=info_key,
             workflow_name="my_workflow",
         )
@@ -713,27 +696,6 @@ class TestWorkflowManager:
         assert result.workflow_name == "my_workflow"
         assert result.problems == []
         assert result.workflow_dependencies == []
-
-    def test_on_get_workflow_info_request_success_by_file_path(self, griptape_nodes: GriptapeNodes) -> None:
-        """GetWorkflowInfoRequest succeeds when using workflow_file_path directly."""
-        from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
-
-        workflow_manager = griptape_nodes.WorkflowManager()
-
-        workspace = griptape_nodes.ConfigManager().workspace_path
-        info_key = str(workspace / "workflows/my_workflow.py")
-        wf_info = WorkflowManager.WorkflowInfo(
-            status=WorkflowManager.WorkflowStatus.FLAWED,
-            workflow_path=info_key,
-            workflow_name="my_workflow",
-        )
-        workflow_manager._workflow_file_path_to_info[info_key] = wf_info
-
-        request = GetWorkflowInfoRequest(workflow_file_path=info_key)
-        result = workflow_manager.on_get_workflow_info_request(request)
-
-        assert isinstance(result, GetWorkflowInfoResultSuccess)
-        assert result.status == "FLAWED"
 
     # --- ListAllWorkflowInfoRequest ---
 
@@ -758,7 +720,7 @@ class TestWorkflowManager:
         workspace = griptape_nodes.ConfigManager().workspace_path
         info_key = str(workspace / "workflows/my_workflow.py")
         wf_info = WorkflowManager.WorkflowInfo(
-            status=WorkflowManager.WorkflowStatus.GOOD,
+            status=WorkflowStatus.GOOD,
             workflow_path=info_key,
             workflow_name="my_workflow",
         )
@@ -775,7 +737,7 @@ class TestWorkflowManager:
 
         assert isinstance(result, ListAllWorkflowInfoResultSuccess)
         assert "my_workflow" in result.workflow_infos
-        assert result.workflow_infos["my_workflow"]["status"] == "GOOD"
+        assert result.workflow_infos["my_workflow"].status == "GOOD"
 
     def test_on_list_all_workflow_info_request_skips_workflows_without_info(
         self, griptape_nodes: GriptapeNodes


### PR DESCRIPTION
## Summary

- Adds `GetWorkflowInfoRequest` to retrieve fitness status, problems, and dependency details for a single workflow by registry key or file path
- Adds `ListAllWorkflowInfoRequest` to retrieve fitness info for all registered workflows in one call (keyed by registry name)
- Removes the startup console table print since this data is now accessible through the API
- Fixes a path resolution bug where `get_complete_file_path` (which calls `.resolve()` to follow symlinks) produced a different key than the one stored in `_workflow_file_path_to_info` (which uses `joinpath` without symlink resolution)

Closes #4152

UI https://github.com/griptape-ai/griptape-vsl-gui/pull/2057