### PR TITLE
feat: add location and name properties to FileDestination

### DIFF
--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -729,6 +729,14 @@ class FileDestination:
         """
         return self._file.resolve()
 
+    @property
+    def location(self) -> str:
+        return self._file.location
+
+    @property
+    def name(self) -> str:
+        return self._file.name
+
     def write_bytes(self, content: bytes) -> File:
         """Write bytes to the file using the configured write policy.
 

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -1065,6 +1065,36 @@ class TestFileBuildFileMetadata:
         assert write_request.file_metadata.situation.macro == "{outputs}/image.png"
 
 
+class TestFileDestinationLocation:
+    """Tests for FileDestination.location property."""
+
+    def test_location_plain_string(self) -> None:
+        dest = FileDestination("workspace/outputs/image.png")
+        assert dest.location == "workspace/outputs/image.png"
+
+    def test_location_macro_path_returns_template(self) -> None:
+        dest = FileDestination("{outputs}/image.png")
+        assert dest.location == "{outputs}/image.png"
+
+    def test_location_no_io_performed(self) -> None:
+        with patch(HANDLE_REQUEST_PATH) as mock_handle:
+            dest = FileDestination("{outputs}/image.png")
+            _ = dest.location
+        mock_handle.assert_not_called()
+
+
+class TestFileDestinationName:
+    """Tests for FileDestination.name property."""
+
+    def test_name_plain_string(self) -> None:
+        dest = FileDestination("workspace/outputs/image.png")
+        assert dest.name == "image.png"
+
+    def test_name_macro_path_returns_filename_from_template(self) -> None:
+        dest = FileDestination("{outputs}/image.png")
+        assert dest.name == "image.png"
+
+
 class TestFileResolve:
     """Tests for File.resolve() method."""
 


### PR DESCRIPTION
`FileDestination` wraps a `File` internally but didn't expose `location` or `name`, forcing callers to use `resolve()` (which performs macro expansion and returns an absolute path) when they only needed the portable template form.

Two properties are added to `FileDestination` that delegate directly to the internal `self._file`:

- `location` — returns the macro template (e.g. `{outputs}/image.png`) when the path contains macro variables, otherwise the plain path string. No I/O is performed.
- `name` — returns the filename component of `location` (e.g. `image.png`).

Tests for both properties are added to `tests/unit/files/test_file.py`.