### PR TITLE
fix: make version compatibility checks library-aware

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -91,6 +91,18 @@ class WorkflowVersionCompatibilityCheck(ABC):
 class SetParameterVersionCompatibilityCheck(ABC):
     """Abstract base class for runtime parameter set version compatibility checks."""
 
+    @staticmethod
+    def get_node_library_name(node: BaseNode) -> str | None:
+        """Get the library name a node belongs to from its metadata.
+
+        Args:
+            node: The node instance
+
+        Returns:
+            The library name string, or None if not available
+        """
+        return node.metadata.get("library")
+
     @abstractmethod
     def applies_to_set_parameter(self, node: BaseNode, parameter_name: str, value: Any) -> bool:
         """Return True if this check applies to the given parameter set operation.

--- a/src/griptape_nodes/version_compatibility/versions/v0_65_4/run_in_parallel_to_run_in_order.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_65_4/run_in_parallel_to_run_in_order.py
@@ -11,7 +11,7 @@ Link: https://github.com/griptape-ai/griptape-nodes/issues/XXXX
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueResultSuccess
 from griptape_nodes.retained_mode.managers.version_compatibility_manager import (
@@ -37,6 +37,8 @@ class RunInParallelToRunInOrderCheck(SetParameterVersionCompatibilityCheck):
     - run_in_parallel=False → run_in_order=True (run sequentially)
     """
 
+    LIBRARY_NAME: ClassVar[str] = "griptape_nodes_library"
+
     def applies_to_set_parameter(self, node: BaseNode, parameter_name: str, _value: Any) -> bool:
         """Return True if this is the old run_in_parallel parameter on an affected node.
 
@@ -49,6 +51,9 @@ class RunInParallelToRunInOrderCheck(SetParameterVersionCompatibilityCheck):
             True if this check should handle this parameter
         """
         if parameter_name != "run_in_parallel":
+            return False
+
+        if self.get_node_library_name(node) != self.LIBRARY_NAME:
             return False
 
         node_type_name = type(node).__name__

--- a/src/griptape_nodes/version_compatibility/versions/v0_65_4/run_in_parallel_to_run_in_order.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_65_4/run_in_parallel_to_run_in_order.py
@@ -37,6 +37,7 @@ class RunInParallelToRunInOrderCheck(SetParameterVersionCompatibilityCheck):
     - run_in_parallel=False → run_in_order=True (run sequentially)
     """
 
+    # The standard library: https://github.com/griptape-ai/griptape-nodes-library-standard
     LIBRARY_NAME: ClassVar[str] = "griptape_nodes_library"
 
     def applies_to_set_parameter(self, node: BaseNode, parameter_name: str, _value: Any) -> bool:

--- a/src/griptape_nodes/version_compatibility/versions/v0_65_5/flux_2_removed_parameters.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_65_5/flux_2_removed_parameters.py
@@ -32,6 +32,7 @@ class Flux2RemovedParametersCheck(SetParameterVersionCompatibilityCheck):
     """
 
     REMOVED_PARAMETERS: ClassVar[set[str]] = {"prompt_upsampling", "aspect_ratio"}
+    LIBRARY_NAME: ClassVar[str] = "griptape_nodes_library"
 
     def __init__(self) -> None:
         """Initialize the check with an empty set of warned workflows."""
@@ -50,6 +51,9 @@ class Flux2RemovedParametersCheck(SetParameterVersionCompatibilityCheck):
             True if this check should handle this parameter
         """
         if parameter_name not in self.REMOVED_PARAMETERS:
+            return False
+
+        if self.get_node_library_name(node) != self.LIBRARY_NAME:
             return False
 
         return type(node).__name__ == "Flux2ImageGeneration"

--- a/src/griptape_nodes/version_compatibility/versions/v0_65_5/flux_2_removed_parameters.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_65_5/flux_2_removed_parameters.py
@@ -32,6 +32,7 @@ class Flux2RemovedParametersCheck(SetParameterVersionCompatibilityCheck):
     """
 
     REMOVED_PARAMETERS: ClassVar[set[str]] = {"prompt_upsampling", "aspect_ratio"}
+    # The standard library: https://github.com/griptape-ai/griptape-nodes-library-standard
     LIBRARY_NAME: ClassVar[str] = "griptape_nodes_library"
 
     def __init__(self) -> None:

--- a/tests/unit/version_compatibility/test_set_parameter_library_awareness.py
+++ b/tests/unit/version_compatibility/test_set_parameter_library_awareness.py
@@ -1,0 +1,115 @@
+"""Tests for library-aware SetParameterVersionCompatibilityCheck implementations.
+
+Verifies that compatibility checks only apply to nodes from the standard library
+and do not interfere with identically-named nodes from extension libraries.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueResultSuccess
+from griptape_nodes.version_compatibility.versions.v0_65_4.run_in_parallel_to_run_in_order import (
+    RunInParallelToRunInOrderCheck,
+)
+from griptape_nodes.version_compatibility.versions.v0_65_5.flux_2_removed_parameters import (
+    Flux2RemovedParametersCheck,
+)
+
+STANDARD_LIBRARY = "griptape_nodes_library"
+EXTENSION_LIBRARY = "blackforestlabs_library"
+
+
+def _make_node(class_name: str, library_name: str) -> MagicMock:
+    """Create a mock node with the given class name and library metadata."""
+    node = MagicMock()
+    node.metadata = {"library": library_name}
+    type(node).__name__ = class_name
+    return node
+
+
+class TestFlux2RemovedParametersCheckLibraryAwareness:
+    """Tests that Flux2RemovedParametersCheck only applies to standard library nodes."""
+
+    @pytest.fixture
+    def check(self) -> Flux2RemovedParametersCheck:
+        return Flux2RemovedParametersCheck()
+
+    def test_applies_to_standard_library_node(self, check: Flux2RemovedParametersCheck) -> None:
+        node = _make_node("Flux2ImageGeneration", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "aspect_ratio", "16:9") is True
+
+    def test_does_not_apply_to_extension_library_node(self, check: Flux2RemovedParametersCheck) -> None:
+        node = _make_node("Flux2ImageGeneration", EXTENSION_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "aspect_ratio", "16:9") is False
+
+    def test_does_not_apply_to_node_without_library_metadata(self, check: Flux2RemovedParametersCheck) -> None:
+        node = MagicMock()
+        node.metadata = {}
+        type(node).__name__ = "Flux2ImageGeneration"
+
+        assert check.applies_to_set_parameter(node, "aspect_ratio", "16:9") is False
+
+    def test_does_not_apply_to_unrelated_parameter(self, check: Flux2RemovedParametersCheck) -> None:
+        node = _make_node("Flux2ImageGeneration", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "width", 1024) is False
+
+    def test_does_not_apply_to_different_node_type(self, check: Flux2RemovedParametersCheck) -> None:
+        node = _make_node("SomeOtherNode", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "aspect_ratio", "16:9") is False
+
+    def test_set_parameter_returns_success(self, check: Flux2RemovedParametersCheck) -> None:
+        node = _make_node("Flux2ImageGeneration", STANDARD_LIBRARY)
+
+        with patch(
+            "griptape_nodes.version_compatibility.versions.v0_65_5.flux_2_removed_parameters.GriptapeNodes"
+        ) as mock_gn:
+            mock_gn.ContextManager.return_value.get_current_workflow_name.return_value = "test_workflow"
+            result = check.set_parameter_value(node, "aspect_ratio", "16:9")
+
+        assert isinstance(result, SetParameterValueResultSuccess)
+        assert result.finalized_value is None
+
+
+class TestRunInParallelToRunInOrderCheckLibraryAwareness:
+    """Tests that RunInParallelToRunInOrderCheck only applies to standard library nodes."""
+
+    @pytest.fixture
+    def check(self) -> RunInParallelToRunInOrderCheck:
+        return RunInParallelToRunInOrderCheck()
+
+    def test_applies_to_standard_library_for_loop_node(self, check: RunInParallelToRunInOrderCheck) -> None:
+        node = _make_node("ForLoopStartNode", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "run_in_parallel", True) is True
+
+    def test_applies_to_standard_library_for_each_node(self, check: RunInParallelToRunInOrderCheck) -> None:
+        node = _make_node("ForEachStartNode", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "run_in_parallel", True) is True
+
+    def test_does_not_apply_to_extension_library_node(self, check: RunInParallelToRunInOrderCheck) -> None:
+        node = _make_node("ForLoopStartNode", EXTENSION_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "run_in_parallel", True) is False
+
+    def test_does_not_apply_to_node_without_library_metadata(self, check: RunInParallelToRunInOrderCheck) -> None:
+        node = MagicMock()
+        node.metadata = {}
+        type(node).__name__ = "ForLoopStartNode"
+
+        assert check.applies_to_set_parameter(node, "run_in_parallel", True) is False
+
+    def test_does_not_apply_to_unrelated_parameter(self, check: RunInParallelToRunInOrderCheck) -> None:
+        node = _make_node("ForLoopStartNode", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "some_other_param", True) is False
+
+    def test_does_not_apply_to_different_node_type(self, check: RunInParallelToRunInOrderCheck) -> None:
+        node = _make_node("SomeOtherNode", STANDARD_LIBRARY)
+
+        assert check.applies_to_set_parameter(node, "run_in_parallel", True) is False


### PR DESCRIPTION
Version compatibility checks (`Flux2RemovedParametersCheck` and `RunInParallelToRunInOrderCheck`) matched nodes solely by `type(node).__name__`, which caused them to incorrectly intercept parameter values on identically-named nodes registered by extension libraries. For example, a `Flux2ImageGeneration` node from the BlackForestLabs extension library would have its `aspect_ratio` and `prompt_upsampling` parameters silently discarded by a check meant only for the standard library's version of that node.

This adds a `get_node_library_name()` static helper to `SetParameterVersionCompatibilityCheck` that reads `node.metadata["library"]`, and a `LIBRARY_NAME` class variable to both `Flux2RemovedParametersCheck` and `RunInParallelToRunInOrderCheck`. Each check now verifies the node belongs to `griptape_nodes_library` before applying.

The `DeprecatedNodeGroupParametersCheck` was not affected because it uses `isinstance()` against a base class rather than matching by class name.

Closes #4194