### PR TITLE
fix: add list support to SetParameterValueRequest.value type

### DIFF
--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -244,7 +244,7 @@ class SetParameterValueRequest(RequestPayload):
     """
 
     parameter_name: str
-    value: str | int | float | bool | dict | None
+    value: str | int | float | bool | dict | list | None
     # If node name is None, use the Current Context
     node_name: str | None = None
     data_type: str | None = None


### PR DESCRIPTION
## Summary

Fixes #4352 

Restores list support to `SetParameterValueRequest.value` type annotation, fixing widgets with list-type parameters that broke after the cattrs refactor.

## Problem

Widgets using list parameters (e.g., Kling Multi-Shot Editor) fail with:
```
invalid value for type, expected str | int | float | bool | dict | None @ $.value
```

## Root Cause

1. **Oct 2025** (`db615eba4`): `value: Any` changed to `str | int | float | bool | dict | None` for type safety
2. **Apr 2026** (`b631cee2`): cattrs refactor enforced strict validation, rejecting list values

## Changes

**File**: `src/griptape_nodes/retained_mode/events/parameter_events.py`

```python
-    value: str | int | float | bool | dict | None
+    value: str | int | float | bool | dict | list | None
```

## Testing

- ✅ Custom color palette widget with list of strings
- ✅ Should fix Kling Multi-Shot Editor widget

## Impact

Restores functionality for:
- Kling Multi-Shot Editor
- Any custom widgets with list parameters
- Maintains type safety improvements from original change

cc @collin - This is a one-line fix to restore list parameter support in widgets that was inadvertently broken by the cattrs refactor. The `after_value_set` callback is never triggered because the request is rejected at the protocol level before reaching the node.