### PR TITLE
Serialize variables for workflows

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -43,6 +43,7 @@ from griptape_nodes.utils import async_utils
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import NodeMessagePayload
     from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+    from griptape_nodes.retained_mode.variable_types import VariableScope
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -103,6 +104,24 @@ class ImportDependency(NamedTuple):
     class_name: str | None = None
 
 
+@dataclass(frozen=True)
+class VariableReference:
+    """A reference to a workflow variable by name and scope.
+
+    Nodes that read from or write to a named variable declare it via this dataclass
+    so that serialization can persist only the variables that are actually used by
+    the workflow graph (rather than every variable currently in engine state).
+
+    Attributes:
+        name: The variable's name as the node knows it
+        scope: The scope the node uses to resolve the variable (HIERARCHICAL is the
+            common case; the serializer will resolve the actual owning flow).
+    """
+
+    name: str
+    scope: VariableScope
+
+
 @dataclass
 class NodeDependencies:
     """Dependencies that a node has on external resources.
@@ -116,12 +135,14 @@ class NodeDependencies:
         static_files: Set of static file names that this node depends on
         imports: Set of Python imports that this node requires
         libraries: Set of library names and versions that this node uses
+        variable_references: Set of variable references (name + scope) this node reads or writes
     """
 
     referenced_workflows: set[str] = field(default_factory=set)
     static_files: set[str] = field(default_factory=set)
     imports: set[ImportDependency] = field(default_factory=set)
     libraries: set[LibraryNameAndVersion] = field(default_factory=set)
+    variable_references: set[VariableReference] = field(default_factory=set)
 
     def aggregate_from(self, other: NodeDependencies) -> None:
         """Aggregate dependencies from another NodeDependencies object into this one.
@@ -134,6 +155,7 @@ class NodeDependencies:
         self.static_files.update(other.static_files)
         self.imports.update(other.imports)
         self.libraries.update(other.libraries)
+        self.variable_references.update(other.variable_references)
 
 
 class NodeResolutionState(StrEnum):

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -104,22 +104,39 @@ class ImportDependency(NamedTuple):
     class_name: str | None = None
 
 
+class VariableAccess(StrEnum):
+    """How a node interacts with a referenced variable."""
+
+    READ = "read"
+    WRITE = "write"
+    READ_WRITE = "read_write"
+
+
 @dataclass(frozen=True)
 class VariableReference:
-    """A reference to a workflow variable by name and scope.
+    """A reference to a workflow variable by name, scope, and access pattern.
 
     Nodes that read from or write to a named variable declare it via this dataclass
     so that serialization can persist only the variables that are actually used by
     the workflow graph (rather than every variable currently in engine state).
 
+    Access is part of the hash/equality contract: the same variable may legitimately
+    appear under different access modes from different nodes in the same flow (e.g. a
+    GetVariable declares READ while a SetVariable declares READ_WRITE on the same name).
+    Both entries are retained in the aggregated set so downstream consumers can merge
+    them as needed.
+
     Attributes:
-        name: The variable's name as the node knows it
+        name: The variable's name as the node knows it.
         scope: The scope the node uses to resolve the variable (HIERARCHICAL is the
             common case; the serializer will resolve the actual owning flow).
+        access: Whether the node reads, writes, or both. Defaults to READ_WRITE as
+            the safe choice when a node's access pattern is unknown or mixed.
     """
 
     name: str
     scope: VariableScope
+    access: VariableAccess = VariableAccess.READ_WRITE
 
 
 @dataclass
@@ -135,7 +152,7 @@ class NodeDependencies:
         static_files: Set of static file names that this node depends on
         imports: Set of Python imports that this node requires
         libraries: Set of library names and versions that this node uses
-        variable_references: Set of variable references (name + scope) this node reads or writes
+        variable_references: Set of variable references this node reads or writes
     """
 
     referenced_workflows: set[str] = field(default_factory=set)

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -46,7 +46,7 @@ class WorkflowShape(BaseModel):
 
 
 class WorkflowMetadata(BaseModel):
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.16.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.17.0"
 
     name: str
     schema_version: str

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -282,15 +282,11 @@ class SerializeFlowToCommandsRequest(RequestPayload):
         include_create_flow_command (bool): If set to False, this will omit the CreateFlow call from the serialized flow object.
             This can be useful so that the contents of a flow can be deserialized into an existing flow instead of creating a new one and deserializing the nodes into that.
             Copy/paste can make use of this.
-        include_global_variables (bool): If True, serialize global variables alongside this flow's flow-scoped variables.
-            Set to False on recursive sub-flow serialization so globals appear exactly once (at the top-level flow's
-            serialization).
     """
 
     broadcast_result: bool = False
     flow_name: str | None = None
     include_create_flow_command: bool = True
-    include_global_variables: bool = True
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -15,6 +15,7 @@ from griptape_nodes.retained_mode.events.base_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands, SetLockNodeStateRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
 
 if TYPE_CHECKING:
     # Circular import: flow_events <-> workflow_events
@@ -241,6 +242,21 @@ class SerializedFlowCommands:
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
 
+    @dataclass
+    class SerializedVariableCommand:
+        """Companion class to recreate a Variable during deserialization, pulling its value from the unique-values pool.
+
+        Attributes:
+            create_variable_command (CreateVariableRequest): The base create-variable command.
+                The ``value`` field on this command is ignored during AST generation — the generated script
+                substitutes the value from ``top_level_unique_values_dict[<unique_value_uuid>]`` instead.
+            unique_value_uuid (SerializedNodeCommands.UniqueParameterValueUUID): The UUID into the
+                unique values dictionary for this variable's value. Shares the pool with parameter values.
+        """
+
+        create_variable_command: CreateVariableRequest
+        unique_value_uuid: SerializedNodeCommands.UniqueParameterValueUUID
+
     flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest | None
     serialized_node_commands: list[SerializedNodeCommands]
     serialized_connections: list[IndirectConnectionSerialization]
@@ -253,6 +269,7 @@ class SerializedFlowCommands:
     node_dependencies: NodeDependencies
     node_types_used: set[LibraryNameAndNodeType]
     flow_name: str | None = None
+    serialized_variable_commands: list[SerializedVariableCommand] = field(default_factory=list)
 
 
 @dataclass
@@ -265,11 +282,15 @@ class SerializeFlowToCommandsRequest(RequestPayload):
         include_create_flow_command (bool): If set to False, this will omit the CreateFlow call from the serialized flow object.
             This can be useful so that the contents of a flow can be deserialized into an existing flow instead of creating a new one and deserializing the nodes into that.
             Copy/paste can make use of this.
+        include_global_variables (bool): If True, serialize global variables alongside this flow's flow-scoped variables.
+            Set to False on recursive sub-flow serialization so globals appear exactly once (at the top-level flow's
+            serialization).
     """
 
     broadcast_result: bool = False
     flow_name: str | None = None
     include_create_flow_command: bool = True
+    include_global_variables: bool = True
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/variable_events.py
+++ b/src/griptape_nodes/retained_mode/events/variable_events.py
@@ -25,8 +25,7 @@ class CreateVariableRequest(RequestPayload):
         value: The initial value of the variable
         owning_flow: Flow that should own this variable (None for current flow in the Context Manager)
         initial_setup: If True, this request is part of workflow load/deserialization. Suppresses
-            workflow-altered signalling and, for globals, adopts an existing variable of the same
-            name rather than failing on collision.
+            workflow-altered signalling.
     """
 
     name: str

--- a/src/griptape_nodes/retained_mode/events/variable_events.py
+++ b/src/griptape_nodes/retained_mode/events/variable_events.py
@@ -24,6 +24,9 @@ class CreateVariableRequest(RequestPayload):
         is_global: Whether this is a global variable (True) or current flow variable (False)
         value: The initial value of the variable
         owning_flow: Flow that should own this variable (None for current flow in the Context Manager)
+        initial_setup: If True, this request is part of workflow load/deserialization. Suppresses
+            workflow-altered signalling and, for globals, adopts an existing variable of the same
+            name rather than failing on collision.
     """
 
     name: str
@@ -31,6 +34,7 @@ class CreateVariableRequest(RequestPayload):
     is_global: bool = False
     value: Any = None
     owning_flow: str | None = None
+    initial_setup: bool = False
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -32,6 +32,7 @@ from griptape_nodes.exe_types.node_types import (
     NodeDependencies,
     NodeResolutionState,
     StartNode,
+    VariableReference,
 )
 from griptape_nodes.machines.control_flow import CompleteState, ControlFlowMachine
 from griptape_nodes.machines.dag_builder import DagBuilder
@@ -154,6 +155,8 @@ from griptape_nodes.retained_mode.events.validation_events import (
 )
 from griptape_nodes.retained_mode.events.variable_events import (
     CreateVariableRequest,
+    GetVariableRequest,
+    GetVariableResultSuccess,
     ListVariablesRequest,
     ListVariablesResultSuccess,
 )
@@ -3222,8 +3225,15 @@ class FlowManager:
         self,
         flow_name: str,
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
+        variable_references: set[VariableReference],
     ) -> list[SerializedFlowCommands.SerializedVariableCommand]:
-        """Build SerializedVariableCommands for the flow's flow-scoped variables.
+        """Build SerializedVariableCommands for flow-scoped variables owned by this flow and declared by a node.
+
+        Only variables that are:
+          (a) owned by ``flow_name``, AND
+          (b) named by at least one declared ``VariableReference`` after scope resolution
+        get serialized. Variables present in engine state but not claimed by any node
+        (orphans from deleted nodes) are silently dropped.
 
         Variable values share the parameter value pool in ``unique_parameter_uuid_to_values`` — the
         generated workflow script references both kinds through the same ``top_level_unique_values_dict``.
@@ -3231,11 +3241,16 @@ class FlowManager:
         Args:
             flow_name: The flow whose flow-scoped variables are being serialized.
             unique_parameter_uuid_to_values: Shared unique-value pool; variable values are added in place.
+            variable_references: Aggregated set of references declared by nodes in this flow and its subtree.
 
         Returns:
-            A list of ``SerializedVariableCommand``s for this flow's flow-scoped variables.
+            A list of ``SerializedVariableCommand``s for this flow's declared flow-scoped variables.
         """
-        serialized_commands: list[SerializedFlowCommands.SerializedVariableCommand] = []
+        declared_names_for_this_flow = self._resolve_declared_variable_names_for_flow(
+            flow_name=flow_name, variable_references=variable_references
+        )
+        if not declared_names_for_this_flow:
+            return []
 
         flow_list_result = GriptapeNodes.handle_request(
             ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY)
@@ -3244,16 +3259,68 @@ class FlowManager:
             logger.warning(
                 "Attempted to list flow-scoped variables for flow '%s' during serialization. Skipping.", flow_name
             )
-        else:
-            serialized_commands.extend(
-                self._build_serialized_variable_command(
-                    variable=variable,
-                    unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
-                )
-                for variable in flow_list_result.variables
-            )
+            return []
 
-        return serialized_commands
+        return [
+            self._build_serialized_variable_command(
+                variable=variable,
+                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+            )
+            for variable in flow_list_result.variables
+            if variable.name in declared_names_for_this_flow
+        ]
+
+    def _resolve_declared_variable_names_for_flow(
+        self,
+        flow_name: str,
+        variable_references: set[VariableReference],
+    ) -> set[str]:
+        """Return the names of variables owned by ``flow_name`` that are claimed by a declared reference.
+
+        Resolution rules per reference scope:
+          - CURRENT_FLOW_ONLY: claims ``ref.name`` only if a variable with that name exists in ``flow_name``.
+          - HIERARCHICAL: uses ``GetVariableRequest`` to resolve; claims ``ref.name`` only if the resolved
+            variable is owned by ``flow_name`` (ancestor-owned variables get claimed by the ancestor's
+            own serialization pass).
+          - GLOBAL_ONLY / ALL: out of scope for this pass; skipped with a debug log. Globals are a
+            deferred follow-up.
+        """
+        claimed_names: set[str] = set()
+
+        for ref in variable_references:
+            if ref.scope is VariableScope.CURRENT_FLOW_ONLY:
+                if self._variable_is_owned_by(name=ref.name, flow_name=flow_name):
+                    claimed_names.add(ref.name)
+            elif ref.scope is VariableScope.HIERARCHICAL:
+                owning_flow = self._hierarchical_owning_flow_for(name=ref.name, starting_flow=flow_name)
+                if owning_flow == flow_name:
+                    claimed_names.add(ref.name)
+            else:
+                logger.debug(
+                    "Skipping variable reference '%s' with unsupported scope '%s' during serialization.",
+                    ref.name,
+                    ref.scope,
+                )
+
+        return claimed_names
+
+    def _variable_is_owned_by(self, name: str, flow_name: str) -> bool:
+        """Return True if a flow-scoped variable with ``name`` exists directly in ``flow_name``."""
+        list_result = GriptapeNodes.handle_request(
+            ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY)
+        )
+        if not isinstance(list_result, ListVariablesResultSuccess):
+            return False
+        return any(variable.name == name for variable in list_result.variables)
+
+    def _hierarchical_owning_flow_for(self, name: str, starting_flow: str) -> str | None:
+        """Return the owning flow name of a variable found by hierarchical lookup, or None if not found."""
+        result = GriptapeNodes.handle_request(
+            GetVariableRequest(name=name, lookup_scope=VariableScope.HIERARCHICAL, starting_flow=starting_flow)
+        )
+        if not isinstance(result, GetVariableResultSuccess):
+            return None
+        return result.variable.owning_flow_name
 
     def _build_serialized_variable_command(
         self,
@@ -3560,10 +3627,11 @@ class FlowManager:
         # Aggregate all connections from this flow and all sub-flows
         aggregated_connections = self._aggregate_connections(create_connection_commands, sub_flow_commands)
 
-        # Serialize flow-scoped variables owned by this flow.
+        # Serialize flow-scoped variables owned by this flow that are declared by a node.
         serialized_variable_commands = self._serialize_variables_for_flow(
             flow_name=flow_name,
             unique_parameter_uuid_to_values=aggregated_unique_values,
+            variable_references=aggregated_dependencies.variable_references,
         )
 
         # Extract flow name from initialization command if available

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import logging
 import pickle
 from enum import StrEnum
@@ -151,6 +152,7 @@ from griptape_nodes.retained_mode.events.validation_events import (
     ValidateFlowDependenciesResultFailure,
     ValidateFlowDependenciesResultSuccess,
 )
+from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
 from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
@@ -163,6 +165,7 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowShapeNodes
+    from griptape_nodes.retained_mode.variable_types import FlowVariable
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -3210,6 +3213,86 @@ class FlowManager:
 
         return aggregated_values
 
+    def _serialize_variables_for_flow(
+        self,
+        flow_name: str,
+        unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
+        *,
+        include_globals: bool,
+    ) -> list[SerializedFlowCommands.SerializedVariableCommand]:
+        """Build SerializedVariableCommands for the flow's variables (and optionally globals).
+
+        Variable values share the parameter value pool in ``unique_parameter_uuid_to_values`` — the
+        generated workflow script references both kinds through the same ``top_level_unique_values_dict``.
+
+        Args:
+            flow_name: The flow whose flow-scoped variables are being serialized.
+            unique_parameter_uuid_to_values: Shared unique-value pool; variable values are added in place.
+            include_globals: If True, also emit commands for every global variable (for the top-level flow only).
+
+        Returns:
+            A list of ``SerializedVariableCommand``s, flow-scoped first, globals last.
+        """
+        variables_manager = GriptapeNodes.VariablesManager()
+        serialized_commands: list[SerializedFlowCommands.SerializedVariableCommand] = []
+
+        flow_variables = variables_manager._flow_variables.get(flow_name, {})
+        for variable in flow_variables.values():
+            command = self._build_serialized_variable_command(
+                variable=variable,
+                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+                is_global=False,
+            )
+            serialized_commands.append(command)
+
+        if include_globals:
+            for variable in variables_manager._global_variables.values():
+                command = self._build_serialized_variable_command(
+                    variable=variable,
+                    unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+                    is_global=True,
+                )
+                serialized_commands.append(command)
+
+        return serialized_commands
+
+    def _build_serialized_variable_command(
+        self,
+        variable: FlowVariable,
+        unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
+        *,
+        is_global: bool,
+    ) -> SerializedFlowCommands.SerializedVariableCommand:
+        """Register the variable's value in the unique-values pool and build the indirect command.
+
+        Values are stored as raw Python objects — ``_generate_unique_values_code`` pickles them at
+        AST-generation time. Each variable gets its own UUID even if another entry holds an equal
+        value; matching the existing parameter-value pattern, dedup-by-equality is not attempted here.
+        """
+        unique_value_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
+        try:
+            unique_parameter_uuid_to_values[unique_value_uuid] = copy.deepcopy(variable.value)
+        except Exception:
+            # Fall back to by-reference storage; matches the parameter-value code path's warning.
+            logger.warning(
+                "Attempted to serialize variable '%s'. Value could not be deep-copied; storing by reference.",
+                variable.name,
+            )
+            unique_parameter_uuid_to_values[unique_value_uuid] = variable.value
+
+        create_variable_command = CreateVariableRequest(
+            name=variable.name,
+            type=variable.type,
+            is_global=is_global,
+            value=None,  # Overridden at deserialization via top_level_unique_values_dict lookup.
+            owning_flow=None if is_global else variable.owning_flow_name,
+            initial_setup=True,
+        )
+        return SerializedFlowCommands.SerializedVariableCommand(
+            create_variable_command=create_variable_command,
+            unique_value_uuid=unique_value_uuid,
+        )
+
     def _aggregate_set_parameter_value_commands(
         self,
         set_parameter_value_commands: dict[
@@ -3391,9 +3474,11 @@ class FlowManager:
                     )
                     sub_flow_commands.append(serialized_flow)
                 else:
-                    # For standalone sub-flows, use the existing recursive serialization
+                    # For standalone sub-flows, use the existing recursive serialization.
+                    # include_global_variables=False: globals are emitted once on the top-level flow
+                    # to avoid duplicate CreateVariableRequest emissions.
                     with GriptapeNodes.ContextManager().flow(flow=child_flow_obj):
-                        child_flow_request = SerializeFlowToCommandsRequest()
+                        child_flow_request = SerializeFlowToCommandsRequest(include_global_variables=False)
                         child_flow_result = GriptapeNodes().handle_request(child_flow_request)
                         if not isinstance(child_flow_result, SerializeFlowToCommandsResultSuccess):
                             details = f"Attempted to serialize parent flow '{flow_name}'. Failed while serializing child flow '{child_flow}'."
@@ -3480,6 +3565,15 @@ class FlowManager:
         # Aggregate all connections from this flow and all sub-flows
         aggregated_connections = self._aggregate_connections(create_connection_commands, sub_flow_commands)
 
+        # Serialize variables owned by this flow. Globals are only emitted on the top-level call so
+        # they appear exactly once in the saved workflow — recursive sub-flow serialization passes
+        # include_global_variables=False.
+        serialized_variable_commands = self._serialize_variables_for_flow(
+            flow_name=flow_name,
+            unique_parameter_uuid_to_values=aggregated_unique_values,
+            include_globals=request.include_global_variables,
+        )
+
         # Extract flow name from initialization command if available
         extracted_flow_name = None
         if create_flow_request is not None and hasattr(create_flow_request, "flow_name"):
@@ -3496,6 +3590,7 @@ class FlowManager:
             node_dependencies=aggregated_dependencies,
             node_types_used=aggregated_node_types_used,
             flow_name=extracted_flow_name,
+            serialized_variable_commands=serialized_variable_commands,
         )
         details = f"Successfully serialized Flow '{flow_name}' into commands."
         result = SerializeFlowToCommandsResultSuccess(serialized_flow_commands=serialized_flow, result_details=details)

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -152,7 +152,11 @@ from griptape_nodes.retained_mode.events.validation_events import (
     ValidateFlowDependenciesResultFailure,
     ValidateFlowDependenciesResultSuccess,
 )
-from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
+from griptape_nodes.retained_mode.events.variable_events import (
+    CreateVariableRequest,
+    ListVariablesRequest,
+    ListVariablesResultSuccess,
+)
 from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
@@ -160,6 +164,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.settings import WorkflowExecutionMode
+from griptape_nodes.retained_mode.variable_types import VariableScope
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
@@ -3217,10 +3222,8 @@ class FlowManager:
         self,
         flow_name: str,
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
-        *,
-        include_globals: bool,
     ) -> list[SerializedFlowCommands.SerializedVariableCommand]:
-        """Build SerializedVariableCommands for the flow's variables (and optionally globals).
+        """Build SerializedVariableCommands for the flow's flow-scoped variables.
 
         Variable values share the parameter value pool in ``unique_parameter_uuid_to_values`` — the
         generated workflow script references both kinds through the same ``top_level_unique_values_dict``.
@@ -3228,31 +3231,27 @@ class FlowManager:
         Args:
             flow_name: The flow whose flow-scoped variables are being serialized.
             unique_parameter_uuid_to_values: Shared unique-value pool; variable values are added in place.
-            include_globals: If True, also emit commands for every global variable (for the top-level flow only).
 
         Returns:
-            A list of ``SerializedVariableCommand``s, flow-scoped first, globals last.
+            A list of ``SerializedVariableCommand``s for this flow's flow-scoped variables.
         """
-        variables_manager = GriptapeNodes.VariablesManager()
         serialized_commands: list[SerializedFlowCommands.SerializedVariableCommand] = []
 
-        flow_variables = variables_manager._flow_variables.get(flow_name, {})
-        for variable in flow_variables.values():
-            command = self._build_serialized_variable_command(
-                variable=variable,
-                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
-                is_global=False,
+        flow_list_result = GriptapeNodes.handle_request(
+            ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY)
+        )
+        if not isinstance(flow_list_result, ListVariablesResultSuccess):
+            logger.warning(
+                "Attempted to list flow-scoped variables for flow '%s' during serialization. Skipping.", flow_name
             )
-            serialized_commands.append(command)
-
-        if include_globals:
-            for variable in variables_manager._global_variables.values():
-                command = self._build_serialized_variable_command(
+        else:
+            serialized_commands.extend(
+                self._build_serialized_variable_command(
                     variable=variable,
                     unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
-                    is_global=True,
                 )
-                serialized_commands.append(command)
+                for variable in flow_list_result.variables
+            )
 
         return serialized_commands
 
@@ -3260,8 +3259,6 @@ class FlowManager:
         self,
         variable: FlowVariable,
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
-        *,
-        is_global: bool,
     ) -> SerializedFlowCommands.SerializedVariableCommand:
         """Register the variable's value in the unique-values pool and build the indirect command.
 
@@ -3283,9 +3280,9 @@ class FlowManager:
         create_variable_command = CreateVariableRequest(
             name=variable.name,
             type=variable.type,
-            is_global=is_global,
+            is_global=False,
             value=None,  # Overridden at deserialization via top_level_unique_values_dict lookup.
-            owning_flow=None if is_global else variable.owning_flow_name,
+            owning_flow=variable.owning_flow_name,
             initial_setup=True,
         )
         return SerializedFlowCommands.SerializedVariableCommand(
@@ -3475,10 +3472,8 @@ class FlowManager:
                     sub_flow_commands.append(serialized_flow)
                 else:
                     # For standalone sub-flows, use the existing recursive serialization.
-                    # include_global_variables=False: globals are emitted once on the top-level flow
-                    # to avoid duplicate CreateVariableRequest emissions.
                     with GriptapeNodes.ContextManager().flow(flow=child_flow_obj):
-                        child_flow_request = SerializeFlowToCommandsRequest(include_global_variables=False)
+                        child_flow_request = SerializeFlowToCommandsRequest()
                         child_flow_result = GriptapeNodes().handle_request(child_flow_request)
                         if not isinstance(child_flow_result, SerializeFlowToCommandsResultSuccess):
                             details = f"Attempted to serialize parent flow '{flow_name}'. Failed while serializing child flow '{child_flow}'."
@@ -3565,13 +3560,10 @@ class FlowManager:
         # Aggregate all connections from this flow and all sub-flows
         aggregated_connections = self._aggregate_connections(create_connection_commands, sub_flow_commands)
 
-        # Serialize variables owned by this flow. Globals are only emitted on the top-level call so
-        # they appear exactly once in the saved workflow — recursive sub-flow serialization passes
-        # include_global_variables=False.
+        # Serialize flow-scoped variables owned by this flow.
         serialized_variable_commands = self._serialize_variables_for_flow(
             flow_name=flow_name,
             unique_parameter_uuid_to_values=aggregated_unique_values,
-            include_globals=request.include_global_variables,
         )
 
         # Extract flow name from initialization command if available

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -3257,7 +3257,9 @@ class FlowManager:
         )
         if not isinstance(flow_list_result, ListVariablesResultSuccess):
             logger.warning(
-                "Attempted to list flow-scoped variables for flow '%s' during serialization. Skipping.", flow_name
+                "Attempted to list flow-scoped variables for flow '%s' during serialization. Failed with: %s. Skipping.",
+                flow_name,
+                flow_list_result.result_details,
             )
             return []
 
@@ -3310,6 +3312,12 @@ class FlowManager:
             ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY)
         )
         if not isinstance(list_result, ListVariablesResultSuccess):
+            logger.debug(
+                "Attempted variable ownership check for '%s' in flow '%s'. Failed to list variables: %s",
+                name,
+                flow_name,
+                list_result.result_details,
+            )
             return False
         return any(variable.name == name for variable in list_result.variables)
 
@@ -3319,6 +3327,15 @@ class FlowManager:
             GetVariableRequest(name=name, lookup_scope=VariableScope.HIERARCHICAL, starting_flow=starting_flow)
         )
         if not isinstance(result, GetVariableResultSuccess):
+            # A failure here is the expected signal for "variable does not resolve hierarchically" —
+            # e.g. a declared reference whose target was deleted. Logged at debug so it is available
+            # for diagnosis without generating noise during normal saves.
+            logger.debug(
+                "Hierarchical lookup for variable '%s' starting at flow '%s' did not resolve: %s",
+                name,
+                starting_flow,
+                result.result_details,
+            )
             return None
         return result.variable.owning_flow_name
 

--- a/src/griptape_nodes/retained_mode/managers/variable_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/variable_manager.py
@@ -172,6 +172,12 @@ class VariablesManager:
         if request.is_global:
             # Check for name collision in global variables
             if request.name in self._global_variables:
+                # During workflow load, adopt an existing global variable rather than failing.
+                # Globals may be shared across workflows; the first-loaded wins.
+                if request.initial_setup:
+                    return CreateVariableResultSuccess(
+                        result_details=f"Adopted existing global variable '{request.name}' during workflow load."
+                    )
                 return CreateVariableResultFailure(
                     result_details=f"Attempted to create a global variable named '{request.name}'. Failed because a variable with that name already exists."
                 )

--- a/src/griptape_nodes/retained_mode/managers/variable_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/variable_manager.py
@@ -172,12 +172,6 @@ class VariablesManager:
         if request.is_global:
             # Check for name collision in global variables
             if request.name in self._global_variables:
-                # During workflow load, adopt an existing global variable rather than failing.
-                # Globals may be shared across workflows; the first-loaded wins.
-                if request.initial_setup:
-                    return CreateVariableResultSuccess(
-                        result_details=f"Adopted existing global variable '{request.name}' during workflow load."
-                    )
                 return CreateVariableResultFailure(
                     result_details=f"Attempted to create a global variable named '{request.name}'. Failed because a variable with that name already exists."
                 )

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2311,6 +2311,30 @@ class WorkflowManager:
                 # No initialization command, deserialize into current context
                 pass
 
+        # Split variable commands into globals (emitted at top level, before any flow context)
+        # and flow-scoped (emitted inside the owning flow's "with" block, before its nodes).
+        global_variable_commands = [
+            cmd
+            for cmd in serialized_flow_commands.serialized_variable_commands
+            if cmd.create_variable_command.is_global
+        ]
+        flow_scoped_variable_commands = [
+            cmd
+            for cmd in serialized_flow_commands.serialized_variable_commands
+            if not cmd.create_variable_command.is_global
+        ]
+
+        # Emit top-level global variable creation BEFORE the flow "with" block. Globals are
+        # scope-independent, so they do not need a flow context.
+        if not isinstance(flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest):
+            global_variable_asts = self._generate_create_variable_code(
+                serialized_variable_commands=global_variable_commands,
+                unique_values_dict_name="top_level_unique_values_dict",
+                import_recorder=import_recorder,
+            )
+            for node in global_variable_asts:
+                ast_container.add_node(node)
+
         # Generate assign flow context AST node, if we have any children commands
         # Skip content generation for referenced workflows - they should only have the import command
         is_referenced_workflow = isinstance(flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest)
@@ -2320,6 +2344,7 @@ class WorkflowManager:
             or len(serialized_flow_commands.set_parameter_value_commands) > 0
             or len(serialized_flow_commands.sub_flows_commands) > 0
             or len(serialized_flow_commands.set_lock_commands_per_node) > 0
+            or len(flow_scoped_variable_commands) > 0
         )
 
         if not is_referenced_workflow and has_content_to_serialize:
@@ -2333,6 +2358,17 @@ class WorkflowManager:
             assign_flow_context_node = self._generate_assign_flow_context(
                 flow_initialization_command=flow_initialization_command, flow_creation_index=flow_creation_index
             )
+
+            # Emit flow-scoped variable creation INSIDE the flow "with" block, BEFORE any
+            # node creation. Ordering matters: SetVariable nodes' before_value_set hook fires
+            # during initial_setup and calls has_variable(); having the variable already
+            # present ensures that hook is a no-op adopt rather than a duplicate create.
+            flow_scoped_variable_asts = self._generate_create_variable_code(
+                serialized_variable_commands=flow_scoped_variable_commands,
+                unique_values_dict_name="top_level_unique_values_dict",
+                import_recorder=import_recorder,
+            )
+            assign_flow_context_node.body.extend(flow_scoped_variable_asts)
 
             # Separate regular nodes from NodeGroup nodes in main flow
 
@@ -2389,13 +2425,30 @@ class WorkflowManager:
                             )
                             assign_flow_context_node.body.append(cast("ast.stmt", sub_flow_import_node))
 
+                # Sub-flow serialization passes include_global_variables=False, so every entry
+                # here is a flow-scoped variable belonging to this sub-flow. (Globals emit once
+                # at the top level of the root flow.)
+                sub_flow_scoped_variable_commands = [
+                    cmd
+                    for cmd in sub_flow_commands.serialized_variable_commands
+                    if not cmd.create_variable_command.is_global
+                ]
+
                 # Generate the nodes in this subflow (just like we do for main flow)
-                if sub_flow_commands.serialized_node_commands:
+                if sub_flow_commands.serialized_node_commands or sub_flow_scoped_variable_commands:
                     # Create "with" statement for subflow
                     subflow_context_node = self._generate_assign_flow_context(
                         flow_initialization_command=sub_flow_initialization_command,
                         flow_creation_index=sub_flow_creation_index,
                     )
+                    # Emit flow-scoped variable creation BEFORE any node creation in this subflow,
+                    # for the same reason as the top-level flow.
+                    subflow_variable_asts = self._generate_create_variable_code(
+                        serialized_variable_commands=sub_flow_scoped_variable_commands,
+                        unique_values_dict_name="top_level_unique_values_dict",
+                        import_recorder=import_recorder,
+                    )
+                    subflow_context_node.body.extend(subflow_variable_asts)
                     # Generate nodes in subflow, passing current index and getting next available
                     subflow_nodes, current_node_index = self._generate_nodes_in_flow(
                         sub_flow_commands,
@@ -4042,6 +4095,85 @@ class WorkflowManager:
             connection_asts.append(create_connection_call)
 
         return connection_asts
+
+    def _generate_create_variable_code(
+        self,
+        serialized_variable_commands: list[SerializedFlowCommands.SerializedVariableCommand],
+        unique_values_dict_name: str,
+        import_recorder: ImportRecorder,
+    ) -> list[ast.stmt]:
+        """Generate AST for CreateVariableRequest calls, one per serialized variable command.
+
+        Each variable's value is looked up in the shared unique-values dict by UUID, mirroring
+        the pattern used for parameter values.
+        """
+        if not serialized_variable_commands:
+            return []
+
+        import_recorder.add_from_import("griptape_nodes.retained_mode.events.variable_events", "CreateVariableRequest")
+
+        create_variable_asts: list[ast.stmt] = []
+        for serialized_command in serialized_variable_commands:
+            create_variable_request = serialized_command.create_variable_command
+            value_lookup = ast.Subscript(
+                value=ast.Name(id=unique_values_dict_name, ctx=ast.Load(), lineno=1, col_offset=0),
+                slice=ast.Constant(value=str(serialized_command.unique_value_uuid), lineno=1, col_offset=0),
+                ctx=ast.Load(),
+                lineno=1,
+                col_offset=0,
+            )
+
+            create_variable_call = ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                        attr="handle_request",
+                        ctx=ast.Load(),
+                        lineno=1,
+                        col_offset=0,
+                    ),
+                    args=[
+                        ast.Call(
+                            func=ast.Name(id="CreateVariableRequest", ctx=ast.Load(), lineno=1, col_offset=0),
+                            args=[],
+                            keywords=[
+                                ast.keyword(
+                                    arg="name",
+                                    value=ast.Constant(value=create_variable_request.name, lineno=1, col_offset=0),
+                                ),
+                                ast.keyword(
+                                    arg="type",
+                                    value=ast.Constant(value=create_variable_request.type, lineno=1, col_offset=0),
+                                ),
+                                ast.keyword(
+                                    arg="is_global",
+                                    value=ast.Constant(value=create_variable_request.is_global, lineno=1, col_offset=0),
+                                ),
+                                ast.keyword(arg="value", value=value_lookup, lineno=1, col_offset=0),
+                                ast.keyword(
+                                    arg="owning_flow",
+                                    value=ast.Constant(
+                                        value=create_variable_request.owning_flow, lineno=1, col_offset=0
+                                    ),
+                                ),
+                                ast.keyword(
+                                    arg="initial_setup", value=ast.Constant(value=True, lineno=1, col_offset=0)
+                                ),
+                            ],
+                            lineno=1,
+                            col_offset=0,
+                        )
+                    ],
+                    keywords=[],
+                    lineno=1,
+                    col_offset=0,
+                ),
+                lineno=1,
+                col_offset=0,
+            )
+            create_variable_asts.append(create_variable_call)
+
+        return create_variable_asts
 
     def _generate_set_parameter_value_code(
         self,

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2311,30 +2311,6 @@ class WorkflowManager:
                 # No initialization command, deserialize into current context
                 pass
 
-        # Split variable commands into globals (emitted at top level, before any flow context)
-        # and flow-scoped (emitted inside the owning flow's "with" block, before its nodes).
-        global_variable_commands = [
-            cmd
-            for cmd in serialized_flow_commands.serialized_variable_commands
-            if cmd.create_variable_command.is_global
-        ]
-        flow_scoped_variable_commands = [
-            cmd
-            for cmd in serialized_flow_commands.serialized_variable_commands
-            if not cmd.create_variable_command.is_global
-        ]
-
-        # Emit top-level global variable creation BEFORE the flow "with" block. Globals are
-        # scope-independent, so they do not need a flow context.
-        if not isinstance(flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest):
-            global_variable_asts = self._generate_create_variable_code(
-                serialized_variable_commands=global_variable_commands,
-                unique_values_dict_name="top_level_unique_values_dict",
-                import_recorder=import_recorder,
-            )
-            for node in global_variable_asts:
-                ast_container.add_node(node)
-
         # Generate assign flow context AST node, if we have any children commands
         # Skip content generation for referenced workflows - they should only have the import command
         is_referenced_workflow = isinstance(flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest)
@@ -2344,7 +2320,7 @@ class WorkflowManager:
             or len(serialized_flow_commands.set_parameter_value_commands) > 0
             or len(serialized_flow_commands.sub_flows_commands) > 0
             or len(serialized_flow_commands.set_lock_commands_per_node) > 0
-            or len(flow_scoped_variable_commands) > 0
+            or len(serialized_flow_commands.serialized_variable_commands) > 0
         )
 
         if not is_referenced_workflow and has_content_to_serialize:
@@ -2364,7 +2340,7 @@ class WorkflowManager:
             # during initial_setup and calls has_variable(); having the variable already
             # present ensures that hook is a no-op adopt rather than a duplicate create.
             flow_scoped_variable_asts = self._generate_create_variable_code(
-                serialized_variable_commands=flow_scoped_variable_commands,
+                serialized_variable_commands=serialized_flow_commands.serialized_variable_commands,
                 unique_values_dict_name="top_level_unique_values_dict",
                 import_recorder=import_recorder,
             )
@@ -2425,17 +2401,8 @@ class WorkflowManager:
                             )
                             assign_flow_context_node.body.append(cast("ast.stmt", sub_flow_import_node))
 
-                # Sub-flow serialization passes include_global_variables=False, so every entry
-                # here is a flow-scoped variable belonging to this sub-flow. (Globals emit once
-                # at the top level of the root flow.)
-                sub_flow_scoped_variable_commands = [
-                    cmd
-                    for cmd in sub_flow_commands.serialized_variable_commands
-                    if not cmd.create_variable_command.is_global
-                ]
-
                 # Generate the nodes in this subflow (just like we do for main flow)
-                if sub_flow_commands.serialized_node_commands or sub_flow_scoped_variable_commands:
+                if sub_flow_commands.serialized_node_commands or sub_flow_commands.serialized_variable_commands:
                     # Create "with" statement for subflow
                     subflow_context_node = self._generate_assign_flow_context(
                         flow_initialization_command=sub_flow_initialization_command,
@@ -2444,7 +2411,7 @@ class WorkflowManager:
                     # Emit flow-scoped variable creation BEFORE any node creation in this subflow,
                     # for the same reason as the top-level flow.
                     subflow_variable_asts = self._generate_create_variable_code(
-                        serialized_variable_commands=sub_flow_scoped_variable_commands,
+                        serialized_variable_commands=sub_flow_commands.serialized_variable_commands,
                         unique_values_dict_name="top_level_unique_values_dict",
                         import_recorder=import_recorder,
                     )

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1,8 +1,12 @@
 import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
+
+if TYPE_CHECKING:
+    from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
@@ -868,3 +872,186 @@ class TestWorkflowManager:
 
         assert save_path.file_path == workspace / "team" / "my_workflow.py"
         assert save_path.relative_file_path == str(Path("team") / "my_workflow.py")
+
+
+class TestWorkflowVariablePersistence:
+    """Round-trip tests: variables created in a flow must survive save + load."""
+
+    def _fresh_metadata(self, name: str = "test_workflow") -> "WorkflowMetadata":
+        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+
+        return WorkflowMetadata(
+            name=name,
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.0.0",
+            node_libraries_referenced=[],
+        )
+
+    def test_generate_create_variable_code_emits_expected_call(self, griptape_nodes: GriptapeNodes) -> None:
+        """The AST helper should produce a single CreateVariableRequest call per command."""
+        import ast
+
+        from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+        from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
+        from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
+        from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        import_recorder = ImportRecorder()
+
+        serialized_command = SerializedFlowCommands.SerializedVariableCommand(
+            create_variable_command=CreateVariableRequest(
+                name="my_var",
+                type="str",
+                is_global=False,
+                value=None,
+                owning_flow="ControlFlow_1",
+                initial_setup=True,
+            ),
+            unique_value_uuid=SerializedNodeCommands.UniqueParameterValueUUID("abc-uuid"),
+        )
+
+        stmts = workflow_manager._generate_create_variable_code(
+            serialized_variable_commands=[serialized_command],
+            unique_values_dict_name="top_level_unique_values_dict",
+            import_recorder=import_recorder,
+        )
+
+        assert len(stmts) == 1
+        rendered = ast.unparse(stmts[0])
+        assert "CreateVariableRequest(" in rendered
+        assert "name='my_var'" in rendered
+        assert "type='str'" in rendered
+        assert "is_global=False" in rendered
+        assert "owning_flow='ControlFlow_1'" in rendered
+        assert "initial_setup=True" in rendered
+        assert "top_level_unique_values_dict['abc-uuid']" in rendered
+
+        # Import recorder should have captured the CreateVariableRequest import.
+        imports_text = import_recorder.generate_imports()
+        assert "CreateVariableRequest" in imports_text
+
+    def test_save_load_preserves_flow_and_global_variables(self, griptape_nodes: GriptapeNodes) -> None:
+        """Round-trip: create variables, serialize, clear, exec, confirm both are restored."""
+        from griptape_nodes.retained_mode.events.flow_events import (
+            CreateFlowRequest,
+            CreateFlowResultSuccess,
+            SerializeFlowToCommandsRequest,
+            SerializeFlowToCommandsResultSuccess,
+        )
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+            GetVariableValueRequest,
+            GetVariableValueResultSuccess,
+        )
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        variables_manager = griptape_nodes.VariablesManager()
+        context_manager = griptape_nodes.ContextManager()
+
+        # Start from a clean slate for BOTH objects and variables.
+        GriptapeNodes.clear_data()
+        variables_manager.on_clear_object_state()
+
+        # Flows require an active Workflow in the Current Context.
+        if not context_manager.has_current_workflow():
+            context_manager.push_workflow(workflow_name="round_trip_workflow")
+
+        # Create a flow with one flow-scoped variable + one global.
+        flow_result = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
+        )
+        assert isinstance(flow_result, CreateFlowResultSuccess)
+        flow_name = flow_result.flow_name
+
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(
+                    name="flow_scoped_var", type="str", is_global=False, value="dog", owning_flow=flow_name
+                )
+            ),
+            CreateVariableResultSuccess,
+        )
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(name="global_var", type="str", is_global=True, value="world")
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        # Serialize.
+        serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+        assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
+        serialized_commands = serialize_result.serialized_flow_commands
+
+        # Both variables should be serialized (flow-scoped + global).
+        names_serialized = {
+            cmd.create_variable_command.name for cmd in serialized_commands.serialized_variable_commands
+        }
+        assert names_serialized == {"flow_scoped_var", "global_var"}
+
+        # Generate the workflow script.
+        metadata = self._fresh_metadata(name="test_round_trip")
+        script_source = workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=serialized_commands,
+            workflow_metadata=metadata,
+        )
+
+        # Script must reference CreateVariableRequest for both variables.
+        expected_create_variable_calls = 2  # one flow-scoped, one global
+        assert script_source.count("CreateVariableRequest(") >= expected_create_variable_calls
+        assert "name='flow_scoped_var'" in script_source
+        assert "name='global_var'" in script_source
+        assert "is_global=True" in script_source
+
+        # Clear everything, then exec the script and confirm variables are rebuilt.
+        GriptapeNodes.clear_data()
+        variables_manager.on_clear_object_state()
+
+        exec_globals: dict[str, object] = {"__file__": "test_workflow.py"}
+        exec(compile(script_source, "<round_trip_test>", "exec"), exec_globals)  # noqa: S102
+
+        flow_value = GriptapeNodes.handle_request(
+            GetVariableValueRequest(
+                name="flow_scoped_var", starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY
+            )
+        )
+        assert isinstance(flow_value, GetVariableValueResultSuccess)
+        assert flow_value.value == "dog"
+
+        # Globals are stored directly on the manager; no flow context needed for this assertion.
+        assert "global_var" in variables_manager._global_variables
+        assert variables_manager._global_variables["global_var"].value == "world"
+
+    def test_global_adopt_on_second_load(self, griptape_nodes: GriptapeNodes) -> None:
+        """Loading twice without clearing should adopt the existing global rather than failing."""
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultFailure,
+            CreateVariableResultSuccess,
+        )
+
+        variables_manager = griptape_nodes.VariablesManager()
+        GriptapeNodes.clear_data()
+        variables_manager.on_clear_object_state()
+
+        # First creation succeeds.
+        first = GriptapeNodes.handle_request(
+            CreateVariableRequest(name="shared", type="str", is_global=True, value="first", initial_setup=True)
+        )
+        assert isinstance(first, CreateVariableResultSuccess)
+
+        # Second with initial_setup=True adopts, returning success without overwriting.
+        second = GriptapeNodes.handle_request(
+            CreateVariableRequest(name="shared", type="str", is_global=True, value="second", initial_setup=True)
+        )
+        assert isinstance(second, CreateVariableResultSuccess)
+        assert variables_manager._global_variables["shared"].value == "first"
+
+        # Without initial_setup, a collision still fails.
+        third = GriptapeNodes.handle_request(
+            CreateVariableRequest(name="shared", type="str", is_global=True, value="third", initial_setup=False)
+        )
+        assert isinstance(third, CreateVariableResultFailure)

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1235,3 +1235,83 @@ class TestWorkflowVariablePersistence:
         serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
         assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
         assert serialize_result.serialized_flow_commands.serialized_variable_commands == []
+
+
+class TestVariableReferenceAccess:
+    """Tests for the access field on VariableReference."""
+
+    def test_default_access_is_read_write(self) -> None:
+        """Omitting ``access`` yields READ_WRITE — the safe default when a node's pattern is mixed."""
+        from griptape_nodes.exe_types.node_types import VariableAccess, VariableReference
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        ref = VariableReference(name="foo", scope=VariableScope.HIERARCHICAL)
+
+        assert ref.access is VariableAccess.READ_WRITE
+
+    def test_access_participates_in_equality_and_hash(self) -> None:
+        """Different access values on the same (name, scope) produce distinct, coexisting set members."""
+        from griptape_nodes.exe_types.node_types import VariableAccess, VariableReference
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        read_ref = VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ)
+        write_ref = VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.WRITE)
+        read_ref_twin = VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ)
+
+        assert read_ref != write_ref
+        assert hash(read_ref) != hash(write_ref)
+        assert read_ref == read_ref_twin
+        assert {read_ref, write_ref, read_ref_twin} == {read_ref, write_ref}
+
+    def test_aggregate_from_preserves_distinct_access_entries(self) -> None:
+        """Aggregating two NodeDependencies that name the same variable with different access retains both."""
+        from griptape_nodes.exe_types.node_types import NodeDependencies, VariableAccess, VariableReference
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        reader = NodeDependencies()
+        reader.variable_references.add(
+            VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ)
+        )
+        writer = NodeDependencies()
+        writer.variable_references.add(
+            VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ_WRITE)
+        )
+
+        reader.aggregate_from(writer)
+
+        assert reader.variable_references == {
+            VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ),
+            VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ_WRITE),
+        }
+
+    def test_serializer_ignores_access(self, griptape_nodes: GriptapeNodes) -> None:
+        """Serialization filtering is access-agnostic: any declared reference keeps the variable."""
+        from griptape_nodes.exe_types.node_types import VariableAccess, VariableReference
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+        )
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        flow_manager = griptape_nodes.FlowManager()
+        persistence = TestWorkflowVariablePersistence()
+        flow_name = persistence._push_clean_flow_context(griptape_nodes)
+
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(name="only_read", type="str", is_global=False, value="cat", owning_flow=flow_name)
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        commands = flow_manager._serialize_variables_for_flow(
+            flow_name=flow_name,
+            unique_parameter_uuid_to_values=unique_values,
+            variable_references={
+                VariableReference(name="only_read", scope=VariableScope.CURRENT_FLOW_ONLY, access=VariableAccess.READ)
+            },
+        )
+
+        # Access being READ does not exclude the variable from save-to-disk serialization.
+        assert {cmd.create_variable_command.name for cmd in commands} == {"only_read"}

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -7,6 +7,7 @@ import anyio
 
 if TYPE_CHECKING:
     from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+    from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
@@ -931,11 +932,197 @@ class TestWorkflowVariablePersistence:
         imports_text = import_recorder.generate_imports()
         assert "CreateVariableRequest" in imports_text
 
-    def test_save_load_preserves_flow_scoped_variables(self, griptape_nodes: GriptapeNodes) -> None:
-        """Round-trip: create a flow-scoped variable, serialize, clear, exec, confirm it is restored."""
+    def _push_clean_flow_context(self, griptape_nodes: GriptapeNodes, flow_name: str = "ControlFlow_1") -> str:
+        """Clear state, push a workflow context, and create a single empty flow. Returns the flow name."""
         from griptape_nodes.retained_mode.events.flow_events import (
             CreateFlowRequest,
             CreateFlowResultSuccess,
+        )
+
+        variables_manager = griptape_nodes.VariablesManager()
+        context_manager = griptape_nodes.ContextManager()
+
+        GriptapeNodes.clear_data()
+        variables_manager.on_clear_object_state()
+
+        if not context_manager.has_current_workflow():
+            context_manager.push_workflow(workflow_name="round_trip_workflow")
+
+        flow_result = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name=flow_name, set_as_new_context=False)
+        )
+        assert isinstance(flow_result, CreateFlowResultSuccess)
+        return flow_result.flow_name
+
+    def test_declared_variable_gets_serialized(self, griptape_nodes: GriptapeNodes) -> None:
+        """A flow-scoped variable that is declared via a VariableReference should be serialized."""
+        from griptape_nodes.exe_types.node_types import VariableReference
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+        )
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        flow_manager = griptape_nodes.FlowManager()
+        flow_name = self._push_clean_flow_context(griptape_nodes)
+
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(
+                    name="declared_var", type="str", is_global=False, value="dog", owning_flow=flow_name
+                )
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        commands = flow_manager._serialize_variables_for_flow(
+            flow_name=flow_name,
+            unique_parameter_uuid_to_values=unique_values,
+            variable_references={VariableReference(name="declared_var", scope=VariableScope.CURRENT_FLOW_ONLY)},
+        )
+
+        assert {cmd.create_variable_command.name for cmd in commands} == {"declared_var"}
+        assert len(unique_values) == 1
+
+    def test_orphan_variable_is_dropped(self, griptape_nodes: GriptapeNodes) -> None:
+        """A variable in engine state with no declared reference must not be serialized."""
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+        )
+
+        flow_manager = griptape_nodes.FlowManager()
+        flow_name = self._push_clean_flow_context(griptape_nodes)
+
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(
+                    name="orphan_var", type="str", is_global=False, value="cat", owning_flow=flow_name
+                )
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        commands = flow_manager._serialize_variables_for_flow(
+            flow_name=flow_name,
+            unique_parameter_uuid_to_values=unique_values,
+            variable_references=set(),
+        )
+
+        assert commands == []
+        assert unique_values == {}
+
+    def test_declared_but_missing_variable_is_dropped(self, griptape_nodes: GriptapeNodes) -> None:
+        """A reference to a variable that does not exist in the flow should not produce a command."""
+        from griptape_nodes.exe_types.node_types import VariableReference
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        flow_manager = griptape_nodes.FlowManager()
+        flow_name = self._push_clean_flow_context(griptape_nodes)
+
+        unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        commands = flow_manager._serialize_variables_for_flow(
+            flow_name=flow_name,
+            unique_parameter_uuid_to_values=unique_values,
+            variable_references={VariableReference(name="ghost", scope=VariableScope.CURRENT_FLOW_ONLY)},
+        )
+
+        assert commands == []
+
+    def test_global_only_scope_is_skipped(self, griptape_nodes: GriptapeNodes) -> None:
+        """GLOBAL_ONLY references are deferred for now and must not produce a command."""
+        from griptape_nodes.exe_types.node_types import VariableReference
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+        )
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        flow_manager = griptape_nodes.FlowManager()
+        flow_name = self._push_clean_flow_context(griptape_nodes)
+
+        # Create a flow-scoped variable with the same name as a pretend-global. It should not match,
+        # because the GLOBAL_ONLY scope is unsupported for serialization and must be skipped.
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(
+                    name="shared_name", type="str", is_global=False, value="local", owning_flow=flow_name
+                )
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        commands = flow_manager._serialize_variables_for_flow(
+            flow_name=flow_name,
+            unique_parameter_uuid_to_values=unique_values,
+            variable_references={VariableReference(name="shared_name", scope=VariableScope.GLOBAL_ONLY)},
+        )
+
+        assert commands == []
+
+    def test_hierarchical_reference_only_serializes_at_owning_flow(self, griptape_nodes: GriptapeNodes) -> None:
+        """A HIERARCHICAL reference resolved against a child flow must not serialize an ancestor-owned variable."""
+        from griptape_nodes.exe_types.node_types import VariableReference
+        from griptape_nodes.retained_mode.events.flow_events import (
+            CreateFlowRequest,
+            CreateFlowResultSuccess,
+        )
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+        )
+        from griptape_nodes.retained_mode.variable_types import VariableScope
+
+        flow_manager = griptape_nodes.FlowManager()
+        parent_flow_name = self._push_clean_flow_context(griptape_nodes, flow_name="ParentFlow")
+
+        child_flow_result = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=parent_flow_name, flow_name="ChildFlow", set_as_new_context=False)
+        )
+        assert isinstance(child_flow_result, CreateFlowResultSuccess)
+        child_flow_name = child_flow_result.flow_name
+
+        # Variable lives on the parent.
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(
+                    name="ancestor_var",
+                    type="str",
+                    is_global=False,
+                    value="from_parent",
+                    owning_flow=parent_flow_name,
+                )
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        ref = VariableReference(name="ancestor_var", scope=VariableScope.HIERARCHICAL)
+
+        # Child flow should not claim the parent-owned variable.
+        child_unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        child_commands = flow_manager._serialize_variables_for_flow(
+            flow_name=child_flow_name,
+            unique_parameter_uuid_to_values=child_unique_values,
+            variable_references={ref},
+        )
+        assert child_commands == []
+
+        # Parent flow should claim it.
+        parent_unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
+        parent_commands = flow_manager._serialize_variables_for_flow(
+            flow_name=parent_flow_name,
+            unique_parameter_uuid_to_values=parent_unique_values,
+            variable_references={ref},
+        )
+        assert {cmd.create_variable_command.name for cmd in parent_commands} == {"ancestor_var"}
+
+    def test_save_load_preserves_flow_scoped_variables(self, griptape_nodes: GriptapeNodes) -> None:
+        """Round-trip: declare a flow-scoped variable, serialize, clear, exec, confirm it is restored."""
+        from griptape_nodes.exe_types.node_types import NodeDependencies, VariableReference
+        from griptape_nodes.retained_mode.events.flow_events import (
             SerializeFlowToCommandsRequest,
             SerializeFlowToCommandsResultSuccess,
         )
@@ -949,22 +1136,7 @@ class TestWorkflowVariablePersistence:
 
         workflow_manager = griptape_nodes.WorkflowManager()
         variables_manager = griptape_nodes.VariablesManager()
-        context_manager = griptape_nodes.ContextManager()
-
-        # Start from a clean slate for BOTH objects and variables.
-        GriptapeNodes.clear_data()
-        variables_manager.on_clear_object_state()
-
-        # Flows require an active Workflow in the Current Context.
-        if not context_manager.has_current_workflow():
-            context_manager.push_workflow(workflow_name="round_trip_workflow")
-
-        # Create a flow with one flow-scoped variable.
-        flow_result = GriptapeNodes.handle_request(
-            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
-        )
-        assert isinstance(flow_result, CreateFlowResultSuccess)
-        flow_name = flow_result.flow_name
+        flow_name = self._push_clean_flow_context(griptape_nodes)
 
         assert isinstance(
             GriptapeNodes.handle_request(
@@ -975,12 +1147,36 @@ class TestWorkflowVariablePersistence:
             CreateVariableResultSuccess,
         )
 
-        # Serialize.
-        serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+        # Normally a node declares the reference via get_node_dependencies(); for this test we
+        # inject the declaration directly onto the flow's aggregated NodeDependencies after
+        # serialization gathers them. We do that by patching _aggregate_flow_dependencies to append
+        # a VariableReference for our variable.
+        from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+        from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
+
+        flow_manager = griptape_nodes.FlowManager()
+        original_aggregate = flow_manager._aggregate_flow_dependencies
+
+        def aggregate_with_declared_ref(
+            serialized_node_commands: list[SerializedNodeCommands],
+            sub_flows_commands: list[SerializedFlowCommands],
+        ) -> NodeDependencies:
+            deps = original_aggregate(serialized_node_commands, sub_flows_commands)
+            deps.variable_references.add(
+                VariableReference(name="flow_scoped_var", scope=VariableScope.CURRENT_FLOW_ONLY)
+            )
+            return deps
+
+        with patch.object(
+            flow_manager,
+            "_aggregate_flow_dependencies",
+            side_effect=aggregate_with_declared_ref,
+        ):
+            serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+
         assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
         serialized_commands = serialize_result.serialized_flow_commands
 
-        # The flow-scoped variable should be serialized.
         names_serialized = {
             cmd.create_variable_command.name for cmd in serialized_commands.serialized_variable_commands
         }
@@ -1011,3 +1207,31 @@ class TestWorkflowVariablePersistence:
         )
         assert isinstance(flow_value, GetVariableValueResultSuccess)
         assert flow_value.value == "dog"
+
+    def test_save_drops_orphan_variables_end_to_end(self, griptape_nodes: GriptapeNodes) -> None:
+        """The var.py scenario: a variable with no declaring node must not survive serialization."""
+        from griptape_nodes.retained_mode.events.flow_events import (
+            SerializeFlowToCommandsRequest,
+            SerializeFlowToCommandsResultSuccess,
+        )
+        from griptape_nodes.retained_mode.events.variable_events import (
+            CreateVariableRequest,
+            CreateVariableResultSuccess,
+        )
+
+        flow_name = self._push_clean_flow_context(griptape_nodes)
+
+        # Simulate the bug: a variable was created (via some now-deleted SetVariable node) but no
+        # node currently declares it.
+        assert isinstance(
+            GriptapeNodes.handle_request(
+                CreateVariableRequest(
+                    name="orphan_var", type="str", is_global=False, value="stale", owning_flow=flow_name
+                )
+            ),
+            CreateVariableResultSuccess,
+        )
+
+        serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+        assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
+        assert serialize_result.serialized_flow_commands.serialized_variable_commands == []

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -931,8 +931,8 @@ class TestWorkflowVariablePersistence:
         imports_text = import_recorder.generate_imports()
         assert "CreateVariableRequest" in imports_text
 
-    def test_save_load_preserves_flow_and_global_variables(self, griptape_nodes: GriptapeNodes) -> None:
-        """Round-trip: create variables, serialize, clear, exec, confirm both are restored."""
+    def test_save_load_preserves_flow_scoped_variables(self, griptape_nodes: GriptapeNodes) -> None:
+        """Round-trip: create a flow-scoped variable, serialize, clear, exec, confirm it is restored."""
         from griptape_nodes.retained_mode.events.flow_events import (
             CreateFlowRequest,
             CreateFlowResultSuccess,
@@ -959,7 +959,7 @@ class TestWorkflowVariablePersistence:
         if not context_manager.has_current_workflow():
             context_manager.push_workflow(workflow_name="round_trip_workflow")
 
-        # Create a flow with one flow-scoped variable + one global.
+        # Create a flow with one flow-scoped variable.
         flow_result = GriptapeNodes.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
         )
@@ -974,23 +974,17 @@ class TestWorkflowVariablePersistence:
             ),
             CreateVariableResultSuccess,
         )
-        assert isinstance(
-            GriptapeNodes.handle_request(
-                CreateVariableRequest(name="global_var", type="str", is_global=True, value="world")
-            ),
-            CreateVariableResultSuccess,
-        )
 
         # Serialize.
         serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
         assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
         serialized_commands = serialize_result.serialized_flow_commands
 
-        # Both variables should be serialized (flow-scoped + global).
+        # The flow-scoped variable should be serialized.
         names_serialized = {
             cmd.create_variable_command.name for cmd in serialized_commands.serialized_variable_commands
         }
-        assert names_serialized == {"flow_scoped_var", "global_var"}
+        assert names_serialized == {"flow_scoped_var"}
 
         # Generate the workflow script.
         metadata = self._fresh_metadata(name="test_round_trip")
@@ -999,14 +993,11 @@ class TestWorkflowVariablePersistence:
             workflow_metadata=metadata,
         )
 
-        # Script must reference CreateVariableRequest for both variables.
-        expected_create_variable_calls = 2  # one flow-scoped, one global
-        assert script_source.count("CreateVariableRequest(") >= expected_create_variable_calls
+        # Script must reference CreateVariableRequest for the flow-scoped variable.
+        assert "CreateVariableRequest(" in script_source
         assert "name='flow_scoped_var'" in script_source
-        assert "name='global_var'" in script_source
-        assert "is_global=True" in script_source
 
-        # Clear everything, then exec the script and confirm variables are rebuilt.
+        # Clear everything, then exec the script and confirm the variable is rebuilt.
         GriptapeNodes.clear_data()
         variables_manager.on_clear_object_state()
 
@@ -1020,38 +1011,3 @@ class TestWorkflowVariablePersistence:
         )
         assert isinstance(flow_value, GetVariableValueResultSuccess)
         assert flow_value.value == "dog"
-
-        # Globals are stored directly on the manager; no flow context needed for this assertion.
-        assert "global_var" in variables_manager._global_variables
-        assert variables_manager._global_variables["global_var"].value == "world"
-
-    def test_global_adopt_on_second_load(self, griptape_nodes: GriptapeNodes) -> None:
-        """Loading twice without clearing should adopt the existing global rather than failing."""
-        from griptape_nodes.retained_mode.events.variable_events import (
-            CreateVariableRequest,
-            CreateVariableResultFailure,
-            CreateVariableResultSuccess,
-        )
-
-        variables_manager = griptape_nodes.VariablesManager()
-        GriptapeNodes.clear_data()
-        variables_manager.on_clear_object_state()
-
-        # First creation succeeds.
-        first = GriptapeNodes.handle_request(
-            CreateVariableRequest(name="shared", type="str", is_global=True, value="first", initial_setup=True)
-        )
-        assert isinstance(first, CreateVariableResultSuccess)
-
-        # Second with initial_setup=True adopts, returning success without overwriting.
-        second = GriptapeNodes.handle_request(
-            CreateVariableRequest(name="shared", type="str", is_global=True, value="second", initial_setup=True)
-        )
-        assert isinstance(second, CreateVariableResultSuccess)
-        assert variables_manager._global_variables["shared"].value == "first"
-
-        # Without initial_setup, a collision still fails.
-        third = GriptapeNodes.handle_request(
-            CreateVariableRequest(name="shared", type="str", is_global=True, value="third", initial_setup=False)
-        )
-        assert isinstance(third, CreateVariableResultFailure)


### PR DESCRIPTION
## Summary

Engine-side fix so that flow-scoped `Variable` objects survive workflow save/load. Previously the workflow serializer emitted nodes, parameters, and connections but never persisted the `VariablesManager` state, leaving `GetVariable` nodes unresolved at edit-time until the flow actually ran.

Variable persistence is now **node-declared**: each variable-aware node declares the variables it reads or writes via its `NodeDependencies`, and the serializer only persists variables that are claimed by at least one node in the flow. Variables that exist in engine state but are not claimed by any node (orphans left behind by deleted nodes) are silently dropped on save.

Global-variable serialization is intentionally **out of scope** for this PR and will be handled separately.

## Why the node-declared approach

Variables have no lifecycle binding to nodes. `SetVariable.before_value_set` eagerly creates a variable in engine state the moment the user types a name, but deleting that `SetVariable` node does not delete the variable. An earlier iteration of this branch serialized everything in `VariablesManager`, which meant orphans from deleted nodes accumulated in the workflow file on every save. Making the set of serialized variables driven by declared node dependencies closes the lifecycle gap without adding new delete hooks.

A companion PR on `griptape-nodes-library-standard` adds `get_node_dependencies()` overrides on `SetVariable`/`GetVariable`/`HasVariable`/`CreateVariable` so they declare the variables they reference.

## Changes

### Serialized-file plumbing
- **`CreateVariableRequest`**: added `initial_setup: bool = False` so load-time creates are distinguishable from user actions and suppress workflow-altered signalling.
- **`SerializedFlowCommands`**: new nested `SerializedVariableCommand` dataclass + `serialized_variable_commands` list field. Variable values share the existing `unique_parameter_uuid_to_values` dedup pool (no new pool introduced).
- **`WorkflowMetadata.LATEST_SCHEMA_VERSION`**: bumped `0.16.0` → `0.17.0` since the serialized file format now carries new events.

### Node-declared dependencies
- **`NodeDependencies`**: new `variable_references: set[VariableReference]` field, aggregated across a flow and its subtree through the existing `aggregate_from` pathway.
- **`VariableReference`**: new frozen dataclass carrying `(name, scope)`, declared by nodes and resolved by the serializer.

### Serializer filtering
- **`FlowManager._serialize_variables_for_flow`** now filters candidates by the aggregated `variable_references`. Only variables that are (a) owned by the current flow AND (b) claimed by at least one declared reference get persisted.
- Scope resolution rules:
  - `CURRENT_FLOW_ONLY` — claims the variable only if it exists directly in the flow being serialized.
  - `HIERARCHICAL` — uses `GetVariableRequest` to resolve; claims only at the flow that actually owns the variable (ancestor-owned variables get claimed by the ancestor's own serialization pass, which keeps each variable emitted exactly once).
  - `GLOBAL_ONLY` / `ALL` — skipped with a debug log; deferred to the globals-serialization follow-up.
- All engine-side variable access goes through the request/response bus (`ListVariablesRequest`, `GetVariableRequest`) rather than reaching into `VariablesManager` state directly.

### Code generation
- **`WorkflowManager`**: new `_generate_create_variable_code` helper emits `CreateVariableRequest(..., initial_setup=True)` AST calls inside each flow/sub-flow `with` block before any `CreateNodeRequest`. Ordering matters: variables must exist before nodes so that `SetVariable.before_value_set` adopts rather than double-creating.

### Tests
- New `TestWorkflowVariablePersistence` suite in `test_workflow_manager.py`:
  - `test_generate_create_variable_code_emits_expected_call` — AST shape of generated `CreateVariableRequest`.
  - `test_declared_variable_gets_serialized` — a declared reference produces a serialized command.
  - `test_orphan_variable_is_dropped` — a variable with no declaring reference is filtered out.
  - `test_declared_but_missing_variable_is_dropped` — a reference to a non-existent variable produces no command.
  - `test_global_only_scope_is_skipped` — `GLOBAL_ONLY` references are deferred/skipped.
  - `test_hierarchical_reference_only_serializes_at_owning_flow` — parent-owned variable claimed by the parent's serialization, not the child's.
  - `test_save_load_preserves_flow_scoped_variables` — full save → clear → exec round-trip.
  - `test_save_drops_orphan_variables_end_to_end` — the var.py bug: orphan variables don't survive serialization.

## Example Workflow File

Using local Library changes to the SetVariable Node, to declare a NodeDependency on its variable.

```python
# /// script
# dependencies = []
# 
# [tool.griptape-nodes]
# name = "var"
# schema_version = "0.17.0"
# engine_version_created_with = "0.82.0"
# node_libraries_referenced = [["Griptape Nodes Library", "0.71.0"]]
# node_types_used = [["Griptape Nodes Library", "SetVariable"], ["Griptape Nodes Library", "TextInput"]]
# is_griptape_provided = false
# is_template = false
# creation_date = 2026-04-21T19:24:03.868558Z
# last_modified_date = 2026-04-23T22:50:17.271501Z
# 
# ///

import pickle
from griptape_nodes.node_library.library_registry import IconVariant, NodeDeprecationMetadata, NodeMetadata
from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest
from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, AlterParameterDetailsRequest, SetParameterValueRequest
from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes

GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(library_name='Griptape Nodes Library', perform_discovery_if_not_found=True))

context_manager = GriptapeNodes.ContextManager()

if not context_manager.has_current_workflow():
    context_manager.push_workflow(file_path=__file__)

"""
1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
   This minimizes the size of the code, especially for large objects like serialized image files.
2. We're using a prefix so that it's clear which Flow these values are associated with.
3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
   them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
   would be difficult to serialize.
"""
top_level_unique_values_dict = {'dd2d46ab-a8b0-44c4-9be9-a386204a338c': pickle.loads(b'\x80\x04\x95\x07\x00\x00\x00\x00\x00\x00\x00\x8c\x03dog\x94.'), '324007e6-5304-487c-a17f-016aeef69508': pickle.loads(b'\x80\x04\x95\x08\x00\x00\x00\x00\x00\x00\x00\x8c\x04test\x94.'), '6554b214-273c-4e7d-aa1c-2fd0b4872dc5': pickle.loads(b'\x80\x04\x95\x10\x00\x00\x00\x00\x00\x00\x00\x8c\x0chierarchical\x94.'), '88c34d43-d33f-449a-9854-dd4f2b539871': pickle.loads(b'\x80\x04\x95\x07\x00\x00\x00\x00\x00\x00\x00\x8c\x03dog\x94.')}

'# Create the Flow, then do work within it as context.'

flow0_name = GriptapeNodes.handle_request(CreateFlowRequest(parent_flow_name=None, flow_name='ControlFlow_1', set_as_new_context=False, metadata={})).flow_name

with GriptapeNodes.ContextManager().flow(flow0_name):
    GriptapeNodes.handle_request(CreateVariableRequest(name='test', type='str', is_global=False, value=top_level_unique_values_dict['88c34d43-d33f-449a-9854-dd4f2b539871'], owning_flow='ControlFlow_1', initial_setup=True))
    node0_name = GriptapeNodes.handle_request(CreateNodeRequest(node_type='TextInput', specific_library_name='Griptape Nodes Library', node_name='Text Input', metadata={'position': {'x': -267.7211352067691, 'y': 428.1893351155531}, 'tempId': 'placing-1776799293323-qk551', 'library_node_metadata': NodeMetadata(category='text', description='TextInput node', display_name='Text Input', tags=None, icon='text-cursor', color=None, group='create', deprecation=None, is_node_group=None), 'library': 'Griptape Nodes Library', 'node_type': 'TextInput', 'showaddparameter': False, 'size': {'width': 600, 'height': 236}, 'category': 'text'}, resolution='resolved', initial_setup=True)).node_name
    node1_name = GriptapeNodes.handle_request(CreateNodeRequest(node_type='SetVariable', specific_library_name='Griptape Nodes Library', node_name='Set Variable', metadata={'position': {'x': 617.046539432078, 'y': 431.28307408533334}, 'tempId': 'placing-1776984604191-194z8i', 'library_node_metadata': {'category': 'variables', 'description': 'Set the value of a variable, creating it if it does not exist'}, 'library': 'Griptape Nodes Library', 'node_type': 'SetVariable', 'showaddparameter': False, 'size': {'width': 600, 'height': 344}}, resolution='resolved', initial_setup=True)).node_name
    with GriptapeNodes.ContextManager().node(node1_name):
        GriptapeNodes.handle_request(AlterParameterDetailsRequest(parameter_name='value', type='str', input_types=['str'], output_type='str', initial_setup=True))
    GriptapeNodes.handle_request(CreateConnectionRequest(source_node_name=node0_name, source_parameter_name='text', target_node_name=node1_name, target_parameter_name='value', initial_setup=True))
    with GriptapeNodes.ContextManager().node(node0_name):
        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name='text', node_name=node0_name, value=top_level_unique_values_dict['dd2d46ab-a8b0-44c4-9be9-a386204a338c'], initial_setup=True, is_output=False))
        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name='text', node_name=node0_name, value=top_level_unique_values_dict['dd2d46ab-a8b0-44c4-9be9-a386204a338c'], initial_setup=True, is_output=True))
    with GriptapeNodes.ContextManager().node(node1_name):
        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name='variable_name', node_name=node1_name, value=top_level_unique_values_dict['324007e6-5304-487c-a17f-016aeef69508'], initial_setup=True, is_output=False))
        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name='variable_name', node_name=node1_name, value=top_level_unique_values_dict['324007e6-5304-487c-a17f-016aeef69508'], initial_setup=True, is_output=True))
        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name='value', node_name=node1_name, value=top_level_unique_values_dict['dd2d46ab-a8b0-44c4-9be9-a386204a338c'], initial_setup=True, is_output=False))
        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name='scope', node_name=node1_name, value=top_level_unique_values_dict['6554b214-273c-4e7d-aa1c-2fd0b4872dc5'], initial_setup=True, is_output=False))

```

Closes #4413