### PR TITLE
fix: canonicalize project paths and expand workspace_directory

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -27,7 +27,7 @@ from griptape_nodes.common.project_templates import (
     load_partial_project_template,
 )
 from griptape_nodes.files.file import File, FileLoadError, FileWriteError
-from griptape_nodes.files.path_utils import resolve_file_path
+from griptape_nodes.files.path_utils import expand_path, resolve_file_path
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.library_events import (
@@ -244,12 +244,13 @@ class ProjectManager:
         5. If usable, cache template in successful_templates
         6. Return LoadProjectTemplateResultSuccess or LoadProjectTemplateResultFailure
         """
-        # Resolve to absolute so the same file always produces the same project_id
-        # regardless of how the caller spelled the path (relative vs absolute,
-        # symlinks, etc.). Both _registered_template_status (keyed by Path) and
+        # Expand ~/env vars and resolve to absolute so the same file always
+        # produces the same project_id regardless of how the caller spelled
+        # the path (relative vs absolute, ~/ prefix, symlinks, etc.). Both
+        # _registered_template_status (keyed by Path) and
         # _successfully_loaded_project_templates (keyed by str project_id) must
-        # use the resolved form so dedupe checks line up.
-        project_file_path = Path(request.project_path).resolve()
+        # use the canonical form so dedupe checks line up.
+        project_file_path = expand_path(str(request.project_path)).resolve()
 
         read_request = ReadFileRequest(
             file_path=str(project_file_path),
@@ -1366,10 +1367,11 @@ class ProjectManager:
         """
         registered_paths: list[str] = self._config_manager.get_config_value(PROJECTS_TO_REGISTER_KEY, default=[]) or []
         for path_str in registered_paths:
-            # Project IDs are absolute paths, so resolve the persisted string
-            # before checking for an existing load (prevents duplicate entries
-            # when the same file was persisted under different spellings).
-            resolved_id = str(Path(path_str).resolve())
+            # Project IDs are canonicalized absolute paths, so expand ~/env
+            # vars and resolve the persisted string before checking for an
+            # existing load (prevents duplicate entries when the same file
+            # was persisted under different spellings).
+            resolved_id = str(expand_path(path_str).resolve())
             if resolved_id in self._successfully_loaded_project_templates:
                 continue
             load_request = LoadProjectTemplateRequest(project_path=Path(path_str))
@@ -1391,9 +1393,10 @@ class ProjectManager:
         """
         try:
             registered: list[str] = self._config_manager.get_config_value(PROJECTS_TO_REGISTER_KEY, default=[]) or []
-            # Compare by resolved path so a previously persisted relative spelling
-            # of the same file isn't re-persisted as a duplicate.
-            resolved_existing = {str(Path(p).resolve()) for p in registered}
+            # Compare by canonicalized path (~/env expansion + resolution) so a
+            # previously persisted relative or ~/ spelling of the same file
+            # isn't re-persisted as a duplicate.
+            resolved_existing = {str(expand_path(p).resolve()) for p in registered}
             if project_id not in resolved_existing:
                 self._config_manager.set_config_value(PROJECTS_TO_REGISTER_KEY, [*registered, project_id])
         except Exception:

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1268,9 +1268,6 @@ class ProjectManager:
                 project_path,
             )
 
-        # Use ConfigManager.workspace_path rather than the raw config string so
-        # that ~/ and relative paths are expanded/resolved consistently with the
-        # rest of the app (otherwise a "~/..." config value silently misses here).
         workspace_dir = self._config_manager.workspace_path
         workspace_project_path = workspace_dir / WORKSPACE_PROJECT_FILE
         if not workspace_project_path.exists():

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -244,8 +244,15 @@ class ProjectManager:
         5. If usable, cache template in successful_templates
         6. Return LoadProjectTemplateResultSuccess or LoadProjectTemplateResultFailure
         """
+        # Resolve to absolute so the same file always produces the same project_id
+        # regardless of how the caller spelled the path (relative vs absolute,
+        # symlinks, etc.). Both _registered_template_status (keyed by Path) and
+        # _successfully_loaded_project_templates (keyed by str project_id) must
+        # use the resolved form so dedupe checks line up.
+        project_file_path = Path(request.project_path).resolve()
+
         read_request = ReadFileRequest(
-            file_path=str(request.project_path),
+            file_path=str(project_file_path),
             encoding="utf-8",
             workspace_only=False,
         )
@@ -253,46 +260,44 @@ class ProjectManager:
 
         if read_result.failed():
             validation = ProjectValidationInfo(status=ProjectValidationStatus.MISSING)
-            self._registered_template_status[request.project_path] = validation
+            self._registered_template_status[project_file_path] = validation
 
             return LoadProjectTemplateResultFailure(
                 validation=validation,
-                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because file not found",
+                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because file not found",
             )
 
         if not isinstance(read_result, ReadFileResultSuccess):
             validation = ProjectValidationInfo(status=ProjectValidationStatus.UNUSABLE)
-            self._registered_template_status[request.project_path] = validation
+            self._registered_template_status[project_file_path] = validation
 
             return LoadProjectTemplateResultFailure(
                 validation=validation,
-                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because file read returned unexpected result type",
+                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because file read returned unexpected result type",
             )
 
         yaml_text = read_result.content
         if not isinstance(yaml_text, str):
             validation = ProjectValidationInfo(status=ProjectValidationStatus.UNUSABLE)
-            self._registered_template_status[request.project_path] = validation
+            self._registered_template_status[project_file_path] = validation
 
             return LoadProjectTemplateResultFailure(
                 validation=validation,
-                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because template must be text, got binary content",
+                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because template must be text, got binary content",
             )
 
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
         overlay = load_partial_project_template(yaml_text, validation)
 
         if overlay is None:
-            self._registered_template_status[request.project_path] = validation
+            self._registered_template_status[project_file_path] = validation
             return LoadProjectTemplateResultFailure(
                 validation=validation,
-                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because YAML could not be parsed",
+                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because YAML could not be parsed",
             )
 
         template = ProjectTemplate.merge(DEFAULT_PROJECT_TEMPLATE, overlay, validation)
 
-        # Generate project_id from file path
-        project_file_path = Path(request.project_path)
         project_id = str(project_file_path)
         project_base_dir = project_file_path.parent
 
@@ -302,10 +307,10 @@ class ProjectManager:
 
         # Now check if validation is usable after collecting all errors
         if not validation.is_usable():
-            self._registered_template_status[request.project_path] = validation
+            self._registered_template_status[project_file_path] = validation
             return LoadProjectTemplateResultFailure(
                 validation=validation,
-                result_details=f"Attempted to load project template from '{request.project_path}'. Failed because template is not usable (status: {validation.status})",
+                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because template is not usable (status: {validation.status})",
             )
 
         # Create consolidated ProjectInfo with fully populated macro caches
@@ -323,7 +328,7 @@ class ProjectManager:
         self._successfully_loaded_project_templates[project_id] = project_info
 
         # Track validation status for all load attempts (for UI display)
-        self._registered_template_status[request.project_path] = validation
+        self._registered_template_status[project_file_path] = validation
 
         # Persist path so the project survives engine restarts
         self._register_project_path(project_id)
@@ -1263,12 +1268,11 @@ class ProjectManager:
                 project_path,
             )
 
-        workspace_dir_value = self._config_manager.get_config_value("workspace_directory")
-        if workspace_dir_value is None:
-            logger.debug("Skipping workspace project load: 'workspace_directory' config value is None")
-            return None
-
-        workspace_project_path = Path(workspace_dir_value) / WORKSPACE_PROJECT_FILE
+        # Use ConfigManager.workspace_path rather than the raw config string so
+        # that ~/ and relative paths are expanded/resolved consistently with the
+        # rest of the app (otherwise a "~/..." config value silently misses here).
+        workspace_dir = self._config_manager.workspace_path
+        workspace_project_path = workspace_dir / WORKSPACE_PROJECT_FILE
         if not workspace_project_path.exists():
             logger.debug("No workspace project file found at '%s'", workspace_project_path)
             return None
@@ -1286,6 +1290,7 @@ class ProjectManager:
         if workspace_project_path is None:
             return
 
+        workspace_project_path = workspace_project_path.resolve()
         logger.info("Found workspace project file at '%s', loading", workspace_project_path)
 
         try:
@@ -1364,7 +1369,11 @@ class ProjectManager:
         """
         registered_paths: list[str] = self._config_manager.get_config_value(PROJECTS_TO_REGISTER_KEY, default=[]) or []
         for path_str in registered_paths:
-            if path_str in self._successfully_loaded_project_templates:
+            # Project IDs are absolute paths, so resolve the persisted string
+            # before checking for an existing load (prevents duplicate entries
+            # when the same file was persisted under different spellings).
+            resolved_id = str(Path(path_str).resolve())
+            if resolved_id in self._successfully_loaded_project_templates:
                 continue
             load_request = LoadProjectTemplateRequest(project_path=Path(path_str))
             result = self.on_load_project_template_request(load_request)
@@ -1385,7 +1394,10 @@ class ProjectManager:
         """
         try:
             registered: list[str] = self._config_manager.get_config_value(PROJECTS_TO_REGISTER_KEY, default=[]) or []
-            if project_id not in registered:
+            # Compare by resolved path so a previously persisted relative spelling
+            # of the same file isn't re-persisted as a duplicate.
+            resolved_existing = {str(Path(p).resolve()) for p in registered}
+            if project_id not in resolved_existing:
                 self._config_manager.set_config_value(PROJECTS_TO_REGISTER_KEY, [*registered, project_id])
         except Exception:
             logger.warning("Failed to persist project path '%s' to config", project_id)

--- a/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
+++ b/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
@@ -526,7 +526,11 @@ class TestSidecarMetadata:
     def temp_dir(self) -> Generator[Path, None, None]:
         """Create a temporary directory for testing."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            yield Path(tmpdir)
+            # Resolve so the path matches what ConfigManager.workspace_path and
+            # the canonicalized project_base_dir store. On Windows, tempfile
+            # returns the 8.3 short form (C:\Users\RUNNER~1\...); both sides
+            # must agree for decompose_source_path's relative_to() check to hold.
+            yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
     def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -2304,6 +2304,42 @@ situations:
         assert absolute_path in pm._registered_template_status
         assert Path("missing.yml") not in pm._registered_template_status
 
+    def test_tilde_and_absolute_spellings_share_project_id(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loading the same file via `~/...` and its absolute path produces one entry."""
+        from griptape_nodes.retained_mode.events.os_events import ReadFileResultSuccess
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+        )
+
+        # Point HOME/USERPROFILE at tmp_path so "~/project.yml" expands to tmp_path / project.yml
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        absolute_path = (tmp_path / "project.yml").resolve()
+        tilde_path = Path("~/project.yml")
+
+        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.handle_request.return_value = ReadFileResultSuccess(
+                content=self.VALID_PROJECT_YAML,
+                file_size=len(self.VALID_PROJECT_YAML),
+                mime_type="text/plain",
+                encoding="utf-8",
+                result_details="ok",
+            )
+
+            absolute_result = pm.on_load_project_template_request(
+                LoadProjectTemplateRequest(project_path=absolute_path)
+            )
+            tilde_result = pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=tilde_path))
+
+        assert isinstance(absolute_result, LoadProjectTemplateResultSuccess)
+        assert isinstance(tilde_result, LoadProjectTemplateResultSuccess)
+        assert absolute_result.project_id == tilde_result.project_id
+        assert absolute_result.project_id == str(absolute_path)
+        assert list(pm._successfully_loaded_project_templates.keys()).count(str(absolute_path)) == 1
+
 
 class TestRegisterProjectPathCanonicalization:
     """Test that _register_project_path dedupes across path spellings."""

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -2219,3 +2219,164 @@ situations:
             await pm.on_app_initialization_complete(AppInitializationComplete())
 
         assert str(registered_path) in pm._successfully_loaded_project_templates
+
+
+class TestLoadProjectTemplatePathCanonicalization:
+    """Test that on_load_project_template_request canonicalizes project paths.
+
+    Project IDs and validation-map keys must be keyed off the resolved absolute
+    path so the same file loaded via different spellings (relative vs absolute,
+    with or without trailing components, etc.) collapses to a single entry.
+    """
+
+    VALID_PROJECT_YAML = """\
+project_template_schema_version: "0.1.0"
+name: Canonicalization Test
+situations:
+  save_node_output:
+    macro: "{outputs}/{file_name_base}.{file_extension}"
+    policy:
+      on_collision: create_new
+      create_dirs: true
+"""
+
+    @pytest.fixture
+    def pm(self) -> ProjectManager:
+        mock_event_manager = Mock()
+        mock_config_manager = Mock()
+        mock_config_manager.project_config = {}
+        mock_config_manager.env_config = {}
+        mock_config_manager.merged_config = {}
+        mock_config_manager.get_config_value.return_value = []
+        return ProjectManager(mock_event_manager, mock_config_manager, Mock())
+
+    def test_relative_and_absolute_spellings_share_project_id(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """Loading the same file via a relative and an absolute path produces one entry."""
+        from griptape_nodes.retained_mode.events.os_events import ReadFileResultSuccess
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+        )
+
+        absolute_path = (tmp_path / "project.yml").resolve()
+
+        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.handle_request.return_value = ReadFileResultSuccess(
+                content=self.VALID_PROJECT_YAML,
+                file_size=len(self.VALID_PROJECT_YAML),
+                mime_type="text/plain",
+                encoding="utf-8",
+                result_details="ok",
+            )
+
+            cwd = Path.cwd()
+            try:
+                os.chdir(tmp_path)
+                relative_path = Path("project.yml")
+                absolute_result = pm.on_load_project_template_request(
+                    LoadProjectTemplateRequest(project_path=absolute_path)
+                )
+                relative_result = pm.on_load_project_template_request(
+                    LoadProjectTemplateRequest(project_path=relative_path)
+                )
+            finally:
+                os.chdir(cwd)
+
+        assert isinstance(absolute_result, LoadProjectTemplateResultSuccess)
+        assert isinstance(relative_result, LoadProjectTemplateResultSuccess)
+        assert absolute_result.project_id == relative_result.project_id
+        assert absolute_result.project_id == str(absolute_path)
+        assert list(pm._successfully_loaded_project_templates.keys()).count(str(absolute_path)) == 1
+
+    def test_registered_template_status_keyed_by_resolved_path(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """Validation status is stored under the resolved path, not the raw input."""
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateRequest
+
+        absolute_path = (tmp_path / "missing.yml").resolve()
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+            pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=Path("missing.yml")))
+        finally:
+            os.chdir(cwd)
+
+        assert absolute_path in pm._registered_template_status
+        assert Path("missing.yml") not in pm._registered_template_status
+
+
+class TestRegisterProjectPathCanonicalization:
+    """Test that _register_project_path dedupes across path spellings."""
+
+    @pytest.fixture
+    def pm(self) -> ProjectManager:
+        mock_event_manager = Mock()
+        mock_config_manager = Mock()
+        mock_config_manager.project_config = {}
+        mock_config_manager.env_config = {}
+        mock_config_manager.merged_config = {}
+        mock_config_manager.get_config_value.return_value = []
+        return ProjectManager(mock_event_manager, mock_config_manager, Mock())
+
+    def test_already_registered_under_different_spelling_is_not_reappended(
+        self, pm: ProjectManager, tmp_path: Path
+    ) -> None:
+        """If the same file is already persisted under a different spelling, skip it."""
+        absolute_path = (tmp_path / "project.yml").resolve()
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+            relative_spelling = str(Path("project.yml").resolve())
+            cast("Mock", pm._config_manager).get_config_value.return_value = [relative_spelling]
+            pm._register_project_path(str(absolute_path))
+        finally:
+            os.chdir(cwd)
+
+        cast("Mock", pm._config_manager).set_config_value.assert_not_called()
+
+
+class TestLoadRegisteredProjectsCanonicalization:
+    """Test that _load_registered_projects treats differently-spelled persisted paths as duplicates."""
+
+    @pytest.fixture
+    def pm(self) -> ProjectManager:
+        mock_event_manager = Mock()
+        mock_config_manager = Mock()
+        mock_config_manager.project_config = {}
+        mock_config_manager.env_config = {}
+        mock_config_manager.merged_config = {}
+        mock_config_manager.get_config_value.return_value = []
+        return ProjectManager(mock_event_manager, mock_config_manager, Mock())
+
+    def test_persisted_unresolved_path_matches_loaded_resolved_entry(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A persisted path is matched against _successfully_loaded_project_templates after resolution."""
+        from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+        resolved_path = (tmp_path / "existing.yml").resolve()
+        validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+        situation_schemas = pm._parse_situation_macros(DEFAULT_PROJECT_TEMPLATE.situations, validation)
+        directory_schemas = pm._parse_directory_macros(DEFAULT_PROJECT_TEMPLATE.directories, validation)
+        project_info = ProjectInfo(
+            project_id=str(resolved_path),
+            project_file_path=resolved_path,
+            project_base_dir=tmp_path,
+            template=DEFAULT_PROJECT_TEMPLATE,
+            validation=validation,
+            parsed_situation_schemas=situation_schemas,
+            parsed_directory_schemas=directory_schemas,
+        )
+        pm._successfully_loaded_project_templates[str(resolved_path)] = project_info
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+            cast("Mock", pm._config_manager).get_config_value.return_value = ["existing.yml"]
+            with patch.object(pm, "on_load_project_template_request") as mock_load:
+                pm._load_registered_projects()
+        finally:
+            os.chdir(cwd)
+
+        mock_load.assert_not_called()

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1376,6 +1376,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         await pm._load_workspace_project()
 
@@ -1399,6 +1400,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1428,6 +1430,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1468,6 +1471,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1499,6 +1503,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1510,13 +1515,15 @@ situations:
         assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
 
     @pytest.mark.asyncio
-    async def test_load_workspace_project_none_workspace_dir_skips(self, pm: ProjectManager) -> None:
-        """None workspace_directory config value skips loading without error."""
+    async def test_load_workspace_project_missing_workspace_dir_skips(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """Workspace directory without a project file skips loading without error."""
         from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
         self._setup_system_defaults(pm)
 
         cast("Mock", pm._config_manager).get_config_value.return_value = None
+        # Point workspace_path at an empty directory so the existence check fails.
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             await pm._load_workspace_project()
@@ -1544,6 +1551,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1570,6 +1578,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         await pm.on_app_initialization_complete(AppInitializationComplete())
 
@@ -1593,6 +1602,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1624,6 +1634,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -1657,6 +1668,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
             mock_file_instance = Mock()
@@ -2193,6 +2205,7 @@ situations:
             return str(tmp_path)
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
             mock_gn.handle_request.return_value = ReadFileResultSuccess(


### PR DESCRIPTION
Closes #4403.

`ProjectManager` was keying its per-template validation map, its loaded-templates dict, and its persisted `projects_to_register` list off whatever spelling of the project path the caller happened to supply. The same file loaded via a relative CLI arg and later via its absolute workspace-discovery path ended up as two separate entries, and the persisted registration list could accumulate duplicate spellings of the same file across engine restarts.

<img width="1062" height="857" alt="image" src="https://github.com/user-attachments/assets/3b439206-7185-4fa8-b84a-7a0d128dc644" />
