### PR TITLE
chore: bump v0.77.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.77.4"
+version = "0.77.5"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.77.4"
+version = "0.77.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.77`.

Cherry-picked commit: 591e6963d4d50e50a5be0b1ed55a980d24c6900e