### PR TITLE
chore: bump v0.84.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-engine"
-version = "0.84.0"
+version = "0.84.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.84.0"
+version = "0.84.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.84`.

Cherry-picked commit: a29342714550219e6025b57693af5286a82a6b8b