### PR TITLE
feat: add ExecuteNodeRequest for direct node execution

### DIFF
--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -458,3 +458,41 @@ class GriptapeEvent(ExecutionPayload):
     parameter_name: str
     type: str
     value: Any
+
+
+@dataclass
+@PayloadRegistry.register
+class ExecuteNodeRequest(RequestPayload):
+    """Execute a node's aprocess() directly with provided parameter values.
+
+    Hydrates the node's input parameters, calls aprocess(), and returns outputs.
+    Unlike ResolveNodeRequest, this bypasses flow/DAG machinery and executes
+    the node's process method directly.
+
+    Args:
+        node_name: Name of the node to execute.
+        parameter_values: Input parameter values to set before execution.
+
+    Results: ExecuteNodeResultSuccess | ExecuteNodeResultFailure
+    """
+
+    node_name: str
+    parameter_values: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+@PayloadRegistry.register
+class ExecuteNodeResultSuccess(ResultPayloadSuccess):
+    """Successful result from executing a node directly.
+
+    Args:
+        parameter_output_values: Output parameter values from the node.
+    """
+
+    parameter_output_values: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+@PayloadRegistry.register
+class ExecuteNodeResultFailure(ResultPayloadFailure):
+    """Failed result from executing a node directly."""

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -53,6 +53,9 @@ from griptape_nodes.retained_mode.events.connection_events import (
 )
 from griptape_nodes.retained_mode.events.execution_events import (
     CancelFlowRequest,
+    ExecuteNodeRequest,
+    ExecuteNodeResultFailure,
+    ExecuteNodeResultSuccess,
     ResolveNodeRequest,
     ResolveNodeResultFailure,
     ResolveNodeResultSuccess,
@@ -300,6 +303,7 @@ class NodeManager:
         )
         event_manager.assign_manager_to_request_type(MigrateParameterRequest, self.on_migrate_parameter_request)
         event_manager.assign_manager_to_request_type(ResolveNodeRequest, self.on_resolve_from_node_request)
+        event_manager.assign_manager_to_request_type(ExecuteNodeRequest, self.on_execute_node_request)
         event_manager.assign_manager_to_request_type(GetAllNodeInfoRequest, self.on_get_all_node_info_request)
         event_manager.assign_manager_to_request_type(
             GetCompatibleParametersRequest, self.on_get_compatible_parameters_request
@@ -2702,6 +2706,39 @@ class NodeManager:
             return ResolveNodeResultFailure(validation_exceptions=[e], result_details=details)
         details = f'Starting to resolve "{node_name}" in "{flow_name}"'
         return ResolveNodeResultSuccess(result_details=details)
+
+    async def on_execute_node_request(self, request: ExecuteNodeRequest) -> ResultPayload:
+        """Execute a node's aprocess() directly with provided parameter values."""
+        node_name = request.node_name
+
+        try:
+            node = self.get_node_by_name(node_name)
+        except ValueError as e:
+            return ExecuteNodeResultFailure(
+                result_details=f"Attempted to execute node '{node_name}'. Failed because node does not exist: {e}",
+            )
+
+        # Hydrate input parameters
+        for param_name, value in request.parameter_values.items():
+            try:
+                node.set_parameter_value(param_name, value)
+            except Exception as e:
+                return ExecuteNodeResultFailure(
+                    result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
+                )
+
+        # Execute the node
+        try:
+            await node.aprocess()
+        except Exception as e:
+            return ExecuteNodeResultFailure(
+                result_details=f"Attempted to execute node '{node_name}'. Failed with error: {e}",
+            )
+
+        return ExecuteNodeResultSuccess(
+            parameter_output_values=dict(node.parameter_output_values),
+            result_details=f"Node '{node_name}' executed successfully.",
+        )
 
     def on_validate_node_dependencies_request(self, request: ValidateNodeDependenciesRequest) -> ResultPayload:
         node_name = request.node_name

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -145,6 +145,7 @@ class AppEvents(BaseModel):
             "SetConfigCategoryRequest",
             "DeleteWorkflowRequest",
             "ResolveNodeRequest",
+            "ExecuteNodeRequest",
             "StartFlowRequest",
             "CancelFlowRequest",
             "UnresolveFlowRequest",

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -26,6 +26,7 @@ from griptape_nodes.retained_mode.events.connection_events import (
     ListConnectionsForNodeRequest,
 )
 from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
     ResolveNodeRequest,
     StartFlowFromNodeRequest,
     StartFlowRequest,
@@ -66,6 +67,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "ListCategoriesInLibraryRequest": ListCategoriesInLibraryRequest,
     # Execution
     "ResolveNodeRequest": ResolveNodeRequest,
+    "ExecuteNodeRequest": ExecuteNodeRequest,
     "StartFlowRequest": StartFlowRequest,
     "StartFlowFromNodeRequest": StartFlowFromNodeRequest,
     # Nodes

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -1,0 +1,112 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultFailure,
+    ExecuteNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+
+class TestExecuteNode:
+    def _get_node_manager(self) -> NodeManager:
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        return GriptapeNodes.NodeManager()
+
+    def _make_mock_node(self, name: str = "test_node") -> MagicMock:
+        node = MagicMock(spec=BaseNode)
+        node.name = name
+        node.aprocess = AsyncMock()
+        node.parameter_output_values = {"output_param": "output_value"}
+        return node
+
+    @pytest.mark.asyncio
+    async def test_execute_node_not_found(self) -> None:
+        node_manager = self._get_node_manager()
+
+        request = ExecuteNodeRequest(node_name="nonexistent_node")
+        result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        assert "nonexistent_node" in str(result.result_details)
+        assert "does not exist" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_execute_node_success(self) -> None:
+        node_manager = self._get_node_manager()
+        mock_node = self._make_mock_node()
+
+        with patch.object(node_manager, "get_node_by_name", return_value=mock_node):
+            request = ExecuteNodeRequest(
+                node_name="test_node",
+                parameter_values={"input_param": "input_value"},
+            )
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        assert result.parameter_output_values == {"output_param": "output_value"}
+        mock_node.set_parameter_value.assert_called_once_with("input_param", "input_value")
+        mock_node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_node_success_no_params(self) -> None:
+        node_manager = self._get_node_manager()
+        mock_node = self._make_mock_node()
+
+        with patch.object(node_manager, "get_node_by_name", return_value=mock_node):
+            request = ExecuteNodeRequest(node_name="test_node")
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        mock_node.set_parameter_value.assert_not_called()
+        mock_node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_node_set_parameter_fails(self) -> None:
+        node_manager = self._get_node_manager()
+        mock_node = self._make_mock_node()
+        mock_node.set_parameter_value.side_effect = ValueError("bad value")
+
+        with patch.object(node_manager, "get_node_by_name", return_value=mock_node):
+            request = ExecuteNodeRequest(
+                node_name="test_node",
+                parameter_values={"bad_param": "bad_value"},
+            )
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        assert "bad_param" in str(result.result_details)
+        mock_node.aprocess.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_node_aprocess_fails(self) -> None:
+        node_manager = self._get_node_manager()
+        mock_node = self._make_mock_node()
+        mock_node.aprocess.side_effect = RuntimeError("process exploded")
+
+        with patch.object(node_manager, "get_node_by_name", return_value=mock_node):
+            request = ExecuteNodeRequest(node_name="test_node")
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        assert "process exploded" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_execute_node_multiple_params(self) -> None:
+        node_manager = self._get_node_manager()
+        mock_node = self._make_mock_node()
+
+        with patch.object(node_manager, "get_node_by_name", return_value=mock_node):
+            request = ExecuteNodeRequest(
+                node_name="test_node",
+                parameter_values={"param_a": 1, "param_b": "two", "param_c": [3]},
+            )
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        expected_param_count = 3
+        assert mock_node.set_parameter_value.call_count == expected_param_count


### PR DESCRIPTION
Adds an `ExecuteNodeRequest` event that directly calls a node's `aprocess()` method with provided parameter values and returns the output values. Unlike `ResolveNodeRequest`, this bypasses the flow/DAG machinery (no validation, no dependency resolution, no unresolving future nodes) and just executes the node's process method directly.

This is extracted from the broader remote execution work on the `gep/libraries` branch, scoped down to just the event types and handler.

Closes #4287