### PR TITLE
Orchestrator performs bare node.process instead of ExecuteNodeRequest

### DIFF
--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -214,11 +214,19 @@ async def _execute_node_on_worker(
     wm: WorkerManager,
     node: BaseNode,
     worker: tuple[str, str],
-) -> ExecuteNodeResultSuccess | ExecuteNodeResultFailure:
-    """Execute a node on a worker.
+) -> None:
+    """Execute a node on a worker and copy its outputs back onto the node.
 
     Sends a single ExecuteNodeRequest carrying node_metadata. The worker creates
     the node on first call (idempotent — no-op if already present) then executes it.
+
+    On success, copies parameter_output_values back onto the in-memory node so
+    that NodeManager's side-effect handling of set_parameter_value can propagate
+    the outputs to downstream connections. The local (in-process) branch must
+    not do this copy-back, because aprocess() already populated outputs in
+    place and propagation already fired during that write.
+
+    Raises RuntimeError if the worker reports failure.
     """
     worker_engine_id, worker_request_topic = worker
     execute_raw = await wm.route_to_worker(
@@ -234,9 +242,13 @@ async def _execute_node_on_worker(
     )
     result_type_name = execute_raw.get("result_type", "")
     result_data = execute_raw.get("result", {})
-    if result_type_name == ExecuteNodeResultSuccess.__name__:
-        return ExecuteNodeResultSuccess(**result_data)
-    return ExecuteNodeResultFailure(**result_data)
+    if result_type_name != ExecuteNodeResultSuccess.__name__:
+        failure = ExecuteNodeResultFailure(**result_data)
+        msg = f"Node '{node.name}' execution failed on worker: {failure.result_details}"
+        raise RuntimeError(msg)
+    result = ExecuteNodeResultSuccess(**result_data)
+    for name, value in result.parameter_output_values.items():
+        node.set_parameter_value(name, value)
 
 
 class NodeExecutor:
@@ -297,21 +309,19 @@ class NodeExecutor:
             library_name = node.metadata.get("library")
             worker = GriptapeNodes.LibraryManager().get_worker_for_library(library_name) if library_name else None
             if wm and worker:
-                result = await _execute_node_on_worker(wm, node, worker)
+                # Worker runs in a different process; _execute_node_on_worker
+                # copies outputs back onto the in-memory node so NodeManager's
+                # side-effect path can propagate them to downstream connections.
+                await _execute_node_on_worker(wm, node, worker)
             else:
-                result = await GriptapeNodes.ahandle_request(
-                    ExecuteNodeRequest(
-                        node_name=node.name,
-                        parameter_values=dict(node.parameter_values),
-                        node_metadata=cast("NodeMetadata", dict(node.metadata)),
-                    )
-                )
-            if isinstance(result, ExecuteNodeResultSuccess):
-                for name, value in result.parameter_output_values.items():
-                    node.set_parameter_value(name, value)
-            else:
-                msg = f"Node '{node.name}' execution failed: {result.result_details}"
-                raise RuntimeError(msg)  # noqa: TRY004
+                # Orchestrator-only path: behave identically to pre-workers.
+                # Run aprocess() directly on this node instance. NodeManager's
+                # on_set_parameter_value_request side-effect path propagates
+                # any new outputs to downstream connections in-process.
+                # Routing through ExecuteNodeRequest here would re-hydrate
+                # inputs via set_parameter_value and was observed to break
+                # single-node flows (e.g. LoadImage / drag-to-load-image).
+                await node.aprocess()
         finally:
             current_executing_node_name.reset(token)
 

--- a/tests/unit/common/test_execute_node_on_worker.py
+++ b/tests/unit/common/test_execute_node_on_worker.py
@@ -68,24 +68,24 @@ class TestExecuteNodeOnWorker:
         assert request.request.parameter_values == {"x": 1}
 
     @pytest.mark.asyncio
-    async def test_returns_execute_result_on_success(self) -> None:
+    async def test_copies_outputs_back_onto_node_on_success(self) -> None:
         node = self._make_node()
         worker = (_ENGINE, _WORKER_REQUEST_TOPIC)
         wm = MagicMock()
         wm.route_to_worker = AsyncMock(return_value=self._EXECUTE_RAW_SUCCESS)
 
-        result = await _execute_node_on_worker(wm, node, worker)
+        await _execute_node_on_worker(wm, node, worker)
 
-        assert isinstance(result, ExecuteNodeResultSuccess)
-        assert result.parameter_output_values == {"out": 42}
+        node.set_parameter_value.assert_called_once_with("out", 42)
 
     @pytest.mark.asyncio
-    async def test_returns_failure_result_from_worker(self) -> None:
+    async def test_raises_runtime_error_on_worker_failure(self) -> None:
         node = self._make_node()
         worker = (_ENGINE, _WORKER_REQUEST_TOPIC)
         wm = MagicMock()
         wm.route_to_worker = AsyncMock(return_value=self._EXECUTE_RAW_FAILURE)
 
-        result = await _execute_node_on_worker(wm, node, worker)
+        with pytest.raises(RuntimeError, match="execution failed"):
+            await _execute_node_on_worker(wm, node, worker)
 
-        assert isinstance(result, ExecuteNodeResultFailure)
+        node.set_parameter_value.assert_not_called()

--- a/tests/unit/common/test_node_executor_contextvar.py
+++ b/tests/unit/common/test_node_executor_contextvar.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from griptape_nodes.common.node_executor import NodeExecutor, current_executing_node_name
-from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeResultSuccess
 
 _GRIPTAPE_NODES_PATH = "griptape_nodes.common.node_executor.GriptapeNodes"
 _EXECUTE_ON_WORKER_PATH = "griptape_nodes.common.node_executor._execute_node_on_worker"
@@ -34,10 +33,6 @@ def _make_node_with_library(name: str, library: str = "my_lib") -> MagicMock:
     return node
 
 
-def _success_result() -> ExecuteNodeResultSuccess:
-    return ExecuteNodeResultSuccess(result_details="ok", parameter_output_values={})
-
-
 class TestCurrentExecutingNodeNameDefault:
     def test_default_is_none(self) -> None:
         assert current_executing_node_name.get() is None
@@ -50,13 +45,13 @@ class TestNodeExecutorContextVar:
         captured: list[str | None] = []
         node = _make_node("TestNode")
 
-        async def fake_handle(_req: Any) -> ExecuteNodeResultSuccess:
+        async def fake_aprocess() -> None:
             captured.append(current_executing_node_name.get())
-            return _success_result()
+
+        node.aprocess = AsyncMock(side_effect=fake_aprocess)
 
         with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
             mock_gn.WorkerManager.return_value = None
-            mock_gn.ahandle_request = AsyncMock(side_effect=fake_handle)
             await _make_executor().execute(node)
 
         assert captured == ["TestNode"]
@@ -68,7 +63,6 @@ class TestNodeExecutorContextVar:
 
         with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
             mock_gn.WorkerManager.return_value = None
-            mock_gn.ahandle_request = AsyncMock(return_value=_success_result())
             await _make_executor().execute(node)
 
         assert current_executing_node_name.get() is None
@@ -77,10 +71,10 @@ class TestNodeExecutorContextVar:
     async def test_contextvar_reset_to_none_when_aprocess_raises(self) -> None:
         """The ContextVar is reset to None even when execution raises an exception."""
         node = _make_node("TestNode")
+        node.aprocess = AsyncMock(side_effect=RuntimeError("node failed"))
 
         with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
             mock_gn.WorkerManager.return_value = None
-            mock_gn.ahandle_request = AsyncMock(side_effect=RuntimeError("node failed"))
 
             with pytest.raises(RuntimeError, match="node failed"):
                 await _make_executor().execute(node)
@@ -95,14 +89,18 @@ class TestNodeExecutorContextVar:
         node_a = _make_node("NodeA")
         node_b = _make_node("NodeB")
 
-        async def fake_handle(req: Any) -> ExecuteNodeResultSuccess:
-            await asyncio.sleep(0)  # yield to allow interleaving
-            results[req.node_name] = current_executing_node_name.get()
-            return _success_result()
+        def _fake_aprocess_for(node_name: str) -> Any:
+            async def _aprocess() -> None:
+                await asyncio.sleep(0)  # yield to allow interleaving
+                results[node_name] = current_executing_node_name.get()
+
+            return _aprocess
+
+        node_a.aprocess = AsyncMock(side_effect=_fake_aprocess_for("NodeA"))
+        node_b.aprocess = AsyncMock(side_effect=_fake_aprocess_for("NodeB"))
 
         with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
             mock_gn.WorkerManager.return_value = None
-            mock_gn.ahandle_request = AsyncMock(side_effect=fake_handle)
 
             executor = _make_executor()
             await asyncio.gather(
@@ -123,9 +121,8 @@ class TestNodeExecutorContextVarWorkerBranch:
         captured: list[str | None] = []
         node = _make_node_with_library("TestNode")
 
-        async def fake_execute(_wm: Any, _node: Any, _worker: Any) -> ExecuteNodeResultSuccess:
+        async def fake_execute(_wm: Any, _node: Any, _worker: Any) -> None:
             captured.append(current_executing_node_name.get())
-            return _success_result()
 
         with (
             patch(_GRIPTAPE_NODES_PATH) as mock_gn,
@@ -144,7 +141,7 @@ class TestNodeExecutorContextVarWorkerBranch:
 
         with (
             patch(_GRIPTAPE_NODES_PATH) as mock_gn,
-            patch(_EXECUTE_ON_WORKER_PATH, new=AsyncMock(return_value=_success_result())),
+            patch(_EXECUTE_ON_WORKER_PATH, new=AsyncMock(return_value=None)),
         ):
             mock_gn.WorkerManager.return_value = MagicMock()
             mock_gn.LibraryManager.return_value.get_worker_for_library.return_value = ("eng-id", "topic")

--- a/tests/unit/common/test_node_executor_propagation.py
+++ b/tests/unit/common/test_node_executor_propagation.py
@@ -1,0 +1,131 @@
+"""Regression tests for downstream propagation on NodeExecutor.execute().
+
+The in-process side-effect path in NodeManager.on_set_parameter_value_request
+already fans outputs to downstream connections when node.aprocess() writes them.
+The workers PR (#4336) routed the orchestrator-only path through
+ExecuteNodeRequest and copied outputs back onto the node via
+node.set_parameter_value, which re-entered the side-effect propagation path
+and duplicated downstream fan-out (observed as "~10 duplicate RescaleImage
+outputs"). The orchestrator-only path also broke single-node flows like
+LoadImage because ExecuteNodeRequest re-hydrates inputs via
+set_parameter_value.
+
+These tests lock in:
+  * orchestrator-only path: bare `await node.aprocess()`; no
+    set_parameter_value, no ExecuteNodeRequest round-trip.
+  * worker branch: _execute_node_on_worker is invoked; the helper (not
+    NodeExecutor.execute) owns the copy-back onto the in-memory node.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.node_executor import NodeExecutor
+
+_GRIPTAPE_NODES_PATH = "griptape_nodes.common.node_executor.GriptapeNodes"
+_EXECUTE_ON_WORKER_PATH = "griptape_nodes.common.node_executor._execute_node_on_worker"
+
+
+def _make_executor() -> NodeExecutor:
+    return NodeExecutor.__new__(NodeExecutor)
+
+
+def _make_local_node() -> MagicMock:
+    node = MagicMock()
+    node.name = "UpstreamNode"
+    node.parameter_values = {}
+    # No "library" key so the executor's `get_worker_for_library` branch
+    # is never exercised — we're on the local path.
+    node.metadata = {}
+    node.aprocess = AsyncMock()
+    return node
+
+
+def _make_worker_node() -> MagicMock:
+    node = MagicMock()
+    node.name = "UpstreamNode"
+    node.parameter_values = {}
+    node.metadata = {"library": "my_lib"}
+    node.aprocess = AsyncMock()
+    return node
+
+
+class TestOrchestratorOnlyPath:
+    """The orchestrator-only path must match pre-workers behavior exactly.
+
+    That means a bare `await node.aprocess()` with no ExecuteNodeRequest
+    round-trip and no copy-back onto the node. aprocess() writes outputs
+    directly on the node, and NodeManager's on_set_parameter_value_request
+    fans them out to downstream connections in-process.
+    """
+
+    @pytest.mark.asyncio
+    async def test_calls_aprocess_directly(self) -> None:
+        node = _make_local_node()
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.WorkerManager.return_value = None
+            mock_gn.ahandle_request = AsyncMock()
+            await _make_executor().execute(node)
+
+        node.aprocess.assert_awaited_once()
+        mock_gn.ahandle_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_set_parameter_value_on_node(self) -> None:
+        node = _make_local_node()
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.WorkerManager.return_value = None
+            await _make_executor().execute(node)
+
+        # The regression: prior code routed through ExecuteNodeRequest and
+        # unconditionally called node.set_parameter_value for each output.
+        # That re-entered the side-effect propagation path and duplicated
+        # downstream fan-out. It also broke LoadImage because the
+        # ExecuteNodeRequest input-hydrate loop re-fired set_parameter_value
+        # on inputs.
+        node.set_parameter_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_propagates_aprocess_exception(self) -> None:
+        node = _make_local_node()
+        node.aprocess = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.WorkerManager.return_value = None
+
+            with pytest.raises(RuntimeError, match="boom"):
+                await _make_executor().execute(node)
+
+        node.set_parameter_value.assert_not_called()
+
+
+class TestWorkerBranchRoutesToHelper:
+    """Worker branch must delegate to _execute_node_on_worker.
+
+    The helper owns the copy-back onto the in-memory node; NodeExecutor.execute
+    itself does not touch node.set_parameter_value.
+    """
+
+    @pytest.mark.asyncio
+    async def test_worker_path_calls_helper_and_skips_aprocess(self) -> None:
+        node = _make_worker_node()
+
+        async def fake_execute(_wm: Any, _node: Any, _worker: Any) -> None:
+            return None
+
+        with (
+            patch(_GRIPTAPE_NODES_PATH) as mock_gn,
+            patch(_EXECUTE_ON_WORKER_PATH, new=AsyncMock(side_effect=fake_execute)) as mock_exec,
+        ):
+            mock_gn.WorkerManager.return_value = MagicMock()
+            mock_gn.LibraryManager.return_value.get_worker_for_library.return_value = ("eng-id", "topic")
+            await _make_executor().execute(node)
+
+        mock_exec.assert_awaited_once()
+        node.aprocess.assert_not_called()


### PR DESCRIPTION
Adds divergence between orchestrator and worker but fixes Jason's duplicate resize image issue