### PR TITLE
apply derivations in on_get_path_for_macro_request

### DIFF
--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.common.project_templates.situation import SituationFilePolicy
-from griptape_nodes.files.derivation import DERIVATION_RULES, apply_derivation_rules
 from griptape_nodes.files.file import File, FileDestination
 from griptape_nodes.files.path_utils import FilenameParts
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
@@ -46,33 +45,11 @@ class ProjectFileDestination(FileDestination):
     Construct directly with a ``MacroPath`` and write policy, or use the
     ``from_situation`` classmethod to build from a situation name and filename.
 
-    Before storing the path, a pre-resolution pass runs the engine's
-    ``DERIVATION_RULES`` against any MacroPath input. Each rule produces a
-    derived variable (e.g. ``file_extension_directory`` from ``file_extension`` +
-    the project's ``file_extension_directories`` table) when its template slot is
-    referenced. This keeps derivation consistent across every caller
-    (``from_situation``, ``FileOutputSetting``, etc.) without each of them
-    duplicating the lookup.
+    Derivation rules (e.g. ``file_extension_directory``) run centrally inside
+    the ``GetPathForMacroRequest`` handler, so any MacroPath stored here gets
+    its derived variables filled in at resolution time without callers having
+    to pre-apply them.
     """
-
-    def __init__(
-        self,
-        file_path: str | MacroPath,
-        *,
-        existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
-        append: bool = False,
-        create_parents: bool = True,
-        file_metadata: SidecarContent | None = None,
-    ) -> None:
-        if isinstance(file_path, MacroPath):
-            file_path = apply_derivation_rules(file_path, DERIVATION_RULES)
-        super().__init__(
-            file_path,
-            existing_file_policy=existing_file_policy,
-            append=append,
-            create_parents=create_parents,
-            file_metadata=file_metadata,
-        )
 
     def write_bytes(self, content: bytes) -> File:
         return self._map_to_macro_file(super().write_bytes(content))
@@ -149,11 +126,12 @@ class ProjectFileDestination(FileDestination):
         if directory_str and directory_str != "." and not parts.directory.is_absolute() and "sub_dirs" not in variables:
             variables["sub_dirs"] = directory_str
 
-        # Derived variables (e.g. file_extension_directory) are populated by
-        # ProjectFileDestination's __init__ via apply_derivation_rules. We run
-        # the pass here too so the sidecar metadata captures the same variables
-        # the write actually uses.
-        macro_path = apply_derivation_rules(MacroPath(ParsedMacro(macro_template), variables), DERIVATION_RULES)
+        # Derived variables (e.g. file_extension_directory) are injected by the
+        # GetPathForMacroRequest handler at resolve time, so we store only the
+        # caller-supplied variables here. The sidecar records the raw inputs;
+        # anyone re-resolving the path against the current project gets the
+        # same derived values the write used.
+        macro_path = MacroPath(ParsedMacro(macro_template), variables)
 
         file_metadata = (
             SidecarContent(

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -26,6 +26,7 @@ from griptape_nodes.common.project_templates import (
     SituationTemplate,
     load_partial_project_template,
 )
+from griptape_nodes.files.derivation import DERIVATION_RULES, apply_derivation_rules
 from griptape_nodes.files.file import File, FileLoadError, FileWriteError
 from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_file_path, resolve_path_safely
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
@@ -65,6 +66,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     LoadProjectTemplateRequest,
     LoadProjectTemplateResultFailure,
     LoadProjectTemplateResultSuccess,
+    MacroPath,
     PathResolutionFailureReason,
     ProjectTemplateInfo,
     SaveProjectTemplateRequest,
@@ -455,15 +457,16 @@ class ProjectManager:
 
         Flow:
         1. Get current project
-        2. Get variables from ParsedMacro.get_variables()
-        3. For each variable:
+        2. Apply derivation rules to inject derived variables (e.g. file_extension_directory)
+        3. Get variables from ParsedMacro.get_variables()
+        4. For each variable:
            - If in directories dict → resolve directory, add to resolution bag
            - Else if in user_supplied_vars → use user value
            - If in BOTH → ERROR: DIRECTORY_OVERRIDE_ATTEMPTED
            - Else → collect as missing
-        4. If any missing → ERROR: MISSING_REQUIRED_VARIABLES
-        5. Resolve macro with complete variable bag
-        6. Return resolved Path
+        5. If any missing → ERROR: MISSING_REQUIRED_VARIABLES
+        6. Resolve macro with complete variable bag
+        7. Return resolved Path
         """
         current_project_request = GetCurrentProjectRequest()
         current_project_result = self.on_get_current_project_request(current_project_request)
@@ -477,9 +480,18 @@ class ProjectManager:
         project_info = current_project_result.project_info
         template = project_info.template
 
+        # Apply derivation rules centrally so every caller of GetPathForMacroRequest
+        # gets derived variables (e.g. file_extension_directory) without duplicating
+        # the pre-pass at each call site. Rules that can't fire (missing inputs,
+        # unreferenced output) abstain silently, so plain macros pass through unchanged.
+        resolved_macro_path = apply_derivation_rules(
+            MacroPath(request.parsed_macro, request.variables), DERIVATION_RULES
+        )
+        effective_variables: MacroVariables = resolved_macro_path.variables
+
         variable_infos = request.parsed_macro.get_variables()
         directory_names = set(template.directories.keys())
-        user_provided_names = set(request.variables.keys())
+        user_provided_names = set(effective_variables.keys())
 
         # Check for directory/user variable name conflicts
         conflicting = directory_names & user_provided_names
@@ -500,7 +512,7 @@ class ProjectManager:
                 directory_def = template.directories[var_name]
                 resolution_bag[var_name] = directory_def.path_macro
             elif var_name in user_provided_names:
-                resolution_bag[var_name] = request.variables[var_name]
+                resolution_bag[var_name] = effective_variables[var_name]
 
             if var_name in BUILTIN_VARIABLES:
                 try:

--- a/tests/unit/files/test_project_file.py
+++ b/tests/unit/files/test_project_file.py
@@ -147,8 +147,8 @@ class TestProjectFileDestinationInit:
 
         return dispatch
 
-    def test_from_situation_file_extension_directory_derived_from_extension(self) -> None:
-        """Known extensions populate file_extension_directory; siblings like png/jpg share a destination."""
+    def test_from_situation_sidecar_omits_derived_variables(self) -> None:
+        """Sidecar stores only caller-supplied inputs; derived values like file_extension_directory are not persisted."""
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
         from griptape_nodes.common.project_templates.situation import (
             SituationFilePolicy,
@@ -167,20 +167,15 @@ class TestProjectFileDestinationInit:
         )
 
         with patch(HANDLE_REQUEST_PATH, side_effect=dispatch):
-            png_dest = ProjectFileDestination.from_situation("foo.png", "save_node_output")
-            jpg_dest = ProjectFileDestination.from_situation("bar.jpg", "save_node_output")
+            dest = ProjectFileDestination.from_situation("foo.png", "save_node_output")
 
-        assert png_dest._file._file_metadata is not None
-        assert png_dest._file._file_metadata.situation is not None
-        png_vars = png_dest._file._file_metadata.situation.variables
-        assert png_vars is not None
-        assert png_vars["file_extension_directory"] == "images"
-
-        assert jpg_dest._file._file_metadata is not None
-        assert jpg_dest._file._file_metadata.situation is not None
-        jpg_vars = jpg_dest._file._file_metadata.situation.variables
-        assert jpg_vars is not None
-        assert jpg_vars["file_extension_directory"] == "images"
+        assert dest._file._file_metadata is not None
+        assert dest._file._file_metadata.situation is not None
+        variables = dest._file._file_metadata.situation.variables
+        assert variables is not None
+        assert variables["file_name_base"] == "foo"
+        assert variables["file_extension"] == "png"
+        assert "file_extension_directory" not in variables
 
     def test_from_situation_file_extension_directory_unmapped_extension(self) -> None:
         """An extension with no mapping leaves file_extension_directory unset so the optional slot degrades."""
@@ -266,7 +261,9 @@ class TestProjectFileDestinationInit:
         assert dest._file._file_metadata.situation is not None
         variables = dest._file._file_metadata.situation.variables
         assert variables is not None
-        assert variables["file_extension_directory"] == "images"
+        # Derived values (file_extension_directory) no longer stored in sidecar;
+        # the case-insensitive lookup is exercised at resolve time instead.
+        assert "file_extension_directory" not in variables
 
     def test_from_situation_file_extension_directory_uses_project_taxonomy(self) -> None:
         """The mapping comes from the current project's template, not an engine constant."""
@@ -289,125 +286,15 @@ class TestProjectFileDestinationInit:
             png_dest = ProjectFileDestination.from_situation("foo.png", "save_node_output")
             psd_dest = ProjectFileDestination.from_situation("bar.psd", "save_node_output")
 
+        # Derived values no longer persisted in sidecar -- re-computed at resolve time.
         assert png_dest._file._file_metadata is not None
         assert png_dest._file._file_metadata.situation is not None
         assert png_dest._file._file_metadata.situation.variables is not None
-        assert png_dest._file._file_metadata.situation.variables["file_extension_directory"] == "renders"
+        assert "file_extension_directory" not in png_dest._file._file_metadata.situation.variables
         assert psd_dest._file._file_metadata is not None
         assert psd_dest._file._file_metadata.situation is not None
         assert psd_dest._file._file_metadata.situation.variables is not None
-        assert psd_dest._file._file_metadata.situation.variables["file_extension_directory"] == "renders"
-
-    def test_from_situation_file_extension_directory_plain_name_skips_resolution(self) -> None:
-        """A plain-name extension macro value (no `{`) must not trigger a GetPathForMacroRequest."""
-        from griptape_nodes.common.project_templates.situation import (
-            SituationFilePolicy,
-            SituationPolicy,
-            SituationTemplate,
-        )
-        from griptape_nodes.retained_mode.events.project_events import GetPathForMacroRequest
-
-        situation = SituationTemplate(
-            name="save_node_output",
-            macro="{outputs}/{file_extension_directory?:/}{file_name_base}.{file_extension}",
-            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
-        )
-
-        call_log: list[object] = []
-        # No macro_resolver supplied -- if the code issues a GetPathForMacroRequest, the
-        # dispatcher raises AssertionError.
-        dispatch = self._make_extension_directory_handle_request(situation, {"png": "images"}, call_log=call_log)
-
-        with patch(HANDLE_REQUEST_PATH, side_effect=dispatch):
-            dest = ProjectFileDestination.from_situation("foo.png", "save_node_output")
-
-        assert dest._file._file_metadata is not None
-        assert dest._file._file_metadata.situation is not None
-        assert dest._file._file_metadata.situation.variables is not None
-        assert dest._file._file_metadata.situation.variables["file_extension_directory"] == "images"
-        assert not any(isinstance(req, GetPathForMacroRequest) for req in call_log)
-
-    def test_from_situation_file_extension_directory_macro_value_resolves(self) -> None:
-        """An extension macro value containing `{...}` is resolved via GetPathForMacroRequest."""
-        from griptape_nodes.common.project_templates.situation import (
-            SituationFilePolicy,
-            SituationPolicy,
-            SituationTemplate,
-        )
-        from griptape_nodes.retained_mode.events.project_events import (
-            GetPathForMacroRequest,
-            GetPathForMacroResultSuccess,
-        )
-
-        situation = SituationTemplate(
-            name="save_node_output",
-            macro="{file_extension_directory?:/}{file_name_base}.{file_extension}",
-            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
-        )
-
-        def macro_resolver(_req: object) -> object:
-            return GetPathForMacroResultSuccess(
-                resolved_path=Path("outputs/videos"),
-                absolute_path=Path("/tmp/test/outputs/videos"),  # noqa: S108
-                result_details="ok",
-            )
-
-        call_log: list[object] = []
-        dispatch = self._make_extension_directory_handle_request(
-            situation,
-            {"mp4": "{outputs}/videos"},
-            macro_resolver=macro_resolver,
-            call_log=call_log,
-        )
-
-        with patch(HANDLE_REQUEST_PATH, side_effect=dispatch):
-            dest = ProjectFileDestination.from_situation("clip.mp4", "save_node_output")
-
-        assert dest._file._file_metadata is not None
-        assert dest._file._file_metadata.situation is not None
-        assert dest._file._file_metadata.situation.variables is not None
-        assert dest._file._file_metadata.situation.variables["file_extension_directory"] == "outputs/videos"
-        assert any(isinstance(req, GetPathForMacroRequest) for req in call_log)
-
-    def test_from_situation_file_extension_directory_macro_value_absolute_still_a_string(self) -> None:
-        """Absolute resolved extension macro values land in variables verbatim; no bypass of the situation macro."""
-        from griptape_nodes.common.project_templates.situation import (
-            SituationFilePolicy,
-            SituationPolicy,
-            SituationTemplate,
-        )
-        from griptape_nodes.retained_mode.events.project_events import GetPathForMacroResultSuccess
-
-        situation = SituationTemplate(
-            name="save_node_output",
-            macro="{file_extension_directory?:/}{file_name_base}.{file_extension}",
-            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
-        )
-
-        absolute_dir = "/Volumes/share/videos"
-
-        def macro_resolver(_req: object) -> object:
-            return GetPathForMacroResultSuccess(
-                resolved_path=Path(absolute_dir),
-                absolute_path=Path(absolute_dir),
-                result_details="ok",
-            )
-
-        dispatch = self._make_extension_directory_handle_request(
-            situation,
-            {"mp4": "{workspace_dir}/share/videos"},
-            macro_resolver=macro_resolver,
-        )
-
-        with patch(HANDLE_REQUEST_PATH, side_effect=dispatch):
-            dest = ProjectFileDestination.from_situation("clip.mp4", "save_node_output")
-
-        assert dest._file._file_metadata is not None
-        assert dest._file._file_metadata.situation is not None
-        assert dest._file._file_metadata.situation.variables is not None
-        assert dest._file._file_metadata.situation.variables["file_extension_directory"] == absolute_dir
-        # Situation macro unchanged -- no engine-side bypass rewriting the template.
-        assert dest._file._file_metadata.situation.macro == situation.macro
+        assert "file_extension_directory" not in psd_dest._file._file_metadata.situation.variables
 
     def test_from_situation_file_extension_directory_resolution_failure_falls_through(self) -> None:
         """Resolution failures leave file_extension_directory unset so the optional slot degrades."""
@@ -487,55 +374,6 @@ class TestProjectFileDestinationInit:
         # Neither the project lookup nor the macro resolver should fire.
         assert not any(isinstance(req, GetCurrentProjectRequest) for req in call_log)
         assert not any(isinstance(req, GetPathForMacroRequest) for req in call_log)
-
-    def test_from_situation_file_extension_directory_macro_value_sees_caller_extras(self) -> None:
-        """Caller kwargs (node_name, etc.) are in scope for extension macro value resolution; filename parts are not."""
-        from griptape_nodes.common.project_templates.situation import (
-            SituationFilePolicy,
-            SituationPolicy,
-            SituationTemplate,
-        )
-        from griptape_nodes.retained_mode.events.project_events import (
-            GetPathForMacroRequest,
-            GetPathForMacroResultSuccess,
-        )
-
-        situation = SituationTemplate(
-            name="save_node_output",
-            macro="{outputs}/{file_extension_directory?:/}{file_name_base}.{file_extension}",
-            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
-        )
-
-        captured_requests: list[GetPathForMacroRequest] = []
-
-        def macro_resolver(req: object) -> object:
-            assert isinstance(req, GetPathForMacroRequest)
-            captured_requests.append(req)
-            return GetPathForMacroResultSuccess(
-                resolved_path=Path("Save Image/foo"),
-                absolute_path=Path("/tmp/test/Save Image/foo"),  # noqa: S108
-                result_details="ok",
-            )
-
-        dispatch = self._make_extension_directory_handle_request(
-            situation,
-            {"png": "{node_name?:/}foo"},
-            macro_resolver=macro_resolver,
-        )
-
-        with patch(HANDLE_REQUEST_PATH, side_effect=dispatch):
-            dest = ProjectFileDestination.from_situation("render.png", "save_node_output", node_name="Save Image")
-
-        assert dest._file._file_metadata is not None
-        assert dest._file._file_metadata.situation is not None
-        assert dest._file._file_metadata.situation.variables is not None
-        assert dest._file._file_metadata.situation.variables["file_extension_directory"] == "Save Image/foo"
-
-        assert len(captured_requests) == 1
-        request_vars = captured_requests[0].variables
-        assert request_vars["node_name"] == "Save Image"
-        assert "file_name_base" not in request_vars
-        assert "file_extension" not in request_vars
 
     def test_from_situation_derives_sub_dirs_from_filename_directory(self) -> None:
         """A path-prefixed filename populates sub_dirs in the resolution variables."""


### PR DESCRIPTION
Derivations should always be applied, previous approach required a separate call leading to missing implementation elsewhere