### PR TITLE
refactor: route workflow saves through a save_workflow situation

### DIFF
--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -38,13 +38,6 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             name="griptape-nodes-thumbnails",
             path_macro=".griptape-nodes-thumbnails",
         ),
-        # Points at the workspace root today for backward compatibility.
-        # Migrating to a dedicated subdirectory is tracked in
-        # https://github.com/griptape-ai/griptape-nodes/issues/2047.
-        "workflows": DirectoryDefinition(
-            name="workflows",
-            path_macro="{workspace_dir}",
-        ),
     },
     environment={},
     situations={
@@ -118,10 +111,13 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             ),
             fallback="save_file",
         ),
+        # Workflows save into the workspace root today for backward compatibility.
+        # Migrating to a dedicated subdirectory is tracked in
+        # https://github.com/griptape-ai/griptape-nodes/issues/2047.
         "save_workflow": SituationTemplate(
             name="save_workflow",
             description="Save a workflow Python file, preserving any sub-directory hierarchy",
-            macro="{workflows}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,

--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -38,6 +38,10 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             name="griptape-nodes-thumbnails",
             path_macro=".griptape-nodes-thumbnails",
         ),
+        "workflows": DirectoryDefinition(
+            name="workflows",
+            path_macro="workflows",
+        ),
     },
     environment={},
     situations={
@@ -105,6 +109,16 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             name="save_griptape_nodes_metadata",
             description="Save sidecar metadata file with preserved directory hierarchy",
             macro="{griptape-nodes-metadata}/{source_relative_path?:/}{source_file_name}.json",
+            policy=SituationPolicy(
+                on_collision=SituationFilePolicy.OVERWRITE,
+                create_dirs=True,
+            ),
+            fallback="save_file",
+        ),
+        "save_workflow": SituationTemplate(
+            name="save_workflow",
+            description="Save a workflow Python file into the workspace workflows directory, preserving any sub-directory hierarchy",
+            macro="{workflows}/{sub_dirs?:/}{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,

--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -38,9 +38,12 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             name="griptape-nodes-thumbnails",
             path_macro=".griptape-nodes-thumbnails",
         ),
+        # Points at the workspace root today for backward compatibility.
+        # Migrating to a dedicated subdirectory is tracked in
+        # https://github.com/griptape-ai/griptape-nodes/issues/2047.
         "workflows": DirectoryDefinition(
             name="workflows",
-            path_macro="workflows",
+            path_macro="{workspace_dir}",
         ),
     },
     environment={},
@@ -117,7 +120,7 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
         ),
         "save_workflow": SituationTemplate(
             name="save_workflow",
-            description="Save a workflow Python file into the workspace workflows directory, preserving any sub-directory hierarchy",
+            description="Save a workflow Python file, preserving any sub-directory hierarchy",
             macro="{workflows}/{sub_dirs?:/}{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1700,10 +1700,17 @@ class WorkflowManager:
         relative_file_path = str(Path(sub_dirs) / file_name) if sub_dirs else file_name
         try:
             resolved = Path(destination.resolve())
-        except FileLoadError:
+        except FileLoadError as err:
             workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            fallback_path = workspace_path.joinpath(relative_file_path)
+            logger.debug(
+                "save_workflow situation unavailable for '%s' (%s); falling back to workspace path %s",
+                file_name,
+                err,
+                fallback_path,
+            )
             return WorkflowManager.WorkflowSavePath(
-                file_path=workspace_path.joinpath(relative_file_path),
+                file_path=fallback_path,
                 relative_file_path=relative_file_path,
             )
 
@@ -1711,6 +1718,10 @@ class WorkflowManager:
         try:
             workspace_relative = resolved.relative_to(workspace_path)
         except ValueError:
+            # TODO: store the macro form (e.g. "{workflows}/foo.py") in the
+            # registry so out-of-workspace save locations stay portable across
+            # machines. Tracked in
+            # https://github.com/griptape-ai/griptape-nodes/issues/2047.
             return WorkflowManager.WorkflowSavePath(file_path=resolved, relative_file_path=str(resolved))
 
         return WorkflowManager.WorkflowSavePath(file_path=resolved, relative_file_path=str(workspace_relative))
@@ -1997,6 +2008,10 @@ class WorkflowManager:
             current_dir = Path(current_workflow.file_path).parent
             # If current_dir is absolute, the workflow lives outside the workspace;
             # save the copy to the workspace root so the registry key stays relative.
+            # Path(".").parent evaluates to Path(".") (a bare filename with no
+            # parent), which would pass "." through as a sub_dirs value and
+            # produce a spurious "./" prefix in the save path. Treat it as
+            # "no sub-directory" to keep the resolved path flat.
             if current_dir.is_absolute() or str(current_dir) == ".":
                 sub_dirs = None
             else:

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1682,7 +1682,7 @@ class WorkflowManager:
         file_path: Path
         relative_file_path: str
 
-    def _build_workflow_save_path(self, relative_file_path: str) -> WorkflowSavePath:
+    def _build_workflow_save_path(self, file_name: str, sub_dirs: str | None = None) -> WorkflowSavePath:
         """Resolve a workflow save path via the ``save_workflow`` situation.
 
         Returns the absolute save path plus a registry-relative form. When the
@@ -1692,13 +1692,12 @@ class WorkflowManager:
         resolve (e.g., no project loaded), we fall through to the plain
         workspace path.
         """
-        relative_path = Path(relative_file_path)
-        parent_str = str(relative_path.parent)
         extra_vars: dict[str, str | int] = {}
-        if parent_str not in (".", ""):
-            extra_vars["sub_dirs"] = parent_str
+        if sub_dirs:
+            extra_vars["sub_dirs"] = sub_dirs
 
-        destination = ProjectFileDestination.from_situation(relative_path.name, "save_workflow", **extra_vars)
+        destination = ProjectFileDestination.from_situation(file_name, "save_workflow", **extra_vars)
+        relative_file_path = str(Path(sub_dirs) / file_name) if sub_dirs else file_name
         try:
             resolved = Path(destination.resolve())
         except FileLoadError:
@@ -1998,11 +1997,11 @@ class WorkflowManager:
             current_dir = Path(current_workflow.file_path).parent
             # If current_dir is absolute, the workflow lives outside the workspace;
             # save the copy to the workspace root so the registry key stays relative.
-            if current_dir.is_absolute():
-                requested_relative = f"{file_name}.py"
+            if current_dir.is_absolute() or str(current_dir) == ".":
+                sub_dirs = None
             else:
-                requested_relative = str(current_dir / f"{file_name}.py")
-            file_path, relative_file_path = self._build_workflow_save_path(requested_relative)
+                sub_dirs = str(current_dir)
+            file_path, relative_file_path = self._build_workflow_save_path(f"{file_name}.py", sub_dirs=sub_dirs)
 
         else:
             # No requested name or no current workflow → first save

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1718,7 +1718,7 @@ class WorkflowManager:
         try:
             workspace_relative = resolved.relative_to(workspace_path)
         except ValueError:
-            # TODO: store the macro form (e.g. "{workflows}/foo.py") in the
+            # TODO: store the macro form (e.g. "{workspace_dir}/foo.py") in the
             # registry so out-of-workspace save locations stay portable across
             # machines. Tracked in
             # https://github.com/griptape-ai/griptape-nodes/issues/2047.

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -27,7 +27,9 @@ from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode, EndNode, StartNode
+from griptape_nodes.files.file import FileLoadError
 from griptape_nodes.files.path_utils import derive_registry_key, resolve_workspace_path
+from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.node_library.workflow_registry import (
     Workflow,
     WorkflowMetadata,
@@ -1674,6 +1676,46 @@ class WorkflowManager:
         success: bool
         error_details: str
 
+    class WorkflowSavePath(NamedTuple):
+        """Absolute save path and its registry-relative form."""
+
+        file_path: Path
+        relative_file_path: str
+
+    def _build_workflow_save_path(self, relative_file_path: str) -> WorkflowSavePath:
+        """Resolve a workflow save path via the ``save_workflow`` situation.
+
+        Returns the absolute save path plus a registry-relative form. When the
+        resolved path lives inside the workspace the relative form stays
+        workspace-relative; otherwise it falls back to the absolute path string
+        so registry lookups land at the same location. If the situation cannot
+        resolve (e.g., no project loaded), we fall through to the plain
+        workspace path.
+        """
+        relative_path = Path(relative_file_path)
+        parent_str = str(relative_path.parent)
+        extra_vars: dict[str, str | int] = {}
+        if parent_str not in (".", ""):
+            extra_vars["sub_dirs"] = parent_str
+
+        destination = ProjectFileDestination.from_situation(relative_path.name, "save_workflow", **extra_vars)
+        try:
+            resolved = Path(destination.resolve())
+        except FileLoadError:
+            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            return WorkflowManager.WorkflowSavePath(
+                file_path=workspace_path.joinpath(relative_file_path),
+                relative_file_path=relative_file_path,
+            )
+
+        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        try:
+            workspace_relative = resolved.relative_to(workspace_path)
+        except ValueError:
+            return WorkflowManager.WorkflowSavePath(file_path=resolved, relative_file_path=str(resolved))
+
+        return WorkflowManager.WorkflowSavePath(file_path=resolved, relative_file_path=str(workspace_relative))
+
     def _write_workflow_file(self, file_path: Path, content: str, file_name: str) -> WriteWorkflowFileResult:
         """Write workflow content to file with proper validation and error handling.
 
@@ -1935,8 +1977,7 @@ class WorkflowManager:
             file_name = self._generate_unique_filename(base_name)
             creation_date = datetime.now(tz=UTC)
             branched_from = None
-            relative_file_path = f"{file_name}.py"
-            file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_file_path)
+            file_path, relative_file_path = self._build_workflow_save_path(f"{file_name}.py")
 
         elif target_workflow:
             # Requested name exists in registry → overwrite it
@@ -1958,10 +1999,10 @@ class WorkflowManager:
             # If current_dir is absolute, the workflow lives outside the workspace;
             # save the copy to the workspace root so the registry key stays relative.
             if current_dir.is_absolute():
-                relative_file_path = f"{file_name}.py"
+                requested_relative = f"{file_name}.py"
             else:
-                relative_file_path = str(current_dir / f"{file_name}.py")
-            file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_file_path)
+                requested_relative = str(current_dir / f"{file_name}.py")
+            file_path, relative_file_path = self._build_workflow_save_path(requested_relative)
 
         else:
             # No requested name or no current workflow → first save
@@ -1969,8 +2010,7 @@ class WorkflowManager:
             file_name = requested_file_name or datetime.now(tz=UTC).strftime("%d.%m_%H.%M")
             creation_date = datetime.now(tz=UTC)
             branched_from = None
-            relative_file_path = f"{file_name}.py"
-            file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_file_path)
+            file_path, relative_file_path = self._build_workflow_save_path(f"{file_name}.py")
 
         # Ensure creation date is valid (backcompat)
         if (creation_date is None) or (creation_date == WorkflowManager.EPOCH_START):
@@ -1994,9 +2034,8 @@ class WorkflowManager:
             # Use provided file path
             file_path = Path(request.file_path)
         else:
-            # Default to workspace path
-            relative_file_path = f"{request.file_name}.py"
-            file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(relative_file_path)
+            # Resolve via the save_workflow situation (workspace-relative by default).
+            file_path = self._build_workflow_save_path(f"{request.file_name}.py").file_path
 
         # Use provided creation date or default to current time
         creation_date = request.creation_date

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -789,3 +789,82 @@ class TestWorkflowManager:
 
         assert isinstance(result, ListAllWorkflowInfoResultSuccess)
         assert result.workflow_infos == {}
+
+    # --- _build_workflow_save_path ---
+
+    def test_build_workflow_save_path_resolves_via_situation(self, griptape_nodes: GriptapeNodes) -> None:
+        """Resolved paths inside the workspace yield a workspace-relative registry key."""
+        workflow_manager = griptape_nodes.WorkflowManager()
+        workspace = griptape_nodes.ConfigManager().workspace_path
+        resolved_path = workspace / "my_workflow.py"
+
+        fake_destination = MagicMock()
+        fake_destination.resolve.return_value = str(resolved_path)
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.workflow_manager.ProjectFileDestination.from_situation",
+            return_value=fake_destination,
+        ) as mock_from_situation:
+            save_path = workflow_manager._build_workflow_save_path("my_workflow.py")
+
+        mock_from_situation.assert_called_once_with("my_workflow.py", "save_workflow")
+        assert save_path.file_path == resolved_path
+        assert save_path.relative_file_path == "my_workflow.py"
+
+    def test_build_workflow_save_path_preserves_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
+        """sub_dirs are passed to the situation and reflected in the resolved workspace-relative key."""
+        workflow_manager = griptape_nodes.WorkflowManager()
+        workspace = griptape_nodes.ConfigManager().workspace_path
+        resolved_path = workspace / "team" / "my_workflow.py"
+
+        fake_destination = MagicMock()
+        fake_destination.resolve.return_value = str(resolved_path)
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.workflow_manager.ProjectFileDestination.from_situation",
+            return_value=fake_destination,
+        ) as mock_from_situation:
+            save_path = workflow_manager._build_workflow_save_path("my_workflow.py", sub_dirs="team")
+
+        mock_from_situation.assert_called_once_with("my_workflow.py", "save_workflow", sub_dirs="team")
+        assert save_path.file_path == resolved_path
+        assert save_path.relative_file_path == str(Path("team") / "my_workflow.py")
+
+    def test_build_workflow_save_path_uses_absolute_when_outside_workspace(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """Paths outside the workspace fall back to the absolute path as the registry key."""
+        workflow_manager = griptape_nodes.WorkflowManager()
+        outside_path = tmp_path / "elsewhere" / "my_workflow.py"
+
+        fake_destination = MagicMock()
+        fake_destination.resolve.return_value = str(outside_path)
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.workflow_manager.ProjectFileDestination.from_situation",
+            return_value=fake_destination,
+        ):
+            save_path = workflow_manager._build_workflow_save_path("my_workflow.py")
+
+        assert save_path.file_path == outside_path
+        assert save_path.relative_file_path == str(outside_path)
+
+    def test_build_workflow_save_path_falls_back_on_file_load_error(self, griptape_nodes: GriptapeNodes) -> None:
+        """If the situation cannot resolve, we fall back to joining against the workspace path."""
+        from griptape_nodes.files.file import FileLoadError
+        from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        workspace = griptape_nodes.ConfigManager().workspace_path
+
+        fake_destination = MagicMock()
+        fake_destination.resolve.side_effect = FileLoadError(FileIOFailureReason.UNKNOWN, "no project loaded")
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.workflow_manager.ProjectFileDestination.from_situation",
+            return_value=fake_destination,
+        ):
+            save_path = workflow_manager._build_workflow_save_path("my_workflow.py", sub_dirs="team")
+
+        assert save_path.file_path == workspace / "team" / "my_workflow.py"
+        assert save_path.relative_file_path == str(Path("team") / "my_workflow.py")


### PR DESCRIPTION
Workflow save paths were computed with hard-coded `workspace_path.joinpath(...)` logic inside `WorkflowManager`, which meant every node that saves files routed through the project template's situation system except this one. Users could not redirect workflow files to a different location per project without forking the manager, and the path logic drifted from the pattern the artifact manager uses for previews.

This change introduces a `workflows` directory (`workflows`) and a `save_workflow` situation (`{workflows}/{sub_dirs?:/}{file_name_base}.{file_extension}`, `overwrite`, fallback `save_file`) in the default project template.

One behavior shift worth flagging for reviewers: new workflows saved through this path land in `{workspace}/workflows/…` and therefore get registry keys prefixed with `workflows/`. Previously-registered workflows at the workspace root keep their existing keys because the `OVERWRITE_EXISTING` branch still uses `target_workflow.file_path` directly.

Closes #4057
Closes #4354
Closes #4355