### PR TITLE
fix: log warning instead of error for unrecognized events

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -253,8 +253,11 @@ async def _process_incoming_messages(client: Client) -> None:
     async for message in client.messages:
         try:
             await _process_api_event(message)
-        except Exception:
-            logger.exception("Error processing event, skipping.")
+        except Exception as e:
+            logger.warning(
+                "Skipping unrecognized event. Your editor may be newer than this engine version. (%s)",
+                e,
+            )
 
 
 async def _process_api_event(event: dict) -> None:


### PR DESCRIPTION
When the engine receives an event type it doesn't recognize, `logger.exception` was used, producing a full ERROR-level traceback. This is misleading because it commonly occurs when the editor/client is newer than the engine — the engine simply cannot deserialize the unknown event type, but it is not a fatal or unexpected condition.

Replaced `logger.exception` with `logger.warning` and updated the message to note that the editor may be newer than the engine version.

Closes #4192