### PR TITLE
feat(flows): add AutoLayoutFlowRequest for topological column layout

### DIFF
--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -165,6 +165,73 @@ class ListFlowsInCurrentContextResultFailure(WorkflowNotAlteredMixin, ResultPayl
     pass
 
 
+@dataclass
+class NodePosition:
+    """Resulting editor position for a node in AutoLayoutFlowResultSuccess."""
+
+    node_name: str
+    x: float
+    y: float
+
+
+@dataclass
+@PayloadRegistry.register
+class AutoLayoutFlowRequest(RequestPayload):
+    """Auto-place every node in a flow on a topological column-and-row grid.
+
+    Use when: an MCP client has just finished building a graph (nodes + connections) and
+    wants the editor to render it in a readable layout without having to compute pixel
+    positions by hand. Runs a topological sort over the flow's data/control edges, assigns
+    each node a layer (longest path from any source), and places layers as columns and
+    siblings within a layer as rows.
+
+    Writes the computed position into each node's `metadata["position"] = {"x", "y"}`,
+    matching the convention the editor and other engine code already use. Existing metadata
+    keys other than `position` are preserved.
+
+    Nodes that participate in a cycle (should not happen in a well-formed flow) are placed
+    at layer 0; a warning is logged.
+
+    Args:
+        flow_name: Flow to lay out. Defaults to the current-context flow, matching the
+            convention used by other flow-scoped requests.
+        origin_x: X coordinate of the first column. Defaults to 0.
+        origin_y: Y coordinate of the first row. Defaults to 0.
+        layer_spacing: Horizontal spacing between columns in editor pixels. 650 is a
+            readable default that matches the pair-node spacing used elsewhere in the engine.
+        row_spacing: Vertical spacing between sibling nodes within a layer.
+
+    Results: AutoLayoutFlowResultSuccess (with per-node final positions) | AutoLayoutFlowResultFailure
+    """
+
+    flow_name: str | None = None
+    origin_x: float = 0.0
+    origin_y: float = 0.0
+    layer_spacing: float = 650.0
+    row_spacing: float = 300.0
+
+
+@dataclass
+@PayloadRegistry.register
+class AutoLayoutFlowResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Auto-layout applied.
+
+    Args:
+        flow_name: Flow that was laid out.
+        positioned_nodes: Final (node_name, x, y) for every node in the flow. Ordered by
+            layer then by row within a layer so callers can reason about the visual shape.
+    """
+
+    flow_name: str
+    positioned_nodes: list[NodePosition] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class AutoLayoutFlowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Auto-layout failed. Common causes: no flow in current context, named flow not found."""
+
+
 # Gives a list of the flows directly parented by the node specified.
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -3168,7 +3168,7 @@ class FlowManager:
 
         return ListFlowsInCurrentContextResultSuccess(flow_names=ret_list, result_details=details)
 
-    def on_auto_layout_flow_request(self, request: AutoLayoutFlowRequest) -> ResultPayload:  # noqa: C901, PLR0912
+    async def on_auto_layout_flow_request(self, request: AutoLayoutFlowRequest) -> ResultPayload:  # noqa: C901, PLR0912
         """Assign editor positions to every node in a flow by topological column layout.
 
         Algorithm (Kahn-ish): walk the data+control edges internal to this flow, compute a
@@ -3250,12 +3250,12 @@ class FlowManager:
             for row_idx, name in enumerate(sorted(layers[layer_idx])):
                 x = request.origin_x + layer_idx * request.layer_spacing
                 y = request.origin_y + row_idx * request.row_spacing
-                # Dispatch the position update through GriptapeNodes.handle_request so the
+                # Dispatch the position update through GriptapeNodes.ahandle_request so the
                 # per-node SetNodeMetadataResultSuccess event is broadcast to subscribers.
                 # The editor listens on that event to move nodes on the canvas live; mutating
                 # node.metadata directly here would update the engine state but leave the UI
                 # stale until a reload.
-                set_metadata_result = GriptapeNodes.handle_request(
+                set_metadata_result = await GriptapeNodes.ahandle_request(
                     SetNodeMetadataRequest(node_name=name, metadata={"position": {"x": x, "y": y}})
                 )
                 if not isinstance(set_metadata_result, SetNodeMetadataResultSuccess):

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -91,6 +91,9 @@ from griptape_nodes.retained_mode.events.execution_events import (
     UnresolveFlowResultSuccess,
 )
 from griptape_nodes.retained_mode.events.flow_events import (
+    AutoLayoutFlowRequest,
+    AutoLayoutFlowResultFailure,
+    AutoLayoutFlowResultSuccess,
     CreateFlowRequest,
     CreateFlowResultFailure,
     CreateFlowResultSuccess,
@@ -120,6 +123,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
     ListNodesInFlowRequest,
     ListNodesInFlowResultFailure,
     ListNodesInFlowResultSuccess,
+    NodePosition,
     OriginalNodeParameter,
     PackageNodesAsSerializedFlowRequest,
     PackageNodesAsSerializedFlowResultFailure,
@@ -143,6 +147,8 @@ from griptape_nodes.retained_mode.events.node_events import (
     SerializedParameterValueTracker,
     SerializeNodeToCommandsRequest,
     SerializeNodeToCommandsResultSuccess,
+    SetNodeMetadataRequest,
+    SetNodeMetadataResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
@@ -265,6 +271,7 @@ class FlowManager:
         event_manager.assign_manager_to_request_type(
             ListFlowsInCurrentContextRequest, self.on_list_flows_in_current_context_request
         )
+        event_manager.assign_manager_to_request_type(AutoLayoutFlowRequest, self.on_auto_layout_flow_request)
         event_manager.assign_manager_to_request_type(CreateConnectionRequest, self.on_create_connection_request)
         event_manager.assign_manager_to_request_type(DeleteConnectionRequest, self.on_delete_connection_request)
         event_manager.assign_manager_to_request_type(StartFlowRequest, self.on_start_flow_request)
@@ -3160,6 +3167,113 @@ class FlowManager:
         details = f"Successfully got the list of Flows in the Current Context (Flow '{parent_flow_name}')."
 
         return ListFlowsInCurrentContextResultSuccess(flow_names=ret_list, result_details=details)
+
+    def on_auto_layout_flow_request(self, request: AutoLayoutFlowRequest) -> ResultPayload:  # noqa: C901, PLR0912
+        """Assign editor positions to every node in a flow by topological column layout.
+
+        Algorithm (Kahn-ish): walk the data+control edges internal to this flow, compute a
+        layer per node as the longest path from any source (node with no incoming edges),
+        then place layers as columns (x = origin_x + layer * layer_spacing) and siblings
+        within a layer as rows (y = origin_y + row_index * row_spacing). Writes
+        `node.metadata['position'] = {'x', 'y'}` for each node, preserving other metadata
+        keys.
+
+        Cycles should not occur in a well-formed flow. If one is detected, nodes that
+        couldn't be topologically ordered are parked at layer 0 and a warning is logged.
+        """
+        flow_name = request.flow_name
+        if not flow_name:
+            if GriptapeNodes.ContextManager().has_current_flow():
+                flow_name = GriptapeNodes.ContextManager().get_current_flow().name
+            else:
+                details = (
+                    "Attempted to auto-layout a flow. Failed because no flow_name was provided "
+                    "and the Current Context has no flow."
+                )
+                return AutoLayoutFlowResultFailure(result_details=details)
+
+        try:
+            flow = self.get_flow_by_name(flow_name)
+        except KeyError as err:
+            details = f"Attempted to auto-layout flow '{flow_name}'. Failed because: {err}"
+            return AutoLayoutFlowResultFailure(result_details=details)
+
+        node_names = list(flow.nodes.keys())
+        if not node_names:
+            return AutoLayoutFlowResultSuccess(
+                flow_name=flow_name,
+                positioned_nodes=[],
+                result_details=f"Flow '{flow_name}' has no nodes; nothing to lay out.",
+            )
+
+        # Build directed edges restricted to this flow so sub-flows and other workflow state
+        # do not contaminate the topological ordering.
+        node_name_set = set(node_names)
+        incoming: dict[str, set[str]] = {name: set() for name in node_names}
+        outgoing: dict[str, set[str]] = {name: set() for name in node_names}
+        for connection in self._connections.connections.values():
+            src = connection.source_node.name
+            tgt = connection.target_node.name
+            if src in node_name_set and tgt in node_name_set and src != tgt:
+                outgoing[src].add(tgt)
+                incoming[tgt].add(src)
+
+        # Kahn's topological sort with layer assignment. `layer[n]` is the longest path from
+        # any source to n, which gives a column that lines up fan-out naturally.
+        layer: dict[str, int] = dict.fromkeys(node_names, 0)
+        in_degree = {name: len(incoming[name]) for name in node_names}
+        ready = [name for name in node_names if in_degree[name] == 0]
+        ready.sort()  # stable layer ordering across runs
+        visited = 0
+        while ready:
+            name = ready.pop(0)
+            visited += 1
+            for child in sorted(outgoing[name]):
+                layer[child] = max(layer[child], layer[name] + 1)
+                in_degree[child] -= 1
+                if in_degree[child] == 0:
+                    ready.append(child)
+
+        if visited < len(node_names):
+            logger.warning(
+                "Auto-layout detected a cycle in flow '%s'; %d node(s) could not be ordered and stay at layer 0.",
+                flow_name,
+                len(node_names) - visited,
+            )
+
+        layers: dict[int, list[str]] = {}
+        for name in node_names:
+            layers.setdefault(layer[name], []).append(name)
+
+        positioned: list[NodePosition] = []
+        for layer_idx in sorted(layers.keys()):
+            for row_idx, name in enumerate(sorted(layers[layer_idx])):
+                x = request.origin_x + layer_idx * request.layer_spacing
+                y = request.origin_y + row_idx * request.row_spacing
+                # Dispatch the position update through GriptapeNodes.handle_request so the
+                # per-node SetNodeMetadataResultSuccess event is broadcast to subscribers.
+                # The editor listens on that event to move nodes on the canvas live; mutating
+                # node.metadata directly here would update the engine state but leave the UI
+                # stale until a reload.
+                set_metadata_result = GriptapeNodes.handle_request(
+                    SetNodeMetadataRequest(node_name=name, metadata={"position": {"x": x, "y": y}})
+                )
+                if not isinstance(set_metadata_result, SetNodeMetadataResultSuccess):
+                    logger.warning(
+                        "Auto-layout failed to update position for node '%s' in flow '%s': %s",
+                        name,
+                        flow_name,
+                        set_metadata_result.result_details,
+                    )
+                    continue
+                positioned.append(NodePosition(node_name=name, x=x, y=y))
+
+        details = f"Laid out {len(positioned)} node(s) in flow '{flow_name}' across {len(layers)} layer(s)."
+        return AutoLayoutFlowResultSuccess(
+            flow_name=flow_name,
+            positioned_nodes=positioned,
+            result_details=details,
+        )
 
     def _aggregate_flow_dependencies(
         self, serialized_node_commands: list[SerializedNodeCommands], sub_flows_commands: list[SerializedFlowCommands]

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -36,6 +36,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     StartFlowRequest,
 )
 from griptape_nodes.retained_mode.events.flow_events import (
+    AutoLayoutFlowRequest,
     CreateFlowRequest,
     DeleteFlowRequest,
     ListFlowsInCurrentContextRequest,
@@ -99,6 +100,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "CreateNodeRequest": CreateNodeRequest,
     "DeleteNodeRequest": DeleteNodeRequest,
     "ListNodesInFlowRequest": ListNodesInFlowRequest,
+    "AutoLayoutFlowRequest": AutoLayoutFlowRequest,
     "GetNodeResolutionStateRequest": GetNodeResolutionStateRequest,
     "GetNodeMetadataRequest": GetNodeMetadataRequest,
     "SetNodeMetadataRequest": SetNodeMetadataRequest,

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -442,7 +442,8 @@ class TestAutoLayoutFlowRequest:
 
         return "layout_flow"
 
-    def test_fails_cleanly_when_no_flow_in_context_and_no_name(self, griptape_nodes: GriptapeNodes) -> None:
+    @pytest.mark.asyncio
+    async def test_fails_cleanly_when_no_flow_in_context_and_no_name(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.flow_events import (
             AutoLayoutFlowRequest,
             AutoLayoutFlowResultFailure,
@@ -451,11 +452,12 @@ class TestAutoLayoutFlowRequest:
         self._cleanup(griptape_nodes)
         flow_manager = griptape_nodes.FlowManager()
 
-        result = flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest())
+        result = await flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest())
 
         assert isinstance(result, AutoLayoutFlowResultFailure)
 
-    def test_lays_out_linear_chain_into_columns(self, griptape_nodes: GriptapeNodes) -> None:
+    @pytest.mark.asyncio
+    async def test_lays_out_linear_chain_into_columns(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.flow_events import (
             AutoLayoutFlowRequest,
             AutoLayoutFlowResultSuccess,
@@ -464,7 +466,7 @@ class TestAutoLayoutFlowRequest:
         flow_name = self._bootstrap_graph(griptape_nodes)
         flow_manager = griptape_nodes.FlowManager()
 
-        result = flow_manager.on_auto_layout_flow_request(
+        result = await flow_manager.on_auto_layout_flow_request(
             AutoLayoutFlowRequest(
                 flow_name=flow_name,
                 origin_x=10.0,
@@ -489,7 +491,8 @@ class TestAutoLayoutFlowRequest:
 
         self._cleanup(griptape_nodes)
 
-    def test_empty_flow_is_handled_gracefully(self, griptape_nodes: GriptapeNodes) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_flow_is_handled_gracefully(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.flow_events import (
             AutoLayoutFlowRequest,
             AutoLayoutFlowResultSuccess,
@@ -498,7 +501,7 @@ class TestAutoLayoutFlowRequest:
         self._bootstrap_workflow_and_flow(griptape_nodes, workflow="empty_wf", flow="empty_flow")
 
         flow_manager = griptape_nodes.FlowManager()
-        result = flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest(flow_name="empty_flow"))
+        result = await flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest(flow_name="empty_flow"))
 
         assert isinstance(result, AutoLayoutFlowResultSuccess)
         assert result.positioned_nodes == []

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -1,6 +1,7 @@
 """Tests for FlowManager.on_extract_flow_commands_from_image_metadata."""
 
 import base64
+import itertools
 import pickle
 import tempfile
 from collections.abc import Generator
@@ -387,3 +388,119 @@ class TestStartFlowCancelsOnWaitTimeout:
 
         assert isinstance(result, StartFlowResultFailure)
         cancel_mock.assert_not_called()
+
+
+class TestAutoLayoutFlowRequest:
+    """Tests for FlowManager.on_auto_layout_flow_request."""
+
+    def _cleanup(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    def _bootstrap_workflow_and_flow(self, griptape_nodes: GriptapeNodes, workflow: str, flow: str) -> None:
+        """Push a workflow + create a flow without depending on any sibling bootstrap PR."""
+        from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+
+        self._cleanup(griptape_nodes)
+        griptape_nodes.ContextManager().push_workflow(workflow)
+        result = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name=flow, set_as_new_context=True)
+        )
+        assert isinstance(result, CreateFlowResultSuccess)
+
+    def _bootstrap_graph(self, griptape_nodes: GriptapeNodes) -> str:
+        """Create a small Workflow + Flow + 3 chained Note nodes (A -> B -> C) for layout tests.
+
+        Uses `Note` from the registered Griptape Nodes Library because it has data params that
+        can actually be connected end to end without triggering LLM calls or external deps.
+        """
+        from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+        from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+
+        self._bootstrap_workflow_and_flow(griptape_nodes, workflow="layout_wf", flow="layout_flow")
+
+        names = []
+        for desired in ("A", "B", "C"):
+            result = griptape_nodes.handle_request(CreateNodeRequest(node_type="Note", node_name=desired))
+            assert isinstance(result, CreateNodeResultSuccess)
+            names.append(result.node_name)
+
+        # Wire A -> B -> C on the Note node's text parameter.
+        for source, target in itertools.pairwise(names):
+            conn_result = griptape_nodes.handle_request(
+                CreateConnectionRequest(
+                    source_node_name=source,
+                    source_parameter_name="note",
+                    target_node_name=target,
+                    target_parameter_name="note",
+                )
+            )
+            # We don't strictly need this to succeed for layout tests (layout runs even without edges),
+            # but the chain is what makes the topological case interesting.
+            _ = conn_result
+
+        return "layout_flow"
+
+    def test_fails_cleanly_when_no_flow_in_context_and_no_name(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import (
+            AutoLayoutFlowRequest,
+            AutoLayoutFlowResultFailure,
+        )
+
+        self._cleanup(griptape_nodes)
+        flow_manager = griptape_nodes.FlowManager()
+
+        result = flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest())
+
+        assert isinstance(result, AutoLayoutFlowResultFailure)
+
+    def test_lays_out_linear_chain_into_columns(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import (
+            AutoLayoutFlowRequest,
+            AutoLayoutFlowResultSuccess,
+        )
+
+        flow_name = self._bootstrap_graph(griptape_nodes)
+        flow_manager = griptape_nodes.FlowManager()
+
+        result = flow_manager.on_auto_layout_flow_request(
+            AutoLayoutFlowRequest(
+                flow_name=flow_name,
+                origin_x=10.0,
+                origin_y=20.0,
+                layer_spacing=100.0,
+                row_spacing=50.0,
+            )
+        )
+
+        assert isinstance(result, AutoLayoutFlowResultSuccess)
+
+        # A -> B -> C on the single data edge makes them land in three separate columns at y=20.
+        positions = {p.node_name: (p.x, p.y) for p in result.positioned_nodes}
+        assert positions["A"] == (10.0, 20.0)
+        assert positions["B"] == (110.0, 20.0)
+        assert positions["C"] == (210.0, 20.0)
+
+        # Metadata was actually written on the live node objects.
+        flow = flow_manager.get_flow_by_name(flow_name)
+        assert flow.nodes["A"].metadata["position"] == {"x": 10.0, "y": 20.0}
+        assert flow.nodes["C"].metadata["position"] == {"x": 210.0, "y": 20.0}
+
+        self._cleanup(griptape_nodes)
+
+    def test_empty_flow_is_handled_gracefully(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import (
+            AutoLayoutFlowRequest,
+            AutoLayoutFlowResultSuccess,
+        )
+
+        self._bootstrap_workflow_and_flow(griptape_nodes, workflow="empty_wf", flow="empty_flow")
+
+        flow_manager = griptape_nodes.FlowManager()
+        result = flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest(flow_name="empty_flow"))
+
+        assert isinstance(result, AutoLayoutFlowResultSuccess)
+        assert result.positioned_nodes == []
+
+        self._cleanup(griptape_nodes)


### PR DESCRIPTION
Closes #4519.

Nodes created via `CreateNodeRequest` without an explicit `metadata.position` all land at the same default coordinates. A graph an agent has just finished building was functionally correct but rendered as a stack of overlapping nodes when a human opened the editor. Computing readable pixel coordinates from the client side meant knowing the editor's spacing conventions, running a topological sort over the connections the agent just wrote, and deciding what to do with cycles and disconnected components, all of which is engine-side knowledge that does not belong in clients.

Adds `AutoLayoutFlowRequest` and the supporting `NodePosition` / result payloads. The handler walks the data + control edges internal to the named flow (defaulting to the current-context flow), runs a Kahn-style topological sort that assigns each node a layer equal to its longest path from any source, then places layers as columns and siblings within a layer as rows. Coordinates are written into `node.metadata['position'] = {'x', 'y'}`, which matches the existing convention for editor positioning. Other metadata keys are preserved.

The position update for each node is dispatched as a `SetNodeMetadataRequest` through `GriptapeNodes.handle_request` rather than mutating `node.metadata` directly. That way the editor's existing subscription to `SetNodeMetadataResultSuccess` fires per node and the canvas updates live; mutating the dict in place would leave the UI stale until the user reloaded.

Cycles should not appear in a well-formed flow, but if one is detected the affected nodes stay parked at layer 0 and a warning is logged so the result is still actionable rather than failing wholesale.

Tests cover three cases: failing cleanly when no flow is in context and no name is given, laying out a linear `A -> B -> C` chain into three columns at custom spacing (and verifying the live `metadata['position']` update on the node objects), and handling an empty flow without raising. The bootstrap helper uses `push_workflow` + `CreateFlowRequest` directly so the tests do not depend on any sibling MCP-bootstrap PR landing first.
