### PR TITLE
test(worker): patch heartbeat_startup_grace_s in timeout test

### DIFF
--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -133,6 +133,7 @@ class TestWorkerHeartbeatMonitor:
         """Monitor raises RuntimeError when no heartbeat arrives within the timeout."""
         monkeypatch.setattr(worker_manager, "heartbeat_interval_s", 0.01)
         monkeypatch.setattr(worker_manager, "heartbeat_timeout_s", 0.0)
+        monkeypatch.setattr(worker_manager, "heartbeat_startup_grace_s", 0.0)
         worker_manager._worker_heartbeat_last_received_at = 0.0
 
         with pytest.raises(RuntimeError, match="Orchestrator heartbeat lost"):


### PR DESCRIPTION
`make test/unit` was hanging at the end for ~2 minutes. `TestWorkerHeartbeatMonitor::test_raises_after_timeout` alone took 120.00s while every other test in the suite finished in well under a second, so under `-n auto` thirteen of fourteen xdist workers sat idle waiting on this single test bucket.

The test sets `heartbeat_timeout_s=0.0` and `_worker_heartbeat_last_received_at=0.0` expecting the timeout branch to fire on the first loop iteration. But `worker_heartbeat_monitor` seeds `_worker_heartbeat_last_received_at = time.monotonic() + heartbeat_startup_grace_s` on entry, which overwrites the test's `0.0` and pushes the deadline 120s (the production default for `heartbeat_startup_grace_s`) into the future. `elapsed` then stays negative until 120 wall-clock seconds pass, at which point the `RuntimeError` finally fires and the test passes, having effectively timed the production startup grace rather than the timeout logic.

Patching `heartbeat_startup_grace_s` to `0.0` alongside the other two values keeps the seed at `time.monotonic()` so `elapsed` is positive immediately. Full unit suite drops from 122.95s to 4.36s.