### PR TITLE
Developer Mode: add UnresolveNodeRequest API for developer tooling

### DIFF
--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1104,3 +1104,35 @@ class MoveNodeToNewFlowResultFailure(ResultPayloadFailure):
     Common causes: node not found, source flow not found, target flow not found,
     node not in source flow, node is a NodeGroup with subflow conflicts.
     """
+
+
+@dataclass
+@PayloadRegistry.register
+class UnresolveNodeRequest(RequestPayload):
+    """Mark a node UNRESOLVED without resetting its parameter values.
+
+    Use when: Forcing a node to re-execute without resetting its parameter values.
+    Downstream nodes are also marked UNRESOLVED. Useful for developer tooling.
+
+    If the node is currently RESOLVING the request fails immediately. Retry
+    after the node has finished resolving to unresolve it.
+
+    Args:
+        node_name: Name of the node to unresolve.
+
+    Results: UnresolveNodeResultSuccess | UnresolveNodeResultFailure
+    """
+
+    node_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class UnresolveNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Node marked UNRESOLVED. Downstream nodes also invalidated."""
+
+
+@dataclass
+@PayloadRegistry.register
+class UnresolveNodeResultFailure(ResultPayloadFailure):
+    """Unresolve failed. Common causes: node not found, node is currently RESOLVING."""

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1108,19 +1108,19 @@ class MoveNodeToNewFlowResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
-class ClearNodeCacheRequest(RequestPayload):
-    """Clear a node's cached outputs and mark it UNRESOLVED.
+class UnresolveNodeRequest(RequestPayload):
+    """Mark a node UNRESOLVED without resetting its parameter values.
 
     Use when: Forcing a node to re-execute without resetting its parameter values.
     Downstream nodes are also marked UNRESOLVED. Useful for developer tooling.
 
     If the node is currently RESOLVING the request fails immediately. Retry
-    after the node has finished resolving to clear its cache.
+    after the node has finished resolving to unresolve it.
 
     Args:
-        node_name: Name of the node whose cache should be cleared.
+        node_name: Name of the node to unresolve.
 
-    Results: ClearNodeCacheResultSuccess | ClearNodeCacheResultFailure
+    Results: UnresolveNodeResultSuccess | UnresolveNodeResultFailure
     """
 
     node_name: str
@@ -1128,11 +1128,11 @@ class ClearNodeCacheRequest(RequestPayload):
 
 @dataclass
 @PayloadRegistry.register
-class ClearNodeCacheResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
-    """Cache cleared and node marked UNRESOLVED. Downstream nodes also invalidated."""
+class UnresolveNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Node marked UNRESOLVED. Downstream nodes also invalidated."""
 
 
 @dataclass
 @PayloadRegistry.register
-class ClearNodeCacheResultFailure(ResultPayloadFailure):
-    """Cache clear failed. Common causes: node not found, node is currently RESOLVING."""
+class UnresolveNodeResultFailure(ResultPayloadFailure):
+    """Unresolve failed. Common causes: node not found, node is currently RESOLVING."""

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -1104,3 +1104,35 @@ class MoveNodeToNewFlowResultFailure(ResultPayloadFailure):
     Common causes: node not found, source flow not found, target flow not found,
     node not in source flow, node is a NodeGroup with subflow conflicts.
     """
+
+
+@dataclass
+@PayloadRegistry.register
+class ClearNodeCacheRequest(RequestPayload):
+    """Clear a node's cached outputs and mark it UNRESOLVED.
+
+    Use when: Forcing a node to re-execute without resetting its parameter values.
+    Downstream nodes are also marked UNRESOLVED. Useful for developer tooling.
+
+    If the node is currently RESOLVING the request fails immediately. Retry
+    after the node has finished resolving to clear its cache.
+
+    Args:
+        node_name: Name of the node whose cache should be cleared.
+
+    Results: ClearNodeCacheResultSuccess | ClearNodeCacheResultFailure
+    """
+
+    node_name: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ClearNodeCacheResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Cache cleared and node marked UNRESOLVED. Downstream nodes also invalidated."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ClearNodeCacheResultFailure(ResultPayloadFailure):
+    """Cache clear failed. Common causes: node not found, node is currently RESOLVING."""

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -83,9 +83,6 @@ from griptape_nodes.retained_mode.events.node_events import (
     CanResetNodeToDefaultsRequest,
     CanResetNodeToDefaultsResultFailure,
     CanResetNodeToDefaultsResultSuccess,
-    ClearNodeCacheRequest,
-    ClearNodeCacheResultFailure,
-    ClearNodeCacheResultSuccess,
     CreateNodeRequest,
     CreateNodeResultFailure,
     CreateNodeResultSuccess,
@@ -140,6 +137,9 @@ from griptape_nodes.retained_mode.events.node_events import (
     SetNodeMetadataRequest,
     SetNodeMetadataResultFailure,
     SetNodeMetadataResultSuccess,
+    UnresolveNodeRequest,
+    UnresolveNodeResultFailure,
+    UnresolveNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.events.object_events import (
     RenameObjectRequest,
@@ -333,7 +333,7 @@ class NodeManager:
             CanResetNodeToDefaultsRequest, self.on_can_reset_node_to_defaults_request
         )
         event_manager.assign_manager_to_request_type(ResetNodeToDefaultsRequest, self.on_reset_node_to_defaults_request)
-        event_manager.assign_manager_to_request_type(ClearNodeCacheRequest, self.on_clear_node_cache_request)
+        event_manager.assign_manager_to_request_type(UnresolveNodeRequest, self.on_unresolve_node_request)
         event_manager.assign_manager_to_request_type(
             BatchSetNodeLockStateRequest, self.on_batch_set_lock_node_state_request
         )
@@ -4796,18 +4796,17 @@ class NodeManager:
             result_details=f"Successfully reordered item in ParameterList '{request.parameter_list_name}' on Node '{node_name}' from index {request.from_index} to {request.to_index}."
         )
 
-    def on_clear_node_cache_request(self, request: ClearNodeCacheRequest) -> ResultPayload:
-        """Clear a single node's cached outputs and mark it UNRESOLVED."""
+    def on_unresolve_node_request(self, request: UnresolveNodeRequest) -> ResultPayload:
+        """Mark a single node UNRESOLVED and propagate to downstream nodes."""
         node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
-            return ClearNodeCacheResultFailure(
-                result_details=f"Attempted to clear cache for Node '{request.node_name}'. Node not found."
+            return UnresolveNodeResultFailure(
+                result_details=f"Attempted to unresolve Node '{request.node_name}'. Node not found."
             )
         if node.state == NodeResolutionState.RESOLVING:
-            return ClearNodeCacheResultFailure(
-                result_details=f"Attempted to clear cache for Node '{request.node_name}'. Node is currently RESOLVING."
+            return UnresolveNodeResultFailure(
+                result_details=f"Attempted to unresolve Node '{request.node_name}'. Node is currently RESOLVING."
             )
         node.make_node_unresolved(current_states_to_trigger_change_event={NodeResolutionState.RESOLVED})
-        node.parameter_output_values.silent_clear()
         GriptapeNodes.FlowManager().get_connections().unresolve_future_nodes(node)
-        return ClearNodeCacheResultSuccess(result_details=f"Cache cleared for node '{request.node_name}'.")
+        return UnresolveNodeResultSuccess(result_details=f"Node '{request.node_name}' marked as unresolved.")

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -83,6 +83,9 @@ from griptape_nodes.retained_mode.events.node_events import (
     CanResetNodeToDefaultsRequest,
     CanResetNodeToDefaultsResultFailure,
     CanResetNodeToDefaultsResultSuccess,
+    ClearNodeCacheRequest,
+    ClearNodeCacheResultFailure,
+    ClearNodeCacheResultSuccess,
     CreateNodeRequest,
     CreateNodeResultFailure,
     CreateNodeResultSuccess,
@@ -330,6 +333,7 @@ class NodeManager:
             CanResetNodeToDefaultsRequest, self.on_can_reset_node_to_defaults_request
         )
         event_manager.assign_manager_to_request_type(ResetNodeToDefaultsRequest, self.on_reset_node_to_defaults_request)
+        event_manager.assign_manager_to_request_type(ClearNodeCacheRequest, self.on_clear_node_cache_request)
         event_manager.assign_manager_to_request_type(
             BatchSetNodeLockStateRequest, self.on_batch_set_lock_node_state_request
         )
@@ -4791,3 +4795,19 @@ class NodeManager:
         return ReorderParameterListItemResultSuccess(
             result_details=f"Successfully reordered item in ParameterList '{request.parameter_list_name}' on Node '{node_name}' from index {request.from_index} to {request.to_index}."
         )
+
+    def on_clear_node_cache_request(self, request: ClearNodeCacheRequest) -> ResultPayload:
+        """Clear a single node's cached outputs and mark it UNRESOLVED."""
+        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(request.node_name, BaseNode)
+        if node is None:
+            return ClearNodeCacheResultFailure(
+                result_details=f"Attempted to clear cache for Node '{request.node_name}'. Node not found."
+            )
+        if node.state == NodeResolutionState.RESOLVING:
+            return ClearNodeCacheResultFailure(
+                result_details=f"Attempted to clear cache for Node '{request.node_name}'. Node is currently RESOLVING."
+            )
+        node.make_node_unresolved(current_states_to_trigger_change_event={NodeResolutionState.RESOLVED})
+        node.parameter_output_values.silent_clear()
+        GriptapeNodes.FlowManager().get_connections().unresolve_future_nodes(node)
+        return ClearNodeCacheResultSuccess(result_details=f"Cache cleared for node '{request.node_name}'.")

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -169,6 +169,9 @@ from griptape_nodes.retained_mode.events.node_events import (
     SetNodeMetadataRequest,
     SetNodeMetadataResultFailure,
     SetNodeMetadataResultSuccess,
+    UnresolveNodeRequest,
+    UnresolveNodeResultFailure,
+    UnresolveNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.events.object_events import (
     RenameObjectRequest,
@@ -396,6 +399,7 @@ class NodeManager:
             CanResetNodeToDefaultsRequest, self.on_can_reset_node_to_defaults_request
         )
         event_manager.assign_manager_to_request_type(ResetNodeToDefaultsRequest, self.on_reset_node_to_defaults_request)
+        event_manager.assign_manager_to_request_type(UnresolveNodeRequest, self.on_unresolve_node_request)
         event_manager.assign_manager_to_request_type(
             BatchSetNodeLockStateRequest, self.on_batch_set_lock_node_state_request
         )
@@ -5412,3 +5416,18 @@ class NodeManager:
         return ReorderParameterListItemResultSuccess(
             result_details=f"Successfully reordered item in ParameterList '{request.parameter_list_name}' on Node '{node_name}' from index {request.from_index} to {request.to_index}."
         )
+
+    def on_unresolve_node_request(self, request: UnresolveNodeRequest) -> ResultPayload:
+        """Mark a single node UNRESOLVED and propagate to downstream nodes."""
+        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(request.node_name, BaseNode)
+        if node is None:
+            return UnresolveNodeResultFailure(
+                result_details=f"Attempted to unresolve Node '{request.node_name}'. Node not found."
+            )
+        if node.state == NodeResolutionState.RESOLVING:
+            return UnresolveNodeResultFailure(
+                result_details=f"Attempted to unresolve Node '{request.node_name}'. Node is currently RESOLVING."
+            )
+        node.make_node_unresolved(current_states_to_trigger_change_event={NodeResolutionState.RESOLVED})
+        GriptapeNodes.FlowManager().get_connections().unresolve_future_nodes(node)
+        return UnresolveNodeResultSuccess(result_details=f"Node '{request.node_name}' marked as unresolved.")

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -9,9 +9,9 @@ from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeMetadataRequest,
     BatchSetNodeMetadataResultFailure,
     BatchSetNodeMetadataResultSuccess,
-    ClearNodeCacheRequest,
-    ClearNodeCacheResultFailure,
-    ClearNodeCacheResultSuccess,
+    UnresolveNodeRequest,
+    UnresolveNodeResultFailure,
+    UnresolveNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -135,12 +135,12 @@ class TestNodeManagerResolutionStateSerialization:
         assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
 
 
-class TestClearNodeCacheRequest:
-    """Tests for the on_clear_node_cache_request handler."""
+class TestUnresolveNodeRequest:
+    """Tests for the on_unresolve_node_request handler."""
 
     def test_node_not_found_returns_failure(self) -> None:
-        result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="nonexistent_node"))
-        assert isinstance(result, ClearNodeCacheResultFailure)
+        result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="nonexistent_node"))
+        assert isinstance(result, UnresolveNodeResultFailure)
         assert "nonexistent_node" in str(result.result_details)
 
     def test_resolving_node_returns_failure_without_side_effects(self) -> None:
@@ -153,14 +153,14 @@ class TestClearNodeCacheRequest:
             "attempt_get_object_by_name_as_type",
             return_value=mock_node,
         ):
-            result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="test_node"))
+            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
 
-        assert isinstance(result, ClearNodeCacheResultFailure)
+        assert isinstance(result, UnresolveNodeResultFailure)
         assert "test_node" in str(result.result_details)
         mock_node.make_node_unresolved.assert_not_called()
         mock_node.parameter_output_values.clear.assert_not_called()
 
-    def test_resolved_node_clears_cache_and_cascades_downstream(self) -> None:
+    def test_resolved_node_unresolves_and_cascades_downstream(self) -> None:
         mock_node = MagicMock(spec=BaseNode)
         mock_node.name = "test_node"
         mock_node.state = NodeResolutionState.RESOLVED
@@ -178,16 +178,16 @@ class TestClearNodeCacheRequest:
                 return_value=mock_connections,
             ),
         ):
-            result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="test_node"))
+            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
 
-        assert isinstance(result, ClearNodeCacheResultSuccess)
+        assert isinstance(result, UnresolveNodeResultSuccess)
         mock_node.make_node_unresolved.assert_called_once_with(
             current_states_to_trigger_change_event={NodeResolutionState.RESOLVED}
         )
-        mock_node.parameter_output_values.silent_clear.assert_called_once()
+        mock_node.parameter_output_values.silent_clear.assert_not_called()
         mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
 
-    def test_unresolved_node_still_clears_outputs_and_cascades(self) -> None:
+    def test_unresolved_node_still_cascades_downstream(self) -> None:
         mock_node = MagicMock(spec=BaseNode)
         mock_node.name = "test_node"
         mock_node.state = NodeResolutionState.UNRESOLVED
@@ -205,10 +205,10 @@ class TestClearNodeCacheRequest:
                 return_value=mock_connections,
             ),
         ):
-            result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="test_node"))
+            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
 
-        assert isinstance(result, ClearNodeCacheResultSuccess)
-        mock_node.parameter_output_values.silent_clear.assert_called_once()
+        assert isinstance(result, UnresolveNodeResultSuccess)
+        mock_node.parameter_output_values.silent_clear.assert_not_called()
         mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
 
 

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -1,12 +1,17 @@
 import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeMetadataRequest,
     BatchSetNodeMetadataResultFailure,
     BatchSetNodeMetadataResultSuccess,
+    ClearNodeCacheRequest,
+    ClearNodeCacheResultFailure,
+    ClearNodeCacheResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -128,6 +133,83 @@ class TestNodeManagerResolutionStateSerialization:
 
         # Resolution should be reset to UNRESOLVED due to serialization failure
         assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
+
+
+class TestClearNodeCacheRequest:
+    """Tests for the on_clear_node_cache_request handler."""
+
+    def test_node_not_found_returns_failure(self) -> None:
+        result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="nonexistent_node"))
+        assert isinstance(result, ClearNodeCacheResultFailure)
+        assert "nonexistent_node" in str(result.result_details)
+
+    def test_resolving_node_returns_failure_without_side_effects(self) -> None:
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.state = NodeResolutionState.RESOLVING
+        mock_node.parameter_output_values = MagicMock()
+        with patch.object(
+            GriptapeNodes.ObjectManager(),
+            "attempt_get_object_by_name_as_type",
+            return_value=mock_node,
+        ):
+            result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="test_node"))
+
+        assert isinstance(result, ClearNodeCacheResultFailure)
+        assert "test_node" in str(result.result_details)
+        mock_node.make_node_unresolved.assert_not_called()
+        mock_node.parameter_output_values.clear.assert_not_called()
+
+    def test_resolved_node_clears_cache_and_cascades_downstream(self) -> None:
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.state = NodeResolutionState.RESOLVED
+        mock_node.parameter_output_values = MagicMock()
+        mock_connections = MagicMock()
+        with (
+            patch.object(
+                GriptapeNodes.ObjectManager(),
+                "attempt_get_object_by_name_as_type",
+                return_value=mock_node,
+            ),
+            patch.object(
+                GriptapeNodes.FlowManager(),
+                "get_connections",
+                return_value=mock_connections,
+            ),
+        ):
+            result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="test_node"))
+
+        assert isinstance(result, ClearNodeCacheResultSuccess)
+        mock_node.make_node_unresolved.assert_called_once_with(
+            current_states_to_trigger_change_event={NodeResolutionState.RESOLVED}
+        )
+        mock_node.parameter_output_values.silent_clear.assert_called_once()
+        mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
+
+    def test_unresolved_node_still_clears_outputs_and_cascades(self) -> None:
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.state = NodeResolutionState.UNRESOLVED
+        mock_node.parameter_output_values = MagicMock()
+        mock_connections = MagicMock()
+        with (
+            patch.object(
+                GriptapeNodes.ObjectManager(),
+                "attempt_get_object_by_name_as_type",
+                return_value=mock_node,
+            ),
+            patch.object(
+                GriptapeNodes.FlowManager(),
+                "get_connections",
+                return_value=mock_connections,
+            ),
+        ):
+            result = GriptapeNodes.handle_request(ClearNodeCacheRequest(node_name="test_node"))
+
+        assert isinstance(result, ClearNodeCacheResultSuccess)
+        mock_node.parameter_output_values.silent_clear.assert_called_once()
+        mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
 
 
 class TestNodeManagerAlterParameterDetailsClearDefaultValue:

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -1,14 +1,18 @@
 import contextlib
 import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeMetadataRequest,
     BatchSetNodeMetadataResultFailure,
     BatchSetNodeMetadataResultSuccess,
+    UnresolveNodeRequest,
+    UnresolveNodeResultFailure,
+    UnresolveNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -288,6 +292,83 @@ class TestSerializeNodeWithoutLibraryMetadata:
         assert create_command.specific_library_name == "Missing Library"
 
         griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+class TestUnresolveNodeRequest:
+    """Tests for the on_unresolve_node_request handler."""
+
+    def test_node_not_found_returns_failure(self) -> None:
+        result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="nonexistent_node"))
+        assert isinstance(result, UnresolveNodeResultFailure)
+        assert "nonexistent_node" in str(result.result_details)
+
+    def test_resolving_node_returns_failure_without_side_effects(self) -> None:
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.state = NodeResolutionState.RESOLVING
+        mock_node.parameter_output_values = MagicMock()
+        with patch.object(
+            GriptapeNodes.ObjectManager(),
+            "attempt_get_object_by_name_as_type",
+            return_value=mock_node,
+        ):
+            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
+
+        assert isinstance(result, UnresolveNodeResultFailure)
+        assert "test_node" in str(result.result_details)
+        mock_node.make_node_unresolved.assert_not_called()
+        mock_node.parameter_output_values.clear.assert_not_called()
+
+    def test_resolved_node_unresolves_and_cascades_downstream(self) -> None:
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.state = NodeResolutionState.RESOLVED
+        mock_node.parameter_output_values = MagicMock()
+        mock_connections = MagicMock()
+        with (
+            patch.object(
+                GriptapeNodes.ObjectManager(),
+                "attempt_get_object_by_name_as_type",
+                return_value=mock_node,
+            ),
+            patch.object(
+                GriptapeNodes.FlowManager(),
+                "get_connections",
+                return_value=mock_connections,
+            ),
+        ):
+            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
+
+        assert isinstance(result, UnresolveNodeResultSuccess)
+        mock_node.make_node_unresolved.assert_called_once_with(
+            current_states_to_trigger_change_event={NodeResolutionState.RESOLVED}
+        )
+        mock_node.parameter_output_values.silent_clear.assert_not_called()
+        mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
+
+    def test_unresolved_node_still_cascades_downstream(self) -> None:
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.state = NodeResolutionState.UNRESOLVED
+        mock_node.parameter_output_values = MagicMock()
+        mock_connections = MagicMock()
+        with (
+            patch.object(
+                GriptapeNodes.ObjectManager(),
+                "attempt_get_object_by_name_as_type",
+                return_value=mock_node,
+            ),
+            patch.object(
+                GriptapeNodes.FlowManager(),
+                "get_connections",
+                return_value=mock_connections,
+            ),
+        ):
+            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
+
+        assert isinstance(result, UnresolveNodeResultSuccess)
+        mock_node.parameter_output_values.silent_clear.assert_not_called()
+        mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
 
 
 class TestNodeManagerAlterParameterDetailsClearDefaultValue:


### PR DESCRIPTION
To test checkout feat/developer-mode on griptape-vsl-gui and griptape-nodes.

Adds a lightweight engine request that clears a single node's cached output values and marks it UNRESOLVED without touching its parameter values or connections, then cascades the invalidation to all downstream nodes. This is intentionally less destructive than ResetNodeToDefaultsRequest, which recreates the node from scratch.

- node_events.py: ClearNodeCacheRequest / ResultSuccess / ResultFailure; documents that callers should retry after resolution if node is RESOLVING
- node_manager.py: handler calls make_node_unresolved({RESOLVED}), parameter_output_values.silent_clear(), and unresolve_future_nodes for cascade; uses silent_clear to avoid N redundant AlterElementEvent websocket sends (the NodeUnresolvedEvent already signals clients of the state change); fixes AttributeError caused by referencing non-existent NodeResolutionState.ERRORED; error messages follow the "Attempted to..." convention
- test_node_manager.py: four unit tests covering not-found, RESOLVING guard, RESOLVED happy path (with cascade assertions), and already-UNRESOLVED path

Part of implementation for: [Developer mode overlay to highlight Node connection sources griptape-ai/griptape-vsl-gui#2229](https://github.com/griptape-ai/griptape-vsl-gui/issues/2229)