### PR TITLE
fix: register cattrs structure hook for JSON-primitive Union types

### DIFF
--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -62,7 +62,7 @@ converter.register_structure_hook(float, lambda v, _: float(v))
 _JSON_PRIMITIVE_TYPES = frozenset({str, int, float, bool, dict, list, type(None)})
 
 
-def _is_json_primitive_union(cls: type) -> bool:
+def _is_json_primitive_union(cls: Any) -> bool:
     origin = get_origin(cls)
     if origin is Union or origin is types.UnionType:
         return all(arg in _JSON_PRIMITIVE_TYPES for arg in get_args(cls))

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
+import types
 from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Union, get_args, get_origin
 
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.preconf.json import make_converter
@@ -53,6 +54,25 @@ converter.register_unstructure_hook(type, lambda t: f"{t.__module__}.{t.__qualna
 # The JSON preset strict mode rejects ints for float fields, but JSON has
 # no distinction between int and float, so coerce int -> float on input.
 converter.register_structure_hook(float, lambda v, _: float(v))
+
+# Union types composed entirely of JSON-primitive types (str, int, float, bool,
+# dict, list, None). The JSON parser already produces the correct Python type,
+# so no transformation is needed. This is required because cattrs cannot
+# disambiguate certain combinations (e.g. dict | list) in a Union.
+_JSON_PRIMITIVE_TYPES = frozenset({str, int, float, bool, dict, list, type(None)})
+
+
+def _is_json_primitive_union(cls: type) -> bool:
+    origin = get_origin(cls)
+    if origin is Union or origin is types.UnionType:
+        return all(arg in _JSON_PRIMITIVE_TYPES for arg in get_args(cls))
+    return False
+
+
+converter.register_structure_hook_func(
+    _is_json_primitive_union,
+    lambda v, _: v,
+)
 
 # Pydantic BaseModel subclasses
 converter.register_structure_hook_func(

--- a/tests/unit/retained_mode/events/test_event_converter.py
+++ b/tests/unit/retained_mode/events/test_event_converter.py
@@ -1,0 +1,147 @@
+"""Tests for event_converter structure/unstructure hooks."""
+
+from typing import Any
+
+import pytest
+
+from griptape_nodes.retained_mode.events.base_events import EventRequest
+from griptape_nodes.retained_mode.events.event_converter import (
+    _is_json_primitive_union,
+    converter,
+)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+
+
+class TestIsJsonPrimitiveUnion:
+    """Test the _is_json_primitive_union predicate."""
+
+    def test_matches_union_of_json_primitives(self) -> None:
+        assert _is_json_primitive_union(str | int | float | bool | dict | list | None) is True
+
+    def test_matches_partial_union(self) -> None:
+        assert _is_json_primitive_union(dict | list | None) is True
+
+    def test_matches_two_member_union(self) -> None:
+        assert _is_json_primitive_union(dict | list) is True
+
+    def test_rejects_non_union(self) -> None:
+        assert _is_json_primitive_union(str) is False
+
+    def test_rejects_union_with_non_primitive(self) -> None:
+        assert _is_json_primitive_union(str | bytes) is False
+
+
+class TestJsonPrimitiveUnionStructuring:
+    """Test that the converter structures JSON-primitive Union types correctly."""
+
+    @pytest.fixture
+    def union_type(self) -> Any:
+        return str | int | float | bool | dict | list | None
+
+    def test_structure_str(self, union_type: type) -> None:
+        assert converter.structure("hello", union_type) == "hello"
+
+    def test_structure_int(self, union_type: type) -> None:
+        value = 42
+        assert converter.structure(value, union_type) == value
+
+    def test_structure_float(self, union_type: type) -> None:
+        value = 3.14
+        assert converter.structure(value, union_type) == value
+
+    def test_structure_bool(self, union_type: type) -> None:
+        assert converter.structure(True, union_type) is True
+
+    def test_structure_none(self, union_type: type) -> None:
+        assert converter.structure(None, union_type) is None
+
+    def test_structure_list(self, union_type: type) -> None:
+        assert converter.structure([1, 2, 3], union_type) == [1, 2, 3]
+
+    def test_structure_dict(self, union_type: type) -> None:
+        assert converter.structure({"key": "value"}, union_type) == {"key": "value"}
+
+    def test_structure_nested_dict(self, union_type: type) -> None:
+        value = {"outer": {"inner": [1, 2, 3]}}
+        assert converter.structure(value, union_type) == value
+
+
+class TestSetParameterValueRequestStructuring:
+    """Test that SetParameterValueRequest structures correctly with complex values."""
+
+    def test_structure_with_dict_value(self) -> None:
+        data = {
+            "node_name": "Load Image",
+            "parameter_name": "image",
+            "value": {"url": "http://example.com/image.jpg", "width": 100},
+        }
+        result = converter.structure(data, SetParameterValueRequest)
+
+        assert result.node_name == "Load Image"
+        assert result.parameter_name == "image"
+        assert result.value == {"url": "http://example.com/image.jpg", "width": 100}
+
+    def test_structure_with_list_value(self) -> None:
+        data = {
+            "node_name": "MyNode",
+            "parameter_name": "items",
+            "value": [1, 2, 3],
+        }
+        result = converter.structure(data, SetParameterValueRequest)
+
+        assert result.value == [1, 2, 3]
+
+    def test_structure_with_string_value(self) -> None:
+        data = {
+            "node_name": "MyNode",
+            "parameter_name": "name",
+            "value": "hello",
+        }
+        result = converter.structure(data, SetParameterValueRequest)
+
+        assert result.value == "hello"
+
+    def test_structure_with_none_value(self) -> None:
+        data = {
+            "node_name": "MyNode",
+            "parameter_name": "name",
+            "value": None,
+        }
+        result = converter.structure(data, SetParameterValueRequest)
+
+        assert result.value is None
+
+    def test_from_dict_with_image_artifact_value(self) -> None:
+        """Reproduce the exact payload that triggered the original bug."""
+        data = {
+            "event_type": "EventRequest",
+            "request_type": "SetParameterValueRequest",
+            "request_id": "bd1743f3-7508-429f-bad1-55cd47e9e181",
+            "response_topic": "sessions/abc123/response",
+            "request": {
+                "node_name": "Load Image",
+                "parameter_name": "image",
+                "value": {
+                    "value": "http://localhost:8124/workspace/inputs/IMG_0798.jpeg",
+                    "width": 3024,
+                    "height": 4032,
+                    "name": "IMG_0798.jpeg",
+                    "type": "ImageUrlArtifact",
+                    "meta": {
+                        "created_at": "2026-04-14T20:12:28.745Z",
+                        "content_hash": "",
+                        "size_bytes": 7996029,
+                        "format": "JPEG",
+                    },
+                },
+            },
+        }
+        event = EventRequest.from_dict(data)
+
+        assert isinstance(event.request, SetParameterValueRequest)
+        assert event.request.node_name == "Load Image"
+        assert event.request.parameter_name == "image"
+        assert isinstance(event.request.value, dict)
+        assert event.request.value["type"] == "ImageUrlArtifact"
+        expected_width = 3024
+        assert event.request.value["width"] == expected_width


### PR DESCRIPTION
The `SetParameterValueRequest.value` field is typed as `str | int | float | bool | dict | list | None`. The cattrs JSON converter handles simple `X | None` unions, but cannot disambiguate `dict | list` within a larger union. This causes "Unsupported type: typing.Union" errors when the editor sends complex values like `ImageUrlArtifact` dicts for parameters such as image inputs.

This was introduced in https://github.com/griptape-ai/griptape-nodes/pull/4353, which added `list` to the union. With both `dict` and `list` present, cattrs no longer knows which type to structure into.

The fix registers a structure hook in `event_converter.py` for Union types composed entirely of JSON-primitive types (`str`, `int`, `float`, `bool`, `dict`, `list`, `None`). Since the JSON parser already deserializes values to the correct Python types, the hook passes values through unchanged.