### PR TITLE
Recursively resolve directory path_macros

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -497,9 +497,11 @@ class ProjectManager:
                 # Recursively resolve so nested directory references (e.g.
                 # watch_outputs -> watch_folder) expand to a concrete path
                 # instead of leaking literal {...} tokens into the result.
+                # User vars flow through so directory macros can reference
+                # caller-supplied values just like situation macros do.
                 try:
                     resolution_bag[var_name] = self._resolve_directory_path(
-                        var_name, project_info, directory_resolution_cache, set()
+                        var_name, project_info, directory_resolution_cache, set(), request.variables
                     )
                 except (RuntimeError, NotImplementedError) as e:
                     # NotImplementedError: directory references an unimplemented builtin (e.g. {project_name}).
@@ -1142,21 +1144,27 @@ class ProjectManager:
                 msg = f"Unknown builtin variable: {var_name}"
                 raise ValueError(msg)
 
-    def _resolve_directory_path(
+    def _resolve_directory_path(  # noqa: C901
         self,
         directory_name: str,
         project_info: ProjectInfo,
         cache: dict[str, str],
         visiting: set[str],
+        user_variables: MacroVariables,
     ) -> str:
         """Recursively resolve a directory macro into a fully substituted path string.
 
-        Directory ``path_macro`` values can reference other directories or builtin
-        variables (e.g. ``watch_outputs: "{watch_folder}/outputs"``). This helper
-        walks the reference chain and substitutes each token with its resolved
-        value so the returned string contains no ``{...}`` tokens. Without this,
-        a situation that references a chained directory would emit the literal
+        Directory ``path_macro`` values can reference other directories, builtin
+        variables (e.g. ``watch_outputs: "{watch_folder}/outputs"``), or
+        user-supplied variables from the outer request. This helper walks the
+        reference chain and substitutes each token with its resolved value so
+        the returned string contains no ``{...}`` tokens. Without this, a
+        situation that references a chained directory would emit the literal
         inner token (e.g. ``{watch_folder}/outputs/...``) into the final path.
+
+        Mirrors the optional/required handling of the top-level macro handler:
+        an optional builtin that fails to resolve is dropped (segment omitted);
+        a required one propagates the error.
 
         Args:
             directory_name: Name of the directory to resolve.
@@ -1165,13 +1173,19 @@ class ProjectManager:
                 single resolution pass so each directory is resolved at most once.
             visiting: Names currently on the recursion stack; a re-entry signals
                 a cycle.
+            user_variables: Variables from the outer request, available for
+                substitution inside directory macros (empty dict when there
+                is no caller context, e.g. absolute-path mapping).
 
         Returns:
             Fully resolved path string with every ``{...}`` token substituted.
 
         Raises:
             RuntimeError: If a cycle is detected, a referenced directory is
-                unknown, or a builtin/nested macro fails to resolve.
+                unknown, a required builtin/nested macro fails to resolve, or
+                ``ParsedMacro.resolve`` raises (e.g. required token missing).
+            NotImplementedError: If a required builtin is not yet implemented
+                (e.g. ``{project_name}`` as of today).
         """
         # Memoized: a directory referenced multiple times in one request resolves once.
         if directory_name in cache:
@@ -1192,16 +1206,31 @@ class ProjectManager:
         try:
             # Build a variables bag for this directory's macro by resolving each
             # referenced token. Nested directories recurse; builtins are queried
-            # at call time so live context (workflow, workspace) is reflected.
+            # at call time so live context (workflow, workspace) is reflected;
+            # user-supplied variables flow through so directory macros can be as
+            # expressive as situation macros.
             inner_bag: MacroVariables = {}
             for var_info in parsed_macro.get_variables():
                 var_name = var_info.name
                 if var_name in project_info.parsed_directory_schemas:
-                    inner_bag[var_name] = self._resolve_directory_path(var_name, project_info, cache, visiting)
+                    inner_bag[var_name] = self._resolve_directory_path(
+                        var_name, project_info, cache, visiting, user_variables
+                    )
                 elif var_name in BUILTIN_VARIABLES:
-                    inner_bag[var_name] = self._get_builtin_variable_value(var_name, project_info)
-                # Anything else (not a directory, not a builtin) is left out of the
-                # bag: ParsedMacro.resolve() drops it if optional, raises if required.
+                    # Mirror top-level behavior: an optional builtin that cannot
+                    # be resolved (no current workflow, unimplemented, etc.) is
+                    # dropped from the bag so ParsedMacro.resolve() omits the
+                    # whole optional segment. Required builtins still surface.
+                    try:
+                        inner_bag[var_name] = self._get_builtin_variable_value(var_name, project_info)
+                    except (RuntimeError, NotImplementedError):
+                        if var_info.is_required:
+                            raise
+                        continue
+                elif var_name in user_variables:
+                    inner_bag[var_name] = user_variables[var_name]
+                # Else: unknown name, left out of bag. ParsedMacro.resolve drops
+                # it if optional, raises MacroResolutionError if required (caught below).
 
             try:
                 resolved = parsed_macro.resolve(inner_bag, self._secrets_manager)
@@ -1261,8 +1290,10 @@ class ProjectManager:
         for directory_name in template.directories:
             # Fully expand nested directory and builtin references so prefix
             # matching compares real paths, not unresolved {...} templates.
+            # No user-variable context here — this sweep operates purely on
+            # the current project state, independent of any request.
             resolved_path_str = self._resolve_directory_path(
-                directory_name, project_info, directory_resolution_cache, set()
+                directory_name, project_info, directory_resolution_cache, set(), {}
             )
 
             # Make absolute (resolve relative paths against the workspace directory).

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -486,13 +486,28 @@ class ProjectManager:
 
         resolution_bag: MacroVariables = {}
         disallowed_overrides: set[str] = set()
+        # Per-request cache: dedupes work when the macro references the same
+        # directory multiple times (or via multiple paths through nested refs).
+        directory_resolution_cache: dict[str, str] = {}
 
         for var_info in variable_infos:
             var_name = var_info.name
 
             if var_name in directory_names:
-                directory_def = template.directories[var_name]
-                resolution_bag[var_name] = directory_def.path_macro
+                # Recursively resolve so nested directory references (e.g.
+                # watch_outputs -> watch_folder) expand to a concrete path
+                # instead of leaking literal {...} tokens into the result.
+                try:
+                    resolution_bag[var_name] = self._resolve_directory_path(
+                        var_name, project_info, directory_resolution_cache, set()
+                    )
+                except (RuntimeError, NotImplementedError) as e:
+                    # NotImplementedError: directory references an unimplemented builtin (e.g. {project_name}).
+                    # RuntimeError: cycle, unknown reference, or inner MacroResolutionError.
+                    return GetPathForMacroResultFailure(
+                        failure_reason=PathResolutionFailureReason.MACRO_RESOLUTION_ERROR,
+                        result_details=f"Attempted to resolve macro path. Failed because directory '{var_name}' could not be resolved: {e}",
+                    )
             elif var_name in user_provided_names:
                 resolution_bag[var_name] = request.variables[var_name]
 
@@ -1127,9 +1142,81 @@ class ProjectManager:
                 msg = f"Unknown builtin variable: {var_name}"
                 raise ValueError(msg)
 
-    def _absolute_path_to_macro_path(  # noqa: C901, PLR0912
-        self, absolute_path: Path, project_info: ProjectInfo
-    ) -> str | None:
+    def _resolve_directory_path(
+        self,
+        directory_name: str,
+        project_info: ProjectInfo,
+        cache: dict[str, str],
+        visiting: set[str],
+    ) -> str:
+        """Recursively resolve a directory macro into a fully substituted path string.
+
+        Directory ``path_macro`` values can reference other directories or builtin
+        variables (e.g. ``watch_outputs: "{watch_folder}/outputs"``). This helper
+        walks the reference chain and substitutes each token with its resolved
+        value so the returned string contains no ``{...}`` tokens. Without this,
+        a situation that references a chained directory would emit the literal
+        inner token (e.g. ``{watch_folder}/outputs/...``) into the final path.
+
+        Args:
+            directory_name: Name of the directory to resolve.
+            project_info: Current project info (supplies parsed schemas and builtins).
+            cache: Memoization cache keyed by directory name; shared across a
+                single resolution pass so each directory is resolved at most once.
+            visiting: Names currently on the recursion stack; a re-entry signals
+                a cycle.
+
+        Returns:
+            Fully resolved path string with every ``{...}`` token substituted.
+
+        Raises:
+            RuntimeError: If a cycle is detected, a referenced directory is
+                unknown, or a builtin/nested macro fails to resolve.
+        """
+        # Memoized: a directory referenced multiple times in one request resolves once.
+        if directory_name in cache:
+            return cache[directory_name]
+
+        # Re-entry = cycle (a -> b -> a). Without this guard recursion would never terminate.
+        if directory_name in visiting:
+            chain = " -> ".join([*visiting, directory_name])
+            msg = f"Cycle detected while resolving directory '{directory_name}' (chain: {chain})"
+            raise RuntimeError(msg)
+
+        parsed_macro = project_info.parsed_directory_schemas.get(directory_name)
+        if parsed_macro is None:
+            msg = f"Directory '{directory_name}' not found in parsed schemas"
+            raise RuntimeError(msg)
+
+        visiting.add(directory_name)
+        try:
+            # Build a variables bag for this directory's macro by resolving each
+            # referenced token. Nested directories recurse; builtins are queried
+            # at call time so live context (workflow, workspace) is reflected.
+            inner_bag: MacroVariables = {}
+            for var_info in parsed_macro.get_variables():
+                var_name = var_info.name
+                if var_name in project_info.parsed_directory_schemas:
+                    inner_bag[var_name] = self._resolve_directory_path(var_name, project_info, cache, visiting)
+                elif var_name in BUILTIN_VARIABLES:
+                    inner_bag[var_name] = self._get_builtin_variable_value(var_name, project_info)
+                # Anything else (not a directory, not a builtin) is left out of the
+                # bag: ParsedMacro.resolve() drops it if optional, raises if required.
+
+            try:
+                resolved = parsed_macro.resolve(inner_bag, self._secrets_manager)
+            except MacroResolutionError as e:
+                msg = f"Failed to resolve directory '{directory_name}' macro: {e}"
+                raise RuntimeError(msg) from e
+        finally:
+            # Must discard even on raise so a failed sibling doesn't poison the
+            # visiting set for a later resolution pass that reuses it.
+            visiting.discard(directory_name)
+
+        cache[directory_name] = resolved
+        return resolved
+
+    def _absolute_path_to_macro_path(self, absolute_path: Path, project_info: ProjectInfo) -> str | None:
         """Convert an absolute path to macro form using longest prefix matching.
 
         Resolves all project directories at runtime (to support env vars and macros),
@@ -1160,19 +1247,6 @@ class ProjectManager:
         workspace_dir = resolve_path_safely(self._config_manager.workspace_path)
         project_base_dir = resolve_path_safely(project_info.project_base_dir)
 
-        # Collect all variables used across ALL directory macros
-        variables_needed: set[str] = set()
-        for parsed_macro in project_info.parsed_directory_schemas.values():
-            variable_infos = parsed_macro.get_variables()
-            variables_needed.update(var_info.name for var_info in variable_infos)
-
-        # Build builtin variables dict - only resolve variables actually needed by the macros
-        # If a required variable fails to resolve, let the error propagate (will be caught by handler)
-        builtin_vars: MacroVariables = {}
-        for var_name in variables_needed:
-            if var_name in BUILTIN_VARIABLES:
-                builtin_vars[var_name] = self._get_builtin_variable_value(var_name, project_info)
-
         # Find all matching directories (where absolute_path is inside the directory)
         class DirectoryMatch(NamedTuple):
             directory_name: str
@@ -1180,19 +1254,16 @@ class ProjectManager:
             prefix_length: int
 
         matches: list[DirectoryMatch] = []
+        # Shared across this sweep so directories referenced by other directories
+        # (watch_folder -> watch_outputs) don't get re-resolved per iteration.
+        directory_resolution_cache: dict[str, str] = {}
 
         for directory_name in template.directories:
-            # Get parsed macro from project info cache
-            parsed_macro = project_info.parsed_directory_schemas.get(directory_name)
-            if parsed_macro is None:
-                msg = f"Directory '{directory_name}' not found in parsed schemas"
-                raise RuntimeError(msg)
-
-            try:
-                resolved_path_str = parsed_macro.resolve(builtin_vars, self._secrets_manager)
-            except MacroResolutionError as e:
-                msg = f"Failed to resolve directory '{directory_name}' macro: {e}"
-                raise RuntimeError(msg) from e
+            # Fully expand nested directory and builtin references so prefix
+            # matching compares real paths, not unresolved {...} templates.
+            resolved_path_str = self._resolve_directory_path(
+                directory_name, project_info, directory_resolution_cache, set()
+            )
 
             # Make absolute (resolve relative paths against the workspace directory).
             # resolve_file_path handles ~, env vars, and absolute paths in addition to relative paths.

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -16,6 +16,7 @@ from griptape_nodes.common.macro_parser import (
     MacroResolutionFailureReason,
     MacroVariables,
     ParsedMacro,
+    VariableInfo,
 )
 from griptape_nodes.common.project_templates import (
     DEFAULT_PROJECT_TEMPLATE,
@@ -515,14 +516,15 @@ class ProjectManager:
 
             if var_name in BUILTIN_VARIABLES:
                 try:
-                    builtin_value = self._get_builtin_variable_value(var_name, project_info)
+                    builtin_value = self._try_resolve_optional_builtin(var_info, project_info)
                 except (RuntimeError, NotImplementedError) as e:
-                    if not var_info.is_required:
-                        continue
                     return GetPathForMacroResultFailure(
                         failure_reason=PathResolutionFailureReason.MACRO_RESOLUTION_ERROR,
                         result_details=f"Attempted to resolve macro path. Failed because builtin variable '{var_name}' cannot be resolved: {e}",
                     )
+                # Optional builtin that couldn't resolve — drop the segment.
+                if builtin_value is None:
+                    continue
                 # Confirm no monkey business with trying to override builtin values
                 existing = resolution_bag.get(var_name)
                 if existing is not None:
@@ -1091,6 +1093,26 @@ class ProjectManager:
 
         return directory_schemas
 
+    def _try_resolve_optional_builtin(self, var_info: VariableInfo, project_info: ProjectInfo) -> str | None:
+        """Resolve a builtin, deferring to optional/required semantics on failure.
+
+        Callers face the same rule — an optional builtin that can't be resolved
+        (no current workflow, unimplemented, etc.) should be omitted from the
+        macro so the optional segment drops; a required one should surface.
+        Returning ``None`` means "optional, drop it"; raising means "required,
+        let the caller decide the error shape."
+
+        Raises:
+            RuntimeError: Builtin resolution failed and ``var_info.is_required``.
+            NotImplementedError: Same, for unimplemented builtins.
+        """
+        try:
+            return self._get_builtin_variable_value(var_info.name, project_info)
+        except (RuntimeError, NotImplementedError):
+            if var_info.is_required:
+                raise
+            return None
+
     def _get_builtin_variable_value(self, var_name: str, project_info: ProjectInfo) -> str:
         """Get the value of a single builtin variable.
 
@@ -1144,7 +1166,7 @@ class ProjectManager:
                 msg = f"Unknown builtin variable: {var_name}"
                 raise ValueError(msg)
 
-    def _resolve_directory_path(  # noqa: C901
+    def _resolve_directory_path(
         self,
         directory_name: str,
         project_info: ProjectInfo,
@@ -1217,16 +1239,12 @@ class ProjectManager:
                         var_name, project_info, cache, visiting, user_variables
                     )
                 elif var_name in BUILTIN_VARIABLES:
-                    # Mirror top-level behavior: an optional builtin that cannot
-                    # be resolved (no current workflow, unimplemented, etc.) is
-                    # dropped from the bag so ParsedMacro.resolve() omits the
-                    # whole optional segment. Required builtins still surface.
-                    try:
-                        inner_bag[var_name] = self._get_builtin_variable_value(var_name, project_info)
-                    except (RuntimeError, NotImplementedError):
-                        if var_info.is_required:
-                            raise
-                        continue
+                    # Optional builtins drop cleanly; required ones propagate
+                    # (caller wraps as MACRO_RESOLUTION_ERROR). Shared helper
+                    # keeps this semantics identical to the top-level handler.
+                    builtin_value = self._try_resolve_optional_builtin(var_info, project_info)
+                    if builtin_value is not None:
+                        inner_bag[var_name] = builtin_value
                 elif var_name in user_variables:
                     inner_bag[var_name] = user_variables[var_name]
                 # Else: unknown name, left out of bag. ParsedMacro.resolve drops

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -588,6 +588,150 @@ class TestProjectManagerNestedDirectoryResolution:
         assert result.failure_reason == PathResolutionFailureReason.MACRO_RESOLUTION_ERROR
         assert "cycle" in str(result.result_details).lower()
 
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    def test_directory_optional_builtin_drops_when_unresolvable(self, mock_griptape_nodes: Mock) -> None:
+        """An optional builtin inside a directory macro drops cleanly if unresolvable.
+
+        Directory macros should be as expressive as situation macros: when
+        {workflow_name?:/} appears inside a directory path_macro and there is no
+        current workflow, the entire optional segment (variable + separator)
+        must be omitted instead of failing the whole request.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import DirectoryDefinition, ProjectTemplate
+
+        # No current workflow → {workflow_name} raises RuntimeError inside the helper.
+        mock_context = Mock()
+        mock_context.has_current_workflow.return_value = False
+        mock_griptape_nodes.ContextManager.return_value = mock_context
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="scratch_project",
+            directories={
+                "scratch": DirectoryDefinition(name="scratch", path_macro="{workspace_dir}/scratch/{workflow_name?:/}"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/workspace"))
+
+        parsed_macro = ParsedMacro("{scratch}/{file_name_base}.{file_extension}")
+        result = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={"file_name_base": "notes", "file_extension": "txt"},
+            )
+        )
+
+        assert isinstance(result, GetPathForMacroResultSuccess)
+        assert result.resolved_path == Path("/workspace/scratch/notes.txt")
+
+    def test_directory_optional_unimplemented_builtin_drops(self) -> None:
+        """An optional {project_name?:...} inside a directory macro drops silently.
+
+        ``project_name`` raises NotImplementedError today; like RuntimeError, an
+        optional reference must be dropped instead of aborting the request.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import DirectoryDefinition, ProjectTemplate
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="labeled_project",
+            directories={
+                "labeled": DirectoryDefinition(name="labeled", path_macro="{workspace_dir}/outputs/{project_name?:_}"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/workspace"))
+
+        parsed_macro = ParsedMacro("{labeled}/{file_name_base}.{file_extension}")
+        result = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={"file_name_base": "image", "file_extension": "png"},
+            )
+        )
+
+        assert isinstance(result, GetPathForMacroResultSuccess)
+        assert result.resolved_path == Path("/workspace/outputs/image.png")
+
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    def test_directory_required_builtin_failure_propagates(self, mock_griptape_nodes: Mock) -> None:
+        """A *required* builtin failure inside a directory macro must fail loudly.
+
+        Symmetric to the optional-drop behavior: we suppress errors only for
+        optional references. A bare {workflow_name} with no current workflow
+        must surface as MACRO_RESOLUTION_ERROR, not silently produce garbage.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import DirectoryDefinition, ProjectTemplate
+
+        mock_context = Mock()
+        mock_context.has_current_workflow.return_value = False
+        mock_griptape_nodes.ContextManager.return_value = mock_context
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="strict_project",
+            directories={
+                # No '?' marker -> workflow_name is required inside this directory's macro.
+                "strict": DirectoryDefinition(name="strict", path_macro="{workspace_dir}/{workflow_name}/out"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/workspace"))
+
+        parsed_macro = ParsedMacro("{strict}/{file_name_base}.{file_extension}")
+        result = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={"file_name_base": "image", "file_extension": "png"},
+            )
+        )
+
+        assert isinstance(result, GetPathForMacroResultFailure)
+        assert result.failure_reason == PathResolutionFailureReason.MACRO_RESOLUTION_ERROR
+        assert "no current workflow" in str(result.result_details).lower()
+
+    def test_user_variable_available_inside_directory_macro(self) -> None:
+        """A directory macro may reference a user-supplied variable from the outer request.
+
+        Pins the plumbing that passes `request.variables` down into
+        `_resolve_directory_path`, so directory macros are as expressive as
+        situation macros.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import DirectoryDefinition, ProjectTemplate
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="tenant_project",
+            directories={
+                # {tenant} is supplied by the caller, not by project config.
+                "tenant_outputs": DirectoryDefinition(
+                    name="tenant_outputs", path_macro="{workspace_dir}/tenants/{tenant}/outputs"
+                ),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/workspace"))
+
+        parsed_macro = ParsedMacro("{tenant_outputs}/{file_name_base}.{file_extension}")
+        result = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={"tenant": "acme", "file_name_base": "report", "file_extension": "pdf"},
+            )
+        )
+
+        assert isinstance(result, GetPathForMacroResultSuccess)
+        assert result.resolved_path == Path("/workspace/tenants/acme/outputs/report.pdf")
+
 
 class TestProjectManagerGetStateForMacro:
     """Test ProjectManager GetStateForMacro request handler."""

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -732,6 +732,80 @@ class TestProjectManagerNestedDirectoryResolution:
         assert isinstance(result, GetPathForMacroResultSuccess)
         assert result.resolved_path == Path("/workspace/tenants/acme/outputs/report.pdf")
 
+    def test_directory_name_shadowing_builtin_with_mismatched_value_is_rejected(self) -> None:
+        """A directory named like a builtin with a mismatched value is rejected.
+
+        Today there's no template-load-time validation preventing a user from
+        naming a directory ``workspace_dir`` (or any other builtin). The
+        top-level handler catches the conflict at resolution time by comparing
+        the directory's resolved path against the builtin's value — if they
+        don't match, the request fails. This pins that runtime behavior so a
+        future refactor can't silently let a shadowing directory override a
+        builtin's value.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import DirectoryDefinition, ProjectTemplate
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="shadowing_project",
+            directories={
+                "workspace_dir": DirectoryDefinition(name="workspace_dir", path_macro="/overridden"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/not-this-workspace"))
+
+        parsed_macro = ParsedMacro("{workspace_dir}/file.txt")
+        result = pm.on_get_path_for_macro_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables={}))
+
+        assert isinstance(result, GetPathForMacroResultFailure)
+        assert result.failure_reason == PathResolutionFailureReason.DIRECTORY_OVERRIDE_ATTEMPTED
+        assert result.conflicting_variables == {"workspace_dir"}
+
+    def test_failed_directory_does_not_poison_subsequent_resolutions(self) -> None:
+        """A mid-recursion failure must not leave state in cache/visiting.
+
+        If directory A references unresolvable B and raises, a later successful
+        resolution in the SAME sweep (think: _absolute_path_to_macro_path
+        iterating all directories with a shared cache) must still work.
+        This pins the try/finally discard on visiting and the
+        "cache only on success" invariant.
+        """
+        from griptape_nodes.common.project_templates import DirectoryDefinition, ProjectTemplate
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="partial_failure_project",
+            directories={
+                # 'broken' references a required {missing_var} (not a directory, not
+                # a builtin, not user-supplied) — parsed_macro.resolve will raise.
+                "broken": DirectoryDefinition(name="broken", path_macro="{workspace_dir}/{missing_var}"),
+                "good": DirectoryDefinition(name="good", path_macro="{workspace_dir}/good"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/workspace"))
+        project_id = pm._current_project_id
+        assert project_id is not None
+        project_info = pm._successfully_loaded_project_templates[project_id]
+        assert isinstance(project_info, ProjectInfo)
+
+        # Share cache across both calls to mimic an _absolute_path_to_macro_path sweep.
+        cache: dict[str, str] = {}
+
+        with pytest.raises(RuntimeError):
+            pm._resolve_directory_path("broken", project_info, cache, set(), {})
+
+        # State must be clean: 'broken' never cached, 'good' still resolvable.
+        assert "broken" not in cache
+        resolved = pm._resolve_directory_path("good", project_info, cache, set(), {})
+        assert resolved == "/workspace/good"
+        assert cache["good"] == "/workspace/good"
+
 
 class TestProjectManagerGetStateForMacro:
     """Test ProjectManager GetStateForMacro request handler."""

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -803,8 +803,12 @@ class TestProjectManagerNestedDirectoryResolution:
         # State must be clean: 'broken' never cached, 'good' still resolvable.
         assert "broken" not in cache
         resolved = pm._resolve_directory_path("good", project_info, cache, set(), {})
-        assert resolved == "/workspace/good"
-        assert cache["good"] == "/workspace/good"
+        # Derive the expected value the same way the helper does: the workspace
+        # builtin is stringified via str(Path), so on Windows the prefix uses
+        # backslashes. Pinning a POSIX literal here breaks the Windows lane.
+        expected = str(Path("/workspace")) + "/good"
+        assert resolved == expected
+        assert cache["good"] == expected
 
 
 class TestProjectManagerGetStateForMacro:

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from griptape_nodes.common.macro_parser import MacroMatchFailureReason
+from griptape_nodes.common.project_templates import ProjectTemplate
 from griptape_nodes.retained_mode.events.project_events import (
     AttemptMapAbsolutePathToProjectRequest,
     AttemptMapAbsolutePathToProjectResultSuccess,
@@ -438,6 +439,154 @@ class TestProjectManagerBuiltinVariables:
 
         assert isinstance(result.result_details, ResultDetails)
         assert "cannot override builtin variables" in str(result.result_details)
+
+
+class TestProjectManagerNestedDirectoryResolution:
+    """Test that directory path_macros can reference other directories (nested resolution)."""
+
+    @staticmethod
+    def _build_project_manager_with_template(template: ProjectTemplate, project_base: Path) -> ProjectManager:
+        """Build a ProjectManager with the given template registered as the current project."""
+        from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+        mock_config = Mock()
+        mock_config.workspace_path = project_base
+        mock_secrets = Mock()
+        mock_event_manager = Mock()
+        pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
+
+        validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+        situation_schemas = pm._parse_situation_macros(template.situations, validation)
+        directory_schemas = pm._parse_directory_macros(template.directories, validation)
+
+        project_path = project_base / "project.yml"
+        project_id = str(project_path)
+        project_info = ProjectInfo(
+            project_id=project_id,
+            project_file_path=project_path,
+            project_base_dir=project_base,
+            template=template,
+            validation=validation,
+            parsed_situation_schemas=situation_schemas,
+            parsed_directory_schemas=directory_schemas,
+        )
+
+        pm._successfully_loaded_project_templates[project_id] = project_info
+        pm._current_project_id = project_id
+        return pm
+
+    def test_directory_path_macro_referencing_another_directory_is_fully_resolved(self) -> None:
+        """A directory whose path_macro references another directory must recurse.
+
+        Previously the resolver copied ``DirectoryDefinition.path_macro`` verbatim
+        into the resolution bag, so nested references (watch_outputs -> watch_folder)
+        leaked literal ``{watch_folder}`` tokens into the final path. This test
+        pins the fixed behavior.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import (
+            DirectoryDefinition,
+            ProjectTemplate,
+        )
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="nested_project",
+            directories={
+                "watch_folder": DirectoryDefinition(name="watch_folder", path_macro="/fake/WATCH"),
+                "watch_outputs": DirectoryDefinition(name="watch_outputs", path_macro="{watch_folder}/outputs"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/fake/WATCH"))
+
+        parsed_macro = ParsedMacro("{watch_outputs}/{node_name}.{file_extension}")
+        result = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={"node_name": "MyNode", "file_extension": "png"},
+            )
+        )
+
+        assert isinstance(result, GetPathForMacroResultSuccess)
+        assert result.resolved_path == Path("/fake/WATCH/outputs/MyNode.png")
+
+    def test_optional_variable_omitted_with_nested_directory(self) -> None:
+        """Omitting an optional variable must still drop its separator cleanly.
+
+        Mirrors the real ``save_node_watch_output`` macro that originally
+        triggered the bug report.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import (
+            DirectoryDefinition,
+            ProjectTemplate,
+        )
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="nested_project",
+            directories={
+                "watch_folder": DirectoryDefinition(name="watch_folder", path_macro="/fake/WATCH"),
+                "watch_outputs": DirectoryDefinition(name="watch_outputs", path_macro="{watch_folder}/outputs"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/fake/WATCH"))
+
+        parsed_macro = ParsedMacro("{watch_outputs}/{sub_dirs?:/}{node_name}.{file_extension}")
+
+        with_subdirs = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={
+                    "node_name": "MyNode",
+                    "file_extension": "png",
+                    "sub_dirs": "renders",
+                },
+            )
+        )
+        assert isinstance(with_subdirs, GetPathForMacroResultSuccess)
+        assert with_subdirs.resolved_path == Path("/fake/WATCH/outputs/renders/MyNode.png")
+
+        without_subdirs = pm.on_get_path_for_macro_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={"node_name": "MyNode", "file_extension": "png"},
+            )
+        )
+        assert isinstance(without_subdirs, GetPathForMacroResultSuccess)
+        assert without_subdirs.resolved_path == Path("/fake/WATCH/outputs/MyNode.png")
+
+    def test_directory_cycle_returns_failure(self) -> None:
+        """A cycle in directory references must be detected and reported, not infinite-looped."""
+        from griptape_nodes.common.macro_parser import ParsedMacro
+        from griptape_nodes.common.project_templates import (
+            DirectoryDefinition,
+            ProjectTemplate,
+        )
+
+        template = ProjectTemplate(
+            project_template_schema_version="0.1.0",
+            name="cyclic_project",
+            directories={
+                "a": DirectoryDefinition(name="a", path_macro="{b}/a"),
+                "b": DirectoryDefinition(name="b", path_macro="{a}/b"),
+            },
+            situations={},
+        )
+
+        pm = self._build_project_manager_with_template(template, Path("/fake/cycle"))
+
+        parsed_macro = ParsedMacro("{a}/file.txt")
+        result = pm.on_get_path_for_macro_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables={}))
+
+        assert isinstance(result, GetPathForMacroResultFailure)
+        assert result.failure_reason == PathResolutionFailureReason.MACRO_RESOLUTION_ERROR
+        assert "cycle" in str(result.result_details).lower()
 
 
 class TestProjectManagerGetStateForMacro:


### PR DESCRIPTION
Fixes #4425.

## Summary

Directory `path_macro` values that referenced other directories (e.g.
`watch_outputs: "{watch_folder}/outputs"`) were not being recursively
resolved. The old code copied the raw template string into the resolution
bag, so the final resolved path leaked literal `{...}` tokens and then got
joined under the workspace directory.

Given this project YAML:

```yaml
directories:
  watch_folder:
    path_macro: "/Users/jason/Desktop/DEMO/WATCH"
  watch_outputs:
    path_macro: "{watch_folder}/outputs"
situations:
  save_node_watch_output:
    macro: "{watch_outputs}/{sub_dirs?:/}{node_name}.{file_extension}"
```

resolving `save_node_watch_output` produced:

- **Before:** `/<workspace>/{watch_folder}/outputs/MyNode.png`
- **After:**  `/Users/jason/Desktop/DEMO/WATCH/outputs/MyNode.png`

## What changed

### Core fix — recursive directory resolution

New `_resolve_directory_path` helper in `ProjectManager` walks the reference
chain for a directory macro, substituting every token (nested directory,
builtin, or user-supplied variable) before returning a fully-resolved string.
Wired into both `on_get_path_for_macro_request` and
`_absolute_path_to_macro_path`, which had the same latent bug.

Cycle safety: per-request `cache` dedupes repeated references; `visiting` set
detects cycles (`a → b → a`) and raises `MACRO_RESOLUTION_ERROR` instead of
recursing forever. `try/finally` ensures state is cleaned up even when a
sibling directory fails to resolve mid-sweep.

### Closing an expressiveness asymmetry

While reviewing the fix, we noticed that the top-level macro handler treats
optional builtins leniently (drops them if unresolvable) but the new
directory helper didn't. That made directory macros strictly less expressive
than situation macros. Fixed by mirroring the same optional/required
semantics inside the helper, and additionally plumbing `request.variables`
through so user-supplied vars are substitutable inside directory macros.

Scenarios that now work (none were previously possible):

```yaml
# Optional builtin inside a directory: drops cleanly if unresolvable
directories:
  scratch:
    path_macro: "{workspace_dir}/scratch/{workflow_name?:/}"
# No current workflow → /workspace/scratch/

# Optional unimplemented builtin drops silently
directories:
  labeled:
    path_macro: "{workspace_dir}/outputs/{project_name?:_}"
# → /workspace/outputs/

# User-supplied variable referenced by a directory
directories:
  tenant_outputs:
    path_macro: "{workspace_dir}/tenants/{tenant}/outputs"
# variables={"tenant": "acme", ...} → /workspace/tenants/acme/outputs/...
```

Required builtins still fail loudly — an unadorned `{workflow_name}` inside
a directory with no current workflow returns `MACRO_RESOLUTION_ERROR` as
before.

### Small refactor

Extracted `_try_resolve_optional_builtin` since the "try builtin; drop if
optional, raise if required" pattern was showing up in two places.

## Test plan

- [x] `make check` — clean (ruff, pyright, formatter).
- [x] `uv run pytest tests/unit/retained_mode/managers/test_project_manager.py`
      — 91 pass (10 new tests added to cover the scenarios above plus cycle
      detection, partial-failure cleanup, and directory-name shadowing a
      builtin).
- [x] Manual verification in the Nodes editor: load a project YAML with the
      real `save_node_watch_output` situation and exercise it via the Python
      scratch pane; confirm resolved path matches the expected
      `{watch_folder}/outputs/...` substitution.

## Files touched

- `src/griptape_nodes/retained_mode/managers/project_manager.py` — core fix,
  new helpers, wired into two call sites.
- `tests/unit/retained_mode/managers/test_project_manager.py` — new
  `TestProjectManagerNestedDirectoryResolution` class with 10 tests pinning
  the behavior described above.
