### PR TITLE
fix: resolve code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/6](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block limiting the `GITHUB_TOKEN` to the minimal required scopes. Since these jobs simply check out code and run format/type-check/lint/spell-check commands, they only need to read the repository contents. The best fix without changing functionality is to add a workflow-level `permissions` block setting `contents: read`, which applies to all jobs that do not specify their own `permissions`. This documents and enforces least privilege while avoiding duplication on each job.

Concretely, in `.github/workflows/code-checks.yml`, insert a `permissions:` section near the top-level, alongside `on:` and `concurrency:` (for example, after the `on:` block and before `concurrency:`). The block should look like:

```yaml
permissions:
  contents: read
```

No imports or other definitions are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
