### PR TITLE
feat: add ui_options parameter to ProjectFileParameter

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
@@ -40,7 +40,7 @@ class ProjectFileParameter:
 
     DEFAULT_SITUATION = "save_node_output"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         node: BaseNode,
         name: str,


### PR DESCRIPTION
Adds a `ui_options: dict | None = None` argument to `ProjectFileParameter.__init__`. When provided, the value is passed through to the generated `Parameter`, giving callers control over UI presentation (e.g. `{"hide": True}`) without needing to patch the parameter after `add_parameter()`.