### PR TITLE
feat(events): add EventRequestBatch envelope for bulk request fan-out

### DIFF
--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -154,6 +154,90 @@ class RequestClient:
             logger.debug("Request %s completed successfully", request_id)
             return result
 
+    async def request_batch(
+        self,
+        requests: list[tuple[str, dict[str, Any]]],
+        topic: str | None = None,
+        timeout_ms: int | None = None,
+        *,
+        return_exceptions: bool = False,
+    ) -> list[Any]:
+        """Send a batch of requests in one frame and gather their responses.
+
+        Each inner request is published as its own EventRequest under one
+        EventRequestBatch envelope. Inner requests carry their own request_ids,
+        so responses arrive as individual EventResultSuccess/Failure messages and
+        are correlated back to per-call futures.
+
+        Args:
+            requests: List of (request_type, payload) pairs. Each becomes an
+                inner EventRequest with its own request_id.
+            topic: Optional per-call request topic override.
+            timeout_ms: Optional timeout applied to the whole batch.
+            return_exceptions: If True, failures and timeouts are returned in
+                their slot instead of raising. Matches asyncio.gather semantics.
+
+        Returns:
+            Responses in submission order. When return_exceptions is False, a
+            single failure raises immediately and pending sub-requests are
+            cancelled. When True, the returned list mirrors submission order
+            with exceptions in failed slots.
+
+        Raises:
+            TimeoutError: If the batch exceeds timeout_ms (only when
+                return_exceptions is False).
+            Exception: First failing inner request's error (only when
+                return_exceptions is False).
+        """
+        if not requests:
+            return []
+
+        # Determine topics and ensure response subscription, just like request().
+        request_topic = topic or self.request_topic_fn()
+        response_topic = self.response_topic_fn()
+        if response_topic not in self._subscribed_response_topics:
+            await self.client.subscribe(response_topic)
+            self._subscribed_response_topics.add(response_topic)
+
+        # Pre-register futures for every inner request so _try_match can resolve
+        # them as responses arrive in arbitrary order.
+        inner_events: list[dict[str, Any]] = []
+        futures: list[asyncio.Future] = []
+        request_ids: list[str] = []
+        for request_type, raw_payload in requests:
+            request_id = str(uuid.uuid4())
+            payload = {**raw_payload, "request_id": request_id}
+            futures.append(await self._track_request(request_id))
+            request_ids.append(request_id)
+            inner_events.append(
+                {
+                    "event_type": "EventRequest",
+                    "request_type": request_type,
+                    "request_id": request_id,
+                    "request": payload,
+                    "response_topic": response_topic,
+                }
+            )
+
+        batch_payload = {"event_type": "EventRequestBatch", "requests": inner_events}
+        logger.debug("Sending batch of %d requests on %s", len(inner_events), request_topic)
+
+        try:
+            await self.client.publish("EventRequestBatch", batch_payload, request_topic)
+            gather = asyncio.gather(*futures, return_exceptions=return_exceptions)
+            if timeout_ms:
+                results = await asyncio.wait_for(gather, timeout=timeout_ms / 1000)
+            else:
+                results = await gather
+        except (TimeoutError, Exception) as e:
+            logger.error("Batch request failed: %s", e)
+            for request_id in request_ids:
+                await self._cancel_request(request_id)
+            raise
+        else:
+            logger.debug("Batch of %d requests completed", len(inner_events))
+            return results
+
     async def track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
         """Register a future for an outgoing request and return it.
 

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -31,6 +31,7 @@ from griptape_nodes.retained_mode.events import app_events, execution_events, wo
 from griptape_nodes.retained_mode.events.base_events import (
     AppEvent,
     EventRequest,
+    EventRequestBatch,
     EventResultFailure,
     EventResultSuccess,
     ExecutionEvent,
@@ -445,6 +446,12 @@ async def _process_api_event(event: dict) -> None:
         griptape_nodes.EventManager().put_event(_deserialize_event(AppEvent.from_dict, payload, "AppEvent"))
         return
 
+    if event_type == "EventRequestBatch":
+        batch = _deserialize_event(EventRequestBatch.from_dict, payload, "EventRequestBatch")
+        for inner in batch.requests:
+            await _dispatch_event_request(inner)
+        return
+
     try:
         payload["request"]
     except KeyError:
@@ -462,6 +469,11 @@ async def _process_api_event(event: dict) -> None:
         msg = f"Deserialized event is not an EventRequest: {type(request_event)}"
         raise TypeError(msg)
 
+    await _dispatch_event_request(request_event)
+
+
+async def _dispatch_event_request(request_event: EventRequest) -> None:
+    """Route a single EventRequest into the engine: skip-the-line goes inline, others queue."""
     # Check if the event implements SkipTheLineMixin for priority processing
     if isinstance(request_event.request, SkipTheLineMixin):
         # Handle the event immediately without queuing

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -326,6 +326,42 @@ class EventRequest[P: Payload](BaseEvent):
         return cls(request=request_payload, **event_data)
 
 
+class EventRequestBatch(BaseEvent):
+    """Wire-only envelope that fans out into N individual EventRequests on ingest.
+
+    Each inner EventRequest carries its own request_id and response_topic, so the
+    engine does not need a batch-aware handler: results come back as individual
+    EventResultSuccess/Failure messages and the caller correlates them by request_id.
+    Use this to dispatch many requests in a single WebSocket frame without paying
+    per-request envelope overhead.
+
+    The envelope intentionally does not carry its own request_id/response_topic.
+    Identity and routing live on the inner requests, which keeps the engine path
+    identical to a stream of individual EventRequest frames.
+    """
+
+    requests: list[EventRequest] = Field(default_factory=list)
+
+    def dict(self, *args, **kwargs) -> dict[str, Any]:
+        """Serialize the envelope, recursing into each inner request's own serializer."""
+        result = super().dict(*args, **kwargs)
+        result["requests"] = [inner.dict() for inner in self.requests]
+        return result
+
+    def get_request(self) -> Payload:
+        """EventRequestBatch is a transport envelope; inspect .requests instead."""
+        msg = "EventRequestBatch is a transport envelope; inspect .requests instead."
+        raise NotImplementedError(msg)
+
+    @classmethod
+    def from_dict(cls, data: builtins.dict[str, Any]) -> EventRequestBatch:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Create a batch envelope by deserializing each inner request individually."""
+        event_data = data.copy()
+        raw_requests = event_data.pop("requests", [])
+        requests = [EventRequest.from_dict(raw) for raw in raw_requests]
+        return cls(requests=requests, **event_data)
+
+
 class EventResult[P: RequestPayload, R: ResultPayload](BaseEvent, ABC):
     """Abstract base class for result events."""
 

--- a/tests/unit/api_client/test_request_client_batch.py
+++ b/tests/unit/api_client/test_request_client_batch.py
@@ -1,0 +1,209 @@
+"""Tests for `RequestClient.request_batch`.
+
+`request_batch` wraps N inner EventRequests in one EventRequestBatch frame on
+the wire. Each inner request gets its own request_id and a future tracked by
+the RequestClient, so responses arriving in arbitrary order can resolve their
+matching slot. The tests below validate the wire shape, future fan-out,
+ordering of returned results, and cancellation on failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from griptape_nodes.api_client.request_client import RequestClient
+
+_BATCH_SIZE_3 = 3
+
+
+class _FakeClient:
+    """Minimal Client stand-in capturing publish/subscribe calls for assertions."""
+
+    def __init__(self) -> None:
+        self.publish = AsyncMock()
+        self.subscribe = AsyncMock()
+        self._filters: list = []
+
+    def add_message_filter(self, fn: Any) -> None:
+        self._filters.append(fn)
+
+    def remove_message_filter(self, fn: Any) -> None:
+        self._filters.remove(fn)
+
+
+@pytest.fixture
+def fake_client() -> _FakeClient:
+    """Capture-only Client surrogate so we can assert on publish/subscribe calls."""
+    return _FakeClient()
+
+
+@pytest_asyncio.fixture
+async def request_client(fake_client: _FakeClient) -> Any:
+    """RequestClient wired against a fake Client and a stable response topic."""
+    rc = RequestClient(
+        client=fake_client,  # type: ignore[arg-type]
+        request_topic_fn=lambda: "request",
+        response_topic_fn=lambda: "response",
+    )
+    async with rc:
+        yield rc
+
+
+async def _resolve(rc: RequestClient, request_id: str, payload: dict[str, Any]) -> None:
+    """Inject a successful response into the tracking map, the way `_try_match` would."""
+    await rc._resolve_request(request_id, payload)
+
+
+class TestRequestBatchWire:
+    @pytest.mark.asyncio
+    async def test_publishes_single_envelope_with_inner_event_requests(
+        self, request_client: RequestClient, fake_client: _FakeClient
+    ) -> None:
+        """A non-empty batch produces one EventRequestBatch publish, one frame on the wire."""
+
+        # Resolve all three slots before publish is awaited so request_batch can complete.
+        async def auto_resolve() -> None:
+            # Wait until publish has been called so request_ids are populated, then resolve.
+            await asyncio.sleep(0)
+            for request_id in list(request_client._pending_requests):
+                await _resolve(request_client, request_id, {"ok": True})
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(auto_resolve())
+            results = await request_client.request_batch(
+                [
+                    ("CreateConnectionRequest", {"target_node_name": "A"}),
+                    ("CreateConnectionRequest", {"target_node_name": "B"}),
+                    ("CreateConnectionRequest", {"target_node_name": "C"}),
+                ]
+            )
+
+        # One publish, with the batch envelope shape.
+        assert fake_client.publish.await_count == 1
+        assert fake_client.publish.await_args is not None
+        event_type, payload, topic = fake_client.publish.await_args.args
+        assert event_type == "EventRequestBatch"
+        assert topic == "request"
+        assert payload["event_type"] == "EventRequestBatch"
+        assert len(payload["requests"]) == _BATCH_SIZE_3
+
+        # Each inner event is a fully-formed EventRequest with its own request_id.
+        inner_ids: list[str] = []
+        for inner, expected_target in zip(payload["requests"], ("A", "B", "C"), strict=True):
+            assert inner["event_type"] == "EventRequest"
+            assert inner["request_type"] == "CreateConnectionRequest"
+            assert inner["response_topic"] == "response"
+            assert inner["request"]["target_node_name"] == expected_target
+            assert inner["request"]["request_id"] == inner["request_id"]
+            inner_ids.append(inner["request_id"])
+
+        # All inner request_ids are unique.
+        assert len(set(inner_ids)) == _BATCH_SIZE_3
+
+        # Caller got one result per inner request, in submission order.
+        assert results == [{"ok": True}, {"ok": True}, {"ok": True}]
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_returns_immediately_without_publishing(
+        self, request_client: RequestClient, fake_client: _FakeClient
+    ) -> None:
+        """No inner requests means no envelope on the wire and no futures registered."""
+        results = await request_client.request_batch([])
+
+        assert results == []
+        fake_client.publish.assert_not_awaited()
+        assert request_client.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_subscribes_to_response_topic_only_once(
+        self, request_client: RequestClient, fake_client: _FakeClient
+    ) -> None:
+        """Repeat batches reuse the existing response subscription, no duplicate subscribes."""
+
+        async def auto_resolve() -> None:
+            await asyncio.sleep(0)
+            for request_id in list(request_client._pending_requests):
+                await _resolve(request_client, request_id, {})
+
+        for _ in range(3):
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(auto_resolve())
+                await request_client.request_batch([("X", {})])
+
+        assert fake_client.subscribe.await_count == 1
+
+
+class TestRequestBatchResolution:
+    @pytest.mark.asyncio
+    async def test_results_returned_in_submission_order_regardless_of_resolution_order(
+        self, request_client: RequestClient
+    ) -> None:
+        """Resolving the third future first must not reorder the returned list."""
+
+        async def out_of_order_resolve() -> None:
+            await asyncio.sleep(0)
+            # Snapshot in insertion order, then resolve in reverse with distinct payloads.
+            ids = list(request_client._pending_requests)
+            await _resolve(request_client, ids[2], {"slot": "C"})
+            await _resolve(request_client, ids[0], {"slot": "A"})
+            await _resolve(request_client, ids[1], {"slot": "B"})
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(out_of_order_resolve())
+            results = await request_client.request_batch([("R", {"k": "a"}), ("R", {"k": "b"}), ("R", {"k": "c"})])
+
+        assert [r["slot"] for r in results] == ["A", "B", "C"]
+
+    @pytest.mark.asyncio
+    async def test_failure_cancels_pending_sub_requests_and_raises(self, request_client: RequestClient) -> None:
+        """A rejected inner future raises by default and pending siblings are cancelled."""
+
+        async def reject_first() -> None:
+            await asyncio.sleep(0)
+            ids = list(request_client._pending_requests)
+            await request_client._reject_request(ids[0], RuntimeError("boom"))
+
+        rejecter = asyncio.create_task(reject_first())
+        try:
+            with pytest.raises(RuntimeError, match="boom"):
+                await request_client.request_batch([("R", {}), ("R", {}), ("R", {})])
+        finally:
+            await rejecter
+
+        # All inner requests have been cleaned up, regardless of which raised.
+        assert request_client.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_return_exceptions_keeps_failures_in_their_slots(self, request_client: RequestClient) -> None:
+        """With return_exceptions=True the result list mirrors gather() semantics."""
+
+        async def mixed_resolve() -> None:
+            await asyncio.sleep(0)
+            ids = list(request_client._pending_requests)
+            await _resolve(request_client, ids[0], {"ok": True})
+            await request_client._reject_request(ids[1], ValueError("bad"))
+            await _resolve(request_client, ids[2], {"ok": True})
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(mixed_resolve())
+            results = await request_client.request_batch(
+                [("R", {}), ("R", {}), ("R", {})],
+                return_exceptions=True,
+            )
+
+        assert results[0] == {"ok": True}
+        assert isinstance(results[1], ValueError)
+        assert results[2] == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_timeout_cancels_pending_requests(self, request_client: RequestClient) -> None:
+        """An overall timeout raises TimeoutError and cleans up every tracking entry."""
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await request_client.request_batch([("R", {}), ("R", {})], timeout_ms=10)
+
+        assert request_client.pending_count == 0

--- a/tests/unit/app/test_app_batch_ingest.py
+++ b/tests/unit/app/test_app_batch_ingest.py
@@ -1,0 +1,180 @@
+"""Tests for the EventRequestBatch ingest path in `app.py`.
+
+The batch envelope is wire-only: when `_process_api_event` sees one, it should
+fan the inner EventRequests out through the same routing the engine uses for
+individual frames. Skip-the-line inner requests are awaited inline; the rest
+are queued on the EventManager's event queue.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.app import app as app_module
+from griptape_nodes.retained_mode.events.app_events import SessionHeartbeatRequest
+from griptape_nodes.retained_mode.events.base_events import (
+    EventRequest,
+    EventRequestBatch,
+    SkipTheLineMixin,
+)
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_BATCH_SIZE_2 = 2
+_BATCH_SIZE_3 = 3
+
+
+def _connection_payload(target: str) -> dict:
+    """Minimal valid CreateConnectionRequest payload for ingest tests."""
+    return {
+        "source_parameter_name": "output",
+        "target_parameter_name": "text",
+        "source_node_name": "Agent_1",
+        "target_node_name": target,
+    }
+
+
+def _wire_event_request(request_type: str, payload: dict, request_id: str) -> dict:
+    """Build the minimal inner EventRequest dict that `EventRequest.from_dict` accepts."""
+    return {
+        "event_type": "EventRequest",
+        "request_type": request_type,
+        "request_id": request_id,
+        "response_topic": "sessions/test/response",
+        "request": {**payload, "request_id": request_id},
+    }
+
+
+def _wire_batch(*inner: dict) -> dict:
+    """Wrap inner EventRequest dicts in the standard API envelope shape."""
+    return {"payload": {"event_type": "EventRequestBatch", "requests": list(inner)}}
+
+
+class TestEventRequestBatchSerialization:
+    def test_round_trip_preserves_inner_request_identity(self) -> None:
+        """from_dict on a serialized batch reconstructs every inner EventRequest payload."""
+        inner_a = _wire_event_request("CreateConnectionRequest", _connection_payload("DisplayText_1"), "req-a")
+        inner_b = _wire_event_request("CreateConnectionRequest", _connection_payload("SaveText_1"), "req-b")
+        envelope = _wire_batch(inner_a, inner_b)["payload"]
+
+        batch = EventRequestBatch.from_dict(envelope)
+
+        assert isinstance(batch, EventRequestBatch)
+        assert len(batch.requests) == _BATCH_SIZE_2
+        assert all(isinstance(req, EventRequest) for req in batch.requests)
+        assert batch.requests[0].request_id == "req-a"
+        assert batch.requests[1].request_id == "req-b"
+        assert isinstance(batch.requests[0].request, CreateConnectionRequest)
+        assert batch.requests[0].request.target_node_name == "DisplayText_1"
+
+    def test_dict_emits_event_type_and_inner_request_dicts(self) -> None:
+        """dict() / json() produce a transport-shaped envelope each consumer can parse."""
+        inner = EventRequest(
+            request=CreateConnectionRequest(
+                source_parameter_name="output",
+                target_parameter_name="text",
+                source_node_name="Agent_1",
+                target_node_name="DisplayText_1",
+            ),
+            request_id="req-a",
+            response_topic="sessions/test/response",
+        )
+        batch = EventRequestBatch(requests=[inner])
+
+        as_dict = batch.dict()
+
+        assert as_dict["event_type"] == "EventRequestBatch"
+        assert isinstance(as_dict["requests"], list)
+        assert as_dict["requests"][0]["event_type"] == "EventRequest"
+        assert as_dict["requests"][0]["request_type"] == "CreateConnectionRequest"
+        # json.loads(json.dumps(...)) sanity-checks that the dict is JSON-clean.
+        json.loads(json.dumps(as_dict, default=str))
+
+    def test_get_request_raises(self) -> None:
+        """get_request is meaningless on a batch; callers must inspect .requests."""
+        batch = EventRequestBatch(requests=[])
+
+        with pytest.raises(NotImplementedError):
+            batch.get_request()
+
+
+class TestProcessApiEventBatchDispatch:
+    @pytest.fixture
+    def event_manager(self) -> MagicMock:
+        """Mock EventManager so we can assert which inner requests landed on the queue."""
+        return MagicMock()
+
+    @pytest.fixture(autouse=True)
+    def _patched_griptape_nodes(self, event_manager: MagicMock) -> Iterator[None]:
+        """Swap `app.griptape_nodes.EventManager()` for a controllable mock."""
+        gtn = MagicMock()
+        gtn.EventManager.return_value = event_manager
+        with patch.object(app_module, "griptape_nodes", gtn):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_batch_with_normal_requests_queues_each_inner_request(self, event_manager: MagicMock) -> None:
+        """Non-skip-the-line inner requests are queued individually for `_process_event_queue`."""
+        envelope = _wire_batch(
+            _wire_event_request("CreateConnectionRequest", _connection_payload("DisplayText_1"), "1"),
+            _wire_event_request("CreateConnectionRequest", _connection_payload("SaveText_1"), "2"),
+            _wire_event_request("CreateConnectionRequest", _connection_payload("PrintText_1"), "3"),
+        )
+
+        await app_module._process_api_event(envelope)
+
+        assert event_manager.put_event.call_count == _BATCH_SIZE_3
+        queued = [call.args[0] for call in event_manager.put_event.call_args_list]
+        assert all(isinstance(ev, EventRequest) for ev in queued)
+        assert [ev.request_id for ev in queued] == ["1", "2", "3"]
+
+    @pytest.mark.asyncio
+    async def test_batch_with_skip_the_line_inner_requests_runs_inline(self, event_manager: MagicMock) -> None:
+        """Inner requests implementing SkipTheLineMixin bypass the queue and run immediately."""
+        envelope = _wire_batch(
+            _wire_event_request("CreateConnectionRequest", _connection_payload("DisplayText_1"), "q"),
+            _wire_event_request("SessionHeartbeatRequest", {}, "s"),
+        )
+
+        # Sanity-check that SessionHeartbeatRequest still represents skip-the-line behavior
+        # so this test stays meaningful as the registry evolves.
+        assert issubclass(SessionHeartbeatRequest, SkipTheLineMixin)
+
+        with patch.object(app_module, "_process_event_request", new=AsyncMock()) as inline:
+            await app_module._process_api_event(envelope)
+
+        # Skip-the-line went inline, normal request was queued.
+        assert inline.await_count == 1
+        assert inline.await_args is not None
+        inline_event = inline.await_args.args[0]
+        assert isinstance(inline_event, EventRequest)
+        assert inline_event.request_id == "s"
+
+        assert event_manager.put_event.call_count == 1
+        queued_event = event_manager.put_event.call_args.args[0]
+        assert queued_event.request_id == "q"
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_is_a_noop(self, event_manager: MagicMock) -> None:
+        """An empty batch is valid and dispatches nothing."""
+        await app_module._process_api_event({"payload": {"event_type": "EventRequestBatch", "requests": []}})
+
+        event_manager.put_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_individual_event_request_still_dispatches(self, event_manager: MagicMock) -> None:
+        """Existing non-batch EventRequest frames continue to flow through the same path."""
+        single = _wire_event_request("CreateConnectionRequest", _connection_payload("DisplayText_1"), "solo")
+
+        await app_module._process_api_event({"payload": single})
+
+        assert event_manager.put_event.call_count == 1
+        queued = event_manager.put_event.call_args.args[0]
+        assert isinstance(queued, EventRequest)
+        assert queued.request_id == "solo"


### PR DESCRIPTION
Closes #4516. Closes #4517. Supersedes #4525 and #4526.

Both #4516 and #4517 describe the same underlying problem at different endpoints: building a graph over MCP costs one round trip per primitive operation, which dominates wall-clock latency and burns context window on echoed envelope boilerplate. The first round of fixes (#4525 `CreateConnectionsRequest`, #4526 `CreateNodesRequest`) solved it endpoint-by-endpoint by introducing bulk request types with bulk handlers. That works, but it scales linearly with API surface: every future operation that someone wants to do in bulk (set parameter values, rename, delete, move, lock, etc.) needs its own bulk request, its own handler, its own MCP entry, and its own outcome model. Each of those is a place the singular and bulk paths can drift.

This PR pushes the fix down to the transport layer instead. `EventRequestBatch` is a wire-only envelope that carries a list of `EventRequest`s. On ingest, the websocket frame is unwrapped and each inner `EventRequest` is dispatched through the existing `_dispatch_event_request` path, preserving `SkipTheLineMixin` semantics and the normal queue. The engine never sees a batch, so no handlers change and no observers see different events. Identity and routing live on the inner requests, which keeps responses flowing back as ordinary per-request `EventResultSuccess`/`EventResultFailure` messages that the caller correlates by `request_id`.


A heterogeneous batch on the wire looks like this. One frame creates a node and connects it to an existing node, and the engine dispatches each inner request through the normal path.

```json
{
  "event_type": "EventRequestBatch",
  "requests": [
    {
      "event_type": "EventRequest",
      "request_type": "CreateNodeRequest",
      "request_id": "8b1c1f2e-1c4a-4f3a-9f1e-a1c2d3e4f501",
      "response_topic": "engine/responses/session-abc",
      "request": {
        "node_type": "TextNode",
        "specific_library_name": "griptape_nodes_library",
        "request_id": "8b1c1f2e-1c4a-4f3a-9f1e-a1c2d3e4f501"
      }
    },
    {
      "event_type": "EventRequest",
      "request_type": "CreateConnectionRequest",
      "request_id": "8b1c1f2e-1c4a-4f3a-9f1e-a1c2d3e4f502",
      "response_topic": "engine/responses/session-abc",
      "request": {
        "source_node_name": "TextNode_1",
        "source_parameter_name": "text",
        "target_node_name": "PromptNode_1",
        "target_parameter_name": "prompt",
        "request_id": "8b1c1f2e-1c4a-4f3a-9f1e-a1c2d3e4f502"
      }
    }
  ]
}
```

Responses come back as ordinary `EventResultSuccess` / `EventResultFailure` frames, one per inner `request_id`, in whatever order the engine finishes them.
