### PR TITLE
fix: fall back to OS-assigned port when preferred static server port is unavailable

### DIFF
--- a/src/griptape_nodes/servers/__init__.py
+++ b/src/griptape_nodes/servers/__init__.py
@@ -6,11 +6,16 @@ import socket
 def bind_free_socket(host: str, port: int) -> socket.socket:
     """Bind a TCP socket to the given host and port and return it.
 
-    When port is 0 the OS assigns a free port automatically. The caller
-    can read the actual port via ``sock.getsockname()[1]`` and must
-    eventually close the socket.
+    When port is 0 the OS assigns a free port automatically. When a
+    non-zero port is requested but already in use, the function falls
+    back to port 0 so the OS assigns a free port. The caller can read
+    the actual port via ``sock.getsockname()[1]`` and must eventually
+    close the socket.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((host, port))
+    try:
+        sock.bind((host, port))
+    except OSError:
+        sock.bind((host, 0))
     return sock

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -25,8 +25,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "true"
 # Host of the static server (where uvicorn binds)
 STATIC_SERVER_HOST = os.getenv("STATIC_SERVER_HOST", "localhost")
-# Port of the static server (where uvicorn binds). 0 means the OS assigns a free port automatically.
-STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "0"))
+# Port of the static server (where uvicorn binds). Falls back to an OS-assigned free port if unavailable.
+STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
 # URL path for the static server
 STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/workspace")
 # Log level for the static server


### PR DESCRIPTION
https://github.com/griptape-ai/griptape-nodes/pull/4239#pullrequestreview-3994575380
> Any consideration for trying 8124/9927 first and then falling back to 0? In case there is anyone assuming the port is 8124/9927

Existing workflow files 😞.

Closes #2707.

The previous fix (#4239) changed the static server to always use port 0, letting the OS assign a free port. However, this broke existing workflow files that had `http://localhost:8124` URLs stored in them, since those URLs are no longer valid after a port change.

This follow-up restores port 8124 as the default for the static server but makes it a preferred port rather than a required one. `bind_free_socket` now attempts to bind to the configured port first, and silently falls back to an OS-assigned free port if it is already in use. This way a single engine instance continues to use the well-known port 8124, while a second instance on the same machine gets a different port automatically instead of crashing.

The MCP server remains fully dynamic (port 0) since its port is not persisted anywhere.