### PR TITLE
fix: use OS-assigned ports for static and MCP servers

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import os
 import threading
 import uuid
 from collections.abc import Iterator
@@ -72,7 +71,8 @@ from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from griptape_nodes.retained_mode.managers.static_files_manager import (
     StaticFilesManager,
 )
-from griptape_nodes.servers.mcp import start_mcp_server
+from griptape_nodes.servers import bind_free_socket
+from griptape_nodes.servers.mcp import GTN_MCP_SERVER_HOST, GTN_MCP_SERVER_PORT, start_mcp_server
 
 if TYPE_CHECKING:
     from griptape.tools.mcp.sessions import StreamableHttpConnection
@@ -81,7 +81,6 @@ logger = logging.getLogger("griptape_nodes")
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
-GTN_MCP_SERVER_PORT = int(os.getenv("GTN_MCP_SERVER_PORT", "9927"))
 
 config_manager = ConfigManager()
 secrets_manager = SecretsManager(config_manager)
@@ -129,6 +128,7 @@ class AgentManager:
         self.image_tool = None
         self.mcp_tool = None
         self.static_files_manager = static_files_manager
+        self._mcp_server_port = GTN_MCP_SERVER_PORT
 
         # Thread management
         self._threads_dir = xdg_data_home() / "griptape_nodes" / "threads"
@@ -319,8 +319,15 @@ class AgentManager:
     def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         secrets_manager = GriptapeNodes.SecretsManager()
         api_key = secrets_manager.get_secret("GT_CLOUD_API_KEY")
+
+        # Pre-bind to port 0 (or the configured port) so the OS assigns a free port before
+        # the server thread starts. This lets us know the actual port immediately with no
+        # race condition between discovering the port and uvicorn binding to it.
+        sock = bind_free_socket(GTN_MCP_SERVER_HOST, GTN_MCP_SERVER_PORT)
+        self._mcp_server_port = sock.getsockname()[1]
+
         # Start MCP server in daemon thread
-        threading.Thread(target=start_mcp_server, args=(api_key,), daemon=True, name="mcp-server").start()
+        threading.Thread(target=start_mcp_server, args=(api_key, sock), daemon=True, name="mcp-server").start()
 
     def _on_handle_run_agent_request(self, request: RunAgentRequest) -> ResultPayload:
         # EventBus functionality removed - events now go directly to event queue
@@ -550,7 +557,7 @@ class AgentManager:
     def _initialize_mcp_tool(self) -> MCPTool:
         connection: StreamableHttpConnection = {  # type: ignore[reportAssignmentType]
             "transport": "streamable_http",
-            "url": f"http://localhost:{GTN_MCP_SERVER_PORT}/mcp/",
+            "url": f"http://localhost:{self._mcp_server_port}/mcp/",
         }
         return MCPTool(connection=connection, name="mcpGriptapeNodes")
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -42,7 +42,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
-from griptape_nodes.servers.static import STATIC_SERVER_URL, start_static_server
+from griptape_nodes.servers import bind_free_socket
+from griptape_nodes.servers.static import STATIC_SERVER_HOST, STATIC_SERVER_PORT, STATIC_SERVER_URL, start_static_server
 from griptape_nodes.utils.url_utils import uri_to_path
 
 logger = logging.getLogger("griptape_nodes")
@@ -306,7 +307,17 @@ class StaticFilesManager:
     def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         # Start static server in daemon thread if enabled
         if isinstance(self.storage_driver, LocalStorageDriver):
-            threading.Thread(target=start_static_server, daemon=True, name="static-server").start()
+            # Pre-bind to port 0 (or the configured port) so the OS assigns a free port before
+            # the server thread starts. This lets us know the actual port immediately with no
+            # race condition between discovering the port and uvicorn binding to it.
+            sock = bind_free_socket(STATIC_SERVER_HOST, STATIC_SERVER_PORT)
+            actual_port = sock.getsockname()[1]
+
+            actual_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
+            self.config_manager.set_config_value("static_server_base_url", actual_base_url)
+            self.storage_driver.base_url = f"{actual_base_url}{STATIC_SERVER_URL}"
+
+            threading.Thread(target=start_static_server, args=(sock,), daemon=True, name="static-server").start()
 
     def save_static_file(
         self,

--- a/src/griptape_nodes/servers/__init__.py
+++ b/src/griptape_nodes/servers/__init__.py
@@ -1,1 +1,16 @@
 """Package for web servers the engine may need to start."""
+
+import socket
+
+
+def bind_free_socket(host: str, port: int) -> socket.socket:
+    """Bind a TCP socket to the given host and port and return it.
+
+    When port is 0 the OS assigns a free port automatically. The caller
+    can read the actual port via ``sock.getsockname()[1]`` and must
+    eventually close the socket.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((host, port))
+    return sock

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -1,7 +1,9 @@
+import asyncio
 import contextlib
 import json
 import logging
 import os
+import socket
 from collections.abc import AsyncIterator
 
 import uvicorn
@@ -90,7 +92,8 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
 }
 
 GTN_MCP_SERVER_HOST = os.getenv("GTN_MCP_SERVER_HOST", "localhost")
-GTN_MCP_SERVER_PORT = int(os.getenv("GTN_MCP_SERVER_PORT", "9927"))
+# Port of the MCP server (where uvicorn binds). 0 means the OS assigns a free port automatically.
+GTN_MCP_SERVER_PORT = int(os.getenv("GTN_MCP_SERVER_PORT", "0"))
 GTN_MCP_SERVER_LOG_LEVEL = os.getenv("GTN_MCP_SERVER_LOG_LEVEL", "ERROR").lower()
 
 config_manager = ConfigManager()
@@ -101,8 +104,13 @@ mcp_server_logger.addHandler(RichHandler(show_time=True, show_path=False, markup
 mcp_server_logger.setLevel(logging.INFO)
 
 
-def start_mcp_server(api_key: str) -> None:
-    """Synchronous version of main entry point for the Griptape Nodes MCP server."""
+def start_mcp_server(api_key: str, sock: socket.socket) -> None:
+    """Synchronous version of main entry point for the Griptape Nodes MCP server.
+
+    The socket should already be bound to the desired address and port before calling
+    this function. Using a pre-bound socket avoids race conditions when discovering
+    the actual port assigned by the OS.
+    """
     mcp_server_logger.debug("Starting MCP GTN server...")
 
     app = Server("mcp-gtn")
@@ -167,14 +175,9 @@ def start_mcp_server(api_key: str) -> None:
     mcp_server_app.mount("/mcp", app=handle_streamable_http)
 
     try:
-        # Run server using uvicorn.run
-        uvicorn.run(
-            mcp_server_app,
-            host=GTN_MCP_SERVER_HOST,
-            port=GTN_MCP_SERVER_PORT,
-            log_config=None,
-            log_level=GTN_MCP_SERVER_LOG_LEVEL,
-        )
+        config = uvicorn.Config(mcp_server_app, log_config=None, log_level=GTN_MCP_SERVER_LOG_LEVEL)
+        server = uvicorn.Server(config)
+        asyncio.run(server.serve(sockets=[sock]))
     except Exception as e:
         mcp_server_logger.error("MCP server failed: %s", e)
         raise

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import binascii
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
+
+if TYPE_CHECKING:
+    import socket
 
 import anyio
 import uvicorn
@@ -20,8 +25,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "true"
 # Host of the static server (where uvicorn binds)
 STATIC_SERVER_HOST = os.getenv("STATIC_SERVER_HOST", "localhost")
-# Port of the static server (where uvicorn binds)
-STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
+# Port of the static server (where uvicorn binds). 0 means the OS assigns a free port automatically.
+STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "0"))
 # URL path for the static server
 STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/workspace")
 # Log level for the static server
@@ -241,8 +246,13 @@ async def _serve_external_file(file_path: str) -> FileResponse:
     return FileResponse(absolute_path)
 
 
-def start_static_server() -> None:
-    """Run uvicorn server synchronously using uvicorn.run."""
+def start_static_server(sock: socket.socket) -> None:
+    """Run uvicorn server synchronously using a pre-bound socket.
+
+    The socket should already be bound to the desired address and port before calling
+    this function. Using a pre-bound socket avoids race conditions when discovering
+    the actual port assigned by the OS.
+    """
     logger.debug("Starting static server...")
 
     # Create FastAPI app
@@ -304,14 +314,9 @@ def start_static_server() -> None:
     )
 
     try:
-        # Run server using uvicorn.run
-        uvicorn.run(
-            app,
-            host=STATIC_SERVER_HOST,
-            port=STATIC_SERVER_PORT,
-            log_level=STATIC_SERVER_LOG_LEVEL,
-            log_config=None,
-        )
+        config = uvicorn.Config(app, log_level=STATIC_SERVER_LOG_LEVEL, log_config=None)
+        server = uvicorn.Server(config)
+        asyncio.run(server.serve(sockets=[sock]))
     except Exception as e:
         logger.error("API server failed: %s", e)
         raise


### PR DESCRIPTION
I can't believe we're actually here.

When multiple engine instances run on the same machine, the static file server (port 8124) and MCP server (port 9927) would both fail to bind because the ports were already in use by the first instance.

Both servers now bind to port 0, letting the OS assign a free port automatically. A socket is pre-bound before the server thread starts so the actual port is known immediately with no race condition — the same socket is passed directly to uvicorn via `uvicorn.Server.serve(sockets=[sock])`, which takes ownership of it.

Once the port is known, `static_server_base_url` in the config and the `LocalStorageDriver.base_url` are updated before any requests can be made. The MCP server stores the actual port in `self._mcp_server_port` so `_initialize_mcp_tool` always connects to the right address.

This fix is safe because localhost file URLs are no longer persisted in workflow files — they are produced on the fly by the editor as needed, so changing the port between runs does not invalidate any stored state.

Closes #2707.