### PR TITLE
Fix sync of parent_element_name AND parent_group_name

### DIFF
--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1228,16 +1228,31 @@ class ParameterGroup(BaseNodeElement, UIOptionsMixin):
 
     def add_child(self, child: BaseNodeElement) -> None:
         child.parent_group_name = self.name
+        # Keep parent_element_name in sync with parent_group_name for Parameters.
+        # These two fields track the same relationship but have different origins:
+        # - parent_group_name: set here by add_child(), always correct
+        # - parent_element_name: set by Parameter constructors and handlers, used by
+        #   BaseNode.add_parameter() to look up the group, and by cattrs serialization
+        # Without this sync, Parameters created via the context manager path (which calls
+        # add_child() directly) would have parent_element_name=None, causing them to
+        # serialize without their parent group reference and reload as flat/root-level.
+        if isinstance(child, Parameter):
+            child.parent_element_name = self.name
         return super().add_child(child)
 
     def remove_child(self, child: BaseNodeElement | str) -> None:
+        """Clear parent tracking fields (inverse of add_child), then remove from the tree."""
         if isinstance(child, str):
             child_from_str = self.find_element_by_name(child)
             if child_from_str is not None and isinstance(child_from_str, BaseNodeElement):
                 child_from_str.parent_group_name = None
+                if isinstance(child_from_str, Parameter):
+                    child_from_str.parent_element_name = None
                 return super().remove_child(child_from_str)
         else:
             child.parent_group_name = None
+            if isinstance(child, Parameter):
+                child.parent_element_name = None
         return super().remove_child(child)
 
 
@@ -1370,16 +1385,23 @@ class ParameterButtonGroup(BaseNodeElement, UIOptionsMixin):
 
     def add_child(self, child: BaseNodeElement) -> None:
         child.parent_group_name = self.name
+        if isinstance(child, Parameter):
+            child.parent_element_name = self.name
         return super().add_child(child)
 
     def remove_child(self, child: BaseNodeElement | str) -> None:
+        """Clear parent tracking fields (inverse of add_child), then remove from the tree."""
         if isinstance(child, str):
             child_from_str = self.find_element_by_name(child)
             if child_from_str is not None and isinstance(child_from_str, BaseNodeElement):
                 child_from_str.parent_group_name = None
+                if isinstance(child_from_str, Parameter):
+                    child_from_str.parent_element_name = None
                 return super().remove_child(child_from_str)
         else:
             child.parent_group_name = None
+            if isinstance(child, Parameter):
+                child.parent_element_name = None
         return super().remove_child(child)
 
 
@@ -1513,6 +1535,15 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
             element_id = str(uuid.uuid4().hex)
         if not element_type:
             element_type = self.__class__.__name__
+
+        # Set parent references BEFORE super().__init__(), which triggers __post_init__().
+        # If this Parameter is being created inside a ParameterGroup context manager,
+        # __post_init__() will call add_child() which overwrites these with the correct
+        # group name. Setting them first ensures they exist as attributes, and the context
+        # manager path gets the final say.
+        self.parent_container_name = parent_container_name
+        self.parent_element_name = parent_element_name
+
         super().__init__(element_id=element_id, element_type=element_type)
         self.name = name
 
@@ -1627,8 +1658,6 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         self.type = type
         self.input_types = input_types
         self.output_type = output_type
-        self.parent_container_name = parent_container_name
-        self.parent_element_name = parent_element_name
 
     def _generate_default_tooltip(
         self,

--- a/tests/unit/exe_types/test_core_types.py
+++ b/tests/unit/exe_types/test_core_types.py
@@ -7,6 +7,7 @@ from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
     NodeMessagePayload,
     Parameter,
+    ParameterButtonGroup,
     ParameterGroup,
 )
 
@@ -478,3 +479,171 @@ class TestParameter:
         param_false_dict = param_false.to_dict()
         assert "settable" in param_false_dict
         assert param_false_dict["settable"] is False
+
+
+def _make_param(name: str = "test_param", **kwargs) -> Parameter:
+    """Helper to create a Parameter with minimal required args."""
+    defaults = {"input_types": ["str"], "type": "str", "output_type": "str", "tooltip": "test"}
+    defaults.update(kwargs)
+    return Parameter(name=name, **defaults)
+
+
+class TestParameterGroupParentSync:
+    """Tests that ParameterGroup keeps parent_element_name in sync with parent_group_name."""
+
+    def test_context_manager_sets_both_parent_fields(self) -> None:
+        """Context manager creation sets both parent_group_name and parent_element_name."""
+        with ParameterGroup(name="my_group"):
+            param = _make_param()
+
+        assert param.parent_group_name == "my_group"
+        assert param.parent_element_name == "my_group"
+
+    def test_explicit_add_child_sets_both_parent_fields(self) -> None:
+        """Calling add_child() directly should set both parent fields."""
+        group = ParameterGroup(name="my_group")
+        param = _make_param()
+
+        group.add_child(param)
+
+        assert param.parent_group_name == "my_group"
+        assert param.parent_element_name == "my_group"
+
+    def test_add_child_non_parameter_does_not_set_parent_element_name(self) -> None:
+        """Non-Parameter children get parent_group_name but not parent_element_name."""
+        group = ParameterGroup(name="my_group")
+        element = BaseNodeElement()
+
+        group.add_child(element)
+
+        assert element.parent_group_name == "my_group"
+        assert not hasattr(element, "parent_element_name")
+
+    def test_remove_child_by_reference_clears_both_fields(self) -> None:
+        """Removing a Parameter by reference should clear both parent fields."""
+        group = ParameterGroup(name="my_group")
+        param = _make_param()
+        group.add_child(param)
+
+        group.remove_child(param)
+
+        assert param.parent_group_name is None
+        assert param.parent_element_name is None
+
+    def test_remove_child_by_name_clears_both_fields(self) -> None:
+        """Removing a Parameter by name (string) should clear both parent fields."""
+        group = ParameterGroup(name="my_group")
+        param = _make_param(name="removable")
+        group.add_child(param)
+
+        group.remove_child("removable")
+
+        assert param.parent_group_name is None
+        assert param.parent_element_name is None
+
+    def test_remove_child_non_parameter_does_not_touch_parent_element_name(self) -> None:
+        """Removing a non-Parameter child should clear parent_group_name only."""
+        group = ParameterGroup(name="my_group")
+        element = BaseNodeElement(element_id="child1")
+        group.add_child(element)
+
+        group.remove_child(element)
+
+        assert element.parent_group_name is None
+        assert not hasattr(element, "parent_element_name")
+
+    def test_context_manager_overrides_explicit_none(self) -> None:
+        """Context manager's add_child() overrides an explicit parent_element_name=None."""
+        with ParameterGroup(name="my_group"):
+            param = Parameter(
+                name="test",
+                input_types=["str"],
+                type="str",
+                output_type="str",
+                tooltip="test",
+                parent_element_name=None,  # explicit None, should be overridden
+            )
+
+        assert param.parent_element_name == "my_group"
+
+    def test_serialization_includes_parent_element_name(self) -> None:
+        """to_dict() should reflect the synced parent_element_name."""
+        with ParameterGroup(name="my_group"):
+            param = _make_param()
+
+        param_dict = param.to_dict()
+        assert param_dict["parent_element_name"] == "my_group"
+        assert param_dict["parent_group_name"] == "my_group"
+
+
+class TestParameterButtonGroupParentSync:
+    """Same sync behavior for ParameterButtonGroup."""
+
+    def test_context_manager_sets_both_parent_fields(self) -> None:
+        with ParameterButtonGroup(name="btn_group"):
+            param = _make_param()
+
+        assert param.parent_group_name == "btn_group"
+        assert param.parent_element_name == "btn_group"
+
+    def test_explicit_add_child_sets_both_parent_fields(self) -> None:
+        group = ParameterButtonGroup(name="btn_group")
+        param = _make_param()
+
+        group.add_child(param)
+
+        assert param.parent_group_name == "btn_group"
+        assert param.parent_element_name == "btn_group"
+
+    def test_remove_child_by_reference_clears_both_fields(self) -> None:
+        group = ParameterButtonGroup(name="btn_group")
+        param = _make_param()
+        group.add_child(param)
+
+        group.remove_child(param)
+
+        assert param.parent_group_name is None
+        assert param.parent_element_name is None
+
+    def test_remove_child_by_name_clears_both_fields(self) -> None:
+        group = ParameterButtonGroup(name="btn_group")
+        param = _make_param(name="removable")
+        group.add_child(param)
+
+        group.remove_child("removable")
+
+        assert param.parent_group_name is None
+        assert param.parent_element_name is None
+
+
+class TestParameterConstructorOrdering:
+    """Tests that Parameter.__init__ sets parent fields before super().__init__()."""
+
+    def test_constructor_default_without_context(self) -> None:
+        """Without a context manager, parent fields should be None (the default)."""
+        param = _make_param()
+
+        assert param.parent_container_name is None
+        assert param.parent_element_name is None
+
+    def test_constructor_explicit_values_without_context(self) -> None:
+        """Explicit parent values should be preserved when no context manager is active."""
+        param = _make_param(parent_container_name="container1", parent_element_name="group1")
+
+        assert param.parent_container_name == "container1"
+        assert param.parent_element_name == "group1"
+
+    def test_context_manager_wins_over_explicit_none(self) -> None:
+        """Context manager overrides constructor default, proving assignment is before super()."""
+        with ParameterGroup(name="ctx_group"):
+            param = _make_param(parent_element_name=None)
+
+        assert param.parent_element_name == "ctx_group"
+
+    def test_nested_groups_innermost_wins(self) -> None:
+        """When groups are nested, the innermost (active) context should win."""
+        with ParameterGroup(name="outer"), ParameterGroup(name="inner"):
+            param = _make_param()
+
+        assert param.parent_group_name == "inner"
+        assert param.parent_element_name == "inner"


### PR DESCRIPTION
## fix: sync `parent_element_name` with `parent_group_name` in ParameterGroup

### Problem

Parameters created inside a `ParameterGroup` context manager lose their group association. `parent_element_name` stays `None`, even though `parent_group_name` is set correctly. This means any code that relies on `parent_element_name` to find a Parameter's parent group (e.g. `BaseNode.add_parameter()`, serialization) sees an orphan.

### Root cause

Two independent bugs that combine to guarantee `parent_element_name` is always `None` for context-manager-created Parameters.

**Bug 1: `add_child()` only sets one of the two parent fields.**

`ParameterGroup.add_child()` sets `parent_group_name` but never touches `parent_element_name`. These two fields track the same relationship — which group owns this Parameter — but have different consumers. Any Parameter created inside a `with ParameterGroup(...)` block gets `parent_group_name` correct but `parent_element_name` stays `None`.

**Bug 2: `Parameter.__init__` clobbers values set by `add_child()`.**

Even if we fix `add_child()`, the constructor ordering defeats it. Here's the call sequence when creating a Parameter inside a context manager:

```
ParameterButton(name="save", ...)
  │
  ├─ Parameter.__init__ starts
  │    ...
  │    super().__init__(element_id, element_type)        # ← BaseNodeElement.__init__
  │      │
  │      └─ BaseNodeElement.__post_init__()
  │           │
  │           └─ current_context.add_child(self)         # ← context manager auto-parenting
  │                │
  │                └─ ParameterGroup.add_child(child)
  │                     child.parent_group_name = "actions"
  │                     child.parent_element_name = "actions"  # ← set correctly!
  │    ...
  │    self.parent_element_name = parent_element_name    # ← CLOBBERS with None
  │
  └─ Parameter.__init__ returns
```

The assignment at the bottom of `__init__` runs *after* `super().__init__()` has already triggered `add_child()`, overwriting whatever `add_child()` set with the constructor default (usually `None`).

### Example

```python
with ParameterGroup(name="condition_1_buttons") as group:
    btn = ParameterButton(name="condition_1_up", label="", icon="arrow-up")

# Before fix:
assert btn.parent_group_name == "condition_1_buttons"  # ✓ set by add_child
assert btn.parent_element_name is None                  # ✗ clobbered by __init__

# After fix:
assert btn.parent_group_name == "condition_1_buttons"   # ✓
assert btn.parent_element_name == "condition_1_buttons"  # ✓
```

### Fix

Three changes, all in `core_types.py`:

1. **`ParameterGroup.add_child()` / `remove_child()`** — sync `parent_element_name` alongside `parent_group_name` for Parameter children.

2. **`ParameterButtonGroup.add_child()` / `remove_child()`** — same sync (ParameterButtonGroup has its own overrides that need the same treatment).

3. **`Parameter.__init__`** — move `self.parent_container_name` and `self.parent_element_name` assignments to *before* the `super().__init__()` call. This ensures the attributes exist (avoiding `AttributeError` if `add_child()` tries to read them) while letting the context manager path have the final say.

After the reorder, the call sequence becomes:

```
ParameterButton(name="save", ...)
  │
  ├─ Parameter.__init__ starts
  │    self.parent_element_name = None                   # ← default, ensures attr exists
  │    self.parent_container_name = None
  │    │
  │    super().__init__(element_id, element_type)
  │      └─ __post_init__()
  │           └─ add_child(self)
  │                child.parent_element_name = "actions"  # ← overwrites None ✓
  │    ...
  │    # no later assignment to clobber it
  │
  └─ Parameter.__init__ returns
```

### Test plan

- Create a workflow with a `PathSelector` node (uses `ParameterButtonGroup` with child buttons)
- Save the workflow
- Verify generated code has `parent_element_name='condition_1_buttons'` on child buttons (not `None`)
- Reload the workflow — buttons should appear nested under their group, not flat at root level
