### PR TITLE
fix: respect custom values for static server base url

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2013,7 +2013,7 @@ class LibraryManager:
                 len(library_data.widgets),
             )
             # Get the static server base URL for constructing absolute bundle URLs
-            static_server_base_url = GriptapeNodes.ConfigManager().get_config_value("static_server_base_url")
+            static_server_base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
             # Get the library directory so we can hash each bundle file
             library_info_for_path = self.get_library_info_by_library_name(request.library)
             library_dir = Path(library_info_for_path.library_path).parent if library_info_for_path is not None else None

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1583,7 +1583,7 @@ class OSManager:
             mime_type: Image MIME type
 
         Returns:
-            URL string (http://localhost:8124/workspace/...) or data URI
+            URL string ({static_server_base_url}/workspace/...) or data URI
         """
         # Store original bytes for preview creation
         original_image_bytes = content
@@ -1606,7 +1606,8 @@ class OSManager:
                     pass
                 else:
                     # File is in static directory, construct URL directly
-                    static_url = f"http://localhost:8124/workspace/{file_relative_to_static}"
+                    static_base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+                    static_url = f"{static_base_url}/workspace/{file_relative_to_static}"
                     msg = f"Image already in workspace directory, returning URL: {static_url}"
                     logger.debug(msg)
                     return static_url

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -4,6 +4,7 @@ import logging
 import threading
 from pathlib import Path
 from typing import NamedTuple
+from urllib.parse import urlparse
 
 from xdg_base_dirs import xdg_config_home
 
@@ -101,8 +102,8 @@ class StaticFilesManager:
         workspace_directory = config_manager.workspace_path
 
         # Build base URL for LocalStorageDriver from configured base URL
-        base_url_config = config_manager.get_config_value("static_server_base_url")
-        base_url = f"{base_url_config}{STATIC_SERVER_URL}"
+        self.static_server_base_url = config_manager.get_config_value("static_server_base_url")
+        base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
 
         match self.storage_backend:
             case StorageBackend.GTC:
@@ -385,9 +386,13 @@ class StaticFilesManager:
             sock = bind_free_socket(STATIC_SERVER_HOST, STATIC_SERVER_PORT)
             actual_port = sock.getsockname()[1]
 
-            actual_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
-            self.config_manager.set_config_value("static_server_base_url", actual_base_url)
-            self.storage_driver.base_url = f"{actual_base_url}{STATIC_SERVER_URL}"
+            # Only update the base URL when the user hasn't configured a custom host
+            # (e.g. an ngrok tunnel or reverse proxy). If the configured host matches the
+            # server's bind host, it's a direct connection and we update the port.
+            parsed = urlparse(self.static_server_base_url)
+            if parsed.hostname == STATIC_SERVER_HOST:
+                self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
+            self.storage_driver.base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
 
             threading.Thread(target=start_static_server, args=(sock,), daemon=True, name="static-server").start()
 

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -41,7 +41,7 @@ async def _create_static_file_upload_url(request: Request) -> dict:
 
     Similar to a presigned URL, but for uploading files to the static server.
     """
-    base_url = GriptapeNodes.ConfigManager().get_config_value("static_server_base_url")
+    base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
 
     body = await request.json()
     file_path = body["file_path"].lstrip("/")
@@ -74,7 +74,7 @@ async def _create_static_file(request: Request, file_path: str) -> dict:
         logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
 
-    base_url = GriptapeNodes.ConfigManager().get_config_value("static_server_base_url")
+    base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
     static_url = urljoin(f"{base_url}{STATIC_SERVER_URL}/", file_path)
     return {"url": static_url}
 
@@ -288,7 +288,7 @@ def start_static_server(sock: socket.socket) -> None:
         "https://editor-nightly.nodes.griptape.ai",
         "http://localhost:5173",
         "http://localhost:5174",
-        GriptapeNodes.ConfigManager().get_config_value("static_server_base_url"),
+        GriptapeNodes.StaticFilesManager().static_server_base_url,
     ]
 
     # Add CORS middleware


### PR DESCRIPTION
Fixes regression from 079730688bfe which overwrite user's custom value for static server base url. Also removes hardcoded localhost reference.

Closes https://github.com/griptape-ai/griptape-nodes/pull/4281/