### PR TITLE
fix: do not cache library modules when import context exits with an exception

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_import_context.py
+++ b/src/griptape_nodes/retained_mode/managers/library_import_context.py
@@ -68,7 +68,10 @@ class LibraryImportContext:
             if module_file is not None and self._is_under_library_path(module_file):
                 library_specific[name] = module
         # Cache this library's modules so they can be restored on re-entry.
-        if library_specific:
+        # Skip caching when an exception occurred — modules may be in a partial or broken
+        # state (e.g. a C extension that failed mid-load), and restoring them on the next
+        # context entry would propagate that broken state to subsequent node loads.
+        if _exc_type is None and library_specific:
             if self._library_name not in self._library_module_caches:
                 self._library_module_caches[self._library_name] = {}
             self._library_module_caches[self._library_name].update(library_specific)

--- a/tests/unit/retained_mode/managers/test_library_import_context.py
+++ b/tests/unit/retained_mode/managers/test_library_import_context.py
@@ -150,6 +150,35 @@ class TestLibraryImportContext:
         # Cleanup
         LibraryImportContext._library_module_caches.pop(library_name, None)
 
+    def test_no_caching_on_exception(self) -> None:
+        """Modules imported during a failed context are not cached, only cleaned up."""
+        library_paths = ["/lib/a/site-packages"]
+        engine_baseline = ["/engine/src"]
+        library_name = "_test_lib_no_cache_on_exception"
+        module_name = "_test_failed_import_module"
+
+        LibraryImportContext._library_module_caches.pop(library_name, None)
+        sys.modules.pop(module_name, None)
+
+        fake_module = types.ModuleType(module_name)
+        fake_module.__file__ = "/lib/a/site-packages/failed_module/__init__.py"
+
+        def _failing_import() -> None:
+            sys.modules[module_name] = fake_module
+            err_msg = "simulated DLL load failure"
+            raise ImportError(err_msg)
+
+        with pytest.raises(ImportError), LibraryImportContext(library_name, library_paths, engine_baseline):
+            _failing_import()
+
+        # Module should be cleaned up from sys.modules
+        assert module_name not in sys.modules
+        # But it should NOT be cached — the import was partial/broken
+        assert library_name not in LibraryImportContext._library_module_caches
+
+        # Cleanup
+        LibraryImportContext._library_module_caches.pop(library_name, None)
+
     def test_no_caching_when_library_name_is_empty(self) -> None:
         """When library_name is empty, no modules are cached or removed on exit."""
         library_paths = ["/lib/a/site-packages"]


### PR DESCRIPTION
When a module fails to load inside LibraryImportContext (e.g. a C extension that raises ImportError due to a missing or incompatible DLL), any modules that were partially added to sys.modules during the failed context were being cached and restored on the next context entry. This caused broken module state to propagate to subsequent node loads in the same library.

Skip caching when __exit__ receives a non-None exc_type. sys.modules is still cleaned up so the failed state does not leak to other libraries.