### PR TITLE
feat: honor absolute filenames in ProjectFileDestination.from_situation

### DIFF
--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -127,6 +127,20 @@ class ProjectFileDestination(FileDestination):
             else None
         )
 
+        # Absolute filenames bypass the situation macro: the caller is declaring
+        # an explicit on-disk location, so honor it verbatim rather than treating
+        # the leading-slash directory as sub_dirs within {outputs}/etc. Drop the
+        # sidecar metadata too -- the situation macro + variables we computed
+        # above won't re-resolve to the actual on-disk location, so recording
+        # them would produce a dishonest provenance trail.
+        if parts.directory.is_absolute():
+            return cls(
+                filename,
+                existing_file_policy=existing_file_policy,
+                create_parents=create_dirs,
+                file_metadata=None,
+            )
+
         macro_path = MacroPath(ParsedMacro(macro_template), variables)
         return cls(
             macro_path,

--- a/tests/unit/files/test_project_file.py
+++ b/tests/unit/files/test_project_file.py
@@ -1,5 +1,6 @@
 """Unit tests for ProjectFileDestination."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from griptape_nodes.files.project_file import ProjectFileDestination
@@ -72,6 +73,34 @@ class TestProjectFileDestinationInit:
         with patch(HANDLE_REQUEST_PATH, return_value=GetSituationResultFailure(result_details="not found")):
             dest = ProjectFileDestination.from_situation("image.png", "missing_situation")
 
+        assert dest._file._file_metadata is None
+
+    def test_from_situation_absolute_filename_bypasses_macro(self, tmp_path: Path) -> None:
+        """An absolute filename is honored verbatim rather than routed through the situation macro."""
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import GetSituationResultSuccess
+
+        situation = SituationTemplate(
+            name="save_node_output",
+            macro="{outputs}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+        )
+
+        absolute_filename = str(tmp_path / "foo" / "bar" / "output.png")
+
+        with patch(
+            HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
+        ):
+            dest = ProjectFileDestination.from_situation(absolute_filename, "save_node_output")
+
+        # The resolved path should be the absolute path as-is, not routed under {outputs}.
+        assert dest._file.location == absolute_filename
+        # No sidecar metadata: the situation macro+variables don't re-resolve to
+        # the absolute path we honored verbatim, so recording them would be a lie.
         assert dest._file._file_metadata is None
 
     def test_file_metadata_policy_matches_situation(self) -> None:


### PR DESCRIPTION
When the filename passed to from_situation is absolute (e.g. "/foo/bar.png"), bypass the situation macro and write to that path verbatim. Sidecar metadata is dropped because the macro + variables would not re-resolve to the honored path.