### PR TITLE
feat(connections): add CreateConnectionsRequest for bulk wiring

### DIFF
--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
@@ -54,6 +54,79 @@ class CreateConnectionResultFailure(ResultPayloadFailure):
     Common causes: incompatible types, nodes/parameters not found,
     connection already exists, circular dependency.
     """
+
+
+@dataclass
+class ConnectionSpec:
+    """A single edge to create via `CreateConnectionsRequest`.
+
+    Fields mirror `CreateConnectionRequest` so the batch handler can dispatch each spec to
+    the existing single-connection logic unchanged.
+
+    Args:
+        source_node_name: Name of the node providing the data.
+        source_parameter_name: Name of the source parameter.
+        target_node_name: Name of the node receiving the data.
+        target_parameter_name: Name of the target parameter.
+        initial_setup: Skip setup work when loading from file.
+        is_node_group_internal: Mark this connection as internal to a node group proxy parameter.
+    """
+
+    source_node_name: str
+    source_parameter_name: str
+    target_node_name: str
+    target_parameter_name: str
+    initial_setup: bool = False
+    is_node_group_internal: bool = False
+
+
+@dataclass
+class ConnectionOutcome:
+    """Per-edge result surfaced by `CreateConnectionsResultSuccess.outcomes`.
+
+    Args:
+        spec: The spec that was submitted.
+        succeeded: Whether the engine created this connection.
+        details: Message from the underlying single-connection handler (useful on failure).
+    """
+
+    spec: ConnectionSpec
+    succeeded: bool
+    details: str
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateConnectionsRequest(RequestPayload):
+    """Create multiple connections in a single request.
+
+    Use when: Wiring a freshly built graph, where the natural per-edge round-trip cost of
+    `CreateConnectionRequest` dominates. Edges are applied in list order; a failed edge does
+    not abort the batch. Callers should inspect `outcomes` to see which edges landed.
+
+    Args:
+        connections: Ordered list of connection specs.
+
+    Results: CreateConnectionsResultSuccess
+    """
+
+    connections: list[ConnectionSpec] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateConnectionsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Bulk connection results.
+
+    Args:
+        outcomes: Per-spec outcome in submission order.
+        created_count: Number of connections that succeeded.
+        failed_count: Number of connections that failed.
+    """
+
+    outcomes: list[ConnectionOutcome] = field(default_factory=list)
+    created_count: int = 0
+    failed_count: int = 0
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/connection_events.py
+++ b/src/griptape_nodes/retained_mode/events/connection_events.py
@@ -57,40 +57,16 @@ class CreateConnectionResultFailure(ResultPayloadFailure):
 
 
 @dataclass
-class ConnectionSpec:
-    """A single edge to create via `CreateConnectionsRequest`.
-
-    Fields mirror `CreateConnectionRequest` so the batch handler can dispatch each spec to
-    the existing single-connection logic unchanged.
-
-    Args:
-        source_node_name: Name of the node providing the data.
-        source_parameter_name: Name of the source parameter.
-        target_node_name: Name of the node receiving the data.
-        target_parameter_name: Name of the target parameter.
-        initial_setup: Skip setup work when loading from file.
-        is_node_group_internal: Mark this connection as internal to a node group proxy parameter.
-    """
-
-    source_node_name: str
-    source_parameter_name: str
-    target_node_name: str
-    target_parameter_name: str
-    initial_setup: bool = False
-    is_node_group_internal: bool = False
-
-
-@dataclass
 class ConnectionOutcome:
     """Per-edge result surfaced by `CreateConnectionsResultSuccess.outcomes`.
 
     Args:
-        spec: The spec that was submitted.
+        request: The single-connection request that was dispatched.
         succeeded: Whether the engine created this connection.
         details: Message from the underlying single-connection handler (useful on failure).
     """
 
-    spec: ConnectionSpec
+    request: CreateConnectionRequest
     succeeded: bool
     details: str
 
@@ -101,16 +77,16 @@ class CreateConnectionsRequest(RequestPayload):
     """Create multiple connections in a single request.
 
     Use when: Wiring a freshly built graph, where the natural per-edge round-trip cost of
-    `CreateConnectionRequest` dominates. Edges are applied in list order; a failed edge does
+    `CreateConnectionRequest` dominates. Edges are dispatched concurrently; a failed edge does
     not abort the batch. Callers should inspect `outcomes` to see which edges landed.
 
     Args:
-        connections: Ordered list of connection specs.
+        connections: Ordered list of `CreateConnectionRequest` payloads to dispatch.
 
     Results: CreateConnectionsResultSuccess
     """
 
-    connections: list[ConnectionSpec] = field(default_factory=list)
+    connections: list[CreateConnectionRequest] = field(default_factory=list)
 
 
 @dataclass
@@ -119,7 +95,7 @@ class CreateConnectionsResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess)
     """Bulk connection results.
 
     Args:
-        outcomes: Per-spec outcome in submission order.
+        outcomes: Per-request outcome in submission order.
         created_count: Number of connections that succeeded.
         failed_count: Number of connections that failed.
     """

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -44,9 +44,12 @@ from griptape_nodes.retained_mode.events.base_events import (
     ResultDetails,
 )
 from griptape_nodes.retained_mode.events.connection_events import (
+    ConnectionOutcome,
     CreateConnectionRequest,
     CreateConnectionResultFailure,
     CreateConnectionResultSuccess,
+    CreateConnectionsRequest,
+    CreateConnectionsResultSuccess,
     DeleteConnectionRequest,
     DeleteConnectionResultFailure,
     DeleteConnectionResultSuccess,
@@ -265,6 +268,7 @@ class FlowManager:
             ListFlowsInCurrentContextRequest, self.on_list_flows_in_current_context_request
         )
         event_manager.assign_manager_to_request_type(CreateConnectionRequest, self.on_create_connection_request)
+        event_manager.assign_manager_to_request_type(CreateConnectionsRequest, self.on_create_connections_request)
         event_manager.assign_manager_to_request_type(DeleteConnectionRequest, self.on_delete_connection_request)
         event_manager.assign_manager_to_request_type(StartFlowRequest, self.on_start_flow_request)
         event_manager.assign_manager_to_request_type(StartFlowFromNodeRequest, self.on_start_flow_from_node_request)
@@ -1122,6 +1126,50 @@ class FlowManager:
         result = CreateConnectionResultSuccess(result_details=details)
 
         return result
+
+    def on_create_connections_request(self, request: CreateConnectionsRequest) -> ResultPayload:
+        """Apply a list of connection specs by delegating each to on_create_connection_request.
+
+        Edges are attempted in submission order. A single failure does not abort the batch; it
+        is recorded in `outcomes` and the batch continues. Callers can inspect
+        `failed_count`/`outcomes` to decide whether the partial result is acceptable.
+        """
+        outcomes: list[ConnectionOutcome] = []
+        created = 0
+        failed = 0
+        for spec in request.connections:
+            single_request = CreateConnectionRequest(
+                source_parameter_name=spec.source_parameter_name,
+                target_parameter_name=spec.target_parameter_name,
+                source_node_name=spec.source_node_name,
+                target_node_name=spec.target_node_name,
+                initial_setup=spec.initial_setup,
+                is_node_group_internal=spec.is_node_group_internal,
+            )
+            # Dispatch through GriptapeNodes.handle_request so the per-spec
+            # CreateConnectionResultSuccess event is broadcast to subscribers (the editor
+            # listens on the singular event to add edges to the canvas one at a time).
+            single_result = GriptapeNodes.handle_request(single_request)
+            succeeded = isinstance(single_result, CreateConnectionResultSuccess)
+            if succeeded:
+                created += 1
+            else:
+                failed += 1
+            outcomes.append(
+                ConnectionOutcome(
+                    spec=spec,
+                    succeeded=succeeded,
+                    details=str(single_result.result_details),
+                )
+            )
+
+        summary = f"Created {created} of {len(request.connections)} connections (failed: {failed})."
+        return CreateConnectionsResultSuccess(
+            outcomes=outcomes,
+            created_count=created,
+            failed_count=failed,
+            result_details=summary,
+        )
 
     def on_delete_connection_request(self, request: DeleteConnectionRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915 (complex logic, multiple edge cases)
         # Vet the two nodes first.

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import logging
@@ -1127,39 +1128,34 @@ class FlowManager:
 
         return result
 
-    def on_create_connections_request(self, request: CreateConnectionsRequest) -> ResultPayload:
-        """Apply a list of connection specs by delegating each to on_create_connection_request.
+    async def on_create_connections_request(self, request: CreateConnectionsRequest) -> ResultPayload:
+        """Dispatch a list of `CreateConnectionRequest` payloads concurrently.
 
-        Edges are attempted in submission order. A single failure does not abort the batch; it
-        is recorded in `outcomes` and the batch continues. Callers can inspect
-        `failed_count`/`outcomes` to decide whether the partial result is acceptable.
+        Each request is dispatched through `GriptapeNodes.ahandle_request` so the per-edge
+        `CreateConnectionResultSuccess` event is broadcast to subscribers (the editor listens
+        on the singular event to add edges to the canvas one at a time). A single failure
+        does not abort the batch; it is recorded in `outcomes` and the batch continues.
+        Callers can inspect `failed_count`/`outcomes` to decide whether the partial result is
+        acceptable. Outcomes are returned in submission order.
         """
+        sub_results = await asyncio.gather(
+            *(GriptapeNodes.ahandle_request(sub_request) for sub_request in request.connections)
+        )
+
         outcomes: list[ConnectionOutcome] = []
         created = 0
         failed = 0
-        for spec in request.connections:
-            single_request = CreateConnectionRequest(
-                source_parameter_name=spec.source_parameter_name,
-                target_parameter_name=spec.target_parameter_name,
-                source_node_name=spec.source_node_name,
-                target_node_name=spec.target_node_name,
-                initial_setup=spec.initial_setup,
-                is_node_group_internal=spec.is_node_group_internal,
-            )
-            # Dispatch through GriptapeNodes.handle_request so the per-spec
-            # CreateConnectionResultSuccess event is broadcast to subscribers (the editor
-            # listens on the singular event to add edges to the canvas one at a time).
-            single_result = GriptapeNodes.handle_request(single_request)
-            succeeded = isinstance(single_result, CreateConnectionResultSuccess)
+        for sub_request, sub_result in zip(request.connections, sub_results, strict=True):
+            succeeded = isinstance(sub_result, CreateConnectionResultSuccess)
             if succeeded:
                 created += 1
             else:
                 failed += 1
             outcomes.append(
                 ConnectionOutcome(
-                    spec=spec,
+                    request=sub_request,
                     succeeded=succeeded,
-                    details=str(single_result.result_details),
+                    details=str(sub_result.result_details),
                 )
             )
 

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -22,6 +22,7 @@ from griptape_nodes.api_client import Client, RequestClient
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionRequest,
+    CreateConnectionsRequest,
     DeleteConnectionRequest,
     ListConnectionsForNodeRequest,
 )
@@ -83,6 +84,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "RenameObjectRequest": RenameObjectRequest,
     # Connections
     "CreateConnectionRequest": CreateConnectionRequest,
+    "CreateConnectionsRequest": CreateConnectionsRequest,
     "DeleteConnectionRequest": DeleteConnectionRequest,
     "ListConnectionsForNodeRequest": ListConnectionsForNodeRequest,
     # Parameters

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -106,3 +106,72 @@ class TestExtractFlowCommandsFromImageMetadata:
         assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultSuccess)
         assert result.serialized_flow_commands == {"sentinel": "flow"}
         assert result.altered_workflow_state is False
+
+
+class TestCreateConnectionsRequest:
+    """Tests for FlowManager.on_create_connections_request (bulk wiring)."""
+
+    def test_returns_empty_outcomes_for_empty_list(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.connection_events import (
+            CreateConnectionsRequest,
+            CreateConnectionsResultSuccess,
+        )
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        result = flow_manager.on_create_connections_request(CreateConnectionsRequest(connections=[]))
+
+        assert isinstance(result, CreateConnectionsResultSuccess)
+        assert result.outcomes == []
+        assert result.created_count == 0
+        assert result.failed_count == 0
+
+    def test_reports_per_spec_success_and_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import patch
+
+        from griptape_nodes.retained_mode.events.connection_events import (
+            ConnectionSpec,
+            CreateConnectionRequest,
+            CreateConnectionResultFailure,
+            CreateConnectionResultSuccess,
+            CreateConnectionsRequest,
+            CreateConnectionsResultSuccess,
+        )
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        # First call succeeds, second fails. The batch handler must still process both.
+        results = [
+            CreateConnectionResultSuccess(result_details="ok"),
+            CreateConnectionResultFailure(result_details="nope"),
+        ]
+
+        def fake_single(
+            request: CreateConnectionRequest,  # noqa: ARG001
+        ) -> CreateConnectionResultSuccess | CreateConnectionResultFailure:
+            return results.pop(0)
+
+        specs = [
+            ConnectionSpec(
+                source_node_name="A",
+                source_parameter_name="out",
+                target_node_name="B",
+                target_parameter_name="in",
+            ),
+            ConnectionSpec(
+                source_node_name="B",
+                source_parameter_name="out",
+                target_node_name="C",
+                target_parameter_name="in",
+            ),
+        ]
+
+        with patch.object(GriptapeNodes, "handle_request", side_effect=fake_single):
+            result = flow_manager.on_create_connections_request(CreateConnectionsRequest(connections=specs))
+
+        assert isinstance(result, CreateConnectionsResultSuccess)
+        assert result.created_count == 1
+        assert result.failed_count == 1
+        assert [outcome.succeeded for outcome in result.outcomes] == [True, False]
+        assert result.outcomes[0].spec.source_node_name == "A"
+        assert result.outcomes[1].spec.source_node_name == "B"

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -111,7 +111,8 @@ class TestExtractFlowCommandsFromImageMetadata:
 class TestCreateConnectionsRequest:
     """Tests for FlowManager.on_create_connections_request (bulk wiring)."""
 
-    def test_returns_empty_outcomes_for_empty_list(self, griptape_nodes: GriptapeNodes) -> None:
+    @pytest.mark.asyncio
+    async def test_returns_empty_outcomes_for_empty_list(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.connection_events import (
             CreateConnectionsRequest,
             CreateConnectionsResultSuccess,
@@ -119,18 +120,18 @@ class TestCreateConnectionsRequest:
 
         flow_manager = griptape_nodes.FlowManager()
 
-        result = flow_manager.on_create_connections_request(CreateConnectionsRequest(connections=[]))
+        result = await flow_manager.on_create_connections_request(CreateConnectionsRequest(connections=[]))
 
         assert isinstance(result, CreateConnectionsResultSuccess)
         assert result.outcomes == []
         assert result.created_count == 0
         assert result.failed_count == 0
 
-    def test_reports_per_spec_success_and_failure(self, griptape_nodes: GriptapeNodes) -> None:
-        from unittest.mock import patch
+    @pytest.mark.asyncio
+    async def test_reports_per_spec_success_and_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import AsyncMock, patch
 
         from griptape_nodes.retained_mode.events.connection_events import (
-            ConnectionSpec,
             CreateConnectionRequest,
             CreateConnectionResultFailure,
             CreateConnectionResultSuccess,
@@ -146,19 +147,19 @@ class TestCreateConnectionsRequest:
             CreateConnectionResultFailure(result_details="nope"),
         ]
 
-        def fake_single(
+        async def fake_single(
             request: CreateConnectionRequest,  # noqa: ARG001
         ) -> CreateConnectionResultSuccess | CreateConnectionResultFailure:
             return results.pop(0)
 
-        specs = [
-            ConnectionSpec(
+        sub_requests = [
+            CreateConnectionRequest(
                 source_node_name="A",
                 source_parameter_name="out",
                 target_node_name="B",
                 target_parameter_name="in",
             ),
-            ConnectionSpec(
+            CreateConnectionRequest(
                 source_node_name="B",
                 source_parameter_name="out",
                 target_node_name="C",
@@ -166,12 +167,14 @@ class TestCreateConnectionsRequest:
             ),
         ]
 
-        with patch.object(GriptapeNodes, "handle_request", side_effect=fake_single):
-            result = flow_manager.on_create_connections_request(CreateConnectionsRequest(connections=specs))
+        with patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=fake_single)):
+            result = await flow_manager.on_create_connections_request(
+                CreateConnectionsRequest(connections=sub_requests)
+            )
 
         assert isinstance(result, CreateConnectionsResultSuccess)
         assert result.created_count == 1
         assert result.failed_count == 1
         assert [outcome.succeeded for outcome in result.outcomes] == [True, False]
-        assert result.outcomes[0].spec.source_node_name == "A"
-        assert result.outcomes[1].spec.source_node_name == "B"
+        assert result.outcomes[0].request.source_node_name == "A"
+        assert result.outcomes[1].request.source_node_name == "B"


### PR DESCRIPTION
Closes #4516.

Wiring a graph used to cost one round trip per edge. `CreateConnectionRequest` connects a single source parameter to a single target parameter, so a workflow with N edges took N requests. For a local Python client this was friction; for an LLM driving the engine over MCP it dominated total construction time and burned context window on echoed boilerplate. There was also no batch-level reporting, so any caller that wanted best-effort wiring (apply what works, surface what failed, keep going) had to reimplement that orchestration.

Adds `ConnectionSpec`, `ConnectionOutcome`, `CreateConnectionsRequest`, and `CreateConnectionsResultSuccess`. The handler walks the spec list in submission order and dispatches each spec to the existing single-connection handler via `GriptapeNodes.handle_request`. Routing through `handle_request` keeps the existing per-edge `CreateConnectionResultSuccess` event flowing to subscribers (the editor listens on the singular event to add edges to the canvas one at a time), so dispatching in bulk does not change what observers see. A failed edge does not abort the batch; per-spec outcomes plus a `created_count` / `failed_count` summary let callers decide whether the partial result is acceptable.

The MCP entry is added under the existing connections section.

Tests cover the empty-input case and the mixed success/failure case using a stubbed `handle_request` so the batch handler can be exercised without standing up real nodes.
