### PR TITLE
Allow UI tag to tell control parameters to render at their position within the node vs. up top.

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -59,8 +59,8 @@ BadgeVariantType = Literal["info", "warning", "error", "success", "tip", "link",
 VALID_BADGE_VARIANTS: frozenset[str] = frozenset(get_args(BadgeVariantType))
 
 # Editor render location for control parameters - controls where they appear in the node UI
-# "top": render at the top (default), "bottom": render at the bottom, "in-position": render in-line with other parameters
-EditorRenderLocation = Literal["top", "bottom", "in-position"]
+# "top": render at the top (default), "bottom": render at the bottom, "in-order": render in-line with other parameters
+EditorRenderLocation = Literal["top", "bottom", "in-order"]
 VALID_EDITOR_RENDER_LOCATIONS: frozenset[str] = frozenset(get_args(EditorRenderLocation))
 
 
@@ -2200,7 +2200,7 @@ class ControlParameter(Parameter, ABC):
         # Set editor_render_location to control where they render:
         # - "top": Render at the top of the node (default for ControlParameter)
         # - "bottom": Render at the bottom of the node
-        # - "in-position": Render in-position in the order they are defined
+        # - "in-order": Render in-order in the order they are defined
         # This is useful for nodes with multiple control outputs that need to appear in specific positions.
         if "editor_render_location" not in processed_ui_options:
             if editor_render_location is not None:

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -2167,10 +2167,26 @@ class ControlParameter(Parameter, ABC):
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         ui_options: dict | None = None,
         *,
+        render_control_at_parameter_position: bool | None = None,
         display_name: str | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
+        # Process ui_options before passing to parent
+        if ui_options is None:
+            processed_ui_options = {}
+        else:
+            processed_ui_options = ui_options.copy()
+
+        # By default, the editor renders all control parameters at the top of the node.
+        # Set render_control_at_parameter_position=True to render them in-line in the order they are defined.
+        # This is useful for nodes with multiple control outputs that need to appear in specific positions.
+        if (
+            render_control_at_parameter_position is not None
+            and "render_control_at_parameter_position" not in processed_ui_options
+        ):
+            processed_ui_options["render_control_at_parameter_position"] = render_control_at_parameter_position
+
         # Call parent with a few explicit tweaks.
         super().__init__(
             type=ParameterTypeBuiltin.CONTROL_TYPE.value,
@@ -2187,7 +2203,7 @@ class ControlParameter(Parameter, ABC):
             traits=traits,
             converters=converters,
             validators=validators,
-            ui_options=ui_options,
+            ui_options=processed_ui_options,
             display_name=display_name,
             user_defined=user_defined,
             private=private,
@@ -2208,6 +2224,7 @@ class ControlParameterInput(ControlParameter):
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         *,
+        render_control_at_parameter_position: bool | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
@@ -2227,6 +2244,7 @@ class ControlParameterInput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
+            render_control_at_parameter_position=render_control_at_parameter_position,
             display_name=display_name,
             user_defined=user_defined,
             private=private,
@@ -2246,6 +2264,7 @@ class ControlParameterOutput(ControlParameter):
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         *,
+        render_control_at_parameter_position: bool | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
@@ -2265,6 +2284,7 @@ class ControlParameterOutput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
+            render_control_at_parameter_position=render_control_at_parameter_position,
             display_name=display_name,
             user_defined=user_defined,
             private=private,

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -58,10 +58,10 @@ N = TypeVar("N", bound="BaseNodeElement")
 BadgeVariantType = Literal["info", "warning", "error", "success", "tip", "link", "docs", "help", "note", "cloud-upload"]
 VALID_BADGE_VARIANTS: frozenset[str] = frozenset(get_args(BadgeVariantType))
 
-# Editor render location for control parameters - controls where they appear in the node UI
+# Parameter render location for control parameters - controls where they appear in the node UI
 # "top": render at the top (default), "bottom": render at the bottom, "in-order": render in-line with other parameters
-EditorRenderLocation = Literal["top", "bottom", "in-order"]
-VALID_EDITOR_RENDER_LOCATIONS: frozenset[str] = frozenset(get_args(EditorRenderLocation))
+ParameterRenderLocation = Literal["top", "bottom", "in-order"]
+VALID_PARAMETER_RENDER_LOCATIONS: frozenset[str] = frozenset(get_args(ParameterRenderLocation))
 
 
 @dataclass
@@ -2172,7 +2172,7 @@ class ControlParameter(Parameter, ABC):
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         ui_options: dict | None = None,
         *,
-        editor_render_location: EditorRenderLocation | None = None,
+        parameter_render_location: ParameterRenderLocation | None = None,
         display_name: str | None = None,
         user_defined: bool = False,
         private: bool = False,
@@ -2184,29 +2184,29 @@ class ControlParameter(Parameter, ABC):
             processed_ui_options = ui_options.copy()
 
         # Validate for conflicts if explicitly provided
-        if editor_render_location is not None:
+        if parameter_render_location is not None:
             self._validate_ui_option_conflict(
                 ui_options_dict=processed_ui_options,
-                param_name="editor_render_location",
-                param_value=editor_render_location,
+                param_name="parameter_render_location",
+                param_value=parameter_render_location,
             )
             # Validate it's a valid value
-            if editor_render_location not in VALID_EDITOR_RENDER_LOCATIONS:
-                msg = f"Invalid editor_render_location '{editor_render_location}' for parameter '{name}'. Valid values: {sorted(VALID_EDITOR_RENDER_LOCATIONS)}. Using 'top'."
+            if parameter_render_location not in VALID_PARAMETER_RENDER_LOCATIONS:
+                msg = f"Invalid parameter_render_location '{parameter_render_location}' for parameter '{name}'. Valid values: {sorted(VALID_PARAMETER_RENDER_LOCATIONS)}. Using 'top'."
                 logger.warning(msg)
-                editor_render_location = "top"
+                parameter_render_location = "top"
 
         # By default, the editor renders all control parameters at the top of the node.
-        # Set editor_render_location to control where they render:
+        # Set parameter_render_location to control where they render:
         # - "top": Render at the top of the node (default for ControlParameter)
         # - "bottom": Render at the bottom of the node
         # - "in-order": Render in-order in the order they are defined
         # This is useful for nodes with multiple control outputs that need to appear in specific positions.
-        if "editor_render_location" not in processed_ui_options:
-            if editor_render_location is not None:
-                processed_ui_options["editor_render_location"] = editor_render_location
+        if "parameter_render_location" not in processed_ui_options:
+            if parameter_render_location is not None:
+                processed_ui_options["parameter_render_location"] = parameter_render_location
             else:
-                processed_ui_options["editor_render_location"] = "top"
+                processed_ui_options["parameter_render_location"] = "top"
 
         # Call parent with a few explicit tweaks.
         super().__init__(
@@ -2245,7 +2245,7 @@ class ControlParameterInput(ControlParameter):
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         *,
-        editor_render_location: EditorRenderLocation | None = None,
+        parameter_render_location: ParameterRenderLocation | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
@@ -2265,7 +2265,7 @@ class ControlParameterInput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
-            editor_render_location=editor_render_location,
+            parameter_render_location=parameter_render_location,
             display_name=display_name,
             user_defined=user_defined,
             private=private,
@@ -2285,7 +2285,7 @@ class ControlParameterOutput(ControlParameter):
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         *,
-        editor_render_location: EditorRenderLocation | None = None,
+        parameter_render_location: ParameterRenderLocation | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
@@ -2305,7 +2305,7 @@ class ControlParameterOutput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
-            editor_render_location=editor_render_location,
+            parameter_render_location=parameter_render_location,
             display_name=display_name,
             user_defined=user_defined,
             private=private,

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -58,6 +58,11 @@ N = TypeVar("N", bound="BaseNodeElement")
 BadgeVariantType = Literal["info", "warning", "error", "success", "tip", "link", "docs", "help", "note", "cloud-upload"]
 VALID_BADGE_VARIANTS: frozenset[str] = frozenset(get_args(BadgeVariantType))
 
+# Editor render location for control parameters - controls where they appear in the node UI
+# "top": render at the top (default), "bottom": render at the bottom, "in-position": render in-line with other parameters
+EditorRenderLocation = Literal["top", "bottom", "in-position"]
+VALID_EDITOR_RENDER_LOCATIONS: frozenset[str] = frozenset(get_args(EditorRenderLocation))
+
 
 @dataclass
 class BadgeData:
@@ -2167,7 +2172,7 @@ class ControlParameter(Parameter, ABC):
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         ui_options: dict | None = None,
         *,
-        render_control_at_parameter_position: bool | None = None,
+        editor_render_location: EditorRenderLocation | None = None,
         display_name: str | None = None,
         user_defined: bool = False,
         private: bool = False,
@@ -2178,14 +2183,30 @@ class ControlParameter(Parameter, ABC):
         else:
             processed_ui_options = ui_options.copy()
 
+        # Validate for conflicts if explicitly provided
+        if editor_render_location is not None:
+            self._validate_ui_option_conflict(
+                ui_options_dict=processed_ui_options,
+                param_name="editor_render_location",
+                param_value=editor_render_location,
+            )
+            # Validate it's a valid value
+            if editor_render_location not in VALID_EDITOR_RENDER_LOCATIONS:
+                msg = f"Invalid editor_render_location '{editor_render_location}' for parameter '{name}'. Valid values: {sorted(VALID_EDITOR_RENDER_LOCATIONS)}. Using 'top'."
+                logger.warning(msg)
+                editor_render_location = "top"
+
         # By default, the editor renders all control parameters at the top of the node.
-        # Set render_control_at_parameter_position=True to render them in-line in the order they are defined.
+        # Set editor_render_location to control where they render:
+        # - "top": Render at the top of the node (default for ControlParameter)
+        # - "bottom": Render at the bottom of the node
+        # - "in-position": Render in-position in the order they are defined
         # This is useful for nodes with multiple control outputs that need to appear in specific positions.
-        if (
-            render_control_at_parameter_position is not None
-            and "render_control_at_parameter_position" not in processed_ui_options
-        ):
-            processed_ui_options["render_control_at_parameter_position"] = render_control_at_parameter_position
+        if "editor_render_location" not in processed_ui_options:
+            if editor_render_location is not None:
+                processed_ui_options["editor_render_location"] = editor_render_location
+            else:
+                processed_ui_options["editor_render_location"] = "top"
 
         # Call parent with a few explicit tweaks.
         super().__init__(
@@ -2224,7 +2245,7 @@ class ControlParameterInput(ControlParameter):
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         *,
-        render_control_at_parameter_position: bool | None = None,
+        editor_render_location: EditorRenderLocation | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
@@ -2244,7 +2265,7 @@ class ControlParameterInput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
-            render_control_at_parameter_position=render_control_at_parameter_position,
+            editor_render_location=editor_render_location,
             display_name=display_name,
             user_defined=user_defined,
             private=private,
@@ -2264,7 +2285,7 @@ class ControlParameterOutput(ControlParameter):
         converters: list[Callable[[Any], Any]] | None = None,
         validators: list[Callable[[Parameter, Any], None]] | None = None,
         *,
-        render_control_at_parameter_position: bool | None = None,
+        editor_render_location: EditorRenderLocation | None = None,
         user_defined: bool = False,
         private: bool = False,
     ):
@@ -2284,7 +2305,7 @@ class ControlParameterOutput(ControlParameter):
             traits=traits,
             converters=converters,
             validators=validators,
-            render_control_at_parameter_position=render_control_at_parameter_position,
+            editor_render_location=editor_render_location,
             display_name=display_name,
             user_defined=user_defined,
             private=private,


### PR DESCRIPTION
(depends on a corresponding editor PR, which is incoming)

Previously, Control Parameters rendered at the top of the node, which is the desired behavior 99% of the time. For some nodes, we want them to render in-line, as demonstrated here:

<img width="1294" height="796" alt="Screenshot 2026-03-31 at 4 04 44 PM" src="https://github.com/user-attachments/assets/6ce9f6e3-92af-4843-a52b-2e1b836f3823" />

This PR adds a flag to the UI to honor the control port's position. It defaults to not being set, maintaining parity with current behavior.