### PR TITLE
chore: bump v0.77.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.77.2"
+version = "0.77.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.77.2"
+version = "0.77.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.77`.

Cherry-picked commit: 8ce67e19e79cb54ab65fbac2e4f5df7824c243a8