### PR TITLE
fix: resolve code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 # Adapted from https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages
 name: Publish
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/34](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/34)

In general, fix this by adding an explicit `permissions` block that limits the `GITHUB_TOKEN` to the minimal required scope. For workflows that only need to read repository contents and do not push commits, create releases, or modify other resources via the API, `contents: read` is an appropriate baseline.

For this workflow, the safest and least intrusive change is to define a top‑level `permissions` block with `contents: read`, which applies to all jobs that don’t override it. The `push_cpu_image` job already has its own `permissions` section; that job‑level block will continue to override the workflow default, so its behavior is unchanged. The `pre-publish-checks` and `publish-pypi` jobs will newly get `contents: read` instead of inheriting possibly broader defaults, while their existing functionality (checkout, running `make check`, building and publishing to PyPI with `PYPI_TOKEN`) is unaffected because none of those require `GITHUB_TOKEN` write permissions.

Concretely:
- Edit `.github/workflows/publish.yml`.
- Insert a workflow‑level `permissions:` block (e.g. between `name: Publish` and `on:`) with `contents: read`.
- Do not change existing steps or the existing `permissions` definition in `push_cpu_image`.

No additional imports or methods are needed; this is a pure YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
