### PR TITLE
feat: add save_workflow_thumbnail situation

### DIFF
--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -34,6 +34,10 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             name="griptape-nodes-metadata",
             path_macro=".griptape-nodes-metadata",
         ),
+        "griptape-nodes-thumbnails": DirectoryDefinition(
+            name="griptape-nodes-thumbnails",
+            path_macro=".griptape-nodes-thumbnails",
+        ),
     },
     environment={},
     situations={
@@ -106,6 +110,16 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
                 create_dirs=True,
             ),
             fallback="save_file",
+        ),
+        "save_workflow_thumbnail": SituationTemplate(
+            name="save_workflow_thumbnail",
+            description="Save a workflow thumbnail image into the hidden workspace thumbnails directory",
+            macro="{griptape-nodes-thumbnails}/{file_name_base}.{file_extension}",
+            policy=SituationPolicy(
+                on_collision=SituationFilePolicy.OVERWRITE,
+                create_dirs=True,
+            ),
+            fallback="save_static_file",
         ),
     },
 )

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -63,11 +63,16 @@ class CreateStaticFileUploadUrlRequest(RequestPayload):
 
     Args:
         file_name: Name of the file to be uploaded
+        situation_name: Project template situation to use for resolving the upload
+            path. Defaults to ``copy_external_file``. Callers that write to a
+            workspace-internal location (e.g. workflow thumbnails) should pass the
+            matching situation name.
 
     Results: CreateStaticFileUploadUrlResultSuccess (with URL and headers) | CreateStaticFileUploadUrlResultFailure (URL creation error)
     """
 
     file_name: str
+    situation_name: str = "copy_external_file"
 
 
 @dataclass
@@ -110,11 +115,15 @@ class CreateStaticFileDownloadUrlRequest(RequestPayload):
 
     Args:
         file_name: Name of the file to be downloaded from the staticfiles directory
+        situation_name: Project template situation to use for resolving the download
+            path. Defaults to ``copy_external_file`` to match the symmetric upload
+            request.
 
     Results: CreateStaticFileDownloadUrlResultSuccess (with URL) | CreateStaticFileDownloadUrlResultFailure (URL creation error)
     """
 
     file_name: str
+    situation_name: str = "copy_external_file"
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -57,7 +57,6 @@ from griptape_nodes.utils.url_utils import uri_to_path
 logger = logging.getLogger("griptape_nodes")
 
 SAVE_STATIC_FILE_SITUATION = "save_static_file"
-COPY_EXTERNAL_FILE_SITUATION = "copy_external_file"
 
 USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config.json"
 
@@ -220,10 +219,11 @@ class StaticFilesManager:
             A result object indicating success or failure.
         """
         file_name = request.file_name
+        situation_name = request.situation_name
 
-        resolved = self._resolve_static_file_path(file_name, COPY_EXTERNAL_FILE_SITUATION)
+        resolved = self._resolve_static_file_path(file_name, situation_name)
         if resolved is None:
-            msg = f"Attempted to create upload URL for '{file_name}'. Failed because the project template is missing the '{COPY_EXTERNAL_FILE_SITUATION}' situation."
+            msg = f"Attempted to create upload URL for '{file_name}'. Failed because the project template is missing the '{situation_name}' situation."
             return CreateStaticFileUploadUrlResultFailure(error=msg, result_details=msg)
 
         try:
@@ -252,9 +252,10 @@ class StaticFilesManager:
         Returns:
             A result object indicating success or failure.
         """
-        resolved = self._resolve_static_file_path(request.file_name, COPY_EXTERNAL_FILE_SITUATION)
+        situation_name = request.situation_name
+        resolved = self._resolve_static_file_path(request.file_name, situation_name)
         if resolved is None:
-            msg = f"Attempted to create download URL for '{request.file_name}'. Failed because the project template is missing the '{COPY_EXTERNAL_FILE_SITUATION}' situation."
+            msg = f"Attempted to create download URL for '{request.file_name}'. Failed because the project template is missing the '{situation_name}' situation."
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
         try:


### PR DESCRIPTION
Workflow thumbnails were uploaded through the generic `copy_external_file` situation, which targets `{inputs}/...` — the same user-facing directory where copied external inputs land. That mixed a UI-generated internal artifact into a directory users treat as their own content. Thumbnails are conceptually closer to `.griptape-nodes-previews` / `.griptape-nodes-metadata` and belong in their own hidden location.

This introduces a dedicated `save_workflow_thumbnail` situation that writes into a new hidden `.griptape-nodes-thumbnails` workspace directory, and extends `CreateStaticFileUploadUrlRequest` / `CreateStaticFileDownloadUrlRequest` with an optional `situation_name` so callers can opt into it. The default remains `copy_external_file` so existing callers are unaffected; the UI passes the new situation for thumbnails in a companion change.

Closes #4375