### PR TITLE
fix: resolve code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit-test-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/9](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/9)

In general, the fix is to explicitly define a `permissions:` block that grants only the minimal scopes required by the workflow, rather than relying on repository/organization defaults. For this workflow, the jobs only check out code, initialize an environment, run tests, and upload coverage to Codecov. None of these require write access to the repo; `contents: read` and (optionally) `packages: read` are sufficient as a minimal, safe baseline.

The best fix without changing existing functionality is to add a root-level `permissions:` block in `.github/workflows/unit-tests.yml`, right after the `concurrency` block (or immediately under `name:` / `on:`—any top-level position is fine) so that it applies to all jobs (`unit-test-ubuntu` and `unit-test-windows`). We’ll set `contents: read` as recommended by the CodeQL message. If your private package registry is involved via actions, you might also add `packages: read`, but based on the shown snippet only `contents: read` is clearly needed, so we’ll keep it minimal. No additional imports or external dependencies are required.

Concretely, in `.github/workflows/unit-tests.yml`, insert:

```yaml
permissions:
  contents: read
```

as a top-level key (aligned with `name`, `on`, `concurrency`, `jobs`). This will constrain `GITHUB_TOKEN` permissions for all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
