### PR TITLE
fix: use resolved workspace path for system default project_base_dir

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1096,19 +1096,9 @@ class ProjectManager:
         # Create validation info to track that defaults were loaded
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
 
-        # System defaults use workspace directory as the base directory
+        # System defaults use workspace directory as the base directory.
         config_manager = GriptapeNodes.ConfigManager()
-        workspace_dir_value = config_manager.get_config_value("workspace_directory")
-        if workspace_dir_value is None:
-            msg = "Attempted to load Project Manager's default project schema. Failed because 'workspace_directory' config value was None"
-            raise RuntimeError(msg)
-
-        try:
-            workspace_dir = Path(workspace_dir_value)
-        except (TypeError, ValueError) as e:
-            msg = f"Attempted to load Project Manager's default project schema with workspace_directory='{workspace_dir_value}'. Failed due to {e}"
-            logger.error(msg)
-            raise RuntimeError(msg) from e
+        workspace_dir = config_manager.workspace_path
 
         # Parse all macros BEFORE creating ProjectInfo (system defaults should always be valid)
         situation_schemas = self._parse_situation_macros(DEFAULT_PROJECT_TEMPLATE.situations, validation)

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1709,6 +1709,62 @@ situations:
         assert pm._current_project_id == str(workspace_project_path)
 
 
+class TestLoadSystemDefaults:
+    """Test _load_system_defaults uses resolved workspace path for project_base_dir."""
+
+    @pytest.fixture
+    def pm(self) -> ProjectManager:
+        mock_event_manager = Mock()
+        mock_config_manager = Mock()
+        mock_config_manager.project_config = {}
+        mock_config_manager.env_config = {}
+        mock_config_manager.merged_config = {}
+        mock_config_manager.get_config_value.return_value = {}
+        return ProjectManager(mock_event_manager, mock_config_manager, Mock())
+
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    def test_project_base_dir_uses_resolved_workspace_path(self, mock_griptape_nodes: Mock, pm: ProjectManager) -> None:
+        """Test that _load_system_defaults uses config_manager.workspace_path (resolved) for project_base_dir.
+
+        This ensures project_base_dir matches the resolved paths used for macro resolution,
+        preventing workspace-internal files from being treated as external.
+        """
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        resolved_path = Path("/Users/testuser/GriptapeNodes")
+        mock_config = Mock()
+        mock_config.workspace_path = resolved_path
+        mock_griptape_nodes.ConfigManager.return_value = mock_config
+
+        pm._load_system_defaults()
+
+        project_info = pm._successfully_loaded_project_templates[SYSTEM_DEFAULTS_KEY]
+        assert project_info.project_base_dir == resolved_path
+
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    def test_project_base_dir_not_raw_config_value(self, mock_griptape_nodes: Mock, pm: ProjectManager) -> None:
+        """Test that _load_system_defaults does NOT use the raw config value with ~ for project_base_dir.
+
+        Previously, _load_system_defaults used get_config_value("workspace_directory") which
+        returns the raw string (e.g., "~/GriptapeNodes"). This caused a mismatch with resolved
+        source paths, making workspace-internal files appear external in preview URL generation.
+        """
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        resolved_path = Path("/Users/testuser/GriptapeNodes")
+        mock_config = Mock()
+        mock_config.workspace_path = resolved_path
+        mock_config.get_config_value.return_value = "~/GriptapeNodes"
+        mock_griptape_nodes.ConfigManager.return_value = mock_config
+
+        pm._load_system_defaults()
+
+        project_info = pm._successfully_loaded_project_templates[SYSTEM_DEFAULTS_KEY]
+        # Should use the resolved path, not the raw config value
+        assert project_info.project_base_dir == resolved_path
+        assert str(project_info.project_base_dir) != "~/GriptapeNodes"
+
+
 class TestProjectManagerProjectWorkspaces:
     """Test ProjectManager project_workspaces lookup in on_set_current_project_request."""
 


### PR DESCRIPTION
Closes #4292

`_load_system_defaults` in `ProjectManager` was reading the raw `workspace_directory` config value (which may contain `~`) and wrapping it in `Path()` to set `project_base_dir`. Since `Path()` does not expand `~`, this created a mismatch with source file paths that are resolved against `config_manager.workspace_path` (which applies `expanduser().resolve()`). The mismatch caused `decompose_source_path` to fail its `relative_to` check and treat workspace-internal files as external, embedding the full absolute system path in preview directory structures and URLs.

The fix replaces the raw config read with `config_manager.workspace_path`, which is already expanded and resolved. This is safe because every existing consumer of `project_base_dir` either already resolves it before use or benefits from it being pre-resolved.