### PR TITLE
Add updates for Subflow Workflow Node

### DIFF
--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -1019,7 +1019,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
     def process(self) -> Any:
         """Synchronous process method - not used for proxy nodes."""
 
-    def after_deleted(self) -> None:
+    def after_node_deleted(self) -> None:
         nodes_to_remove = list(self.nodes.values())
         self.remove_nodes_from_group(nodes_to_remove)
         subflow_name = self.metadata.get("subflow_name")

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -11,6 +11,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterTypeBuiltin,
     Trait,
 )
+from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
 from griptape_nodes.exe_types.node_types import (
     LOCAL_EXECUTION,
@@ -22,11 +23,13 @@ from griptape_nodes.retained_mode.events.connection_events import (
     DeleteConnectionRequest,
     DeleteConnectionResultSuccess,
 )
+from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     AddParameterToNodeResultSuccess,
     RemoveParameterFromNodeRequest,
 )
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 if TYPE_CHECKING:
@@ -1015,6 +1018,15 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
     def process(self) -> Any:
         """Synchronous process method - not used for proxy nodes."""
+
+    def on_delete(self) -> None:
+        nodes_to_remove = list(self.nodes.values())
+        self.remove_nodes_from_group(nodes_to_remove)
+        subflow_name = self.metadata.get("subflow_name")
+        if subflow_name is not None:
+            subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
+            if subflow is not None:
+                GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
 
     def delete_group(self) -> str | None:
         nodes_to_remove = list(self.nodes.values())

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -23,7 +23,7 @@ from griptape_nodes.retained_mode.events.connection_events import (
     DeleteConnectionRequest,
     DeleteConnectionResultSuccess,
 )
-from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest
+from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest, DeleteFlowResultFailure
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     AddParameterToNodeResultSuccess,
@@ -1019,14 +1019,23 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
     def process(self) -> Any:
         """Synchronous process method - not used for proxy nodes."""
 
-    def on_delete(self) -> None:
+    def after_deleted(self) -> None:
         nodes_to_remove = list(self.nodes.values())
         self.remove_nodes_from_group(nodes_to_remove)
         subflow_name = self.metadata.get("subflow_name")
         if subflow_name is not None:
             subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
             if subflow is not None:
-                GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+                delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+                if isinstance(delete_result, DeleteFlowResultFailure):
+                    # This will propagate up to DeleteNodeRequest, and prevent the node from deleting.
+                    msg = f"Failed to delete subflow {subflow_name} when deleting node {self.name}"
+                    raise ValueError(msg)
+            else:
+                msg = f"Node {self.name} has a subflow name of {subflow_name} but {subflow_name} doesn't exist. Removing from metadata."
+                logger.warning(msg)
+            # Delete the subflow name since now there is no subflow attached.
+            self.metadata.pop("subflow_name")
 
     @property
     def subflow_execution_component(self) -> SubflowExecutionComponent:

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -1028,12 +1028,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             if subflow is not None:
                 GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
 
-    def delete_group(self) -> str | None:
-        nodes_to_remove = list(self.nodes.values())
-        self.remove_nodes_from_group(nodes_to_remove)
-        subflow_name = self.metadata.get("subflow_name")
-        return subflow_name
-
     @property
     def subflow_execution_component(self) -> SubflowExecutionComponent:
         """Get the subflow execution component for real-time status updates."""

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -484,6 +484,9 @@ class BaseNode(ABC):
         # Default behavior is to do nothing, and indicate no other modified Parameters.
         return None  # noqa: RET501
 
+    def on_delete(self) -> None:
+        """Called before a node is deleted. Override to perform cleanup (e.g. deleting a loaded subflow)."""
+
     def after_settings_changed(self, **kwargs: Any) -> None:  # noqa: ARG002
         """Callback for when the settings of this Node are changed."""
         # Waiting for https://github.com/griptape-ai/griptape-nodes/issues/1309

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -484,8 +484,9 @@ class BaseNode(ABC):
         # Default behavior is to do nothing, and indicate no other modified Parameters.
         return None  # noqa: RET501
 
-    def on_delete(self) -> None:
+    def after_deleted(self) -> None:
         """Called before a node is deleted. Override to perform cleanup (e.g. deleting a loaded subflow)."""
+        return
 
     def after_settings_changed(self, **kwargs: Any) -> None:  # noqa: ARG002
         """Callback for when the settings of this Node are changed."""

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -484,7 +484,7 @@ class BaseNode(ABC):
         # Default behavior is to do nothing, and indicate no other modified Parameters.
         return None  # noqa: RET501
 
-    def after_deleted(self) -> None:
+    def after_node_deleted(self) -> None:
         """Called before a node is deleted. Override to perform cleanup (e.g. deleting a loaded subflow)."""
         return
 

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -22,6 +22,12 @@ class LibraryNameAndNodeType(NamedTuple):
     node_type: str
 
 
+class WorkflowInfo(NamedTuple):
+    metadata: WorkflowMetadata
+    file_path: str
+    is_synced: bool
+
+
 # Type aliases for clarity
 type NodeName = str
 type ParameterName = str
@@ -179,13 +185,17 @@ class WorkflowRegistry(metaclass=SingletonMeta):
         return {key: instance._workflows[key].get_workflow_metadata() for key in instance._workflows}
 
     @classmethod
-    def list_valid_workflows(cls) -> dict[str, dict]:
+    def list_callable_workflows(cls) -> dict[str, WorkflowInfo]:
         """Return only workflows that have a workflow_shape (i.e. contain StartFlow and EndFlow nodes)."""
         instance = cls()
         result = {}
         for key, workflow in instance._workflows.items():
             if workflow.metadata.workflow_shape is not None:
-                result[key] = workflow.get_workflow_metadata()
+                result[key] = WorkflowInfo(
+                    metadata=workflow.metadata,
+                    file_path=workflow.file_path,
+                    is_synced=workflow.is_synced,
+                )
         return result
 
     @classmethod

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -22,12 +22,6 @@ class LibraryNameAndNodeType(NamedTuple):
     node_type: str
 
 
-class WorkflowInfo(NamedTuple):
-    metadata: WorkflowMetadata
-    file_path: str
-    is_synced: bool
-
-
 # Type aliases for clarity
 type NodeName = str
 type ParameterName = str
@@ -183,20 +177,6 @@ class WorkflowRegistry(metaclass=SingletonMeta):
     def list_workflows(cls) -> dict[str, dict]:
         instance = cls()
         return {key: instance._workflows[key].get_workflow_metadata() for key in instance._workflows}
-
-    @classmethod
-    def list_callable_workflows(cls) -> dict[str, WorkflowInfo]:
-        """Return only workflows that have a workflow_shape (i.e. contain StartFlow and EndFlow nodes)."""
-        instance = cls()
-        result = {}
-        for key, workflow in instance._workflows.items():
-            if workflow.metadata.workflow_shape is not None:
-                result[key] = WorkflowInfo(
-                    metadata=workflow.metadata,
-                    file_path=workflow.file_path,
-                    is_synced=workflow.is_synced,
-                )
-        return result
 
     @classmethod
     def get_complete_file_path(cls, relative_file_path: str) -> str:

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -179,6 +179,16 @@ class WorkflowRegistry(metaclass=SingletonMeta):
         return {key: instance._workflows[key].get_workflow_metadata() for key in instance._workflows}
 
     @classmethod
+    def list_valid_workflows(cls) -> dict[str, dict]:
+        """Return only workflows that have a workflow_shape (i.e. contain StartFlow and EndFlow nodes)."""
+        instance = cls()
+        result = {}
+        for key, workflow in instance._workflows.items():
+            if workflow.metadata.workflow_shape is not None:
+                result[key] = workflow.get_workflow_metadata()
+        return result
+
+    @classmethod
     def get_complete_file_path(cls, relative_file_path: str) -> str:
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Literal
 
-from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowShape
+from griptape_nodes.node_library.workflow_registry import WorkflowInfo, WorkflowMetadata, WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -207,6 +207,24 @@ class ListAllWorkflowsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucces
 @PayloadRegistry.register
 class ListAllWorkflowsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Workflow listing failed. Common causes: registry not initialized, registry error."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ListCallableWorkflowsRequest(RequestPayload):
+    """List workflows that have a workflow_shape (i.e. contain StartFlow and EndFlow nodes)."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ListCallableWorkflowsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    workflows: dict[str, WorkflowInfo]
+
+
+@dataclass
+@PayloadRegistry.register
+class ListCallableWorkflowsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Callable workflow listing failed."""
 
 
 @dataclass
@@ -1010,15 +1028,13 @@ class SaveSubflowToWorkflowRequest(RequestPayload):
 
     Args:
         flow_name: The engine flow name of the subflow to serialize
-        file_path: The target file path to save the workflow to
-        workflow_name: Optional registry key for looking up existing metadata
+        workflow_name: Registry key for the target workflow (used to derive file path and metadata)
 
     Results: SaveSubflowToWorkflowResultSuccess | SaveSubflowToWorkflowResultFailure
     """
 
     flow_name: str
-    file_path: str
-    workflow_name: str | None = None
+    workflow_name: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Literal
 
-from griptape_nodes.node_library.workflow_registry import WorkflowInfo, WorkflowMetadata, WorkflowShape
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -218,7 +218,7 @@ class ListCallableWorkflowsRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class ListCallableWorkflowsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    workflows: dict[str, WorkflowInfo]
+    workflow_names: list[str]
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -330,6 +330,7 @@ class ImportWorkflowAsReferencedSubFlowRequest(RequestPayload):
     workflow_name: str
     flow_name: str | None = None  # If None, import into current context flow
     imported_flow_metadata: dict | None = None  # Metadata to apply to the imported flow
+    track_as_referenced: bool = True  # If False, the flow serializes as inline content instead of an import command
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -998,3 +998,44 @@ class SaveWorkflowFileFromSerializedFlowResultSuccess(WorkflowNotAlteredMixin, R
 @PayloadRegistry.register
 class SaveWorkflowFileFromSerializedFlowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Workflow file save failed. Common causes: file system error, permission denied, invalid serialized commands."""
+
+
+@dataclass
+@PayloadRegistry.register
+class SaveSubflowToWorkflowRequest(RequestPayload):
+    """Serialize a subflow and save it back to its original workflow file.
+
+    Use when: Persisting changes made to a subflow in a modal editor back to
+    the workflow file it was loaded from.
+
+    Args:
+        flow_name: The engine flow name of the subflow to serialize
+        file_path: The target file path to save the workflow to
+        workflow_name: Optional registry key for looking up existing metadata
+
+    Results: SaveSubflowToWorkflowResultSuccess | SaveSubflowToWorkflowResultFailure
+    """
+
+    flow_name: str
+    file_path: str
+    workflow_name: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class SaveSubflowToWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Subflow saved successfully to workflow file.
+
+    Args:
+        file_path: Path where the workflow file was written
+        workflow_metadata: The metadata generated for the saved workflow
+    """
+
+    file_path: str
+    workflow_metadata: WorkflowMetadata
+
+
+@dataclass
+@PayloadRegistry.register
+class SaveSubflowToWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Subflow save to workflow file failed. Common causes: serialization error, file system error, invalid flow name."""

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4155,11 +4155,14 @@ class FlowManager:
         # Clear and use the global execution queue
         self._global_flow_queue.queue.clear()
 
-        # Get all flows and collect all nodes across all flows
+        # Get all flows and collect all nodes across all flows.
+        # Exclude nodes from referenced subflows - they are executed explicitly via
+        # StartLocalSubflowRequest and should not participate in the top-level queue.
         all_flows = GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow)
         all_nodes = []
         for current_flow in all_flows.values():
-            all_nodes.extend(current_flow.nodes.values())
+            if not self.is_referenced_workflow(current_flow):
+                all_nodes.extend(current_flow.nodes.values())
 
         # if no nodes across all flows, no execution possible
         if not all_nodes:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -378,11 +378,13 @@ class FlowManager:
             if parent_name == flow_name:
                 child_flow_names.add(child_name)
 
-        # Build set of all node names in this flow and its direct children
+        # Build set of all node names in this flow and its direct children.
+        # Exclude nodes from referenced workflow children - their internal connections
+        # are not serialized at the parent level (they serialize as a standalone workflow).
         all_node_names = set(flow.nodes.keys())
         for child_flow_name in child_flow_names:
             child_flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
-            if child_flow is not None:
+            if child_flow is not None and not self.is_referenced_workflow(child_flow):
                 all_node_names.update(child_flow.nodes.keys())
 
         # Include connections where both nodes are in this flow hierarchy

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -909,11 +909,11 @@ class NodeManager:
             if cancel_result is not None:
                 return cancel_result
 
-            # Call after_deleted hook for cleanup of a node, implemented by node author.
+            # Call after_node_deleted hook for cleanup of a node, implemented by node author.
             try:
-                node.after_deleted()
+                node.after_node_deleted()
             except ValueError as err:
-                msg = f"Failed to delete node {node_name}, after_deleted method failed to run with error: {err}"
+                msg = f"Failed to delete node {node_name}, after_node_deleted method failed to run with error: {err}"
                 return DeleteNodeResultFailure(result_details=msg)
             # Remove all connections from this Node using a loop to handle cascading deletions
             any_connections_remain = True

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -909,21 +909,9 @@ class NodeManager:
             cancel_result = self.cancel_conditionally(parent_flow, parent_flow_name, node)
             if cancel_result is not None:
                 return cancel_result
-            
+
             # Call on_delete hook for cleanup of a node, implemented by node author.
             node.on_delete()
-
-            subflow_name = None
-            # Remove nodes from the node group (if it is one) before deleting connections.
-            # TODO: leaving for backwards compatibility — will remove eventually.
-            if isinstance(node, SubflowNodeGroup) and hasattr(node, "delete_group"):
-                try:
-                    subflow_name = node.delete_group()
-                except ValueError as err:
-                    details = (
-                        f"Attempted to delete NodeGroup '{request.node_name}'. Failed to remove nodes from group: {err}"
-                    )
-                    return DeleteNodeResultFailure(result_details=details)
             # Remove all connections from this Node using a loop to handle cascading deletions
             any_connections_remain = True
             while any_connections_remain:
@@ -978,11 +966,6 @@ class NodeManager:
             except ValueError as e:
                 details = f"Attempted to delete a Node '{node_name}'. Failed to remove it from the node group: {e}"
                 return DeleteNodeResultFailure(result_details=details)
-        # Backwards compatibility: delete the subflow for old SubflowNodeGroup libraries that
-        # don't override on_delete. New nodes handle this themselves via on_delete(), but older
-        # library versions won't have that override, so we fall back to deleting it here.
-        if subflow_name is not None:
-            GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
 
         parent_flow.remove_node(node.name)
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -59,7 +59,6 @@ from griptape_nodes.retained_mode.events.execution_events import (
     StartFlowResultFailure,
 )
 from griptape_nodes.retained_mode.events.flow_events import (
-    DeleteFlowRequest,
     ListNodesInFlowRequest,
     ListNodesInFlowResultSuccess,
 )
@@ -910,8 +909,12 @@ class NodeManager:
             if cancel_result is not None:
                 return cancel_result
 
-            # Call on_delete hook for cleanup of a node, implemented by node author.
-            node.on_delete()
+            # Call after_deleted hook for cleanup of a node, implemented by node author.
+            try:
+                node.after_deleted()
+            except ValueError as err:
+                msg = f"Failed to delete node {node_name}, after_deleted method failed to run with error: {err}"
+                return DeleteNodeResultFailure(result_details=msg)
             # Remove all connections from this Node using a loop to handle cascading deletions
             any_connections_remain = True
             while any_connections_remain:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -909,10 +909,14 @@ class NodeManager:
             cancel_result = self.cancel_conditionally(parent_flow, parent_flow_name, node)
             if cancel_result is not None:
                 return cancel_result
+            
+            # Call on_delete hook for cleanup of a node, implemented by node author.
+            node.on_delete()
 
             subflow_name = None
             # Remove nodes from the node group (if it is one) before deleting connections.
-            if isinstance(node, SubflowNodeGroup):
+            # TODO: leaving for backwards compatibility — will remove eventually.
+            if isinstance(node, SubflowNodeGroup) and hasattr(node, "delete_group"):
                 try:
                     subflow_name = node.delete_group()
                 except ValueError as err:
@@ -974,6 +978,12 @@ class NodeManager:
             except ValueError as e:
                 details = f"Attempted to delete a Node '{node_name}'. Failed to remove it from the node group: {e}"
                 return DeleteNodeResultFailure(result_details=details)
+        # Backwards compatibility: delete the subflow for old SubflowNodeGroup libraries that
+        # don't override on_delete. New nodes handle this themselves via on_delete(), but older
+        # library versions won't have that override, so we fall back to deleting it here.
+        if subflow_name is not None:
+            GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+
         parent_flow.remove_node(node.name)
 
         # Now remove the record keeping
@@ -984,18 +994,6 @@ class NodeManager:
         if request.node_name is None:
             GriptapeNodes.ContextManager().pop_node()
 
-        # Delete subflow if it has one and it still exists
-        # Note: The subflow may have already been deleted if we're being called as part of
-        # a parent flow deletion (which deletes child flows before nodes)
-        if subflow_name is not None:
-            subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
-            if subflow is not None:
-                delete_flow_request = DeleteFlowRequest(flow_name=subflow_name)
-                delete_flow_result = GriptapeNodes.handle_request(delete_flow_request)
-
-                if delete_flow_result.failed():
-                    details = f"Attempted to delete NodeGroup '{request.node_name}'. Failed to delete subflow '{subflow_name}': {delete_flow_result.result_details}"
-                    return DeleteNodeResultFailure(result_details=details)
         details = f"Successfully deleted Node '{node_name}'."
         return DeleteNodeResultSuccess(result_details=details)
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -855,12 +855,15 @@ class WorkflowManager:
         await self._workflows_loading_complete.wait()
 
         try:
-            workflows = WorkflowRegistry.list_callable_workflows()
+            workflow_names = [
+                key for key, wf in WorkflowRegistry.list_workflows().items() if wf.get("workflow_shape") is not None
+            ]
         except Exception:
             details = "Failed to list callable workflows."
             return ListCallableWorkflowsResultFailure(result_details=details)
         return ListCallableWorkflowsResultSuccess(
-            workflows=workflows, result_details=f"Successfully retrieved {len(workflows)} callable workflows."
+            workflow_names=workflow_names,
+            result_details=f"Successfully retrieved {len(workflow_names)} callable workflows.",
         )
 
     async def on_delete_workflows_request(self, request: DeleteWorkflowRequest) -> ResultPayload:

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -107,6 +107,9 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowsRequest,
     ListAllWorkflowsResultFailure,
     ListAllWorkflowsResultSuccess,
+    ListCallableWorkflowsRequest,
+    ListCallableWorkflowsResultFailure,
+    ListCallableWorkflowsResultSuccess,
     LoadWorkflowMetadata,
     LoadWorkflowMetadataResultFailure,
     LoadWorkflowMetadataResultSuccess,
@@ -321,6 +324,10 @@ class WorkflowManager:
         event_manager.assign_manager_to_request_type(
             ListAllWorkflowsRequest,
             self.on_list_all_workflows_request,
+        )
+        event_manager.assign_manager_to_request_type(
+            ListCallableWorkflowsRequest,
+            self.on_list_callable_workflows_request,
         )
         event_manager.assign_manager_to_request_type(
             DeleteWorkflowRequest,
@@ -842,6 +849,18 @@ class WorkflowManager:
             return ListAllWorkflowsResultFailure(result_details=details)
         return ListAllWorkflowsResultSuccess(
             workflows=workflows, result_details=f"Successfully retrieved {len(workflows)} workflows."
+        )
+
+    async def on_list_callable_workflows_request(self, _request: ListCallableWorkflowsRequest) -> ResultPayload:
+        await self._workflows_loading_complete.wait()
+
+        try:
+            workflows = WorkflowRegistry.list_callable_workflows()
+        except Exception:
+            details = "Failed to list callable workflows."
+            return ListCallableWorkflowsResultFailure(result_details=details)
+        return ListCallableWorkflowsResultSuccess(
+            workflows=workflows, result_details=f"Successfully retrieved {len(workflows)} callable workflows."
         )
 
     async def on_delete_workflows_request(self, request: DeleteWorkflowRequest) -> ResultPayload:
@@ -2032,26 +2051,24 @@ class WorkflowManager:
 
     async def on_save_subflow_to_workflow(self, request: SaveSubflowToWorkflowRequest) -> ResultPayload:
         """Save a subflow back to its original workflow file."""
-        file_path_obj = Path(request.file_path)
-        file_name = file_path_obj.stem
+        registry_key = request.workflow_name
 
-        # Derive registry key from caller-provided name or from the file path.
-        if request.workflow_name is not None:
-            registry_key = request.workflow_name
-        else:
-            workspace_path = GriptapeNodes.ConfigManager().workspace_path
-            try:
-                relative = file_path_obj.relative_to(workspace_path)
-                registry_key = derive_registry_key(str(relative))
-            except ValueError:
-                registry_key = derive_registry_key(request.file_path)
+        if not WorkflowRegistry.has_workflow_with_name(registry_key):
+            details = (
+                f"Attempted to save subflow '{request.flow_name}'. Workflow '{registry_key}' not found in registry."
+            )
+            return SaveSubflowToWorkflowResultFailure(result_details=details)
+
+        workflow = WorkflowRegistry.get_workflow_by_name(registry_key)
+        file_path = WorkflowRegistry.get_complete_file_path(workflow.file_path)
+        file_name = Path(file_path).stem
 
         # Serialize the subflow.
         serialized_flow_result = await GriptapeNodes.ahandle_request(
             SerializeFlowToCommandsRequest(flow_name=request.flow_name, include_create_flow_command=True)
         )
         if not isinstance(serialized_flow_result, SerializeFlowToCommandsResultSuccess):
-            details = f"Attempted to save subflow '{request.flow_name}' to '{request.file_path}'. Failed when serializing flow."
+            details = f"Attempted to save subflow '{request.flow_name}' to '{file_path}'. Failed when serializing flow."
             return SaveSubflowToWorkflowResultFailure(result_details=details)
         commands = serialized_flow_result.serialized_flow_commands
 
@@ -2068,6 +2085,8 @@ class WorkflowManager:
             )
         except ValueError:
             workflow_shape = None
+            msg = f"The workflow {registry_key} is being saved without Start and End Flow parameters. It will no longer be a callable workflow."
+            logger.warning(msg)
 
         # Preserve existing metadata from the registry.
         existing = self._get_existing_metadata(registry_key)
@@ -2077,7 +2096,7 @@ class WorkflowManager:
         save_file_request = SaveWorkflowFileFromSerializedFlowRequest(
             serialized_flow_commands=commands,
             file_name=file_name,
-            file_path=request.file_path,
+            file_path=file_path,
             display_name=resolved_display_name,
             description=existing.description,
             image_path=existing.image,
@@ -2088,16 +2107,15 @@ class WorkflowManager:
         save_file_result = await self.on_save_workflow_file_from_serialized_flow_request(save_file_request)
         if not isinstance(save_file_result, SaveWorkflowFileFromSerializedFlowResultSuccess):
             details = (
-                f"Attempted to save subflow '{request.flow_name}' to '{request.file_path}'. "
+                f"Attempted to save subflow '{request.flow_name}' to '{file_path}'. "
                 f"Failed during file generation: {save_file_result.result_details}"
             )
             return SaveSubflowToWorkflowResultFailure(result_details=details)
 
         workflow_metadata = save_file_result.workflow_metadata
 
-        # Update the registry entry if the workflow is already registered.
-        if WorkflowRegistry.has_workflow_with_name(registry_key):
-            WorkflowRegistry.get_workflow_by_name(registry_key).metadata = workflow_metadata
+        # Update the registry entry with the new metadata.
+        workflow.metadata = workflow_metadata
 
         details = f"Successfully saved subflow '{request.flow_name}' to: {save_file_result.file_path}"
         return SaveSubflowToWorkflowResultSuccess(

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4445,9 +4445,14 @@ class WorkflowManager:
         obj_manager = GriptapeNodes.ObjectManager()
         flows_before = set(obj_manager.get_filtered_subset(type=ControlFlow).keys())
 
-        # Execute the workflow within the target flow context and referenced context
-        with GriptapeNodes.ContextManager().flow(flow_name):  # noqa: SIM117
-            with self.ReferencedWorkflowContext(self, request.workflow_name):
+        # Execute the workflow within the target flow context.
+        # When track_as_referenced is True, wrap in ReferencedWorkflowContext so the flow
+        # serializes as an import command. When False, the flow serializes as inline content.
+        with GriptapeNodes.ContextManager().flow(flow_name):
+            if request.track_as_referenced:
+                with self.ReferencedWorkflowContext(self, request.workflow_name):
+                    workflow_result = await self.run_workflow(workflow.file_path)
+            else:
                 workflow_result = await self.run_workflow(workflow.file_path)
 
         if not workflow_result.execution_successful:

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -140,6 +140,9 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     RunWorkflowWithCurrentStateRequest,
     RunWorkflowWithCurrentStateResultFailure,
     RunWorkflowWithCurrentStateResultSuccess,
+    SaveSubflowToWorkflowRequest,
+    SaveSubflowToWorkflowResultFailure,
+    SaveSubflowToWorkflowResultSuccess,
     SaveWorkflowFileFromSerializedFlowRequest,
     SaveWorkflowFileFromSerializedFlowResultFailure,
     SaveWorkflowFileFromSerializedFlowResultSuccess,
@@ -339,6 +342,10 @@ class WorkflowManager:
         event_manager.assign_manager_to_request_type(
             SaveWorkflowFileFromSerializedFlowRequest,
             self.on_save_workflow_file_from_serialized_flow_request,
+        )
+        event_manager.assign_manager_to_request_type(
+            SaveSubflowToWorkflowRequest,
+            self.on_save_subflow_to_workflow,
         )
         event_manager.assign_manager_to_request_type(LoadWorkflowMetadata, self.on_load_workflow_metadata_request)
         event_manager.assign_manager_to_request_type(
@@ -2019,6 +2026,84 @@ class WorkflowManager:
         details = f"Successfully saved workflow file at: {file_path}"
         return SaveWorkflowFileFromSerializedFlowResultSuccess(
             file_path=str(file_path),
+            workflow_metadata=workflow_metadata,
+            result_details=ResultDetails(message=details, level=logging.INFO),
+        )
+
+    async def on_save_subflow_to_workflow(self, request: SaveSubflowToWorkflowRequest) -> ResultPayload:
+        """Save a subflow back to its original workflow file."""
+        file_path_obj = Path(request.file_path)
+        file_name = file_path_obj.stem
+
+        # Derive registry key from caller-provided name or from the file path.
+        if request.workflow_name is not None:
+            registry_key = request.workflow_name
+        else:
+            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            try:
+                relative = file_path_obj.relative_to(workspace_path)
+                registry_key = derive_registry_key(str(relative))
+            except ValueError:
+                registry_key = derive_registry_key(request.file_path)
+
+        # Serialize the subflow.
+        serialized_flow_result = await GriptapeNodes.ahandle_request(
+            SerializeFlowToCommandsRequest(flow_name=request.flow_name, include_create_flow_command=True)
+        )
+        if not isinstance(serialized_flow_result, SerializeFlowToCommandsResultSuccess):
+            details = f"Attempted to save subflow '{request.flow_name}' to '{request.file_path}'. Failed when serializing flow."
+            return SaveSubflowToWorkflowResultFailure(result_details=details)
+        commands = serialized_flow_result.serialized_flow_commands
+
+        # Strip parent_flow_name so the saved file stands alone as a top-level workflow.
+        if isinstance(commands.flow_initialization_command, CreateFlowRequest):
+            commands.flow_initialization_command.parent_flow_name = None
+
+        # Extract workflow shape from the specific subflow (not the top-level flow).
+        try:
+            workflow_shape_dict = self.extract_workflow_shape(
+                workflow_name=registry_key, flow_name=request.flow_name
+            )
+            workflow_shape = WorkflowShape(
+                inputs=workflow_shape_dict["input"],
+                outputs=workflow_shape_dict["output"],
+            )
+        except ValueError:
+            workflow_shape = None
+
+        # Preserve existing metadata from the registry.
+        existing = self._get_existing_metadata(registry_key)
+        resolved_display_name = existing.display_name
+
+        # Delegate file generation and writing to the existing lower-level handler.
+        save_file_request = SaveWorkflowFileFromSerializedFlowRequest(
+            serialized_flow_commands=commands,
+            file_name=file_name,
+            file_path=request.file_path,
+            display_name=resolved_display_name,
+            description=existing.description,
+            image_path=existing.image,
+            is_template=existing.is_template,
+            execution_flow_name=file_name,
+            workflow_shape=workflow_shape,
+        )
+        save_file_result = await self.on_save_workflow_file_from_serialized_flow_request(save_file_request)
+        if not isinstance(save_file_result, SaveWorkflowFileFromSerializedFlowResultSuccess):
+            details = (
+                f"Attempted to save subflow '{request.flow_name}' to '{request.file_path}'. "
+                f"Failed during file generation: {save_file_result.result_details}"
+            )
+            return SaveSubflowToWorkflowResultFailure(result_details=details)
+
+        workflow_metadata = save_file_result.workflow_metadata
+
+        # Update the registry entry if the workflow is already registered.
+        if WorkflowRegistry.has_workflow_with_name(registry_key):
+            WorkflowRegistry.get_workflow_by_name(registry_key).metadata = workflow_metadata
+
+        details = f"Successfully saved subflow '{request.flow_name}' to: {save_file_result.file_path}"
+        return SaveSubflowToWorkflowResultSuccess(
+            file_path=save_file_result.file_path,
             workflow_metadata=workflow_metadata,
             result_details=ResultDetails(message=details, level=logging.INFO),
         )
@@ -4088,24 +4173,29 @@ class WorkflowManager:
                         workflow_shape[workflow_shape_type][node.name] = {param.name: param_info}
         return workflow_shape
 
-    def extract_workflow_shape(self, workflow_name: str) -> dict[str, Any]:
+    def extract_workflow_shape(self, workflow_name: str, flow_name: str | None = None) -> dict[str, Any]:
         """Extracts the input and output shape for a workflow.
 
         Here we gather information about the Workflow's exposed input and output Parameters
         such that a client invoking the Workflow can understand what values to provide
         as well as what values to expect back as output.
+
+        Args:
+            workflow_name: Registry key used in error messages.
+            flow_name: Specific flow to inspect. If None, the top-level flow is used.
         """
         workflow_shape: dict[str, Any] = {"input": {}, "output": {}}
 
         flow_manager = GriptapeNodes.FlowManager()
-        result = flow_manager.on_get_top_level_flow_request(GetTopLevelFlowRequest())
-        if result.failed():
-            details = f"Workflow '{workflow_name}' does not have a top-level flow."
-            raise ValueError(details)
-        flow_name = cast("GetTopLevelFlowResultSuccess", result).flow_name
         if flow_name is None:
-            details = f"Workflow '{workflow_name}' does not have a top-level flow."
-            raise ValueError(details)
+            result = flow_manager.on_get_top_level_flow_request(GetTopLevelFlowRequest())
+            if result.failed():
+                details = f"Workflow '{workflow_name}' does not have a top-level flow."
+                raise ValueError(details)
+            flow_name = cast("GetTopLevelFlowResultSuccess", result).flow_name
+            if flow_name is None:
+                details = f"Workflow '{workflow_name}' does not have a top-level flow."
+                raise ValueError(details)
 
         control_flow = flow_manager.get_flow_by_name(flow_name)
         nodes = control_flow.nodes

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2076,7 +2076,16 @@ class WorkflowManager:
         commands = serialized_flow_result.serialized_flow_commands
 
         # Strip parent_flow_name so the saved file stands alone as a top-level workflow.
-        if isinstance(commands.flow_initialization_command, CreateFlowRequest):
+        # If the subflow is tracked as a referenced workflow, replace the self-referential
+        # import command with a plain CreateFlowRequest for the standalone save.
+        if isinstance(commands.flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest):
+            commands.flow_initialization_command = CreateFlowRequest(
+                flow_name=request.flow_name,
+                parent_flow_name=None,
+                set_as_new_context=False,
+                metadata=commands.flow_initialization_command.imported_flow_metadata,
+            )
+        elif isinstance(commands.flow_initialization_command, CreateFlowRequest):
             commands.flow_initialization_command.parent_flow_name = None
 
         # Extract workflow shape from the specific subflow (not the top-level flow).

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2061,9 +2061,7 @@ class WorkflowManager:
 
         # Extract workflow shape from the specific subflow (not the top-level flow).
         try:
-            workflow_shape_dict = self.extract_workflow_shape(
-                workflow_name=registry_key, flow_name=request.flow_name
-            )
+            workflow_shape_dict = self.extract_workflow_shape(workflow_name=registry_key, flow_name=request.flow_name)
             workflow_shape = WorkflowShape(
                 inputs=workflow_shape_dict["input"],
                 outputs=workflow_shape_dict["output"],


### PR DESCRIPTION
This update adds a hook to WorkflowManager to get valid workflows for the subflow node dropdown. 
As well, it adds an `on_delete` hook in base node that Workflow Node and SubflowNodes override in order to delete the subflows that they are attached to. 
closes #4229 
linked to https://github.com/griptape-ai/griptape-nodes-library-standard/pull/114