### PR TITLE
fix: resolve docs build failure with pygments 2.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ docs = [
   "mkdocs>=1.5.2",
   "mkdocstrings[python]>=0.29.1",
   "mkdocs-mermaid2-plugin>=1.2.2",
+  "pymdown-extensions>=10.17",
 ]
 test = [
   "pytest>=8.3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -454,6 +454,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pymdown-extensions" },
 ]
 test = [
     { name = "coverage" },
@@ -517,6 +518,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.6.9" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.2" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
+    { name = "pymdown-extensions", specifier = ">=10.17" },
 ]
 test = [
     { name = "coverage", specifier = ">=7.0.0" },
@@ -1308,15 +1310,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.16.1"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pygments 2.20.0 (bumped in #4312) introduced stricter handling of the `filename` parameter in `HtmlFormatter`, which no longer accepts `None`. `pymdown-extensions` 10.16.1 had a bug where it passed `title=None` as `filename` to the Pygments formatter when processing indented code blocks, causing `html.escape(None)` to crash with `AttributeError: 'NoneType' object has no attribute 'replace'`.

This adds `pymdown-extensions>=10.17` to the docs dependencies, which contains the fix for the `None` filename handling and is compatible with Pygments 2.20.0.