### PR TITLE
fix: resolve for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/3](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/3)

In general, this problem is fixed by explicitly declaring a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal capabilities needed. You can define this either at the top level of the workflow (applies to all jobs without their own `permissions:`) or per job. Since all four jobs in this workflow are simple code-checks that only need to read the repository contents, the best fix is to add a single top-level `permissions:` block with `contents: read`. This preserves existing behavior (the jobs can still check out code and run checks) while preventing unintended write access.

Concretely, edit `.github/workflows/code-checks.yml` to insert a `permissions:` section near the top, alongside `on:` and `concurrency:`. For example, after the `on:` block and before `concurrency:`, add:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required; this is purely a configuration change within the workflow file. All existing jobs (`format`, `type-check`, `lint`, `spell-check`) will implicitly inherit these restricted permissions since they do not define their own `permissions:` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
