### PR TITLE
fix: resolve code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,5 +1,8 @@
 name: Code Checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/griptape-ai/griptape-nodes/security/code-scanning/1](https://github.com/griptape-ai/griptape-nodes/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying `permissions` for the `GITHUB_TOKEN` in the workflow, limiting it to the least privileges necessary. Since these jobs only check out code and run checks, they should only need read access to repository contents.

The best fix without changing existing functionality is to add a single top-level `permissions` block (applies to all jobs) right after `name: Code Checks` or after the `on:` block. This block will set `contents: read`, which is sufficient for `actions/checkout` and typical code-check tasks. If `./.github/actions/init-environment` needed more privileges, they can be added later, but with the current information we keep it minimal.

Concretely, in `.github/workflows/code-checks.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., between `name: Code Checks` and `on:`). No other methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
