### PR TITLE
fix: preserve custom `static_server_base_url` and make override explicit

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -1,4 +1,3 @@
-import os
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
@@ -293,12 +292,10 @@ class Settings(BaseModel):
         default_factory=list,
         description="List of Model Context Protocol server configurations",
     )
-    static_server_base_url: str = Field(
+    static_server_base_url: str | None = Field(
         category=STATIC_SERVER,
-        default_factory=lambda: (
-            f"http://{os.getenv('STATIC_SERVER_HOST', 'localhost')}:{os.getenv('STATIC_SERVER_PORT', '8124')}"
-        ),
-        description="Base URL for the static server. Defaults to http://localhost:8124 (or values from STATIC_SERVER_HOST/PORT env vars). Override this when using tunnels (ngrok, cloudflare) or reverse proxies.",
+        default=None,
+        description="Base URL for the static server. Leave unset to derive it from the server's host/port (including the OS-assigned port when the configured port is unavailable). Set this only to override the derived URL, e.g. when fronting the server with a tunnel (ngrok, cloudflare) or reverse proxy.",
     )
     artifacts: dict[str, Any] = Field(
         category=ARTIFACTS,

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -389,11 +389,12 @@ class StaticFilesManager:
             sock = bind_free_socket(STATIC_SERVER_HOST, STATIC_SERVER_PORT)
             actual_port = sock.getsockname()[1]
 
-            # Only update the base URL when the user hasn't configured a custom host
-            # (e.g. an ngrok tunnel or reverse proxy). If the configured host matches the
-            # server's bind host, it's a direct connection and we update the port.
+            # Only update the base URL when the user hasn't customized the host or port
+            # (e.g. an ngrok tunnel, reverse proxy, or `ssh -L` tunnel on a different port).
+            # If both host and port match the server defaults, it's a direct connection and
+            # we update the port to reflect the OS-assigned value.
             parsed = urlparse(self.static_server_base_url)
-            if parsed.hostname == STATIC_SERVER_HOST:
+            if parsed.hostname == STATIC_SERVER_HOST and parsed.port == STATIC_SERVER_PORT:
                 self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}".rstrip("/")
             self.storage_driver.base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -4,7 +4,6 @@ import logging
 import threading
 from pathlib import Path
 from typing import NamedTuple
-from urllib.parse import urlparse
 
 from xdg_base_dirs import xdg_config_home
 
@@ -97,8 +96,15 @@ class StaticFilesManager:
         self.storage_backend = config_manager.get_config_value("storage_backend", default=StorageBackend.LOCAL)
         workspace_directory = config_manager.workspace_path
 
-        # Build base URL for LocalStorageDriver from configured base URL
-        self.static_server_base_url = config_manager.get_config_value("static_server_base_url").rstrip("/")
+        # Build base URL for LocalStorageDriver. When the user has not configured an explicit
+        # base URL, derive it from the server's host/port so on_app_initialization_complete can
+        # later swap in the OS-assigned port. An explicit override is taken verbatim.
+        configured_base_url = config_manager.get_config_value("static_server_base_url")
+        self._static_server_base_url_overridden = configured_base_url is not None
+        if configured_base_url is None:
+            self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}"
+        else:
+            self.static_server_base_url = configured_base_url.rstrip("/")
         base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
 
         match self.storage_backend:
@@ -389,13 +395,12 @@ class StaticFilesManager:
             sock = bind_free_socket(STATIC_SERVER_HOST, STATIC_SERVER_PORT)
             actual_port = sock.getsockname()[1]
 
-            # Only update the base URL when the user hasn't customized the host or port
+            # Only update the base URL when the user hasn't provided an explicit override
             # (e.g. an ngrok tunnel, reverse proxy, or `ssh -L` tunnel on a different port).
-            # If both host and port match the server defaults, it's a direct connection and
-            # we update the port to reflect the OS-assigned value.
-            parsed = urlparse(self.static_server_base_url)
-            if parsed.hostname == STATIC_SERVER_HOST and parsed.port == STATIC_SERVER_PORT:
-                self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}".rstrip("/")
+            # Without an override the URL is server-derived, so we refresh the port to reflect
+            # the OS-assigned value.
+            if not self._static_server_base_url_overridden:
+                self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
             self.storage_driver.base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
 
             threading.Thread(target=start_static_server, args=(sock,), daemon=True, name="static-server").start()

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -96,16 +96,17 @@ class StaticFilesManager:
         self.storage_backend = config_manager.get_config_value("storage_backend", default=StorageBackend.LOCAL)
         workspace_directory = config_manager.workspace_path
 
-        # Build base URL for LocalStorageDriver. When the user has not configured an explicit
-        # base URL, derive it from the server's host/port so on_app_initialization_complete can
-        # later swap in the OS-assigned port. An explicit override is taken verbatim.
+        # Capture any explicit base URL override now; leave the underlying field None otherwise
+        # so on_app_initialization_complete can derive the URL from the OS-assigned port. A set
+        # value here (including one that equals the server defaults) is the signal for "user
+        # override" and short-circuits the port refresh.
         configured_base_url = config_manager.get_config_value("static_server_base_url")
-        self._static_server_base_url_overridden = configured_base_url is not None
-        if configured_base_url is None:
-            self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{STATIC_SERVER_PORT}"
-        else:
-            self.static_server_base_url = configured_base_url.rstrip("/")
-        base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
+        self._static_server_base_url: str | None = (
+            configured_base_url.rstrip("/") if configured_base_url is not None else None
+        )
+        base_url = (
+            f"{self._static_server_base_url}{STATIC_SERVER_URL}" if self._static_server_base_url is not None else None
+        )
 
         match self.storage_backend:
             case StorageBackend.GTC:
@@ -151,6 +152,18 @@ class StaticFilesManager:
                 self.on_app_initialization_complete,
             )
             # TODO: Listen for shutdown event (https://github.com/griptape-ai/griptape-nodes/issues/2149) to stop static server
+
+    @property
+    def static_server_base_url(self) -> str:
+        """Base URL for the static server.
+
+        Resolved during ``on_app_initialization_complete`` once the server has bound to a
+        port. Reading this before that event fires indicates a startup-ordering bug.
+        """
+        if self._static_server_base_url is None:
+            msg = "static_server_base_url accessed before on_app_initialization_complete resolved it."
+            raise RuntimeError(msg)
+        return self._static_server_base_url
 
     def _generate_preview_if_needed(self, file_path: Path) -> tuple[Path, dict | None]:
         """Generate preview for a file if needed.
@@ -395,13 +408,12 @@ class StaticFilesManager:
             sock = bind_free_socket(STATIC_SERVER_HOST, STATIC_SERVER_PORT)
             actual_port = sock.getsockname()[1]
 
-            # Only update the base URL when the user hasn't provided an explicit override
-            # (e.g. an ngrok tunnel, reverse proxy, or `ssh -L` tunnel on a different port).
-            # Without an override the URL is server-derived, so we refresh the port to reflect
-            # the OS-assigned value.
-            if not self._static_server_base_url_overridden:
-                self.static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
-            self.storage_driver.base_url = f"{self.static_server_base_url}{STATIC_SERVER_URL}"
+            # When there's no explicit override, derive the base URL from the bind host and
+            # the OS-assigned port. An override set in __init__ (e.g. an ngrok tunnel, reverse
+            # proxy, or `ssh -L` tunnel on a different port) is taken verbatim.
+            if self._static_server_base_url is None:
+                self._static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
+            self.storage_driver.base_url = f"{self._static_server_base_url}{STATIC_SERVER_URL}"
 
             threading.Thread(target=start_static_server, args=(sock,), daemon=True, name="static-server").start()
 

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -921,3 +921,76 @@ class TestStaticFilesManagerBaseUrlTrailingSlash:
             )
 
         assert manager.static_server_base_url == expected_url
+
+
+class TestStaticFilesManagerOnAppInitializationComplete:
+    """Test port handling in on_app_initialization_complete.
+
+    The engine binds a free port at startup and may rewrite `static_server_base_url`
+    to reflect the OS-assigned port. That rewrite must only happen when the user has
+    not customized host or port away from the defaults, otherwise it clobbers tunnel
+    configurations (e.g. `ssh -L 8888:localhost:8124`, ngrok, reverse proxies).
+    """
+
+    @pytest.fixture
+    def mock_secrets_manager(self) -> Mock:
+        return Mock()
+
+    def _build_manager(self, mock_secrets_manager: Mock, configured_url: str) -> StaticFilesManager:
+        from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
+
+        mock_config = Mock()
+        mock_config.get_config_value.side_effect = lambda key, default=None: {
+            "storage_backend": "local",
+            "static_server_base_url": configured_url,
+        }.get(key, default)
+        mock_config.workspace_path = Path("/mock/workspace")
+
+        with patch("griptape_nodes.retained_mode.managers.static_files_manager.LocalStorageDriver") as driver_cls:
+            driver_cls.return_value = Mock(spec=LocalStorageDriver)
+            manager = StaticFilesManager(
+                config_manager=mock_config, secrets_manager=mock_secrets_manager, event_manager=None
+            )
+        return manager
+
+    def _invoke_initialization(self, manager: StaticFilesManager, actual_port: int) -> None:
+        from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+
+        mock_sock = Mock()
+        mock_sock.getsockname.return_value = ("127.0.0.1", actual_port)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.static_files_manager.bind_free_socket",
+                return_value=mock_sock,
+            ),
+            patch("griptape_nodes.retained_mode.managers.static_files_manager.threading.Thread"),
+        ):
+            manager.on_app_initialization_complete(AppInitializationComplete())
+
+    def test_default_host_and_port_rewritten_to_actual_port(self, mock_secrets_manager: Mock) -> None:
+        """When config matches the defaults, the OS-assigned port replaces the default port."""
+        manager = self._build_manager(mock_secrets_manager, "http://localhost:8124")
+
+        self._invoke_initialization(manager, actual_port=54321)
+
+        assert manager.static_server_base_url == "http://localhost:54321"
+        assert manager.storage_driver.base_url == "http://localhost:54321/workspace"
+
+    def test_custom_port_on_localhost_preserved(self, mock_secrets_manager: Mock) -> None:
+        """A custom port (e.g. from an `ssh -L 8888:localhost:8124` tunnel) must not be overwritten."""
+        manager = self._build_manager(mock_secrets_manager, "http://localhost:8888")
+
+        self._invoke_initialization(manager, actual_port=54321)
+
+        assert manager.static_server_base_url == "http://localhost:8888"
+        assert manager.storage_driver.base_url == "http://localhost:8888/workspace"
+
+    def test_custom_hostname_preserved(self, mock_secrets_manager: Mock) -> None:
+        """A custom host (e.g. an ngrok tunnel) must not be overwritten."""
+        manager = self._build_manager(mock_secrets_manager, "https://my-tunnel.ngrok.io")
+
+        self._invoke_initialization(manager, actual_port=54321)
+
+        assert manager.static_server_base_url == "https://my-tunnel.ngrok.io"
+        assert manager.storage_driver.base_url == "https://my-tunnel.ngrok.io/workspace"

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -1003,3 +1003,10 @@ class TestStaticFilesManagerOnAppInitializationComplete:
 
         assert manager.static_server_base_url == "http://localhost:8124"
         assert manager.storage_driver.base_url == "http://localhost:8124/workspace"
+
+    def test_access_before_initialization_complete_raises(self, mock_secrets_manager: Mock) -> None:
+        """Reading the property before on_app_initialization_complete resolves it is a startup bug."""
+        manager = self._build_manager(mock_secrets_manager, None)
+
+        with pytest.raises(RuntimeError, match="static_server_base_url accessed before"):
+            _ = manager.static_server_base_url

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -928,15 +928,15 @@ class TestStaticFilesManagerOnAppInitializationComplete:
 
     The engine binds a free port at startup and may rewrite `static_server_base_url`
     to reflect the OS-assigned port. That rewrite must only happen when the user has
-    not customized host or port away from the defaults, otherwise it clobbers tunnel
-    configurations (e.g. `ssh -L 8888:localhost:8124`, ngrok, reverse proxies).
+    not provided an explicit override, otherwise it clobbers tunnel configurations
+    (e.g. `ssh -L 8888:localhost:8124`, ngrok, reverse proxies).
     """
 
     @pytest.fixture
     def mock_secrets_manager(self) -> Mock:
         return Mock()
 
-    def _build_manager(self, mock_secrets_manager: Mock, configured_url: str) -> StaticFilesManager:
+    def _build_manager(self, mock_secrets_manager: Mock, configured_url: str | None) -> StaticFilesManager:
         from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 
         mock_config = Mock()
@@ -968,9 +968,9 @@ class TestStaticFilesManagerOnAppInitializationComplete:
         ):
             manager.on_app_initialization_complete(AppInitializationComplete())
 
-    def test_default_host_and_port_rewritten_to_actual_port(self, mock_secrets_manager: Mock) -> None:
-        """When config matches the defaults, the OS-assigned port replaces the default port."""
-        manager = self._build_manager(mock_secrets_manager, "http://localhost:8124")
+    def test_unset_base_url_rewritten_to_actual_port(self, mock_secrets_manager: Mock) -> None:
+        """When no override is configured, the OS-assigned port replaces the server's default port."""
+        manager = self._build_manager(mock_secrets_manager, None)
 
         self._invoke_initialization(manager, actual_port=54321)
 
@@ -994,3 +994,12 @@ class TestStaticFilesManagerOnAppInitializationComplete:
 
         assert manager.static_server_base_url == "https://my-tunnel.ngrok.io"
         assert manager.storage_driver.base_url == "https://my-tunnel.ngrok.io/workspace"
+
+    def test_override_matching_defaults_is_still_preserved(self, mock_secrets_manager: Mock) -> None:
+        """An explicit override is respected even when it happens to equal the server defaults."""
+        manager = self._build_manager(mock_secrets_manager, "http://localhost:8124")
+
+        self._invoke_initialization(manager, actual_port=54321)
+
+        assert manager.static_server_base_url == "http://localhost:8124"
+        assert manager.storage_driver.base_url == "http://localhost:8124/workspace"


### PR DESCRIPTION
Closes #4416

The guard added in #4286 only checked hostname, so a `localhost` tunnel on a non-default port (`ssh -L 8888:localhost:8124`) was treated as the default config and had its port clobbered with the OS-assigned static server port. The first commit adds the port to the equality check so localhost-with-custom-port tunnels are preserved alongside the non-localhost cases (ngrok, reverse proxies) that were already safe.

Reviewing the fix surfaced a second problem: the "is this the default?" test was a heuristic over two sources that can desync. `static_server_base_url` is a persisted config value; its default was derived from `STATIC_SERVER_HOST`/`STATIC_SERVER_PORT` env vars at first run and written to the user's config. If those env vars later changed, the persisted URL stayed put and the hostname/port equality check would fail even though the user never intended an override, silently leaving a stale port in place.

The second commit replaces the heuristic with an explicit signal. `static_server_base_url` now defaults to `None`, meaning "derive from the server's host/port." `StaticFilesManager.__init__` resolves that to the runtime default and records an override flag; `on_app_initialization_complete` refreshes the port only when the flag is unset. No more inference from string contents, no more desync window. An explicit override that happens to equal the defaults is also now respected (previously it would have been rewritten).