### PR TITLE
feat(mcp): add EventRequestBatch tool

### DIFF
--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -5,6 +5,7 @@ import logging
 import os
 import socket
 from collections.abc import AsyncIterator
+from typing import Any
 
 import uvicorn
 from fastapi import FastAPI
@@ -125,6 +126,33 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "GetConnectionsForParameterRequest": GetConnectionsForParameterRequest,
 }
 
+# Synthetic MCP tool name for the batch envelope. Not a request payload (and so not a member of
+# SUPPORTED_REQUEST_EVENTS); the call_tool dispatch special-cases it onto manager.request_batch.
+EVENT_REQUEST_BATCH_TOOL_NAME = "EventRequestBatch"
+EVENT_REQUEST_BATCH_DESCRIPTION = (
+    "Send N requests in a single round trip and gather their responses.\n\n"
+    "Each inner request is validated and dispatched as if it were its own MCP tool call, but\n"
+    "they all travel as a single transport frame to the engine, so this collapses an N-call\n"
+    "build phase down to one round trip. Use it whenever you already know the shape of what\n"
+    "you want to build (e.g. several CreateNodeRequest + SetParameterValueRequest +\n"
+    "CreateConnectionRequest calls in a row).\n\n"
+    "Args:\n"
+    "    requests: ordered list of inner calls. Each entry is\n"
+    "        {request_type: <name of a supported tool>, request: <that tool's argument object>}.\n"
+    "    timeout_ms: overall timeout for the whole batch in milliseconds. Defaults to\n"
+    "        30000 ms per inner request, capped at 300000 ms.\n\n"
+    "Returns:\n"
+    "    list of trimmed responses in submission order. Each entry has the same shape as a\n"
+    "    single tool call ({ok, details, ...payload fields}). Failures appear as\n"
+    "    {ok: false, details: ...} in their slot rather than aborting the rest of the batch.\n"
+)
+# Per-inner-request timeout used when the caller does not pass timeout_ms. Mirrors the timeout the
+# single-request path applies (see call_tool below) so a batch of one behaves identically.
+_BATCH_PER_REQUEST_TIMEOUT_MS = 30000
+# Hard ceiling for an auto-computed batch timeout. Long enough to accommodate a large build phase
+# without letting a runaway batch hold the connection open indefinitely.
+_BATCH_MAX_AUTO_TIMEOUT_MS = 300000
+
 GTN_MCP_SERVER_HOST = os.getenv("GTN_MCP_SERVER_HOST", "localhost")
 # Port of the MCP server (where uvicorn binds). 0 means the OS assigns a free port automatically.
 GTN_MCP_SERVER_PORT = int(os.getenv("GTN_MCP_SERVER_PORT", "0"))
@@ -180,6 +208,131 @@ def _trim_response(result: dict) -> dict:
     return trimmed
 
 
+def _event_request_batch_input_schema() -> dict[str, Any]:
+    """JSON schema for the synthetic EventRequestBatch tool.
+
+    The `request` payload of each inner entry is left as a free-form object because JSON Schema
+    cannot easily express "validate this against the dataclass selected by request_type"; the
+    server-side handler validates each payload by instantiating the matching RequestPayload
+    class, mirroring the single-request dispatch path.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "requests": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "request_type": {
+                            "type": "string",
+                            "enum": sorted(SUPPORTED_REQUEST_EVENTS),
+                            "description": "Name of one of the supported single-request tools (e.g. CreateNodeRequest).",
+                        },
+                        "request": {
+                            "type": "object",
+                            "description": "Argument object that tool would accept individually.",
+                        },
+                    },
+                    "required": ["request_type", "request"],
+                },
+            },
+            "timeout_ms": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Overall timeout for the batch in milliseconds.",
+            },
+        },
+        "required": ["requests"],
+    }
+
+
+def _build_batch_pairs(raw_requests: object) -> list[tuple[str, dict[str, Any]]]:
+    """Validate the inner requests array and return (request_type, payload_dict) pairs.
+
+    Mirrors the single-request dispatch: each inner request is validated by instantiating the
+    matching RequestPayload class so missing required fields and unknown kwargs fail fast,
+    before anything reaches the wire.
+    """
+    if not isinstance(raw_requests, list):
+        msg = "Attempted to dispatch EventRequestBatch. Failed because 'requests' must be a list."
+        raise TypeError(msg)
+    if not raw_requests:
+        msg = "Attempted to dispatch EventRequestBatch. Failed because 'requests' was empty."
+        raise ValueError(msg)
+
+    pairs: list[tuple[str, dict[str, Any]]] = []
+    for index, entry in enumerate(raw_requests):
+        if not isinstance(entry, dict):
+            msg = f"Attempted to dispatch EventRequestBatch entry {index}. Failed because the entry was not an object."
+            raise TypeError(msg)
+        request_type = entry.get("request_type")
+        if not isinstance(request_type, str) or request_type not in SUPPORTED_REQUEST_EVENTS:
+            msg = (
+                f"Attempted to dispatch EventRequestBatch entry {index}. "
+                f"Failed because request_type {request_type!r} is not a supported tool."
+            )
+            raise ValueError(msg)
+        inner = entry.get("request", {})
+        if not isinstance(inner, dict):
+            msg = (
+                f"Attempted to dispatch EventRequestBatch entry {index} ({request_type}). "
+                f"Failed because 'request' must be an object."
+            )
+            raise TypeError(msg)
+
+        payload_cls = SUPPORTED_REQUEST_EVENTS[request_type]
+        try:
+            payload_obj = payload_cls(**inner)
+        except TypeError as exc:
+            msg = (
+                f"Attempted to construct {request_type} for EventRequestBatch entry {index}. "
+                f"Failed with arguments {inner!r} because of {exc}."
+            )
+            raise ValueError(msg) from exc
+
+        pairs.append((request_type, dict(payload_obj.__dict__)))
+
+    return pairs
+
+
+def _resolve_batch_timeout_ms(override: object, num_requests: int) -> int:
+    """Return the timeout_ms to apply to a batch, validating any caller override.
+
+    Without an override, scales the per-request timeout linearly with batch size and clamps to a
+    ceiling so a malformed call cannot hold the connection open indefinitely.
+    """
+    if override is None:
+        return min(_BATCH_PER_REQUEST_TIMEOUT_MS * num_requests, _BATCH_MAX_AUTO_TIMEOUT_MS)
+    # bool is a subclass of int; reject explicitly so True does not get treated as 1ms.
+    if not isinstance(override, int) or isinstance(override, bool):
+        msg = (
+            "Attempted to dispatch EventRequestBatch. "
+            f"Failed because timeout_ms must be a positive integer, got {override!r}."
+        )
+        raise TypeError(msg)
+    if override <= 0:
+        msg = (
+            "Attempted to dispatch EventRequestBatch. "
+            f"Failed because timeout_ms must be a positive integer, got {override!r}."
+        )
+        raise ValueError(msg)
+    return override
+    return override
+
+
+def _trim_batch_results(raw_results: list[Any]) -> list[dict[str, Any]]:
+    """Trim each inner response, mapping exceptions returned by request_batch to ok=false slots."""
+    trimmed: list[dict[str, Any]] = []
+    for raw in raw_results:
+        if isinstance(raw, BaseException):
+            trimmed.append({"ok": False, "details": str(raw)})
+        else:
+            trimmed.append(_trim_response(raw))
+    return trimmed
+
+
 def start_mcp_server(api_key: str, sock: socket.socket) -> None:
     """Synchronous version of main entry point for the Griptape Nodes MCP server.
 
@@ -196,16 +349,29 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
 
     @app.list_tools()
     async def list_tools() -> list[Tool]:
-        return [
+        single_tools = [
             Tool(name=event.__name__, description=event.__doc__, inputSchema=TypeAdapter(event).json_schema())
             for (name, event) in SUPPORTED_REQUEST_EVENTS.items()
         ]
+        batch_tool = Tool(
+            name=EVENT_REQUEST_BATCH_TOOL_NAME,
+            description=EVENT_REQUEST_BATCH_DESCRIPTION,
+            inputSchema=_event_request_batch_input_schema(),
+        )
+        return [*single_tools, batch_tool]
 
     @app.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         if manager is None:
             msg = "Request manager not initialized"
             raise RuntimeError(msg)
+
+        if name == EVENT_REQUEST_BATCH_TOOL_NAME:
+            pairs = _build_batch_pairs(arguments.get("requests"))
+            timeout_ms = _resolve_batch_timeout_ms(arguments.get("timeout_ms"), len(pairs))
+            raw_results = await manager.request_batch(pairs, timeout_ms=timeout_ms, return_exceptions=True)
+            mcp_server_logger.debug("Got %d batch results", len(raw_results))
+            return [TextContent(type="text", text=json.dumps(_trim_batch_results(raw_results)))]
 
         if name not in SUPPORTED_REQUEST_EVENTS:
             msg = f"Unsupported tool: {name}"

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -319,7 +319,6 @@ def _resolve_batch_timeout_ms(override: object, num_requests: int) -> int:
         )
         raise ValueError(msg)
     return override
-    return override
 
 
 def _trim_batch_results(raw_results: list[Any]) -> list[dict[str, Any]]:

--- a/tests/unit/servers/test_mcp.py
+++ b/tests/unit/servers/test_mcp.py
@@ -1,4 +1,17 @@
-from griptape_nodes.servers.mcp import _summarize_result_details, _trim_response
+import pytest
+
+from griptape_nodes.servers.mcp import (
+    _BATCH_MAX_AUTO_TIMEOUT_MS,
+    _BATCH_PER_REQUEST_TIMEOUT_MS,
+    EVENT_REQUEST_BATCH_TOOL_NAME,
+    SUPPORTED_REQUEST_EVENTS,
+    _build_batch_pairs,
+    _event_request_batch_input_schema,
+    _resolve_batch_timeout_ms,
+    _summarize_result_details,
+    _trim_batch_results,
+    _trim_response,
+)
 
 
 class TestSummarizeResultDetails:
@@ -83,3 +96,149 @@ class TestTrimResponse:
         trimmed = _trim_response({"result_type": "SomethingSuccess"})
 
         assert trimmed == {"ok": True}
+
+
+class TestEventRequestBatchInputSchema:
+    def test_enumerates_every_supported_request_type(self) -> None:
+        schema = _event_request_batch_input_schema()
+
+        request_type_enum = schema["properties"]["requests"]["items"]["properties"]["request_type"]["enum"]
+        assert set(request_type_enum) == set(SUPPORTED_REQUEST_EVENTS)
+
+    def test_marks_requests_required_and_non_empty(self) -> None:
+        schema = _event_request_batch_input_schema()
+
+        assert schema["required"] == ["requests"]
+        assert schema["properties"]["requests"]["minItems"] == 1
+
+
+class TestBuildBatchPairs:
+    def test_builds_pairs_for_valid_inner_requests(self) -> None:
+        raw = [
+            {"request_type": "CreateNodeRequest", "request": {"node_type": "TextInput"}},
+            {
+                "request_type": "CreateConnectionRequest",
+                "request": {
+                    "source_parameter_name": "text",
+                    "target_parameter_name": "prompt",
+                    "source_node_name": "TextInput_1",
+                    "target_node_name": "Agent_1",
+                },
+            },
+        ]
+
+        pairs = _build_batch_pairs(raw)
+
+        assert [request_type for request_type, _ in pairs] == ["CreateNodeRequest", "CreateConnectionRequest"]
+        # Defaults from the dataclasses are filled in, so payload dicts carry every field.
+        assert pairs[0][1]["node_type"] == "TextInput"
+        assert pairs[1][1]["source_node_name"] == "TextInput_1"
+
+    def test_rejects_non_list_requests(self) -> None:
+        with pytest.raises(TypeError, match="must be a list"):
+            _build_batch_pairs("not a list")
+
+    def test_rejects_empty_list(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            _build_batch_pairs([])
+
+    def test_rejects_non_dict_entry(self) -> None:
+        with pytest.raises(TypeError, match="entry 0"):
+            _build_batch_pairs(["not a dict"])
+
+    def test_rejects_unknown_request_type(self) -> None:
+        with pytest.raises(ValueError, match="is not a supported tool"):
+            _build_batch_pairs([{"request_type": "NopeRequest", "request": {}}])
+
+    def test_rejects_non_dict_request_payload(self) -> None:
+        with pytest.raises(TypeError, match="must be an object"):
+            _build_batch_pairs([{"request_type": "ListRegisteredLibrariesRequest", "request": "bad"}])
+
+    def test_rejects_unknown_kwargs_in_inner_payload(self) -> None:
+        with pytest.raises(ValueError, match="Attempted to construct CreateNodeRequest"):
+            _build_batch_pairs([{"request_type": "CreateNodeRequest", "request": {"node_type": "X", "bogus_field": 1}}])
+
+
+class TestResolveBatchTimeoutMs:
+    _BATCH_OF_FOUR = 4
+    _LARGE_BATCH = 100
+    _EXPLICIT_OVERRIDE_MS = 15000
+
+    def test_scales_default_with_batch_size(self) -> None:
+        assert (
+            _resolve_batch_timeout_ms(None, self._BATCH_OF_FOUR) == _BATCH_PER_REQUEST_TIMEOUT_MS * self._BATCH_OF_FOUR
+        )
+
+    def test_caps_default_at_ceiling(self) -> None:
+        # A 100-call batch would scale past the cap; the helper clamps it.
+        assert _resolve_batch_timeout_ms(None, self._LARGE_BATCH) == _BATCH_MAX_AUTO_TIMEOUT_MS
+
+    def test_passes_through_explicit_override(self) -> None:
+        assert _resolve_batch_timeout_ms(self._EXPLICIT_OVERRIDE_MS, self._BATCH_OF_FOUR) == self._EXPLICIT_OVERRIDE_MS
+
+    def test_rejects_non_int_override(self) -> None:
+        with pytest.raises(TypeError, match="must be a positive integer"):
+            _resolve_batch_timeout_ms("15s", self._BATCH_OF_FOUR)
+
+    def test_rejects_zero_or_negative_override(self) -> None:
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            _resolve_batch_timeout_ms(0, self._BATCH_OF_FOUR)
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            _resolve_batch_timeout_ms(-1, self._BATCH_OF_FOUR)
+
+    def test_rejects_bool_override(self) -> None:
+        # bools are technically ints in Python; reject explicitly so True does not become 1ms.
+        with pytest.raises(TypeError, match="must be a positive integer"):
+            _resolve_batch_timeout_ms(True, self._BATCH_OF_FOUR)
+
+
+class TestTrimBatchResults:
+    def test_trims_each_inner_response(self) -> None:
+        raw = [
+            {
+                "result_type": "CreateNodeResultSuccess",
+                "result": {
+                    "result_details": {"result_details": [{"level": 10, "message": "a"}]},
+                    "node_name": "A_1",
+                },
+            },
+            {
+                "result_type": "CreateNodeResultSuccess",
+                "result": {
+                    "result_details": {"result_details": [{"level": 10, "message": "b"}]},
+                    "node_name": "B_1",
+                },
+            },
+        ]
+
+        trimmed = _trim_batch_results(raw)
+
+        assert trimmed == [
+            {"ok": True, "details": "a", "node_name": "A_1"},
+            {"ok": True, "details": "b", "node_name": "B_1"},
+        ]
+
+    def test_maps_exception_slots_to_failure_responses(self) -> None:
+        raw = [
+            Exception("boom"),
+            {
+                "result_type": "CreateNodeResultSuccess",
+                "result": {
+                    "result_details": {"result_details": [{"level": 10, "message": "ok"}]},
+                    "node_name": "A_1",
+                },
+            },
+        ]
+
+        trimmed = _trim_batch_results(raw)
+
+        assert trimmed[0] == {"ok": False, "details": "boom"}
+        assert trimmed[1]["ok"] is True
+        assert trimmed[1]["node_name"] == "A_1"
+
+
+class TestEventRequestBatchToolName:
+    def test_is_not_a_supported_request_event(self) -> None:
+        # The batch tool is intentionally synthetic; gating it on SUPPORTED_REQUEST_EVENTS would
+        # require a fake RequestPayload subclass and break call_tool's payload-class lookup.
+        assert EVENT_REQUEST_BATCH_TOOL_NAME not in SUPPORTED_REQUEST_EVENTS


### PR DESCRIPTION
Closes #4576.

The engine has `manager.request_batch` and the wire-level `EventRequestBatch` envelope already, but the MCP server only ever exposed singular request types as tools. An MCP client building a graph still pays one MCP `call_tool` per primitive, which is exactly the round-trip cost #4516 and #4517 set out to remove for direct websocket clients.

This adds an `EventRequestBatch` MCP tool that takes an ordered list of inner `{request_type, request}` pairs, validates each one by instantiating the matching `RequestPayload` dataclass (so missing required fields and unknown kwargs fail fast before anything reaches the wire), and forwards them to `manager.request_batch` in a single dispatch. Inner responses come back in submission order with the same trimmed shape as a single tool call, and per-entry failures land as `{ok: false, details: ...}` slots rather than aborting the rest of the batch.

The tool is intentionally synthetic: it lives outside `SUPPORTED_REQUEST_EVENTS` and is special-cased in `call_tool`, because gating it on that map would require inventing a fake `RequestPayload` subclass and would break the per-entry payload-class lookup the dispatch path needs. The default timeout scales linearly with batch size and clamps at a ceiling so a malformed call cannot hold the connection open indefinitely; callers can override it with `timeout_ms`.
