### PR TITLE
Do not set upstream branch during version/publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ version/publish: ## Create and push git tags.
 	@git tag v$$(make version/get)
 	@git tag stable -f
 	@git push -f --tags
-	@git push -u origin HEAD:refs/heads/release/v$$(make version/get | awk -F. '{print $$1 "." $$2}')
+	@git push origin HEAD:refs/heads/release/v$$(make version/get | awk -F. '{print $$1 "." $$2}')
 	
 .PHONY: run
 run: ## Run the project.


### PR DESCRIPTION
`make version/publish` would set your upstream branch to origin/release/v0.X. This was unexpected as cutting a release branch does not 'need' to change the upstream branch. There is no effect on the release process/performance of version/publish.

This unknown upstream branch change led me to accidently running `make version/minor` with the release branch upstream, not `main` as I expected.