### PR TITLE
fix: handle Windows absolute paths in external file URLs

### DIFF
--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -156,8 +156,9 @@ class LocalStorageDriver(BaseStorageDriver):
             # Internal files: use workspace-relative path
             url = f"{self.base_url}/{workspace_relative_path.as_posix()}"
         except ValueError:
-            # For external files, use /external path and strip leading slash from absolute path
-            path_str = str(absolute_path).removeprefix("/")
+            # For external files, use /external path and strip leading slash from absolute path.
+            # Use as_posix() to normalize backslashes to forward slashes for URLs (important on Windows).
+            path_str = absolute_path.as_posix().removeprefix("/")
             # Build URL with /external prefix, replacing the /workspace part of base_url
             base_without_workspace = self.base_url.rsplit("/workspace", 1)[0]
             url = f"{base_without_workspace}/external/{path_str}"

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -226,8 +226,14 @@ async def _serve_external_file(file_path: str) -> FileResponse:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    # Reconstruct absolute path by adding leading slash
-    absolute_path = Path(f"/{file_path}")
+    # Reconstruct absolute path.
+    # On Windows, the path already starts with a drive letter (e.g., "C:/Users/...") and is absolute.
+    # On Unix, the leading slash was stripped, so it needs to be re-added.
+    candidate = Path(file_path)
+    if candidate.is_absolute():
+        absolute_path = candidate
+    else:
+        absolute_path = Path(f"/{file_path}")
 
     anyio_absolute_path = anyio.Path(absolute_path)
 

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -226,14 +226,8 @@ async def _serve_external_file(file_path: str) -> FileResponse:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    # Reconstruct absolute path.
-    # On Unix, paths need a leading slash (e.g., "tmp/video.mp4" -> "/tmp/video.mp4").
-    # On Windows, paths already start with a drive letter (e.g., "C:/Users/..."), so no slash is needed.
-    has_drive_letter = len(file_path) >= 2 and file_path[1] == ":"  # noqa: PLR2004
-    if has_drive_letter:
-        absolute_path = Path(file_path)
-    else:
-        absolute_path = Path(f"/{file_path}")
+    # Reconstruct absolute path by adding leading slash
+    absolute_path = Path(f"/{file_path}")
 
     anyio_absolute_path = anyio.Path(absolute_path)
 

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -226,8 +226,14 @@ async def _serve_external_file(file_path: str) -> FileResponse:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    # Reconstruct absolute path by adding leading slash
-    absolute_path = Path(f"/{file_path}")
+    # Reconstruct absolute path.
+    # On Unix, paths need a leading slash (e.g., "tmp/video.mp4" -> "/tmp/video.mp4").
+    # On Windows, paths already start with a drive letter (e.g., "C:/Users/..."), so no slash is needed.
+    has_drive_letter = len(file_path) >= 2 and file_path[1] == ":"  # noqa: PLR2004
+    if has_drive_letter:
+        absolute_path = Path(file_path)
+    else:
+        absolute_path = Path(f"/{file_path}")
 
     anyio_absolute_path = anyio.Path(absolute_path)
 

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -145,3 +145,55 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             mock_os_manager.on_write_file_request.assert_called_once()
             call_args = mock_os_manager.on_write_file_request.call_args[0][0]
             assert call_args.existing_file_policy == ExistingFilePolicy.OVERWRITE
+
+
+class TestLocalStorageDriverCreateSignedDownloadUrl:
+    """Test LocalStorageDriver.create_signed_download_url() method."""
+
+    @pytest.fixture
+    def local_storage_driver(self) -> LocalStorageDriver:
+        """Create LocalStorageDriver instance for testing."""
+        return LocalStorageDriver(Path("/workspace"))
+
+    def test_internal_file_uses_workspace_relative_url(self, local_storage_driver: LocalStorageDriver) -> None:
+        """Internal files should produce a workspace-relative URL."""
+        with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
+            mock_time.time.return_value = 1000
+            url = local_storage_driver.create_signed_download_url(Path("/workspace/images/photo.png"))
+
+        assert url == "http://localhost:8124/workspace/images/photo.png?t=1000"
+
+    def test_external_unix_file_uses_external_url(self, local_storage_driver: LocalStorageDriver) -> None:
+        """External Unix files should produce a /external/ URL with forward slashes."""
+        with (
+            patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time,
+            patch("griptape_nodes.drivers.storage.local_storage_driver.resolve_workspace_path") as mock_resolve,
+        ):
+            mock_time.time.return_value = 1000
+            external_path = Path("/external/video.mp4")
+            mock_resolve.return_value = external_path
+            url = local_storage_driver.create_signed_download_url(external_path)
+
+        assert url == "http://localhost:8124/external/external/video.mp4?t=1000"
+
+    def test_external_windows_file_uses_forward_slashes_in_url(self, local_storage_driver: LocalStorageDriver) -> None:
+        """External Windows-style files should produce a URL with forward slashes, not backslashes."""
+        with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
+            mock_time.time.return_value = 1000
+
+            # Simulate a Windows absolute path by patching resolve_workspace_path
+            # to return a PurePosixPath that mimics what a Windows Path would look like after as_posix()
+            with patch("griptape_nodes.drivers.storage.local_storage_driver.resolve_workspace_path") as mock_resolve:
+                # On Windows, Path("C:/Users/foo/image.png") has str() = "C:\\Users\\foo\\image.png"
+                # but .as_posix() = "C:/Users/foo/image.png"
+                mock_path = Mock()
+                mock_path.relative_to.side_effect = ValueError("not relative")
+                mock_path.as_posix.return_value = "C:/Users/foo/image.png"
+                mock_path.__str__ = lambda _self: "C:\\Users\\foo\\image.png"
+                mock_resolve.return_value = mock_path
+                url = local_storage_driver.create_signed_download_url(Path("C:/Users/foo/image.png"))
+
+        # The URL must use forward slashes and not have backslashes
+        assert "\\" not in url
+        assert "C:/Users/foo/image.png" in url
+        assert url == "http://localhost:8124/external/C:/Users/foo/image.png?t=1000"

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -22,28 +22,3 @@ class TestServeExternalFile:
             response = await _serve_external_file(file_path_in_url)
 
         assert Path(response.path) == test_file
-
-    @pytest.mark.anyio
-    async def test_windows_drive_letter_path_reconstruction(self) -> None:
-        """Windows-style paths with drive letters (e.g., C:/...) should NOT get a leading slash prepended."""
-        # Simulate a Windows path coming through the URL: "C:/Users/foo/image.png"
-        # We can't create an actual Windows path on macOS/Linux, but we can test the path reconstruction logic.
-        # The key assertion is that the function doesn't prepend "/" to a drive-letter path.
-        windows_style_path = "C:/Users/foo/image.png"
-
-        with (
-            patch("griptape_nodes.servers.static.STATIC_SERVER_ENABLED", True),
-            patch("griptape_nodes.servers.static.anyio.Path") as mock_anyio_path,
-            patch("griptape_nodes.servers.static.FileResponse") as mock_response,
-        ):
-            mock_path_instance = AsyncMock()
-            mock_path_instance.exists.return_value = True
-            mock_path_instance.is_file.return_value = True
-            mock_anyio_path.return_value = mock_path_instance
-
-            await _serve_external_file(windows_style_path)
-
-            # The path passed to FileResponse should be C:/Users/foo/image.png, NOT /C:/Users/foo/image.png
-            call_args = mock_response.call_args[0][0]
-            assert str(call_args) != "/C:/Users/foo/image.png"
-            assert "C:" in str(call_args)

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from griptape_nodes.servers.static import _serve_external_file
+
+
+class TestServeExternalFile:
+    """Test _serve_external_file() path reconstruction."""
+
+    @pytest.mark.anyio
+    async def test_unix_path_reconstruction(self, tmp_path: Path) -> None:
+        """Unix-style paths (no drive letter) should get a leading slash prepended."""
+        test_file = tmp_path / "image.png"
+        test_file.write_bytes(b"fake png")
+
+        # Strip the leading slash, as the URL router would
+        file_path_in_url = str(test_file).removeprefix("/")
+
+        with patch("griptape_nodes.servers.static.STATIC_SERVER_ENABLED", True):
+            response = await _serve_external_file(file_path_in_url)
+
+        assert Path(response.path) == test_file
+
+    @pytest.mark.anyio
+    async def test_windows_drive_letter_path_reconstruction(self) -> None:
+        """Windows-style paths with drive letters (e.g., C:/...) should NOT get a leading slash prepended."""
+        # Simulate a Windows path coming through the URL: "C:/Users/foo/image.png"
+        # We can't create an actual Windows path on macOS/Linux, but we can test the path reconstruction logic.
+        # The key assertion is that the function doesn't prepend "/" to a drive-letter path.
+        windows_style_path = "C:/Users/foo/image.png"
+
+        with (
+            patch("griptape_nodes.servers.static.STATIC_SERVER_ENABLED", True),
+            patch("griptape_nodes.servers.static.anyio.Path") as mock_anyio_path,
+            patch("griptape_nodes.servers.static.FileResponse") as mock_response,
+        ):
+            mock_path_instance = AsyncMock()
+            mock_path_instance.exists.return_value = True
+            mock_path_instance.is_file.return_value = True
+            mock_anyio_path.return_value = mock_path_instance
+
+            await _serve_external_file(windows_style_path)
+
+            # The path passed to FileResponse should be C:/Users/foo/image.png, NOT /C:/Users/foo/image.png
+            call_args = mock_response.call_args[0][0]
+            assert str(call_args) != "/C:/Users/foo/image.png"
+            assert "C:" in str(call_args)

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -22,3 +22,30 @@ class TestServeExternalFile:
             response = await _serve_external_file(file_path_in_url)
 
         assert Path(response.path) == test_file
+
+    @pytest.mark.anyio
+    async def test_absolute_path_not_prepended_with_slash(self) -> None:
+        """Paths that are already absolute should not get a leading slash prepended."""
+        # On Windows, Path("C:/Users/foo/image.png") is already absolute.
+        # Prepending "/" would produce "\C:\Users\..." which is invalid.
+        # We simulate this by patching Path.is_absolute to return True.
+        already_absolute_path = "C:/Users/foo/image.png"
+
+        with (
+            patch("griptape_nodes.servers.static.STATIC_SERVER_ENABLED", True),
+            patch("griptape_nodes.servers.static.Path") as mock_path_cls,
+            patch("griptape_nodes.servers.static.anyio.Path") as mock_anyio_path,
+            patch("griptape_nodes.servers.static.FileResponse") as mock_response,
+        ):
+            mock_candidate = mock_path_cls.return_value
+            mock_candidate.is_absolute.return_value = True
+            mock_anyio_instance = AsyncMock()
+            mock_anyio_instance.exists.return_value = True
+            mock_anyio_instance.is_file.return_value = True
+            mock_anyio_path.return_value = mock_anyio_instance
+
+            await _serve_external_file(already_absolute_path)
+
+            # Path() should have been called with the raw path, not with "/" prepended
+            mock_path_cls.assert_called_once_with(already_absolute_path)
+            mock_response.assert_called_once_with(mock_candidate)

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -9,7 +9,7 @@ from griptape_nodes.servers.static import _serve_external_file
 class TestServeExternalFile:
     """Test _serve_external_file() path reconstruction."""
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_unix_path_reconstruction(self, tmp_path: Path) -> None:
         """Unix-style paths (no drive letter) should get a leading slash prepended."""
         test_file = tmp_path / "image.png"
@@ -23,7 +23,7 @@ class TestServeExternalFile:
 
         assert Path(response.path) == test_file
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_absolute_path_not_prepended_with_slash(self) -> None:
         """Paths that are already absolute should not get a leading slash prepended."""
         # On Windows, Path("C:/Users/foo/image.png") is already absolute.


### PR DESCRIPTION
Fixes #4254

On Windows, external file paths (files outside the workspace) failed to preview because of two issues in how URLs were constructed and resolved:

1. `LocalStorageDriver.create_signed_download_url()` used `str()` on the path, which on Windows produces backslash-separated paths (e.g., `C:\Users\foo\image.png`). Backslashes are invalid in URLs. Changed to `as_posix()` to normalize to forward slashes.

2. `_serve_external_file()` unconditionally prepended `/` to reconstruct the absolute path. On Windows, this turned `C:/Users/foo/image.png` into `\C:\Users\foo\image.png`, which is invalid. Now uses `Path.is_absolute()` to skip the prepend when the path already has a drive letter.

<img width="489" height="436" alt="image" src="https://github.com/user-attachments/assets/7001b886-18f8-4678-9ac1-ce220f01f557" />
