### PR TITLE
feat: add ProjectTemplate.to_yaml for full-dump serialization

### DIFF
--- a/src/griptape_nodes/common/project_templates/project.py
+++ b/src/griptape_nodes/common/project_templates/project.py
@@ -69,13 +69,31 @@ class ProjectTemplate(BaseModel):
         }
         output.update(diff)
 
+        return self._dump_yaml(output)
+
+    def to_yaml(self) -> str:
+        """Export the complete, fully-resolved project template as YAML.
+
+        Unlike to_overlay_yaml(), this emits every field without requiring a
+        base template to merge against. Intended for standalone consumers
+        (e.g., Griptape Cloud bundles) that receive the project on its own
+        and have no DEFAULT_PROJECT_TEMPLATE to layer an overlay on top of.
+        """
+        return self._dump_yaml(self.model_dump(mode="json", exclude_none=True))
+
+    @staticmethod
+    def _dump_yaml(data: dict) -> str:
+        """Serialize project-template data to YAML using shared conventions.
+
+        Loader injects `name` into nested objects from their dict keys, so
+        nested `name` keys are filtered out to avoid duplication on round-trip.
+        """
         yaml = YAML()
         yaml.default_flow_style = False
         yaml.width = 4096
         # Double-quote all strings; bools and ints are left untagged: https://yaml.org/spec/1.2.2/
         yaml.representer.add_representer(str, lambda r, d: r.represent_scalar("tag:yaml.org,2002:str", d, style='"'))
 
-        # loader injects name from the YAML dict key — exclude it from all nested objects
         nested_skip = frozenset({"name"})
 
         def filter_keys(d: dict, skip_keys: frozenset) -> dict:
@@ -83,7 +101,7 @@ class ProjectTemplate(BaseModel):
                 k: (filter_keys(v, skip_keys) if isinstance(v, dict) else v) for k, v in d.items() if k not in skip_keys
             }
 
-        filtered = {k: (filter_keys(v, nested_skip) if isinstance(v, dict) else v) for k, v in output.items()}
+        filtered = {k: (filter_keys(v, nested_skip) if isinstance(v, dict) else v) for k, v in data.items()}
 
         stream = io.StringIO()
         yaml.dump(filtered, stream)

--- a/tests/unit/common/test_project_templates_merge.py
+++ b/tests/unit/common/test_project_templates_merge.py
@@ -8,6 +8,7 @@ from griptape_nodes.common.project_templates import (
     ProjectValidationInfo,
     ProjectValidationStatus,
     load_partial_project_template,
+    load_project_template_from_yaml,
 )
 
 # Use system defaults directly (no longer loading from YAML)
@@ -721,3 +722,59 @@ situations:
         # Check validation error for incomplete policy
         assert validation.status == ProjectValidationStatus.UNUSABLE
         assert any("policy" in p.field_path and "both" in p.message.lower() for p in validation.problems)
+
+
+class TestProjectTemplateToYaml:
+    """Tests for ProjectTemplate.to_yaml()."""
+
+    def test_to_yaml_contains_required_top_level_fields(self) -> None:
+        yaml_str = DEFAULT_PROJECT_TEMPLATE.to_yaml()
+
+        # The dumper quotes all string scalars, including keys.
+        assert '"project_template_schema_version":' in yaml_str
+        assert '"name":' in yaml_str
+        assert '"situations":' in yaml_str
+        assert '"directories":' in yaml_str
+
+    def test_to_yaml_excludes_none_description(self) -> None:
+        template = ProjectTemplate(
+            project_template_schema_version=ProjectTemplate.LATEST_SCHEMA_VERSION,
+            name="x",
+            situations={},
+            directories={},
+            description=None,
+        )
+
+        assert "description" not in template.to_yaml()
+
+    def test_to_yaml_strips_nested_name_keys(self) -> None:
+        # Loader injects `name` into nested situations/directories from their dict keys,
+        # so emitting `name:` inside those nested objects would duplicate on round-trip.
+        yaml_str = DEFAULT_PROJECT_TEMPLATE.to_yaml()
+
+        # Only the top-level `name:` (with no indentation) should appear.
+        indented_name_lines = [
+            line for line in yaml_str.splitlines() if line.lstrip().startswith("name:") and line != line.lstrip()
+        ]
+        assert indented_name_lines == []
+
+    def test_to_yaml_round_trip(self) -> None:
+        yaml_str = DEFAULT_PROJECT_TEMPLATE.to_yaml()
+
+        validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+        loaded = load_project_template_from_yaml(yaml_str, validation)
+
+        assert loaded is not None
+        assert validation.status == ProjectValidationStatus.GOOD
+        assert loaded.name == DEFAULT_PROJECT_TEMPLATE.name
+        assert loaded.project_template_schema_version == DEFAULT_PROJECT_TEMPLATE.project_template_schema_version
+        assert set(loaded.situations.keys()) == set(DEFAULT_PROJECT_TEMPLATE.situations.keys())
+        assert set(loaded.directories.keys()) == set(DEFAULT_PROJECT_TEMPLATE.directories.keys())
+
+    def test_to_yaml_larger_than_overlay_against_self(self) -> None:
+        # Overlay against self contains only the two required fields; the full
+        # dump always contains every section, so must be strictly longer.
+        overlay = DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE)
+        full = DEFAULT_PROJECT_TEMPLATE.to_yaml()
+
+        assert len(full) > len(overlay)


### PR DESCRIPTION
Closes #4392.

`ProjectTemplate` only supported overlay serialization via `to_overlay_yaml(base)`, which is fine for local `project.yml` persistence (the loader merges against `DEFAULT_PROJECT_TEMPLATE` at read time) but insufficient for standalone consumers. The Griptape Cloud workflow publisher bundles `project.yml` for a Cloud Structure runtime that has no matching base to merge against, so it needs the fully resolved template. It was calling `template.to_yaml()`, which no longer exists, and crashing mid-publish.

Added `to_yaml()` back on `ProjectTemplate`, emitting a complete dump with `model_dump(exclude_none=True)`. The YAML formatter boilerplate (representer, width, nested-`name` key filtering) now lives in a shared `_dump_yaml` helper used by both `to_yaml` and `to_overlay_yaml`, so output conventions stay identical. Keeping the name `to_yaml` preserves the external callsite's interface so the publisher doesn't need a coordinated rename.