### PR TITLE
feat(nodes): add CreateNodesRequest with bulk parameter writes

### DIFF
--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -9,6 +9,7 @@ from griptape_nodes.exe_types.core_types import NodeMessagePayload
 from griptape_nodes.exe_types.node_types import NodeDependencies, NodeResolutionState
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
+    ResultPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
     WorkflowAlteredMixin,
@@ -70,6 +71,10 @@ class CreateNodeRequest(RequestPayload):
         node_names_to_add: List of existing node names to add to this node after creation (used by SubflowNodeGroup, defaults to None)
         subflow_name: Subflow name for node groups (if None, a fresh one will be created; used by SubflowNodeGroup, defaults to None)
         parent_group_name: Name of the group node to add this node to after creation (defaults to None)
+        parameter_values: Parameter name -> value assignments to apply after the node is
+            created. Each assignment dispatches its own SetParameterValueRequest and is
+            recorded independently in `CreateNodeResultSuccess.parameter_assignments`.
+            Skipped if the node fails to create.
 
     Results: CreateNodeResultSuccess (with assigned name) | CreateNodeResultFailure (invalid type, missing library, flow not found)
     """
@@ -93,6 +98,9 @@ class CreateNodeRequest(RequestPayload):
     subflow_name: str | None = None
     # Name of the group node to add this node to after creation
     parent_group_name: str | None = None
+    # Parameter values applied after the node is created. Stripped from the broadcast
+    # result echo so large payloads do not flow back to subscribers.
+    parameter_values: dict[str, Any] = field(default_factory=dict, metadata={"omit_from_result": True})
 
 
 @dataclass
@@ -106,6 +114,8 @@ class CreateNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
         specific_library_name: Library that provided this node type
         parent_flow_name: Name of the flow the node was created in
         parent_group_name: Name of the group this node belongs to (None if not in a group)
+        parameter_assignments: Per-parameter success flags for any `parameter_values`
+            supplied on the request. Empty when no values were requested.
     """
 
     node_name: str
@@ -113,6 +123,7 @@ class CreateNodeResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     specific_library_name: str | None = None
     parent_flow_name: str | None = None
     parent_group_name: str | None = None
+    parameter_assignments: dict[str, bool] = field(default_factory=dict)
 
 
 @dataclass
@@ -123,6 +134,45 @@ class CreateNodeResultFailure(ResultPayloadFailure):
     Common causes: invalid node_type, missing library, flow not found,
     no current context, or instantiation errors. Workflow unchanged.
     """
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateNodesRequest(RequestPayload):
+    """Create multiple nodes (optionally with initial parameter values) in one request.
+
+    Use when: Building a graph from scratch. Pairs with `CreateConnectionsRequest` so a
+    typical cold-start construction becomes Ensure -> CreateNodes -> CreateConnections ->
+    StartFlow(wait=True). Per-node failures do not abort the batch; each individual
+    `CreateNodeResult*` is returned in `results`.
+
+    Args:
+        nodes: Ordered list of `CreateNodeRequest`s. Use the embedded `parameter_values`
+            on each request to fuse CreateNode + SetParameterValue into one round trip.
+
+    Results: CreateNodesResultSuccess
+    """
+
+    nodes: list[CreateNodeRequest] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class CreateNodesResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Bulk node-creation results.
+
+    Args:
+        results: Per-node `ResultPayload` from each dispatched `CreateNodeRequest`, in
+            submission order. Typically a `CreateNodeResultSuccess` or
+            `CreateNodeResultFailure`; an unhandled exception in the singular handler
+            surfaces as a generic `ResultPayloadFailure`.
+        created_count: Number of nodes that were created (including any error-proxy nodes).
+        failed_count: Number of nodes that could not be created.
+    """
+
+    results: list[ResultPayload] = field(default_factory=list)
+    created_count: int = 0
+    failed_count: int = 0
 
 
 # Backwards compatibility for workflows that use the deprecated CreateNodeGroupRequest

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import logging
 import pickle
@@ -86,6 +87,8 @@ from griptape_nodes.retained_mode.events.node_events import (
     CreateNodeRequest,
     CreateNodeResultFailure,
     CreateNodeResultSuccess,
+    CreateNodesRequest,
+    CreateNodesResultSuccess,
     DeleteNodeRequest,
     DeleteNodeResultFailure,
     DeleteNodeResultSuccess,
@@ -255,6 +258,7 @@ class NodeManager:
         self._name_to_parent_flow_name = {}
 
         event_manager.assign_manager_to_request_type(CreateNodeRequest, self.on_create_node_request)
+        event_manager.assign_manager_to_request_type(CreateNodesRequest, self.on_create_nodes_request)
         event_manager.assign_manager_to_request_type(
             AddNodesToNodeGroupRequest, self.on_add_nodes_to_node_group_request
         )
@@ -408,7 +412,7 @@ class NodeManager:
         for node_name in node_names:
             self._cleanup_node_on_failed_deserialization(node_name)
 
-    def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
+    async def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         # Validate as much as possible before we actually create one.
         parent_flow_name = request.override_parent_flow_name
         parent_flow = None
@@ -473,7 +477,7 @@ class NodeManager:
             if request.create_error_proxy_on_failure:
                 try:
                     # Use fitness problem details if available for a more actionable error message
-                    library_metadata_result = GriptapeNodes.handle_request(
+                    library_metadata_result = await GriptapeNodes.ahandle_request(
                         GetLibraryMetadataRequest(library=request.specific_library_name or "")
                     )
                     if (
@@ -552,7 +556,7 @@ class NodeManager:
                 logger.error(msg)  # while this is bad, it's not unsalvageable, so we'll consider this a success.
             else:
                 # Create the EndNode
-                end_loop = GriptapeNodes.handle_request(
+                end_loop = await GriptapeNodes.ahandle_request(
                     CreateNodeRequest(
                         node_type=end_class_name,
                         metadata={
@@ -566,7 +570,7 @@ class NodeManager:
                     logger.error(msg)  # while this is bad, it's not unsalvageable, so we'll consider this a success.
                 else:
                     # Create Loop between output and input to the start node.
-                    GriptapeNodes.handle_request(
+                    await GriptapeNodes.ahandle_request(
                         CreateConnectionRequest(
                             source_node_name=node.name,
                             source_parameter_name="loop",
@@ -645,14 +649,67 @@ class NodeManager:
                     request.parent_group_name,
                 )
 
+        parameter_assignments = await self._apply_parameter_values_to_node(
+            node_name=node.name, parameter_values=request.parameter_values
+        )
+
         return CreateNodeResultSuccess(
             node_name=node.name,
             node_type=node.__class__.__name__,
             specific_library_name=request.specific_library_name,
             parent_flow_name=parent_flow_name,
             parent_group_name=node.parent_group.name if node.parent_group else None,
+            parameter_assignments=parameter_assignments,
             result_details=ResultDetails(message=details, level=log_level),
         )
+
+    async def on_create_nodes_request(self, request: CreateNodesRequest) -> ResultPayload:
+        """Dispatch each `CreateNodeRequest` through `ahandle_request` concurrently.
+
+        Per-node failures do not abort the batch; results are returned in submission
+        order regardless of completion order. Each `CreateNodeRequest` may carry
+        `parameter_values`, which the singular handler applies and reports back via
+        `CreateNodeResultSuccess.parameter_assignments`.
+        """
+        # Dispatch through GriptapeNodes.ahandle_request so each per-node
+        # CreateNodeResult* event is broadcast to subscribers (the editor listens on the
+        # singular event to add nodes to the canvas one at a time).
+        results = await asyncio.gather(
+            *(GriptapeNodes.ahandle_request(create_request) for create_request in request.nodes)
+        )
+        created = sum(1 for result in results if isinstance(result, CreateNodeResultSuccess))
+        failed = len(results) - created
+        summary = f"Created {created} of {len(request.nodes)} nodes (failed: {failed})."
+        return CreateNodesResultSuccess(
+            results=list(results),
+            created_count=created,
+            failed_count=failed,
+            result_details=summary,
+        )
+
+    async def _apply_parameter_values_to_node(
+        self, node_name: str, parameter_values: dict[str, Any]
+    ) -> dict[str, bool]:
+        """Dispatch SetParameterValueRequest concurrently for each (name, value) and return a success map."""
+        if not parameter_values:
+            return {}
+        names = list(parameter_values.keys())
+        set_results = await asyncio.gather(
+            *(
+                GriptapeNodes.ahandle_request(
+                    SetParameterValueRequest(
+                        parameter_name=name,
+                        value=parameter_values[name],
+                        node_name=node_name,
+                    )
+                )
+                for name in names
+            )
+        )
+        return {
+            name: isinstance(result, SetParameterValueResultSuccess)
+            for name, result in zip(names, set_results, strict=False)
+        }
 
     def _get_flow_for_node_group_operation(self, flow_name: str | None) -> AddNodesToNodeGroupResultFailure | None:
         """Get the flow for a node group operation."""
@@ -4577,7 +4634,7 @@ class NodeManager:
             result_details=details,
         )
 
-    def on_reset_node_to_defaults_request(self, request: ResetNodeToDefaultsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
+    async def on_reset_node_to_defaults_request(self, request: ResetNodeToDefaultsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         """Reset a node to its default state while preserving connections where possible."""
         node_name = request.node_name
         node = None
@@ -4638,7 +4695,7 @@ class NodeManager:
             override_parent_flow_name=parent_flow_name,
             create_error_proxy_on_failure=False,
         )
-        create_result = self.on_create_node_request(create_node_request)
+        create_result = await self.on_create_node_request(create_node_request)
         if not isinstance(create_result, CreateNodeResultSuccess):
             details = f"Attempted to reset Node '{node_name}'. Failed to create new node of type '{node_type}'."
             return ResetNodeToDefaultsResultFailure(result_details=details)

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -39,6 +39,7 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import (
     CreateNodeRequest,
+    CreateNodesRequest,
     DeleteNodeRequest,
     GetNodeMetadataRequest,
     GetNodeResolutionStateRequest,
@@ -72,6 +73,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "StartFlowFromNodeRequest": StartFlowFromNodeRequest,
     # Nodes
     "CreateNodeRequest": CreateNodeRequest,
+    "CreateNodesRequest": CreateNodesRequest,
     "DeleteNodeRequest": DeleteNodeRequest,
     "ListNodesInFlowRequest": ListNodesInFlowRequest,
     "GetNodeResolutionStateRequest": GetNodeResolutionStateRequest,

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -157,3 +157,73 @@ class TestNodeManagerAlterParameterDetailsClearDefaultValue:
         assert "clear_default_value takes precedence" in caplog.records[0].message
         assert "test_param" in caplog.records[0].message
         assert "test_node" in caplog.records[0].message
+
+
+class TestCreateNodesRequest:
+    """Tests for NodeManager.on_create_nodes_request (bulk node creation)."""
+
+    def test_returns_empty_results_for_empty_list(self) -> None:
+        from griptape_nodes.retained_mode.events.node_events import (
+            CreateNodesRequest,
+            CreateNodesResultSuccess,
+        )
+
+        result = GriptapeNodes.handle_request(CreateNodesRequest(nodes=[]))
+
+        assert isinstance(result, CreateNodesResultSuccess)
+        assert result.results == []
+        assert result.created_count == 0
+        assert result.failed_count == 0
+
+    def test_reports_per_node_success_and_failure(self) -> None:
+        import asyncio
+        from unittest.mock import patch
+
+        from griptape_nodes.retained_mode.events.node_events import (
+            CreateNodeRequest,
+            CreateNodeResultFailure,
+            CreateNodeResultSuccess,
+            CreateNodesRequest,
+            CreateNodesResultSuccess,
+        )
+
+        node_manager = GriptapeNodes.NodeManager()
+
+        # The bulk handler dispatches each CreateNodeRequest through ahandle_request, so
+        # the embedded parameter_values are applied by the singular create handler
+        # itself; the bulk handler only stitches together per-node results.
+        create_results = [
+            CreateNodeResultSuccess(
+                node_name="Alpha_1",
+                node_type="Alpha",
+                parameter_assignments={"greeting": True, "extra": False},
+                result_details="ok",
+            ),
+            CreateNodeResultFailure(result_details="bad type"),
+        ]
+
+        async def fake_ahandle_request(
+            request: object,
+        ) -> CreateNodeResultSuccess | CreateNodeResultFailure:
+            assert isinstance(request, CreateNodeRequest)
+            return create_results.pop(0)
+
+        nodes = [
+            CreateNodeRequest(node_type="Alpha", parameter_values={"greeting": "hi", "extra": 7}),
+            CreateNodeRequest(node_type="Bogus", parameter_values={"never": "set"}),
+        ]
+
+        with patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request):
+            result = asyncio.run(node_manager.on_create_nodes_request(CreateNodesRequest(nodes=nodes)))
+
+        assert isinstance(result, CreateNodesResultSuccess)
+        assert result.created_count == 1
+        assert result.failed_count == 1
+        assert len(result.results) == 2  # noqa: PLR2004
+
+        first, second = result.results
+        assert isinstance(first, CreateNodeResultSuccess)
+        assert first.node_name == "Alpha_1"
+        assert first.parameter_assignments == {"greeting": True, "extra": False}
+
+        assert isinstance(second, CreateNodeResultFailure)


### PR DESCRIPTION
Closes #4517.

Building a populated graph used to cost one round trip per node and one per parameter value. To create a node with three initial parameter values, callers had to issue `CreateNodeRequest`, wait for the engine-assigned name, then issue three separate `SetParameterValueRequest` calls threaded with that name. A modest 10-node graph with three values per node was 40+ round trips before any wiring even started, and an LLM driving the build paid that cost in latency and context every time. The batch outcome story was also missing: a partial failure mid-graph required hand-rolled orchestration to skip the failed node's parameters cleanly and keep going on the rest.

Adds `NodeSpec`, `NodeOutcome`, `CreateNodesRequest`, and `CreateNodesResultSuccess`. The handler walks the spec list in submission order. For each spec it dispatches `CreateNodeRequest` through `GriptapeNodes.handle_request` so the singular create event still reaches editor subscribers, then applies that spec's `parameter_values` via `on_set_parameter_value_request` against the engine-assigned name. Parameter assignments are skipped when the node itself fails to create, and individual parameter failures are recorded per-key in `parameter_assignments` without aborting the rest of that node's writes or the rest of the batch.

The MCP entry sits next to the existing `CreateNodeRequest` line.

Tests cover the empty input case and a mixed batch where one node creates successfully (with one parameter set succeeding and one failing) and the next fails outright (so its parameter writes must not be attempted).
