### PR TITLE
fix: run blocking video preview work off the event loop

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -100,6 +100,7 @@ from griptape_nodes.retained_mode.managers.artifact_providers.utils import (
     normalize_friendly_name_to_key,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
+from griptape_nodes.utils.async_utils import to_thread
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -396,7 +397,9 @@ class ArtifactManager:
                 return GeneratePreviewResultFailure(result_details=error_details)
 
             # Step 1: Create metadata object
-            _artifact_metadata = provider_class.get_artifact_metadata(source_path)
+            # Run in a thread because video providers shell out to ffprobe synchronously,
+            # which would otherwise block the event loop.
+            _artifact_metadata = await to_thread(provider_class.get_artifact_metadata, source_path)
             metadata = PreviewMetadata(
                 version=PreviewMetadata.LATEST_SCHEMA_VERSION,
                 source_macro_path=request.macro_path.parsed_macro.template,
@@ -580,7 +583,7 @@ class ArtifactManager:
                     generate_result = await self.on_handle_generate_preview_from_defaults_request(generate_request)
 
                     if isinstance(generate_result, GeneratePreviewFromDefaultsResultSuccess):
-                        _artifact_metadata = provider_class.get_artifact_metadata(str(source_path))
+                        _artifact_metadata = await to_thread(provider_class.get_artifact_metadata, str(source_path))
                         return GetPreviewForArtifactResultSuccess(
                             result_details=f"Preview generated for '{source_path}'",
                             paths_to_preview=generate_result.paths_to_preview,
@@ -734,7 +737,7 @@ class ArtifactManager:
             generate_result = await self.on_handle_generate_preview_from_defaults_request(generate_request)
 
             if isinstance(generate_result, GeneratePreviewFromDefaultsResultSuccess):
-                _artifact_metadata = provider_class.get_artifact_metadata(str(source_path))
+                _artifact_metadata = await to_thread(provider_class.get_artifact_metadata, str(source_path))
                 return GetPreviewForArtifactResultSuccess(
                     result_details=f"Preview regenerated for '{source_path}'",
                     paths_to_preview=generate_result.paths_to_preview,

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/video/preview_generators/ffmpeg_preview_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/video/preview_generators/ffmpeg_preview_generator.py
@@ -17,7 +17,7 @@ from griptape_nodes.retained_mode.managers.artifact_providers.base_generator_par
     BaseGeneratorParameters,
     Field,
 )
-from griptape_nodes.utils.async_utils import subprocess_run
+from griptape_nodes.utils.async_utils import subprocess_run, to_thread
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -106,8 +106,10 @@ class FFmpegPreviewGenerator(BaseArtifactPreviewGenerator):
             OSError: If preview generation fails
         """
         # FAILURE CASE: ffmpeg not available
+        # Run in a thread because the first call downloads and extracts the ffmpeg binary,
+        # which would otherwise block the event loop long enough to disconnect WebSocket clients.
         try:
-            ffmpeg_path, _ffprobe_path = static_ffmpeg_run.get_or_fetch_platform_executables_else_raise()
+            ffmpeg_path, _ffprobe_path = await to_thread(static_ffmpeg_run.get_or_fetch_platform_executables_else_raise)
         except Exception as e:
             msg = f"Attempted to get ffmpeg binary via static-ffmpeg. Failed because: {e}"
             raise FileNotFoundError(msg) from e


### PR DESCRIPTION
(Hopefully) Closes #4370

The video artifact preview pipeline was calling `static_ffmpeg.get_or_fetch_platform_executables_else_raise()` directly from async contexts, and invoking `VideoArtifactProvider.get_artifact_metadata` (which shells out to `ffprobe` with blocking `subprocess.run`) synchronously from async request handlers. On a user's first video upload, the one-time ffmpeg binary download and extract would stall the event loop for several seconds, causing the editor's WebSocket connection to be torn down with `ConnectionResetError [WinError 10054]`.

This wraps both sites with the existing `to_thread` helper so the work runs on a worker thread instead of blocking the loop:

- In `ffmpeg_preview_generator.py`, the `static_ffmpeg` fetch in `attempt_generate_preview` is now awaited via `to_thread`.
- In `artifact_manager.py`, all three `provider_class.get_artifact_metadata(...)` call sites now go through `to_thread`, which also covers the blocking `ffprobe` subprocess inside `VideoArtifactProvider._run_ffprobe` without needing to change the sync abstract interface on `BaseArtifactProvider`.