### PR TITLE
feat(execution): add wait_for_completion and current-context flow fallback to StartFlowRequest

### DIFF
--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -65,6 +65,11 @@ class StartFlowRequest(RequestPayload):
         flow_name: Name of the flow to start (deprecated, use flow_node_name)
         flow_node_name: Name of the flow node to start
         debug_mode: Whether to run in debug mode (default: False)
+        wait_for_completion: When True, the handler polls until the flow resolves before
+            returning. Converts the fire-and-forget kickoff into a synchronous run so callers
+            can read output values immediately afterwards without polling node state themselves.
+        completion_timeout_ms: Only meaningful when wait_for_completion=True. Maximum time to
+            wait for the flow to resolve. None means wait indefinitely.
 
     Results: StartFlowResultSuccess | StartFlowResultFailure (with validation exceptions)
     """
@@ -75,6 +80,8 @@ class StartFlowRequest(RequestPayload):
     debug_mode: bool = False
     # If this is true, the final ControlFLowResolvedEvent will be pickled to be picked up from inside a subprocess.
     pickle_control_flow_result: bool = False
+    wait_for_completion: bool = False
+    completion_timeout_ms: int | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import logging
@@ -2599,13 +2600,21 @@ class FlowManager:
         sanitized_node_name = node_name.replace(" ", "_").replace(".", "_")
         return f"{prefix}{sanitized_node_name}_{parameter_name}"
 
-    async def on_start_flow_request(self, request: StartFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912
+    async def on_start_flow_request(self, request: StartFlowRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         # which flow
         flow_name = request.flow_name
         if not flow_name:
-            details = "Must provide flow name to start a flow."
-
-            return StartFlowResultFailure(validation_exceptions=[], result_details=details)
+            # Fall back to the current-context flow so callers do not have to echo the name
+            # EnsureWorkflowAndFlowRequest / CreateFlowRequest just returned. If nothing is in
+            # context either, preserve the original "you must provide one" error.
+            if GriptapeNodes.ContextManager().has_current_flow():
+                flow_name = GriptapeNodes.ContextManager().get_current_flow().name
+            else:
+                details = (
+                    "Must provide flow_name, or set a flow in the Current Context "
+                    "(e.g. via EnsureWorkflowAndFlowRequest or CreateFlowRequest) first."
+                )
+                return StartFlowResultFailure(validation_exceptions=[], result_details=details)
         # get the flow by ID
         try:
             flow = self.get_flow_by_name(flow_name)
@@ -2678,7 +2687,17 @@ class FlowManager:
                     validation_exceptions=[exception] if error_message else [], result_details=result_details
                 )
 
-        details = f"Successfully kicked off flow with name {flow_name}"
+        if request.wait_for_completion:
+            wait_error = await self._await_flow_completion(request.completion_timeout_ms)
+            if wait_error is not None:
+                exception = RuntimeError(wait_error)
+                return StartFlowResultFailure(
+                    validation_exceptions=[exception],
+                    result_details=f"Flow '{flow_name}' did not complete cleanly: {wait_error}",
+                )
+            details = f"Flow '{flow_name}' kicked off and completed successfully."
+        else:
+            details = f"Successfully kicked off flow with name {flow_name}"
 
         return StartFlowResultSuccess(result_details=details)
 
@@ -2686,9 +2705,16 @@ class FlowManager:
         # which flow
         flow_name = request.flow_name
         if not flow_name:
-            details = "Must provide flow name to start a flow."
-
-            return StartFlowResultFailure(validation_exceptions=[], result_details=details)
+            # Same current-context fallback as on_start_flow_request so StartFlowFromNode
+            # behaves consistently.
+            if GriptapeNodes.ContextManager().has_current_flow():
+                flow_name = GriptapeNodes.ContextManager().get_current_flow().name
+            else:
+                details = (
+                    "Must provide flow_name, or set a flow in the Current Context "
+                    "(e.g. via EnsureWorkflowAndFlowRequest or CreateFlowRequest) first."
+                )
+                return StartFlowResultFailure(validation_exceptions=[], result_details=details)
         # get the flow by ID
         try:
             flow = self.get_flow_by_name(flow_name)
@@ -4044,6 +4070,28 @@ class FlowManager:
             not self._global_control_flow_machine.context.resolution_machine.is_complete()
             and self._global_control_flow_machine.context.resolution_machine.is_started()
         )
+
+    async def _await_flow_completion(self, timeout_ms: int | None) -> str | None:
+        """Block until the current flow resolves, erroring, or the timeout elapses.
+
+        Polls `check_for_existing_running_flow()` because the control flow machine does not
+        expose a completion future today; this is the same signal the UI uses to decide when
+        the run is idle. Returns None on clean completion, or an error string describing why
+        the wait ended unsuccessfully (timeout, or flow error).
+        """
+        poll_interval_sec = 0.05
+        elapsed_ms = 0
+        while self.check_for_existing_running_flow():
+            if timeout_ms is not None and elapsed_ms >= timeout_ms:
+                return f"Timed out waiting for flow completion after {timeout_ms} ms."
+            await asyncio.sleep(poll_interval_sec)
+            elapsed_ms += int(poll_interval_sec * 1000)
+
+        if self._global_control_flow_machine is not None:
+            resolution_machine = self._global_control_flow_machine.resolution_machine
+            if resolution_machine.is_errored():
+                return resolution_machine.get_error_message() or "Flow errored during execution."
+        return None
 
     async def cancel_flow_run(self) -> None:
         if not self.check_for_existing_running_flow():

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -2690,6 +2690,21 @@ class FlowManager:
         if request.wait_for_completion:
             wait_error = await self._await_flow_completion(request.completion_timeout_ms)
             if wait_error is not None:
+                # On timeout the flow is still running, so cancel it before returning
+                # failure. If the wait ended because the flow already errored, there is
+                # nothing left to cancel and check_for_existing_running_flow() returns False.
+                if self.check_for_existing_running_flow():
+                    try:
+                        await self.cancel_flow_run()
+                    except Exception as cancel_err:
+                        # Defensive: cancellation is best-effort cleanup. Surface a warning
+                        # but keep the original wait_error as the user-visible failure.
+                        logger.warning(
+                            "Attempted to cancel flow '%s' after wait_for_completion failure. "
+                            "Cancellation itself failed because of: %s",
+                            flow_name,
+                            cancel_err,
+                        )
                 exception = RuntimeError(wait_error)
                 return StartFlowResultFailure(
                     validation_exceptions=[exception],
@@ -2702,19 +2717,28 @@ class FlowManager:
         return StartFlowResultSuccess(result_details=details)
 
     async def on_start_flow_from_node_request(self, request: StartFlowFromNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912
+        # Resolve the node first, falling back to the current-context node when node_name is
+        # omitted. flow_name on this request is deprecated; when not supplied we derive it
+        # from the node's parent flow so callers do not have to keep them in sync.
+        node_name = request.node_name
+        if node_name is None:
+            if GriptapeNodes.ContextManager().has_current_node():
+                node_name = GriptapeNodes.ContextManager().get_current_node().name
+            else:
+                details = "Must provide node_name, or set a node in the Current Context first."
+                return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
+        start_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        if not start_node:
+            details = f"Provided node with name {node_name} does not exist"
+            return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
         # which flow
         flow_name = request.flow_name
         if not flow_name:
-            # Same current-context fallback as on_start_flow_request so StartFlowFromNode
-            # behaves consistently.
-            if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow().name
-            else:
-                details = (
-                    "Must provide flow_name, or set a flow in the Current Context "
-                    "(e.g. via EnsureWorkflowAndFlowRequest or CreateFlowRequest) first."
-                )
-                return StartFlowResultFailure(validation_exceptions=[], result_details=details)
+            try:
+                flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+            except KeyError as err:
+                details = f"Could not derive parent flow for node '{node_name}': {err}"
+                return StartFlowFromNodeResultFailure(validation_exceptions=[err], result_details=details)
         # get the flow by ID
         try:
             flow = self.get_flow_by_name(flow_name)
@@ -2725,14 +2749,6 @@ class FlowManager:
         if self.check_for_existing_running_flow():
             details = "Cannot start flow. Flow is already running."
             return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
-        node_name = request.node_name
-        if node_name is None:
-            details = "Must provide node name to start a flow."
-            return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
-        start_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
-        if not start_node:
-            details = f"Provided node with name {node_name} does not exist"
-            return StartFlowResultFailure(validation_exceptions=[], result_details=details)
         result = await self.on_validate_flow_dependencies_request(
             ValidateFlowDependenciesRequest(flow_name=flow_name, flow_node_name=start_node.name if start_node else None)
         )

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2620,9 +2620,6 @@ class NodeManager:
         node_name = request.node_name
         debug_mode = request.debug_mode
 
-        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4532 - fall back to
-        # ContextManager().get_current_node() when node_name is omitted, mirroring
-        # StartFlowRequest / StartFlowFromNodeRequest.
         if node_name is None:
             details = "No Node name was provided. Failed to resolve node."
 
@@ -2693,6 +2690,9 @@ class NodeManager:
         except Exception as e:
             details = f'Failed to resolve "{node_name}".  Error: {e}'
             return ResolveNodeResultFailure(validation_exceptions=[e], result_details=details)
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4532 - support
+        # wait_for_completion / completion_timeout_ms here, mirroring StartFlowRequest so
+        # callers do not have to poll check_for_existing_running_flow() themselves.
         details = f'Starting to resolve "{node_name}" in "{flow_name}"'
         return ResolveNodeResultSuccess(result_details=details)
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2620,6 +2620,9 @@ class NodeManager:
         node_name = request.node_name
         debug_mode = request.debug_mode
 
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4532 - fall back to
+        # ContextManager().get_current_node() when node_name is omitted, mirroring
+        # StartFlowRequest / StartFlowFromNodeRequest.
         if node_name is None:
             details = "No Node name was provided. Failed to resolve node."
 

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -106,3 +106,112 @@ class TestExtractFlowCommandsFromImageMetadata:
         assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultSuccess)
         assert result.serialized_flow_commands == {"sentinel": "flow"}
         assert result.altered_workflow_state is False
+
+
+class TestAwaitFlowCompletion:
+    """Tests for FlowManager._await_flow_completion (the wait_for_completion helper)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_flow_finishes_cleanly(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import patch
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        # No control flow machine -> no error to report; simulate "flow finished" with a single False.
+        with patch.object(flow_manager, "check_for_existing_running_flow", return_value=False):
+            result = await flow_manager._await_flow_completion(timeout_ms=None)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_timeout_string_when_timeout_exceeded(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import patch
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        # Keep reporting "still running" so the timeout path fires quickly.
+        with patch.object(flow_manager, "check_for_existing_running_flow", return_value=True):
+            result = await flow_manager._await_flow_completion(timeout_ms=10)
+
+        assert result is not None
+        assert "Timed out" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_error_message_when_resolution_machine_errored(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import MagicMock, patch
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        fake_resolution_machine = MagicMock()
+        fake_resolution_machine.is_errored.return_value = True
+        fake_resolution_machine.get_error_message.return_value = "boom"
+        fake_machine = MagicMock()
+        fake_machine.resolution_machine = fake_resolution_machine
+
+        with (
+            patch.object(flow_manager, "check_for_existing_running_flow", return_value=False),
+            patch.object(flow_manager, "_global_control_flow_machine", fake_machine),
+        ):
+            result = await flow_manager._await_flow_completion(timeout_ms=None)
+
+        assert result == "boom"
+
+
+class TestStartFlowRequestDefaultsToCurrentContext:
+    """Tests for StartFlowRequest / StartFlowFromNodeRequest current-context fallback."""
+
+    @pytest.mark.asyncio
+    async def test_start_flow_fails_cleanly_when_no_flow_and_no_context(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.execution_events import (
+            StartFlowRequest,
+            StartFlowResultFailure,
+        )
+
+        flow_manager = griptape_nodes.FlowManager()
+        griptape_nodes.handle_request(
+            __import__(
+                "griptape_nodes.retained_mode.events.object_events",
+                fromlist=["ClearAllObjectStateRequest"],
+            ).ClearAllObjectStateRequest(i_know_what_im_doing=True)
+        )
+
+        assert not griptape_nodes.ContextManager().has_current_flow()
+
+        result = await flow_manager.on_start_flow_request(StartFlowRequest())
+
+        assert isinstance(result, StartFlowResultFailure)
+        # Message should now name a concrete remediation, not the old generic one.
+        assert "Current Context" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_start_flow_uses_current_context_flow_when_name_omitted(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import patch
+
+        from griptape_nodes.retained_mode.events.execution_events import (
+            StartFlowRequest,
+            StartFlowResultFailure,
+        )
+        from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        flow_manager = griptape_nodes.FlowManager()
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        # Bootstrap manually via push_workflow + CreateFlowRequest so this test does not
+        # depend on any sibling MCP-bootstrap PR landing first.
+        griptape_nodes.ContextManager().push_workflow("wf")
+        create_flow_result = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="flow_in_ctx", set_as_new_context=True)
+        )
+        assert isinstance(create_flow_result, CreateFlowResultSuccess)
+
+        # Short-circuit get_flow_by_name so we can assert on the resolved name without
+        # actually running a control flow.
+        with patch.object(flow_manager, "get_flow_by_name", side_effect=KeyError("stop here")) as get_flow:
+            result = await flow_manager.on_start_flow_request(StartFlowRequest())
+
+        # The handler should have looked up the current-context flow name, not bailed with
+        # the "must provide flow name" error.
+        assert isinstance(result, StartFlowResultFailure)
+        get_flow.assert_called_once_with("flow_in_ctx")
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -215,3 +215,175 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         get_flow.assert_called_once_with("flow_in_ctx")
 
         griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    @pytest.mark.asyncio
+    async def test_start_flow_from_node_fails_cleanly_when_no_node_and_no_context(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        from griptape_nodes.retained_mode.events.execution_events import (
+            StartFlowFromNodeRequest,
+            StartFlowFromNodeResultFailure,
+        )
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        flow_manager = griptape_nodes.FlowManager()
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+        assert not griptape_nodes.ContextManager().has_current_node()
+
+        result = await flow_manager.on_start_flow_from_node_request(StartFlowFromNodeRequest())
+
+        assert isinstance(result, StartFlowFromNodeResultFailure)
+        assert "Current Context" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_start_flow_from_node_uses_current_context_node_and_derives_parent_flow(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from griptape_nodes.exe_types.node_types import BaseNode
+        from griptape_nodes.retained_mode.events.execution_events import (
+            StartFlowFromNodeRequest,
+            StartFlowFromNodeResultFailure,
+        )
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        flow_manager = griptape_nodes.FlowManager()
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+        # Stand in a current node so the handler can fall back to it. The node itself only
+        # needs to expose `.name`; we short-circuit object lookup below.
+        fake_node = MagicMock(spec=BaseNode)
+        fake_node.name = "node_in_ctx"
+        ctx = griptape_nodes.ContextManager()
+        with (
+            patch.object(ctx, "has_current_node", return_value=True),
+            patch.object(ctx, "get_current_node", return_value=fake_node),
+            patch.object(
+                griptape_nodes.ObjectManager(),
+                "attempt_get_object_by_name_as_type",
+                return_value=fake_node,
+            ),
+            patch.object(
+                griptape_nodes.NodeManager(),
+                "get_node_parent_flow_by_name",
+                return_value="derived_parent_flow",
+            ) as get_parent_flow,
+            patch.object(flow_manager, "get_flow_by_name", side_effect=KeyError("stop here")) as get_flow,
+        ):
+            result = await flow_manager.on_start_flow_from_node_request(StartFlowFromNodeRequest())
+
+        # The handler should have used the current-context node and derived its parent flow,
+        # not bailed with the "must provide node name" error.
+        assert isinstance(result, StartFlowFromNodeResultFailure)
+        get_parent_flow.assert_called_once_with("node_in_ctx")
+        get_flow.assert_called_once_with("derived_parent_flow")
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+class TestStartFlowCancelsOnWaitTimeout:
+    """Tests for the wait_for_completion cancel-on-timeout cleanup in on_start_flow_request."""
+
+    @pytest.mark.asyncio
+    async def test_cancels_running_flow_when_wait_for_completion_times_out(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from griptape_nodes.retained_mode.events.execution_events import (
+            StartFlowRequest,
+            StartFlowResultFailure,
+        )
+        from griptape_nodes.retained_mode.events.validation_events import (
+            ValidateFlowDependenciesResultSuccess,
+        )
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        fake_flow = MagicMock()
+        fake_flow.name = "timeout_flow"
+        validate_success = ValidateFlowDependenciesResultSuccess(
+            validation_succeeded=True, exceptions=[], result_details="validated"
+        )
+        cancel_mock = AsyncMock()
+
+        # check_for_existing_running_flow is consulted twice along the wait path:
+        # once before kicking off (must be False), and once after the timeout to decide
+        # whether to cancel (must be True since the flow is still churning).
+        running_flow_states = iter([False, True])
+
+        with (
+            patch.object(flow_manager, "get_flow_by_name", return_value=fake_flow),
+            patch.object(
+                flow_manager,
+                "check_for_existing_running_flow",
+                side_effect=lambda: next(running_flow_states),
+            ),
+            patch.object(
+                flow_manager,
+                "on_validate_flow_dependencies_request",
+                AsyncMock(return_value=validate_success),
+            ),
+            patch.object(flow_manager, "start_flow", AsyncMock()),
+            patch.object(flow_manager, "_global_control_flow_machine", None),
+            patch.object(
+                flow_manager,
+                "_await_flow_completion",
+                AsyncMock(return_value="Timed out waiting for flow completion after 10 ms."),
+            ),
+            patch.object(flow_manager, "cancel_flow_run", cancel_mock),
+        ):
+            result = await flow_manager.on_start_flow_request(
+                StartFlowRequest(flow_name="timeout_flow", wait_for_completion=True, completion_timeout_ms=10)
+            )
+
+        assert isinstance(result, StartFlowResultFailure)
+        assert "did not complete cleanly" in str(result.result_details)
+        cancel_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_cancel_when_flow_already_finished_with_error(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from griptape_nodes.retained_mode.events.execution_events import (
+            StartFlowRequest,
+            StartFlowResultFailure,
+        )
+        from griptape_nodes.retained_mode.events.validation_events import (
+            ValidateFlowDependenciesResultSuccess,
+        )
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        fake_flow = MagicMock()
+        fake_flow.name = "errored_flow"
+        validate_success = ValidateFlowDependenciesResultSuccess(
+            validation_succeeded=True, exceptions=[], result_details="validated"
+        )
+        cancel_mock = AsyncMock()
+
+        # First call (kickoff gate) returns False; second call (post-wait cancel gate) also
+        # returns False because the flow already finished with an error.
+        with (
+            patch.object(flow_manager, "get_flow_by_name", return_value=fake_flow),
+            patch.object(flow_manager, "check_for_existing_running_flow", return_value=False),
+            patch.object(
+                flow_manager,
+                "on_validate_flow_dependencies_request",
+                AsyncMock(return_value=validate_success),
+            ),
+            patch.object(flow_manager, "start_flow", AsyncMock()),
+            patch.object(flow_manager, "_global_control_flow_machine", None),
+            patch.object(
+                flow_manager,
+                "_await_flow_completion",
+                AsyncMock(return_value="boom"),
+            ),
+            patch.object(flow_manager, "cancel_flow_run", cancel_mock),
+        ):
+            result = await flow_manager.on_start_flow_request(
+                StartFlowRequest(flow_name="errored_flow", wait_for_completion=True)
+            )
+
+        assert isinstance(result, StartFlowResultFailure)
+        cancel_mock.assert_not_called()


### PR DESCRIPTION
Closes #4518.

`StartFlowRequest` had two friction points for callers that just finished building a graph and want to read its outputs.

The handler returned as soon as the run was kicked off. Callers that wanted to consume output values had to invent their own polling loop on top of node resolution state, with no shared definition of "the flow finished" or "the flow errored." Every client reinvented the heuristic, and getting it slightly wrong (sleeping too long, missing an error transition) was hard to spot.

The handler also required `flow_name` even when the engine had exactly one flow in the current context. That is the case the caller almost always just established, so the request rejected with a generic "Must provide flow name" message even though the engine knew which flow was active.

This change adds two opt-in fields, `wait_for_completion` and `completion_timeout_ms`, plus a `_await_flow_completion` helper that polls `check_for_existing_running_flow()` (the same signal the UI uses to decide when the run is idle) and returns a clean error string on timeout or when the resolution machine reports an error. When `wait_for_completion=True`, the handler converts the fire-and-forget kickoff into a synchronous run and the caller can read outputs immediately afterwards. The default stays False so existing callers see no behavior change.

Both `on_start_flow_request` and `on_start_flow_from_node_request` now fall back to the current-context flow when `flow_name` is omitted, with a more concrete failure message that points at `EnsureWorkflowAndFlowRequest` or `CreateFlowRequest` if no context is set either.

Tests cover three slices: `_await_flow_completion` returns None on clean completion, returns a timeout string when the flow never finishes, and surfaces the resolution machine's error message on flow error. The current-context fallback test bootstraps a workflow + flow manually via `push_workflow` + `CreateFlowRequest` so it does not depend on any sibling MCP-bootstrap PR landing first.
