### PR TITLE
fix: demote node rename notice from warning to debug

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -533,8 +533,7 @@ class NodeManager:
 
         log_level = logging.DEBUG
         if remapped_requested_node_name:
-            log_level = logging.WARNING
-            details = f"{details}. WARNING: Had to rename from original node name requested '{request.node_name}' as an object with this name already existed."
+            details = f"{details}. Had to rename from original node name requested '{request.node_name}' as an object with this name already existed."
 
         # Special handling for paired classes (e.g., create a Start node and it automatically creates a corresponding End node already connected).
         if isinstance(node, BaseIterativeStartNode) and not request.initial_setup:


### PR DESCRIPTION
When `CreateNodeRequest` is sent with a node name that already exists, the manager remaps the name and emits a log message. Previously this was logged at `WARNING` with a `WARNING:` prefix baked into the message, which is noisy for what is a normal, automatic remap. This drops the level back to `DEBUG` (matching the other success path) and removes the inline `WARNING:` prefix so the message reads as an informational note.

```
[13:45:12] WARNING  Successfully created Node 'image_20(23)_1' in the Current Context (Flow 'ControlFlow_1'). WARNING: Had to rename from original node name
                    requested 'image_20(23)' as an object with this name already existed.
```