### PR TITLE
Add troubleshooting section for common node development issues

### DIFF
--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -334,6 +334,13 @@ self.add_parameter(
 )
 ```
 
+**Why `ParameterImage` is better:**
+
+- **Standardized type conversion logic:** Handles ImageArtifact, ImageUrlArtifact, and string inputs consistently
+- **Built-in UI features:** File browser, webcam capture, mask editing
+- **Less boilerplate:** Automatically configures types and options
+- **Robust error handling:** Gracefully handles various input formats (URLs, file paths, data URIs)
+
 **Recommended Pattern:**
 
 ```python
@@ -346,6 +353,8 @@ self.add_parameter(
     )
 )
 ```
+
+`ParameterImage` standardizes how your node handles different image input types, reducing conversion errors and improving reliability.
 
 ##### `ParameterAudio` / `ParameterVideo` / `Parameter3D`
 
@@ -1228,6 +1237,28 @@ class MyVideoNode(ControlNode):
 - Call `build_file()` to get a `ProjectFileDestination` instance
 - Use `write_bytes()` to save the file
 - Access the saved file's URL/path via `saved.location`
+
+**❌ Common Mistake: Not Capturing write_bytes() Return Value**
+
+```python
+# WRONG - Don't do this:
+dest = self._output_video_file.build_file()
+dest.write_bytes(video_bytes)  # ❌ Return value not captured
+artifact = VideoUrlArtifact(dest.location)  # Using dest, not saved file
+
+# This will fail with: "Failed because missing required variables: file_extension, file_name_base"
+```
+
+**Why it fails:** Macro variables like `{file_extension}` and `{file_name_base}` are resolved when `write_bytes()` saves the file and returns the saved file object, not by `build_file()`. Using `dest.location` before writing causes macro resolution errors.
+
+```python
+# CORRECT:
+dest = self._output_video_file.build_file()
+saved = dest.write_bytes(video_bytes)  # ✅ Capture return value
+artifact = VideoUrlArtifact(saved.location)  # Use saved file's resolved location
+```
+
+The `saved` object contains the fully resolved file path with all macros filled in.
 
 #### Pattern 2: ProjectFileDestination Directly (For Utility Functions)
 
@@ -4323,6 +4354,74 @@ Document:
 Common errors and solutions
 
 ## Troubleshooting
+
+### Common Errors and Solutions
+
+#### Error: "Missing required variables: file_extension, file_name_base"
+
+**Full Error:**
+
+```
+ERROR: Attempted to resolve macro path. Failed because missing required variables: file_extension, file_name_base
+ERROR: Attempted to create download URL. Failed with file_path='{outputs}/{node_name?:_}{file_name_base}{_index?:03}.{file_extension}'
+```
+
+**Cause:** Not capturing the return value from `write_bytes()`. Using `dest.location` instead of `saved.location`.
+
+**Incorrect Code:**
+
+```python
+dest = self._output_file.build_file()
+dest.write_bytes(video_bytes)  # ❌ Return value not captured
+artifact = VideoUrlArtifact(dest.location)  # Using dest, not saved file
+```
+
+**Solution:**
+
+```python
+dest = self._output_file.build_file()
+saved = dest.write_bytes(video_bytes)  # ✅ Capture the saved file
+artifact = VideoUrlArtifact(saved.location)  # Use saved file's resolved location
+```
+
+**Explanation:** Macro variables are populated when `write_bytes()` actually saves the file. The `saved` object returned by `write_bytes()` contains the fully resolved path.
+
+---
+
+#### Error: Type Conversion Issues with Image Parameters
+
+**Symptom:** Image parameters don't handle different input types consistently, or errors occur when passing URLs, file paths, or artifacts between nodes.
+
+**Problem:** Using generic `Parameter` with manual type configuration doesn't standardize type conversion logic:
+
+```python
+# ❌ Inconsistent type handling
+Parameter(
+    name="image",
+    input_types=["ImageArtifact", "ImageUrlArtifact", "str"],
+    type="ImageArtifact",
+)
+```
+
+**Solution:** Use `ParameterImage` for standardized type conversion:
+
+```python
+# ✅ Standardized type handling
+ParameterImage(
+    name="image",
+    tooltip="Input image",
+    allow_output=False,
+)
+```
+
+**Benefits:**
+
+- Handles ImageArtifact, ImageUrlArtifact, and strings consistently
+- Built-in support for URLs, file paths, and data URIs
+- Graceful error handling for various input formats
+- Reduces type conversion errors in complex workflows
+
+---
 
 FAQ-style troubleshooting guide
 

--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -4362,9 +4362,11 @@ Common errors and solutions
 **Full Error:**
 
 ```
+
 ERROR: Attempted to resolve macro path. Failed because missing required variables: file_extension, file_name_base
-ERROR: Attempted to create download URL. Failed with file_path='{outputs}/{node_name?:_}{file_name_base}{_index?:03}.{file_extension}'
-```
+ERROR: Attempted to create download URL. Failed with file_path='{outputs}/{node_name?:\_}{file_name_base}{\_index?:03}.{file_extension}'
+
+````
 
 **Cause:** Not capturing the return value from `write_bytes()`. Using `dest.location` instead of `saved.location`.
 
@@ -4374,7 +4376,7 @@ ERROR: Attempted to create download URL. Failed with file_path='{outputs}/{node_
 dest = self._output_file.build_file()
 dest.write_bytes(video_bytes)  # ❌ Return value not captured
 artifact = VideoUrlArtifact(dest.location)  # Using dest, not saved file
-```
+````
 
 **Solution:**
 
@@ -4386,7 +4388,7 @@ artifact = VideoUrlArtifact(saved.location)  # Use saved file's resolved locatio
 
 **Explanation:** Macro variables are populated when `write_bytes()` actually saves the file. The `saved` object returned by `write_bytes()` contains the fully resolved path.
 
----
+______________________________________________________________________
 
 #### Error: Type Conversion Issues with Image Parameters
 
@@ -4421,7 +4423,7 @@ ParameterImage(
 - Graceful error handling for various input formats
 - Reduces type conversion errors in complex workflows
 
----
+______________________________________________________________________
 
 FAQ-style troubleshooting guide
 
@@ -4440,7 +4442,8 @@ Where to get help
 ## Version History
 
 Link to CHANGELOG
-```
+
+````
 
 #### Model Comparison Table
 
@@ -4452,7 +4455,7 @@ Always include a comparison table for services with multiple models:
 | V5    | 4 min        | Superior | Fastest | Prompt: 5000, Style: 1000 |
 | V4_5  | 8 min        | High     | Fast    | Prompt: 5000, Style: 1000 |
 | V4    | 4 min        | Best     | Medium  | Prompt: 3000, Style: 200  |
-```
+````
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Overview

Adds comprehensive troubleshooting guidance to the comprehensive node development guide based on real debugging sessions.

## Changes

### 1. ProjectFileParameter Anti-Pattern (Working with Project System section)

Added warning about not capturing `write_bytes()` return value:

**Problem:**
```python
dest = self._output_file.build_file()
dest.write_bytes(video_bytes)  # ❌ Not capturing return
artifact = VideoUrlArtifact(dest.location)  # Wrong location
```

**Error:** "missing required variables: file_extension, file_name_base"

**Solution:**
```python
dest = self._output_file.build_file()
saved = dest.write_bytes(video_bytes)  # ✅ Capture return
artifact = VideoUrlArtifact(saved.location)  # Correct location
```

### 2. Enhanced ParameterImage Guidance (Parameters section)

Clarified why `ParameterImage` is preferred over generic `Parameter`:
- Standardized type conversion logic
- Handles ImageArtifact, ImageUrlArtifact, and strings consistently
- Built-in UI features and robust error handling

### 3. New Troubleshooting Section

Added detailed error patterns and solutions:
- Macro resolution errors with ProjectFileParameter
- Type conversion issues with image parameters
- Clear examples of incorrect vs correct code

## Testing

Documentation reviewed against:
- Real debugging session that identified these issues
- Flux image generation node (working example in standard library)
- Kling video generation nodes (where issues were discovered and fixed)

## Related

- Standalone guide PR: griptape-ai/griptape-nodes-node-development-guide#1
- Code fixes: griptape-ai/griptape-nodes-library-kling#23

---

@sshlife Ready for review

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4283.org.readthedocs.build/en/4283/

<!-- readthedocs-preview griptape-nodes end -->