### PR TITLE
fix: restore #4427 and #4430 silently reverted by squash-merges of stale branches

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -52,6 +52,14 @@ class LocalWorkflowExecutor(WorkflowExecutor):
     async def __aenter__(self) -> Self:
         """Async context manager entry: initialize queue and broadcast app initialization."""
         GriptapeNodes.EventManager().initialize_queue()
+
+        # Activate the user-specified project BEFORE broadcasting AppInitializationComplete.
+        # At this point ProjectManager._initialization_complete is still False, so the
+        # project switch skips the heavy library reload that would otherwise clear the
+        # flow/nodes already created at module import time.
+        if self._project_file_path is not None:
+            await self._load_project(self._project_file_path)
+
         await GriptapeNodes.EventManager().abroadcast_app_event(
             AppInitializationComplete(
                 skip_library_loading=self._skip_library_loading, workflows_to_register=self._workflows_to_register
@@ -226,9 +234,6 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         flow_name = self._load_flow_for_workflow()
         # Now let's set the input to the flow
         await self._set_input_for_flow(flow_name=flow_name, flow_input=flow_input)
-
-        if self._project_file_path is not None:
-            await self._load_project(self._project_file_path)
 
         return flow_name
 

--- a/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
@@ -110,16 +110,21 @@ class ProjectFileParameter:
 
         If an upstream node implements FileDestinationProvider (e.g., FileOutputSettings),
         its FileDestination is retrieved directly without deserializing from the wire.
+        An upstream provider that returns None (misconfigured) raises instead of silently
+        falling back to the default situation, since that fallback hides user intent.
 
-        If the parameter holds a string filename, parses it into
-        file_name_base/file_extension, builds a MacroPath using the
-        situation's macro template, and wraps it in a FileDestination.
+        Otherwise the parameter's string value is parsed into
+        file_name_base/file_extension, combined with this component's default
+        situation, and wrapped in a FileDestination.
 
         Args:
             **extra_vars: Additional variables for the macro (e.g., sub_dirs="renders")
 
         Returns:
             FileDestination with a MacroPath and baked-in write policy for deferred path resolution
+
+        Raises:
+            ValueError: If an upstream FileDestinationProvider is connected but returns None.
         """
         result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self._node.name))
         if isinstance(result, ListConnectionsForNodeResultSuccess):
@@ -128,8 +133,14 @@ class ProjectFileParameter:
                     source_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name(conn.source_node_name)
                     if isinstance(source_node, FileDestinationProvider):
                         file_dest = source_node.file_destination
-                        if file_dest is not None:
-                            return file_dest
+                        if file_dest is None:
+                            msg = (
+                                f"Attempted to build file destination for {self._node.name}.{self._name}. "
+                                f"Failed because upstream node '{conn.source_node_name}' provides a "
+                                f"FileDestination but returned None (likely missing a filename)."
+                            )
+                            raise ValueError(msg)
+                        return file_dest
 
         value = self._node.get_parameter_value(self._name)
 

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -236,6 +236,12 @@ class ProjectManager:
             self.on_app_initialization_complete,
         )
 
+        # Load system defaults eagerly so project-aware requests work before
+        # AppInitializationComplete fires. Workflow scripts run in CLI mode
+        # construct nodes at module import time, before the event is broadcast.
+        self._load_system_defaults()
+        self._current_project_id = SYSTEM_DEFAULTS_KEY
+
     def on_load_project_template_request(
         self, request: LoadProjectTemplateRequest
     ) -> LoadProjectTemplateResultSuccess | LoadProjectTemplateResultFailure:
@@ -945,9 +951,20 @@ class ProjectManager:
 
         Called by EventManager after all libraries are loaded.
         Loads system defaults, then checks workspace for a griptape-nodes-project.yml
-        overlay file and sets it as the current project if found.
+        overlay file and sets it as the current project if found. If a project has
+        already been explicitly selected before this event (e.g., by a CLI executor
+        via --project-file-path), preserves that choice and skips workspace discovery.
         """
-        self._load_system_defaults()
+        # If an explicit project was selected before init completed (e.g., by
+        # LocalWorkflowExecutor loading --project-file-path), keep it. Still load
+        # registered projects for visibility and mark init complete.
+        explicit_project_selected = (
+            self._current_project_id is not None and self._current_project_id != SYSTEM_DEFAULTS_KEY
+        )
+        if explicit_project_selected:
+            self._load_registered_projects()
+            self._initialization_complete = True
+            return
 
         # Set system defaults as current project (using synthetic key for system defaults)
         set_request = SetCurrentProjectRequest(project_id=SYSTEM_DEFAULTS_KEY)
@@ -1438,7 +1455,7 @@ class ProjectManager:
                     result.result_details,
                 )
             else:
-                logger.info("Reloaded registered project from '%s'", path_str)
+                logger.debug("Reloaded registered project from '%s'", path_str)
 
     def _register_project_path(self, project_id: str) -> None:
         """Persist a project file path so it is loaded on the next engine restart.

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -97,8 +97,15 @@ class TestProjectManagerMacroHandlers:
 class TestProjectManagerInitialization:
     """Test ProjectManager initialization and state."""
 
-    def test_project_manager_initializes_empty(self) -> None:
-        """Test ProjectManager starts with empty state."""
+    def test_project_manager_initializes_with_system_defaults(self) -> None:
+        """System defaults loaded eagerly in __init__.
+
+        Project-aware requests must work before AppInitializationComplete fires
+        because CLI workflow scripts construct nodes at module import time,
+        before the event is broadcast.
+        """
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
         mock_config = Mock()
         mock_secrets = Mock()
         mock_event_manager = Mock()
@@ -106,8 +113,8 @@ class TestProjectManagerInitialization:
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         assert pm._registered_template_status == {}
-        assert pm._successfully_loaded_project_templates == {}
-        assert pm._current_project_id is None
+        assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
+        assert SYSTEM_DEFAULTS_KEY in pm._successfully_loaded_project_templates
 
     def test_project_manager_stores_manager_references(self) -> None:
         """Test ProjectManager stores config and secrets manager references."""
@@ -488,6 +495,7 @@ class TestProjectManagerGetStateForMacro:
         mock_secrets = Mock()
         mock_event_manager = Mock()
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
+        pm._current_project_id = None
 
         parsed_macro = ParsedMacro("{file_name}.txt")
 
@@ -632,6 +640,7 @@ class TestProjectManagerGetCurrentProject:
         mock_secrets = Mock()
         mock_event_manager = Mock()
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
+        pm._current_project_id = None
 
         request = GetCurrentProjectRequest()
         result = pm.on_get_current_project_request(request)
@@ -1038,7 +1047,8 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         """Test mapping when no current project is set (returns failure)."""
         from griptape_nodes.retained_mode.events.project_events import AttemptMapAbsolutePathToProjectResultFailure
 
-        # No project set up
+        # Clear the system defaults loaded in __init__ to simulate no current project
+        project_manager._current_project_id = None
 
         absolute_path = Path("/Users/test/project/outputs/file.png")
 


### PR DESCRIPTION
Two PRs that landed earlier today got silently reverted by later squash-merges and need to be put back: `#4427` (respect `--project-file-path` in CLI mode) and `#4430` (raise when upstream `FileDestinationProvider` returns `None`).


This branch cherry-picks `e60d710de` (`#4427`) and `bf53246fe` (`#4430`). The `project_manager.py` auto-merge from the first cherry-pick correctly reassembles `#4427`'s blocks alongside `#4436`'s `persisted_project_file` and clear-on-unregister blocks, so both PRs coexist. The second cherry-pick only takes effect in `project_file_parameter.py` since the other files in `bf53246fe`'s squash were reverts of `#4427` that git's 3-way merge sees are already reapplied. `make check` passes.