### PR TITLE
Add Flag to Skip Published Workflow Registration

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -474,6 +474,7 @@ class PublishWorkflowResultSuccess(ResultPayloadSuccess):
 
     published_workflow_file_path: str
     metadata: dict | None = None
+    skip_published_workflow_registration: bool = False
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4200,7 +4200,7 @@ class WorkflowManager:
             await GriptapeNodes.ahandle_request(SaveWorkflowRequest(file_name=workflow_file_name))
 
             result = await asyncio.to_thread(publishing_handler.handler, request)
-            if isinstance(result, PublishWorkflowResultSuccess):
+            if isinstance(result, PublishWorkflowResultSuccess) and not result.skip_published_workflow_registration:
                 workflow_file = Path(result.published_workflow_file_path)
                 result = self._register_published_workflow_file(workflow_file, result)
 


### PR DESCRIPTION
* Add flag to PublishWorkflowResultSuccess to skip registration of the generated workflow file
  * Some publishing use cases, like publishing to a local folder, do not require the generation of a "published workflow" version, which is typically used to invoke a remote/deployed workflow 