### PR TITLE
fix: resolve code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/5](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/5)

To fix the problem, explicitly define the GITHUB_TOKEN permissions used by this workflow, restricting them to the minimum needed. All jobs in this file only check out the code and run local `make` commands; they do not interact with GitHub resources in a write capacity. Therefore, a workflow‑level `permissions` block with `contents: read` is sufficient and adheres to least privilege.

The best fix without changing functionality is to add a top‑level `permissions:` section right after the `on:` block (e.g., after line 10). This block will apply to all jobs (`format`, `type-check`, `lint`, `spell-check`) since none of them define their own `permissions`. No other code, steps, or imports need to be modified. Concretely, in `.github/workflows/code-checks.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the existing `concurrency:` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
