### PR TITLE
refactor: rename PyPI distribution to `griptape-nodes-engine`

### DIFF
--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -3933,13 +3933,13 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "griptape-nodes",
+    "griptape-nodes-engine",
     "requests",
     # Add other dependencies
 ]
 
 [tool.uv.sources]
-griptape-nodes = { git = "https://github.com/griptape-ai/griptape-nodes", rev="latest"}
+griptape-nodes-engine = { git = "https://github.com/griptape-ai/griptape-nodes", rev="latest"}
 
 [tool.hatch.build.targets.wheel]
 packages = ["library_name"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "griptape-nodes"
+name = "griptape-nodes-engine"
 version = "0.84.0"
 description = "Add your description here"
 readme = "README.md"
@@ -71,12 +71,16 @@ test = [
 ]
 
 [project.scripts]
+# TODO: remove these entries when the CLI moves to the griptape-nodes-app repo. https://github.com/griptape-ai/griptape-nodes-app/issues/7
 griptape-nodes = "griptape_nodes:main"
 gtn = "griptape_nodes:main"
 
 [build-system]
 requires = ["uv_build>=0.7.2,<0.12"]
 build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "griptape_nodes"
 
 [tool.uv.sources]
 griptape-cloud-client = { git = "https://github.com/griptape-ai/griptape-cloud-python-client", rev = "main" }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-"""Top level src package."""

--- a/src/griptape_nodes/cli/shared.py
+++ b/src/griptape_nodes/cli/shared.py
@@ -36,7 +36,7 @@ ENV_FILE = CONFIG_DIR / ".env"
 CONFIG_FILE = CONFIG_DIR / "griptape_nodes_config.json"
 
 # URLs and constants
-PACKAGE_NAME = "griptape-nodes"
+PACKAGE_NAME = "griptape-nodes-engine"
 NODES_APP_URL = "https://nodes.griptape.ai"
 NODES_TARBALL_URL = "https://github.com/griptape-ai/griptape-nodes/archive/refs/tags/{tag}.tar.gz"
 GT_CLOUD_BASE_URL = os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -268,7 +268,7 @@ class WorkflowPackager:
 
     @staticmethod
     def find_griptape_nodes_distribution() -> importlib.metadata.Distribution | None:
-        """Find the griptape_nodes distribution from the current executable's venv."""
+        """Find the griptape-nodes-engine distribution from the current executable's venv."""
         import sys
 
         exe_path = Path(sys.executable)
@@ -278,21 +278,21 @@ class WorkflowPackager:
         if not site_packages.exists():
             logger.info("Venv site-packages not found at %s, falling back to default lookup", site_packages)
             try:
-                return importlib.metadata.distribution("griptape_nodes")
+                return importlib.metadata.distribution("griptape-nodes-engine")
             except importlib.metadata.PackageNotFoundError:
                 return None
 
         for dist in importlib.metadata.distributions(path=[str(site_packages)]):
-            if dist.metadata["Name"] == "griptape-nodes":
+            if dist.metadata["Name"] == "griptape-nodes-engine":
                 return dist
 
         try:
-            return importlib.metadata.distribution("griptape_nodes")
+            return importlib.metadata.distribution("griptape-nodes-engine")
         except importlib.metadata.PackageNotFoundError:
             return None
 
     def get_install_source(self) -> tuple[Literal["git", "file", "pypi"], str | None]:  # noqa: PLR0911
-        """Detect whether griptape-nodes was installed from git, file, or pypi."""
+        """Detect whether griptape-nodes-engine was installed from git, file, or pypi."""
         dist = self.find_griptape_nodes_distribution()
         if dist is None:
             return "pypi", None
@@ -337,7 +337,7 @@ class WorkflowPackager:
             engine_version = commit_id
 
         dependencies: list[str] = [
-            f"griptape-nodes @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}",
+            f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}",
         ]
 
         for library_ref in workflow.metadata.node_libraries_referenced:

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 console = Console()
 
-engine_version = importlib.metadata.version("griptape_nodes")
+engine_version = importlib.metadata.version("griptape-nodes-engine")
 
 
 def get_current_version() -> str:
@@ -44,7 +44,7 @@ def get_install_source() -> tuple[Literal["git", "file", "pypi", "unknown"], str
             (
                 d
                 for d in importlib.metadata.distributions(path=[str(code_site_packages)])
-                if d.metadata.get("Name", "").lower() in ("griptape-nodes", "griptape_nodes")
+                if d.metadata.get("Name", "").lower() in ("griptape-nodes-engine", "griptape_nodes_engine")
             ),
             None,
         )
@@ -53,7 +53,7 @@ def get_install_source() -> tuple[Literal["git", "file", "pypi", "unknown"], str
     # rather than site-packages, so the dist-info won't be found above.
     if dist is None:
         try:
-            dist = importlib.metadata.distribution("griptape_nodes")
+            dist = importlib.metadata.distribution("griptape-nodes-engine")
         except importlib.metadata.PackageNotFoundError:
             return "unknown", None
 

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "griptape-nodes"
+name = "griptape-nodes-engine"
 version = "0.84.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
Renames the PyPI distribution from `griptape-nodes` to `griptape-nodes-engine` so the `griptape-nodes` name on PyPI can be claimed by the closed-source application repo. The `griptape_nodes` import path is unchanged and stays a stable public API, so existing workflow files and library `pyproject.toml` files that import from `griptape_nodes` keep working.

Closes griptape-ai/griptape-nodes-app#7.

The rename only touches places that refer to this project as a *library* / PyPI distribution: the `[project] name`, internal `importlib.metadata` lookups in `version_utils.py` and `workflow_packager.py`, the unused `PACKAGE_NAME` constant, the workflow packager's pinned `griptape-nodes @ git+...` dependency string, and the example `pyproject.toml` snippet in the node-developer guide. References that describe this project as an *executable application you launch* (`uv tool install griptape-nodes`, `griptape-nodes` / `gtn` CLI commands, the Docker `CMD`, the `[project.scripts]` entries, install scripts, FAQ install/uninstall instructions) are left alone for now since the `griptape-nodes` CLI binary will still be produced from this repo until the app repo takes over. A TODO next to `[project.scripts]` references the tracking issue.

The uv build backend's default `module-name` is derived from the distribution name, so renaming the distribution would have made it look for `src/griptape_nodes_engine/`. `[tool.uv.build-backend] module-name = "griptape_nodes"` pins the module path back to the actual package directory. Setting that explicitly turned out to be stricter about layout than the auto-detected default and rejected a stray `src/__init__.py` that was making `src` itself look like a package; that file was unused (no `from src` / `import src` anywhere), so it's gone.

Verified `uv build` produces `griptape_nodes_engine-0.84.0-py3-none-any.whl` containing a top-level `griptape_nodes/` directory, `importlib.metadata.version("griptape-nodes-engine")` resolves, the `griptape-nodes` / `gtn` console scripts still launch, `make check` is clean, and the unit suite passes.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4549.org.readthedocs.build/en/4549/

<!-- readthedocs-preview griptape-nodes end -->