### PR TITLE
feat(mcp): trim response envelope and broaden SUPPORTED_REQUEST_EVENTS

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "griptape-nodes": {
+      "url": "http://localhost:8126/mcp/",
+      "lifecycle": "lazy",
+      "directTools": true
+    }
+  }
+}

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -25,13 +25,22 @@ from griptape_nodes.retained_mode.events.connection_events import (
     DeleteConnectionRequest,
     ListConnectionsForNodeRequest,
 )
+from griptape_nodes.retained_mode.events.context_events import (
+    GetWorkflowContextRequest,
+    SetWorkflowContextRequest,
+)
 from griptape_nodes.retained_mode.events.execution_events import (
     ExecuteNodeRequest,
     ResolveNodeRequest,
     StartFlowFromNodeRequest,
     StartFlowRequest,
 )
-from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    DeleteFlowRequest,
+    ListFlowsInCurrentContextRequest,
+    ListNodesInFlowRequest,
+)
 from griptape_nodes.retained_mode.events.library_events import (
     ListCategoriesInLibraryRequest,
     ListNodeTypesInLibraryRequest,
@@ -47,20 +56,30 @@ from griptape_nodes.retained_mode.events.node_events import (
     SetLockNodeStateRequest,
     SetNodeMetadataRequest,
 )
-from griptape_nodes.retained_mode.events.object_events import RenameObjectRequest
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    RenameObjectRequest,
+)
 from griptape_nodes.retained_mode.events.parameter_events import (
     GetConnectionsForParameterRequest,
     GetParameterDetailsRequest,
     GetParameterValueRequest,
     SetParameterValueRequest,
 )
-from griptape_nodes.retained_mode.events.workflow_events import RunWorkflowWithCurrentStateRequest
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ListAllWorkflowsRequest,
+    RunWorkflowWithCurrentStateRequest,
+)
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
 SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     # Workflows
     "RunWorkflowWithCurrentStateRequest": RunWorkflowWithCurrentStateRequest,
+    "ListAllWorkflowsRequest": ListAllWorkflowsRequest,
+    # Workflow context
+    "SetWorkflowContextRequest": SetWorkflowContextRequest,
+    "GetWorkflowContextRequest": GetWorkflowContextRequest,
     # Libraries
     "ListRegisteredLibrariesRequest": ListRegisteredLibrariesRequest,
     "ListNodeTypesInLibraryRequest": ListNodeTypesInLibraryRequest,
@@ -70,6 +89,10 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "ExecuteNodeRequest": ExecuteNodeRequest,
     "StartFlowRequest": StartFlowRequest,
     "StartFlowFromNodeRequest": StartFlowFromNodeRequest,
+    # Flows
+    "CreateFlowRequest": CreateFlowRequest,
+    "DeleteFlowRequest": DeleteFlowRequest,
+    "ListFlowsInCurrentContextRequest": ListFlowsInCurrentContextRequest,
     # Nodes
     "CreateNodeRequest": CreateNodeRequest,
     "DeleteNodeRequest": DeleteNodeRequest,
@@ -81,6 +104,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "SetLockNodeStateRequest": SetLockNodeStateRequest,
     # Objects
     "RenameObjectRequest": RenameObjectRequest,
+    "ClearAllObjectStateRequest": ClearAllObjectStateRequest,
     # Connections
     "CreateConnectionRequest": CreateConnectionRequest,
     "DeleteConnectionRequest": DeleteConnectionRequest,
@@ -104,6 +128,48 @@ secrets_manager = SecretsManager(config_manager)
 mcp_server_logger = logging.getLogger("griptape_nodes_mcp_server")
 mcp_server_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
 mcp_server_logger.setLevel(logging.INFO)
+
+
+def _summarize_result_details(result_details: object) -> str | list[dict] | None:
+    """Collapse the engine's nested result_details payload into something terse.
+
+    The engine emits `result_details` as a dict wrapping a list of ResultDetail entries,
+    e.g. ``{"result_details": [{"level": 10, "message": "..."}, ...]}``. For the MCP
+    surface we only really need the messages, joined on newlines. Anything we do not
+    recognize is returned as-is so we never hide information we did not intend to hide.
+    """
+    if result_details is None:
+        return None
+    if isinstance(result_details, str):
+        return result_details
+    if isinstance(result_details, dict):
+        inner = result_details.get("result_details")
+        if isinstance(inner, list):
+            messages = [entry.get("message", "") for entry in inner if isinstance(entry, dict)]
+            joined = "\n".join(message for message in messages if message)
+            if joined:
+                return joined
+            return inner
+    return result_details  # type: ignore[return-value]
+
+
+def _trim_response(result: dict) -> dict:
+    """Strip envelope noise from an engine response before we hand it back to the MCP client.
+
+    The raw response wraps the real payload in engine/session/routing metadata and an echoed
+    request. Agents only need to know whether the call succeeded and the payload fields the
+    handler produced, so we surface a success discriminator, a terse `details` string, and the
+    rest of the inner `result` object.
+    """
+    inner = dict(result.get("result") or {})
+    result_type = result.get("result_type", "")
+    details = _summarize_result_details(inner.pop("result_details", None))
+
+    trimmed: dict = {"ok": result_type.endswith("Success")}
+    if details is not None:
+        trimmed["details"] = details
+    trimmed.update(inner)
+    return trimmed
 
 
 def start_mcp_server(api_key: str, sock: socket.socket) -> None:
@@ -144,7 +210,7 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
         )
         mcp_server_logger.debug("Got result: %s", result)
 
-        return [TextContent(type="text", text=json.dumps(result))]
+        return [TextContent(type="text", text=json.dumps(_trim_response(result)))]
 
     # Create the session manager with our app and event store
     session_manager = StreamableHTTPSessionManager(

--- a/tests/unit/servers/test_mcp.py
+++ b/tests/unit/servers/test_mcp.py
@@ -1,0 +1,85 @@
+from griptape_nodes.servers.mcp import _summarize_result_details, _trim_response
+
+
+class TestSummarizeResultDetails:
+    def test_returns_none_for_none(self) -> None:
+        assert _summarize_result_details(None) is None
+
+    def test_passes_strings_through(self) -> None:
+        assert _summarize_result_details("already a string") == "already a string"
+
+    def test_joins_messages_from_nested_result_details(self) -> None:
+        payload = {
+            "result_details": [
+                {"level": 20, "message": "first"},
+                {"level": 10, "message": "second"},
+            ]
+        }
+
+        assert _summarize_result_details(payload) == "first\nsecond"
+
+    def test_returns_inner_list_when_all_messages_empty(self) -> None:
+        payload = {"result_details": [{"level": 20, "message": ""}]}
+
+        # Fall back to the raw list so we never hide data we did not recognize.
+        assert _summarize_result_details(payload) == [{"level": 20, "message": ""}]
+
+    def test_returns_input_unchanged_for_unrecognized_shape(self) -> None:
+        payload = {"something_else": 1}
+
+        assert _summarize_result_details(payload) == payload
+
+
+class TestTrimResponse:
+    def test_drops_envelope_noise_and_flattens_details(self) -> None:
+        raw = {
+            "engine_id": "engine-1",
+            "session_id": "session-1",
+            "request": {"node_type": "Probe", "library": "demo"},
+            "request_id": "abc",
+            "response_topic": "response",
+            "retained_mode": "cmd.create_node(...)",
+            "event_type": "EventResultSuccess",
+            "request_type": "CreateNodeRequest",
+            "result_type": "CreateNodeResultSuccess",
+            "result": {
+                "result_details": {
+                    "result_details": [
+                        {"level": 10, "message": "Created node 'Probe_1'"},
+                    ]
+                },
+                "altered_workflow_state": True,
+                "node_name": "Probe_1",
+            },
+        }
+
+        trimmed = _trim_response(raw)
+
+        assert trimmed == {
+            "ok": True,
+            "details": "Created node 'Probe_1'",
+            "altered_workflow_state": True,
+            "node_name": "Probe_1",
+        }
+
+    def test_marks_failures_with_ok_false(self) -> None:
+        raw = {
+            "result_type": "CreateNodeResultFailure",
+            "result": {
+                "result_details": {
+                    "result_details": [{"level": 40, "message": "boom"}],
+                },
+                "altered_workflow_state": False,
+            },
+        }
+
+        trimmed = _trim_response(raw)
+
+        assert trimmed["ok"] is False
+        assert trimmed["details"] == "boom"
+        assert trimmed["altered_workflow_state"] is False
+
+    def test_handles_missing_result_gracefully(self) -> None:
+        trimmed = _trim_response({"result_type": "SomethingSuccess"})
+
+        assert trimmed == {"ok": True}


### PR DESCRIPTION
Closes #4514.

The MCP server's tool surface had two pain points for an LLM-driven agent. First, every tool call returned the engine's full response envelope (`engine_id`, `session_id`, `request_id`, `response_topic`, the echoed request, `event_type`, `request_type`, `result_type`, plus a doubly-nested `result_details`). The agent had to walk that structure to recover the success bit and the human-readable message, and the noise burned a lot of context tokens on metadata it could not act on.

Second, `SUPPORTED_REQUEST_EVENTS` was missing several request types that the engine has had stable handlers for since well before the MCP work. Listing all workflows, getting/setting workflow context, listing flows, and clearing engine state were unreachable from MCP, even though those are the operations a session opens with. The combined effect was that an agent could author nodes but could not orient itself in the workspace or reset state between attempts.

This change introduces `_summarize_result_details` to flatten the nested message list into a single string, and `_trim_response` to drop the envelope keys and produce a small `{"ok": bool, "details": str, ...payload}` object per call. The remaining handler-produced fields (e.g. `node_name`, `altered_workflow_state`) pass through unchanged, so callers that already read those keep working. `SUPPORTED_REQUEST_EVENTS` is also extended with the workflow-context, flow-listing, and state-reset requests that already existed on main but were not previously exposed.

Subsequent PRs (`EnsureWorkflowAndFlowRequest`, `CreateConnectionsRequest`, `CreateNodesRequest`, `AutoLayoutFlowRequest`, `DescribeNodeTypeRequest`, `RegisterSandboxNodeFromSourceRequest`) each add their own entry to this table, so the lines they touch are isolated to one entry per PR.

Tests cover the full happy path of the trim helpers and the failure-path branches that fall back to the raw payload when the response shape is not the expected one.
