### PR TITLE
fix: resolve DuplicateSelectedNodesRequest deserialization error

### DIFF
--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -6,7 +6,6 @@ from dataclasses import is_dataclass
 from datetime import datetime
 from typing import Any
 
-from cattrs.cols import is_namedtuple, namedtuple_dict_structure_factory, namedtuple_dict_unstructure_factory
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.preconf.json import make_converter
 from cattrs.strategies import use_class_methods
@@ -51,6 +50,10 @@ converter.register_unstructure_hook(type, lambda t: f"{t.__module__}.{t.__qualna
 
 # --- Structure hooks (deserialization) ---
 
+# The JSON preset strict mode rejects ints for float fields, but JSON has
+# no distinction between int and float, so coerce int -> float on input.
+converter.register_structure_hook(float, lambda v, _: float(v))
+
 # Pydantic BaseModel subclasses
 converter.register_structure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, BaseModel),
@@ -62,15 +65,6 @@ converter.register_structure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, Exception),
     lambda obj, cls: cls(obj) if isinstance(obj, str) else cls(str(obj)),
 )
-
-
-# --- Hook factories for NamedTuples ---
-#
-# cattrs passes NamedTuples through unchanged by default. Register the built-in dict
-# factories so NamedTuples are serialized as dicts with recursive field handling.
-
-converter.register_unstructure_hook_factory(is_namedtuple, namedtuple_dict_unstructure_factory)
-converter.register_structure_hook_factory(is_namedtuple, namedtuple_dict_structure_factory)
 
 
 # --- Class-specific (un)structuring methods ---

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -33,6 +33,21 @@ class NewPosition(NamedTuple):
     x: float
     y: float
 
+    @classmethod
+    def _cattrs_structure(cls, data: Any, _type: type) -> NewPosition:
+        """Custom cattrs structuring hook.
+
+        The editor sends positions as plain arrays (e.g. [976.66, 760]) with
+        values that may be ints or floats. The default cattrs NamedTuple
+        structuring cannot resolve the float type annotation because this
+        module uses `from __future__ import annotations`, which turns
+        annotations into ForwardRef strings. This hook handles both list and
+        dict inputs and explicitly coerces values to float.
+        """
+        if isinstance(data, dict):
+            return cls(x=float(data["x"]), y=float(data["y"]))
+        return cls(x=float(data[0]), y=float(data[1]))
+
 
 @dataclass
 @PayloadRegistry.register


### PR DESCRIPTION
Closes #4304

Duplicating nodes in the editor failed with:

```
WARNING  Skipping unrecognized event. Your editor may be newer than this engine version. (Unable to convert request JSON into a valid EventRequest object. Error Message: 'invalid value for type, expected float @ $.positions[0].x; invalid value for type, expected float @ $.positions[0].y')
```

The cattrs refactor (#4270) registered `namedtuple_dict_structure_factory` which expects positions as dicts (`{"x": ..., "y": ...}`), but the editor sends them as plain arrays (`[976.66, 760]`). Additionally, `node_events.py` uses `from __future__ import annotations` which turns type annotations into `ForwardRef` strings that the default cattrs NamedTuple structuring cannot resolve.

This removes the global NamedTuple dict structure/unstructure factories from the converter (restoring the default tuple-based behavior), adds a `_cattrs_structure` classmethod to `NewPosition` that handles both list and dict inputs while explicitly coercing values to `float`, and registers a `float` structure hook to handle JSON's lack of int/float distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)