### PR TITLE
Strip query params from URL

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from typing import Any, ClassVar
+from urllib.parse import urlparse
 from uuid import uuid4
 
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
@@ -125,7 +126,7 @@ class PublicArtifactUrlParameter:
         from griptape_nodes.files.file import File
 
         file_contents = File(url).read_bytes()
-        filename = Path(url).name
+        filename = Path(urlparse(url).path).name
 
         self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
 


### PR DESCRIPTION
The Luma Video Modify node wasn't working properly with this error: 
```
Failed to create presigned upload URL for file artifact_url_storage/c8267452374f402ea26d8659d75a7eab/dog_bark_load_wednesday.mp4?t=1774640380: Client error '404 Not Found' for url                                                                                     
                    'https://cloud.griptape.ai/api/buckets/ca1a37a5-3f93-4aac-81b3-174a47f5f44f/asset-urls/artifact_url_storage/c8267452374f402ea26d8659d75a7eab/dog_bark_load_wednesday.mp4?t=1774640380'                                                                                  
                    For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404   
```
because of query params. This update here fixes the bug for all nodes that use public_artifact_url 