### PR TITLE
fix(libraries): recreate broken library venvs instead of reusing them

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -209,7 +209,7 @@ from griptape_nodes.utils.library_utils import (
     filter_old_xdg_library_paths,
     is_monorepo,
 )
-from griptape_nodes.utils.uv_utils import find_uv_bin
+from griptape_nodes.utils.uv_utils import find_uv_bin, is_venv_functional, venv_python_path
 from griptape_nodes.utils.version_utils import get_complete_version_string
 
 if TYPE_CHECKING:
@@ -1925,7 +1925,7 @@ class LibraryManager:
 
             # Check if a functional venv already exists; a broken directory will be
             # recreated by _init_library_venv, in which case dependencies must be installed.
-            venv_already_exists = self._is_library_venv_functional(venv_path)
+            venv_already_exists = is_venv_functional(venv_path)
 
             # Only install dependencies if conditions are met
             try:
@@ -1991,30 +1991,6 @@ class LibraryManager:
             result_details=f"Successfully registered library from requirement specifier: {request.requirement_specifier}",
         )
 
-    @staticmethod
-    def _library_venv_python_path(library_venv_path: Path) -> Path:
-        """Return the expected Python executable path inside a library venv."""
-        if OSManager.is_windows():
-            return library_venv_path / "Scripts" / "python.exe"
-        return library_venv_path / "bin" / "python"
-
-    @classmethod
-    def _is_library_venv_functional(cls, library_venv_path: Path) -> bool:
-        """Check whether a venv directory contains a usable virtual environment.
-
-        A venv is considered functional only if its directory exists, contains a
-        ``pyvenv.cfg`` marker, and has a Python executable at the expected
-        platform-specific location. The Python executable's target is not followed,
-        because uv's own venv check works the same way: a missing or unresolvable
-        interpreter on disk causes ``uv pip install --python <venv>/bin/python`` to
-        fail with ``No virtual environment or system Python installation found``.
-        """
-        if not library_venv_path.is_dir():
-            return False
-        if not (library_venv_path / "pyvenv.cfg").is_file():
-            return False
-        return cls._library_venv_python_path(library_venv_path).exists()
-
     async def _init_library_venv(self, library_venv_path: Path) -> Path:
         """Initialize a virtual environment for the library.
 
@@ -2034,9 +2010,9 @@ class LibraryManager:
         """
         python_version = platform.python_version()
 
-        if self._is_library_venv_functional(library_venv_path):
+        if is_venv_functional(library_venv_path):
             logger.debug("Reusing existing virtual environment at %s", library_venv_path)
-            return self._library_venv_python_path(library_venv_path)
+            return venv_python_path(library_venv_path)
 
         if await anyio.Path(library_venv_path).exists():
             logger.warning(
@@ -2074,7 +2050,7 @@ class LibraryManager:
             raise RuntimeError(msg) from e
         logger.debug("Created virtual environment at %s", library_venv_path)
 
-        return self._library_venv_python_path(library_venv_path)
+        return venv_python_path(library_venv_path)
 
     def _check_library_requirements(
         self, requirements: dict[str, Any], library_name: str

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -1922,8 +1923,9 @@ class LibraryManager:
             # Determine venv path for dependency installation
             venv_path = self._get_library_venv_path(package_name, None)
 
-            # Check if venv already exists before initialization
-            venv_already_exists = await anyio.Path(venv_path).exists()
+            # Check if a functional venv already exists; a broken directory will be
+            # recreated by _init_library_venv, in which case dependencies must be installed.
+            venv_already_exists = self._is_library_venv_functional(venv_path)
 
             # Only install dependencies if conditions are met
             try:
@@ -1989,10 +1991,37 @@ class LibraryManager:
             result_details=f"Successfully registered library from requirement specifier: {request.requirement_specifier}",
         )
 
+    @staticmethod
+    def _library_venv_python_path(library_venv_path: Path) -> Path:
+        """Return the expected Python executable path inside a library venv."""
+        if OSManager.is_windows():
+            return library_venv_path / "Scripts" / "python.exe"
+        return library_venv_path / "bin" / "python"
+
+    @classmethod
+    def _is_library_venv_functional(cls, library_venv_path: Path) -> bool:
+        """Check whether a venv directory contains a usable virtual environment.
+
+        A venv is considered functional only if its directory exists, contains a
+        ``pyvenv.cfg`` marker, and has a Python executable at the expected
+        platform-specific location. The Python executable's target is not followed,
+        because uv's own venv check works the same way: a missing or unresolvable
+        interpreter on disk causes ``uv pip install --python <venv>/bin/python`` to
+        fail with ``No virtual environment or system Python installation found``.
+        """
+        if not library_venv_path.is_dir():
+            return False
+        if not (library_venv_path / "pyvenv.cfg").is_file():
+            return False
+        return cls._library_venv_python_path(library_venv_path).exists()
+
     async def _init_library_venv(self, library_venv_path: Path) -> Path:
         """Initialize a virtual environment for the library.
 
-        If the virtual environment already exists, it will not be recreated.
+        If a functional virtual environment already exists at the path, it is reused.
+        If a directory exists at the path but is not a functional venv (e.g. missing
+        ``pyvenv.cfg`` or Python executable, or referencing a Python interpreter that
+        has since been removed), it is deleted and recreated.
 
         Args:
             library_venv_path: Path to the virtual environment directory
@@ -2003,47 +2032,49 @@ class LibraryManager:
         Raises:
             RuntimeError: If the virtual environment cannot be created.
         """
-        # Create a virtual environment for the library
         python_version = platform.python_version()
 
+        if self._is_library_venv_functional(library_venv_path):
+            logger.debug("Reusing existing virtual environment at %s", library_venv_path)
+            return self._library_venv_python_path(library_venv_path)
+
         if await anyio.Path(library_venv_path).exists():
-            logger.debug("Virtual environment already exists at %s", library_venv_path)
-        else:
-            # Check disk space before creating virtual environment
-            config_manager = GriptapeNodes.ConfigManager()
-            min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
-            if not OSManager.check_available_disk_space(library_venv_path.parent, min_space_gb):
-                error_msg = OSManager.format_disk_space_error(library_venv_path.parent)
-                logger.error(
-                    "Attempted to create virtual environment (requires %.1f GB). Failed: %s", min_space_gb, error_msg
-                )
-                error_message = (
-                    f"Disk space error creating virtual environment (requires {min_space_gb} GB): {error_msg}"
-                )
-                raise RuntimeError(error_message)
-
+            logger.warning(
+                "Existing path at %s is not a functional virtual environment; recreating it", library_venv_path
+            )
             try:
-                uv_path = find_uv_bin()
-                logger.info("Creating virtual environment at %s with Python %s", library_venv_path, python_version)
-                is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
-                await subprocess_run(
-                    [uv_path, "venv", str(library_venv_path), "--python", python_version],
-                    check=True,
-                    capture_output=not is_debug,
-                    text=True,
-                )
-            except subprocess.CalledProcessError as e:
-                msg = f"Failed to create virtual environment at {library_venv_path} with Python {python_version}: return code={e.returncode}, stdout={e.stdout}, stderr={e.stderr}"
+                await asyncio.to_thread(shutil.rmtree, library_venv_path, onexc=OSManager.remove_readonly)
+            except OSError as e:
+                msg = f"Failed to remove broken virtual environment at {library_venv_path}: {e}"
                 raise RuntimeError(msg) from e
-            logger.debug("Created virtual environment at %s", library_venv_path)
 
-        # Grab the python executable from the virtual environment so that we can pip install there
-        if OSManager.is_windows():
-            library_venv_python_path = library_venv_path / "Scripts" / "python.exe"
-        else:
-            library_venv_python_path = library_venv_path / "bin" / "python"
+        # Check disk space before creating virtual environment
+        config_manager = GriptapeNodes.ConfigManager()
+        min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
+        if not OSManager.check_available_disk_space(library_venv_path.parent, min_space_gb):
+            error_msg = OSManager.format_disk_space_error(library_venv_path.parent)
+            logger.error(
+                "Attempted to create virtual environment (requires %.1f GB). Failed: %s", min_space_gb, error_msg
+            )
+            error_message = f"Disk space error creating virtual environment (requires {min_space_gb} GB): {error_msg}"
+            raise RuntimeError(error_message)
 
-        return library_venv_python_path
+        try:
+            uv_path = find_uv_bin()
+            logger.info("Creating virtual environment at %s with Python %s", library_venv_path, python_version)
+            is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
+            await subprocess_run(
+                [uv_path, "venv", str(library_venv_path), "--python", python_version],
+                check=True,
+                capture_output=not is_debug,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            msg = f"Failed to create virtual environment at {library_venv_path} with Python {python_version}: return code={e.returncode}, stdout={e.stdout}, stderr={e.stderr}"
+            raise RuntimeError(msg) from e
+        logger.debug("Created virtual environment at %s", library_venv_path)
+
+        return self._library_venv_python_path(library_venv_path)
 
     def _check_library_requirements(
         self, requirements: dict[str, Any], library_name: str

--- a/src/griptape_nodes/utils/uv_utils.py
+++ b/src/griptape_nodes/utils/uv_utils.py
@@ -1,5 +1,8 @@
 """Utilities for working with the UV package manager."""
 
+import sys
+from pathlib import Path
+
 import uv
 from xdg_base_dirs import xdg_data_home
 
@@ -16,3 +19,27 @@ def find_uv_bin() -> str:
         return str(dedicated_uv_path)
 
     return uv.find_uv_bin()
+
+
+def venv_python_path(venv_path: Path) -> Path:
+    """Return the expected Python executable path inside a virtual environment."""
+    if sys.platform.startswith("win"):
+        return venv_path / "Scripts" / "python.exe"
+    return venv_path / "bin" / "python"
+
+
+def is_venv_functional(venv_path: Path) -> bool:
+    """Check whether a directory contains a usable virtual environment.
+
+    A venv is considered functional only if its directory exists, contains a
+    ``pyvenv.cfg`` marker, and has a Python executable at the expected
+    platform-specific location. The Python executable's target is not followed,
+    because uv's own venv check works the same way: a missing or unresolvable
+    interpreter on disk causes ``uv pip install --python <venv>/bin/python`` to
+    fail with ``No virtual environment or system Python installation found``.
+    """
+    if not venv_path.is_dir():
+        return False
+    if not (venv_path / "pyvenv.cfg").is_file():
+        return False
+    return venv_python_path(venv_path).exists()

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -699,6 +699,159 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert isinstance(result, InstallLibraryDependenciesResultFailure)
 
 
+def _fake_config_value(key: str, **_: object) -> object:
+    """Return realistic values for config keys touched by venv initialization."""
+    if key == "log_level":
+        return "INFO"
+    if key == "minimum_disk_space_gb_libraries":
+        return 5.0
+    return None
+
+
+class TestLibraryManagerVenvHealth:
+    """Tests for venv functional checks and broken-venv recovery in _init_library_venv."""
+
+    @staticmethod
+    def _make_functional_venv(venv_path: Path) -> Path:
+        """Create a directory layout that mimics a working venv on the current platform."""
+        venv_path.mkdir(parents=True, exist_ok=True)
+        (venv_path / "pyvenv.cfg").write_text("home = /fake\n")
+        if sys.platform == "win32":
+            python_dir = venv_path / "Scripts"
+            python_path = python_dir / "python.exe"
+        else:
+            python_dir = venv_path / "bin"
+            python_path = python_dir / "python"
+        python_dir.mkdir(parents=True, exist_ok=True)
+        python_path.write_text("")
+        return python_path
+
+    def test_is_functional_returns_false_when_directory_missing(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        assert mgr._is_library_venv_functional(tmp_path / "nope") is False
+
+    def test_is_functional_returns_false_when_pyvenv_cfg_missing(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        self._make_functional_venv(venv_path)
+        (venv_path / "pyvenv.cfg").unlink()
+
+        assert mgr._is_library_venv_functional(venv_path) is False
+
+    def test_is_functional_returns_false_when_python_executable_missing(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        python_path = self._make_functional_venv(venv_path)
+        python_path.unlink()
+
+        assert mgr._is_library_venv_functional(venv_path) is False
+
+    def test_is_functional_returns_true_for_complete_layout(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        self._make_functional_venv(venv_path)
+
+        assert mgr._is_library_venv_functional(venv_path) is True
+
+    @pytest.mark.asyncio
+    async def test_init_reuses_functional_venv_without_running_uv(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        expected_python = self._make_functional_venv(venv_path)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                new_callable=AsyncMock,
+            ) as mock_subprocess,
+            patch("griptape_nodes.retained_mode.managers.library_manager.find_uv_bin") as mock_find_uv,
+        ):
+            python_path = await mgr._init_library_venv(venv_path)
+
+        assert python_path == expected_python
+        mock_subprocess.assert_not_called()
+        mock_find_uv.assert_not_called()
+        assert (venv_path / "pyvenv.cfg").exists()
+
+    @pytest.mark.asyncio
+    async def test_init_recreates_broken_venv(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        """A directory at the venv path that is missing the python executable must be recreated."""
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        venv_path.mkdir()
+        (venv_path / "pyvenv.cfg").write_text("home = /fake\n")
+        # Leave a stray file behind to prove the directory was wiped
+        (venv_path / "stray.txt").write_text("old")
+
+        recreated_python_path: dict[str, Path] = {}
+
+        async def fake_subprocess_run(args: list[str], **_: object) -> MagicMock:
+            recreated_venv = Path(args[2])
+            recreated_python_path["path"] = self._make_functional_venv(recreated_venv)
+            return MagicMock()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                side_effect=fake_subprocess_run,
+            ) as mock_subprocess,
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.find_uv_bin",
+                return_value="/fake/uv",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            python_path = await mgr._init_library_venv(venv_path)
+
+        mock_subprocess.assert_called_once()
+        assert python_path == recreated_python_path["path"]
+        assert not (venv_path / "stray.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_init_creates_venv_when_directory_absent(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+
+        async def fake_subprocess_run(args: list[str], **_: object) -> MagicMock:
+            self._make_functional_venv(Path(args[2]))
+            return MagicMock()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                side_effect=fake_subprocess_run,
+            ) as mock_subprocess,
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.find_uv_bin",
+                return_value="/fake/uv",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            python_path = await mgr._init_library_venv(venv_path)
+
+        mock_subprocess.assert_called_once()
+        assert python_path.exists()
+        assert (venv_path / "pyvenv.cfg").exists()
+
+
 class TestListRegisteredLibraries:
     """Test the on_list_registered_libraries_request functionality in LibraryManager."""
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -709,7 +709,7 @@ def _fake_config_value(key: str, **_: object) -> object:
 
 
 class TestLibraryManagerVenvHealth:
-    """Tests for venv functional checks and broken-venv recovery in _init_library_venv."""
+    """Tests for broken-venv recovery in _init_library_venv."""
 
     @staticmethod
     def _make_functional_venv(venv_path: Path) -> Path:
@@ -725,41 +725,6 @@ class TestLibraryManagerVenvHealth:
         python_dir.mkdir(parents=True, exist_ok=True)
         python_path.write_text("")
         return python_path
-
-    def test_is_functional_returns_false_when_directory_missing(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        mgr = griptape_nodes.LibraryManager()
-        assert mgr._is_library_venv_functional(tmp_path / "nope") is False
-
-    def test_is_functional_returns_false_when_pyvenv_cfg_missing(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        mgr = griptape_nodes.LibraryManager()
-        venv_path = tmp_path / ".venv"
-        self._make_functional_venv(venv_path)
-        (venv_path / "pyvenv.cfg").unlink()
-
-        assert mgr._is_library_venv_functional(venv_path) is False
-
-    def test_is_functional_returns_false_when_python_executable_missing(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        mgr = griptape_nodes.LibraryManager()
-        venv_path = tmp_path / ".venv"
-        python_path = self._make_functional_venv(venv_path)
-        python_path.unlink()
-
-        assert mgr._is_library_venv_functional(venv_path) is False
-
-    def test_is_functional_returns_true_for_complete_layout(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        mgr = griptape_nodes.LibraryManager()
-        venv_path = tmp_path / ".venv"
-        self._make_functional_venv(venv_path)
-
-        assert mgr._is_library_venv_functional(venv_path) is True
 
     @pytest.mark.asyncio
     async def test_init_reuses_functional_venv_without_running_uv(

--- a/tests/unit/utils/test_uv_utils.py
+++ b/tests/unit/utils/test_uv_utils.py
@@ -1,13 +1,14 @@
 """Tests for uv_utils module."""
 
 import platform
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
-from griptape_nodes.utils.uv_utils import find_uv_bin
+from griptape_nodes.utils.uv_utils import find_uv_bin, is_venv_functional, venv_python_path
 
 
 @pytest.mark.skipif(
@@ -111,3 +112,63 @@ class TestUvUtils:
             # Should raise the exception from the system UV lookup
             with pytest.raises(RuntimeError, match="UV not found"):
                 find_uv_bin()
+
+
+def _make_functional_venv(venv_path: Path) -> Path:
+    """Create a directory layout that mimics a working venv on the current platform."""
+    venv_path.mkdir(parents=True, exist_ok=True)
+    (venv_path / "pyvenv.cfg").write_text("home = /fake\n")
+    if sys.platform == "win32":
+        python_dir = venv_path / "Scripts"
+        python_path = python_dir / "python.exe"
+    else:
+        python_dir = venv_path / "bin"
+        python_path = python_dir / "python"
+    python_dir.mkdir(parents=True, exist_ok=True)
+    python_path.write_text("")
+    return python_path
+
+
+class TestVenvPythonPath:
+    """Test the platform-specific Python executable path resolution."""
+
+    def test_returns_bin_python_on_posix(self) -> None:
+        with patch("griptape_nodes.utils.uv_utils.sys.platform", "linux"):
+            assert venv_python_path(Path("/v")) == Path("/v/bin/python")
+
+    def test_returns_scripts_python_exe_on_windows(self) -> None:
+        with patch("griptape_nodes.utils.uv_utils.sys.platform", "win32"):
+            assert venv_python_path(Path("/v")) == Path("/v/Scripts/python.exe")
+
+
+class TestIsVenvFunctional:
+    """Test the venv-layout health check."""
+
+    def test_returns_false_when_directory_missing(self, tmp_path: Path) -> None:
+        assert is_venv_functional(tmp_path / "nope") is False
+
+    def test_returns_false_when_path_is_a_file(self, tmp_path: Path) -> None:
+        venv_path = tmp_path / ".venv"
+        venv_path.write_text("not a venv")
+
+        assert is_venv_functional(venv_path) is False
+
+    def test_returns_false_when_pyvenv_cfg_missing(self, tmp_path: Path) -> None:
+        venv_path = tmp_path / ".venv"
+        _make_functional_venv(venv_path)
+        (venv_path / "pyvenv.cfg").unlink()
+
+        assert is_venv_functional(venv_path) is False
+
+    def test_returns_false_when_python_executable_missing(self, tmp_path: Path) -> None:
+        venv_path = tmp_path / ".venv"
+        python_path = _make_functional_venv(venv_path)
+        python_path.unlink()
+
+        assert is_venv_functional(venv_path) is False
+
+    def test_returns_true_for_complete_layout(self, tmp_path: Path) -> None:
+        venv_path = tmp_path / ".venv"
+        _make_functional_venv(venv_path)
+
+        assert is_venv_functional(venv_path) is True


### PR DESCRIPTION
Closes #4564.

`LibraryManager._init_library_venv` decided whether to (re)create a library's venv based purely on whether the `.venv` directory existed. Any leftover directory was treated as a working venv, even when it was missing `pyvenv.cfg`, missing `bin/python`, or pointing at a Python interpreter uv had since removed. The engine would then run `uv pip install --python <venv>/bin/python ...`, uv would refuse with `No virtual environment or system Python installation found`, and the library would stall before reaching `LOADED`. From the user's perspective the library showed up as `GOOD` in the fitness report (which only validates schema) but its nodes never appeared, with no obvious indication that the venv was the culprit.

The fix introduces an explicit `_is_library_venv_functional` check that requires the directory, `pyvenv.cfg`, and the platform-specific Python executable to all exist. `_init_library_venv` reuses the venv only when that check passes; otherwise it removes whatever is at the path (using the existing Windows-aware `OSManager.remove_readonly` hook) and recreates it from scratch. The requirement-specifier registration path uses the same functional check to decide whether dependencies need to be (re)installed, so a recreated venv always gets its dependencies installed instead of being left empty.

Verified manually by deleting `.venv/bin/python*` from a real third-party library that exhibited this exact failure: with the patch the engine logs `is not a functional virtual environment; recreating it`, rebuilds the venv, installs dependencies, and the library's nodes load. New `TestLibraryManagerVenvHealth` covers the helpers and the reuse / recreate / fresh-create branches of `_init_library_venv`.