### PR TITLE
fix: use File to resolve paths in PublicArtifactUrlParameter

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 from typing import Any, ClassVar
-from urllib.parse import urlparse
 from uuid import uuid4
 
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
@@ -123,16 +122,12 @@ class PublicArtifactUrlParameter:
         if url.startswith(("http://", "https://")) and "localhost" not in url:
             return url
 
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
-        static_files_dir = str(self._get_config_value("static_files_directory", default="staticfiles"))
-        static_files_path = workspace_path / static_files_dir
+        from griptape_nodes.files.file import File
 
-        parsed_url = urlparse(url)
-        filename = Path(parsed_url.path).name
-        with (static_files_path / filename).open("rb") as f:
-            file_contents = f.read()
+        file_contents = File(url).read_bytes()
+        filename = Path(url).name
 
-        self.gtc_file_path = Path(static_files_dir) / "artifact_url_storage" / uuid4().hex / filename
+        self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
 
         # upload to Griptape Cloud and get a public URL
         public_url = self._storage_driver.upload_file(path=self.gtc_file_path, file_content=file_contents)


### PR DESCRIPTION
`get_public_url_for_parameter()` was hardcoding a lookup into `<workspace>/staticfiles/<filename>` to read the file before uploading it to Griptape Cloud. This failed whenever the artifact's path was a macro path like `{outputs}/file.mp4` or a localhost URL pointing outside the `staticfiles/` directory, producing `[Errno 2] No such file or directory`.

The fix replaces the manual file reading with `File(url).read_bytes()`. The `File` class already handles macro path resolution (via `GetPathForMacroRequest`), localhost URLs (via the static server file driver), and absolute paths, so no special-casing is needed. The `gtc_file_path` base was also simplified from `Path(static_files_dir) / "artifact_url_storage"` to `Path("artifact_url_storage")` since `static_files_dir` was only relevant to the old lookup.

Closes #4188