### PR TITLE
fix: skip metadata injection for empty upload placeholder file

### DIFF
--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -56,6 +56,7 @@ class LocalStorageDriver(BaseStorageDriver):
             file_path=str(absolute_path),
             content=b"",  # Empty content for URL generation
             existing_file_policy=existing_file_policy,
+            skip_metadata_injection=True,
         )
         result = os_manager.on_write_file_request(write_request)
 


### PR DESCRIPTION
## Summary

- Pass `skip_metadata_injection=True` when writing the 0-byte placeholder file in `LocalStorageDriver.create_signed_upload_url`

## Context

`create_signed_upload_url` writes an empty file to "claim" a filename path before issuing the upload URL, preventing race conditions when `CREATE_NEW` policy is in use. Since the file is intentionally empty, running metadata injection on it serves no purpose and emits a spurious `WARNING: Cannot inject metadata: empty data` log on every image upload URL request.

Closes #4167