### PR TITLE
feat: add GTN_PROJECT_FILE env var to specify project file path

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -736,7 +736,14 @@ class ProjectManager:
         # If GTN_PROJECT_FILE is set, load that project directly and skip the workspace file.
         # Otherwise, check the workspace for an optional project overlay file.
         if os.environ.get(GTN_PROJECT_FILE_ENV_VAR) is not None:
-            self._load_env_var_project()
+            try:
+                self._load_env_var_project()
+            except RuntimeError:
+                logger.error(
+                    "Aborting project initialization: failed to load project from %s",
+                    GTN_PROJECT_FILE_ENV_VAR,
+                )
+                return
         else:
             self._load_workspace_project()
 
@@ -1196,12 +1203,15 @@ class ProjectManager:
         If the environment variable is set, loads the project file at that path and sets it
         as the current project. This takes precedence over the workspace project file.
         If the variable is not set, no action is taken.
+
+        Raises:
+            RuntimeError: If the project file cannot be loaded or set as current.
         """
         env_project_path_str = os.environ.get(GTN_PROJECT_FILE_ENV_VAR)
         if env_project_path_str is None:
             return
 
-        env_project_path = Path(env_project_path_str)
+        env_project_path = Path(env_project_path_str).resolve()
         logger.info(
             "Found %s='%s', loading project from environment variable",
             GTN_PROJECT_FILE_ENV_VAR,
@@ -1209,34 +1219,21 @@ class ProjectManager:
         )
 
         if not env_project_path.exists():
-            logger.error(
-                "Attempted to load project from %s='%s'. Failed because file does not exist",
-                GTN_PROJECT_FILE_ENV_VAR,
-                env_project_path,
-            )
-            return
+            msg = f"Attempted to load project from {GTN_PROJECT_FILE_ENV_VAR}='{env_project_path}'. Failed because file does not exist"
+            raise RuntimeError(msg)
 
         try:
             yaml_text = File(str(env_project_path)).read_text()
         except FileLoadError as e:
-            logger.error(
-                "Attempted to read project file at '%s' from %s. Failed with: %s",
-                env_project_path,
-                GTN_PROJECT_FILE_ENV_VAR,
-                e.result_details,
-            )
-            return
+            msg = f"Attempted to read project file at '{env_project_path}' from {GTN_PROJECT_FILE_ENV_VAR}. Failed with: {e.result_details}"
+            raise RuntimeError(msg) from e
 
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
         overlay = load_partial_project_template(yaml_text, validation)
 
         if overlay is None:
-            logger.error(
-                "Attempted to load project from '%s' via %s. Failed because YAML could not be parsed",
-                env_project_path,
-                GTN_PROJECT_FILE_ENV_VAR,
-            )
-            return
+            msg = f"Attempted to load project from '{env_project_path}' via {GTN_PROJECT_FILE_ENV_VAR}. Failed because YAML could not be parsed"
+            raise RuntimeError(msg)
 
         template = ProjectTemplate.merge(DEFAULT_PROJECT_TEMPLATE, overlay, validation)
 
@@ -1247,14 +1244,8 @@ class ProjectManager:
                 else f"{p.field_path}: {p.message}"
                 for p in validation.problems
             )
-            logger.error(
-                "Attempted to load project from '%s' via %s. Failed because template is not usable (status: %s). Problems: %s",
-                env_project_path,
-                GTN_PROJECT_FILE_ENV_VAR,
-                validation.status,
-                problem_details,
-            )
-            return
+            msg = f"Attempted to load project from '{env_project_path}' via {GTN_PROJECT_FILE_ENV_VAR}. Failed because template is not usable (status: {validation.status}). Problems: {problem_details}"
+            raise RuntimeError(msg)
 
         project_id = str(env_project_path)
         situation_schemas = self._parse_situation_macros(template.situations, validation)
@@ -1276,12 +1267,7 @@ class ProjectManager:
         set_result = self.on_set_current_project_request(set_request)
 
         if set_result.failed():
-            logger.error(
-                "Attempted to set project '%s' (from %s) as current. Failed with: %s",
-                env_project_path,
-                GTN_PROJECT_FILE_ENV_VAR,
-                set_result.result_details,
-            )
-            return
+            msg = f"Attempted to set project '{env_project_path}' (from {GTN_PROJECT_FILE_ENV_VAR}) as current. Failed with: {set_result.result_details}"
+            raise RuntimeError(msg)
 
         logger.info("Successfully loaded project from %s='%s'", GTN_PROJECT_FILE_ENV_VAR, env_project_path)

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1656,9 +1656,7 @@ situations:
         assert "copy_external_file" in template.situations
 
     def test_load_env_var_project_file_not_found(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """A nonexistent file path in GTN_PROJECT_FILE leaves system defaults as current project."""
-        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
-
+        """A nonexistent file path in GTN_PROJECT_FILE raises RuntimeError."""
         self._setup_system_defaults(pm, str(tmp_path))
         nonexistent = tmp_path / "does-not-exist.yml"
 
@@ -1666,57 +1664,49 @@ situations:
             patch.dict(os.environ, {"GTN_PROJECT_FILE": str(nonexistent)}),
             patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls,
         ):
-            pm._load_env_var_project()
+            with pytest.raises(RuntimeError):
+                pm._load_env_var_project()
             mock_file_cls.assert_not_called()
 
-        assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
-
-    def test_load_env_var_project_read_failure_keeps_defaults(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """A file read failure leaves system defaults as current project."""
+    def test_load_env_var_project_read_failure_raises(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A file read failure raises RuntimeError."""
         from griptape_nodes.files.file import FileLoadError
         from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
-        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
         self._setup_system_defaults(pm, str(tmp_path))
 
         project_file = tmp_path / "my-project.yml"
         project_file.write_text(self.VALID_PROJECT_YAML)
 
+        mock_file_instance = Mock()
+        mock_file_instance.read_text.side_effect = FileLoadError(
+            failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
+            result_details="permission denied",
+        )
+
         with (
             patch.dict(os.environ, {"GTN_PROJECT_FILE": str(project_file)}),
-            patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls,
+            patch("griptape_nodes.retained_mode.managers.project_manager.File", return_value=mock_file_instance),
+            pytest.raises(RuntimeError),
         ):
-            mock_file_instance = Mock()
-            mock_file_instance.read_text.side_effect = FileLoadError(
-                failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
-                result_details="permission denied",
-            )
-            mock_file_cls.return_value = mock_file_instance
-
             pm._load_env_var_project()
 
-        assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
-
-    def test_load_env_var_project_invalid_yaml_keeps_defaults(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """Invalid YAML in the project file leaves system defaults as current project."""
-        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
-
+    def test_load_env_var_project_invalid_yaml_raises(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """Invalid YAML in the project file raises RuntimeError."""
         self._setup_system_defaults(pm, str(tmp_path))
 
         project_file = tmp_path / "my-project.yml"
         project_file.write_text(self.VALID_PROJECT_YAML)
 
+        mock_file_instance = Mock()
+        mock_file_instance.read_text.return_value = "not: valid: yaml: ]["
+
         with (
             patch.dict(os.environ, {"GTN_PROJECT_FILE": str(project_file)}),
-            patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls,
+            patch("griptape_nodes.retained_mode.managers.project_manager.File", return_value=mock_file_instance),
+            pytest.raises(RuntimeError),
         ):
-            mock_file_instance = Mock()
-            mock_file_instance.read_text.return_value = "not: valid: yaml: ]["
-            mock_file_cls.return_value = mock_file_instance
-
             pm._load_env_var_project()
-
-        assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
 
     @pytest.mark.asyncio
     async def test_app_initialization_complete_uses_env_var_project(self, pm: ProjectManager, tmp_path: Path) -> None:
@@ -1776,3 +1766,26 @@ situations:
         # Should use the env var project, not the workspace one
         assert pm._current_project_id == str(project_file)
         assert str(workspace_project_path) not in pm._successfully_loaded_project_templates
+
+    @pytest.mark.asyncio
+    async def test_app_initialization_complete_aborts_when_env_var_project_fails(
+        self, pm: ProjectManager, tmp_path: Path
+    ) -> None:
+        """on_app_initialization_complete aborts when GTN_PROJECT_FILE is set but loading fails."""
+        from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        nonexistent = tmp_path / "does-not-exist.yml"
+
+        with (
+            patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn,
+            patch.dict(os.environ, {"GTN_PROJECT_FILE": str(nonexistent)}),
+        ):
+            mock_config = Mock()
+            mock_config.get_config_value.return_value = str(tmp_path)
+            mock_gn.ConfigManager.return_value = mock_config
+
+            await pm.on_app_initialization_complete(AppInitializationComplete())
+
+        # Current project should remain system defaults — the load failed and was aborted
+        assert pm._current_project_id == SYSTEM_DEFAULTS_KEY


### PR DESCRIPTION
## Summary
- Adds `GTN_PROJECT_FILE` environment variable support to `ProjectManager`
- When set, the engine loads the project template from that path instead of looking for `griptape-nodes-project.yml` in the workspace directory
- The workspace project file is skipped entirely when `GTN_PROJECT_FILE` is set

## Usage
```bash
GTN_PROJECT_FILE=/path/to/my-project.yml gtn
```

Closes #4154