### PR TITLE
fix: anchor URL-encoded filenames to workspace in resolve_file_path

### DIFF
--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -375,7 +375,13 @@ def resolve_file_path(path_str: str, base_dir: Path) -> Path:
         Resolved Path object
     """
     if path_needs_expansion(path_str):
-        return expand_path(path_str)
+        expanded = expand_path(path_str)
+        # Expansion can leave a path still relative when it doesn't match an env var
+        # (e.g. URL-encoded filenames like "foo%20bar.png" which contain '%' but are not
+        # Windows env var references). In that case we still need to anchor to base_dir.
+        if expanded.is_absolute():
+            return expanded
+        return resolve_path_safely(base_dir / expanded)
     return resolve_path_safely(base_dir / path_str)
 
 

--- a/tests/unit/files/test_path_utils.py
+++ b/tests/unit/files/test_path_utils.py
@@ -280,6 +280,41 @@ class TestResolveFilePath:
         assert result.is_absolute()
         assert str(result).startswith(str(tmp_path))
 
+    def test_anchors_url_encoded_filename_to_base_dir(self, tmp_path: Path) -> None:
+        """URL-encoded filenames trip path_needs_expansion via '%' but contain no env var.
+
+        So expand_path returns the original relative string. The result must still be
+        anchored to base_dir instead of being returned as a relative path.
+        """
+        filename = "As%20Fast%20As%20Can%20Be-thumbnail-2026-01-14.png"
+
+        result = resolve_file_path(filename, tmp_path)
+
+        assert result.is_absolute()
+        assert result == tmp_path / filename
+
+    def test_anchors_dollar_sign_filename_to_base_dir(self, tmp_path: Path) -> None:
+        """Filenames containing '$' with no matching env var must still be joined to base_dir."""
+        filename = "price$5.png"
+
+        result = resolve_file_path(filename, tmp_path)
+
+        assert result.is_absolute()
+        assert result == tmp_path / filename
+
+    def test_expands_env_var_path_outside_base_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A path whose env var expands to an absolute location must keep that absolute location.
+
+        It must NOT be re-anchored to base_dir.
+        """
+        target = tmp_path / "external"
+        target.mkdir()
+        monkeypatch.setenv("RESOLVE_FILE_PATH_TEST_DIR", str(target))
+
+        result = resolve_file_path("$RESOLVE_FILE_PATH_TEST_DIR/file.txt", Path("/unused/base"))
+
+        assert result == target / "file.txt"
+
 
 class TestParseFileUri:
     """Tests for parse_file_uri function."""


### PR DESCRIPTION
``path_needs_expansion`` flags any string containing ``%`` or ``$`` as an env-var reference, which is overly broad: URL-encoded filenames like ``As%20Fast%20As%20Can%20Be.png`` match too. In that branch ``resolve_file_path`` returned ``expand_path``'s result directly, without joining to ``base_dir``, so the returned path was still relative. Downstream, ``Path.resolve()`` then re-anchored against CWD (not the workspace), so the containment check in ``StaticFilesManager`` failed and the workspace-fallback warning fired on every such filename.

Keeps the existing fast path for true env-var / tilde / absolute inputs, but re-anchors to ``base_dir`` whenever expansion leaves the result relative.

Closes #4377