### PR TITLE
refactor: add canonicalize_for_identity and canonicalize_for_io path helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,16 @@ Instance methods come first because they can call anything. Class methods come n
 
 **Include context in error messages** - Use the format: "Attempted to do X. Failed with data Y because of Z." Include `{self.name}` when available. Include relevant parameter names and operation context.
 
+## Path Handling
+
+**Canonicalize at the boundary, not in the middle** - The OS boundary (`OSManager.on_write_file_request`, `LocalFileDriver._resolve_path`) already canonicalizes incoming paths. Do not wrap a path with `canonicalize_for_io` before passing it to `ReadFileRequest` / `WriteFileRequest` or to a `FileDriver` method, it is redundant.
+
+**Use `canonicalize_for_identity` for keys** - When a path is about to become a dict key, cache key, dedupe-set member, or workspace-containment input, call `canonicalize_for_identity(path)` from `griptape_nodes.files.path_utils`. It sanitizes + expands `~`/env vars + absolutizes + follows symlinks, so two spellings of the same file collide. Prefer it over ad-hoc `Path(x).resolve()`, which skips `expanduser` and causes identity drift.
+
+**Use `canonicalize_for_io` for OS-level I/O** - Reach for `canonicalize_for_io(path)` only when handing a path directly to the OS (inside a handler or driver, or calling `open()`/`os.*` yourself). It does the same work as the identity variant without following symlinks and adds the Windows long-path prefix when needed.
+
+**Prefer the named helpers over composing primitives** - `sanitize_path_string`, `expand_path`, `resolve_path_safely`, and `normalize_path_for_platform` are building blocks. If you find yourself chaining them, use one of the two canonicalize helpers instead so behavior stays consistent across call sites.
+
 ## Architecture
 
 **Singleton managers** - `GriptapeNodes` is a singleton holding 25+ managers (e.g., `FlowManager`, `NodeManager`), each accessed via `GriptapeNodes.ManagerName()` classmethods.

--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import NamedTuple, Protocol, cast, runtime_checkable
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
-from griptape_nodes.files.path_utils import canonicalize_for_io
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     FileIOFailureReason,
@@ -490,11 +489,8 @@ class File:
         Raises:
             FileLoadError: If the file cannot be read.
         """
-        resolved_path = _resolve_file_path(self._file_path)
-        canonical_path = str(canonicalize_for_io(resolved_path))
-
         request = ReadFileRequest(
-            file_path=canonical_path,
+            file_path=_resolve_file_path(self._file_path),
             encoding=encoding,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -523,11 +519,8 @@ class File:
         Raises:
             FileLoadError: If the file cannot be read.
         """
-        resolved_path = await _aresolve_file_path(self._file_path)
-        canonical_path = str(canonicalize_for_io(resolved_path))
-
         request = ReadFileRequest(
-            file_path=canonical_path,
+            file_path=await _aresolve_file_path(self._file_path),
             encoding=encoding,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -572,11 +565,8 @@ class File:
         Raises:
             FileWriteError: If the file cannot be written.
         """
-        resolved_path = _resolve_file_path(self._file_path)
-        canonical_path = str(canonicalize_for_io(resolved_path))
-
         request = WriteFileRequest(
-            file_path=canonical_path,
+            file_path=_resolve_file_path(self._file_path),
             content=content,
             encoding=encoding,
             existing_file_policy=existing_file_policy,
@@ -620,11 +610,8 @@ class File:
         Raises:
             FileWriteError: If the file cannot be written.
         """
-        resolved_path = await _aresolve_file_path(self._file_path)
-        canonical_path = str(canonicalize_for_io(resolved_path))
-
         request = WriteFileRequest(
-            file_path=canonical_path,
+            file_path=await _aresolve_file_path(self._file_path),
             content=content,
             encoding=encoding,
             existing_file_policy=existing_file_policy,

--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -89,21 +89,18 @@ _PATH_FAILURE_TO_FILE_IO: dict[PathResolutionFailureReason, FileIOFailureReason]
 }
 
 
-def _resolve_file_path(file_path: str | MacroPath | None) -> str | None:
+def _resolve_file_path(file_path: str | MacroPath) -> str:
     """Resolve a file path, handling MacroPath resolution if needed.
 
     Args:
-        file_path: A plain path string, a MacroPath, or None.
+        file_path: A plain path string or a MacroPath.
 
     Returns:
-        A resolved path string, or None if file_path is None.
+        A resolved path string.
 
     Raises:
         FileLoadError: If macro resolution fails.
     """
-    if file_path is None:
-        return None
-
     if isinstance(file_path, str):
         return file_path
 
@@ -123,23 +120,20 @@ def _resolve_file_path(file_path: str | MacroPath | None) -> str | None:
     return str(resolve_result.absolute_path)  # type: ignore[union-attr]
 
 
-async def _aresolve_file_path(file_path: str | MacroPath | None) -> str | None:
+async def _aresolve_file_path(file_path: str | MacroPath) -> str:
     """Async version of _resolve_file_path.
 
     Resolve a file path, handling MacroPath resolution if needed.
 
     Args:
-        file_path: A plain path string, a MacroPath, or None.
+        file_path: A plain path string or a MacroPath.
 
     Returns:
-        A resolved path string, or None if file_path is None.
+        A resolved path string.
 
     Raises:
         FileLoadError: If macro resolution fails.
     """
-    if file_path is None:
-        return None
-
     if isinstance(file_path, str):
         return file_path
 
@@ -219,13 +213,7 @@ class File:
         Raises:
             FileLoadError: If macro resolution fails (e.g. no project loaded).
         """
-        resolved = _resolve_file_path(self._file_path)
-        if resolved is None:
-            raise FileLoadError(
-                failure_reason=FileIOFailureReason.INVALID_PATH,
-                result_details="Cannot resolve path: file_path is None",
-            )
-        return resolved
+        return _resolve_file_path(self._file_path)
 
     @property
     def location(self) -> str:
@@ -503,7 +491,7 @@ class File:
             FileLoadError: If the file cannot be read.
         """
         resolved_path = _resolve_file_path(self._file_path)
-        canonical_path = str(canonicalize_for_io(resolved_path)) if resolved_path is not None else None
+        canonical_path = str(canonicalize_for_io(resolved_path))
 
         request = ReadFileRequest(
             file_path=canonical_path,
@@ -536,7 +524,7 @@ class File:
             FileLoadError: If the file cannot be read.
         """
         resolved_path = await _aresolve_file_path(self._file_path)
-        canonical_path = str(canonicalize_for_io(resolved_path)) if resolved_path is not None else None
+        canonical_path = str(canonicalize_for_io(resolved_path))
 
         request = ReadFileRequest(
             file_path=canonical_path,
@@ -585,13 +573,6 @@ class File:
             FileWriteError: If the file cannot be written.
         """
         resolved_path = _resolve_file_path(self._file_path)
-
-        if resolved_path is None:
-            raise FileWriteError(
-                failure_reason=FileIOFailureReason.INVALID_PATH,
-                result_details="Cannot write: file_path is None",
-            )
-
         canonical_path = str(canonicalize_for_io(resolved_path))
 
         request = WriteFileRequest(
@@ -640,13 +621,6 @@ class File:
             FileWriteError: If the file cannot be written.
         """
         resolved_path = await _aresolve_file_path(self._file_path)
-
-        if resolved_path is None:
-            raise FileWriteError(
-                failure_reason=FileIOFailureReason.INVALID_PATH,
-                result_details="Cannot write: file_path is None",
-            )
-
         canonical_path = str(canonicalize_for_io(resolved_path))
 
         request = WriteFileRequest(

--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import NamedTuple, Protocol, cast, runtime_checkable
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
+from griptape_nodes.files.path_utils import canonicalize_for_io
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     FileIOFailureReason,
@@ -502,9 +503,10 @@ class File:
             FileLoadError: If the file cannot be read.
         """
         resolved_path = _resolve_file_path(self._file_path)
+        canonical_path = str(canonicalize_for_io(resolved_path)) if resolved_path is not None else None
 
         request = ReadFileRequest(
-            file_path=resolved_path,
+            file_path=canonical_path,
             encoding=encoding,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -534,9 +536,10 @@ class File:
             FileLoadError: If the file cannot be read.
         """
         resolved_path = await _aresolve_file_path(self._file_path)
+        canonical_path = str(canonicalize_for_io(resolved_path)) if resolved_path is not None else None
 
         request = ReadFileRequest(
-            file_path=resolved_path,
+            file_path=canonical_path,
             encoding=encoding,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -589,8 +592,10 @@ class File:
                 result_details="Cannot write: file_path is None",
             )
 
+        canonical_path = str(canonicalize_for_io(resolved_path))
+
         request = WriteFileRequest(
-            file_path=resolved_path,
+            file_path=canonical_path,
             content=content,
             encoding=encoding,
             existing_file_policy=existing_file_policy,
@@ -642,8 +647,10 @@ class File:
                 result_details="Cannot write: file_path is None",
             )
 
+        canonical_path = str(canonicalize_for_io(resolved_path))
+
         request = WriteFileRequest(
-            file_path=resolved_path,
+            file_path=canonical_path,
             content=content,
             encoding=encoding,
             existing_file_policy=existing_file_policy,

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -33,6 +33,25 @@ _WINDOWS_UNC_PATTERN = re.compile(_WINDOWS_UNC_MATCH_PATTERN)
 _MACOS_VOLUME_PATTERN = re.compile(_MACOS_VOLUME_MATCH_PATTERN)
 _LINUX_MOUNT_PATTERN = re.compile(_LINUX_MOUNT_MATCH_PATTERN)
 
+# Windows MAX_PATH limit - paths at or above this length need the \\?\ prefix.
+WINDOWS_MAX_PATH = 260
+
+
+def _apply_windows_long_path_prefix(path_str: str) -> str:
+    r"""Prepend the Windows long-path prefix (``\\?\``) when required.
+
+    No-op on non-Windows platforms, on paths shorter than ``WINDOWS_MAX_PATH``,
+    or on paths that already carry the prefix. UNC paths (``\\server\share``)
+    get the ``\\?\UNC\`` variant.
+    """
+    if not sys.platform.startswith("win"):
+        return path_str
+    if len(path_str) < WINDOWS_MAX_PATH or path_str.startswith("\\\\?\\"):
+        return path_str
+    if path_str.startswith("\\\\"):
+        return f"\\\\?\\UNC\\{path_str[2:]}"
+    return f"\\\\?\\{path_str}"
+
 
 def derive_registry_key(file_path: str) -> str:
     """Derive a workflow registry key from a file path.
@@ -258,24 +277,13 @@ def normalize_path_for_platform(path: Path) -> str:
         String representation of path, cleaned of newlines/carriage returns,
         with Windows long path prefix if needed
     """
-    # Windows MAX_PATH limit - paths longer than this need \\?\ prefix
-    windows_max_path = 260
-
     path_str = str(path.resolve())
 
     # Clean path to remove newlines/carriage returns, shell escapes, and quotes
     # This handles cases where merge_texts nodes accidentally add newlines between path components
     path_str = sanitize_path_string(path_str)
 
-    # Windows long path handling (paths > windows_max_path chars need \\?\ prefix)
-    if sys.platform.startswith("win") and len(path_str) >= windows_max_path and not path_str.startswith("\\\\?\\"):
-        # UNC paths (\\server\share) need \\?\UNC\ prefix
-        if path_str.startswith("\\\\"):
-            return f"\\\\?\\UNC\\{path_str[2:]}"
-        # Regular paths need \\?\ prefix
-        return f"\\\\?\\{path_str}"
-
-    return path_str
+    return _apply_windows_long_path_prefix(path_str)
 
 
 def expand_path(path_str: str) -> Path:
@@ -411,25 +419,17 @@ def canonicalize_for_io(path: str | Path, *, base: Path | None = None) -> Path:
     Returns:
         Canonical Path ready for filesystem operations.
     """
-    # Windows MAX_PATH limit - paths longer than this need \\?\ prefix
-    windows_max_path = 260
-
     sanitized = sanitize_path_string(path)
     expanded = expand_path(sanitized)
     if not expanded.is_absolute():
         expanded = (base if base is not None else Path.cwd()) / expanded
     normalized = resolve_path_safely(expanded)
 
-    if not sys.platform.startswith("win"):
+    normalized_str = str(normalized)
+    prefixed = _apply_windows_long_path_prefix(normalized_str)
+    if prefixed == normalized_str:
         return normalized
-
-    path_str = str(normalized)
-    if len(path_str) < windows_max_path or path_str.startswith("\\\\?\\"):
-        return normalized
-    # UNC paths (\\server\share) need \\?\UNC\ prefix
-    if path_str.startswith("\\\\"):
-        return Path(f"\\\\?\\UNC\\{path_str[2:]}")
-    return Path(f"\\\\?\\{path_str}")
+    return Path(prefixed)
 
 
 def resolve_file_path(path_str: str, base_dir: Path) -> Path:

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -399,8 +399,10 @@ def canonicalize_for_io(path: str | Path, *, base: Path | None = None) -> Path:
     paths that do not yet exist) and applies the Windows long-path
     (``\\?\``) prefix when the result exceeds MAX_PATH.
 
-    Use this when constructing a ``ReadFileRequest`` / ``WriteFileRequest`` or
-    otherwise handing a path to an OS-level I/O call.
+    Use this at the boundary that actually hands the path to the OS (driver
+    or request handler). Do NOT call it before constructing a
+    ``ReadFileRequest`` / ``WriteFileRequest`` — those handlers already
+    canonicalize on the way in, so a caller-side call is redundant.
 
     Args:
         path: Raw path string or Path object.

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -44,6 +44,7 @@ def _apply_windows_long_path_prefix(path_str: str) -> str:
     or on paths that already carry the prefix. UNC paths (``\\server\share``)
     get the ``\\?\UNC\`` variant.
     """
+    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4418
     if not sys.platform.startswith("win"):
         return path_str
     if len(path_str) < WINDOWS_MAX_PATH or path_str.startswith("\\\\?\\"):

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -364,6 +364,72 @@ def resolve_path_safely(path: Path) -> Path:
     return Path(os.path.normpath(path))
 
 
+def canonicalize_for_identity(path: str | Path, *, base: Path | None = None) -> Path:
+    """Produce a stable path identity for use as a dict key, cache key, or ID.
+
+    Sanitizes shell escapes/quotes, expands ~ and environment variables, anchors
+    relative paths to ``base`` (defaults to CWD), normalizes ``.`` and ``..``,
+    and follows symlinks via ``Path.resolve(strict=False)`` so two spellings of
+    the same file collide on equality. Non-existent paths do not raise; the
+    resolvable prefix is resolved and the remainder is appended verbatim.
+
+    Use this whenever a path is about to become a key: project IDs, cache
+    lookups, dedupe sets, workspace-containment checks.
+
+    Args:
+        path: Raw path string or Path object (may contain ~, env vars, quotes,
+            shell escapes, or relative segments).
+        base: Base directory for relative paths. Defaults to ``Path.cwd()``.
+
+    Returns:
+        Canonical absolute Path.
+    """
+    sanitized = sanitize_path_string(path)
+    expanded = expand_path(sanitized)
+    if not expanded.is_absolute():
+        expanded = (base if base is not None else Path.cwd()) / expanded
+    return resolve_path_safely(expanded).resolve(strict=False)
+
+
+def canonicalize_for_io(path: str | Path, *, base: Path | None = None) -> Path:
+    r"""Produce a path suitable for handing to the filesystem.
+
+    Same sanitization, expansion, absolutization, and normalization as
+    ``canonicalize_for_identity``, but does NOT follow symlinks (safe for
+    paths that do not yet exist) and applies the Windows long-path
+    (``\\?\``) prefix when the result exceeds MAX_PATH.
+
+    Use this when constructing a ``ReadFileRequest`` / ``WriteFileRequest`` or
+    otherwise handing a path to an OS-level I/O call.
+
+    Args:
+        path: Raw path string or Path object.
+        base: Base directory for relative paths. Defaults to ``Path.cwd()``.
+
+    Returns:
+        Canonical Path ready for filesystem operations.
+    """
+    # Windows MAX_PATH limit - paths longer than this need \\?\ prefix
+    windows_max_path = 260
+
+    sanitized = sanitize_path_string(path)
+    expanded = expand_path(sanitized)
+    if not expanded.is_absolute():
+        expanded = (base if base is not None else Path.cwd()) / expanded
+    normalized = resolve_path_safely(expanded)
+
+    if not sys.platform.startswith("win"):
+        return normalized
+
+    path_str = str(normalized)
+    if len(path_str) < windows_max_path or path_str.startswith("\\\\?\\"):
+        return normalized
+    # UNC paths (\\server\share) need \\?\UNC\ prefix
+    if path_str.startswith("\\\\"):
+        return Path(f"\\\\?\\UNC\\{path_str[2:]}")
+    return Path(f"\\\\?\\{path_str}")
+
+
 def resolve_file_path(path_str: str, base_dir: Path) -> Path:
     """Resolve a file path, handling absolute, relative, and tilde paths.
 

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_rounded_preview_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_rounded_preview_generator.py
@@ -9,7 +9,6 @@ from typing import Any
 from PIL import Image, ImageDraw, ImageOps
 from pydantic import PositiveInt  # noqa: TC002 - Runtime validation, not type-only
 
-from griptape_nodes.files.path_utils import canonicalize_for_io
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     ReadFileRequest,
@@ -139,7 +138,7 @@ class PILRoundedPreviewGenerator(BaseArtifactPreviewGenerator):
         """
         # Step 1: Read source file
         read_request = ReadFileRequest(
-            file_path=str(canonicalize_for_io(self.source_file_location)),
+            file_path=self.source_file_location,
             workspace_only=False,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -190,9 +189,7 @@ class PILRoundedPreviewGenerator(BaseArtifactPreviewGenerator):
             output_bytes = output_buffer.getvalue()
 
         # Step 4: Write output file
-        destination_path = str(
-            canonicalize_for_io(Path(self.destination_preview_directory) / self.destination_preview_file_name)
-        )
+        destination_path = str(Path(self.destination_preview_directory) / self.destination_preview_file_name)
 
         write_request = WriteFileRequest(
             file_path=destination_path,

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_rounded_preview_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_rounded_preview_generator.py
@@ -9,6 +9,7 @@ from typing import Any
 from PIL import Image, ImageDraw, ImageOps
 from pydantic import PositiveInt  # noqa: TC002 - Runtime validation, not type-only
 
+from griptape_nodes.files.path_utils import canonicalize_for_io
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     ReadFileRequest,
@@ -138,7 +139,7 @@ class PILRoundedPreviewGenerator(BaseArtifactPreviewGenerator):
         """
         # Step 1: Read source file
         read_request = ReadFileRequest(
-            file_path=self.source_file_location,
+            file_path=str(canonicalize_for_io(self.source_file_location)),
             workspace_only=False,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -189,7 +190,9 @@ class PILRoundedPreviewGenerator(BaseArtifactPreviewGenerator):
             output_bytes = output_buffer.getvalue()
 
         # Step 4: Write output file
-        destination_path = str(Path(self.destination_preview_directory) / self.destination_preview_file_name)
+        destination_path = str(
+            canonicalize_for_io(Path(self.destination_preview_directory) / self.destination_preview_file_name)
+        )
 
         write_request = WriteFileRequest(
             file_path=destination_path,

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_thumbnail_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_thumbnail_generator.py
@@ -9,6 +9,7 @@ from typing import Any
 from PIL import Image, ImageOps
 from pydantic import PositiveInt  # noqa: TC002 - Runtime validation, not type-only
 
+from griptape_nodes.files.path_utils import canonicalize_for_io
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     ReadFileRequest,
@@ -108,7 +109,9 @@ class PILThumbnailGenerator(BaseArtifactPreviewGenerator):
         """
         # Read the source image file
         read_request = ReadFileRequest(
-            file_path=self.source_file_location, workspace_only=False, should_transform_image_content_to_thumbnail=False
+            file_path=str(canonicalize_for_io(self.source_file_location)),
+            workspace_only=False,
+            should_transform_image_content_to_thumbnail=False,
         )
         read_result = GriptapeNodes.handle_request(read_request)
 
@@ -135,7 +138,9 @@ class PILThumbnailGenerator(BaseArtifactPreviewGenerator):
             output_bytes = output_buffer.getvalue()
 
         # Construct full path for writing
-        destination_path = str(Path(self.destination_preview_directory) / self.destination_preview_file_name)
+        destination_path = str(
+            canonicalize_for_io(Path(self.destination_preview_directory) / self.destination_preview_file_name)
+        )
 
         # Write the preview file
         write_request = WriteFileRequest(

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_thumbnail_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/preview_generators/pil_thumbnail_generator.py
@@ -9,7 +9,6 @@ from typing import Any
 from PIL import Image, ImageOps
 from pydantic import PositiveInt  # noqa: TC002 - Runtime validation, not type-only
 
-from griptape_nodes.files.path_utils import canonicalize_for_io
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     ReadFileRequest,
@@ -109,7 +108,7 @@ class PILThumbnailGenerator(BaseArtifactPreviewGenerator):
         """
         # Read the source image file
         read_request = ReadFileRequest(
-            file_path=str(canonicalize_for_io(self.source_file_location)),
+            file_path=self.source_file_location,
             workspace_only=False,
             should_transform_image_content_to_thumbnail=False,
         )
@@ -138,9 +137,7 @@ class PILThumbnailGenerator(BaseArtifactPreviewGenerator):
             output_bytes = output_buffer.getvalue()
 
         # Construct full path for writing
-        destination_path = str(
-            canonicalize_for_io(Path(self.destination_preview_directory) / self.destination_preview_file_name)
-        )
+        destination_path = str(Path(self.destination_preview_directory) / self.destination_preview_file_name)
 
         # Write the preview file
         write_request = WriteFileRequest(

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from griptape_nodes.exe_types.flow import ControlFlow
-from griptape_nodes.files.path_utils import derive_registry_key
+from griptape_nodes.files.path_utils import canonicalize_for_identity, derive_registry_key
 from griptape_nodes.retained_mode.events.context_events import (
     GetWorkflowContextRequest,
     GetWorkflowContextSuccess,
@@ -490,8 +489,8 @@ class ContextManager:
             # Lazy import required: context_manager is imported by griptape_nodes, creating a circular dependency.
             from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-            resolved = Path(file_path).resolve()
-            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            resolved = canonicalize_for_identity(file_path)
+            workspace_path = canonicalize_for_identity(GriptapeNodes.ConfigManager().workspace_path)
             if resolved.is_relative_to(workspace_path):
                 path_for_key = str(resolved.relative_to(workspace_path))
             else:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -31,7 +31,7 @@ from xdg_base_dirs import xdg_data_home
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
-from griptape_nodes.files.path_utils import resolve_workspace_path
+from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_workspace_path
 from griptape_nodes.node_library.library_registry import (
     CategoryDefinition,
     Library,
@@ -1120,7 +1120,7 @@ class LibraryManager:
             Merged list of NodeDefinitions
         """
         # Create mapping of discovered files for quick lookup (use absolute resolved paths)
-        discovered_file_paths = {str(f.resolve()): f for f in discovered_files}
+        discovered_file_paths = {str(canonicalize_for_identity(f)): f for f in discovered_files}
 
         # Keep existing nodes that still have corresponding files
         merged_nodes = []
@@ -1129,7 +1129,7 @@ class LibraryManager:
         for existing_node in existing_schema.nodes:
             # Resolve the file path to absolute for comparison
             try:
-                existing_file_path = str(Path(existing_node.file_path).resolve())
+                existing_file_path = str(canonicalize_for_identity(existing_node.file_path))
             except Exception as e:
                 logger.warning(
                     "Could not resolve path for existing node '%s' at '%s': %s. Skipping.",
@@ -1157,7 +1157,7 @@ class LibraryManager:
 
         # Add new files as placeholder nodes
         for discovered_file in discovered_files:
-            discovered_file_path = str(discovered_file.resolve())
+            discovered_file_path = str(canonicalize_for_identity(discovered_file))
 
             if discovered_file_path not in existing_file_paths:
                 # Create placeholder node definition for new file

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -945,6 +945,7 @@ class OSManager:
     def platform() -> str:
         return sys.platform
 
+    # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4418
     @staticmethod
     def is_windows() -> bool:
         return sys.platform.startswith("win")

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -31,7 +31,7 @@ from griptape_nodes.files.drivers.local_file_driver import LocalFileDriver
 from griptape_nodes.files.drivers.static_server_file_driver import StaticServerFileDriver
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.files.file_driver import FileDriverNotFoundError, FileDriverRegistry
-from griptape_nodes.files.path_utils import path_needs_expansion
+from griptape_nodes.files.path_utils import canonicalize_for_identity, path_needs_expansion
 from griptape_nodes.files.path_utils import resolve_path_safely as pr_resolve
 from griptape_nodes.retained_mode.events.base_events import ResultDetails, ResultPayload
 from griptape_nodes.retained_mode.events.os_events import (
@@ -607,12 +607,11 @@ class OSManager:
         """
         workspace = GriptapeNodes.ConfigManager().workspace_path
 
-        # Ensure both paths are resolved for comparison
-        # Both path and workspace should use .resolve() to follow symlinks consistently
-        # (e.g., /var -> /private/var on macOS). Even if path doesn't exist yet,
-        # .resolve() will resolve parent directories and symlinks in the path.
-        path = path.resolve()
-        workspace = workspace.resolve()  # Workspace should always exist
+        # Canonicalize both sides so ~ / env vars / symlinks / relative spellings
+        # all compare equal. Non-existent paths don't raise; the resolvable
+        # prefix is resolved and the remainder is appended verbatim.
+        path = canonicalize_for_identity(path)
+        workspace = canonicalize_for_identity(workspace)
 
         msg = f"Validating path: {path} against workspace: {workspace}"
         logger.debug(msg)
@@ -1293,7 +1292,7 @@ class OSManager:
             need_relative_paths = request.workspace_only is True
             workspace_path = GriptapeNodes.ConfigManager().workspace_path
             if need_relative_paths or request.include_absolute_path:
-                resolved_workspace = workspace_path.resolve()
+                resolved_workspace = canonicalize_for_identity(workspace_path)
             else:
                 resolved_workspace = None
 
@@ -2815,7 +2814,7 @@ class OSManager:
             _, file_path = self._validate_workspace_path(resolved_path)
 
             # Also get absolute resolved path
-            absolute_resolved_path = str(resolved_path.resolve())
+            absolute_resolved_path = str(canonicalize_for_identity(resolved_path))
 
             file_entry = FileSystemEntry(
                 name=resolved_path.name,

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -101,9 +101,6 @@ from griptape_nodes.utils.image_preview import create_image_preview_from_bytes
 
 console = Console()
 
-# Windows MAX_PATH limit - paths longer than this need \\?\ prefix
-WINDOWS_MAX_PATH = 260
-
 # Maximum number of indexed candidates to try when CREATE_NEW policy is used
 MAX_INDEXED_CANDIDATES = 1000
 

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -31,8 +31,13 @@ from griptape_nodes.files.drivers.local_file_driver import LocalFileDriver
 from griptape_nodes.files.drivers.static_server_file_driver import StaticServerFileDriver
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.files.file_driver import FileDriverNotFoundError, FileDriverRegistry
-from griptape_nodes.files.path_utils import canonicalize_for_identity, path_needs_expansion
-from griptape_nodes.files.path_utils import resolve_path_safely as pr_resolve
+from griptape_nodes.files.path_utils import (
+    canonicalize_for_identity,
+    normalize_path_for_platform,
+    path_needs_expansion,
+    resolve_path_safely,
+    sanitize_path_string,
+)
 from griptape_nodes.retained_mode.events.base_events import ResultDetails, ResultPayload
 from griptape_nodes.retained_mode.events.os_events import (
     CopyFileRequest,
@@ -427,43 +432,7 @@ class OSManager:
             expanded_user = os.path.expanduser(expanded_vars)  # noqa: PTH111
             final_path = Path(expanded_user)
 
-        return self.resolve_path_safely(final_path)
-
-    def resolve_path_safely(self, path: Path) -> Path:
-        """Resolve a path consistently across platforms.
-
-        Unlike Path.resolve() which behaves differently on Windows vs Unix
-        for non-existent paths, this method provides consistent behavior:
-        - Converts relative paths to absolute (using CWD as base)
-        - Normalizes path separators and removes . and ..
-        - Does NOT resolve symlinks if path doesn't exist
-        - Does NOT change path based on CWD for absolute paths
-
-        Use this instead of .resolve() when:
-        - Path might not exist (file creation, validation, user input)
-        - You need consistent cross-platform comparison
-        - You're about to create the file/directory
-
-        Use .resolve() when:
-        - Path definitely exists and you need symlink resolution
-        - You're checking actual file locations
-
-        Args:
-            path: Path to resolve (relative or absolute, existing or not)
-
-        Returns:
-            Absolute, normalized Path object
-
-        Examples:
-            # Relative path
-            resolve_path_safely(Path("relative/file.txt"))
-            → Path("/current/dir/relative/file.txt")
-
-            # Absolute non-existent path (Windows safe)
-            resolve_path_safely(Path("/abs/nonexistent/path"))
-            → Path("/abs/nonexistent/path")  # NOT resolved relative to CWD
-        """
-        return pr_resolve(path)
+        return resolve_path_safely(final_path)
 
     def _resolve_file_path(self, path_str: str, *, workspace_only: bool = False) -> Path:
         """Resolve a file path, handling absolute, relative, and tilde paths.
@@ -478,7 +447,7 @@ class OSManager:
         try:
             if path_needs_expansion(path_str):
                 return self._expand_path(path_str)
-            return self.resolve_path_safely(self._get_workspace_path() / path_str)
+            return resolve_path_safely(self._get_workspace_path() / path_str)
         except (ValueError, RuntimeError):
             if workspace_only:
                 msg = f"Path '{path_str}' not found, using workspace directory: {self._get_workspace_path()}"
@@ -553,7 +522,7 @@ class OSManager:
             # OVERWRITE policy: existence OK
             self._validate_file_path_for_write(path, check_not_exists=False, create_parents=False)
         """
-        normalized_path = self.normalize_path_for_platform(file_path)
+        normalized_path = normalize_path_for_platform(file_path)
 
         # Check if path is a directory
         try:
@@ -583,7 +552,7 @@ class OSManager:
                 ) from e
 
         # Check parent directory exists or can be created
-        parent_normalized = self.normalize_path_for_platform(file_path.parent)
+        parent_normalized = normalize_path_for_platform(file_path.parent)
         try:
             if not Path(parent_normalized).exists() and not create_parents:
                 raise FilePathValidationError(
@@ -626,91 +595,6 @@ class OSManager:
         msg = f"Path is within workspace, relative path: {relative}"
         logger.debug(msg)
         return True, relative
-
-    @staticmethod
-    def strip_surrounding_quotes(path_str: str) -> str:
-        """Strip surrounding quotes only if they match (from 'Copy as Pathname').
-
-        Args:
-            path_str: The path string to process
-
-        Returns:
-            Path string with surrounding quotes removed if present
-        """
-        from griptape_nodes.files.path_utils import strip_surrounding_quotes as pr_strip
-
-        return pr_strip(path_str)
-
-    def sanitize_path_string(self, path: str | Path | Any) -> str | Any:
-        r"""Clean path strings by removing newlines, carriage returns, shell escapes, and quotes.
-
-        This method handles multiple path cleaning concerns:
-        1. Removes newlines/carriage returns that cause WinError 123 on Windows
-           (from merge_texts nodes accidentally adding newlines between path components)
-        2. Removes shell escape characters and quotes (from macOS Finder 'Copy as Pathname')
-        3. Strips leading/trailing whitespace
-
-        Handles macOS Finder's 'Copy as Pathname' format which escapes
-        spaces, apostrophes, and other special characters with backslashes.
-        Only removes backslashes before shell-special characters to avoid
-        breaking Windows paths like C:\Users\file.txt.
-
-        Examples:
-            macOS Finder paths:
-                "/Downloads/Dragon\'s\ Curse/screenshot.jpg"
-                -> "/Downloads/Dragon's Curse/screenshot.jpg"
-
-                "/Test\ Images/Level\ 1\ -\ Knight\'s\ Quest/file.png"
-                -> "/Test Images/Level 1 - Knight's Quest/file.png"
-
-            Quoted paths:
-                '"/path/with spaces/file.txt"'
-                -> "/path/with spaces/file.txt"
-
-            Windows paths with newlines:
-                "C:\\Users\\file\\n\\n.txt"
-                -> "C:\\Users\\file.txt"
-
-            Windows extended-length paths:
-                r"\\?\C:\Very\ Long\ Path\file.txt"
-                -> r"\\?\C:\Very Long Path\file.txt"
-
-            Path objects:
-                Path("/path/to/file")
-                -> "/path/to/file"
-
-        Args:
-            path: Path string, Path object, or any other type to sanitize
-
-        Returns:
-            Sanitized path string, or original value if not a string/Path
-        """
-        from griptape_nodes.files.path_utils import sanitize_path_string as pr_sanitize
-
-        return pr_sanitize(path)
-
-    def normalize_path_for_platform(self, path: Path) -> str:
-        r"""Convert Path to string with Windows long path support if needed.
-
-        Windows has a 260 character path limit (MAX_PATH). Paths longer than this
-        need the \\?\ prefix to work correctly. This method transparently adds
-        the prefix when needed on Windows.
-
-        Also cleans paths to remove newlines/carriage returns that cause Windows errors.
-
-        Note: This method assumes the path exists or will exist. For non-existent
-        paths that need cross-platform normalization, use resolve_path_safely() first.
-
-        Args:
-            path: Path object to convert to string
-
-        Returns:
-            String representation of path, cleaned of newlines/carriage returns,
-            with Windows long path prefix if needed
-        """
-        from griptape_nodes.files.path_utils import normalize_path_for_platform as pr_normalize
-
-        return pr_normalize(path)
 
     @staticmethod
     def format_command_line(args: list[str]) -> str:
@@ -1147,12 +1031,12 @@ class OSManager:
             if self.is_windows():
                 # Linter complains but this is the recommended way on Windows
                 # We can ignore this warning as we've validated the path
-                os.startfile(self.normalize_path_for_platform(path))  # noqa: S606 # pyright: ignore[reportAttributeAccessIssue]
+                os.startfile(normalize_path_for_platform(path))  # noqa: S606 # pyright: ignore[reportAttributeAccessIssue]
                 logger.info("Opened path on Windows: %s", path)
             elif self.is_mac():
                 # On macOS, open should be in a standard location
                 subprocess.run(  # noqa: S603
-                    ["/usr/bin/open", self.normalize_path_for_platform(path)],
+                    ["/usr/bin/open", normalize_path_for_platform(path)],
                     check=True,  # Explicitly use check
                     capture_output=True,
                     text=True,
@@ -1172,7 +1056,7 @@ class OSManager:
                     )
 
                 subprocess.run(  # noqa: S603
-                    [xdg_path, self.normalize_path_for_platform(path)],
+                    [xdg_path, normalize_path_for_platform(path)],
                     check=True,  # Explicitly use check
                     capture_output=True,
                     text=True,
@@ -1268,7 +1152,7 @@ class OSManager:
             elif path_needs_expansion(directory_path_str):
                 directory = self._expand_path(directory_path_str)
             else:
-                directory = self.resolve_path_safely(self._get_workspace_path() / directory_path_str)
+                directory = resolve_path_safely(self._get_workspace_path() / directory_path_str)
 
             # Check if directory exists
             if not directory.exists():
@@ -1568,7 +1452,7 @@ class OSManager:
             return ReadFileResultFailure(failure_reason=FileIOFailureReason.INVALID_PATH, result_details=msg)
 
         # Sanitize path string (basic cleanup)
-        location = self.sanitize_path_string(location)
+        location = sanitize_path_string(location)
 
         # Read via driver system (driver handles all validation and I/O)
         return await self._read_via_driver(location, request)
@@ -1735,7 +1619,7 @@ class OSManager:
             path_display = f"{request.file_path.parsed_macro}"
         else:
             # Sanitize string path (removes shell escapes, quotes, etc.)
-            resolved_path_str = self.sanitize_path_string(request.file_path)
+            resolved_path_str = sanitize_path_string(request.file_path)
             path_display = resolved_path_str
 
         # Convert str → Path
@@ -1773,7 +1657,7 @@ class OSManager:
             )
 
         # Normalize path
-        normalized_path = self.normalize_path_for_platform(file_path)
+        normalized_path = normalize_path_for_platform(file_path)
 
         # Inject workflow metadata into file content if applicable
         content = request.content
@@ -1933,7 +1817,7 @@ class OSManager:
                         if parent_failure_reason is not None:
                             return self._handle_parent_directory_failure(parent_failure_reason, candidate_path)
 
-                        normalized_candidate_path = self.normalize_path_for_platform(candidate_path)
+                        normalized_candidate_path = normalize_path_for_platform(candidate_path)
 
                         # Try to write this indexed candidate using helper
                         result = self._attempt_file_write(
@@ -2004,7 +1888,7 @@ class OSManager:
             None on success, FileIOFailureReason if validation/creation fails
         """
         if create_parents:
-            parent_normalized = self.normalize_path_for_platform(file_path.parent)
+            parent_normalized = normalize_path_for_platform(file_path.parent)
             try:
                 if not Path(parent_normalized).exists():
                     Path(parent_normalized).mkdir(parents=True, exist_ok=True)
@@ -2192,8 +2076,8 @@ class OSManager:
             PermissionError: If permission denied
         """
         # Normalize both paths for platform (handles Windows long paths)
-        src_normalized = self.normalize_path_for_platform(src_path)
-        dest_normalized = self.normalize_path_for_platform(dest_path)
+        src_normalized = normalize_path_for_platform(src_path)
+        dest_normalized = normalize_path_for_platform(dest_path)
 
         # Copy file preserving metadata
         shutil.copy2(src_normalized, dest_normalized)
@@ -2417,9 +2301,9 @@ class OSManager:
 
         # Resolve path - if absolute, use as-is; if relative, align to workspace
         if is_absolute:
-            file_path = self.resolve_path_safely(Path(full_path_str))
+            file_path = resolve_path_safely(Path(full_path_str))
         else:
-            file_path = self.resolve_path_safely(self._get_workspace_path() / full_path_str)
+            file_path = resolve_path_safely(self._get_workspace_path() / full_path_str)
 
         # Check if it already exists - warn but treat as success
         if file_path.exists():
@@ -2557,7 +2441,7 @@ class OSManager:
         # Resolve source path
         try:
             source_path = self._resolve_file_path(request.source_path, workspace_only=False)
-            source_normalized = self.normalize_path_for_platform(source_path)
+            source_normalized = normalize_path_for_platform(source_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid source path: {e}"
             logger.error(msg)
@@ -2578,7 +2462,7 @@ class OSManager:
         # Resolve destination path
         try:
             destination_path = self._resolve_file_path(request.destination_path, workspace_only=False)
-            dest_normalized = self.normalize_path_for_platform(destination_path)
+            dest_normalized = normalize_path_for_platform(destination_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid destination path: {e}"
             logger.error(msg)
@@ -2642,7 +2526,7 @@ class OSManager:
         if not GriptapeNodes.OSManager().is_windows():
             return
 
-        long_path = Path(GriptapeNodes.OSManager().normalize_path_for_platform(Path(path)))
+        long_path = Path(normalize_path_for_platform(Path(path)))
 
         try:
             Path.chmod(long_path, stat.S_IWRITE)
@@ -2876,7 +2760,7 @@ class OSManager:
         # Resolve and normalize source path
         try:
             source_path = self._resolve_file_path(source_str, workspace_only=False)
-            source_normalized = self.normalize_path_for_platform(source_path)
+            source_normalized = normalize_path_for_platform(source_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid source path: {e}"
             logger.error(msg)
@@ -2897,7 +2781,7 @@ class OSManager:
         # Resolve and normalize destination path
         try:
             destination_path = self._resolve_file_path(dest_str, workspace_only=False)
-            dest_normalized = self.normalize_path_for_platform(destination_path)
+            dest_normalized = normalize_path_for_platform(destination_path)
         except (ValueError, RuntimeError) as e:
             msg = f"Invalid destination path: {e}"
             logger.error(msg)

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -27,7 +27,7 @@ from griptape_nodes.common.project_templates import (
     load_partial_project_template,
 )
 from griptape_nodes.files.file import File, FileLoadError, FileWriteError
-from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_file_path
+from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_file_path, resolve_path_safely
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.library_events import (
@@ -512,9 +512,8 @@ class ProjectManager:
                     # For directory builtin variables, compare as resolved paths
                     builtin_info = _BUILTIN_VARIABLE_INFO.get(var_name)
                     if builtin_info and builtin_info.is_directory:
-                        os_manager = GriptapeNodes.OSManager()
-                        resolved_existing = os_manager.resolve_path_safely(Path(str(existing)))
-                        resolved_builtin = os_manager.resolve_path_safely(Path(builtin_value))
+                        resolved_existing = resolve_path_safely(Path(str(existing)))
+                        resolved_builtin = resolve_path_safely(Path(builtin_value))
                         if resolved_existing != resolved_builtin:
                             disallowed_overrides.add(var_name)
                     elif str(existing) != builtin_value:
@@ -1155,12 +1154,11 @@ class ProjectManager:
             /Users/james/Downloads/file.png → None
         """
         # Normalize paths for consistent cross-platform comparison
-        os_manager = GriptapeNodes.OSManager()
-        absolute_path = os_manager.resolve_path_safely(absolute_path)
+        absolute_path = resolve_path_safely(absolute_path)
 
         template = project_info.template
-        workspace_dir = os_manager.resolve_path_safely(self._config_manager.workspace_path)
-        project_base_dir = os_manager.resolve_path_safely(project_info.project_base_dir)
+        workspace_dir = resolve_path_safely(self._config_manager.workspace_path)
+        project_base_dir = resolve_path_safely(project_info.project_base_dir)
 
         # Collect all variables used across ALL directory macros
         variables_needed: set[str] = set()
@@ -1200,7 +1198,7 @@ class ProjectManager:
             # resolve_file_path handles ~, env vars, and absolute paths in addition to relative paths.
             resolved_dir_path = resolve_file_path(resolved_path_str, workspace_dir)
             # Normalize for consistent cross-platform comparison
-            resolved_dir_path = os_manager.resolve_path_safely(resolved_dir_path)
+            resolved_dir_path = resolve_path_safely(resolved_dir_path)
 
             # Check if absolute_path is inside this directory
             try:

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -27,7 +27,7 @@ from griptape_nodes.common.project_templates import (
     load_partial_project_template,
 )
 from griptape_nodes.files.file import File, FileLoadError, FileWriteError
-from griptape_nodes.files.path_utils import expand_path, resolve_file_path
+from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_file_path
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.library_events import (
@@ -255,7 +255,7 @@ class ProjectManager:
         # _registered_template_status (keyed by Path) and
         # _successfully_loaded_project_templates (keyed by str project_id) must
         # use the canonical form so dedupe checks line up.
-        project_file_path = expand_path(str(request.project_path)).resolve()
+        project_file_path = canonicalize_for_identity(request.project_path)
 
         read_request = ReadFileRequest(
             file_path=str(project_file_path),
@@ -570,9 +570,9 @@ class ProjectManager:
 
     def _find_workspace_override(self, project_file_path: Path, project_workspaces: dict[str, str]) -> str | None:
         """Return the user-configured workspace override for a project file, or None if not mapped."""
-        resolved_project_path = str(project_file_path.resolve())
+        resolved_project_path = str(canonicalize_for_identity(project_file_path))
         return next(
-            (v for k, v in project_workspaces.items() if str(Path(k).resolve()) == resolved_project_path),
+            (v for k, v in project_workspaces.items() if str(canonicalize_for_identity(k)) == resolved_project_path),
             None,
         )
 
@@ -1408,7 +1408,7 @@ class ProjectManager:
             # vars and resolve the persisted string before checking for an
             # existing load (prevents duplicate entries when the same file
             # was persisted under different spellings).
-            resolved_id = str(expand_path(path_str).resolve())
+            resolved_id = str(canonicalize_for_identity(path_str))
             if resolved_id in self._successfully_loaded_project_templates:
                 continue
             load_request = LoadProjectTemplateRequest(project_path=Path(path_str))
@@ -1433,7 +1433,7 @@ class ProjectManager:
             # Compare by canonicalized path (~/env expansion + resolution) so a
             # previously persisted relative or ~/ spelling of the same file
             # isn't re-persisted as a duplicate.
-            resolved_existing = {str(expand_path(p).resolve()) for p in registered}
+            resolved_existing = {str(canonicalize_for_identity(p)) for p in registered}
             if project_id not in resolved_existing:
                 self._config_manager.set_config_value(PROJECTS_TO_REGISTER_KEY, [*registered, project_id])
         except Exception:

--- a/src/griptape_nodes/retained_mode/managers/sync_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/sync_manager.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from watchfiles import Change, PythonFilter, watch
 
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
+from griptape_nodes.files.path_utils import canonicalize_for_identity
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.base_events import AppEvent, ResultDetails
 from griptape_nodes.retained_mode.events.sync_events import (
@@ -77,10 +78,7 @@ class SyncManager:
             path: Path to the file that will be written
             content: The exact bytes that will be written to the file
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        os_manager = GriptapeNodes.OSManager()
-        path_str = str(os_manager.resolve_path_safely(Path(path)))
+        path_str = str(canonicalize_for_identity(path))
         file_hash = hashlib.sha256(content).hexdigest()
         with self._hash_lock:
             self._file_hashes[path_str] = file_hash
@@ -99,7 +97,7 @@ class SyncManager:
             True if the file content matches our expected hash (self-triggered event),
             False if it doesn't match or no expected hash exists (external change)
         """
-        path_str = str(Path(path).resolve())
+        path_str = str(canonicalize_for_identity(path))
         with self._hash_lock:
             expected_hash = self._file_hashes.get(path_str)
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -28,7 +28,7 @@ from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode, EndNode, StartNode
 from griptape_nodes.files.file import FileLoadError
-from griptape_nodes.files.path_utils import derive_registry_key, resolve_workspace_path
+from griptape_nodes.files.path_utils import canonicalize_for_identity, derive_registry_key, resolve_workspace_path
 from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.node_library.workflow_registry import (
     Workflow,
@@ -844,7 +844,7 @@ class WorkflowManager:
         full_path = WorkflowRegistry.get_complete_file_path(request.file_path)
         config_manager = GriptapeNodes.ConfigManager()
         try:
-            Path(full_path).resolve().relative_to(Path(config_manager.workspace_path).resolve())
+            canonicalize_for_identity(full_path).relative_to(canonicalize_for_identity(config_manager.workspace_path))
         except ValueError:
             existing_workflows = config_manager.get_config_value(WORKFLOWS_TO_REGISTER_KEY)
             if not existing_workflows:
@@ -1707,7 +1707,7 @@ class WorkflowManager:
         destination = ProjectFileDestination.from_situation(file_name, "save_workflow", **extra_vars)
         relative_file_path = str(Path(sub_dirs) / file_name) if sub_dirs else file_name
         try:
-            resolved = Path(destination.resolve())
+            resolved = canonicalize_for_identity(destination.resolve())
         except FileLoadError as err:
             workspace_path = GriptapeNodes.ConfigManager().workspace_path
             fallback_path = workspace_path.joinpath(relative_file_path)

--- a/tests/unit/files/test_path_utils.py
+++ b/tests/unit/files/test_path_utils.py
@@ -9,6 +9,8 @@ import pytest
 
 from griptape_nodes.files.path_utils import (
     FilenameParts,
+    canonicalize_for_identity,
+    canonicalize_for_io,
     decompose_source_path,
     expand_path,
     normalize_path_for_platform,
@@ -663,3 +665,125 @@ class TestDecomposeSourcePath:
         assert result.drive_volume_mount == "C"
         assert result.source_relative_path == "Users/james/Documents"
         assert result.source_file_name == "file.txt"
+
+
+class TestCanonicalizeForIdentity:
+    """Tests for canonicalize_for_identity."""
+
+    def test_expands_tilde(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """~ is expanded to the user's home directory."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows
+        result = canonicalize_for_identity("~/project.yml")
+        assert result == (tmp_path / "project.yml").resolve()
+
+    def test_expands_env_vars(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Environment variables in the path are expanded."""
+        monkeypatch.setenv("MYDIR", str(tmp_path))
+        result = (
+            canonicalize_for_identity("$MYDIR/file.txt")
+            if sys.platform != "win32"
+            else canonicalize_for_identity("%MYDIR%/file.txt")
+        )
+        assert result == (tmp_path / "file.txt").resolve()
+
+    def test_strips_surrounding_quotes(self, tmp_path: Path) -> None:
+        """Quoted paths are unquoted before canonicalization."""
+        quoted = f'"{tmp_path}/file.txt"'
+        result = canonicalize_for_identity(quoted)
+        assert result == (tmp_path / "file.txt").resolve()
+
+    def test_anchors_relative_to_base(self, tmp_path: Path) -> None:
+        """Relative paths are anchored to the provided base directory."""
+        result = canonicalize_for_identity("sub/file.txt", base=tmp_path)
+        assert result == (tmp_path / "sub" / "file.txt").resolve()
+
+    def test_relative_path_defaults_to_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Relative paths default to CWD when no base is provided."""
+        monkeypatch.chdir(tmp_path)
+        result = canonicalize_for_identity("file.txt")
+        assert result == (tmp_path / "file.txt").resolve()
+
+    def test_nonexistent_path_does_not_raise(self, tmp_path: Path) -> None:
+        """Non-existent paths canonicalize without error."""
+        result = canonicalize_for_identity(tmp_path / "does" / "not" / "exist.txt")
+        assert result.is_absolute()
+        # The resolvable prefix is resolved; remainder appended verbatim.
+        assert result.name == "exist.txt"
+
+    def test_normalizes_dot_and_dotdot(self, tmp_path: Path) -> None:
+        """. and .. components are collapsed."""
+        result = canonicalize_for_identity(f"{tmp_path}/a/../b/./c.txt")
+        assert result == (tmp_path / "b" / "c.txt").resolve()
+
+    def test_equivalent_spellings_collide(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two spellings of the same file produce identical canonical paths."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        target = tmp_path / "project.yml"
+        target.touch()
+
+        via_tilde = canonicalize_for_identity("~/project.yml")
+        via_abs = canonicalize_for_identity(str(target))
+        via_dotdot = canonicalize_for_identity(str(tmp_path / "sub" / ".." / "project.yml"))
+
+        assert via_tilde == via_abs == via_dotdot
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlinks")
+    def test_follows_symlinks_when_target_exists(self, tmp_path: Path) -> None:
+        """Existing symlinks are resolved to their target."""
+        target = tmp_path / "real.txt"
+        target.touch()
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+
+        result = canonicalize_for_identity(link)
+        assert result == target.resolve()
+
+
+class TestCanonicalizeForIo:
+    """Tests for canonicalize_for_io."""
+
+    def test_expands_tilde(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """~ is expanded."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        result = canonicalize_for_io("~/file.txt")
+        assert str(result).endswith("file.txt")
+        assert result.is_absolute()
+
+    def test_anchors_relative_to_base(self, tmp_path: Path) -> None:
+        """Relative paths are anchored to the provided base."""
+        result = canonicalize_for_io("sub/file.txt", base=tmp_path)
+        assert Path(os.path.normpath(tmp_path / "sub" / "file.txt")) == result
+
+    def test_nonexistent_path_does_not_raise(self, tmp_path: Path) -> None:
+        """Non-existent paths canonicalize without error."""
+        result = canonicalize_for_io(tmp_path / "new_file.txt")
+        assert result == tmp_path / "new_file.txt"
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlinks")
+    def test_does_not_follow_symlinks(self, tmp_path: Path) -> None:
+        """Symlinks are preserved (not followed) so newly-created parents work."""
+        target = tmp_path / "real.txt"
+        target.touch()
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+
+        result = canonicalize_for_io(link)
+        # The io helper should NOT resolve the symlink.
+        assert result == link
+
+    @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows long-path prefix")
+    def test_adds_long_path_prefix_on_windows(self, tmp_path: Path) -> None:
+        r"""Paths exceeding MAX_PATH get the \\?\ prefix on Windows."""
+        long_name = "a" * 300
+        result = canonicalize_for_io(tmp_path / long_name)
+        assert str(result).startswith("\\\\?\\")
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="non-Windows has no long-path prefix")
+    def test_no_long_path_prefix_off_windows(self, tmp_path: Path) -> None:
+        r"""Long paths on non-Windows platforms don't get \\?\ prefix."""
+        long_name = "a" * 300
+        result = canonicalize_for_io(tmp_path / long_name)
+        assert not str(result).startswith("\\\\?\\")

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -9,6 +9,7 @@ import anyio
 import pytest
 import send2trash
 
+from griptape_nodes.files.path_utils import normalize_path_for_platform, resolve_path_safely
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.os_events import (
     CreateFileRequest,
@@ -734,7 +735,7 @@ class TestExpandPath:
         with patch.object(os_manager, "_get_windows_special_folder_path", return_value=mock_downloads) as mock_get:
             result = os_manager._expand_path("~/Downloads")
             mock_get.assert_called_once()
-            assert result == os_manager.resolve_path_safely(mock_downloads)
+            assert result == resolve_path_safely(mock_downloads)
 
     def test_expand_path_non_windows_uses_expanduser(
         self,
@@ -746,7 +747,7 @@ class TestExpandPath:
             pytest.skip("Non-Windows test")
         os_manager = griptape_nodes.OSManager()
         result = os_manager._expand_path("~/Downloads")
-        expected = os_manager.resolve_path_safely(Path.home() / "Downloads")
+        expected = resolve_path_safely(Path.home() / "Downloads")
         assert result == expected
 
 
@@ -775,30 +776,27 @@ class TestWindowsLongPathHandling:
         path_parts = [temp_dir] + [long_component] * 6  # Will exceed 260 chars
         return Path(*path_parts)
 
-    def test_normalize_path_short_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_normalize_path_short_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:  # noqa: ARG002
         """Test that short paths are not modified."""
-        os_manager = griptape_nodes.OSManager()
         short_path = temp_dir / "short.txt"
-        result = os_manager.normalize_path_for_platform(short_path)
+        result = normalize_path_for_platform(short_path)
 
         # Should return string without \\?\ prefix
         assert not result.startswith("\\\\?\\")
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
-    def test_normalize_path_long_path_windows(self, griptape_nodes: GriptapeNodes, long_path: Path) -> None:
+    def test_normalize_path_long_path_windows(self, griptape_nodes: GriptapeNodes, long_path: Path) -> None:  # noqa: ARG002
         r"""Test that long paths on Windows get \\?\ prefix."""
-        os_manager = griptape_nodes.OSManager()
-        result = os_manager.normalize_path_for_platform(long_path)
+        result = normalize_path_for_platform(long_path)
 
         # On Windows, long paths should get the prefix
         if len(str(long_path.resolve())) >= WINDOWS_MAX_PATH:
             assert result.startswith("\\\\?\\")
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Non-Windows test")
-    def test_normalize_path_long_path_non_windows(self, griptape_nodes: GriptapeNodes, long_path: Path) -> None:
+    def test_normalize_path_long_path_non_windows(self, griptape_nodes: GriptapeNodes, long_path: Path) -> None:  # noqa: ARG002
         """Test that long paths on non-Windows don't get prefix."""
-        os_manager = griptape_nodes.OSManager()
-        result = os_manager.normalize_path_for_platform(long_path)
+        result = normalize_path_for_platform(long_path)
 
         # On non-Windows, no prefix should be added
         assert not result.startswith("\\\\?\\")

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -2495,6 +2495,19 @@ class TestRegisterProjectPathCanonicalization:
 
         cast("Mock", pm._config_manager).set_config_value.assert_not_called()
 
+    def test_tilde_spelling_dedupes_against_absolute_entry(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ~-spelled persisted path is matched against an absolute incoming one."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        absolute_path = (tmp_path / "project.yml").resolve()
+        cast("Mock", pm._config_manager).get_config_value.return_value = ["~/project.yml"]
+
+        pm._register_project_path(str(absolute_path))
+
+        cast("Mock", pm._config_manager).set_config_value.assert_not_called()
+
 
 class TestLoadRegisteredProjectsCanonicalization:
     """Test that _load_registered_projects treats differently-spelled persisted paths as duplicates."""

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -967,20 +967,11 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
-        # Mock GriptapeNodes.ConfigManager(), ContextManager(), and OSManager()
+        # Mock GriptapeNodes.ContextManager()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
-
-            # Mock OSManager - use real resolve_path_safely implementation
-            from griptape_nodes.retained_mode.managers.os_manager import OSManager
-
-            mock_os_manager = Mock(spec=OSManager)
-            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
-                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
-            )
-            mock_gn.OSManager.return_value = mock_os_manager
 
             # Test path inside outputs directory
             absolute_path = project_base / "outputs" / "renders" / "file.png"
@@ -1033,15 +1024,6 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
-
-            # Mock OSManager - use real resolve_path_safely implementation
-            from griptape_nodes.retained_mode.managers.os_manager import OSManager
-
-            mock_os_manager = Mock(spec=OSManager)
-            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
-                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
-            )
-            mock_gn.OSManager.return_value = mock_os_manager
 
             # Test path outside project
             absolute_path = Path("/Users/test/Downloads/file.png")
@@ -1110,15 +1092,6 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
 
-            # Mock OSManager - use real resolve_path_safely implementation
-            from griptape_nodes.retained_mode.managers.os_manager import OSManager
-
-            mock_os_manager = Mock(spec=OSManager)
-            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
-                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
-            )
-            mock_gn.OSManager.return_value = mock_os_manager
-
             # Test path inside outputs/inputs subdirectory (should match outputs, not inputs)
             absolute_path = project_base / "outputs" / "inputs" / "file.png"
 
@@ -1171,15 +1144,6 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
 
-            # Mock OSManager - use real resolve_path_safely implementation
-            from griptape_nodes.retained_mode.managers.os_manager import OSManager
-
-            mock_os_manager = Mock(spec=OSManager)
-            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
-                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
-            )
-            mock_gn.OSManager.return_value = mock_os_manager
-
             # Test path exactly at outputs directory
             absolute_path = project_base / "outputs"
 
@@ -1229,15 +1193,6 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
             mock_gn.ContextManager.return_value = mock_context
-
-            # Mock OSManager - use real resolve_path_safely implementation
-            from griptape_nodes.retained_mode.managers.os_manager import OSManager
-
-            mock_os_manager = Mock(spec=OSManager)
-            mock_os_manager.resolve_path_safely.side_effect = lambda p: Path(
-                os.path.normpath(p if p.is_absolute() else Path.cwd() / p)
-            )
-            mock_gn.OSManager.return_value = mock_os_manager
 
             # Test path inside project_base_dir but not in any defined directory
             absolute_path = project_base / "random_folder" / "file.txt"
@@ -1291,6 +1246,8 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         project_manager._current_project_id = SYSTEM_DEFAULTS_KEY
         project_manager._secrets_manager = Mock()
         project_manager._secrets_manager.resolve.return_value = "test_value"
+
+        cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes - workflow_name will fail because no workflow
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:


### PR DESCRIPTION
Follow-up to #4404, which fixed the immediate `~/project.yml` dedupe bug in `project_manager` by sprinkling `expand_path(x).resolve()` at three sites. The same bug class still exists across `context_manager`, `library_manager`, `workflow_manager`, `sync_manager`, and `os_manager`, each of which calls bare `Path(x).resolve()` without `expanduser` and so treats two spellings of the same file as distinct dict keys or cache entries.

Before settling on an approach I looked at how other ecosystems handle this. Python's PEP 428 is deliberate about `pathlib` not auto-canonicalizing: `.resolve()` is the documented entry point, and everything else is the caller's problem. Go (`filepath.Clean` + `Abs` + `EvalSymlinks`), Rust (`std::fs::canonicalize` plus the `dunce` crate to avoid `\\?\` leaking into user-visible paths on Windows), and Node (`path.normalize`/`path.resolve`) all converge on the same shape: keep the primitives composable, expose a small number of named policies for the common cases, and canonicalize at the boundary rather than in the middle of the stack. VS Code's `extpath.ts` is a nice concrete example of the latter, splitting identity-use from io-use for exactly the reason we hit here.

The useful split is identity vs io. Identity-use is anything that ends up as a dict key, a cache key, or an ID string, where `~/foo` and `/Users/me/foo` must collide. Io-use is handoff to the filesystem, where we want full expansion and absolutization but must not follow symlinks (the target may not exist yet) and want the Windows long-path prefix applied. This PR adds `canonicalize_for_identity` and `canonicalize_for_io` in `path_utils` as thin wrappers over the existing primitives (`sanitize_path_string`, `expand_path`, `resolve_path_safely`, plus an inlined long-path-prefix decision for the io helper, since we can't reuse `normalize_path_for_platform` here without it following symlinks).