### PR TITLE
fix: silence ParameterString allowed_modes convenience warning

### DIFF
--- a/src/griptape_nodes/exe_types/param_types/parameter_string.py
+++ b/src/griptape_nodes/exe_types/param_types/parameter_string.py
@@ -129,6 +129,14 @@ class ParameterString(Parameter):
             final_input_types = ["str"]
             final_converters = existing_converters
 
+        # When allowed_modes is explicitly provided, it takes precedence over the
+        # allow_input/allow_property/allow_output convenience parameters. Forward defaults
+        # for the convenience parameters so Parameter does not emit a conflict warning.
+        if allowed_modes is not None:
+            allow_input = True
+            allow_property = True
+            allow_output = True
+
         # Call parent with explicit parameters, following ControlParameter pattern
         super().__init__(
             name=name,


### PR DESCRIPTION
Callers that pass `allowed_modes` to `ParameterString` were hitting a `UserWarning` from `Parameter.__init__` complaining about a conflict with `allow_input`/`allow_property`/`allow_output`, even when they did not touch those convenience parameters. The warning fires whenever `allowed_modes` is set alongside any convenience param whose value differs from the parent's default of `True`, and `ParameterString` was always forwarding whatever convenience values it received. When the caller set `allow_input=False` (or similar) alongside `allowed_modes`, or when a wrapper tightened the defaults, the parent saw a perceived conflict and warned, despite `allowed_modes` being authoritative.

When `allowed_modes` is explicitly provided, `ParameterString` now normalizes the convenience parameters back to `True` before forwarding, so `Parameter` sees only `allowed_modes` and does not emit the conflict warning. Behavior is unchanged otherwise, since `Parameter` was already ignoring the convenience values in favor of `allowed_modes`.

Closes #4444