### PR TITLE
fix: use copy_external_file situation in download URL handler

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -203,9 +203,9 @@ class StaticFilesManager:
         Returns:
             A result object indicating success or failure.
         """
-        resolved = self._resolve_static_file_path(request.file_name)
+        resolved = self._resolve_static_file_path(request.file_name, COPY_EXTERNAL_FILE_SITUATION)
         if resolved is None:
-            msg = f"Attempted to create download URL for '{request.file_name}'. Failed because the project template is missing the '{SAVE_STATIC_FILE_SITUATION}' situation."
+            msg = f"Attempted to create download URL for '{request.file_name}'. Failed because the project template is missing the '{COPY_EXTERNAL_FILE_SITUATION}' situation."
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
         try:


### PR DESCRIPTION
The `on_handle_create_static_file_download_url_request` handler was using the `save_static_file` situation to resolve the file path, which maps to the `staticfiles/` directory. However, files are uploaded via `CreateStaticFileUploadUrlRequest`, which uses the `copy_external_file` situation mapping to `inputs/`. This mismatch meant the generated download URL pointed to `staticfiles/<filename>` while the file actually lived at `inputs/<filename>`.

The fix updates `on_handle_create_static_file_download_url_request` to use `COPY_EXTERNAL_FILE_SITUATION`, consistent with the upload handler.

Closes #4233