### PR TITLE
fix: resolve code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/8](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/8)

In general, the fix is to add an explicit `permissions` block defining the minimal set of `GITHUB_TOKEN` permissions required by this workflow. Since these jobs only need to read repository contents (for checkout) and do not appear to need any write capabilities, `contents: read` is a safe minimal setting.

The single best change, without altering existing functional behavior, is to add a top-level `permissions` block (at the same level as `on:` and `jobs:`) that applies to all jobs. Set it to `contents: read`. If later a job needs more, a per-job `permissions` override can be added, but nothing in the given snippet indicates such a need now. Concretely, in `.github/workflows/unit-tests.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `concurrency:` section (e.g., after line 9). No imports or additional methods are required since this is a YAML workflow change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
