### PR TITLE
feat: derive sub_dirs from filename in ProjectFileDestination.from_si…

### DIFF
--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -110,6 +110,15 @@ class ProjectFileDestination(FileDestination):
             "file_extension": parts.extension,
             **extra_vars,
         }
+        # When the filename carries its own relative directory component (e.g.
+        # "foo/bar/output.png"), populate sub_dirs so situations with {sub_dirs?:/}
+        # route the file into that sub-directory. An explicit sub_dirs kwarg in
+        # extra_vars takes precedence. Absolute filenames still flow through the
+        # macro; we skip the sub_dirs override for them so we don't feed a
+        # leading-slash value into the macro substitution.
+        directory_str = str(parts.directory)
+        if directory_str and directory_str != "." and not parts.directory.is_absolute() and "sub_dirs" not in variables:
+            variables["sub_dirs"] = directory_str
 
         file_metadata = (
             SidecarContent(

--- a/tests/unit/files/test_project_file.py
+++ b/tests/unit/files/test_project_file.py
@@ -1,5 +1,6 @@
 """Unit tests for ProjectFileDestination."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from griptape_nodes.files.project_file import ProjectFileDestination
@@ -73,6 +74,116 @@ class TestProjectFileDestinationInit:
             dest = ProjectFileDestination.from_situation("image.png", "missing_situation")
 
         assert dest._file._file_metadata is None
+
+    def test_from_situation_derives_sub_dirs_from_filename_directory(self) -> None:
+        """A path-prefixed filename populates sub_dirs in the resolution variables."""
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import GetSituationResultSuccess
+
+        situation = SituationTemplate(
+            name="save_workflow",
+            macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+        )
+
+        with patch(
+            HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
+        ):
+            dest = ProjectFileDestination.from_situation("renders/foo.png", "save_workflow")
+
+        assert dest._file._file_metadata is not None
+        assert dest._file._file_metadata.situation is not None
+        variables = dest._file._file_metadata.situation.variables
+        assert variables is not None
+        assert variables["sub_dirs"] == "renders"
+        assert variables["file_name_base"] == "foo"
+        assert variables["file_extension"] == "png"
+
+    def test_from_situation_derives_nested_sub_dirs_from_filename(self) -> None:
+        """A filename with nested directory components populates sub_dirs with the full relative path."""
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import GetSituationResultSuccess
+
+        situation = SituationTemplate(
+            name="save_workflow",
+            macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+        )
+
+        with patch(
+            HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
+        ):
+            dest = ProjectFileDestination.from_situation("act_1/scene_3/intro.py", "save_workflow")
+
+        assert dest._file._file_metadata is not None
+        assert dest._file._file_metadata.situation is not None
+        variables = dest._file._file_metadata.situation.variables
+        assert variables is not None
+        assert variables["sub_dirs"] == str(Path("act_1/scene_3"))
+        assert variables["file_name_base"] == "intro"
+        assert variables["file_extension"] == "py"
+
+    def test_from_situation_no_sub_dirs_when_filename_has_no_directory(self) -> None:
+        """A bare filename leaves sub_dirs unpopulated so the builtin can fill in."""
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import GetSituationResultSuccess
+
+        situation = SituationTemplate(
+            name="save_node_output",
+            macro="{outputs}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+        )
+
+        with patch(
+            HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
+        ):
+            dest = ProjectFileDestination.from_situation("image.png", "save_node_output")
+
+        assert dest._file._file_metadata is not None
+        assert dest._file._file_metadata.situation is not None
+        variables = dest._file._file_metadata.situation.variables
+        assert variables is not None
+        assert "sub_dirs" not in variables
+
+    def test_from_situation_explicit_sub_dirs_wins_over_filename_directory(self) -> None:
+        """An explicit sub_dirs kwarg is not clobbered by a filename-derived value."""
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import GetSituationResultSuccess
+
+        situation = SituationTemplate(
+            name="save_workflow",
+            macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+        )
+
+        with patch(
+            HANDLE_REQUEST_PATH, return_value=GetSituationResultSuccess(situation=situation, result_details="ok")
+        ):
+            dest = ProjectFileDestination.from_situation(
+                "renders/foo.png", "save_workflow", sub_dirs="explicit_override"
+            )
+
+        assert dest._file._file_metadata is not None
+        assert dest._file._file_metadata.situation is not None
+        variables = dest._file._file_metadata.situation.variables
+        assert variables is not None
+        assert variables["sub_dirs"] == "explicit_override"
 
     def test_file_metadata_policy_matches_situation(self) -> None:
         """SidecarContent.situation.policy mirrors the situation's policy."""


### PR DESCRIPTION
…tuation

When a filename passed to from_situation carries a relative directory component (e.g. "foo/bar/output.png"), populate variables["sub_dirs"] so situations with {sub_dirs?:/} route the file into that sub-directory. Explicit sub_dirs in extra_vars still wins.