### PR TITLE
LoD Image Previews

### DIFF
--- a/src/griptape_nodes/retained_mode/events/artifact_events.py
+++ b/src/griptape_nodes/retained_mode/events/artifact_events.py
@@ -164,12 +164,12 @@ class GetPreviewForArtifactResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
             - str: Single preview file path (e.g., "/path/to/image.png.webp")
             - dict[str, str]: Multiple preview files with semantic keys
               (e.g., {"mask_r": "/path/to/output_R.png", "mask_g": "/path/to/output_G.png"})
-        original_metadata: Provider-extracted metadata from the source file (e.g., image
+        artifact_metadata: Provider-extracted metadata from the source file (e.g., image
             dimensions, channels). None if not available or not applicable.
     """
 
     paths_to_preview: str | dict[str, str]
-    original_metadata: dict[str, Any] | None = field(default=None)
+    artifact_metadata: dict[str, Any] | None = field(default=None)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/artifact_events.py
+++ b/src/griptape_nodes/retained_mode/events/artifact_events.py
@@ -164,9 +164,12 @@ class GetPreviewForArtifactResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
             - str: Single preview file path (e.g., "/path/to/image.png.webp")
             - dict[str, str]: Multiple preview files with semantic keys
               (e.g., {"mask_r": "/path/to/output_R.png", "mask_g": "/path/to/output_G.png"})
+        original_metadata: Provider-extracted metadata from the source file (e.g., image
+            dimensions, channels). None if not available or not applicable.
     """
 
     paths_to_preview: str | dict[str, str]
+    original_metadata: dict[str, Any] | None = field(default=None)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -153,13 +153,23 @@ class CreateStaticFileDownloadUrlResultSuccess(WorkflowNotAlteredMixin, ResultPa
     Args:
         url: Presigned URL for downloading the file
         file_url: File URI (file://) for the absolute path to the file that was used to create the download URL
-        original_metadata: Original image properties extracted from the source file header.
-            Only populated when preview=True and the file is a local image.
-            Contains: width, height, format, channels, color_space, file_size.
     """
 
     url: str
     file_url: str = ""
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateStaticFileDownloadUrlFromPathResultSuccess(CreateStaticFileDownloadUrlResultSuccess):
+    """Static file download URL created successfully from an arbitrary path.
+
+    Args:
+        original_metadata: Original properties extracted from the source file header.
+            Only populated when preview=True and the file is a local image.
+            Contains: width, height, format, channels, color_space, file_size.
+    """
+
     original_metadata: dict | None = None
 
 

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -153,10 +153,14 @@ class CreateStaticFileDownloadUrlResultSuccess(WorkflowNotAlteredMixin, ResultPa
     Args:
         url: Presigned URL for downloading the file
         file_url: File URI (file://) for the absolute path to the file that was used to create the download URL
+        original_metadata: Original image properties extracted from the source file header.
+            Only populated when preview=True and the file is a local image.
+            Contains: width, height, format, channels, color_space, file_size.
     """
 
     url: str
     file_url: str = ""
+    original_metadata: dict | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -134,12 +134,15 @@ class CreateStaticFileDownloadUrlFromPathRequest(RequestPayload):
         macro_variables: Optional variable substitutions for macro paths
                          (e.g., {"file_name": "output", "file_ext": "png"}).
                          Ignored for non-macro paths.
+        preview: If True, adds ?preview=true to the URL for images to serve smaller preview versions.
+                 Defaults to False.
 
     Results: CreateStaticFileDownloadUrlResultSuccess (with URL) | CreateStaticFileDownloadUrlResultFailure (URL creation error)
     """
 
     file_path: str
     macro_variables: MacroVariables = field(default_factory=dict)
+    preview: bool = False
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -127,15 +127,15 @@ class CreateStaticFileDownloadUrlFromPathRequest(RequestPayload):
 
     Args:
         file_path: File path or URL. Accepts:
-                   - file:// URLs (e.g., "file:///absolute/path/to/file.jpg")
-                   - Absolute paths (e.g., "/absolute/path/to/file.jpg")
-                   - Workspace-relative paths (e.g., "relative/path/to/file.jpg")
-                   - Macro paths (e.g., "{outputs}/file.png")
+            - file:// URLs (e.g., "file:///absolute/path/to/file.jpg")
+            - Absolute paths (e.g., "/absolute/path/to/file.jpg")
+            - Workspace-relative paths (e.g., "relative/path/to/file.jpg")
+            - Macro paths (e.g., "{outputs}/file.png")
         macro_variables: Optional variable substitutions for macro paths
-                         (e.g., {"file_name": "output", "file_ext": "png"}).
-                         Ignored for non-macro paths.
-        preview: If True, adds ?preview=true to the URL for images to serve smaller preview versions.
-                 Defaults to False.
+            (e.g., {"file_name": "output", "file_ext": "png"}).
+            Ignored for non-macro paths.
+        preview: If True, generates and returns preview(s) rather than the original file.
+            Defaults to False.
 
     Results: CreateStaticFileDownloadUrlResultSuccess (with URL) | CreateStaticFileDownloadUrlResultFailure (URL creation error)
     """

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -165,12 +165,12 @@ class CreateStaticFileDownloadUrlFromPathResultSuccess(CreateStaticFileDownloadU
     """Static file download URL created successfully from an arbitrary path.
 
     Args:
-        original_metadata: Original properties extracted from the source file header.
+        artifact_metadata: Original properties extracted from the source file header.
             Only populated when preview=True and the file is a local image.
             Contains: width, height, format, channels, color_space, file_size.
     """
 
-    original_metadata: dict | None = None
+    artifact_metadata: dict | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -139,7 +139,7 @@ class PreviewMetadata(BaseModel):
     preview_file_names: str | dict[str, str]
     preview_generator_name: str
     preview_generator_parameters: dict[str, Any]
-    original_metadata: dict[str, Any] | None = None
+    artifact_metadata: dict[str, Any] | None = None
 
 
 class PreviewSettings(BaseModel):
@@ -403,7 +403,7 @@ class ArtifactManager:
                 preview_file_names=preview_file_names,
                 preview_generator_name=generator_name,
                 preview_generator_parameters=deepcopy(request.preview_generator_parameters),
-                original_metadata=provider_class.get_original_metadata(source_path),
+                artifact_metadata=provider_class.get_artifact_metadata(source_path),
             )
 
             # Step 2: Serialize to JSON
@@ -581,7 +581,7 @@ class ArtifactManager:
                         return GetPreviewForArtifactResultSuccess(
                             result_details=f"Preview generated for '{source_path}'",
                             paths_to_preview=generate_result.paths_to_preview,
-                            original_metadata=provider_class.get_original_metadata(str(source_path)),
+                            artifact_metadata=provider_class.get_artifact_metadata(str(source_path)),
                         )
                     return GetPreviewForArtifactResultFailure(
                         result_details=f"Attempted to generate preview for '{source_path}'. Failed due to: {generate_result.result_details}"
@@ -734,7 +734,7 @@ class ArtifactManager:
                 return GetPreviewForArtifactResultSuccess(
                     result_details=f"Preview regenerated for '{source_path}'",
                     paths_to_preview=generate_result.paths_to_preview,
-                    original_metadata=provider_class.get_original_metadata(str(source_path)),
+                    artifact_metadata=provider_class.get_artifact_metadata(str(source_path)),
                 )
             return GetPreviewForArtifactResultFailure(
                 result_details=f"Attempted to regenerate preview for '{source_path}'. Failed due to: {generate_result.result_details}"
@@ -753,7 +753,7 @@ class ArtifactManager:
         return GetPreviewForArtifactResultSuccess(
             result_details=f"Preview retrieved for '{source_path}'",
             paths_to_preview=paths_to_preview,
-            original_metadata=metadata.original_metadata,
+            artifact_metadata=metadata.artifact_metadata,
         )
 
     def on_handle_list_artifact_providers_request(

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -403,7 +403,7 @@ class ArtifactManager:
                 preview_file_names=preview_file_names,
                 preview_generator_name=generator_name,
                 preview_generator_parameters=deepcopy(request.preview_generator_parameters),
-                original_metadata=provider_class.get_source_metadata(source_path),
+                original_metadata=provider_class.get_original_metadata(source_path),
             )
 
             # Step 2: Serialize to JSON
@@ -581,7 +581,7 @@ class ArtifactManager:
                         return GetPreviewForArtifactResultSuccess(
                             result_details=f"Preview generated for '{source_path}'",
                             paths_to_preview=generate_result.paths_to_preview,
-                            original_metadata=provider_class.get_source_metadata(str(source_path)),
+                            original_metadata=provider_class.get_original_metadata(str(source_path)),
                         )
                     return GetPreviewForArtifactResultFailure(
                         result_details=f"Attempted to generate preview for '{source_path}'. Failed due to: {generate_result.result_details}"
@@ -734,7 +734,7 @@ class ArtifactManager:
                 return GetPreviewForArtifactResultSuccess(
                     result_details=f"Preview regenerated for '{source_path}'",
                     paths_to_preview=generate_result.paths_to_preview,
-                    original_metadata=provider_class.get_source_metadata(str(source_path)),
+                    original_metadata=provider_class.get_original_metadata(str(source_path)),
                 )
             return GetPreviewForArtifactResultFailure(
                 result_details=f"Attempted to regenerate preview for '{source_path}'. Failed due to: {generate_result.result_details}"

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -395,6 +395,7 @@ class ArtifactManager:
                 return GeneratePreviewResultFailure(result_details=error_details)
 
             # Step 1: Create metadata object
+            _artifact_metadata = provider_class.get_artifact_metadata(source_path)
             metadata = PreviewMetadata(
                 version=PreviewMetadata.LATEST_SCHEMA_VERSION,
                 source_macro_path=request.macro_path.parsed_macro.template,
@@ -403,7 +404,7 @@ class ArtifactManager:
                 preview_file_names=preview_file_names,
                 preview_generator_name=generator_name,
                 preview_generator_parameters=deepcopy(request.preview_generator_parameters),
-                artifact_metadata=provider_class.get_artifact_metadata(source_path),
+                artifact_metadata=_artifact_metadata.model_dump() if _artifact_metadata else None,
             )
 
             # Step 2: Serialize to JSON
@@ -578,10 +579,11 @@ class ArtifactManager:
                     generate_result = await self.on_handle_generate_preview_from_defaults_request(generate_request)
 
                     if isinstance(generate_result, GeneratePreviewFromDefaultsResultSuccess):
+                        _artifact_metadata = provider_class.get_artifact_metadata(str(source_path))
                         return GetPreviewForArtifactResultSuccess(
                             result_details=f"Preview generated for '{source_path}'",
                             paths_to_preview=generate_result.paths_to_preview,
-                            artifact_metadata=provider_class.get_artifact_metadata(str(source_path)),
+                            artifact_metadata=_artifact_metadata.model_dump() if _artifact_metadata else None,
                         )
                     return GetPreviewForArtifactResultFailure(
                         result_details=f"Attempted to generate preview for '{source_path}'. Failed due to: {generate_result.result_details}"
@@ -731,10 +733,11 @@ class ArtifactManager:
             generate_result = await self.on_handle_generate_preview_from_defaults_request(generate_request)
 
             if isinstance(generate_result, GeneratePreviewFromDefaultsResultSuccess):
+                _artifact_metadata = provider_class.get_artifact_metadata(str(source_path))
                 return GetPreviewForArtifactResultSuccess(
                     result_details=f"Preview regenerated for '{source_path}'",
                     paths_to_preview=generate_result.paths_to_preview,
-                    artifact_metadata=provider_class.get_artifact_metadata(str(source_path)),
+                    artifact_metadata=_artifact_metadata.model_dump() if _artifact_metadata else None,
                 )
             return GetPreviewForArtifactResultFailure(
                 result_details=f"Attempted to regenerate preview for '{source_path}'. Failed due to: {generate_result.result_details}"

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -139,6 +139,7 @@ class PreviewMetadata(BaseModel):
     preview_file_names: str | dict[str, str]
     preview_generator_name: str
     preview_generator_parameters: dict[str, Any]
+    original_metadata: dict[str, Any] | None = None
 
 
 class PreviewSettings(BaseModel):
@@ -402,6 +403,7 @@ class ArtifactManager:
                 preview_file_names=preview_file_names,
                 preview_generator_name=generator_name,
                 preview_generator_parameters=deepcopy(request.preview_generator_parameters),
+                original_metadata=provider_class.get_source_metadata(source_path),
             )
 
             # Step 2: Serialize to JSON
@@ -579,6 +581,7 @@ class ArtifactManager:
                         return GetPreviewForArtifactResultSuccess(
                             result_details=f"Preview generated for '{source_path}'",
                             paths_to_preview=generate_result.paths_to_preview,
+                            original_metadata=provider_class.get_source_metadata(str(source_path)),
                         )
                     return GetPreviewForArtifactResultFailure(
                         result_details=f"Attempted to generate preview for '{source_path}'. Failed due to: {generate_result.result_details}"
@@ -731,6 +734,7 @@ class ArtifactManager:
                 return GetPreviewForArtifactResultSuccess(
                     result_details=f"Preview regenerated for '{source_path}'",
                     paths_to_preview=generate_result.paths_to_preview,
+                    original_metadata=provider_class.get_source_metadata(str(source_path)),
                 )
             return GetPreviewForArtifactResultFailure(
                 result_details=f"Attempted to regenerate preview for '{source_path}'. Failed due to: {generate_result.result_details}"
@@ -749,6 +753,7 @@ class ArtifactManager:
         return GetPreviewForArtifactResultSuccess(
             result_details=f"Preview retrieved for '{source_path}'",
             paths_to_preview=paths_to_preview,
+            original_metadata=metadata.original_metadata,
         )
 
     def on_handle_list_artifact_providers_request(

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
@@ -224,7 +224,7 @@ class BaseArtifactProvider(ABC):
         return data
 
     @classmethod
-    def get_original_metadata(cls, source_path: str) -> dict[str, Any] | None:  # noqa: ARG003
+    def get_artifact_metadata(cls, source_path: str) -> dict[str, Any] | None:  # noqa: ARG003
         """Extract original file metadata to store alongside the preview.
 
         Override in subclasses to return format-specific metadata (e.g., image

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
@@ -224,7 +224,7 @@ class BaseArtifactProvider(ABC):
         return data
 
     @classmethod
-    def get_source_metadata(cls, source_path: str) -> dict[str, Any] | None:  # noqa: ARG003
+    def get_original_metadata(cls, source_path: str) -> dict[str, Any] | None:  # noqa: ARG003
         """Extract original file metadata to store alongside the preview.
 
         Override in subclasses to return format-specific metadata (e.g., image

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
@@ -222,3 +222,18 @@ class BaseArtifactProvider(ABC):
             Processed bytes (or original bytes if no processing needed)
         """
         return data
+
+    @classmethod
+    def get_source_metadata(cls, source_path: str) -> dict[str, Any] | None:  # noqa: ARG003
+        """Extract original file metadata to store alongside the preview.
+
+        Override in subclasses to return format-specific metadata (e.g., image
+        dimensions, channels). Default returns None.
+
+        Args:
+            source_path: Absolute path to the source file.
+
+        Returns:
+            Metadata dict or None if not applicable.
+        """
+        return None

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel
+
 from griptape_nodes.retained_mode.managers.artifact_providers.utils import (
     normalize_friendly_name_to_key,
 )
@@ -14,6 +16,13 @@ if TYPE_CHECKING:
         BaseArtifactPreviewGenerator,
     )
     from griptape_nodes.retained_mode.managers.artifact_providers.provider_registry import ProviderRegistry
+
+
+class BaseArtifactMetadata(BaseModel):
+    """Base model for metadata extracted from a source artifact file.
+
+    Subclass and add fields for each artifact type (e.g. ImageArtifactMetadata).
+    """
 
 
 class BaseArtifactProvider(ABC):
@@ -224,16 +233,13 @@ class BaseArtifactProvider(ABC):
         return data
 
     @classmethod
-    def get_artifact_metadata(cls, source_path: str) -> dict[str, Any] | None:  # noqa: ARG003
-        """Extract original file metadata to store alongside the preview.
+    @abstractmethod
+    def get_artifact_metadata(cls, source_path: str) -> BaseArtifactMetadata | None:
+        """Extract metadata from the source file to store alongside the preview.
 
-        Override in subclasses to return format-specific metadata (e.g., image
-        dimensions, channels). Default returns None.
+        Implement in subclasses to return format-specific metadata (e.g., image
+        dimensions and channels for images). Return None if not applicable.
 
         Args:
             source_path: Absolute path to the source file.
-
-        Returns:
-            Metadata dict or None if not applicable.
         """
-        return None

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from PIL import Image
 
@@ -45,9 +45,55 @@ class ImageArtifactProvider(BaseArtifactProvider):
     def get_friendly_name(cls) -> str:
         return "Image"
 
+    # Maps PIL image mode to (channels, color_space) for metadata reporting
+    _PIL_MODE_INFO: ClassVar[dict[str, tuple[int, str]]] = {
+        "L": (1, "Grayscale"),
+        "P": (1, "Palette"),
+        "RGB": (3, "RGB"),
+        "RGBA": (4, "RGBA"),
+        "CMYK": (4, "CMYK"),
+        "YCbCr": (3, "YCbCr"),
+        "LAB": (3, "LAB"),
+        "HSV": (3, "HSV"),
+        "I": (1, "Grayscale"),
+        "F": (1, "Grayscale"),
+        "LA": (2, "Grayscale+Alpha"),
+        "RGBa": (4, "RGBA"),  # spellchecker:disable-line
+        "RGBX": (4, "RGB"),
+    }
+
     @classmethod
     def get_supported_formats(cls) -> set[str]:
         return {"png", "jpg", "jpeg", "gif", "bmp", "webp", "tiff", "tif", "tga"}
+
+    @classmethod
+    def supports_file_extension(cls, file_extension: str) -> bool:
+        """Return True if the given file extension (with or without leading dot) is a supported image format."""
+        return file_extension.lstrip(".").lower() in cls.get_supported_formats()
+
+    @classmethod
+    def get_mode_info(cls, mode: str) -> tuple[int, str]:
+        """Return (channels, color_space) for a PIL image mode, with a sensible fallback."""
+        return cls._PIL_MODE_INFO.get(mode, (3, mode))
+
+    @classmethod
+    def get_source_metadata(cls, source_path: str) -> dict[str, Any] | None:
+        """Extract original image metadata via PIL's lazy header read (no full decode)."""
+        try:
+            path = Path(source_path)
+            with Image.open(path) as img:
+                width, height = img.size
+                channels, color_space = cls.get_mode_info(img.mode)
+                return {
+                    "width": width,
+                    "height": height,
+                    "format": (img.format or path.suffix.lstrip(".")).upper(),
+                    "channels": channels,
+                    "color_space": color_space,
+                    "file_size": path.stat().st_size,
+                }
+        except Exception:
+            return None
 
     @classmethod
     def get_preview_formats(cls) -> set[str]:

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
@@ -77,7 +77,7 @@ class ImageArtifactProvider(BaseArtifactProvider):
         return cls._PIL_MODE_INFO.get(mode, (3, mode))
 
     @classmethod
-    def get_original_metadata(cls, source_path: str) -> dict[str, Any] | None:
+    def get_artifact_metadata(cls, source_path: str) -> dict[str, Any] | None:
         """Extract original image metadata via PIL's lazy header read (no full decode)."""
         try:
             path = Path(source_path)

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
@@ -77,7 +77,7 @@ class ImageArtifactProvider(BaseArtifactProvider):
         return cls._PIL_MODE_INFO.get(mode, (3, mode))
 
     @classmethod
-    def get_source_metadata(cls, source_path: str) -> dict[str, Any] | None:
+    def get_original_metadata(cls, source_path: str) -> dict[str, Any] | None:
         """Extract original image metadata via PIL's lazy header read (no full decode)."""
         try:
             path = Path(source_path)

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from PIL import Image
 
@@ -14,6 +14,7 @@ from griptape_nodes.drivers.image_metadata.image_metadata_driver_registry import
 )
 from griptape_nodes.retained_mode.file_metadata.workflow_metadata import collect_workflow_metadata
 from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import (
+    BaseArtifactMetadata,
     BaseArtifactProvider,
 )
 
@@ -24,6 +25,17 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.artifact_providers.provider_registry import ProviderRegistry
 
 logger = logging.getLogger("griptape_nodes")
+
+
+class ImageArtifactMetadata(BaseArtifactMetadata):
+    """Metadata extracted from the header of an image source file."""
+
+    width: int
+    height: int
+    format: str
+    channels: int
+    color_space: str
+    file_size: int
 
 
 class ImageArtifactProvider(BaseArtifactProvider):
@@ -77,21 +89,21 @@ class ImageArtifactProvider(BaseArtifactProvider):
         return cls._PIL_MODE_INFO.get(mode, (3, mode))
 
     @classmethod
-    def get_artifact_metadata(cls, source_path: str) -> dict[str, Any] | None:
+    def get_artifact_metadata(cls, source_path: str) -> ImageArtifactMetadata | None:
         """Extract original image metadata via PIL's lazy header read (no full decode)."""
         try:
             path = Path(source_path)
             with Image.open(path) as img:
                 width, height = img.size
                 channels, color_space = cls.get_mode_info(img.mode)
-                return {
-                    "width": width,
-                    "height": height,
-                    "format": (img.format or path.suffix.lstrip(".")).upper(),
-                    "channels": channels,
-                    "color_space": color_space,
-                    "file_size": path.stat().st_size,
-                }
+                return ImageArtifactMetadata(
+                    width=width,
+                    height=height,
+                    format=(img.format or path.suffix.lstrip(".")).upper(),
+                    channels=channels,
+                    color_space=color_space,
+                    file_size=path.stat().st_size,
+                )
         except Exception:
             return None
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4601,12 +4601,12 @@ class NodeManager:
         # TODO: (griptape-nodes) Don't rely on manually copying metadata fields. https://github.com/griptape-ai/griptape-nodes/issues/2862
         # Copy only position and size from original node's metadata to preserve layout.
         # We don't copy the full metadata because it contains instance-specific data that shouldn't be transferred.
-        original_metadata = all_info_result.metadata
+        artifact_metadata = all_info_result.metadata
         new_node = self.get_node_by_name(new_node_name)
-        if "position" in original_metadata:
-            new_node.metadata["position"] = copy.deepcopy(original_metadata["position"])
-        if "size" in original_metadata:
-            new_node.metadata["size"] = copy.deepcopy(original_metadata["size"])
+        if "position" in artifact_metadata:
+            new_node.metadata["position"] = copy.deepcopy(artifact_metadata["position"])
+        if "size" in artifact_metadata:
+            new_node.metadata["size"] = copy.deepcopy(artifact_metadata["size"])
 
         # NON-FATAL: Attempt to reconnect connections
         failed_incoming: list[IncomingConnection] = []

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -152,7 +152,7 @@ class StaticFilesManager:
     def _generate_preview_if_needed(self, file_path: Path) -> tuple[Path, dict | None]:
         """Generate preview for an image file if needed.
 
-        Returns (path, original_metadata) where path is the preview if generated/cached,
+        Returns (path, artifact_metadata) where path is the preview if generated/cached,
         or the original file path if the file is not an image or preview generation fails.
 
         Args:
@@ -179,7 +179,7 @@ class StaticFilesManager:
         if isinstance(result, GetPreviewForArtifactResultSuccess) and isinstance(result.paths_to_preview, str):
             preview_path = Path(result.paths_to_preview)
             logger.debug("Serving thumbnail for %s -> %s", file_path, preview_path)
-            return preview_path, result.original_metadata
+            return preview_path, result.artifact_metadata
 
         logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
         return file_path, None
@@ -298,19 +298,19 @@ class StaticFilesManager:
             preview: Whether to generate and serve a preview.
 
         Returns:
-            Tuple of (path to serve, original source metadata or None).
+            Tuple of (path to serve, artifact metadata or None).
         """
         if not preview:
             logger.debug("Serving full image for %s", file_path)
             return file_path, None
         try:
-            preview_path, original_metadata = self._generate_preview_if_needed(file_path)
+            preview_path, artifact_metadata = self._generate_preview_if_needed(file_path)
         except Exception as e:
             logger.warning("Preview generation failed for %s, using original: %s", file_path, e)
             return file_path, None
         if preview_path == file_path:
             logger.debug("Serving full image (no thumbnail available) for %s", file_path)
-        return preview_path, original_metadata
+        return preview_path, artifact_metadata
 
     def on_handle_create_static_file_download_url_from_path_request(
         self,
@@ -360,8 +360,8 @@ class StaticFilesManager:
             # For local paths, convert URI to path
             file_path_for_driver = Path(uri_to_path(file_path))
 
-        # If preview requested, generate preview and get preview path + source metadata
-        file_path_to_use, original_metadata = self._resolve_preview_path(file_path_for_driver, preview=request.preview)
+        # If preview requested, generate preview and get preview path + artifact metadata
+        file_path_to_use, artifact_metadata = self._resolve_preview_path(file_path_for_driver, preview=request.preview)
 
         try:
             url = driver.create_signed_download_url(file_path_to_use)
@@ -372,7 +372,7 @@ class StaticFilesManager:
         return CreateStaticFileDownloadUrlFromPathResultSuccess(
             url=url,
             file_url=driver.get_asset_url(file_path_for_driver),
-            original_metadata=original_metadata,
+            artifact_metadata=artifact_metadata,
             result_details="Successfully created static file download URL",
         )
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -5,6 +5,7 @@ import threading
 from pathlib import Path
 from typing import NamedTuple
 
+from PIL import Image
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
@@ -52,6 +53,9 @@ SAVE_STATIC_FILE_SITUATION = "save_static_file"
 COPY_EXTERNAL_FILE_SITUATION = "copy_external_file"
 
 USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config.json"
+
+# Supported image extensions for preview generation
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif"}
 
 
 class ResolvedStaticFilePath(NamedTuple):
@@ -138,6 +142,107 @@ class StaticFilesManager:
                 self.on_app_initialization_complete,
             )
             # TODO: Listen for shutdown event (https://github.com/griptape-ai/griptape-nodes/issues/2149) to stop static server
+
+    def _is_preview_up_to_date(self, original_path: Path, preview_path: Path) -> bool:
+        """Check if cached preview exists and is newer than the original file.
+
+        Args:
+            original_path: Path to the original image file
+            preview_path: Path to the cached preview
+
+        Returns:
+            True if preview exists and is up-to-date, False otherwise
+        """
+        if not preview_path.exists():
+            return False
+
+        try:
+            original_mtime = original_path.stat().st_mtime
+            preview_mtime = preview_path.stat().st_mtime
+        except OSError as e:
+            logger.warning("Failed to check preview modification time: %s", e)
+            return False
+        else:
+            return preview_mtime >= original_mtime
+
+    def _generate_preview_if_needed(self, file_path: Path) -> Path:
+        """Generate preview for an image file if needed.
+
+        Returns path to preview file if generated/cached, or original file path if:
+        - File is not an image
+        - Preview generation fails
+
+        Args:
+            file_path: Path to the original file
+
+        Returns:
+            Path to preview file or original file
+        """
+        # Check if file is an image
+        file_extension = file_path.suffix.lower()
+        if file_extension not in IMAGE_EXTENSIONS:
+            return file_path
+
+        # Determine preview cache path using workflow-aware directory structure
+        workspace_path = self.config_manager.workspace_path
+
+        # Get the base directory for the original file relative to workspace
+        try:
+            relative_file_path = file_path.relative_to(workspace_path)
+        except ValueError:
+            # File is outside workspace, use absolute path structure
+            logger.warning("File %s is outside workspace, using absolute path for preview", file_path)
+            # For external files, use a flattened structure in workspace/thumbnails
+            preview_cache_dir = workspace_path / "thumbnails" / "external"
+            preview_filename = f"{file_path.stem}_{hash(str(file_path))}.webp"
+            preview_path = preview_cache_dir / preview_filename
+        else:
+            # File is inside workspace, use workflow-aware structure
+            # Replace staticfiles with thumbnails in the path
+            relative_str = str(relative_file_path)
+            if "staticfiles" in relative_str:
+                preview_relative_str = relative_str.replace("staticfiles", "thumbnails", 1)
+            else:
+                # File not in staticfiles directory, use parallel thumbnails structure
+                preview_relative_str = str(Path("thumbnails") / relative_file_path)
+
+            preview_relative_path = Path(preview_relative_str).with_suffix(".webp")
+            preview_path = workspace_path / preview_relative_path
+
+        # Check if cached preview is up-to-date
+        if self._is_preview_up_to_date(file_path, preview_path):
+            return preview_path
+
+        # Generate preview
+        try:
+            with Image.open(file_path) as original_img:
+                # Convert RGBA to RGB for formats that don't support transparency
+                if original_img.mode in ("RGBA", "LA", "P"):
+                    # Create white background
+                    background = Image.new("RGB", original_img.size, (255, 255, 255))
+                    img_to_paste = original_img.convert("RGBA") if original_img.mode == "P" else original_img
+                    background.paste(
+                        img_to_paste, mask=img_to_paste.split()[-1] if img_to_paste.mode in ("RGBA", "LA") else None
+                    )
+                    processed_img = background
+                elif original_img.mode != "RGB":
+                    processed_img = original_img.convert("RGB")
+                else:
+                    processed_img = original_img.copy()
+
+                # Resize while maintaining aspect ratio
+                processed_img.thumbnail((512, 512), Image.Resampling.LANCZOS)
+
+                # Create preview directory if it doesn't exist
+                preview_path.parent.mkdir(parents=True, exist_ok=True)
+
+                # Save preview to cache
+                processed_img.save(preview_path, format="WEBP", quality=85)
+        except Exception as e:
+            logger.warning("Failed to generate preview for %s: %s", file_path, e)
+            return file_path
+        else:
+            return preview_path
 
     def on_handle_create_static_file_request(
         self,
@@ -252,7 +357,7 @@ class StaticFilesManager:
         """Handle request to create download URL from arbitrary file path.
 
         Args:
-            request: Request containing file_path parameter.
+            request: Request containing file_path and preview parameters.
 
         Returns:
             Result with download URL or failure message.
@@ -292,8 +397,18 @@ class StaticFilesManager:
             # For local paths, convert URI to path
             file_path_for_driver = Path(uri_to_path(file_path))
 
+        # If preview requested, generate preview and get preview path
+        if request.preview:
+            try:
+                file_path_to_use = self._generate_preview_if_needed(file_path_for_driver)
+            except Exception as e:
+                logger.warning("Preview generation failed for %s, using original: %s", request.file_path, e)
+                file_path_to_use = file_path_for_driver
+        else:
+            file_path_to_use = file_path_for_driver
+
         try:
-            url = driver.create_signed_download_url(file_path_for_driver)
+            url = driver.create_signed_download_url(file_path_to_use)
         except Exception as e:
             msg = f"Failed to create presigned URL for file {file_path}: {e}"
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import NamedTuple
 
 from PIL import Image
-
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
@@ -77,7 +76,7 @@ _PIL_MODE_INFO: dict[str, tuple[int, str]] = {
     "I": (1, "Grayscale"),
     "F": (1, "Grayscale"),
     "LA": (2, "Grayscale+Alpha"),
-    "RGBa": (4, "RGBA"),
+    "RGBa": (4, "RGBA"),  # spellchecker:disable-line
     "RGBX": (4, "RGB"),
 }
 
@@ -313,6 +312,29 @@ class StaticFilesManager:
             static_files_directory=static_files_directory,
         )
 
+    def _resolve_preview_path(self, file_path: Path, *, preview: bool) -> Path:
+        """Return the path to serve, generating a preview when requested.
+
+        Args:
+            file_path: Path to the original file.
+            preview: Whether to generate and serve a preview.
+
+        Returns:
+            Path to the preview file, or original file path if preview is not
+            requested or generation fails.
+        """
+        if not preview:
+            logger.debug("Serving full image for %s", file_path)
+            return file_path
+        try:
+            preview_path = self._generate_preview_if_needed(file_path)
+        except Exception as e:
+            logger.warning("Preview generation failed for %s, using original: %s", file_path, e)
+            return file_path
+        if preview_path == file_path:
+            logger.debug("Serving full image (no thumbnail available) for %s", file_path)
+        return preview_path
+
     def on_handle_create_static_file_download_url_from_path_request(
         self,
         request: CreateStaticFileDownloadUrlFromPathRequest,
@@ -362,17 +384,7 @@ class StaticFilesManager:
             file_path_for_driver = Path(uri_to_path(file_path))
 
         # If preview requested, generate preview and get preview path
-        if request.preview:
-            try:
-                file_path_to_use = self._generate_preview_if_needed(file_path_for_driver)
-            except Exception as e:
-                logger.warning("Preview generation failed for %s, using original: %s", request.file_path, e)
-                file_path_to_use = file_path_for_driver
-            if file_path_to_use == file_path_for_driver:
-                logger.debug("Serving full image (no thumbnail available) for %s", file_path_for_driver)
-        else:
-            logger.debug("Serving full image for %s", file_path_for_driver)
-            file_path_to_use = file_path_for_driver
+        file_path_to_use = self._resolve_preview_path(file_path_for_driver, preview=request.preview)
 
         try:
             url = driver.create_signed_download_url(file_path_to_use)

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -183,10 +183,10 @@ class StaticFilesManager:
         # Check if file is an image
         file_extension = file_path.suffix.lower()
         if file_extension not in IMAGE_EXTENSIONS:
-            logger.warning("Skipping preview for non-image file: %s", file_path)
+            logger.debug("Skipping preview for non-image file: %s", file_path)
             return file_path
 
-        logger.warning("Attempting to generate preview for image: %s", file_path)
+        logger.debug("Attempting to generate preview for image: %s", file_path)
         try:
             result = GriptapeNodes.handle_request(
                 GetPreviewForArtifactRequest(
@@ -201,7 +201,7 @@ class StaticFilesManager:
 
         if isinstance(result, GetPreviewForArtifactResultSuccess) and isinstance(result.paths_to_preview, str):
             preview_path = Path(result.paths_to_preview)
-            logger.warning("Serving thumbnail for %s -> %s", file_path, preview_path)
+            logger.debug("Serving thumbnail for %s -> %s", file_path, preview_path)
             return preview_path
 
         logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
@@ -326,7 +326,7 @@ class StaticFilesManager:
             Result with download URL or failure message.
         """
         file_path = request.file_path
-        logger.warning("CreateStaticFileDownloadUrlFromPath: file_path=%s, preview=%s", file_path, request.preview)
+        logger.debug("CreateStaticFileDownloadUrlFromPath: file_path=%s, preview=%s", file_path, request.preview)
 
         # Resolve macro paths (e.g. "{outputs}/file.png") before further processing
         try:
@@ -369,9 +369,9 @@ class StaticFilesManager:
                 logger.warning("Preview generation failed for %s, using original: %s", request.file_path, e)
                 file_path_to_use = file_path_for_driver
             if file_path_to_use == file_path_for_driver:
-                logger.warning("Serving full image (no thumbnail available) for %s", file_path_for_driver)
+                logger.debug("Serving full image (no thumbnail available) for %s", file_path_for_driver)
         else:
-            logger.warning("Serving full image for %s", file_path_for_driver)
+            logger.debug("Serving full image for %s", file_path_for_driver)
             file_path_to_use = file_path_for_driver
 
         try:

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from PIL import Image
+
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
@@ -15,12 +16,18 @@ from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import Griptap
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 from griptape_nodes.files.path_utils import FilenameParts
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+from griptape_nodes.retained_mode.events.artifact_events import (
+    GetPreviewForArtifactRequest,
+    GetPreviewForArtifactResultSuccess,
+    PreviewGenerationPolicy,
+)
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.events.project_events import (
     GetPathForMacroRequest,
     GetPathForMacroResultSuccess,
     GetSituationRequest,
     GetSituationResultSuccess,
+    MacroPath,
 )
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
@@ -56,6 +63,23 @@ USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config
 
 # Supported image extensions for preview generation
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif"}
+
+# Maps PIL image mode to (channels, color_space) for original metadata reporting
+_PIL_MODE_INFO: dict[str, tuple[int, str]] = {
+    "L": (1, "Grayscale"),
+    "P": (1, "Palette"),
+    "RGB": (3, "RGB"),
+    "RGBA": (4, "RGBA"),
+    "CMYK": (4, "CMYK"),
+    "YCbCr": (3, "YCbCr"),
+    "LAB": (3, "LAB"),
+    "HSV": (3, "HSV"),
+    "I": (1, "Grayscale"),
+    "F": (1, "Grayscale"),
+    "LA": (2, "Grayscale+Alpha"),
+    "RGBa": (4, "RGBA"),
+    "RGBX": (4, "RGB"),
+}
 
 
 class ResolvedStaticFilePath(NamedTuple):
@@ -143,28 +167,6 @@ class StaticFilesManager:
             )
             # TODO: Listen for shutdown event (https://github.com/griptape-ai/griptape-nodes/issues/2149) to stop static server
 
-    def _is_preview_up_to_date(self, original_path: Path, preview_path: Path) -> bool:
-        """Check if cached preview exists and is newer than the original file.
-
-        Args:
-            original_path: Path to the original image file
-            preview_path: Path to the cached preview
-
-        Returns:
-            True if preview exists and is up-to-date, False otherwise
-        """
-        if not preview_path.exists():
-            return False
-
-        try:
-            original_mtime = original_path.stat().st_mtime
-            preview_mtime = preview_path.stat().st_mtime
-        except OSError as e:
-            logger.warning("Failed to check preview modification time: %s", e)
-            return False
-        else:
-            return preview_mtime >= original_mtime
-
     def _generate_preview_if_needed(self, file_path: Path) -> Path:
         """Generate preview for an image file if needed.
 
@@ -181,68 +183,29 @@ class StaticFilesManager:
         # Check if file is an image
         file_extension = file_path.suffix.lower()
         if file_extension not in IMAGE_EXTENSIONS:
+            logger.warning("Skipping preview for non-image file: %s", file_path)
             return file_path
 
-        # Determine preview cache path using workflow-aware directory structure
-        workspace_path = self.config_manager.workspace_path
-
-        # Get the base directory for the original file relative to workspace
+        logger.warning("Attempting to generate preview for image: %s", file_path)
         try:
-            relative_file_path = file_path.relative_to(workspace_path)
-        except ValueError:
-            # File is outside workspace, use absolute path structure
-            logger.warning("File %s is outside workspace, using absolute path for preview", file_path)
-            # For external files, use a flattened structure in workspace/thumbnails
-            preview_cache_dir = workspace_path / "thumbnails" / "external"
-            preview_filename = f"{file_path.stem}_{hash(str(file_path))}.webp"
-            preview_path = preview_cache_dir / preview_filename
-        else:
-            # File is inside workspace, use workflow-aware structure
-            # Replace staticfiles with thumbnails in the path
-            relative_str = str(relative_file_path)
-            if "staticfiles" in relative_str:
-                preview_relative_str = relative_str.replace("staticfiles", "thumbnails", 1)
-            else:
-                # File not in staticfiles directory, use parallel thumbnails structure
-                preview_relative_str = str(Path("thumbnails") / relative_file_path)
-
-            preview_relative_path = Path(preview_relative_str).with_suffix(".webp")
-            preview_path = workspace_path / preview_relative_path
-
-        # Check if cached preview is up-to-date
-        if self._is_preview_up_to_date(file_path, preview_path):
-            return preview_path
-
-        # Generate preview
-        try:
-            with Image.open(file_path) as original_img:
-                # Convert RGBA to RGB for formats that don't support transparency
-                if original_img.mode in ("RGBA", "LA", "P"):
-                    # Create white background
-                    background = Image.new("RGB", original_img.size, (255, 255, 255))
-                    img_to_paste = original_img.convert("RGBA") if original_img.mode == "P" else original_img
-                    background.paste(
-                        img_to_paste, mask=img_to_paste.split()[-1] if img_to_paste.mode in ("RGBA", "LA") else None
-                    )
-                    processed_img = background
-                elif original_img.mode != "RGB":
-                    processed_img = original_img.convert("RGB")
-                else:
-                    processed_img = original_img.copy()
-
-                # Resize while maintaining aspect ratio
-                processed_img.thumbnail((512, 512), Image.Resampling.LANCZOS)
-
-                # Create preview directory if it doesn't exist
-                preview_path.parent.mkdir(parents=True, exist_ok=True)
-
-                # Save preview to cache
-                processed_img.save(preview_path, format="WEBP", quality=85)
+            result = GriptapeNodes.handle_request(
+                GetPreviewForArtifactRequest(
+                    macro_path=MacroPath(ParsedMacro(str(file_path)), {}),
+                    artifact_provider_name="Image",
+                    preview_generation_policy=PreviewGenerationPolicy.ONLY_IF_STALE,
+                )
+            )
         except Exception as e:
             logger.warning("Failed to generate preview for %s: %s", file_path, e)
             return file_path
-        else:
+
+        if isinstance(result, GetPreviewForArtifactResultSuccess) and isinstance(result.paths_to_preview, str):
+            preview_path = Path(result.paths_to_preview)
+            logger.warning("Serving thumbnail for %s -> %s", file_path, preview_path)
             return preview_path
+
+        logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
+        return file_path
 
     def on_handle_create_static_file_request(
         self,
@@ -363,6 +326,7 @@ class StaticFilesManager:
             Result with download URL or failure message.
         """
         file_path = request.file_path
+        logger.warning("CreateStaticFileDownloadUrlFromPath: file_path=%s, preview=%s", file_path, request.preview)
 
         # Resolve macro paths (e.g. "{outputs}/file.png") before further processing
         try:
@@ -404,7 +368,10 @@ class StaticFilesManager:
             except Exception as e:
                 logger.warning("Preview generation failed for %s, using original: %s", request.file_path, e)
                 file_path_to_use = file_path_for_driver
+            if file_path_to_use == file_path_for_driver:
+                logger.warning("Serving full image (no thumbnail available) for %s", file_path_for_driver)
         else:
+            logger.warning("Serving full image for %s", file_path_for_driver)
             file_path_to_use = file_path_for_driver
 
         try:
@@ -413,9 +380,29 @@ class StaticFilesManager:
             msg = f"Failed to create presigned URL for file {file_path}: {e}"
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
+        # Extract original image metadata via PIL's lazy header read (no full decode).
+        # Only for local image files when a preview was requested.
+        original_metadata = None
+        if request.preview and bucket_id is None and file_path_for_driver.suffix.lower() in IMAGE_EXTENSIONS:
+            try:
+                with Image.open(file_path_for_driver) as img:
+                    width, height = img.size
+                    channels, color_space = _PIL_MODE_INFO.get(img.mode, (3, img.mode))
+                    original_metadata = {
+                        "width": width,
+                        "height": height,
+                        "format": (img.format or file_path_for_driver.suffix.lstrip(".")).upper(),
+                        "channels": channels,
+                        "color_space": color_space,
+                        "file_size": file_path_for_driver.stat().st_size,
+                    }
+            except Exception as e:
+                logger.debug("Could not read original image metadata for %s: %s", file_path_for_driver, e)
+
         return CreateStaticFileDownloadUrlResultSuccess(
             url=url,
             file_url=driver.get_asset_url(file_path_for_driver),
+            original_metadata=original_metadata,
             result_details="Successfully created static file download URL",
         )
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -176,13 +176,13 @@ class StaticFilesManager:
             )
         )
 
-        if isinstance(result, GetPreviewForArtifactResultSuccess) and isinstance(result.paths_to_preview, str):
-            preview_path = Path(result.paths_to_preview)
-            logger.debug("Serving thumbnail for %s -> %s", file_path, preview_path)
-            return preview_path, result.artifact_metadata
+        if not isinstance(result, GetPreviewForArtifactResultSuccess) or not isinstance(result.paths_to_preview, str):
+            logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
+            return file_path, None
 
-        logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
-        return file_path, None
+        preview_path = Path(result.paths_to_preview)
+        logger.debug("Serving thumbnail for %s -> %s", file_path, preview_path)
+        return preview_path, result.artifact_metadata
 
     def on_handle_create_static_file_request(
         self,

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -160,6 +160,9 @@ class StaticFilesManager:
         Returns:
             Tuple of (path to serve, original source metadata or None)
         """
+        # TODO: Ask the Artifact Manager which providers support this file extension,
+        # then route to the correct provider — rather than hardcoding ImageArtifactProvider here.
+        # https://github.com/griptape-ai/griptape-nodes/issues/4251
         if not ImageArtifactProvider.supports_file_extension(file_path.suffix):
             logger.debug("Skipping preview for non-image file: %s", file_path)
             return file_path, None

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -29,6 +29,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
+    CreateStaticFileDownloadUrlFromPathResultSuccess,
     CreateStaticFileDownloadUrlRequest,
     CreateStaticFileDownloadUrlResultFailure,
     CreateStaticFileDownloadUrlResultSuccess,
@@ -314,7 +315,7 @@ class StaticFilesManager:
     def on_handle_create_static_file_download_url_from_path_request(
         self,
         request: CreateStaticFileDownloadUrlFromPathRequest,
-    ) -> CreateStaticFileDownloadUrlResultSuccess | CreateStaticFileDownloadUrlResultFailure:
+    ) -> CreateStaticFileDownloadUrlFromPathResultSuccess | CreateStaticFileDownloadUrlResultFailure:
         """Handle request to create download URL from arbitrary file path.
 
         Args:
@@ -368,7 +369,7 @@ class StaticFilesManager:
             msg = f"Failed to create presigned URL for file {file_path}: {e}"
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
-        return CreateStaticFileDownloadUrlResultSuccess(
+        return CreateStaticFileDownloadUrlFromPathResultSuccess(
             url=url,
             file_url=driver.get_asset_url(file_path_for_driver),
             original_metadata=original_metadata,

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -164,18 +164,13 @@ class StaticFilesManager:
             logger.debug("Skipping preview for non-image file: %s", file_path)
             return file_path, None
 
-        logger.debug("Attempting to generate preview for image: %s", file_path)
-        try:
-            result = GriptapeNodes.handle_request(
-                GetPreviewForArtifactRequest(
-                    macro_path=MacroPath(ParsedMacro(str(file_path)), {}),
-                    artifact_provider_name="Image",
-                    preview_generation_policy=PreviewGenerationPolicy.ONLY_IF_STALE,
-                )
+        result = GriptapeNodes.handle_request(
+            GetPreviewForArtifactRequest(
+                macro_path=MacroPath(ParsedMacro(str(file_path)), {}),
+                artifact_provider_name="Image",
+                preview_generation_policy=PreviewGenerationPolicy.ONLY_IF_STALE,
             )
-        except Exception as e:
-            logger.warning("Failed to generate preview for %s: %s", file_path, e)
-            return file_path, None
+        )
 
         if isinstance(result, GetPreviewForArtifactResultSuccess) and isinstance(result.paths_to_preview, str):
             preview_path = Path(result.paths_to_preview)

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -5,7 +5,6 @@ import threading
 from pathlib import Path
 from typing import NamedTuple
 
-from PIL import Image
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
@@ -46,6 +45,9 @@ from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import (
     SituationPolicy,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.artifact_providers.image.image_artifact_provider import (
+    ImageArtifactProvider,
+)
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -59,26 +61,6 @@ SAVE_STATIC_FILE_SITUATION = "save_static_file"
 COPY_EXTERNAL_FILE_SITUATION = "copy_external_file"
 
 USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config.json"
-
-# Supported image extensions for preview generation
-IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif"}
-
-# Maps PIL image mode to (channels, color_space) for original metadata reporting
-_PIL_MODE_INFO: dict[str, tuple[int, str]] = {
-    "L": (1, "Grayscale"),
-    "P": (1, "Palette"),
-    "RGB": (3, "RGB"),
-    "RGBA": (4, "RGBA"),
-    "CMYK": (4, "CMYK"),
-    "YCbCr": (3, "YCbCr"),
-    "LAB": (3, "LAB"),
-    "HSV": (3, "HSV"),
-    "I": (1, "Grayscale"),
-    "F": (1, "Grayscale"),
-    "LA": (2, "Grayscale+Alpha"),
-    "RGBa": (4, "RGBA"),  # spellchecker:disable-line
-    "RGBX": (4, "RGB"),
-}
 
 
 class ResolvedStaticFilePath(NamedTuple):
@@ -166,24 +148,21 @@ class StaticFilesManager:
             )
             # TODO: Listen for shutdown event (https://github.com/griptape-ai/griptape-nodes/issues/2149) to stop static server
 
-    def _generate_preview_if_needed(self, file_path: Path) -> Path:
+    def _generate_preview_if_needed(self, file_path: Path) -> tuple[Path, dict | None]:
         """Generate preview for an image file if needed.
 
-        Returns path to preview file if generated/cached, or original file path if:
-        - File is not an image
-        - Preview generation fails
+        Returns (path, original_metadata) where path is the preview if generated/cached,
+        or the original file path if the file is not an image or preview generation fails.
 
         Args:
             file_path: Path to the original file
 
         Returns:
-            Path to preview file or original file
+            Tuple of (path to serve, original source metadata or None)
         """
-        # Check if file is an image
-        file_extension = file_path.suffix.lower()
-        if file_extension not in IMAGE_EXTENSIONS:
+        if not ImageArtifactProvider.supports_file_extension(file_path.suffix):
             logger.debug("Skipping preview for non-image file: %s", file_path)
-            return file_path
+            return file_path, None
 
         logger.debug("Attempting to generate preview for image: %s", file_path)
         try:
@@ -196,15 +175,15 @@ class StaticFilesManager:
             )
         except Exception as e:
             logger.warning("Failed to generate preview for %s: %s", file_path, e)
-            return file_path
+            return file_path, None
 
         if isinstance(result, GetPreviewForArtifactResultSuccess) and isinstance(result.paths_to_preview, str):
             preview_path = Path(result.paths_to_preview)
             logger.debug("Serving thumbnail for %s -> %s", file_path, preview_path)
-            return preview_path
+            return preview_path, result.original_metadata
 
         logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
-        return file_path
+        return file_path, None
 
     def on_handle_create_static_file_request(
         self,
@@ -312,28 +291,27 @@ class StaticFilesManager:
             static_files_directory=static_files_directory,
         )
 
-    def _resolve_preview_path(self, file_path: Path, *, preview: bool) -> Path:
-        """Return the path to serve, generating a preview when requested.
+    def _resolve_preview_path(self, file_path: Path, *, preview: bool) -> tuple[Path, dict | None]:
+        """Return the path to serve and any source metadata, generating a preview when requested.
 
         Args:
             file_path: Path to the original file.
             preview: Whether to generate and serve a preview.
 
         Returns:
-            Path to the preview file, or original file path if preview is not
-            requested or generation fails.
+            Tuple of (path to serve, original source metadata or None).
         """
         if not preview:
             logger.debug("Serving full image for %s", file_path)
-            return file_path
+            return file_path, None
         try:
-            preview_path = self._generate_preview_if_needed(file_path)
+            preview_path, original_metadata = self._generate_preview_if_needed(file_path)
         except Exception as e:
             logger.warning("Preview generation failed for %s, using original: %s", file_path, e)
-            return file_path
+            return file_path, None
         if preview_path == file_path:
             logger.debug("Serving full image (no thumbnail available) for %s", file_path)
-        return preview_path
+        return preview_path, original_metadata
 
     def on_handle_create_static_file_download_url_from_path_request(
         self,
@@ -383,33 +361,14 @@ class StaticFilesManager:
             # For local paths, convert URI to path
             file_path_for_driver = Path(uri_to_path(file_path))
 
-        # If preview requested, generate preview and get preview path
-        file_path_to_use = self._resolve_preview_path(file_path_for_driver, preview=request.preview)
+        # If preview requested, generate preview and get preview path + source metadata
+        file_path_to_use, original_metadata = self._resolve_preview_path(file_path_for_driver, preview=request.preview)
 
         try:
             url = driver.create_signed_download_url(file_path_to_use)
         except Exception as e:
             msg = f"Failed to create presigned URL for file {file_path}: {e}"
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
-
-        # Extract original image metadata via PIL's lazy header read (no full decode).
-        # Only for local image files when a preview was requested.
-        original_metadata = None
-        if request.preview and bucket_id is None and file_path_for_driver.suffix.lower() in IMAGE_EXTENSIONS:
-            try:
-                with Image.open(file_path_for_driver) as img:
-                    width, height = img.size
-                    channels, color_space = _PIL_MODE_INFO.get(img.mode, (3, img.mode))
-                    original_metadata = {
-                        "width": width,
-                        "height": height,
-                        "format": (img.format or file_path_for_driver.suffix.lstrip(".")).upper(),
-                        "channels": channels,
-                        "color_space": color_space,
-                        "file_size": file_path_for_driver.stat().st_size,
-                    }
-            except Exception as e:
-                logger.debug("Could not read original image metadata for %s: %s", file_path_for_driver, e)
 
         return CreateStaticFileDownloadUrlResultSuccess(
             url=url,

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -216,45 +216,6 @@ async def _serve_library_widget(library_name: str, file_path: str) -> FileRespon
     )
 
 
-async def _serve_workspace_file(file_path: str, _request: Request) -> FileResponse:
-    """Serve a file from the workspace directory.
-
-    Preview generation now happens in StaticFilesManager when creating download URLs.
-    This endpoint simply serves the requested file.
-
-    Args:
-        file_path: The relative file path within workspace (e.g., "images/photo.jpg")
-        _request: FastAPI Request object (unused, kept for route signature compatibility)
-
-    Returns:
-        FileResponse with the requested file
-    """
-    if not STATIC_SERVER_ENABLED:
-        msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
-        raise HTTPException(status_code=500, detail=msg)
-
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
-    full_file_path = workspace_directory / file_path
-
-    if not full_file_path.exists():
-        logger.warning("Workspace file not found: %s", file_path)
-        raise HTTPException(status_code=404, detail=f"File {file_path} not found")
-
-    if not full_file_path.is_file():
-        msg = f"Path {file_path} is not a file"
-        logger.error(msg)
-        raise HTTPException(status_code=400, detail=msg)
-
-    try:
-        full_file_path.resolve().relative_to(workspace_directory.resolve())
-    except ValueError as e:
-        msg = f"Invalid path: {file_path}"
-        logger.error(msg)
-        raise HTTPException(status_code=400, detail=msg) from e
-
-    return FileResponse(full_file_path)
-
-
 async def _serve_external_file(file_path: str) -> FileResponse:
     """Serve a file from outside the workspace.
 
@@ -338,11 +299,10 @@ def start_static_server(sock: socket.socket) -> None:
     workspace_directory = GriptapeNodes.ConfigManager().workspace_path
     static_files_directory = Path(GriptapeNodes.ConfigManager().get_config_value("static_files_directory"))
 
-    # Register workspace file handler with preview generation
-    app.add_api_route(
-        f"{STATIC_SERVER_URL}/{{file_path:path}}",
-        _serve_workspace_file,
-        methods=["GET"],
+    app.mount(
+        STATIC_SERVER_URL,
+        StaticFiles(directory=workspace_directory),
+        name="workspace",
     )
     static_files_path = workspace_directory / static_files_directory
     static_files_path.mkdir(parents=True, exist_ok=True)

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -216,6 +216,45 @@ async def _serve_library_widget(library_name: str, file_path: str) -> FileRespon
     )
 
 
+async def _serve_workspace_file(file_path: str, _request: Request) -> FileResponse:
+    """Serve a file from the workspace directory.
+
+    Preview generation now happens in StaticFilesManager when creating download URLs.
+    This endpoint simply serves the requested file.
+
+    Args:
+        file_path: The relative file path within workspace (e.g., "images/photo.jpg")
+        _request: FastAPI Request object (unused, kept for route signature compatibility)
+
+    Returns:
+        FileResponse with the requested file
+    """
+    if not STATIC_SERVER_ENABLED:
+        msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
+        raise HTTPException(status_code=500, detail=msg)
+
+    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    full_file_path = workspace_directory / file_path
+
+    if not full_file_path.exists():
+        logger.warning("Workspace file not found: %s", file_path)
+        raise HTTPException(status_code=404, detail=f"File {file_path} not found")
+
+    if not full_file_path.is_file():
+        msg = f"Path {file_path} is not a file"
+        logger.error(msg)
+        raise HTTPException(status_code=400, detail=msg)
+
+    try:
+        full_file_path.resolve().relative_to(workspace_directory.resolve())
+    except ValueError as e:
+        msg = f"Invalid path: {file_path}"
+        logger.error(msg)
+        raise HTTPException(status_code=400, detail=msg) from e
+
+    return FileResponse(full_file_path)
+
+
 async def _serve_external_file(file_path: str) -> FileResponse:
     """Serve a file from outside the workspace.
 
@@ -299,10 +338,11 @@ def start_static_server(sock: socket.socket) -> None:
     workspace_directory = GriptapeNodes.ConfigManager().workspace_path
     static_files_directory = Path(GriptapeNodes.ConfigManager().get_config_value("static_files_directory"))
 
-    app.mount(
-        STATIC_SERVER_URL,
-        StaticFiles(directory=workspace_directory),
-        name="workspace",
+    # Register workspace file handler with preview generation
+    app.add_api_route(
+        f"{STATIC_SERVER_URL}/{{file_path:path}}",
+        _serve_workspace_file,
+        methods=["GET"],
     )
     static_files_path = workspace_directory / static_files_directory
     static_files_path.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/retained_mode/managers/test_provider_registry.py
+++ b/tests/unit/retained_mode/managers/test_provider_registry.py
@@ -53,6 +53,10 @@ class TestProviderRegistry:
             def get_default_preview_generators(cls) -> list:
                 return []
 
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
+
         registry = ProviderRegistry()
         registry.register_provider(TestProvider)
 
@@ -65,7 +69,7 @@ class TestProviderRegistry:
         assert "test" in registry._friendly_name_to_provider_class
         assert registry._friendly_name_to_provider_class["test"] is TestProvider
 
-    def test_register_provider_duplicate_friendly_name_raises(self) -> None:
+    def test_register_provider_duplicate_friendly_name_raises(self) -> None:  # noqa: C901
         """Test that registering a provider with duplicate friendly name raises ValueError."""
 
         class Provider1(BaseArtifactProvider):
@@ -85,6 +89,10 @@ class TestProviderRegistry:
             def get_default_preview_generators(cls) -> list:
                 return []
 
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
+
         class Provider2(BaseArtifactProvider):
             @classmethod
             def get_friendly_name(cls) -> str:
@@ -102,13 +110,17 @@ class TestProviderRegistry:
             def get_default_preview_generators(cls) -> list:
                 return []
 
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
+
         registry = ProviderRegistry()
         registry.register_provider(Provider1)
 
         with pytest.raises(ValueError, match="duplicate friendly name"):
             registry.register_provider(Provider2)
 
-    def test_register_provider_case_insensitive_duplicate_raises(self) -> None:
+    def test_register_provider_case_insensitive_duplicate_raises(self) -> None:  # noqa: C901
         """Test that friendly name duplicate detection is case-insensitive."""
 
         class UpperProvider(BaseArtifactProvider):
@@ -128,6 +140,10 @@ class TestProviderRegistry:
             def get_default_preview_generators(cls) -> list:
                 return []
 
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
+
         class LowerProvider(BaseArtifactProvider):
             @classmethod
             def get_friendly_name(cls) -> str:
@@ -144,6 +160,10 @@ class TestProviderRegistry:
             @classmethod
             def get_default_preview_generators(cls) -> list:
                 return []
+
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
 
         registry = ProviderRegistry()
         registry.register_provider(UpperProvider)
@@ -226,6 +246,10 @@ class TestProviderRegistry:
             def get_default_preview_generators(cls) -> list:
                 return []
 
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
+
         registry = ProviderRegistry()
         registry.register_provider(ImageArtifactProvider)
         registry.register_provider(AlternateImageProvider)
@@ -283,6 +307,10 @@ class TestProviderRegistry:
             def get_default_preview_generators(cls) -> list:
                 return []
 
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
+
         class TestProvider2(BaseArtifactProvider):
             @classmethod
             def get_friendly_name(cls) -> str:
@@ -307,6 +335,10 @@ class TestProviderRegistry:
             @classmethod
             def get_default_preview_generators(cls) -> list:
                 return []
+
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
 
         registry = ProviderRegistry()
         registry.register_provider(TestProvider1)
@@ -347,6 +379,10 @@ class TestProviderRegistry:
             @classmethod
             def get_default_preview_generators(cls) -> list:
                 return []
+
+            @classmethod
+            def get_artifact_metadata(cls, _source_path: str) -> None:
+                return None
 
         registry = ProviderRegistry()
         registry.register_provider(ImageArtifactProvider)


### PR DESCRIPTION
This change, alongside https://github.com/griptape-ai/griptape-vsl-gui/pull/2102, introduces Load-on-Demand image previews. Images will be rendered using the relevant preview_generator (and user config) when viewed from a normal zoom level. When lightboxed (opened) or zoomed in (>50% of the viewport), the full resolution image will be displayed instead. When the image is outside the viewport, it will be unloaded. All of this is to save browser/editor memory and improve performance.

Part of https://github.com/griptape-ai/griptape-nodes/issues/4230