### PR TITLE
fix: preserve windows drive letters in uri_to_path

### DIFF
--- a/src/griptape_nodes/utils/url_utils.py
+++ b/src/griptape_nodes/utils/url_utils.py
@@ -1,8 +1,8 @@
 import logging
 import mimetypes
 from pathlib import Path
-from urllib.parse import urlparse
-from urllib.request import url2pathname
+
+from griptape_nodes.files.path_utils import parse_file_uri
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -28,11 +28,18 @@ def get_content_type_from_extension(file_path: str | Path) -> str | None:
 
 
 def uri_to_path(uri: str) -> Path:
-    """Convert a file URI to a file system path."""
+    r"""Convert a file URI to a file system path.
+
+    Strings that are not file:// URIs are passed through as Path unchanged.
+    This preserves Windows paths like "Z:\foo\bar" which urlparse would
+    otherwise treat as a URI with scheme "z".
+    """
     # TODO: replace with Path.from_uri() when we upgrade to python >=3.13
     # https://docs.python.org/3/library/pathlib.html#pathlib.Path.from_uri
-    parsed = urlparse(uri)
-    return Path(url2pathname(parsed.path))
+    file_path = parse_file_uri(uri)
+    if file_path is not None:
+        return Path(file_path)
+    return Path(uri)
 
 
 def is_url_or_path(value: str) -> bool:

--- a/tests/unit/utils/test_url_utils.py
+++ b/tests/unit/utils/test_url_utils.py
@@ -243,3 +243,22 @@ class TestUriToPath:
         result = uri_to_path("file:///any/path")
         assert isinstance(result, Path)
         assert hasattr(result, "exists")  # Verify it's a Path with Path methods
+
+    def test_windows_drive_letter_path_preserved(self) -> None:
+        """Windows drive letters must not be treated as URI schemes."""
+        result = uri_to_path(r"Z:\Griptape\inputs\REX_MC_10_10_Image.jpg")
+        assert isinstance(result, Path)
+        # The drive letter "Z:" must be preserved, not parsed away as a URI scheme
+        assert str(result).startswith("Z:")
+
+    def test_plain_absolute_path_preserved(self) -> None:
+        """Plain absolute paths (no file:// scheme) must pass through unchanged."""
+        result = uri_to_path("/home/user/file.txt")
+        assert isinstance(result, Path)
+        assert result.as_posix() == "/home/user/file.txt"
+
+    def test_plain_relative_path_preserved(self) -> None:
+        """Plain relative paths must pass through unchanged."""
+        result = uri_to_path("relative/path/file.txt")
+        assert isinstance(result, Path)
+        assert result.as_posix() == "relative/path/file.txt"


### PR DESCRIPTION
`uri_to_path` previously routed every input through `urlparse`, which treats a Windows drive letter like `Z:` as a URI scheme and strips it away. A path such as `Z:\Griptape\inputs\REX_MC_10_10_Image.jpg` became `\Griptape\inputs\REX_MC_10_10_Image.jpg` before flowing into the preview pipeline, which then failed to locate the file and surfaced the nested "Failed to read source image" error reported by the user.

`uri_to_path` now delegates to `parse_file_uri`, which only strips the `file://` scheme for real file URIs. Anything else, including drive-letter paths, relative paths, and plain absolute paths, is passed through as a `Path` unchanged. Regression tests cover the `Z:\...` case along with plain absolute and relative paths.

Closes #4368