### PR TITLE
refactor: integrate PayloadRegistry into from_dict() methods

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -30,7 +30,6 @@ from griptape_nodes.retained_mode.events.base_events import (
     GriptapeNodeEvent,
     ProgressEvent,
     SkipTheLineMixin,
-    deserialize_event,
 )
 from griptape_nodes.retained_mode.events.logger_events import LogHandlerEvent
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -290,7 +289,7 @@ async def _process_api_event(event: dict) -> None:
 
     # Now attempt to convert it into an EventRequest.
     try:
-        request_event = deserialize_event(json_data=payload)
+        request_event = EventRequest.from_dict(payload)
     except Exception as e:
         details = str(e)
         if isinstance(e, BaseValidationError):

--- a/src/griptape_nodes/bootstrap/workflow_executors/subprocess_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/subprocess_workflow_executor.py
@@ -16,18 +16,18 @@ from griptape_nodes.retained_mode.events.base_events import (
     EventResultFailure,
     EventResultSuccess,
     ExecutionEvent,
-    ResultPayload,
 )
 from griptape_nodes.retained_mode.events.execution_events import (
     ControlFlowCancelledEvent,
     ControlFlowResolvedEvent,
     StartFlowRequest,
 )
-from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from types import TracebackType
+
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
 logger = logging.getLogger(__name__)
 
@@ -143,19 +143,13 @@ class SubprocessWorkflowExecutor(WorkflowExecutor, PythonSubprocessExecutor, Sub
     async def _process_execution_event(self, event: dict) -> None:
         payload = event.get("payload", {})
         event_type = payload.get("event_type", "")
-        payload_type_name = payload.get("payload_type", "")
-        payload_type = PayloadRegistry.get_type(payload_type_name)
 
         # Focusing on ExecutionEvent types for the workflow executor
         if event_type not in ["ExecutionEvent", "EventResultSuccess", "EventResultFailure"]:
             logger.debug("Ignoring event type: %s", event_type)
             return
 
-        if payload_type is None:
-            logger.warning("Unknown payload type: %s", payload_type_name)
-            return
-
-        ex_event = ExecutionEvent.from_dict(data=payload, payload_type=payload_type)
+        ex_event = ExecutionEvent.from_dict(data=payload)
 
         if isinstance(ex_event.payload, ControlFlowResolvedEvent):
             logger.info("Workflow execution completed successfully")
@@ -180,26 +174,14 @@ class SubprocessWorkflowExecutor(WorkflowExecutor, PythonSubprocessExecutor, Sub
 
     async def _process_result_event(self, event: dict) -> None:
         payload = event.get("payload", {})
-        request_type_name = payload.get("request_type", "")
-        response_type_name = payload.get("result_type", "")
-        request_payload_type = PayloadRegistry.get_type(request_type_name)
-        response_payload_type = PayloadRegistry.get_type(response_type_name)
-
-        if request_payload_type is None or response_payload_type is None:
-            logger.warning("Unknown payload types: %s, %s", request_type_name, response_type_name)
-            return
         if payload.get("type", "unknown") == "success_result":
-            result_event = EventResultSuccess.from_dict(
-                data=payload, req_payload_type=request_payload_type, res_payload_type=response_payload_type
-            )
+            result_event = EventResultSuccess.from_dict(data=payload)
         else:
-            result_event = EventResultFailure.from_dict(
-                data=payload, req_payload_type=request_payload_type, res_payload_type=response_payload_type
-            )
+            result_event = EventResultFailure.from_dict(data=payload)
 
         if isinstance(result_event.request, StartFlowRequest):
             logger.info("Received StartFlowRequest result event")
             if self._on_start_flow_result:
                 self._on_start_flow_result(result_event.result)
         else:
-            logger.warning("Ignoring result event for request type: %s", request_type_name)
+            logger.warning("Ignoring result event for request type: %s", type(result_event.request).__name__)

--- a/src/griptape_nodes/exe_types/param_components/subflow_execution_component.py
+++ b/src/griptape_nodes/exe_types/param_components/subflow_execution_component.py
@@ -17,10 +17,8 @@ from griptape_nodes.retained_mode.events.execution_events import (
     NodeResolvedEvent,
     NodeStartProcessEvent,
 )
-from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.workflow_events import (
     PublishWorkflowProgressEvent,
-    PublishWorkflowRequest,
     PublishWorkflowResultFailure,
     PublishWorkflowResultSuccess,
 )
@@ -176,14 +174,7 @@ class SubflowExecutionComponent:
             return None
 
         payload = event.get("payload", {})
-        payload_type_name = payload.get("payload_type", "")
-        payload_type = PayloadRegistry.get_type(payload_type_name)
-
-        if payload_type is None:
-            logger.debug("Unknown payload type: %s", payload_type_name)
-            return None
-
-        return ExecutionEvent.from_dict(data=payload, payload_type=payload_type)
+        return ExecutionEvent.from_dict(data=payload)
 
     def handle_publishing_event(self, event: dict) -> None:
         """Handle events from SubprocessWorkflowPublisher.
@@ -223,30 +214,20 @@ class SubflowExecutionComponent:
             event: The event dictionary containing the result
         """
         payload = event.get("payload", {})
-        result_type_name = payload.get("result_type", "")
-        result_payload_type = PayloadRegistry.get_type(result_type_name)
-
-        if result_payload_type is None:
-            logger.debug("Unknown result type: %s", result_type_name)
-            return
-
         result_data = payload.get("result", {})
 
-        if result_payload_type == PublishWorkflowResultSuccess:
-            event_result = EventResultSuccess.from_dict(
-                data=payload, req_payload_type=PublishWorkflowRequest, res_payload_type=PublishWorkflowResultSuccess
+        event_result = EventResultSuccess.from_dict(data=payload)
+        if isinstance(event_result.result, PublishWorkflowResultSuccess):
+            publish_workflow_result_success = event_result.result
+            target_link = (
+                publish_workflow_result_success.metadata.get("publish_target_link")
+                if publish_workflow_result_success.metadata
+                else None
             )
-            if isinstance(event_result.result, PublishWorkflowResultSuccess):
-                publish_workflow_result_success = event_result.result
-                target_link = (
-                    publish_workflow_result_success.metadata.get("publish_target_link")
-                    if publish_workflow_result_success.metadata
-                    else None
-                )
-                if target_link:
-                    self._node.set_parameter_value("publishing_target_link", target_link)
+            if target_link:
+                self._node.set_parameter_value("publishing_target_link", target_link)
 
-        elif result_payload_type == PublishWorkflowResultFailure:
+        elif isinstance(event_result.result, PublishWorkflowResultFailure):
             result_details = result_data.get("result_details", "Unknown error")
             self.append_event(f"Publishing failed: {result_details}")
 

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -27,16 +27,20 @@ def _resolve_payload_type(event_data: dict[str, Any], type_key: str) -> type:
     Raises:
         ValueError: If the type cannot be resolved.
     """
+    # Lazy import to avoid circular dependency: payload_registry imports Payload from this module.
     from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
     type_name = event_data.pop(type_key, None)
-    if type_name is not None:
-        resolved = PayloadRegistry.get_type(type_name)
-        if resolved is not None:
-            return resolved
+    if type_name is None:
+        msg = f"Cannot resolve payload type: '{type_key}' not found in event data."
+        raise ValueError(msg)
 
-    msg = f"Cannot resolve payload type: '{type_key}' not found or not registered."
-    raise ValueError(msg)
+    resolved = PayloadRegistry.get_type(type_name)
+    if resolved is None:
+        msg = f"Cannot resolve payload type: '{type_name}' is not registered."
+        raise ValueError(msg)
+
+    return resolved
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -14,6 +14,31 @@ if TYPE_CHECKING:
     import builtins
 
 
+def _resolve_payload_type(event_data: dict[str, Any], type_key: str) -> type:
+    """Resolve a payload type from a type-name field in the event data.
+
+    Args:
+        event_data: The event dictionary (mutated: the type-name key is popped if used).
+        type_key: The key in event_data that holds the payload type name (e.g. "request_type").
+
+    Returns:
+        The resolved concrete type.
+
+    Raises:
+        ValueError: If the type cannot be resolved.
+    """
+    from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+    type_name = event_data.pop(type_key, None)
+    if type_name is not None:
+        resolved = PayloadRegistry.get_type(type_name)
+        if resolved is not None:
+            return resolved
+
+    msg = f"Cannot resolve payload type: '{type_key}' not found or not registered."
+    raise ValueError(msg)
+
+
 @dataclass
 class ResultDetail:
     """A single detail about an operation result, including logging level and human readable message."""
@@ -287,16 +312,13 @@ class EventRequest[P: Payload](BaseEvent):
         return self.request
 
     @classmethod
-    def from_dict(cls, data: builtins.dict[str, Any], payload_type: type[P]) -> EventRequest:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_dict(cls, data: builtins.dict[str, Any]) -> EventRequest:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Create an event from a dictionary."""
         event_data = data.copy()
         request_data = event_data.pop("request", {})
+        resolved_type = _resolve_payload_type(event_data, "request_type")
 
-        if not payload_type:
-            msg = "Cannot create EventRequest without a payload type"
-            raise ValueError(msg)
-
-        request_payload = converter.structure(request_data, payload_type)
+        request_payload = converter.structure(request_data, resolved_type)
         return cls(request=request_payload, **event_data)
 
 
@@ -348,23 +370,17 @@ class EventResult[P: RequestPayload, R: ResultPayload](BaseEvent, ABC):
         """
 
     @classmethod
-    def from_dict(  # pyright: ignore[reportIncompatibleMethodOverride]
-        cls, data: builtins.dict[str, Any], req_payload_type: type[P], res_payload_type: type[R]
-    ) -> EventResult:
+    def from_dict(cls, data: builtins.dict[str, Any]) -> EventResult:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Create an event from a dictionary."""
         event_data = data.copy()
         request_data = event_data.pop("request", {})
         result_data = event_data.pop("result", {})
 
-        if not req_payload_type:
-            msg = f"Cannot create {cls.__name__} without a request payload type"
-            raise ValueError(msg)
-        if not res_payload_type:
-            msg = f"Cannot create {cls.__name__} without a result payload type"
-            raise ValueError(msg)
+        resolved_req_type = _resolve_payload_type(event_data, "request_type")
+        resolved_res_type = _resolve_payload_type(event_data, "result_type")
 
-        request_payload = converter.structure(request_data, req_payload_type)
-        result_payload = converter.structure(result_data, res_payload_type)
+        request_payload = converter.structure(request_data, resolved_req_type)
+        result_payload = converter.structure(result_data, resolved_res_type)
         return cls(request=request_payload, result=result_payload)
 
 
@@ -392,57 +408,6 @@ class EventResultFailure(EventResult[P, R]):
         return False
 
 
-# Helper function to deserialize event from JSON
-def deserialize_event(json_data: str | dict | Any) -> BaseEvent:
-    """Deserialize an event from JSON or dict, using the payload type information embedded in the data.
-
-    Args:
-        json_data: JSON string or dictionary representing an event
-
-    Returns:
-        The deserialized event with the correct payload
-    """
-    from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
-
-    # Parse the data if it's a string, otherwise use as is
-    if isinstance(json_data, str):
-        data = json.loads(json_data)
-    elif isinstance(json_data, dict):
-        data = json_data
-    else:
-        msg = "Expected json_data to be str or dict"
-        raise TypeError(msg)
-
-    event_type = data.get("event_type")
-
-    # Get payload types from embedded type information
-    request_type_name = data.get("request_type")
-    result_type_name = data.get("result_type")
-
-    # Look up the actual payload types
-    request_type = PayloadRegistry.get_type(request_type_name) if request_type_name else None
-    result_type = PayloadRegistry.get_type(result_type_name) if result_type_name else None
-
-    # Determine the event class based on event_type and deserialize
-    if event_type == "EventRequest":
-        if request_type:
-            return EventRequest.from_dict(data, request_type)
-        msg = f"Cannot deserialize EventRequest: unknown payload type '{request_type_name}'"
-        raise ValueError(msg)
-    if event_type == "EventResultSuccess":
-        if request_type and result_type:
-            return EventResultSuccess.from_dict(data, request_type, result_type)
-        msg = f"Cannot deserialize EventResultSuccess: unknown payload types request={request_type_name}, result={result_type_name}"
-        raise ValueError(msg)
-    if event_type == "EventResultFailure":
-        if request_type and result_type:
-            return EventResultFailure.from_dict(data, request_type, result_type)
-        msg = f"Cannot deserialize EventResultFailure: unknown payload types request={request_type_name}, result={result_type_name}"
-        raise ValueError(msg)
-    msg = f"Unknown/unsupported event type '{event_type}' encountered."
-    raise TypeError(msg)
-
-
 # EXECUTION EVENT BASE (this event type is used for the execution of a Griptape Nodes flow)
 class ExecutionEvent[E: ExecutionPayload](BaseEvent):
     payload: E
@@ -467,16 +432,13 @@ class ExecutionEvent[E: ExecutionPayload](BaseEvent):
         return self.payload
 
     @classmethod
-    def from_dict(cls, data: builtins.dict[str, Any], payload_type: type[E]) -> ExecutionEvent:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_dict(cls, data: builtins.dict[str, Any]) -> ExecutionEvent:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Create an event from a dictionary."""
         event_data = data.copy()
         payload_data = event_data.pop("payload", {})
+        resolved_type = _resolve_payload_type(event_data, "payload_type")
 
-        if not payload_type:
-            msg = "Cannot create ExecutionEvent without a payload type"
-            raise ValueError(msg)
-
-        event_payload = converter.structure(payload_data, payload_type)
+        event_payload = converter.structure(payload_data, resolved_type)
         return cls(payload=event_payload, **event_data)
 
 
@@ -504,16 +466,13 @@ class AppEvent[A: AppPayload](BaseEvent):
         return self.payload
 
     @classmethod
-    def from_dict(cls, data: builtins.dict[str, Any], payload_type: type[E]) -> AppEvent:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def from_dict(cls, data: builtins.dict[str, Any]) -> AppEvent:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Create an event from a dictionary."""
         event_data = data.copy()
         payload_data = event_data.pop("payload", {})
+        resolved_type = _resolve_payload_type(event_data, "payload_type")
 
-        if not payload_type:
-            msg = "Cannot create AppEvent without a payload type"
-            raise ValueError(msg)
-
-        event_payload = converter.structure(payload_data, payload_type)
+        event_payload = converter.structure(payload_data, resolved_type)
         return cls(payload=event_payload, **event_data)
 
 

--- a/tests/unit/retained_mode/events/test_from_dict.py
+++ b/tests/unit/retained_mode/events/test_from_dict.py
@@ -1,0 +1,127 @@
+"""Tests for from_dict() PayloadRegistry integration and _resolve_payload_type."""
+
+import pytest
+
+from griptape_nodes.retained_mode.events.base_events import (
+    EventRequest,
+    EventResultFailure,
+    EventResultSuccess,
+    _resolve_payload_type,
+)
+from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigValueRequest,
+    GetConfigValueResultFailure,
+    GetConfigValueResultSuccess,
+)
+
+
+class TestResolvePayloadType:
+    def test_resolves_registered_type(self) -> None:
+        event_data = {"request_type": "GetConfigValueRequest"}
+        resolved = _resolve_payload_type(event_data, "request_type")
+
+        assert resolved is GetConfigValueRequest
+
+    def test_pops_key_from_event_data(self) -> None:
+        event_data = {"request_type": "GetConfigValueRequest", "other": "value"}
+        _resolve_payload_type(event_data, "request_type")
+
+        assert "request_type" not in event_data
+        assert event_data["other"] == "value"
+
+    def test_raises_when_key_missing(self) -> None:
+        event_data = {}
+        with pytest.raises(ValueError, match="not found"):
+            _resolve_payload_type(event_data, "request_type")
+
+    def test_raises_when_type_not_registered(self) -> None:
+        event_data = {"request_type": "NonExistentType"}
+        with pytest.raises(ValueError, match="not registered"):
+            _resolve_payload_type(event_data, "request_type")
+
+
+class TestEventRequestFromDict:
+    def test_from_dict(self) -> None:
+        data = {
+            "event_type": "EventRequest",
+            "request_type": "GetConfigValueRequest",
+            "request": {"category_and_key": "foo.bar"},
+        }
+        event = EventRequest.from_dict(data)
+
+        assert isinstance(event.request, GetConfigValueRequest)
+        assert event.request.category_and_key == "foo.bar"
+
+    def test_from_dict_missing_request_type(self) -> None:
+        data = {
+            "event_type": "EventRequest",
+            "request": {"category_and_key": "foo.bar"},
+        }
+        with pytest.raises(ValueError, match="request_type"):
+            EventRequest.from_dict(data)
+
+
+class TestEventResultFromDict:
+    def test_success_from_dict(self) -> None:
+        data = {
+            "event_type": "EventResultSuccess",
+            "request_type": "GetConfigValueRequest",
+            "result_type": "GetConfigValueResultSuccess",
+            "request": {"category_and_key": "foo.bar"},
+            "result": {"value": 42, "result_details": "ok"},
+        }
+        event = EventResultSuccess.from_dict(data)
+
+        assert isinstance(event.request, GetConfigValueRequest)
+        assert isinstance(event.result, GetConfigValueResultSuccess)
+        expected_value = 42
+        assert event.result.value == expected_value
+        assert event.succeeded()
+
+    def test_failure_from_dict(self) -> None:
+        data = {
+            "event_type": "EventResultFailure",
+            "request_type": "GetConfigValueRequest",
+            "result_type": "GetConfigValueResultFailure",
+            "request": {"category_and_key": "foo.bar"},
+            "result": {"result_details": "not found"},
+        }
+        event = EventResultFailure.from_dict(data)
+
+        assert isinstance(event.request, GetConfigValueRequest)
+        assert isinstance(event.result, GetConfigValueResultFailure)
+        assert not event.succeeded()
+
+    def test_from_dict_missing_result_type(self) -> None:
+        data = {
+            "event_type": "EventResultSuccess",
+            "request_type": "GetConfigValueRequest",
+            "request": {"category_and_key": "foo.bar"},
+            "result": {"value": 42, "result_details": "ok"},
+        }
+        with pytest.raises(ValueError, match="result_type"):
+            EventResultSuccess.from_dict(data)
+
+
+class TestRoundTrip:
+    def test_event_request_round_trip(self) -> None:
+        request = GetConfigValueRequest(category_and_key="foo.bar")
+        event = EventRequest(request=request)
+        serialized = event.dict()
+
+        assert serialized["request_type"] == "GetConfigValueRequest"
+
+        restored = EventRequest.from_dict(serialized)
+
+        assert isinstance(restored.request, GetConfigValueRequest)
+        assert restored.request.category_and_key == "foo.bar"
+
+    def test_event_request_round_trip_with_defaults(self) -> None:
+        request = GetConfigValueRequest(category_and_key="a.b")
+        event = EventRequest(request=request, request_id="test-123")
+        serialized = event.dict()
+
+        restored = EventRequest.from_dict(serialized)
+
+        assert isinstance(restored.request, GetConfigValueRequest)
+        assert restored.request.category_and_key == "a.b"


### PR DESCRIPTION
Moves `PayloadRegistry` type resolution into the `from_dict()` methods on `EventRequest`, `EventResult`, `ExecutionEvent`, and `AppEvent`. Previously, every call site had to manually extract type-name strings from event dicts, call `PayloadRegistry.get_type()`, and pass the resolved types as arguments. Now `from_dict()` handles this internally via a shared `_resolve_payload_type()` helper that pops the type-name key (e.g. `request_type`, `result_type`, `payload_type`) from the event data and resolves it through the registry.

This removes the `deserialize_event()` function (its only caller in `app.py` now calls `EventRequest.from_dict()` directly), eliminates direct `PayloadRegistry` imports from `subprocess_workflow_executor.py` and `subflow_execution_component.py`, and drops the now-unused explicit `payload_type` parameters from all `from_dict()` signatures.