### PR TITLE
feat: wrap saved workflows in async build_workflow() with ahandle_request

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -192,6 +192,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
 )
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
 from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER_KEY
+from griptape_nodes.utils.ast_utils import rewrite_string_comments
 from griptape_nodes.utils.string_utils import normalize_display_name
 
 if TYPE_CHECKING:
@@ -2539,35 +2540,9 @@ class WorkflowManager:
         # Rewrite string-literal lines of the form `'# foo'` or `"# foo"` into real `# foo`
         # comments. `ast.unparse` cannot emit comments directly, so the generators above
         # smuggle them in as bare-string statements and we unwrap them here.
-        ast_output = self._rewrite_string_comments(ast_output)
+        ast_output = rewrite_string_comments(ast_output)
         import_output = import_recorder.generate_imports()
         return f"{metadata_block}\n\n{import_output}\n\n{ast_output}\n"
-
-    @staticmethod
-    def _rewrite_string_comments(source: str) -> str:
-        """Turn bare-string statements that start with `#` into real Python comments.
-
-        Only whole-line matches are rewritten; indentation is preserved so comments inside
-        functions / `with` blocks stay indented correctly. The body may contain the
-        opposing quote character (ast.unparse flips quoting style when the body already
-        contains one) but must not contain the enclosing quote.
-        """
-        # Smallest valid bare-string comment is `"#"` or `'#'` — three characters.
-        min_quoted_len = 3
-        rewritten_lines = []
-        for line in source.splitlines():
-            stripped = line.lstrip()
-            indent = line[: len(line) - len(stripped)]
-            if len(stripped) >= min_quoted_len and stripped[0] in ('"', "'") and stripped[-1] == stripped[0]:
-                quote = stripped[0]
-                body = stripped[1:-1]
-                # Must be a single-line literal with no embedded matching quote,
-                # and must look like a comment ("#..." with no surprises).
-                if quote not in body and body.startswith("#"):
-                    rewritten_lines.append(f"{indent}{body}")
-                    continue
-            rewritten_lines.append(line)
-        return "\n".join(rewritten_lines)
 
     def _replace_workflow_metadata_header(self, workflow_content: str, new_metadata: WorkflowMetadata) -> str | None:
         """Replace the metadata header in a workflow file with new metadata.
@@ -3578,7 +3553,7 @@ class WorkflowManager:
 
         # Comment lines explaining what we're doing. Each line is emitted as its own bare-string
         # statement so that it unparses onto a single source line. A post-process pass in
-        # _generate_workflow_file_content (via _rewrite_string_comments) then strips the surrounding
+        # _generate_workflow_file_content (via rewrite_string_comments) then strips the surrounding
         # quotes to turn each line into a real Python `#` comment.
         comment_lines = [
             "# 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.",

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from inspect import getmodule, isclass
+from inspect import getmodule, isclass, iscoroutinefunction
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar, cast
 
@@ -690,7 +690,22 @@ class WorkflowManager:
             # Now execute the workflow.
             async with await anyio.open_file(Path(complete_file_path), encoding="utf-8") as file:
                 workflow_content = await file.read()
-            exec(workflow_content)  # noqa: S102
+
+            # Execute the workflow module with a dedicated namespace so `__file__` resolves
+            # to the workflow path and the `if __name__ == "__main__"` guard does not fire
+            # (which would try to spin up a second event loop via asyncio.run).
+            namespace: dict[str, Any] = {
+                "__file__": str(complete_file_path),
+                "__name__": "__gtn_workflow__",
+            }
+            exec(workflow_content, namespace)  # noqa: S102
+
+            # New-style workflows wrap graph-building requests in `async def build_workflow()`
+            # so the module is inert at import time. Await it here. Legacy workflows without
+            # build_workflow() have already executed their requests top-to-bottom during exec().
+            workflow_builder = namespace.get("build_workflow")
+            if workflow_builder is not None and iscoroutinefunction(workflow_builder):
+                await workflow_builder()
 
             # After workflow execution, ensure there's always a current context by pushing
             # the top-level flow if the context is empty. This fixes regressions where
@@ -2269,14 +2284,17 @@ class WorkflowManager:
 
         ast_container = ASTContainer()
 
+        # Graph-building statements accumulate into the body of `async def main()`,
+        # so the emitted workflow file only mutates engine state when main() is awaited.
+        main_body: list[ast.stmt] = []
+
         # Extract library names from workflow metadata
         library_names = [lib.library_name for lib in workflow_metadata.node_libraries_referenced]
 
         prereq_code = self._generate_workflow_run_prerequisite_code(
             import_recorder=import_recorder, library_names=library_names
         )
-        for node in prereq_code:
-            ast_container.add_node(node)
+        main_body.extend(cast("ast.stmt", node) for node in prereq_code)
 
         # Generate unique values code AST node
         unique_values_node = self._generate_unique_values_code(
@@ -2284,7 +2302,8 @@ class WorkflowManager:
             prefix="top_level",
             import_recorder=import_recorder,
         )
-        ast_container.add_node(unique_values_node)
+        # Helper returns an ast.Module; unpack its body into statements.
+        main_body.extend(cast("ast.stmt", stmt) for stmt in unique_values_node.body)
 
         # Keep track of each flow and node index we've created
         flow_creation_index = 0
@@ -2298,15 +2317,13 @@ class WorkflowManager:
                 create_flow_context_module = self._generate_create_flow(
                     flow_initialization_command, import_recorder, flow_creation_index
                 )
-                for node in create_flow_context_module.body:
-                    ast_container.add_node(node)
+                main_body.extend(cast("ast.stmt", node) for node in create_flow_context_module.body)
             case ImportWorkflowAsReferencedSubFlowRequest():
                 # Generate import workflow context AST module
                 import_workflow_context_module = self._generate_import_workflow(
                     flow_initialization_command, import_recorder, flow_creation_index
                 )
-                for node in import_workflow_context_module.body:
-                    ast_container.add_node(node)
+                main_body.extend(cast("ast.stmt", node) for node in import_workflow_context_module.body)
             case None:
                 # No initialization command, deserialize into current context
                 pass
@@ -2476,9 +2493,38 @@ class WorkflowManager:
             )
             assign_flow_context_node.body.extend(set_parameter_value_asts)
 
-            ast_container.add_node(assign_flow_context_node)
+            main_body.append(cast("ast.stmt", assign_flow_context_node))
 
-        # Generate workflow execution code
+        # Wrap all graph-building statements in `async def build_workflow()` so the file is
+        # inert until build_workflow() is awaited (by the engine loader or the CLI entrypoint).
+        # The name pairs with the executor entrypoints (execute_workflow / aexecute_workflow)
+        # to make the two phases — graph construction vs execution — visually distinct.
+        main_func_def = ast.AsyncFunctionDef(
+            name="build_workflow",
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
+            body=main_body or [ast.Pass()],
+            decorator_list=[],
+            returns=ast.Constant(value=None),
+            type_params=[],
+        )
+        ast.fix_missing_locations(main_func_def)
+        ast_container.add_node(main_func_def)
+
+        # Generate workflow execution code. Only emitted when the workflow has a Start/End
+        # shape — that's what makes the file runnable as a CLI program. Shapeless workflows
+        # have no input/output surface and are loaded by the engine via `await build_workflow()`
+        # (see WorkflowManager.run_workflow), so they don't need a `__main__` guard.
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4205 — decide how shapeless
+        # workflows should behave when invoked directly (build-only vs build + StartFlowRequest)
+        # and emit an appropriate `__main__` guard.
         workflow_execution_code = self._generate_workflow_execution(
             import_recorder=import_recorder,
             workflow_metadata=workflow_metadata,
@@ -2488,10 +2534,40 @@ class WorkflowManager:
             for node in workflow_execution_code:
                 ast_container.add_node(node)
 
-        # Generate final code from ASTContainer
+        # Generate final code from ASTContainer.
         ast_output = "\n\n".join([ast.unparse(node) for node in ast_container.get_ast()])
+        # Rewrite string-literal lines of the form `'# foo'` or `"# foo"` into real `# foo`
+        # comments. `ast.unparse` cannot emit comments directly, so the generators above
+        # smuggle them in as bare-string statements and we unwrap them here.
+        ast_output = self._rewrite_string_comments(ast_output)
         import_output = import_recorder.generate_imports()
         return f"{metadata_block}\n\n{import_output}\n\n{ast_output}\n"
+
+    @staticmethod
+    def _rewrite_string_comments(source: str) -> str:
+        """Turn bare-string statements that start with `#` into real Python comments.
+
+        Only whole-line matches are rewritten; indentation is preserved so comments inside
+        functions / `with` blocks stay indented correctly. The body may contain the
+        opposing quote character (ast.unparse flips quoting style when the body already
+        contains one) but must not contain the enclosing quote.
+        """
+        # Smallest valid bare-string comment is `"#"` or `'#'` — three characters.
+        min_quoted_len = 3
+        rewritten_lines = []
+        for line in source.splitlines():
+            stripped = line.lstrip()
+            indent = line[: len(line) - len(stripped)]
+            if len(stripped) >= min_quoted_len and stripped[0] in ('"', "'") and stripped[-1] == stripped[0]:
+                quote = stripped[0]
+                body = stripped[1:-1]
+                # Must be a single-line literal with no embedded matching quote,
+                # and must look like a comment ("#..." with no surprises).
+                if quote not in body and body.startswith("#"):
+                    rewritten_lines.append(f"{indent}{body}")
+                    continue
+            rewritten_lines.append(line)
+        return "\n".join(rewritten_lines)
 
     def _replace_workflow_metadata_header(self, workflow_content: str, new_metadata: WorkflowMetadata) -> str | None:
         """Replace the metadata header in a workflow file with new metadata.
@@ -2729,11 +2805,25 @@ class WorkflowManager:
             )
         )
 
+        # `await build_workflow()` constructs the graph before the executor runs;
+        # build_workflow() is the async function emitted by _generate_workflow_file_content
+        # that contains all graph-building requests.
+        await_main_call = ast.Expr(
+            value=ast.Await(
+                value=ast.Call(
+                    func=ast.Name(id="build_workflow", ctx=ast.Load()),
+                    args=[],
+                    keywords=[],
+                )
+            )
+        )
+
         # === Generate async aexecute_workflow function ===
         async_func_def = ast.AsyncFunctionDef(
             name="aexecute_workflow",
             args=args,
             body=[
+                await_main_call,
                 ensure_context_call,
                 storage_backend_convert,
                 project_file_path_resolve,
@@ -3156,15 +3246,15 @@ class WorkflowManager:
     def _generate_ensure_flow_context_function(
         self,
         import_recorder: ImportRecorder,
-    ) -> ast.FunctionDef:
-        """Generates the _ensure_workflow_context function for the serialized workflow file."""
+    ) -> ast.AsyncFunctionDef:
+        """Generates the async _ensure_workflow_context function for the serialized workflow file."""
         import_recorder.add_from_import("griptape_nodes.retained_mode.events.flow_events", "GetTopLevelFlowRequest")
         import_recorder.add_from_import(
             "griptape_nodes.retained_mode.events.flow_events", "GetTopLevelFlowResultSuccess"
         )
 
-        # Function signature: def _ensure_workflow_context():
-        func_def = ast.FunctionDef(
+        # Function signature: async def _ensure_workflow_context():
+        func_def = ast.AsyncFunctionDef(
             name="_ensure_workflow_context",
             args=ast.arguments(
                 posonlyargs=[],
@@ -3218,17 +3308,19 @@ class WorkflowManager:
             ),
         )
 
-        # top_level_flow_result = GriptapeNodes.handle_request(top_level_flow_request)  # noqa: ERA001
+        # top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)  # noqa: ERA001
         flow_result_assign = ast.Assign(
             targets=[ast.Name(id="top_level_flow_result", ctx=ast.Store())],
-            value=ast.Call(
-                func=ast.Attribute(
-                    value=ast.Name(id="GriptapeNodes", ctx=ast.Load()),
-                    attr="handle_request",
-                    ctx=ast.Load(),
+            value=ast.Await(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load()),
+                        attr="ahandle_request",
+                        ctx=ast.Load(),
+                    ),
+                    args=[ast.Name(id="top_level_flow_request", ctx=ast.Load())],
+                    keywords=[],
                 ),
-                args=[ast.Name(id="top_level_flow_request", ctx=ast.Load())],
-                keywords=[],
             ),
         )
 
@@ -3335,12 +3427,14 @@ class WorkflowManager:
     def _generate_ensure_flow_context_call(
         self,
     ) -> ast.Expr:
-        """Generates the call to _ensure_workflow_context() function."""
+        """Generates the call to await _ensure_workflow_context() function."""
         return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="_ensure_workflow_context", ctx=ast.Load()),
-                args=[],
-                keywords=[],
+            value=ast.Await(
+                value=ast.Call(
+                    func=ast.Name(id="_ensure_workflow_context", ctx=ast.Load()),
+                    args=[],
+                    keywords=[],
+                )
             )
         )
 
@@ -3358,29 +3452,31 @@ class WorkflowManager:
         # Generate one RegisterLibraryFromFileRequest call per library
         for library_name in library_names:
             register_call = ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load()),
-                        attr="handle_request",
-                        ctx=ast.Load(),
-                    ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(id="RegisterLibraryFromFileRequest", ctx=ast.Load()),
-                            args=[],
-                            keywords=[
-                                ast.keyword(
-                                    arg="library_name",
-                                    value=ast.Constant(value=library_name),
-                                ),
-                                ast.keyword(
-                                    arg="perform_discovery_if_not_found",
-                                    value=ast.Constant(value=True),
-                                ),
-                            ],
-                        )
-                    ],
-                    keywords=[],
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load()),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id="RegisterLibraryFromFileRequest", ctx=ast.Load()),
+                                args=[],
+                                keywords=[
+                                    ast.keyword(
+                                        arg="library_name",
+                                        value=ast.Constant(value=library_name),
+                                    ),
+                                    ast.keyword(
+                                        arg="perform_discovery_if_not_found",
+                                        value=ast.Constant(value=True),
+                                    ),
+                                ],
+                            )
+                        ],
+                        keywords=[],
+                    )
                 )
             )
             ast.fix_missing_locations(register_call)
@@ -3440,7 +3536,7 @@ class WorkflowManager:
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
         prefix: str,
         import_recorder: ImportRecorder,
-    ) -> ast.AST:
+    ) -> ast.Module:
         if len(unique_parameter_uuid_to_values) == 0:
             return ast.Module(body=[], type_ignores=[])
 
@@ -3480,16 +3576,18 @@ class WorkflowManager:
             # Collect import statements for all classes in the object tree
             self._collect_object_imports(unique_parameter_value, import_recorder, global_modules_set)
 
-        # Generate a comment explaining what we're doing:
-        comment_text = (
-            "\n"
-            "1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.\n"
-            "   This minimizes the size of the code, especially for large objects like serialized image files.\n"
-            "2. We're using a prefix so that it's clear which Flow these values are associated with.\n"
-            "3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes\n"
-            "   them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise\n"
-            "   would be difficult to serialize.\n"
-        )
+        # Comment lines explaining what we're doing. Each line is emitted as its own bare-string
+        # statement so that it unparses onto a single source line. A post-process pass in
+        # _generate_workflow_file_content (via _rewrite_string_comments) then strips the surrounding
+        # quotes to turn each line into a real Python `#` comment.
+        comment_lines = [
+            "# 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.",
+            "#    This minimizes the size of the code, especially for large objects like serialized image files.",
+            "# 2. We're using a prefix so that it's clear which Flow these values are associated with.",
+            "# 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes",
+            "#    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise",
+            "#    would be difficult to serialize.",
+        ]
 
         # Generate the dictionary of unique values
         unique_values_dict_name = f"{prefix}_unique_values_dict"
@@ -3520,11 +3618,12 @@ class WorkflowManager:
             col_offset=0,
         )
 
-        # Create the final AST with comments
-        module_body = [
-            ast.Expr(value=ast.Constant(value=comment_text, lineno=1, col_offset=0), lineno=1, col_offset=0),
-            unique_values_ast,
+        # Create the final AST with comment lines followed by the dict assignment.
+        comment_exprs = [
+            ast.Expr(value=ast.Constant(value=line, lineno=1, col_offset=0), lineno=1, col_offset=0)
+            for line in comment_lines
         ]
+        module_body: list[ast.stmt] = [*comment_exprs, unique_values_ast]
         full_ast = ast.Module(body=module_body, type_ignores=[])
         return full_ast
 
@@ -3575,24 +3674,28 @@ class WorkflowManager:
         create_flow_result = ast.Assign(
             targets=[ast.Name(id=flow_variable_name, ctx=ast.Store(), lineno=1, col_offset=0)],
             value=ast.Attribute(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
-                        attr="handle_request",
-                        ctx=ast.Load(),
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                            lineno=1,
+                            col_offset=0,
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id="CreateFlowRequest", ctx=ast.Load(), lineno=1, col_offset=0),
+                                args=[],
+                                keywords=create_flow_request_args,
+                                lineno=1,
+                                col_offset=0,
+                            )
+                        ],
+                        keywords=[],
                         lineno=1,
                         col_offset=0,
                     ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(id="CreateFlowRequest", ctx=ast.Load(), lineno=1, col_offset=0),
-                            args=[],
-                            keywords=create_flow_request_args,
-                            lineno=1,
-                            col_offset=0,
-                        )
-                    ],
-                    keywords=[],
                     lineno=1,
                     col_offset=0,
                 ),
@@ -3628,9 +3731,9 @@ class WorkflowManager:
             AST assignment node representing the import workflow command
 
         Example output:
-            flow1_name = GriptapeNodes.handle_request(ImportWorkflowAsReferencedSubFlowRequest(
+            flow1_name = (await GriptapeNodes.ahandle_request(ImportWorkflowAsReferencedSubFlowRequest(
                 file_path='/path/to/workflow.py'
-            )).created_flow_name
+            ))).created_flow_name
         """
         import_recorder.add_from_import(
             "griptape_nodes.retained_mode.events.workflow_events", "ImportWorkflowAsReferencedSubFlowRequest"
@@ -3653,26 +3756,33 @@ class WorkflowManager:
         import_workflow_result = ast.Assign(
             targets=[ast.Name(id=flow_variable_name, ctx=ast.Store(), lineno=1, col_offset=0)],
             value=ast.Attribute(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
-                        attr="handle_request",
-                        ctx=ast.Load(),
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                            lineno=1,
+                            col_offset=0,
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(
+                                    id="ImportWorkflowAsReferencedSubFlowRequest",
+                                    ctx=ast.Load(),
+                                    lineno=1,
+                                    col_offset=0,
+                                ),
+                                args=[],
+                                keywords=import_workflow_request_args,
+                                lineno=1,
+                                col_offset=0,
+                            )
+                        ],
+                        keywords=[],
                         lineno=1,
                         col_offset=0,
                     ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(
-                                id="ImportWorkflowAsReferencedSubFlowRequest", ctx=ast.Load(), lineno=1, col_offset=0
-                            ),
-                            args=[],
-                            keywords=import_workflow_request_args,
-                            lineno=1,
-                            col_offset=0,
-                        )
-                    ],
-                    keywords=[],
                     lineno=1,
                     col_offset=0,
                 ),
@@ -3883,24 +3993,28 @@ class WorkflowManager:
         create_node_call_ast = ast.Assign(
             targets=[ast.Name(id=node_variable_name, ctx=ast.Store(), lineno=1, col_offset=0)],
             value=ast.Attribute(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
-                        attr="handle_request",
-                        ctx=ast.Load(),
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                            lineno=1,
+                            col_offset=0,
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id=request_class_name, ctx=ast.Load(), lineno=1, col_offset=0),
+                                args=[],
+                                keywords=create_node_request_args,
+                                lineno=1,
+                                col_offset=0,
+                            )
+                        ],
+                        keywords=[],
                         lineno=1,
                         col_offset=0,
                     ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(id=request_class_name, ctx=ast.Load(), lineno=1, col_offset=0),
-                            args=[],
-                            keywords=create_node_request_args,
-                            lineno=1,
-                            col_offset=0,
-                        )
-                    ],
-                    keywords=[],
                     lineno=1,
                     col_offset=0,
                 ),
@@ -3974,28 +4088,32 @@ class WorkflowManager:
                                 )
                             )
 
-                # Create the handle_request call
+                # Create the await ahandle_request call
                 handle_request_call = ast.Expr(
-                    value=ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
-                            attr="handle_request",
-                            ctx=ast.Load(),
+                    value=ast.Await(
+                        value=ast.Call(
+                            func=ast.Attribute(
+                                value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                                attr="ahandle_request",
+                                ctx=ast.Load(),
+                                lineno=1,
+                                col_offset=0,
+                            ),
+                            args=[
+                                ast.Call(
+                                    func=ast.Name(
+                                        id=element_command.__class__.__name__, ctx=ast.Load(), lineno=1, col_offset=0
+                                    ),
+                                    args=[],
+                                    keywords=element_command_args,
+                                    lineno=1,
+                                    col_offset=0,
+                                )
+                            ],
+                            keywords=[],
                             lineno=1,
                             col_offset=0,
                         ),
-                        args=[
-                            ast.Call(
-                                func=ast.Name(
-                                    id=element_command.__class__.__name__, ctx=ast.Load(), lineno=1, col_offset=0
-                                ),
-                                args=[],
-                                keywords=element_command_args,
-                                lineno=1,
-                                col_offset=0,
-                            )
-                        ],
-                        keywords=[],
                         lineno=1,
                         col_offset=0,
                     ),
@@ -4044,18 +4162,22 @@ class WorkflowManager:
             ]
 
             create_connection_call = ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load()), attr="handle_request", ctx=ast.Load()
-                    ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(id="CreateConnectionRequest", ctx=ast.Load()),
-                            args=[],
-                            keywords=create_connection_request_args,
-                        )
-                    ],
-                    keywords=[],
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load()),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id="CreateConnectionRequest", ctx=ast.Load()),
+                                args=[],
+                                keywords=create_connection_request_args,
+                            )
+                        ],
+                        keywords=[],
+                    )
                 )
             )
 
@@ -4218,45 +4340,53 @@ class WorkflowManager:
             )
 
             set_parameter_value_request_call = ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
-                        attr="handle_request",
-                        ctx=ast.Load(),
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                            lineno=1,
+                            col_offset=0,
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id="SetParameterValueRequest", ctx=ast.Load(), lineno=1, col_offset=0),
+                                args=[],
+                                keywords=[
+                                    ast.keyword(
+                                        arg="parameter_name",
+                                        value=ast.Constant(
+                                            value=command.set_parameter_value_command.parameter_name,
+                                            lineno=1,
+                                            col_offset=0,
+                                        ),
+                                    ),
+                                    ast.keyword(
+                                        arg="node_name",
+                                        value=ast.Name(id=node_variable_name, ctx=ast.Load(), lineno=1, col_offset=0),
+                                    ),
+                                    ast.keyword(arg="value", value=value_lookup, lineno=1, col_offset=0),
+                                    ast.keyword(
+                                        arg="initial_setup", value=ast.Constant(value=True, lineno=1, col_offset=0)
+                                    ),
+                                    ast.keyword(
+                                        arg="is_output",
+                                        value=ast.Constant(
+                                            value=command.set_parameter_value_command.is_output,
+                                            lineno=1,
+                                            col_offset=0,
+                                        ),
+                                    ),
+                                ],
+                                lineno=1,
+                                col_offset=0,
+                            )
+                        ],
+                        keywords=[],
                         lineno=1,
                         col_offset=0,
                     ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(id="SetParameterValueRequest", ctx=ast.Load(), lineno=1, col_offset=0),
-                            args=[],
-                            keywords=[
-                                ast.keyword(
-                                    arg="parameter_name",
-                                    value=ast.Constant(
-                                        value=command.set_parameter_value_command.parameter_name, lineno=1, col_offset=0
-                                    ),
-                                ),
-                                ast.keyword(
-                                    arg="node_name",
-                                    value=ast.Name(id=node_variable_name, ctx=ast.Load(), lineno=1, col_offset=0),
-                                ),
-                                ast.keyword(arg="value", value=value_lookup, lineno=1, col_offset=0),
-                                ast.keyword(
-                                    arg="initial_setup", value=ast.Constant(value=True, lineno=1, col_offset=0)
-                                ),
-                                ast.keyword(
-                                    arg="is_output",
-                                    value=ast.Constant(
-                                        value=command.set_parameter_value_command.is_output, lineno=1, col_offset=0
-                                    ),
-                                ),
-                            ],
-                            lineno=1,
-                            col_offset=0,
-                        )
-                    ],
-                    keywords=[],
                     lineno=1,
                     col_offset=0,
                 ),
@@ -4272,29 +4402,36 @@ class WorkflowManager:
             )
 
             lock_node_call_ast = ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
-                        attr="handle_request",
-                        ctx=ast.Load(),
+                value=ast.Await(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id="GriptapeNodes", ctx=ast.Load(), lineno=1, col_offset=0),
+                            attr="ahandle_request",
+                            ctx=ast.Load(),
+                            lineno=1,
+                            col_offset=0,
+                        ),
+                        args=[
+                            ast.Call(
+                                func=ast.Name(id="SetLockNodeStateRequest", ctx=ast.Load(), lineno=1, col_offset=0),
+                                args=[],
+                                keywords=[
+                                    ast.keyword(
+                                        arg="node_name", value=ast.Constant(value=None, lineno=1, col_offset=0)
+                                    ),
+                                    ast.keyword(
+                                        arg="lock",
+                                        value=ast.Constant(value=lock_node_command.lock, lineno=1, col_offset=0),
+                                    ),
+                                ],
+                                lineno=1,
+                                col_offset=0,
+                            )
+                        ],
+                        keywords=[],
                         lineno=1,
                         col_offset=0,
                     ),
-                    args=[
-                        ast.Call(
-                            func=ast.Name(id="SetLockNodeStateRequest", ctx=ast.Load(), lineno=1, col_offset=0),
-                            args=[],
-                            keywords=[
-                                ast.keyword(arg="node_name", value=ast.Constant(value=None, lineno=1, col_offset=0)),
-                                ast.keyword(
-                                    arg="lock", value=ast.Constant(value=lock_node_command.lock, lineno=1, col_offset=0)
-                                ),
-                            ],
-                            lineno=1,
-                            col_offset=0,
-                        )
-                    ],
-                    keywords=[],
                     lineno=1,
                     col_offset=0,
                 ),

--- a/src/griptape_nodes/utils/ast_utils.py
+++ b/src/griptape_nodes/utils/ast_utils.py
@@ -1,0 +1,29 @@
+"""Utility functions for working with `ast`-generated source code."""
+
+from __future__ import annotations
+
+
+def rewrite_string_comments(source: str) -> str:
+    """Turn bare-string statements that start with `#` into real Python comments.
+
+    Only whole-line matches are rewritten; indentation is preserved so comments inside
+    functions / `with` blocks stay indented correctly. The body may contain the
+    opposing quote character (ast.unparse flips quoting style when the body already
+    contains one) but must not contain the enclosing quote.
+    """
+    # Smallest valid bare-string comment is `"#"` or `'#'` — three characters.
+    min_quoted_len = 3
+    rewritten_lines = []
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        indent = line[: len(line) - len(stripped)]
+        if len(stripped) >= min_quoted_len and stripped[0] in ('"', "'") and stripped[-1] == stripped[0]:
+            quote = stripped[0]
+            body = stripped[1:-1]
+            # Must be a single-line literal with no embedded matching quote,
+            # and must look like a comment ("#..." with no surprises).
+            if quote not in body and body.startswith("#"):
+                rewritten_lines.append(f"{indent}{body}")
+                continue
+        rewritten_lines.append(line)
+    return "\n".join(rewritten_lines)

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1382,6 +1382,11 @@ class TestWorkflowVariablePersistence:
         exec_globals: dict[str, object] = {"__file__": "test_workflow.py"}
         exec(compile(script_source, "<round_trip_test>", "exec"), exec_globals)  # noqa: S102
 
+        # Graph-building requests now live inside `async def build_workflow()`; await it so the
+        # flow/variable are actually materialized before we query them.
+        build_workflow = exec_globals["build_workflow"]
+        asyncio.run(build_workflow())  # type: ignore[operator]
+
         flow_value = GriptapeNodes.handle_request(
             GetVariableValueRequest(
                 name="flow_scoped_var", starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1,3 +1,4 @@
+import ast
 import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -10,8 +11,10 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
 
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.exe_types.node_types import NodeDependencies
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
+from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 from griptape_nodes.retained_mode.events.workflow_events import (
     CreateWorkflowFromTemplateRequest,
     CreateWorkflowFromTemplateResultFailure,
@@ -873,6 +876,185 @@ class TestWorkflowManager:
 
         assert save_path.file_path == workspace / "team" / "my_workflow.py"
         assert save_path.relative_file_path == str(Path("team") / "my_workflow.py")
+
+    # --- _generate_workflow_file_content (save output) ---
+
+    @staticmethod
+    def _empty_serialized_flow_commands() -> SerializedFlowCommands:
+        """Build a shape-free SerializedFlowCommands with no nodes/connections/values."""
+        return SerializedFlowCommands(
+            flow_initialization_command=None,
+            serialized_node_commands=[],
+            serialized_connections=[],
+            unique_parameter_uuid_to_values={},
+            set_parameter_value_commands={},
+            set_lock_commands_per_node={},
+            sub_flows_commands=[],
+            node_dependencies=NodeDependencies(),
+            node_types_used=set(),
+        )
+
+    @staticmethod
+    def _minimal_workflow_metadata(*, with_shape: bool = False) -> WorkflowMetadata:
+        return WorkflowMetadata(
+            name="test_workflow",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="1.0.0",
+            node_libraries_referenced=[],
+            workflow_shape=WorkflowShape(inputs={}, outputs={}) if with_shape else None,
+        )
+
+    def _generate(self, griptape_nodes: GriptapeNodes, *, with_shape: bool = False) -> str:
+        workflow_manager = griptape_nodes.WorkflowManager()
+        return workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=self._empty_serialized_flow_commands(),
+            workflow_metadata=self._minimal_workflow_metadata(with_shape=with_shape),
+        )
+
+    def test_generate_workflow_file_content_wraps_graph_building_in_async_build_workflow(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """Saved workflows must wrap graph-building statements in `async def build_workflow()`."""
+        content = self._generate(griptape_nodes)
+
+        # The file must declare build_workflow as an async function.
+        module = ast.parse(content)
+        build_workflow_defs = [
+            node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "build_workflow"
+        ]
+        assert len(build_workflow_defs) == 1, "build_workflow must be defined exactly once as async"
+
+    def test_generate_workflow_file_content_is_inert_at_import(self, griptape_nodes: GriptapeNodes) -> None:
+        """A shape-free saved workflow must contain no module-level side effects.
+
+        Only function/class definitions and imports should appear at the top level so that
+        `exec()`-ing the module does not mutate engine state until build_workflow() is awaited.
+        """
+        content = self._generate(griptape_nodes)
+        module = ast.parse(content)
+
+        allowed_top_level = (
+            ast.Import,
+            ast.ImportFrom,
+            ast.FunctionDef,
+            ast.AsyncFunctionDef,
+            ast.ClassDef,
+            ast.Expr,  # docstring-style literal; still inert
+        )
+        for node in module.body:
+            assert isinstance(node, allowed_top_level), (
+                f"Unexpected top-level statement of type {type(node).__name__} in shape-free workflow"
+            )
+
+    def test_generate_workflow_file_content_prereq_lives_inside_build_workflow(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """Prerequisite code (context_manager setup) must live inside build_workflow, not at module scope."""
+        content = self._generate(griptape_nodes)
+        module = ast.parse(content)
+
+        build_workflow = next(
+            node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "build_workflow"
+        )
+        body_src = "\n".join(ast.unparse(stmt) for stmt in build_workflow.body)
+        assert "context_manager = GriptapeNodes.ContextManager()" in body_src
+        assert "context_manager.push_workflow(file_path=__file__)" in body_src
+
+    def test_generate_workflow_file_content_empty_build_workflow_has_pass_body(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """If we somehow produce no graph-building statements, build_workflow should still be valid Python."""
+        workflow_manager = griptape_nodes.WorkflowManager()
+        # Stub out the two generators so main_body ends up empty and the `or [ast.Pass()]` branch runs.
+        with (
+            patch.object(workflow_manager, "_generate_workflow_run_prerequisite_code", return_value=[]),
+            patch.object(
+                workflow_manager,
+                "_generate_unique_values_code",
+                return_value=ast.Module(body=[], type_ignores=[]),
+            ),
+        ):
+            content = workflow_manager._generate_workflow_file_content(
+                serialized_flow_commands=self._empty_serialized_flow_commands(),
+                workflow_metadata=self._minimal_workflow_metadata(),
+            )
+
+        module = ast.parse(content)
+        build_workflow = next(
+            node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "build_workflow"
+        )
+        assert len(build_workflow.body) == 1
+        assert isinstance(build_workflow.body[0], ast.Pass)
+
+    def test_generate_workflow_file_content_aexecute_awaits_build_workflow_first(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """aexecute_workflow must `await build_workflow()` before running the executor.
+
+        Shape-bearing workflows emit execute_workflow + aexecute_workflow, and the async
+        version is expected to construct the graph before invoking the executor.
+        """
+        content = self._generate(griptape_nodes, with_shape=True)
+        module = ast.parse(content)
+
+        aexecute = next(
+            node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "aexecute_workflow"
+        )
+        first_stmt = aexecute.body[0]
+        # Expected shape: `await build_workflow()`
+        assert isinstance(first_stmt, ast.Expr)
+        assert isinstance(first_stmt.value, ast.Await)
+        call = first_stmt.value.value
+        assert isinstance(call, ast.Call)
+        assert isinstance(call.func, ast.Name)
+        assert call.func.id == "build_workflow"
+
+    def test_generate_workflow_file_content_ensure_context_is_async(self, griptape_nodes: GriptapeNodes) -> None:
+        """_ensure_workflow_context is now async and must await ahandle_request."""
+        content = self._generate(griptape_nodes, with_shape=True)
+        module = ast.parse(content)
+
+        ensure = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_ensure_workflow_context"
+        )
+        body_src = "\n".join(ast.unparse(stmt) for stmt in ensure.body)
+        assert "await GriptapeNodes.ahandle_request" in body_src
+        # Sanity check: the old sync variant is gone.
+        assert "GriptapeNodes.handle_request(" not in body_src
+
+    def test_generate_workflow_file_content_register_library_uses_await_ahandle_request(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """Each referenced library emits `await GriptapeNodes.ahandle_request(RegisterLibraryFromFileRequest(...))`."""
+        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        metadata = WorkflowMetadata(
+            name="test_workflow",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="1.0.0",
+            node_libraries_referenced=[LibraryNameAndVersion(library_name="my_lib", library_version="1.2.3")],
+        )
+        content = workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=self._empty_serialized_flow_commands(),
+            workflow_metadata=metadata,
+        )
+
+        module = ast.parse(content)
+        build_workflow = next(
+            node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "build_workflow"
+        )
+        body_src = "\n".join(ast.unparse(stmt) for stmt in build_workflow.body)
+        assert "await GriptapeNodes.ahandle_request(RegisterLibraryFromFileRequest(" in body_src
+        assert "library_name='my_lib'" in body_src
+
+    def test_generate_workflow_file_content_is_valid_python(self, griptape_nodes: GriptapeNodes) -> None:
+        """Generated content must parse cleanly (no smuggled-string comments left behind)."""
+        content = self._generate(griptape_nodes, with_shape=True)
+        # ast.parse raises SyntaxError if rewrite_string_comments left bad output behind.
+        ast.parse(content)
 
 
 class TestWorkflowVariablePersistence:

--- a/tests/unit/utils/test_ast_utils.py
+++ b/tests/unit/utils/test_ast_utils.py
@@ -1,0 +1,82 @@
+"""Unit tests for ast_utils module."""
+
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes.utils.ast_utils import rewrite_string_comments
+
+
+class TestRewriteStringComments:
+    def test_double_quoted_comment_rewritten(self) -> None:
+        assert rewrite_string_comments('"# hello"') == "# hello"
+
+    def test_single_quoted_comment_rewritten(self) -> None:
+        assert rewrite_string_comments("'# hello'") == "# hello"
+
+    def test_preserves_leading_indent(self) -> None:
+        assert rewrite_string_comments('    "# indented"') == "    # indented"
+
+    def test_preserves_tab_indent(self) -> None:
+        assert rewrite_string_comments('\t"# tabbed"') == "\t# tabbed"
+
+    def test_non_comment_string_literal_left_alone(self) -> None:
+        # Not prefixed with '#', so it is not a comment.
+        assert rewrite_string_comments('"hello"') == '"hello"'
+
+    def test_code_lines_untouched(self) -> None:
+        source = "x = 1\ny = 2"
+        assert rewrite_string_comments(source) == source
+
+    def test_multiple_lines_mixed(self) -> None:
+        source = '"# first comment"\nx = 1\n    "# nested comment"\n"keep me"'
+        expected = '# first comment\nx = 1\n    # nested comment\n"keep me"'
+        assert rewrite_string_comments(source) == expected
+
+    def test_empty_string(self) -> None:
+        assert rewrite_string_comments("") == ""
+
+    def test_blank_lines_between_content_preserved(self) -> None:
+        source = '"# first"\n\n"# second"'
+        assert rewrite_string_comments(source) == "# first\n\n# second"
+
+    def test_too_short_literal_ignored(self) -> None:
+        # Fewer than the 3-char minimum — not enough room for a "#" body.
+        assert rewrite_string_comments('""') == '""'
+
+    def test_mismatched_quotes_left_alone(self) -> None:
+        # Opening double, closing single — not a well-formed single-line literal.
+        assert rewrite_string_comments("\"# hello'") == "\"# hello'"
+
+    def test_embedded_matching_quote_skipped(self) -> None:
+        # The double-quoted body embeds another double quote, which means naive
+        # unwrap would produce invalid output — leave it untouched.
+        source = '"# has " inside"'
+        assert rewrite_string_comments(source) == source
+
+    def test_body_may_contain_opposing_quote(self) -> None:
+        # ast.unparse flips quote style when the body contains the opposing
+        # quote; the rewrite should still handle it.
+        assert rewrite_string_comments("'# it\"s fine'") == '# it"s fine'
+
+    def test_trailing_content_on_line_not_rewritten(self) -> None:
+        # The rule is "whole-line match"; trailing code means this is not a bare
+        # string statement.
+        source = '"# hello" + x'
+        assert rewrite_string_comments(source) == source
+
+    def test_preserves_line_ordering(self) -> None:
+        source = '"# one"\n"# two"\n"# three"'
+        assert rewrite_string_comments(source) == "# one\n# two\n# three"
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ('"#"', "#"),
+            ("'#'", "#"),
+            ('"# a"', "# a"),
+            ('    "# indented"', "    # indented"),
+        ],
+    )
+    def test_parametrized_valid_rewrites(self, source: str, expected: str) -> None:
+        assert rewrite_string_comments(source) == expected


### PR DESCRIPTION
Closes #4448.

Saved workflow files now emit all graph-building requests inside `async def build_workflow()` instead of at module scope, and issue them via `await GriptapeNodes.ahandle_request(...)` instead of the sync `handle_request`. The file is inert at import time — engine state only mutates when `build_workflow()` is awaited.

`WorkflowManager.run_workflow` now `exec`s the workflow into a dedicated namespace with `__file__` set to the workflow path and `__name__ = "__gtn_workflow__"`, then awaits `namespace["build_workflow"]()` when present. `__file__` resolves correctly now, and the emitted `__main__` guard no longer fires during engine load (it would otherwise try to spin up a second event loop via `asyncio.run`). Legacy files that still run requests at module scope keep working since the loader only awaits `build_workflow` when it's defined as a coroutine.

`aexecute_workflow` awaits `build_workflow()` before spinning up the executor, so the CLI path (`execute_workflow` → `asyncio.run(aexecute_workflow(...))`) runs graph construction and execution in one call without duplication. The generated `_ensure_workflow_context` helper is now async and awaits `ahandle_request` too, keeping the whole emitted file on the async path.

The `__main__` guard is only emitted when the workflow has a Start/End shape — that's what makes `python my_workflow.py` meaningful, since `LocalWorkflowExecutor` needs flow I/O. Shapeless workflows become library-style modules with no guard. A TODO in the generator points at #4205 for deciding what CLI invocation of a shapeless workflow should do later.

One implementation detail worth calling out: `ast.unparse` can't emit real `#` comments, so the two existing explanatory comments (the pickle/unique-values docstring and the "Create the Flow" note) are smuggled through as bare-string statements whose text begins with `#`, then post-processed into real comments after unparsing. Indentation inside `async def build_workflow` / `with` blocks is preserved.