### PR TITLE
fix: save workflow in workspace when template has absolute file path

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4495,7 +4495,7 @@ class WorkflowManager:
             )
             return CreateWorkflowFromTemplateResultFailure(result_details=details)
 
-        base_name = request.file_name or derive_registry_key(template_workflow.file_path)
+        base_name = request.file_name or Path(template_workflow.file_path).stem
         new_file_name = self._generate_unique_filename(base_name)
         relative_file_path = f"{new_file_name}.py"
 

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -343,6 +343,72 @@ class TestWorkflowManager:
         assert result.file_path == new_full_path
         mock_save.assert_called_once_with(new_full_path)
 
+    def test_on_create_workflow_from_template_request_absolute_file_path(self, griptape_nodes: GriptapeNodes) -> None:
+        """Test that templates with absolute file paths save the new workflow in the workspace, not at the template path."""
+        workflow_manager = griptape_nodes.WorkflowManager()
+        request = CreateWorkflowFromTemplateRequest(
+            template_name="/some/external/library/workflows/templates/my_template"
+        )
+
+        mock_template = MagicMock()
+        mock_template.file_path = "/some/external/library/workflows/templates/my_template.py"
+        mock_template.metadata = MagicMock()
+        mock_template.metadata.is_template = True
+        mock_template.metadata.schema_version = "0.16.0"
+        mock_template.metadata.engine_version_created_with = "1.0.0"
+        mock_template.metadata.node_libraries_referenced = []
+        mock_template.metadata.node_types_used = set()
+        mock_template.metadata.workflows_referenced = None
+        mock_template.metadata.description = "A template"
+        mock_template.metadata.image = None
+        mock_template.metadata.last_modified_date = None
+
+        template_content = "# /// script\n# [tool]\n# ///\nprint('body')\n"
+        new_full_path = "/workspace/my_template.py"
+
+        generate_unique_filename_calls = []
+
+        def capture_generate_unique_filename(base_name: str) -> str:
+            generate_unique_filename_calls.append(base_name)
+            return "my_template"
+
+        with (
+            patch.object(
+                WorkflowRegistry,
+                "get_workflow_by_name",
+                return_value=mock_template,
+            ),
+            patch.object(
+                WorkflowRegistry,
+                "get_complete_file_path",
+                return_value=new_full_path,
+            ),
+            patch.object(Path, "is_file", return_value=True),
+            patch.object(Path, "read_text", return_value=template_content),
+            patch.object(
+                workflow_manager,
+                "_generate_unique_filename",
+                side_effect=capture_generate_unique_filename,
+            ),
+            patch.object(
+                workflow_manager,
+                "_replace_workflow_metadata_header",
+                return_value="updated_content",
+            ),
+            patch.object(Path, "write_text"),
+            patch.object(WorkflowRegistry, "generate_new_workflow"),
+            patch.object(
+                griptape_nodes.ConfigManager(),
+                "save_user_workflow_json",
+            ),
+        ):
+            result = workflow_manager.on_create_workflow_from_template_request(request)
+
+        assert isinstance(result, CreateWorkflowFromTemplateResultSuccess)
+        # The base name passed to _generate_unique_filename must be just the stem,
+        # not the full absolute path, so the file is saved in the workspace.
+        assert generate_unique_filename_calls == ["my_template"]
+
     def test_on_create_workflow_from_template_request_template_not_found(self, griptape_nodes: GriptapeNodes) -> None:
         """Test create from template when template is not in registry."""
         workflow_manager = griptape_nodes.WorkflowManager()


### PR DESCRIPTION
When templates from external libraries have absolute file paths, derive_registry_key preserved the full path structure, causing _generate_unique_filename to resolve against the absolute path instead of the workspace. Use Path.stem to extract only the filename stem so new workflows always land in the workspace.

Closes #4164