### PR TITLE
feat(libraries): add RegisterSandboxNodeFromSourceRequest

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -431,6 +431,23 @@ class Library:
         self._node_metadata[node_class_as_str] = metadata
         return library_problem
 
+    def unregister_node_type(self, node_class_name: str) -> None:
+        """Remove a single node type from this library.
+
+        Exists to support incremental re-registration (e.g. an agent iterates on a sandbox
+        node's source code during a session). Does not touch existing node instances of this
+        class that are already living in a flow; callers are responsible for deleting and
+        recreating them if they want the new class to take effect.
+        """
+        if node_class_name not in self._node_types:
+            msg = (
+                f"Node type '{node_class_name}' was requested to be unregistered from library "
+                f"'{self._library_data.name}', but it wasn't registered in the first place."
+            )
+            raise KeyError(msg)
+        del self._node_types[node_class_name]
+        self._node_metadata.pop(node_class_name, None)
+
     def get_library_data(self) -> LibrarySchema:
         return self._library_data
 

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple
 
 from griptape_nodes.node_library.library_registry import (
@@ -169,6 +169,74 @@ class GetNodeMetadataFromLibraryResultSuccess(WorkflowNotAlteredMixin, ResultPay
 @PayloadRegistry.register
 class GetNodeMetadataFromLibraryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Node metadata retrieval failed. Common causes: library not found, node type not found, library not loaded."""
+
+
+@dataclass
+@PayloadRegistry.register
+class RegisterSandboxNodeFromSourceRequest(RequestPayload):
+    """Register the BaseNode subclasses declared in a Python source file already on disk inside the sandbox library directory.
+
+    Use when: An agent has just written a `.py` file into the configured sandbox directory
+    (via `WriteFileRequest` or any other means) and wants the engine to import it and
+    register its `BaseNode` subclasses without restarting. The engine never writes anything
+    itself; it only imports and registers what is already at `file_path`. The new node types
+    are immediately usable via `CreateNodeRequest` / `CreateNodesRequest`.
+
+    The file persists on disk, so subsequent engine startups pick it up through the normal
+    sandbox scan-and-load pipeline. Auto-generated metadata follows the same conventions the
+    engine applies to files placed in the sandbox directory through the UI.
+
+    Security note: the imported source runs inside the engine process with no isolation.
+    Anyone who can reach this request, or who can write into the sandbox directory, can
+    execute arbitrary Python. This mirrors the existing sandbox-directory behaviour, but
+    makes that surface reachable via MCP.
+
+    Args:
+        file_path: Path to a `.py` file inside the configured sandbox library directory.
+            Absolute paths must resolve under the sandbox directory; relative paths are
+            resolved against it. The file must already exist on disk.
+        replace_if_exists: When True, any node type of the same class name already registered
+            in the Sandbox Library is unregistered before registering the new class. Existing
+            node instances of that class in a running workflow are NOT migrated.
+
+    Results: RegisterSandboxNodeFromSourceResultSuccess | RegisterSandboxNodeFromSourceResultFailure
+    """
+
+    file_path: str
+    replace_if_exists: bool = True
+
+
+@dataclass
+@PayloadRegistry.register
+class RegisterSandboxNodeFromSourceResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Source file imported and at least one BaseNode subclass registered.
+
+    Args:
+        file_path: Absolute path to the .py file that was imported.
+        library_name: Name of the library the class(es) were registered with (always the
+            Sandbox Library for now).
+        registered_class_names: Node class names that were registered by this call, in module
+            declaration order.
+        replaced_class_names: Subset of registered_class_names for which an existing
+            registration was unregistered first (only meaningful when replace_if_exists=True).
+    """
+
+    file_path: str
+    library_name: str
+    registered_class_names: list[str] = field(default_factory=list)
+    replaced_class_names: list[str] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class RegisterSandboxNodeFromSourceResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Sandbox node registration failed.
+
+    Common causes: sandbox_library_directory not configured, file_path resolves outside the
+    sandbox directory or has the wrong extension, file does not exist, Python import error
+    (syntax error, missing dependency), no BaseNode subclass found in the file, or name
+    collision when replace_if_exists=False.
+    """
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -31,7 +31,7 @@ from xdg_base_dirs import xdg_data_home
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
-from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_workspace_path
+from griptape_nodes.files.path_utils import canonicalize_for_identity, canonicalize_for_io, resolve_workspace_path
 from griptape_nodes.node_library.library_registry import (
     CategoryDefinition,
     Library,
@@ -119,6 +119,9 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromRequirementSpecifierRequest,
     RegisterLibraryFromRequirementSpecifierResultFailure,
     RegisterLibraryFromRequirementSpecifierResultSuccess,
+    RegisterSandboxNodeFromSourceRequest,
+    RegisterSandboxNodeFromSourceResultFailure,
+    RegisterSandboxNodeFromSourceResultSuccess,
     ReloadAllLibrariesRequest,
     ReloadAllLibrariesResultFailure,
     ReloadAllLibrariesResultSuccess,
@@ -414,6 +417,9 @@ class LibraryManager:
             LoadMetadataForAllLibrariesRequest, self.load_metadata_for_all_libraries_request
         )
         event_manager.assign_manager_to_request_type(ScanSandboxDirectoryRequest, self.scan_sandbox_directory_request)
+        event_manager.assign_manager_to_request_type(
+            RegisterSandboxNodeFromSourceRequest, self.register_sandbox_node_from_source_request
+        )
         event_manager.assign_manager_to_request_type(
             UnloadLibraryFromRegistryRequest, self.unload_library_from_registry_request
         )
@@ -1257,6 +1263,143 @@ class LibraryManager:
             result_details=details,
         )
         return result
+
+    def register_sandbox_node_from_source_request(  # noqa: C901, PLR0911
+        self, request: RegisterSandboxNodeFromSourceRequest
+    ) -> ResultPayload:
+        """Import a Python source file from the sandbox dir and register its BaseNode subclasses.
+
+        Leverages existing engine primitives end to end:
+          * `_get_sandbox_directory` resolves the configured path.
+          * `_load_module_from_file` imports the source (with the existing hot-reload
+            semantics when replacing an iterating draft).
+          * `Library.register_new_node_type` attaches the class to the Sandbox Library, and
+            `Library.unregister_node_type` removes any prior registration first when
+            `replace_if_exists=True`.
+
+        The handler does not write `request.file_path`; the caller is expected to have placed
+        the file in the sandbox directory already (e.g. via `WriteFileRequest`). The file
+        stays on disk, so the normal sandbox scan-and-load pipeline picks it up on the next
+        engine start. We intentionally do not update the sandbox's
+        `griptape_nodes_library.json` here: startup's own merge step (`_merge_sandbox_nodes`)
+        discovers files that exist on disk but are absent from the manifest, and the loader
+        resolves their class names and writes the manifest back for us.
+        """
+        # Resolve and validate the sandbox directory. Agents cannot register nodes on a
+        # system that has not opted in to a sandbox.
+        sandbox_dir = self._get_sandbox_directory()
+        if sandbox_dir is None:
+            details = (
+                "Attempted to register a sandbox node from source. Failed because "
+                "`sandbox_library_directory` is not configured (or the configured path does "
+                "not exist). Set it in Settings -> Libraries -> Sandbox Settings first."
+            )
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+
+        # Canonicalize the requested path against the sandbox dir. Relative paths anchor to
+        # the sandbox; absolute paths stay where they are. We then verify the result lives
+        # under the canonical sandbox dir so callers can never reach outside it via `..` or
+        # absolute paths to other locations.
+        sandbox_root = canonicalize_for_identity(sandbox_dir)
+        file_path = canonicalize_for_io(request.file_path, base=sandbox_dir)
+        file_identity = canonicalize_for_identity(request.file_path, base=sandbox_dir)
+        if not file_identity.is_relative_to(sandbox_root):
+            details = (
+                f"Attempted to register a sandbox node with file_path={request.file_path!r}. "
+                f"Failed because the resolved path '{file_identity}' is not inside the "
+                f"sandbox directory '{sandbox_root}'."
+            )
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+        if file_path.suffix != ".py":
+            details = (
+                f"Attempted to register a sandbox node with file_path={request.file_path!r}. "
+                "Failed because file_path must point at a `.py` file so the sandbox loader "
+                "can pick it up."
+            )
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+        if not file_path.is_file():
+            details = (
+                f"Attempted to register a sandbox node with file_path={request.file_path!r}. "
+                f"Failed because no file exists at the resolved path '{file_path}'. Write "
+                "the source file into the sandbox directory before calling this request."
+            )
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+
+        # Import the module. `_load_module_from_file` handles both first-load and hot-reload
+        # (re-importing an existing module with fresh source), which is exactly what an agent
+        # iterating on a draft needs.
+        try:
+            module = self._load_module_from_file(file_path, LibraryManager.SANDBOX_LIBRARY_NAME)
+        except ImportError as err:
+            details = f"Attempted to register a sandbox node from '{file_path}'. Failed at import time: {err}"
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+
+        # The Sandbox Library must already be registered. It is created as part of normal
+        # engine startup when the sandbox directory is configured; if it is missing here, the
+        # user hasn't run through the sandbox setup at all.
+        try:
+            sandbox_library = LibraryRegistry.get_library(LibraryManager.SANDBOX_LIBRARY_NAME)
+        except KeyError:
+            details = (
+                "Attempted to register a sandbox node, but the Sandbox Library is not "
+                "registered in the engine. Ensure the sandbox directory has been initialized "
+                "(it is scanned once at engine startup) before calling this request."
+            )
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+
+        # Discover BaseNode subclasses defined in this module. The filter matches the one in
+        # `_attempt_load_nodes_from_sandbox_library_using_existing_schema` so that files
+        # registered via MCP and files scanned at startup surface identically.
+        registered_class_names: list[str] = []
+        replaced_class_names: list[str] = []
+        for class_name, obj in vars(module).items():
+            if not (
+                isinstance(obj, type)
+                and issubclass(obj, BaseNode)
+                and type(obj) is not BaseNode
+                and obj.__module__ == module.__name__
+            ):
+                continue
+
+            if sandbox_library.has_node_type(class_name):
+                if not request.replace_if_exists:
+                    details = (
+                        f"Attempted to register node type '{class_name}' from '{file_path}'. "
+                        "Failed because a node type with that name is already registered in "
+                        "the Sandbox Library and replace_if_exists=False."
+                    )
+                    return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+                sandbox_library.unregister_node_type(class_name)
+                replaced_class_names.append(class_name)
+
+            metadata = NodeMetadata(
+                category=self.SANDBOX_CATEGORY_NAME,
+                description=f"'{class_name}' (loaded from the {LibraryManager.SANDBOX_LIBRARY_NAME}).",
+                display_name=class_name,
+            )
+            sandbox_library.register_new_node_type(obj, metadata)
+            registered_class_names.append(class_name)
+
+        if not registered_class_names:
+            details = (
+                f"Imported '{file_path}' successfully, but it does not declare any BaseNode "
+                "subclasses (must be `class X(BaseNode):` defined in this file, not "
+                "re-exported from another module). Nothing was registered."
+            )
+            return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
+
+        summary = (
+            f"Registered {len(registered_class_names)} node type(s) from '{file_path}' "
+            f"into the {LibraryManager.SANDBOX_LIBRARY_NAME} "
+            f"(replaced: {len(replaced_class_names)})."
+        )
+        return RegisterSandboxNodeFromSourceResultSuccess(
+            file_path=str(file_path),
+            library_name=LibraryManager.SANDBOX_LIBRARY_NAME,
+            registered_class_names=registered_class_names,
+            replaced_class_names=replaced_class_names,
+            result_details=summary,
+        )
 
     def list_categories_in_library_request(self, request: ListCategoriesInLibraryRequest) -> ResultPayload:
         # Does this library exist?
@@ -3361,8 +3504,16 @@ class LibraryManager:
                     actual_node_definitions.append(node_definition)
 
         if not actual_node_definitions:
-            logger.debug("No nodes found in sandbox library '%s'. Skipping.", sandbox_library_dir)
-            return
+            # The sandbox directory exists but currently holds no files that declare a
+            # BaseNode subclass. Previously the loader bailed here and left the Sandbox
+            # Library unregistered, which made it impossible to add the first node via
+            # `RegisterSandboxNodeFromSourceRequest` (and similar incremental tools) without
+            # first seeding a throwaway file by hand. We now fall through and register the
+            # library with zero nodes so it is a valid target for subsequent registrations.
+            logger.debug(
+                "No nodes found in sandbox library '%s'. Registering empty library so it can be populated incrementally.",
+                sandbox_library_dir,
+            )
 
         # Use the existing schema but replace nodes with actual discovered ones
         library_data = LibrarySchema(

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -45,6 +45,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     ListCategoriesInLibraryRequest,
     ListNodeTypesInLibraryRequest,
     ListRegisteredLibrariesRequest,
+    RegisterSandboxNodeFromSourceRequest,
 )
 from griptape_nodes.retained_mode.events.node_events import (
     CreateNodeRequest,
@@ -84,6 +85,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "ListRegisteredLibrariesRequest": ListRegisteredLibrariesRequest,
     "ListNodeTypesInLibraryRequest": ListNodeTypesInLibraryRequest,
     "ListCategoriesInLibraryRequest": ListCategoriesInLibraryRequest,
+    "RegisterSandboxNodeFromSourceRequest": RegisterSandboxNodeFromSourceRequest,
     # Execution
     "ResolveNodeRequest": ResolveNodeRequest,
     "ExecuteNodeRequest": ExecuteNodeRequest,

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1,11 +1,14 @@
 import asyncio
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.node_library.library_registry import (
+    LibraryRegistry,
+)
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.library_events import (
     GetAllInfoForAllLibrariesRequest,
@@ -874,3 +877,272 @@ class TestAddLibraryPathsToSysPath:
             assert str(base_dir) in sys.path
         finally:
             sys.path[:] = original_sys_path
+            sys.path[:] = original_sys_path
+
+
+class TestRegisterSandboxNodeFromSourceRequest:
+    """Tests for LibraryManager.register_sandbox_node_from_source_request."""
+
+    _LIBRARY_NAME = "Sandbox Library"
+    _FILE_NAME = "probe_sandbox_node.py"
+    _SOURCE_OK = (
+        "from griptape_nodes.exe_types.node_types import BaseNode\n"
+        "\n"
+        "class ProbeSandboxNode(BaseNode):\n"
+        "    def process(self) -> None:  # noqa: D401\n"
+        '        """Probe."""\n'
+        "        return None\n"
+    )
+
+    @pytest.fixture(autouse=True)
+    def _isolate_registry_and_config(
+        self,
+        griptape_nodes: GriptapeNodes,
+        tmp_path: Path,
+    ) -> Generator[Path, None, None]:
+        """Configure a temp sandbox directory + register the Sandbox Library for this test.
+
+        The Sandbox Library is normally created during engine startup. Our tests start from a
+        bare engine, so we recreate the minimal state the handler expects.
+
+        We stub `_get_sandbox_directory` rather than round-tripping `set_config_value`, which
+        calls `load_configs` and reads the on-disk USER_CONFIG_PATH. The conftest patches
+        USER_CONFIG_PATH to an empty file, so config-layer writes get clobbered between the
+        fixture and the handler call. Stubbing the resolver keeps the test focused on handler
+        behaviour, not config serialisation.
+        """
+        from unittest.mock import patch
+
+        from griptape_nodes.node_library.library_registry import (
+            CategoryDefinition,
+        )
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata as _LibraryMetadata,
+        )
+        from griptape_nodes.node_library.library_registry import (
+            LibrarySchema as _LibrarySchema,
+        )
+        from griptape_nodes.retained_mode.managers.library_manager import (
+            LibraryManager as _LibraryManager,
+        )
+
+        LibraryRegistry._libraries.clear()
+        LibraryRegistry._node_aliases.clear()
+        LibraryRegistry._collision_node_names_to_library_names.clear()
+        LibraryRegistry._registered_widgets.clear()
+
+        sandbox_dir = tmp_path / "sandbox"
+        sandbox_dir.mkdir()
+
+        # Stand up a minimal Sandbox Library so the handler has somewhere to register into.
+        sandbox_schema = _LibrarySchema(
+            name=_LibraryManager.SANDBOX_LIBRARY_NAME,
+            library_schema_version=_LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=_LibraryMetadata(
+                author="test",
+                description="test sandbox",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+            ),
+            categories=[
+                {
+                    _LibraryManager.SANDBOX_CATEGORY_NAME: CategoryDefinition(
+                        title="Sandbox",
+                        description="test",
+                        color="#000",
+                        icon="Folder",
+                    )
+                }
+            ],
+            nodes=[],
+        )
+        LibraryRegistry.generate_new_library(library_data=sandbox_schema)
+
+        library_manager = griptape_nodes.LibraryManager()
+        # Default: return the tmp sandbox. Individual tests that need the "not configured"
+        # branch override via their own patch.
+        with patch.object(library_manager, "_get_sandbox_directory", return_value=sandbox_dir):
+            try:
+                yield sandbox_dir
+            finally:
+                LibraryRegistry._libraries.clear()
+                LibraryRegistry._node_aliases.clear()
+                LibraryRegistry._collision_node_names_to_library_names.clear()
+                LibraryRegistry._registered_widgets.clear()
+
+    def test_imports_existing_file_and_registers_node_type(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
+    ) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultSuccess,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        sandbox_dir = _isolate_registry_and_config
+        source_file = sandbox_dir / self._FILE_NAME
+        source_file.write_text(self._SOURCE_OK)
+
+        result = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=str(source_file))
+        )
+
+        assert isinstance(result, RegisterSandboxNodeFromSourceResultSuccess)
+        assert result.registered_class_names == ["ProbeSandboxNode"]
+        assert result.replaced_class_names == []
+        assert result.library_name == self._LIBRARY_NAME
+        # Class is now registered and retrievable via the registry.
+        assert LibraryRegistry.get_library(self._LIBRARY_NAME).has_node_type("ProbeSandboxNode")
+
+    def test_accepts_path_relative_to_sandbox_directory(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
+    ) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultSuccess,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        sandbox_dir = _isolate_registry_and_config
+        (sandbox_dir / self._FILE_NAME).write_text(self._SOURCE_OK)
+
+        # Bare filename, no directory component: must resolve under the sandbox dir.
+        result = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=self._FILE_NAME)
+        )
+
+        assert isinstance(result, RegisterSandboxNodeFromSourceResultSuccess)
+        assert result.registered_class_names == ["ProbeSandboxNode"]
+
+    def test_replace_if_exists_swaps_the_old_class(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
+    ) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultSuccess,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        sandbox_dir = _isolate_registry_and_config
+        source_file = sandbox_dir / self._FILE_NAME
+        source_file.write_text(self._SOURCE_OK)
+
+        # First registration: baseline.
+        first = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=str(source_file), replace_if_exists=True)
+        )
+        assert isinstance(first, RegisterSandboxNodeFromSourceResultSuccess)
+        assert first.replaced_class_names == []
+
+        # Second registration of the same class name should report the prior was replaced.
+        second = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=str(source_file), replace_if_exists=True)
+        )
+        assert isinstance(second, RegisterSandboxNodeFromSourceResultSuccess)
+        assert second.replaced_class_names == ["ProbeSandboxNode"]
+
+    def test_fails_when_sandbox_directory_is_not_configured(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - fixture installs the default sandbox stub we override here
+    ) -> None:
+        from unittest.mock import patch
+
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultFailure,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        # Override the fixture's default stub so the resolver returns None, simulating the
+        # "no sandbox configured" case.
+        with patch.object(library_manager, "_get_sandbox_directory", return_value=None):
+            result = library_manager.register_sandbox_node_from_source_request(
+                RegisterSandboxNodeFromSourceRequest(file_path=self._FILE_NAME)
+            )
+
+        assert isinstance(result, RegisterSandboxNodeFromSourceResultFailure)
+        assert "sandbox_library_directory" in str(result.result_details)
+
+    def test_rejects_paths_outside_sandbox_or_with_wrong_extension(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to seed source files
+        tmp_path: Path,
+    ) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultFailure,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        sandbox_dir = _isolate_registry_and_config
+
+        # Create a real file outside the sandbox so the failure is about containment, not
+        # about the file being missing.
+        outside = tmp_path / "outside.py"
+        outside.write_text(self._SOURCE_OK)
+
+        # Wrong extension: write a real file inside the sandbox so the failure is purely
+        # about the suffix check, not about existence.
+        wrong_ext = sandbox_dir / "probe.txt"
+        wrong_ext.write_text(self._SOURCE_OK)
+
+        # Escape attempt: a relative path with `..` resolves outside the sandbox dir.
+        escape_target = tmp_path / "escape.py"
+        escape_target.write_text(self._SOURCE_OK)
+
+        bad_paths = [str(outside), str(wrong_ext), "../escape.py"]
+        for bad_path in bad_paths:
+            result = library_manager.register_sandbox_node_from_source_request(
+                RegisterSandboxNodeFromSourceRequest(file_path=bad_path)
+            )
+            assert isinstance(result, RegisterSandboxNodeFromSourceResultFailure), bad_path
+
+    def test_fails_when_file_does_not_exist(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - fixture installs the sandbox stub
+    ) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultFailure,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+
+        result = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path="never_written.py")
+        )
+
+        assert isinstance(result, RegisterSandboxNodeFromSourceResultFailure)
+        assert "never_written.py" in str(result.result_details)
+
+    def test_fails_when_source_has_no_base_node_subclass(
+        self,
+        griptape_nodes: GriptapeNodes,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
+    ) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultFailure,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        sandbox_dir = _isolate_registry_and_config
+        no_node_file = sandbox_dir / "no_node.py"
+        no_node_file.write_text("x = 1\n")
+
+        result = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=str(no_node_file))
+        )
+
+        assert isinstance(result, RegisterSandboxNodeFromSourceResultFailure)
+        assert "BaseNode" in str(result.result_details)


### PR DESCRIPTION
Closes #4520.

There was no way to introduce a new node type during a running session. The only paths were restarting the engine after dropping a `.py` into the sandbox directory by hand, or registering a full library. An agent that just discovered "I need a node that does X" could not act on that without leaving the session. Worse, even when the sandbox directory was configured, the Sandbox Library was only registered at engine startup if at least one `BaseNode` subclass was found on disk, so the first sandbox node a user wanted to add had nowhere to land.

Adds `RegisterSandboxNodeFromSourceRequest`, which takes a `file_path` to a `.py` file already on disk inside the configured sandbox directory, imports it through the existing hot-reload helper `_load_module_from_file`, finds `BaseNode` subclasses defined in that module, and registers each one in the Sandbox Library. The handler does not write the file itself; callers are expected to have placed it in the sandbox directory (e.g. via `WriteFileRequest`) before calling, which keeps file-write policy in one place and matches how agents already touch the workspace. `file_path` may be absolute (must resolve under the sandbox dir) or relative (resolved against the sandbox dir). The class filter matches the one the startup scan uses, so files registered live and files discovered on next boot end up identical. `replace_if_exists=True` swaps the previous registration (without migrating live node instances) so an agent iterating on a draft can call this repeatedly. The path is canonicalized via `canonicalize_for_io` / `canonicalize_for_identity` and rejected if it lands outside the sandbox dir, does not end in `.py`, or does not exist. There is an explicit security note in the request docstring: the imported source runs inside the engine process with no isolation, mirroring the existing sandbox-directory behaviour, but makes that surface reachable via MCP.

Adds `Library.unregister_node_type` to support the replace path. Adjusts `_attempt_load_nodes_from_sandbox_library_using_existing_schema` so an empty sandbox directory still registers the Sandbox Library (with zero nodes) instead of bailing; otherwise the very first sandbox-node registration would have nowhere to land.

The MCP entry sits next to the existing library/node-type listings.
