### PR TITLE
feat: support disabling libraries in libraries_to_register

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -33,10 +33,13 @@ class DiscoveredLibrary(NamedTuple):
     Attributes:
         path: Absolute path to the library JSON file or sandbox directory
         is_sandbox: True if this is a sandbox library (user-created nodes in workspace), False for regular libraries
+        enabled: False when the entry is present in libraries_to_register but explicitly disabled.
+            Disabled libraries are still discovered (so they appear in status output) but are not loaded.
     """
 
     path: Path
     is_sandbox: bool
+    enabled: bool = True
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -189,6 +189,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
+    LibraryRegistration,
 )
 from griptape_nodes.utils.async_utils import subprocess_run
 from griptape_nodes.utils.dict_utils import merge_dicts, normalize_secrets_to_register
@@ -214,8 +215,10 @@ from griptape_nodes.utils.git_utils import (
 from griptape_nodes.utils.library_utils import (
     LIBRARY_GIT_URLS,
     clone_and_get_library_version,
+    extract_library_path,
     filter_old_xdg_library_paths,
     is_monorepo,
+    normalize_library_registrations,
 )
 from griptape_nodes.utils.uv_utils import find_uv_bin, is_venv_functional, venv_python_path
 from griptape_nodes.utils.version_utils import get_complete_version_string
@@ -262,58 +265,6 @@ class LibraryUpdateResult(NamedTuple):
     old_version: str
     new_version: str
     result: ResultPayload
-
-
-class _RegisterEntry(NamedTuple):
-    """A normalized libraries_to_register entry.
-
-    The config field accepts either a bare path string or an object with `path`
-    and `enabled` fields. Both shapes are normalized to this tuple before consumption.
-    """
-
-    path: str
-    enabled: bool
-
-
-def _entry_path(entry: Any) -> str:
-    """Extract the path string from a libraries_to_register entry (str or dict).
-
-    Returns an empty string for entries with no usable path.
-    """
-    if isinstance(entry, str):
-        return entry
-    if isinstance(entry, dict):
-        path = entry.get("path")
-        return path if isinstance(path, str) else ""
-    path_attr = getattr(entry, "path", None)
-    return path_attr if isinstance(path_attr, str) else ""
-
-
-def _normalize_register_entries(raw: list[Any]) -> list[_RegisterEntry]:
-    """Normalize a libraries_to_register config list into typed entries.
-
-    Bare strings become enabled entries. Dict-shaped entries honor their `enabled`
-    field (defaulting to True). Entries without a usable path are skipped with a warning.
-    """
-    entries: list[_RegisterEntry] = []
-    for item in raw:
-        if isinstance(item, str):
-            if item:
-                entries.append(_RegisterEntry(path=item, enabled=True))
-        elif isinstance(item, dict):
-            path = item.get("path")
-            if not isinstance(path, str) or not path:
-                logger.warning("Skipping libraries_to_register entry without a 'path': %r", item)
-                continue
-            enabled = item.get("enabled", True)
-            entries.append(_RegisterEntry(path=path, enabled=bool(enabled)))
-        else:
-            logger.warning(
-                "Skipping libraries_to_register entry of unexpected type %s: %r",
-                type(item).__name__,
-                item,
-            )
-    return entries
 
 
 class LibraryManager:
@@ -3799,7 +3750,7 @@ class LibraryManager:
             libraries_to_register_category = [
                 library
                 for library in libraries_to_register_category
-                if _entry_path(library).lower() not in paths_to_remove
+                if extract_library_path(library).lower() not in paths_to_remove
             ]
             config_mgr.set_config_value(config_category, libraries_to_register_category)
 
@@ -3829,7 +3780,7 @@ class LibraryManager:
         # surviving entry's original shape (so disabled entries keep their `enabled: false`).
         path_to_entry: dict[str, Any] = {}
         for entry in libraries_to_register:
-            entry_path = _entry_path(entry)
+            entry_path = extract_library_path(entry)
             if entry_path:
                 path_to_entry[entry_path] = entry
 
@@ -4215,18 +4166,18 @@ class LibraryManager:
 
         return LoadLibrariesResultSuccess(result_details=ResultDetails(message=message, level=logging.INFO))
 
-    def _discover_library_files(self) -> list[_RegisterEntry]:
+    def _discover_library_files(self) -> list[LibraryRegistration]:
         """Discover library JSON files from config and workspace recursively.
 
         Returns:
-            List of register entries (path string + enabled flag) in the order they appear
-            in config. Directory entries expand to one entry per discovered library file,
-            inheriting the directory entry's enabled flag.
+            List of LibraryRegistration entries (path + enabled flag) in the order they
+            appear in config. Directory entries expand to one entry per discovered library
+            file, inheriting the directory entry's enabled flag.
         """
         config_mgr = GriptapeNodes.ConfigManager()
         user_libraries_section = LIBRARIES_TO_REGISTER_KEY
 
-        discovered_entries: list[_RegisterEntry] = []
+        discovered_entries: list[LibraryRegistration] = []
         seen_paths: set[Path] = set()
 
         def process_path(path: Path, *, enabled: bool) -> None:
@@ -4236,14 +4187,14 @@ class LibraryManager:
                 for lib_path in find_files_recursive(path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN):
                     if lib_path not in seen_paths:
                         seen_paths.add(lib_path)
-                        discovered_entries.append(_RegisterEntry(path=str(lib_path), enabled=enabled))
+                        discovered_entries.append(LibraryRegistration(path=str(lib_path), enabled=enabled))
             elif path.suffix == ".json" and path not in seen_paths:
                 seen_paths.add(path)
-                discovered_entries.append(_RegisterEntry(path=str(path), enabled=enabled))
+                discovered_entries.append(LibraryRegistration(path=str(path), enabled=enabled))
 
         # Add from config
         config_libraries = config_mgr.get_config_value(user_libraries_section, default=[])
-        for entry in _normalize_register_entries(config_libraries):
+        for entry in normalize_library_registrations(config_libraries):
             # TODO: Update to check on project manager for workspace path. https://github.com/griptape-ai/griptape-nodes/issues/4396
             library_path = resolve_workspace_path(Path(entry.path), Path(config_mgr.workspace_path))
             if library_path.exists():
@@ -4748,7 +4699,7 @@ class LibraryManager:
         # Add library JSON file path to config so it's registered on future startups
         libraries_to_register = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
         library_json_str = str(library_json_path)
-        existing_paths = {_entry_path(entry) for entry in libraries_to_register}
+        existing_paths = {extract_library_path(entry) for entry in libraries_to_register}
         if library_json_str not in existing_paths:
             libraries_to_register.append(library_json_str)
             config_mgr.set_config_value(LIBRARIES_TO_REGISTER_KEY, libraries_to_register)
@@ -4856,7 +4807,7 @@ class LibraryManager:
         download_config = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
         register_config = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
         # Disabled entries are still synced; disabling only affects loading.
-        git_urls_from_register = [path for entry in register_config if is_git_url(path := _entry_path(entry))]
+        git_urls_from_register = [path for entry in register_config if is_git_url(path := extract_library_path(entry))]
 
         # Combine and deduplicate
         all_git_urls = list(set(download_config + git_urls_from_register))

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -264,6 +264,58 @@ class LibraryUpdateResult(NamedTuple):
     result: ResultPayload
 
 
+class _RegisterEntry(NamedTuple):
+    """A normalized libraries_to_register entry.
+
+    The config field accepts either a bare path string or an object with `path`
+    and `enabled` fields. Both shapes are normalized to this tuple before consumption.
+    """
+
+    path: str
+    enabled: bool
+
+
+def _entry_path(entry: Any) -> str:
+    """Extract the path string from a libraries_to_register entry (str or dict).
+
+    Returns an empty string for entries with no usable path.
+    """
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        path = entry.get("path")
+        return path if isinstance(path, str) else ""
+    path_attr = getattr(entry, "path", None)
+    return path_attr if isinstance(path_attr, str) else ""
+
+
+def _normalize_register_entries(raw: list[Any]) -> list[_RegisterEntry]:
+    """Normalize a libraries_to_register config list into typed entries.
+
+    Bare strings become enabled entries. Dict-shaped entries honor their `enabled`
+    field (defaulting to True). Entries without a usable path are skipped with a warning.
+    """
+    entries: list[_RegisterEntry] = []
+    for item in raw:
+        if isinstance(item, str):
+            if item:
+                entries.append(_RegisterEntry(path=item, enabled=True))
+        elif isinstance(item, dict):
+            path = item.get("path")
+            if not isinstance(path, str) or not path:
+                logger.warning("Skipping libraries_to_register entry without a 'path': %r", item)
+                continue
+            enabled = item.get("enabled", True)
+            entries.append(_RegisterEntry(path=path, enabled=bool(enabled)))
+        else:
+            logger.warning(
+                "Skipping libraries_to_register entry of unexpected type %s: %r",
+                type(item).__name__,
+                item,
+            )
+    return entries
+
+
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
     LIBRARY_CONFIG_FILENAME = "griptape_nodes_library.json"
@@ -286,6 +338,7 @@ class LibraryManager:
         WORKER_DELEGATED = "worker_delegated"
         WORKER_PENDING = "worker_pending"
         LOADED = "loaded"
+        DISABLED = "disabled"
 
     class LibraryFitness(StrEnum):
         """Fitness of the library that was attempted to be loaded."""
@@ -607,8 +660,13 @@ class LibraryManager:
         # Add rows for each library info
         for lib_info in library_infos:
             # Library column with emoji, name, version, colored status, and file path underneath
-            emoji = status_emoji.get(lib_info.fitness, "ERROR: Unknown/Unexpected Library Status")
-            colored_status = status_text.get(lib_info.fitness, "(UNKNOWN)")
+            is_disabled = lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.DISABLED
+            if is_disabled:
+                emoji = "[dim]-[/dim]"
+                colored_status = "[dim](DISABLED)[/dim]"
+            else:
+                emoji = status_emoji.get(lib_info.fitness, "ERROR: Unknown/Unexpected Library Status")
+                colored_status = status_text.get(lib_info.fitness, "(UNKNOWN)")
             name = lib_info.library_name or "*UNKNOWN*"
 
             library_version = lib_info.library_version
@@ -894,9 +952,10 @@ class LibraryManager:
         # Discover library files for metadata loading
         library_files = self._discover_library_files()
 
-        # Load metadata for all discovered library files
+        # Load metadata for all discovered library files (including disabled ones,
+        # so their names/versions can be displayed in status output).
         for library_file in library_files:
-            metadata_request = LoadLibraryMetadataFromFileRequest(file_path=str(library_file))
+            metadata_request = LoadLibraryMetadataFromFileRequest(file_path=library_file.path)
             metadata_result = self.load_library_metadata_from_file_request(metadata_request)
 
             if isinstance(metadata_result, LoadLibraryMetadataFromFileResultSuccess):
@@ -1714,6 +1773,16 @@ class LibraryManager:
                 case LibraryManager.LibraryLifecycleState.FAILURE:
                     # Terminal state: failure
                     details = f"Library '{library_info.library_name}' is in FAILURE state and cannot be loaded"
+                    self._library_file_path_to_info[library_info.library_path] = library_info
+                    return RegisterLibraryFromFileResultFailure(result_details=details)
+
+                case LibraryManager.LibraryLifecycleState.DISABLED:
+                    # Terminal state: the user has disabled this library in libraries_to_register.
+                    # Loading was intentionally skipped.
+                    details = (
+                        f"Library at '{library_info.library_path}' is disabled in libraries_to_register "
+                        f"and was not loaded"
+                    )
                     self._library_file_path_to_info[library_info.library_path] = library_info
                     return RegisterLibraryFromFileResultFailure(result_details=details)
 
@@ -2833,7 +2902,7 @@ class LibraryManager:
             lib_path = str(discovered_lib.path)
             lib_info = self._library_file_path_to_info.get(lib_path)
 
-            if lib_info:
+            if lib_info and lib_info.lifecycle_state != LibraryManager.LibraryLifecycleState.DISABLED:
                 libraries_to_load.append(lib_path)
 
         if not libraries_to_load:
@@ -3728,7 +3797,9 @@ class LibraryManager:
 
         if paths_to_remove and libraries_to_register_category:
             libraries_to_register_category = [
-                library for library in libraries_to_register_category if library.lower() not in paths_to_remove
+                library
+                for library in libraries_to_register_category
+                if _entry_path(library).lower() not in paths_to_remove
             ]
             config_mgr.set_config_value(config_category, libraries_to_register_category)
 
@@ -3753,12 +3824,21 @@ class LibraryManager:
         if not libraries_to_register:
             return
 
-        # Filter and get which libraries were removed
-        filtered_libraries, removed_library_names = filter_old_xdg_library_paths(libraries_to_register)
+        # filter_old_xdg_library_paths operates on bare path strings; extract paths from
+        # any object-shaped entries, run the filter, then rebuild the list preserving each
+        # surviving entry's original shape (so disabled entries keep their `enabled: false`).
+        path_to_entry: dict[str, Any] = {}
+        for entry in libraries_to_register:
+            entry_path = _entry_path(entry)
+            if entry_path:
+                path_to_entry[entry_path] = entry
+
+        filtered_paths, removed_library_names = filter_old_xdg_library_paths(list(path_to_entry))
 
         # If any paths were removed
-        paths_removed = len(libraries_to_register) - len(filtered_libraries)
+        paths_removed = len(path_to_entry) - len(filtered_paths)
         if paths_removed > 0:
+            filtered_libraries = [path_to_entry[p] for p in filtered_paths]
             # Update libraries_to_register
             config_mgr.set_config_value(register_key, filtered_libraries)
 
@@ -3866,11 +3946,13 @@ class LibraryManager:
         )
         return ReloadAllLibrariesResultSuccess(result_details=ResultDetails(message=details, level=logging.INFO))
 
-    def _create_library_info_entry(self, file_path_str: str, *, is_sandbox: bool) -> None:
+    def _create_library_info_entry(self, file_path_str: str, *, is_sandbox: bool, enabled: bool = True) -> None:
         """Create a LibraryInfo entry for a discovered library.
 
         Loads metadata if possible and creates the entry in the appropriate lifecycle state.
-        Only creates the entry if it doesn't already exist in tracking.
+        When `enabled` is False, the entry is created in the DISABLED terminal state and
+        is skipped by load_all_libraries_from_config. Only creates the entry if it doesn't
+        already exist in tracking.
         """
         if file_path_str in self._library_file_path_to_info:
             return
@@ -3890,6 +3972,9 @@ class LibraryManager:
             worker_cfg = metadata_result.library_schema.metadata.worker
             requires_worker = bool(worker_cfg and worker_cfg.enabled)
             lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
+
+        if not enabled:
+            lifecycle_state = LibraryManager.LibraryLifecycleState.DISABLED
 
         self._library_file_path_to_info[file_path_str] = LibraryManager.LibraryInfo(
             lifecycle_state=lifecycle_state,
@@ -3911,7 +3996,7 @@ class LibraryManager:
         Scans configured library paths and creates LibraryInfo entries in DISCOVERED state.
         """
         try:
-            config_library_paths = self._discover_library_files()
+            config_library_entries = self._discover_library_files()
         except Exception as e:
             logger.exception("Failed to discover library files")
             return DiscoverLibrariesResultFailure(
@@ -3956,16 +4041,17 @@ class LibraryManager:
                     self._create_library_info_entry(sandbox_json_path_str, is_sandbox=True)
 
         # Add all regular libraries from config
-        for file_path in config_library_paths:
-            file_path_str = str(file_path)
+        for entry in config_library_entries:
+            file_path = Path(entry.path)
+            file_path_str = entry.path
 
             # Add to discovered libraries with is_sandbox=False
             if file_path not in seen_libraries:
                 seen_libraries.add(file_path)
-                discovered_libraries.append(DiscoveredLibrary(path=file_path, is_sandbox=False))
+                discovered_libraries.append(DiscoveredLibrary(path=file_path, is_sandbox=False, enabled=entry.enabled))
 
             # Create LibraryInfo entry for the library
-            self._create_library_info_entry(file_path_str, is_sandbox=False)
+            self._create_library_info_entry(file_path_str, is_sandbox=False, enabled=entry.enabled)
 
         # Success path at the end
         return DiscoverLibrariesResultSuccess(
@@ -4030,7 +4116,7 @@ class LibraryManager:
             if lib_info and discovered_lib.is_sandbox:
                 lib_info.is_sandbox = True
 
-            if lib_info:
+            if lib_info and lib_info.lifecycle_state != LibraryManager.LibraryLifecycleState.DISABLED:
                 libraries_to_load.append(lib_path)
 
         if not libraries_to_load:
@@ -4129,41 +4215,41 @@ class LibraryManager:
 
         return LoadLibrariesResultSuccess(result_details=ResultDetails(message=message, level=logging.INFO))
 
-    def _discover_library_files(self) -> list[Path]:
+    def _discover_library_files(self) -> list[_RegisterEntry]:
         """Discover library JSON files from config and workspace recursively.
 
         Returns:
-            List of library file paths found, in the order they appear in config
+            List of register entries (path string + enabled flag) in the order they appear
+            in config. Directory entries expand to one entry per discovered library file,
+            inheriting the directory entry's enabled flag.
         """
         config_mgr = GriptapeNodes.ConfigManager()
         user_libraries_section = LIBRARIES_TO_REGISTER_KEY
 
-        discovered_libraries = []
-        seen_libraries = set()
+        discovered_entries: list[_RegisterEntry] = []
+        seen_paths: set[Path] = set()
 
-        def process_path(path: Path) -> None:
+        def process_path(path: Path, *, enabled: bool) -> None:
             """Process a path, handling both files and directories."""
             if path.is_dir():
                 # Recursively find library files, skipping hidden directories
                 for lib_path in find_files_recursive(path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN):
-                    if lib_path not in seen_libraries:
-                        seen_libraries.add(lib_path)
-                        discovered_libraries.append(lib_path)
-            elif path.suffix == ".json" and path not in seen_libraries:
-                seen_libraries.add(path)
-                discovered_libraries.append(path)
+                    if lib_path not in seen_paths:
+                        seen_paths.add(lib_path)
+                        discovered_entries.append(_RegisterEntry(path=str(lib_path), enabled=enabled))
+            elif path.suffix == ".json" and path not in seen_paths:
+                seen_paths.add(path)
+                discovered_entries.append(_RegisterEntry(path=str(path), enabled=enabled))
 
         # Add from config
         config_libraries = config_mgr.get_config_value(user_libraries_section, default=[])
-        for library_path_str in config_libraries:
-            # Filter out falsy values that will resolve to current directory
-            if library_path_str:
-                # TODO: Update to check on project manager for workspace path. https://github.com/griptape-ai/griptape-nodes/issues/4396
-                library_path = resolve_workspace_path(Path(library_path_str), Path(config_mgr.workspace_path))
-                if library_path.exists():
-                    process_path(library_path)
+        for entry in _normalize_register_entries(config_libraries):
+            # TODO: Update to check on project manager for workspace path. https://github.com/griptape-ai/griptape-nodes/issues/4396
+            library_path = resolve_workspace_path(Path(entry.path), Path(config_mgr.workspace_path))
+            if library_path.exists():
+                process_path(library_path, enabled=entry.enabled)
 
-        return discovered_libraries
+        return discovered_entries
 
     async def check_library_update_request(self, request: CheckLibraryUpdateRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         """Check if a library has updates available via git."""
@@ -4662,7 +4748,8 @@ class LibraryManager:
         # Add library JSON file path to config so it's registered on future startups
         libraries_to_register = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
         library_json_str = str(library_json_path)
-        if library_json_str not in libraries_to_register:
+        existing_paths = {_entry_path(entry) for entry in libraries_to_register}
+        if library_json_str not in existing_paths:
             libraries_to_register.append(library_json_str)
             config_mgr.set_config_value(LIBRARIES_TO_REGISTER_KEY, libraries_to_register)
             logger.info("Added library '%s' to config for auto-registration on startup", library_name)
@@ -4768,7 +4855,8 @@ class LibraryManager:
         # Collect git URLs from both config keys
         download_config = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
         register_config = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
-        git_urls_from_register = [entry for entry in register_config if is_git_url(entry)]
+        # Disabled entries are still synced; disabling only affects loading.
+        git_urls_from_register = [path for entry in register_config if is_git_url(path := _entry_path(entry))]
 
         # Combine and deduplicate
         all_git_urls = list(set(download_config + git_urls_from_register))

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -107,14 +107,34 @@ class MCPServerConfig(BaseModel):
         return f"{self.name} ({'enabled' if self.enabled else 'disabled'})"
 
 
+class LibraryRegistration(BaseModel):
+    """A library entry in libraries_to_register with optional metadata.
+
+    Bare path strings remain valid in the config; this object form is used when
+    additional fields (such as `enabled`) need to be set per entry.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(description="Path to a griptape_nodes_library.json file or a directory scanned recursively.")
+    enabled: bool = Field(
+        default=True,
+        description="When False, the library remains in config but is not loaded on startup.",
+    )
+
+
 class AppInitializationComplete(BaseModel):
     libraries_to_download: list[str] = Field(
         default_factory=list,
         description="Git URLs of libraries to automatically download when the engine starts. Downloaded into libraries_directory. Supports full URLs or GitHub shorthand (e.g., 'user/repo'). Optionally specify a branch, tag, or commit with @ref syntax (e.g., 'user/repo@stable' or 'https://github.com/user/repo@v1.0.0'). If no ref is specified, uses the repository's default branch.",
     )
-    libraries_to_register: list[str] = Field(
+    libraries_to_register: list[str | LibraryRegistration] = Field(
         default_factory=list,
-        description="Libraries to automatically load when the engine starts. Can contain paths to individual griptape_nodes_library.json files or directory paths (scanned recursively for library JSON files).",
+        description=(
+            "Libraries to automatically load when the engine starts. Each entry is either a path string "
+            "(loaded as enabled) or an object with `path` and `enabled` fields. Paths may point to a "
+            "griptape_nodes_library.json file or a directory scanned recursively for library JSON files."
+        ),
     )
     workflows_to_register: list[str] = Field(default_factory=list)
     secrets_to_register: list[str] | dict[str, str] = Field(

--- a/src/griptape_nodes/utils/library_utils.py
+++ b/src/griptape_nodes/utils/library_utils.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
+from pydantic import ValidationError
 from xdg_base_dirs import xdg_data_home
 
+from griptape_nodes.retained_mode.managers.settings import LibraryRegistration
 from griptape_nodes.utils.file_utils import find_all_files_in_directory
 from griptape_nodes.utils.git_utils import (
     get_git_repository_root,
@@ -122,3 +124,49 @@ def filter_old_xdg_library_paths(library_paths: list[str]) -> tuple[list[str], s
             filtered_libraries.append(library)
 
     return filtered_libraries, removed_library_names
+
+
+def extract_library_path(entry: Any) -> str:
+    """Extract the path string from a libraries_to_register entry.
+
+    Accepts a bare path string, a dict-shaped entry from raw config, or an already
+    parsed LibraryRegistration. Returns an empty string for entries that contain no
+    usable path.
+    """
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, LibraryRegistration):
+        return entry.path
+    if isinstance(entry, dict):
+        path = entry.get("path")
+        return path if isinstance(path, str) else ""
+    return ""
+
+
+def normalize_library_registrations(raw: list[Any]) -> list[LibraryRegistration]:
+    """Normalize a libraries_to_register config list into LibraryRegistration entries.
+
+    Bare strings become enabled entries. Dict-shaped entries are validated against
+    the LibraryRegistration schema. Already parsed LibraryRegistration instances pass
+    through unchanged. Malformed entries are skipped with a warning so a single bad
+    entry cannot block startup.
+    """
+    entries: list[LibraryRegistration] = []
+    for item in raw:
+        if isinstance(item, LibraryRegistration):
+            entries.append(item)
+        elif isinstance(item, str):
+            if item:
+                entries.append(LibraryRegistration(path=item))
+        elif isinstance(item, dict):
+            try:
+                entries.append(LibraryRegistration.model_validate(item))
+            except ValidationError as err:
+                logger.warning("Skipping malformed libraries_to_register entry %r: %s", item, err)
+        else:
+            logger.warning(
+                "Skipping libraries_to_register entry of unexpected type %s: %r",
+                type(item).__name__,
+                item,
+            )
+    return entries

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -519,3 +519,33 @@ class TestConfigManagerEventEmission:
         event = received_events[0]
         assert event.key == "app_events.on_app_initialization_complete.libraries_to_register"
         assert event.new_value == ["/path/to/lib"]
+
+    def test_libraries_to_register_accepts_mixed_str_and_object_entries(self) -> None:
+        """Settings validation accepts a mix of bare path strings and objects with `enabled`."""
+        from griptape_nodes.retained_mode.managers.settings import LibraryRegistration, Settings
+
+        validated = Settings.model_validate(
+            {
+                "app_events": {
+                    "on_app_initialization_complete": {
+                        "libraries_to_register": [
+                            "/path/to/enabled.json",
+                            {"path": "/path/to/disabled.json", "enabled": False},
+                        ],
+                    },
+                },
+            },
+        )
+
+        entries = validated.app_events.on_app_initialization_complete.libraries_to_register
+        assert entries[0] == "/path/to/enabled.json"
+        assert isinstance(entries[1], LibraryRegistration)
+        assert entries[1].path == "/path/to/disabled.json"
+        assert entries[1].enabled is False
+
+        # Round-trip: bare strings stay strings, objects stay objects.
+        dumped = validated.app_events.on_app_initialization_complete.model_dump()
+        assert dumped["libraries_to_register"] == [
+            "/path/to/enabled.json",
+            {"path": "/path/to/disabled.json", "enabled": False},
+        ]

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -36,7 +36,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultFailure,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.library_manager import _RegisterEntry
+from griptape_nodes.retained_mode.managers.settings import LibraryRegistration
 
 
 class TestLibraryManagerLoadLibraries:
@@ -68,7 +68,7 @@ class TestLibraryManagerLoadLibraries:
         with (
             patch.object(library_manager, "_library_file_path_to_info", {"some_lib": mock_lib_info}),
             patch.object(
-                library_manager, "_discover_library_files", return_value=[_RegisterEntry(path="some_lib", enabled=True)]
+                library_manager, "_discover_library_files", return_value=[LibraryRegistration(path="some_lib")]
             ),
             patch.object(library_manager, "load_all_libraries_from_config", mock_load_config),
             patch.object(LibraryRegistry, "get_library", return_value=mock_library),
@@ -93,7 +93,7 @@ class TestLibraryManagerLoadLibraries:
         with (
             patch.object(library_manager, "_library_file_path_to_info", {}),
             patch.object(
-                library_manager, "_discover_library_files", return_value=[_RegisterEntry(path="new_lib", enabled=True)]
+                library_manager, "_discover_library_files", return_value=[LibraryRegistration(path="new_lib")]
             ),
             patch.object(library_manager, "load_all_libraries_from_config", mock_load_config),
         ):
@@ -120,7 +120,7 @@ class TestLibraryManagerLoadLibraries:
         with (
             patch.object(library_manager, "_library_file_path_to_info", {}),
             patch.object(
-                library_manager, "_discover_library_files", return_value=[_RegisterEntry(path="new_lib", enabled=True)]
+                library_manager, "_discover_library_files", return_value=[LibraryRegistration(path="new_lib")]
             ),
             patch.object(library_manager, "load_all_libraries_from_config", mock_load_config),
         ):

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -36,6 +36,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultFailure,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.library_manager import _RegisterEntry
 
 
 class TestLibraryManagerLoadLibraries:
@@ -66,7 +67,9 @@ class TestLibraryManagerLoadLibraries:
         mock_library.name = "SomeLib"
         with (
             patch.object(library_manager, "_library_file_path_to_info", {"some_lib": mock_lib_info}),
-            patch.object(library_manager, "_discover_library_files", return_value=[Path("some_lib")]),
+            patch.object(
+                library_manager, "_discover_library_files", return_value=[_RegisterEntry(path="some_lib", enabled=True)]
+            ),
             patch.object(library_manager, "load_all_libraries_from_config", mock_load_config),
             patch.object(LibraryRegistry, "get_library", return_value=mock_library),
         ):
@@ -89,7 +92,9 @@ class TestLibraryManagerLoadLibraries:
         mock_load_config = AsyncMock()
         with (
             patch.object(library_manager, "_library_file_path_to_info", {}),
-            patch.object(library_manager, "_discover_library_files", return_value=[Path("new_lib")]),
+            patch.object(
+                library_manager, "_discover_library_files", return_value=[_RegisterEntry(path="new_lib", enabled=True)]
+            ),
             patch.object(library_manager, "load_all_libraries_from_config", mock_load_config),
         ):
             request = LoadLibrariesRequest()
@@ -114,7 +119,9 @@ class TestLibraryManagerLoadLibraries:
         mock_load_config = AsyncMock(side_effect=Exception("Config error"))
         with (
             patch.object(library_manager, "_library_file_path_to_info", {}),
-            patch.object(library_manager, "_discover_library_files", return_value=[Path("new_lib")]),
+            patch.object(
+                library_manager, "_discover_library_files", return_value=[_RegisterEntry(path="new_lib", enabled=True)]
+            ),
             patch.object(library_manager, "load_all_libraries_from_config", mock_load_config),
         ):
             request = LoadLibrariesRequest()
@@ -126,6 +133,104 @@ class TestLibraryManagerLoadLibraries:
             assert isinstance(result.result_details, ResultDetails)
             # Test that failure was indicated in the result message
             assert "failed" in result.result_details.result_details[0].message.lower()
+
+
+class TestLibraryManagerDisabledEntries:
+    """Behavior when libraries_to_register entries have enabled=False."""
+
+    @pytest.fixture
+    def lib_files(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Two empty library JSON files in distinct directories."""
+        enabled_dir = tmp_path / "enabled"
+        disabled_dir = tmp_path / "disabled"
+        enabled_dir.mkdir()
+        disabled_dir.mkdir()
+        enabled_lib = enabled_dir / "griptape_nodes_library.json"
+        disabled_lib = disabled_dir / "griptape_nodes_library.json"
+        enabled_lib.write_text("{}")
+        disabled_lib.write_text("{}")
+        return enabled_lib, disabled_lib
+
+    def test_discover_library_files_marks_disabled_entries(
+        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+    ) -> None:
+        """Object-shaped entries with enabled=False produce disabled register entries."""
+        library_manager = griptape_nodes.LibraryManager()
+        enabled_lib, disabled_lib = lib_files
+
+        config = [
+            str(enabled_lib),
+            {"path": str(disabled_lib), "enabled": False},
+        ]
+
+        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config):
+            result = library_manager._discover_library_files()
+
+        by_path = {Path(entry.path): entry.enabled for entry in result}
+        assert by_path[enabled_lib] is True
+        assert by_path[disabled_lib] is False
+
+    def test_discover_library_files_bare_string_defaults_to_enabled(
+        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+    ) -> None:
+        """Bare path strings continue to be treated as enabled."""
+        library_manager = griptape_nodes.LibraryManager()
+        enabled_lib, _ = lib_files
+
+        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=[str(enabled_lib)]):
+            result = library_manager._discover_library_files()
+
+        assert len(result) == 1
+        assert result[0].enabled is True
+
+    def test_discover_libraries_request_marks_disabled_lifecycle(
+        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+    ) -> None:
+        """discover_libraries_request creates LibraryInfo with DISABLED lifecycle for disabled entries."""
+        from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesRequest
+        from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+        library_manager = griptape_nodes.LibraryManager()
+        enabled_lib, disabled_lib = lib_files
+
+        config = [str(enabled_lib), {"path": str(disabled_lib), "enabled": False}]
+        # Reset tracking so this test does not depend on prior state.
+        library_manager._library_file_path_to_info = {}
+
+        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config):
+            result = library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
+
+        from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesResultSuccess
+
+        assert isinstance(result, DiscoverLibrariesResultSuccess)
+        states = {
+            entry.path: library_manager._library_file_path_to_info[str(entry.path)].lifecycle_state
+            for entry in result.libraries_discovered
+        }
+        assert states[enabled_lib] != LibraryManager.LibraryLifecycleState.DISABLED
+        assert states[disabled_lib] == LibraryManager.LibraryLifecycleState.DISABLED
+        # The discovery result also surfaces the enabled flag.
+        flags = {entry.path: entry.enabled for entry in result.libraries_discovered}
+        assert flags[enabled_lib] is True
+        assert flags[disabled_lib] is False
+
+    def test_invalid_entry_is_skipped_with_warning(
+        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Entries that are neither strings nor dicts with a path are skipped."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        config = [42, {"enabled": True}]  # missing 'path', and a bare int
+
+        with (
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+        ):
+            result = library_manager._discover_library_files()
+
+        assert result == []
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("libraries_to_register" in m for m in warnings)
 
 
 class TestLibraryManagerMigrateOldXdgPaths:

--- a/tests/unit/retained_mode/managers/test_library_manager_ordering.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_ordering.py
@@ -51,7 +51,8 @@ class TestLibraryManagerDeterministicOrdering:
             result = library_manager._discover_library_files()
 
             # Should preserve config order, not alphabetical
-            assert result == [lib_z, lib_a, lib_m]
+            assert [Path(entry.path) for entry in result] == [lib_z, lib_a, lib_m]
+            assert all(entry.enabled for entry in result)
 
     def test_discover_library_files_handles_directories_deterministically(
         self, griptape_nodes: GriptapeNodes, temp_dir: Path
@@ -80,7 +81,7 @@ class TestLibraryManagerDeterministicOrdering:
             result = library_manager._discover_library_files()
 
             # Files from directory should be sorted alphabetically by path
-            assert result == [lib_a, lib_b, lib_z]
+            assert [Path(entry.path) for entry in result] == [lib_a, lib_b, lib_z]
 
     def test_discover_library_files_mixed_files_and_directories_preserves_order(
         self, griptape_nodes: GriptapeNodes, temp_dir: Path
@@ -119,7 +120,7 @@ class TestLibraryManagerDeterministicOrdering:
 
             # Should be: direct_lib, dir_lib_a, dir_lib_b, another_direct
             # (directory contents are sorted alphabetically by path)
-            assert result == [direct_lib, dir_lib_a, dir_lib_b, another_direct]
+            assert [Path(entry.path) for entry in result] == [direct_lib, dir_lib_a, dir_lib_b, another_direct]
 
     def test_discover_library_files_deduplicates_preserving_first_occurrence(
         self, griptape_nodes: GriptapeNodes, temp_dir: Path
@@ -140,7 +141,7 @@ class TestLibraryManagerDeterministicOrdering:
             result = library_manager._discover_library_files()
 
             # Should only appear once
-            assert result == [lib]
+            assert [Path(entry.path) for entry in result] == [lib]
             assert len(result) == 1
 
     def test_discover_libraries_request_returns_list_in_order(


### PR DESCRIPTION
Closes #4569.

`libraries_to_register` accepts either a bare path string (existing shape, treated as enabled) or `{"path": ..., "enabled": false}`. Disabled entries stay in config and are still discovered, so they appear in the startup status table as `DISABLED` rather than vanishing or being mistaken for missing files. They are skipped during load, are kept by `_remove_missing_libraries_from_config`, and still participate in `sync_libraries_request` when their path is a git URL (disabling controls loading, not downloading).

Example `griptape_nodes_config.json`:

```json
{
  "app_events": {
    "on_app_initialization_complete": {
      "libraries_to_register": [
        "/path/to/standard/griptape_nodes_library.json",
        {
          "path": "/path/to/worktree/griptape_nodes_library.json",
          "enabled": true
        },
        "/path/to/testing/griptape_nodes_library.json",
        {
          "path": "/path/to/topazlabs/griptape_nodes_library.json",
          "enabled": false
        }
      ]
    }
  }
}
```

<img width="835" height="432" alt="image" src="https://github.com/user-attachments/assets/2dc1280b-4d8d-4280-a21a-7efd399ca211" />

