### PR TITLE
fix: return a non-error success when an image has no embedded workflow

### DIFF
--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -337,13 +337,17 @@ class ExtractFlowCommandsFromImageMetadataRequest(RequestPayload):
 class ExtractFlowCommandsFromImageMetadataResultSuccess(ResultPayloadSuccess):
     """Flow commands extracted successfully from image metadata.
 
+    An image without embedded flow commands is still a success: the image simply
+    carries no workflow payload, which is a valid state. In that case
+    serialized_flow_commands is None.
+
     Args:
-        serialized_flow_commands: The extracted and decoded SerializedFlowCommands object
+        serialized_flow_commands: The extracted and decoded SerializedFlowCommands object, or None if the image has no embedded flow commands
         flow_name: Name of the deserialized flow (only present if deserialize=True)
         node_name_mappings: Mapping from original to deserialized node names (only present if deserialize=True)
     """
 
-    serialized_flow_commands: SerializedFlowCommands
+    serialized_flow_commands: SerializedFlowCommands | None = None
     flow_name: str | None = None
     node_name_mappings: dict[str, str] = field(default_factory=dict)
 

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -3792,21 +3792,22 @@ class FlowManager:
                     file_path=file_url_or_path,
                 )
 
-        # Validation: Check if image has metadata
-        if not hasattr(pil_image, "info") or not pil_image.info:
-            return ExtractFlowCommandsFromImageMetadataResultFailure(
+        # An image without embedded flow commands is a valid state, not an error.
+        metadata = pil_image.info if hasattr(pil_image, "info") else {}
+        if not metadata:
+            return ExtractFlowCommandsFromImageMetadataResultSuccess(
                 result_details=f"Image has no metadata: {file_url_or_path}",
-                file_path=file_url_or_path,
+                serialized_flow_commands=None,
+                altered_workflow_state=False,
             )
 
-        metadata = pil_image.info
         metadata_keys = [str(key) for key in metadata]
 
-        # Validation: Check if flow commands metadata exists
         if FLOW_COMMANDS_KEY not in metadata:
-            return ExtractFlowCommandsFromImageMetadataResultFailure(
+            return ExtractFlowCommandsFromImageMetadataResultSuccess(
                 result_details=f"No flow commands metadata found in image. Available keys: {metadata_keys}",
-                file_path=file_url_or_path,
+                serialized_flow_commands=None,
+                altered_workflow_state=False,
             )
 
         encoded_flow_commands = metadata[FLOW_COMMANDS_KEY]

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -1,0 +1,108 @@
+"""Tests for FlowManager.on_extract_flow_commands_from_image_metadata."""
+
+import base64
+import pickle
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from PIL.PngImagePlugin import PngInfo
+
+from griptape_nodes.retained_mode.events.flow_events import (
+    ExtractFlowCommandsFromImageMetadataRequest,
+    ExtractFlowCommandsFromImageMetadataResultFailure,
+    ExtractFlowCommandsFromImageMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+@pytest.fixture
+def image_without_metadata() -> Generator[str, None, None]:
+    """A plain PNG with no embedded text chunks."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        Image.new("RGB", (4, 4), color="red").save(f, format="PNG")
+        path = f.name
+    try:
+        yield path
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.fixture
+def image_with_unrelated_metadata() -> Generator[str, None, None]:
+    """A PNG that has metadata but no gtn flow commands key."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        info = PngInfo()
+        info.add_text("Description", "not a workflow")
+        Image.new("RGB", (4, 4), color="green").save(f, format="PNG", pnginfo=info)
+        path = f.name
+    try:
+        yield path
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.fixture
+def image_with_flow_commands() -> Generator[str, None, None]:
+    """A PNG whose FLOW_COMMANDS_KEY payload is a valid pickle."""
+    payload = base64.b64encode(pickle.dumps({"sentinel": "flow"})).decode("ascii")
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        info = PngInfo()
+        info.add_text(FLOW_COMMANDS_KEY, payload)
+        Image.new("RGB", (4, 4), color="blue").save(f, format="PNG", pnginfo=info)
+        path = f.name
+    try:
+        yield path
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+class TestExtractFlowCommandsFromImageMetadata:
+    """Covers the non-error success paths for images that carry no workflow payload."""
+
+    def test_returns_success_with_none_when_image_has_no_metadata(
+        self, griptape_nodes: GriptapeNodes, image_without_metadata: str
+    ) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+        request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path=image_without_metadata)
+
+        result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
+
+        assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultSuccess)
+        assert result.serialized_flow_commands is None
+        assert result.altered_workflow_state is False
+
+    def test_returns_success_with_none_when_flow_commands_key_missing(
+        self, griptape_nodes: GriptapeNodes, image_with_unrelated_metadata: str
+    ) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+        request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path=image_with_unrelated_metadata)
+
+        result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
+
+        assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultSuccess)
+        assert result.serialized_flow_commands is None
+        assert result.altered_workflow_state is False
+
+    def test_returns_failure_when_file_missing(self, griptape_nodes: GriptapeNodes) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+        request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path="/does/not/exist.png")
+
+        result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
+
+        assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultFailure)
+
+    def test_returns_commands_when_flow_commands_key_present(
+        self, griptape_nodes: GriptapeNodes, image_with_flow_commands: str
+    ) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+        request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path=image_with_flow_commands)
+
+        result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
+
+        assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultSuccess)
+        assert result.serialized_flow_commands == {"sentinel": "flow"}
+        assert result.altered_workflow_state is False


### PR DESCRIPTION
The editor also uses `ExtractFlowCommandsFromImageMetadataRequest` as a probe when the user drops an image on the canvas, so ordinary PNGs that were never saved by Griptape Nodes hit this code path constantly. That was always returning `ExtractFlowCommandsFromImageMetadataResultFailure` with `Image has no metadata: ...` or `No flow commands metadata found in image. Available keys: [...]`, which surfaced as engine-side error logs for a case that is not actually an error.

This change makes `serialized_flow_commands` on `ExtractFlowCommandsFromImageMetadataResultSuccess` `Optional` and returns that success shape with `serialized_flow_commands=None` for both the no-metadata branch and the no-`gtn_flow_commands`-key branch in `FlowManager.on_extract_flow_commands_from_image_metadata`. Real I/O errors (missing file, failed download, base64/pickle decode failures, downstream deserialize failures) still return `ExtractFlowCommandsFromImageMetadataResultFailure`.

Added a new `tests/unit/retained_mode/managers/test_flow_manager.py` covering the no-metadata, no-`gtn_flow_commands`-key, missing-file, and populated-flow-commands paths.

Closes #4373