### PR TITLE
fix: add back ConfigManager.workspace_path to minimize breaking change

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -125,6 +125,9 @@ class ConfigManager:
         # and importing GriptapeNodes at module level would cause a circular dependency.
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+        logger.warning(
+            "ConfigManager.workspace_path is deprecated. Use GriptapeNodes.ProjectManager().workspace_path instead."
+        )
         return GriptapeNodes.ProjectManager().workspace_path
 
     @property


### PR DESCRIPTION

<img width="1248" height="626" alt="image" src="https://github.com/user-attachments/assets/87b07fc1-5bd2-40f5-81a9-c8edf4ae6e43" />


Got removed in eaf5ae816c26. Didn't realize libs were using it.