### PR TITLE
fix: resolve code scanning alert no. 22: Incomplete URL substring sanitization

### DIFF
--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -120,13 +120,11 @@ def parse_git_url_with_ref(url_with_ref: str) -> GitUrlWithRef:
 
 def _is_github_https_url(url: str) -> bool:
     """Return True if the URL is an HTTP(S) URL whose hostname is github.com."""
-    if not url.startswith(("http://", "https://")):
-        return False
     try:
         parsed = urlparse(url)
     except ValueError:
         return False
-    return parsed.hostname == "github.com"
+    return parsed.scheme in ("http", "https") and parsed.hostname == "github.com"
 
 
 def normalize_github_url(url_or_shorthand: str) -> str:

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import NamedTuple
+from urllib.parse import urlparse
 
 import pygit2
 
@@ -117,6 +118,17 @@ def parse_git_url_with_ref(url_with_ref: str) -> GitUrlWithRef:
     return GitUrlWithRef(url=url_with_ref, ref=None)
 
 
+def _is_github_https_url(url: str) -> bool:
+    """Return True if the URL is an HTTP(S) URL whose hostname is github.com."""
+    if not url.startswith(("http://", "https://")):
+        return False
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.hostname == "github.com"
+
+
 def normalize_github_url(url_or_shorthand: str) -> str:
     """Normalize a GitHub URL or shorthand to a full HTTPS git URL.
 
@@ -148,8 +160,8 @@ def normalize_github_url(url_or_shorthand: str) -> str:
     if not is_git_url(url) and "/" in url and url.count("/") == 1:
         # Assume GitHub shorthand
         normalized = f"https://github.com/{url}.git"
-    elif "github.com" in url and not url.endswith(".git"):
-        # If it's a GitHub URL, ensure .git suffix
+    elif _is_github_https_url(url) and not url.endswith(".git"):
+        # If it's an HTTPS GitHub URL, ensure .git suffix
         normalized = f"{url}.git"
     else:
         # Pass through all other URLs unchanged


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/22](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/22)

In general, the problem should be fixed by avoiding substring checks on the entire URL string to infer the host, and instead properly parsing the URL and inspecting its hostname. For Git URLs, we also need to treat common SSH‑style patterns (`git@github.com:owner/repo.git`) differently because they aren’t valid HTTP URLs and won’t parse with `urlparse` in the same way. The goal is to reliably detect when the host is actually `github.com` (or, if desired, a GitHub subdomain) and only then enforce the `.git` suffix, while leaving all other URLs unchanged.

For this file, the best targeted fix is to replace the `"github.com" in url` heuristic in `normalize_github_url` with a small helper that checks whether a given git URL actually points to GitHub. The helper should:
- For URLs starting with `http://` or `https://`, use `urllib.parse.urlparse` and check whether `parsed.hostname == "github.com"`.
- For SSH‑style URLs like `git@github.com:owner/repo.git`, treat them as GitHub URLs by checking that they start with `git@github.com:`. These are already handled by the earlier `is_git_url` logic and, per the docstring, we should pass them through unchanged, so we do not add `.git` to such URLs in `normalize_github_url`.
- For all others, return False.

Then, update the GitHub URL branch to use this helper, e.g.:

```python
elif _is_github_https_url(url) and not url.endswith(".git"):
    normalized = f"{url}.git"
```

This preserves existing behavior for:
- Shorthand `owner/repo` → still normalized to `https://github.com/owner/repo.git`.
- Proper HTTPS GitHub URLs missing `.git` → now detected via hostname and fixed.
- SSH GitHub URLs (`git@github.com:user/repo.git`) → still passed through unchanged.
And it prevents accidental classification of arbitrary URLs that merely contain `github.com` somewhere in the string.

To implement this, in `src/griptape_nodes/utils/git_utils.py`:
- Add an import for `urlparse` from `urllib.parse` near the top (no conflicting import exists in the shown snippet).
- Add a new small helper function (e.g., `_is_github_https_url`) above `normalize_github_url`.
- Replace the `elif "github.com" in url and not url.endswith(".git"):` clause with one that calls the helper.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
