### PR TITLE
fix: add version bounds to uv_build build-system requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ griptape-nodes = "griptape_nodes:main"
 gtn = "griptape_nodes:main"
 
 [build-system]
-requires = ["uv_build"]
+requires = ["uv_build>=0.7.2,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.sources]


### PR DESCRIPTION
Closes #4363

The `uv_build` entry in `build-system.requires` had no version constraints, causing uv to warn about a missing upper bound. This pins it to `>=0.7.2,<0.12` to prevent future breaking releases from silently breaking the build while still allowing patch and minor updates within the current major version range.