### PR TITLE
chore: bump v0.78.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.78.0"
+version = "0.78.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.78.0"
+version = "0.78.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.78`.

Cherry-picked commit: d359f174e33ff9828acd2248659d2e27356731a1