### PR TITLE
fix: quiet logs when preview source file is missing

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -194,11 +194,12 @@ class StaticFilesManager:
                 macro_path=MacroPath(ParsedMacro(str(file_path)), {}),
                 artifact_provider_name=provider_name,
                 preview_generation_policy=PreviewGenerationPolicy.ONLY_IF_STALE,
+                failure_log_level=logging.DEBUG,
             )
         )
 
         if not isinstance(result, GetPreviewForArtifactResultSuccess) or not isinstance(result.paths_to_preview, str):
-            logger.warning("Preview generation failed for %s: %s", file_path, result.result_details)
+            logger.debug("Preview generation failed for %s: %s", file_path, result.result_details)
             return file_path, None
 
         preview_path = Path(result.paths_to_preview)

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -239,7 +239,7 @@ async def _serve_external_file(file_path: str) -> FileResponse:
 
     # Check if file exists
     if not await anyio_absolute_path.exists():
-        logger.warning("External file not found: %s", absolute_path)
+        logger.debug("External file not found: %s", absolute_path)
         raise HTTPException(status_code=404, detail=f"File {absolute_path} not found")
 
     # Check if it's actually a file (not a directory)


### PR DESCRIPTION
Closes #4442

Missing source files during preview generation were producing three log lines (one `ERROR`, two `WARNING`) for the same condition, and the `ERROR` surfaces in the GUI as a toast for a situation users can't act on (outputs cleaned up, watched files moved between runs).

Routes this case through the existing `failure_log_level` hook on `GetPreviewForArtifactRequest` so the artifact-manager failure logs at `DEBUG`, drops the re-log in `StaticFilesManager._generate_preview_if_needed` to `DEBUG` so it no longer duplicates the HTTP-boundary message, and drops the `External file not found` warning in `_serve_external_file` to `DEBUG` since uvicorn's access log + the 404 status already capture that signal. Other preview failure modes (provider bugs, malformed metadata, etc.) still surface as warnings because they'll fall through to the same log sites without the `source file not found` path short-circuiting first.