### PR TITLE
fix: pass RELEASE_PAT via token input in release workflows

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -31,9 +31,8 @@ jobs:
           git push origin "$tag" -f --tags
       - name: Create release
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           tag_name: latest
           generate_release_notes: false
           make_latest: false

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - name: Create release
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           generate_release_notes: true
           make_latest: true
           prerelease: false


### PR DESCRIPTION
`softprops/action-gh-release@v2.5.3` changed token precedence to prefer the `token` input parameter over the `GITHUB_TOKEN` environment variable. Both `stable-release.yml` and `latest-release.yml` were passing `RELEASE_PAT` via `env: GITHUB_TOKEN:`, which the action now ignores, causing releases to be authored by `github-actions[bot]` instead of the user.

Moves the token from `env: GITHUB_TOKEN:` to `with: token:` in both workflows.

Closes #4236