### PR TITLE
fix: demote noisy info logs to debug

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2007,7 +2007,7 @@ class LibraryManager:
         widgets_info: list[WidgetInfo] | None = None
         library_data = library.get_library_data()
         if library_data.widgets:
-            logger.info(
+            logger.debug(
                 "Library '%s' has %d widget(s), building widget info",
                 request.library,
                 len(library_data.widgets),

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1751,7 +1751,7 @@ class WorkflowManager:
         branched_from = save_target.branched_from
         registry_key = derive_registry_key(relative_file_path)
 
-        logger.info(
+        logger.debug(
             "Save workflow: scenario=%s, file_name=%s, file_path=%s, branched_from=%s",
             save_target.scenario.value,
             file_name,


### PR DESCRIPTION
A couple of per-operation info logs (the library widget-info build message and the save-workflow summary) fire on routine actions and clutter normal output without carrying information a user needs at info level. Demoting them to `debug` keeps them available for troubleshooting while quieting the default logs.