### PR TITLE
feat(context): add EnsureWorkflowAndFlowRequest for cold-start bootstrap

### DIFF
--- a/src/griptape_nodes/retained_mode/events/context_events.py
+++ b/src/griptape_nodes/retained_mode/events/context_events.py
@@ -89,3 +89,50 @@ class GetWorkflowContextSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
 @PayloadRegistry.register
 class GetWorkflowContextFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Workflow context retrieval failed. Common causes: context not initialized, system error."""
+
+
+@dataclass
+@PayloadRegistry.register
+class EnsureWorkflowAndFlowRequest(RequestPayload):
+    """Ensure a workflow + flow context exists, creating scratch ones if needed.
+
+    Use when: Bootstrapping from a cold engine state. This is the typical opening call from
+    an MCP client that is about to build a workflow from scratch. Idempotent: if both a
+    workflow and a flow are already in the current context, returns their names without
+    creating new ones. Only creates the pieces that are missing.
+
+    Args:
+        workflow_name: Name to use if a new workflow must be created. Ignored when a
+            workflow is already in context. Defaults to an auto-generated scratch name.
+        flow_name: Name to use if a new flow must be created. Ignored when a flow is
+            already in context. Defaults to the engine-assigned name.
+
+    Results: EnsureWorkflowAndFlowResultSuccess | EnsureWorkflowAndFlowResultFailure
+    """
+
+    workflow_name: str | None = None
+    flow_name: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class EnsureWorkflowAndFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Workflow + flow context is ready for subsequent CreateNode calls.
+
+    Args:
+        workflow_name: Name of the workflow in the current context.
+        flow_name: Name of the flow in the current context.
+        created_workflow: True if this call created the workflow; False if an existing one was reused.
+        created_flow: True if this call created the flow; False if an existing one was reused.
+    """
+
+    workflow_name: str
+    flow_name: str
+    created_workflow: bool
+    created_flow: bool
+
+
+@dataclass
+@PayloadRegistry.register
+class EnsureWorkflowAndFlowResultFailure(ResultPayloadFailure):
+    """EnsureWorkflowAndFlow failed. Common causes: could not push workflow context, flow creation rejected by the engine."""

--- a/src/griptape_nodes/retained_mode/events/context_events.py
+++ b/src/griptape_nodes/retained_mode/events/context_events.py
@@ -103,7 +103,12 @@ class EnsureWorkflowAndFlowRequest(RequestPayload):
 
     Args:
         workflow_name: Name to use if a new workflow must be created. Ignored when a
-            workflow is already in context. Defaults to an auto-generated scratch name.
+            workflow is already in context. When None or starting with the unsaved
+            registry-key prefix ("unsaved:"), the engine auto-registers an unsaved
+            entry and the resolved key is returned in the success result.
+        display_name: Human-readable name attached to the auto-registered unsaved
+            entry. Ignored when the workflow is already in context or when a saved
+            workflow_name is supplied.
         flow_name: Name to use if a new flow must be created. Ignored when a flow is
             already in context. Defaults to the engine-assigned name.
 
@@ -111,6 +116,7 @@ class EnsureWorkflowAndFlowRequest(RequestPayload):
     """
 
     workflow_name: str | None = None
+    display_name: str | None = None
     flow_name: str | None = None
 
 

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -303,9 +303,10 @@ class ContextManager:
     def on_ensure_workflow_and_flow_request(self, request: EnsureWorkflowAndFlowRequest) -> ResultPayload:
         """Cold-start bootstrap that guarantees a workflow + flow context exist.
 
-        Composes push_workflow (from this manager) with CreateFlowRequest (handled by
-        FlowManager) so callers can go straight from a blank engine to CreateNode in a
-        single round trip instead of three.
+        Delegates the workflow side to SetWorkflowContextRequest so the unsaved-registry-key
+        scheme ("unsaved:<uuid>") stays the single source of truth for scratch workflows;
+        composes that with CreateFlowRequest so callers can go from a blank engine to
+        CreateNode in a single round trip.
         """
         # Lazy import required: context_manager is imported by griptape_nodes, creating a circular dependency.
         from griptape_nodes.retained_mode.events.flow_events import (
@@ -318,8 +319,20 @@ class ContextManager:
         if self.has_current_workflow():
             workflow_name = self.get_current_workflow_name()
         else:
-            workflow_name = request.workflow_name or f"scratch_workflow_{uuid.uuid4().hex[:8]}"
-            self.push_workflow(workflow_name)
+            set_workflow_result = GriptapeNodes.handle_request(
+                SetWorkflowContextRequest(
+                    workflow_name=request.workflow_name,
+                    display_name=request.display_name,
+                )
+            )
+            if not isinstance(set_workflow_result, SetWorkflowContextSuccess):
+                return EnsureWorkflowAndFlowResultFailure(
+                    result_details=(
+                        f"Attempted to ensure a workflow + flow context. Failed while setting the workflow: "
+                        f"{set_workflow_result.result_details}"
+                    )
+                )
+            workflow_name = set_workflow_result.workflow_name
             created_workflow = True
 
         created_flow = False

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -8,6 +8,9 @@ from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.files.path_utils import canonicalize_for_identity, derive_registry_key
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.context_events import (
+    EnsureWorkflowAndFlowRequest,
+    EnsureWorkflowAndFlowResultFailure,
+    EnsureWorkflowAndFlowResultSuccess,
     GetWorkflowContextRequest,
     GetWorkflowContextSuccess,
     SetWorkflowContextFailure,
@@ -251,6 +254,9 @@ class ContextManager:
         event_manager.assign_manager_to_request_type(
             request_type=GetWorkflowContextRequest, callback=self.on_get_workflow_context_request
         )
+        event_manager.assign_manager_to_request_type(
+            request_type=EnsureWorkflowAndFlowRequest, callback=self.on_ensure_workflow_and_flow_request
+        )
 
     def on_set_workflow_context_request(self, request: SetWorkflowContextRequest) -> ResultPayload:
         # As of today, we only allow a single Workflow context at a time. This may change in the future.
@@ -292,6 +298,63 @@ class ContextManager:
             workflow_name=workflow_name,
             is_saved=is_saved,
             result_details=f"Successfully retrieved workflow context: {workflow_name or 'None'}",
+        )
+
+    def on_ensure_workflow_and_flow_request(self, request: EnsureWorkflowAndFlowRequest) -> ResultPayload:
+        """Cold-start bootstrap that guarantees a workflow + flow context exist.
+
+        Composes push_workflow (from this manager) with CreateFlowRequest (handled by
+        FlowManager) so callers can go straight from a blank engine to CreateNode in a
+        single round trip instead of three.
+        """
+        # Lazy import required: context_manager is imported by griptape_nodes, creating a circular dependency.
+        from griptape_nodes.retained_mode.events.flow_events import (
+            CreateFlowRequest,
+            CreateFlowResultSuccess,
+        )
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        created_workflow = False
+        if self.has_current_workflow():
+            workflow_name = self.get_current_workflow_name()
+        else:
+            workflow_name = request.workflow_name or f"scratch_workflow_{uuid.uuid4().hex[:8]}"
+            self.push_workflow(workflow_name)
+            created_workflow = True
+
+        created_flow = False
+        if self.has_current_flow():
+            flow_name = self.get_current_flow().name
+        else:
+            create_flow_result = GriptapeNodes.handle_request(
+                CreateFlowRequest(
+                    parent_flow_name=None,
+                    flow_name=request.flow_name,
+                    set_as_new_context=True,
+                )
+            )
+            if not isinstance(create_flow_result, CreateFlowResultSuccess):
+                # Roll the workflow push back so a partial failure does not leave hanging state.
+                if created_workflow:
+                    self.pop_workflow()
+                return EnsureWorkflowAndFlowResultFailure(
+                    result_details=(
+                        f"Attempted to ensure a workflow + flow context. Failed while creating the flow: "
+                        f"{create_flow_result.result_details}"
+                    )
+                )
+            flow_name = create_flow_result.flow_name
+            created_flow = True
+
+        return EnsureWorkflowAndFlowResultSuccess(
+            workflow_name=workflow_name,
+            flow_name=flow_name,
+            created_workflow=created_workflow,
+            created_flow=created_flow,
+            result_details=(
+                f"Workflow '{workflow_name}' and Flow '{flow_name}' are ready "
+                f"(created_workflow={created_workflow}, created_flow={created_flow})."
+            ),
         )
 
     def workflow(self, workflow_name: str) -> ContextManager.WorkflowContext:

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -26,6 +26,7 @@ from griptape_nodes.retained_mode.events.connection_events import (
     ListConnectionsForNodeRequest,
 )
 from griptape_nodes.retained_mode.events.context_events import (
+    EnsureWorkflowAndFlowRequest,
     GetWorkflowContextRequest,
     SetWorkflowContextRequest,
 )
@@ -81,6 +82,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     # Workflow context
     "SetWorkflowContextRequest": SetWorkflowContextRequest,
     "GetWorkflowContextRequest": GetWorkflowContextRequest,
+    "EnsureWorkflowAndFlowRequest": EnsureWorkflowAndFlowRequest,
     # Libraries
     "ListRegisteredLibrariesRequest": ListRegisteredLibrariesRequest,
     "ListNodeTypesInLibraryRequest": ListNodeTypesInLibraryRequest,

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -184,6 +184,7 @@ class TestEnsureWorkflowAndFlowRequest:
         self._cleanup(griptape_nodes)
 
     def test_auto_generates_workflow_name_when_none_given(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,
             EnsureWorkflowAndFlowResultSuccess,
@@ -195,7 +196,8 @@ class TestEnsureWorkflowAndFlowRequest:
         result = context_manager.on_ensure_workflow_and_flow_request(EnsureWorkflowAndFlowRequest())
 
         assert isinstance(result, EnsureWorkflowAndFlowResultSuccess)
-        assert result.workflow_name.startswith("scratch_workflow_")
+        assert result.workflow_name.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX)
+        assert WorkflowRegistry.has_workflow_with_name(result.workflow_name)
         assert result.created_workflow is True
         assert result.created_flow is True
 

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -118,3 +118,85 @@ class TestGeneratedWorkflowCode:
 
         assert "push_workflow(file_path=__file__)" in source
         assert "workflow_name=" not in source
+        assert "workflow_name=" not in source
+
+
+class TestEnsureWorkflowAndFlowRequest:
+    """Tests for ContextManager.on_ensure_workflow_and_flow_request."""
+
+    def _cleanup(self, griptape_nodes: GriptapeNodes) -> None:
+        """Tear down any workflow/flow state left over between tests."""
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    def test_creates_workflow_and_flow_from_cold_start(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.context_events import (
+            EnsureWorkflowAndFlowRequest,
+            EnsureWorkflowAndFlowResultSuccess,
+        )
+
+        self._cleanup(griptape_nodes)
+        context_manager = griptape_nodes.ContextManager()
+        assert not context_manager.has_current_workflow()
+        assert not context_manager.has_current_flow()
+
+        result = context_manager.on_ensure_workflow_and_flow_request(
+            EnsureWorkflowAndFlowRequest(workflow_name="my_workflow", flow_name="my_flow")
+        )
+
+        assert isinstance(result, EnsureWorkflowAndFlowResultSuccess)
+        assert result.workflow_name == "my_workflow"
+        assert result.flow_name == "my_flow"
+        assert result.created_workflow is True
+        assert result.created_flow is True
+        assert context_manager.has_current_workflow()
+        assert context_manager.has_current_flow()
+
+        self._cleanup(griptape_nodes)
+
+    def test_reuses_existing_workflow_and_flow(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.context_events import (
+            EnsureWorkflowAndFlowRequest,
+            EnsureWorkflowAndFlowResultSuccess,
+        )
+
+        self._cleanup(griptape_nodes)
+        context_manager = griptape_nodes.ContextManager()
+
+        # Bootstrap once.
+        first = context_manager.on_ensure_workflow_and_flow_request(
+            EnsureWorkflowAndFlowRequest(workflow_name="scratch", flow_name="canvas")
+        )
+        assert isinstance(first, EnsureWorkflowAndFlowResultSuccess)
+
+        # Calling again with different names should be a no-op: existing context wins.
+        second = context_manager.on_ensure_workflow_and_flow_request(
+            EnsureWorkflowAndFlowRequest(workflow_name="ignored", flow_name="also_ignored")
+        )
+
+        assert isinstance(second, EnsureWorkflowAndFlowResultSuccess)
+        assert second.workflow_name == "scratch"
+        assert second.flow_name == "canvas"
+        assert second.created_workflow is False
+        assert second.created_flow is False
+
+        self._cleanup(griptape_nodes)
+
+    def test_auto_generates_workflow_name_when_none_given(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.context_events import (
+            EnsureWorkflowAndFlowRequest,
+            EnsureWorkflowAndFlowResultSuccess,
+        )
+
+        self._cleanup(griptape_nodes)
+        context_manager = griptape_nodes.ContextManager()
+
+        result = context_manager.on_ensure_workflow_and_flow_request(EnsureWorkflowAndFlowRequest())
+
+        assert isinstance(result, EnsureWorkflowAndFlowResultSuccess)
+        assert result.workflow_name.startswith("scratch_workflow_")
+        assert result.created_workflow is True
+        assert result.created_flow is True
+
+        self._cleanup(griptape_nodes)


### PR DESCRIPTION
Closes #4515.

A freshly started engine has no workflow and no flow in the current context. To reach the point where `CreateNodeRequest` will succeed, callers had to push a workflow into context, then issue `CreateFlowRequest` with `set_as_new_context=True`, in that order, and reimplement the cleanup if the second call failed after the first succeeded. Every MCP client that wanted to start building a graph paid this round-trip and boilerplate cost on every cold start, and the partial-failure case was easy to get wrong.

Adds `EnsureWorkflowAndFlowRequest`, an idempotent bootstrap that creates only the pieces missing from the current context.