### PR TITLE
fix: inject node_name into ProjectFileDestination in build_file()

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
@@ -137,9 +137,9 @@ class ProjectFileParameter:
         if "node_name" not in extra_vars:
             extra_vars["node_name"] = self._node.name
 
-        return ProjectFileDestination(
-            filename=filename,
-            situation=self._situation_name,
+        return ProjectFileDestination.from_situation(
+            filename,
+            self._situation_name,
             **extra_vars,
         )
 

--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -35,19 +35,54 @@ SITUATION_TO_FILE_POLICY: dict[str, ExistingFilePolicy] = {
 
 
 class ProjectFileDestination(FileDestination):
-    """A FileDestination built from a project situation template.
+    """A FileDestination that maps written absolute paths back to project macro form.
 
-    Resolves the macro template and write policy from the named situation in the
-    current project, then delegates all I/O to the parent FileDestination.
+    After each write, attempts to convert the resulting absolute path to its
+    portable macro representation (e.g. ``{outputs}/image.png``).  Falls back
+    to the plain absolute path if mapping is not possible.
+
+    Construct directly with a ``MacroPath`` and write policy, or use the
+    ``from_situation`` classmethod to build from a situation name and filename.
     """
 
-    def __init__(
-        self,
+    def write_bytes(self, content: bytes) -> File:
+        return self._map_to_macro_file(super().write_bytes(content))
+
+    async def awrite_bytes(self, content: bytes) -> File:
+        return self._map_to_macro_file(await super().awrite_bytes(content))
+
+    def write_text(self, content: str, encoding: str = "utf-8") -> File:
+        return self._map_to_macro_file(super().write_text(content, encoding))
+
+    async def awrite_text(self, content: str, encoding: str = "utf-8") -> File:
+        return self._map_to_macro_file(await super().awrite_text(content, encoding))
+
+    def _map_to_macro_file(self, result_file: File) -> File:
+        """Attempt to convert the written path to its portable macro form.
+
+        Returns a File holding the macro template (e.g. ``{outputs}/image.png``)
+        when the path is inside a project directory, so callers can store a
+        portable reference via ``file.as_macro()``.  Falls back to the original
+        File (absolute path) if mapping is not possible.
+        """
+        map_result = GriptapeNodes.handle_request(
+            AttemptMapAbsolutePathToProjectRequest(absolute_path=Path(result_file.resolve()))
+        )
+        if isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess) and map_result.mapped_path is not None:
+            return File(map_result.mapped_path)
+        return result_file
+
+    @classmethod
+    def from_situation(
+        cls,
         filename: str,
         situation: str,
         **extra_vars: str | int,
-    ) -> None:
-        """Build a FileDestination from a project situation template.
+    ) -> "ProjectFileDestination":
+        """Build a ProjectFileDestination from a project situation template.
+
+        Looks up the named situation in the current project to obtain the macro
+        template and write policy, then constructs the destination.
 
         Args:
             filename: Filename to parse into base and extension components.
@@ -93,36 +128,9 @@ class ProjectFileDestination(FileDestination):
         )
 
         macro_path = MacroPath(ParsedMacro(macro_template), variables)
-        super().__init__(
+        return cls(
             macro_path,
             existing_file_policy=existing_file_policy,
             create_parents=create_dirs,
             file_metadata=file_metadata,
         )
-
-    def write_bytes(self, content: bytes) -> File:
-        return self._map_to_macro_file(super().write_bytes(content))
-
-    async def awrite_bytes(self, content: bytes) -> File:
-        return self._map_to_macro_file(await super().awrite_bytes(content))
-
-    def write_text(self, content: str, encoding: str = "utf-8") -> File:
-        return self._map_to_macro_file(super().write_text(content, encoding))
-
-    async def awrite_text(self, content: str, encoding: str = "utf-8") -> File:
-        return self._map_to_macro_file(await super().awrite_text(content, encoding))
-
-    def _map_to_macro_file(self, result_file: File) -> File:
-        """Attempt to convert the written path to its portable macro form.
-
-        Returns a File holding the macro template (e.g. ``{outputs}/image.png``)
-        when the path is inside a project directory, so callers can store a
-        portable reference via ``file.as_macro()``.  Falls back to the original
-        File (absolute path) if mapping is not possible.
-        """
-        map_result = GriptapeNodes.handle_request(
-            AttemptMapAbsolutePathToProjectRequest(absolute_path=Path(result_file.resolve()))
-        )
-        if isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess) and map_result.mapped_path is not None:
-            return File(map_result.mapped_path)
-        return result_file

--- a/tests/unit/files/test_project_file.py
+++ b/tests/unit/files/test_project_file.py
@@ -29,7 +29,7 @@ class TestProjectFileDestinationInit:
         with patch(
             HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
         ):
-            dest = ProjectFileDestination("image.png", "save_node_output")
+            dest = ProjectFileDestination.from_situation("image.png", "save_node_output")
 
         assert dest._file._file_metadata is not None
         assert isinstance(dest._file._file_metadata, SidecarContent)
@@ -55,7 +55,7 @@ class TestProjectFileDestinationInit:
         with patch(
             HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
         ):
-            dest = ProjectFileDestination("render.png", "save_node_output", node_name="MyNode")
+            dest = ProjectFileDestination.from_situation("render.png", "save_node_output", node_name="MyNode")
 
         assert dest._file._file_metadata is not None
         assert dest._file._file_metadata.situation is not None
@@ -70,7 +70,7 @@ class TestProjectFileDestinationInit:
         from griptape_nodes.retained_mode.events.project_events import GetSituationResultFailure
 
         with patch(HANDLE_REQUEST_PATH, return_value=GetSituationResultFailure(result_details="not found")):
-            dest = ProjectFileDestination("image.png", "missing_situation")
+            dest = ProjectFileDestination.from_situation("image.png", "missing_situation")
 
         assert dest._file._file_metadata is None
 
@@ -92,7 +92,7 @@ class TestProjectFileDestinationInit:
         with patch(
             HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
         ):
-            dest = ProjectFileDestination("data.json", "save_node_output")
+            dest = ProjectFileDestination.from_situation("data.json", "save_node_output")
 
         assert dest._file._file_metadata is not None
         assert dest._file._file_metadata.situation is not None


### PR DESCRIPTION
`ProjectFileParameter.build_file()` never passed `node_name` to `ProjectFileDestination`, so the `{node_name?:_}` placeholder in the `save_node_output` situation template silently resolved to nothing. This produced paths like `{outputs}/seedream_image000.png` instead of the expected `{outputs}/Seedream Image Generation_seedream_image000.png`.

This PR also refactors `ProjectFileDestination` so its `__init__` accepts a `MacroPath` directly (matching `FileDestination`), with the situation-lookup logic moved into a new `from_situation` classmethod. This makes `ProjectFileDestination` directly constructible from any `MacroPath`, enabling downstream consumers (like `FileOutputSettings`) to use it without going through the situation lookup.

Closes #4186