### PR TITLE
chore: bump v0.84.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes"
-version = "0.83.0"
+version = "0.84.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.83.0"
+version = "0.84.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.83`.

Cherry-picked commit: f9b4ebf63202d60cff535bf16b423dc9e7d09fd6