### PR TITLE
Adding ability to tag individual nodes and libraries with properties.

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from pydantic import BaseModel, Field, field_validator
@@ -74,6 +75,24 @@ class ResourceRequirements(BaseModel):
         return converted
 
 
+class PreproductionStatus(StrEnum):
+    """Pre-production maturity. Absence from properties means production."""
+
+    ALPHA = "alpha"
+    BETA = "beta"
+
+
+class LibraryCanonicalKey(StrEnum):
+    """Canonical keys recognized in LibraryMetadata.properties.
+
+    Values are the literal strings used in library JSON. Any key not listed here
+    is permitted in the dict but carries no validation.
+    """
+
+    PREPRODUCTION_STATUS = "preproduction_status"
+    REQUIRES_ENTITLEMENTS = "requires_entitlements"
+
+
 class LibraryMetadata(BaseModel):
     """Metadata that explains details about the library, including versioning and search details."""
 
@@ -87,6 +106,8 @@ class LibraryMetadata(BaseModel):
     is_griptape_nodes_searchable: bool = True
     # Resource requirements for this library. If None, library is assumed to work on any platform.
     resources: ResourceRequirements | None = None
+    # Extensible bag of canonical + ad-hoc metadata. Canonical keys are defined in LibraryCanonicalKey.
+    properties: dict[str, Any] | None = None
 
 
 class IconVariant(BaseModel):
@@ -103,6 +124,17 @@ class NodeDeprecationMetadata(BaseModel):
     removal_version: str | None = None
 
 
+class NodeCanonicalKey(StrEnum):
+    """Canonical keys recognized in NodeMetadata.properties.
+
+    Values are the literal strings used in library JSON. Any key not listed here
+    is permitted in the dict but carries no validation.
+    """
+
+    PREPRODUCTION_STATUS = "preproduction_status"
+    RUNS_ARBITRARY_CODE = "runs_arbitrary_code"
+
+
 class NodeMetadata(BaseModel):
     """Metadata about each node within the library, which informs where in the hierarchy it sits, details on usage, and tags to assist search."""
 
@@ -115,6 +147,8 @@ class NodeMetadata(BaseModel):
     group: str | None = None
     deprecation: NodeDeprecationMetadata | None = None
     is_node_group: bool | None = None
+    # Extensible bag of canonical + ad-hoc metadata. Canonical keys are defined in NodeCanonicalKey.
+    properties: dict[str, Any] | None = None
 
 
 class CategoryDefinition(BaseModel):
@@ -166,7 +200,7 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.6.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.7.0"
 
     name: str
     library_schema_version: str


### PR DESCRIPTION
# Library Properties and Permissions

Status: experimental. Lives on `feat/properties-entitlements`.

This document summarizes the properties-and-permissions system introduced in this
branch: what authors declare in `griptape_nodes_library.json`, what code on the node
side looks like, and how the engine validates and evaluates those declarations.

______________________________________________________________________

## Why this exists

Before this change, libraries and nodes had no structured way to declare:

- **Capabilities** — "this node executes arbitrary Python," "this node calls a
    proxy model," "this node uses GPT-4."
- **Compliance facts** — terms-of-service URLs, production/BETA status,
    customer-key vs. Griptape-key requirements.
- **Access requirements** — which permissions a caller must have in order to use
    the library or any of its nodes.

As a result, studios couldn't gate individual nodes, admins couldn't write
per-capability policies, and node authors had no idiomatic way to surface
information that customers need before installing a library.

The system on this branch closes those gaps with:

1. A typed `properties` list on `LibraryMetadata` and `NodeMetadata`, serialized
    into `griptape_nodes_library.json`.
1. A library-owned **permission catalog** (the library names the permissions its
    nodes need; the engine ships a small set of built-ins).
1. A library-owned **model-entitlement catalog** — each third-party model is
    declared once, with its provider/family/T&C URL and the permission required to
    use it; nodes reference entitlements by short name.
1. A `PermissionsManager` that answers three event-bus questions:
    - `EvaluatePermissionRequest` — is this permission granted for this node?
    - `ListModelEntitlementsRequest` — which of this node's declared model
        entitlements is the caller permitted to use?
    - `EvaluateNodePermissionsRequest` — report grant/deny outcomes for every
        permission this node declared. Lets nodes iterate their own permission
        surface instead of hard-coding names that already live in the library
        JSON, which keeps node code from drifting out of sync with declarations.

______________________________________________________________________

## `griptape_nodes_library.json` — what changes

Schema version bumps to `0.8.0`. Older libraries (`0.6.0`, `0.4.0`) continue to
load unchanged because `properties` defaults to `[]` at both the library and
node level.

### Library-level metadata — before

```jsonc
{
  "name": "Griptape Nodes Library",
  "library_schema_version": "0.6.0",
  "metadata": {
    "author": "Griptape, Inc",
    "description": "Default nodes for Griptape Nodes",
    "library_version": "0.72.0",
    "engine_version": "0.79.0",
    "tags": ["Griptape", "AI"],
    "dependencies": { ... }
  },
  "nodes": [ ... ]
}
```

### Library-level metadata — after

```jsonc
{
  "name": "Griptape Nodes Library",
  "library_schema_version": "0.8.0",
  "metadata": {
    "author": "Griptape, Inc",
    "description": "Default nodes for Griptape Nodes",
    "library_version": "0.72.0",
    "engine_version": "0.79.0",
    "tags": ["Griptape", "AI"],
    "dependencies": { ... },

    "properties": [
      { "type": "production_status", "status": "PRODUCTION" },

      {
        "type": "permission_catalog",
        "permissions": {
          "use_anthropic": {
            "description": "Call Anthropic prompt models.",
            "policies": [
              "permit(principal in Group::\"paying_customers\", action == Action::\"use_model\", resource == Entitlement::\"use_anthropic\");",
              "forbid(principal, action == Action::\"use_model\", resource == Entitlement::\"use_anthropic\") unless { principal.has_anthropic_contract };"
            ]
          },
          "use_openai": {
            "description": "Call OpenAI prompt models.",
            "policies": [
              "permit(principal in Group::\"paying_customers\", action == Action::\"use_model\", resource == Entitlement::\"use_openai\");"
            ]
          },
          "use_kling": {
            "description": "Generate video via Kling models.",
            "policies": [
              "permit(principal in Group::\"trusted_users\", action == Action::\"use_model\", resource == Entitlement::\"use_kling\");"
            ]
          }
        }
      },

      {
        "type": "model_catalog",
        "entitlements": {
          "anthropic_claude_opus": {
            "display_name": "Claude Opus 4",
            "provider": "Anthropic",
            "family": "Claude 4",
            "model": "claude-opus-4",
            "terms_url": "https://www.anthropic.com/legal/commercial-terms",
            "requires_permission": "use_anthropic"
          },
          "openai_gpt4o_mini": {
            "display_name": "GPT-4o mini",
            "provider": "OpenAI",
            "family": "GPT-4",
            "model": "gpt-4o-mini",
            "terms_url": "https://openai.com/policies/terms-of-use",
            "requires_permission": "use_openai"
          },
          "kling_v2": {
            "display_name": "Kling v2",
            "provider": "Kling",
            "family": "Kling v2",
            "terms_url": "https://app.klingai.com/global/about/terms",
            "requires_permission": "use_kling"
          }
        }
      }
    ]
  },
  "nodes": [ ... ]
}
```

A few things worth noting:

- **`production_status`** communicates lifecycle state. `PRODUCTION`, `BETA`,
    `ALPHA`, and `EXPERIMENTAL` are the enum values. Absence of this property on a
    library is intentionally distinguishable from `PRODUCTION` — consumers surface
    it as "author did not declare a production status."

- **`permission_catalog`** declares the library's own permission vocabulary.
    Engine built-ins (`run_arbitrary_python`, `access_engine`, `use_proxy_model`)
    are always available; libraries cannot shadow them.

- **`model_catalog`** declares model entitlements once. A node that uses Kling
    v2 references it by short name (`"kling_v2"`) — no more duplicating provider,
    family, or terms URL across every node.

- **Cross-library collision policy**: permission names are bare. If library A and
    library B both declare `use_kling`, admin policies apply uniformly to both.
    Libraries that want isolation self-prefix (e.g., `mylib_use_kling`).

______________________________________________________________________

## Per-node metadata — examples

### A pure utility node (no changes)

```jsonc
{
  "class_name": "AddToList",
  "file_path": "griptape_nodes_library/lists/add_to_list.py",
  "metadata": {
    "category": "lists",
    "description": "Adds an item to an existing list.",
    "display_name": "Add To List",
    "group": "edit"
  }
}
```

No `properties` key needed. The node inherits the library's `PRODUCTION` status,
advertises no capabilities, and has no permission gates.

### ExecutePython — capability marker

```jsonc
{
  "class_name": "ExecutePython",
  "file_path": "griptape_nodes_library/engine/execute_python.py",
  "metadata": {
    "category": "engine",
    "description": "Execute Python code with input variables and capture output",
    "display_name": "Execute Python",
    "icon": "Code",

    "properties": [
      { "type": "execute_arbitrary_code" }
    ]
  }
}
```

The `execute_arbitrary_code` marker maps automatically (via the engine's built-in
`marker_mapping`) to the built-in `run_arbitrary_python` permission. The author
didn't have to write any permission reference; the marker says what the node
does, and the mapping makes the gate real.

### AnthropicPrompt — single-provider node

```jsonc
{
  "class_name": "AnthropicPrompt",
  "file_path": "griptape_nodes_library/config/prompt/anthropic_prompt.py",
  "metadata": {
    "category": "agents/prompt_models",
    "description": "Prompt Models available from Anthropic",
    "display_name": "Anthropic Prompt",
    "icon": {
      "dark": "logos/anthropic.svg",
      "light": "logos/anthropic_dark.svg"
    },

    "properties": [
      { "type": "model_usage", "name": "anthropic_claude_opus" },
      { "type": "key_support", "support": "REQUIRES_CUSTOMER_KEY" }
    ]
  }
}
```

The node references a library-level entitlement by name — everything about the
model (display label, provider, family, terms URL, required permission) lives in
one place. `key_support` communicates that this node needs a customer-supplied
API key.

### GenerateImage — multi-provider dropdown

```jsonc
{
  "class_name": "GenerateImage",
  "file_path": "griptape_nodes_library/image/generate_image.py",
  "metadata": {
    "category": "image",
    "description": "Generate an image with a chosen provider.",
    "display_name": "Generate Image",

    "properties": [
      { "type": "model_usage", "name": "kling_v2" },
      { "type": "model_usage", "name": "openai_gpt4o_mini" }
    ]
  }
}
```

At runtime the node's dropdown options are filtered to the entitlements the
caller is permitted to use (see node code below). If the current user doesn't
have `use_kling`, the Kling option never appears.

### KlingVideoExtension — BETA override + bespoke gate

```jsonc
{
  "class_name": "KlingVideoExtension",
  "file_path": "griptape_nodes_library/video/kling_video_extension.py",
  "metadata": {
    "category": "video",
    "description": "Extend a Kling video by 4-5 seconds.",
    "display_name": "Kling Video Extension",

    "properties": [
      { "type": "production_status", "status": "BETA" },
      { "type": "model_usage", "name": "kling_v2" },
      { "type": "required_permissions", "names": ["use_kling"] },
      { "type": "key_support", "support": "REQUIRES_GRIPTAPE_KEY" }
    ]
  }
}
```

`required_permissions` is the whole-node gate (this one happens to mirror the
Kling entitlement's `requires_permission` — authors can reference the same name
for whole-node culling and per-option filtering).

______________________________________________________________________

## Node code — what changes

All runtime queries go through `GriptapeNodes.handle_request(...)`. The node
never holds a reference to the `PermissionsManager`.

### Simple gate: "do I have permission X for this node?"

```python
from griptape_nodes.retained_mode.events.permission_events import (
    EvaluatePermissionGranted,
    EvaluatePermissionDenied,
    EvaluatePermissionResultFailure,
)


class ExecutePython(BaseNode):
    def process(self) -> None:
        result = self.check_permission("run_arbitrary_python")

        match result:
            case EvaluatePermissionGranted():
                self._run_user_code()

            case EvaluatePermissionDenied():
                reasons = "; ".join(r.message for r in result.denial_reasons)
                raise PermissionError(f"Cannot execute: {reasons}")

            case EvaluatePermissionResultFailure():
                # Unknown library or node-type from the manager's POV --
                # the library was deregistered or metadata drifted.
                raise RuntimeError(f"Permission evaluation failed: {result.result_details}")
```

`BaseNode.check_permission(name)` dispatches an `EvaluatePermissionRequest` under
the hood. It returns one of three typed results:

| Result                            | Meaning                                                                                                                                          |
| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
| `EvaluatePermissionGranted`       | Permission is granted.                                                                                                                           |
| `EvaluatePermissionDenied`        | Evaluation completed and denied. `denial_reasons` lists every reason (unknown permission, scope violation, policy denied).                       |
| `EvaluatePermissionResultFailure` | Evaluation could not complete (unknown library or node type). Caller supplied a subject the engine can't resolve; distinct from a policy denial. |

### Filtered dropdown: "which entitlements am I permitted to use?"

```python
from griptape_nodes.node_library.workflow_registry import LibraryNameAndNodeType
from griptape_nodes.retained_mode.events.permission_events import (
    ListModelEntitlementsRequest,
    ListModelEntitlementsResultSuccess,
)
from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes


class GenerateImage(BaseNode):
    def __init__(self, name: str, metadata: dict) -> None:
        super().__init__(name=name, metadata=metadata)
        self.model_param = Parameter(
            name="model",
            options=self._permitted_model_labels(),
        )

    def _permitted_model_labels(self) -> list[str]:
        subject = LibraryNameAndNodeType(
            library_name=self.metadata["library"],
            node_type=self.metadata["node_type"],
        )
        result = GriptapeNodes.handle_request(ListModelEntitlementsRequest(subject=subject))
        if not isinstance(result, ListModelEntitlementsResultSuccess):
            return []  # unknown library/node — UI will show an empty dropdown
        return [e.display_name for e in result.entitlements]
```

One round-trip gets the filtered list. The node never walks the library registry
itself; the manager does. This matters because the `PermissionsManager` is the
intended integration point for a real entitlements engine — when that engine
ships, nothing in node code changes.

### Node self-introspection: "which of my declared permissions are fulfilled?"

The first two patterns still require the node to repeat permission name strings
that already live in the library JSON. `BaseNode.evaluate_node_permissions()`
closes that gap: the node asks the manager to evaluate every permission it
declared (across `RequiredPermissionsNodeProperty`, marker-mapped permissions,
and `ModelEntitlement.requires_permission`) and gets back grant/deny outcomes
in declaration order.

```python
from griptape_nodes.retained_mode.events.permission_events import (
    EvaluateNodePermissionsResultSuccess,
    EvaluateNodePermissionsResultFailure,
)


class GenerateImage(BaseNode):
    def process(self) -> None:
        result = self.evaluate_node_permissions()

        match result:
            case EvaluateNodePermissionsResultSuccess():
                # Outcomes are in the order the library declared them.
                for outcome in result.granted:
                    logger.info("✓ %s", outcome.name)
                for outcome in result.denied:
                    reasons = ", ".join(r.message for r in outcome.reasons)
                    logger.warning("✗ %s (%s)", outcome.name, reasons)

            case EvaluateNodePermissionsResultFailure():
                raise RuntimeError(f"Could not evaluate permissions: {result.result_details}")
```

Each outcome is a `PermissionOutcome(name, reasons)`. Granted outcomes carry an
empty `reasons` list; denied outcomes carry every `DenialReason` that applied,
so callers can echo specific rejections back to the user. `granted` and `denied`
are lists, not sets, because preserving declaration order makes error messages
match the library JSON a user is reading.

______________________________________________________________________

## Declaration checks that happen at library load

When a library loads, the engine runs
`validate_library_declarations(library_data)` to resolve every cross-reference.
Two categories of problem emerge:

**Fatal (blocks library load):**

| Problem type                             | Triggered when                                                                                                                 |
| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| `BuiltinPermissionShadowedProblem`       | Library declares a permission name that's reserved as a built-in (`run_arbitrary_python`, `access_engine`, `use_proxy_model`). |
| `UndeclaredPermissionReferenceProblem`   | A `requires_permission` or `RequiredPermissions*.names` entry references a name that's not in the effective catalog.           |
| `UnrecognizedMarkerDiscriminatorProblem` | `marker_mapping` key isn't a recognized marker discriminator.                                                                  |
| `UndeclaredModelUsageReferenceProblem`   | `ModelUsageNodeProperty.name` doesn't resolve to an entry in `ModelCatalogLibraryProperty.entitlements`.                       |

**Warning (library loads but surfaces as FLAWED):**

| Problem type                           | Triggered when                                                                                                          |
| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
| `UnreferencedCatalogPermissionProblem` | Library declares a permission that nothing in the library references. Surfaced so authors notice stale catalog entries. |

Warnings flow through the same `LibraryInfo.problems` list that carries
deprecation warnings, version-compat issues, and every other library-load signal,
so there's one consistent surface for UI and diagnostics.

______________________________________________________________________

## Cedar policies: how permissions decide grants

Each entry in a library's `permission_catalog.permissions` carries a `policies`
list. Every entry in that list is a single Cedar policy statement, written as
source text (the same text you'd put in a `.cedar` file). This is how the
library tells the engine _under what circumstances_ a permission is granted.

A realistic example:

```jsonc
"use_anthropic": {
  "description": "Call Anthropic prompt models.",
  "policies": [
    "permit(principal in Group::\"paying_customers\", action == Action::\"use_model\", resource == Entitlement::\"use_anthropic\");",
    "forbid(principal, action == Action::\"use_model\", resource == Entitlement::\"use_anthropic\") unless { principal.has_anthropic_contract };"
  ]
}
```

Two statements here:

1. A `permit` statement granting the permission to any principal that's a
    member of the `paying_customers` group for the `use_model` action against
    the `use_anthropic` entitlement.
1. A `forbid` statement that overrides the permit unless the principal has an
    `has_anthropic_contract` attribute set.

**What the engine does with these today:** stores and round-trips them. The
evaluator that would actually parse and apply the Cedar statements is the same
stub that grants every permission unconditionally.

**What the engine will do later:** parse and evaluate them via a real Cedar
engine (likely the `cedar-policy` Rust binding). At that point:

- `_is_allowed(name)` on the permissions manager becomes a real evaluation
    against the principal's attributes and the catalog's policies.
- Cedar syntax errors at library-load time become a new
    `InvalidCedarPolicyProblem` that prevents library registration, surfaced
    through the same library-problem pipeline as every other load-time issue.

For authors writing libraries today: **include the policies you intend for your
permissions to enforce**. They'll be dead weight under the current stub, but
every library that ships with correct Cedar source is one less library that has
to be updated when real evaluation arrives. Authors who don't know what
policies they want can leave `policies` as an empty list (the default); the
library still loads and the permission still exists as a named declaration.

______________________________________________________________________

## Engine-provided built-ins

Libraries don't need to declare these — they're always available:

**Permissions:**

| Name                   | Description                                  |
| ---------------------- | -------------------------------------------- |
| `run_arbitrary_python` | Execute arbitrary Python code inside a node. |
| `access_engine`        | Use direct engine access (EngineNode).       |
| `use_proxy_model`      | Call a Griptape-hosted model proxy endpoint. |

**Marker mappings** (when a node carries the marker, the engine treats it as if
it declared the mapped permission):

| Marker (node property `type`) | Maps to permission     |
| ----------------------------- | ---------------------- |
| `execute_arbitrary_code`      | `run_arbitrary_python` |
| `engine_control`              | `access_engine`        |
| `proxy_model`                 | `use_proxy_model`      |

A library can override these mappings in its own `marker_mapping` if it wants to
route a marker to a library-specific permission name.

______________________________________________________________________

## Files of interest

- [src/griptape_nodes/node_library/library_properties.py](../../src/griptape_nodes/node_library/library_properties.py)
    — every property and helper type.
- [src/griptape_nodes/node_library/permission_builtins.py](../../src/griptape_nodes/node_library/permission_builtins.py)
    — built-in permission names and marker-mapping defaults.
- [src/griptape_nodes/node_library/library_validation.py](../../src/griptape_nodes/node_library/library_validation.py)
    — load-time cross-reference validation.
- [src/griptape_nodes/retained_mode/events/permission_events.py](../../src/griptape_nodes/retained_mode/events/permission_events.py)
    — `EvaluatePermissionRequest`, `ListModelEntitlementsRequest`,
    `EvaluateNodePermissionsRequest`, and their result types.
- [src/griptape_nodes/retained_mode/managers/permissions_manager.py](../../src/griptape_nodes/retained_mode/managers/permissions_manager.py)
    — request handlers + declaration resolution.
- [src/griptape_nodes/exe_types/node_types.py](../../src/griptape_nodes/exe_types/node_types.py)
    — `BaseNode.check_permission(name)` and `BaseNode.evaluate_node_permissions()`
    convenience wrappers.

______________________________________________________________________

## Current limitations

- **`_is_allowed` is a stub** that grants everything. The real entitlement
    evaluator — which will parse and apply Cedar policies on each permission
    declaration — replaces its body. The rest of the system is ready for it.
- **Cedar policy strings are stored but not validated** at library load. They
    round-trip through JSON correctly but the engine doesn't check them for
    syntactic validity. Cedar-parse validation at library load is planned and
    slots into `library_validation.py` alongside the existing cross-reference
    checks; syntactically invalid policies would surface as a new
    `InvalidCedarPolicyProblem` that blocks library registration, consistent
    with how other fatal library-load problems surface today.
- **Built-in permissions carry empty policy lists**. Their Cedar policies will
    be specified alongside the real Cedar evaluator — they're engine-authored
    and intentionally not configurable by libraries.
- **Admin policy authoring UI doesn't exist yet** — admins would need to
    hand-edit configuration. Rendering comes later.
- **The permissions manager is in-process** today. When it moves behind a
    closed-source boundary, the contract stays the same: a request carries
    `(library_name, node_type, permission_name)`, the manager resolves everything
    else from `LibraryRegistry`.
