### PR TITLE
feat(docs): add llms.txt and per-page markdown surface

### DIFF
--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -4,8 +4,8 @@
 
     This guide is available as post-processed markdown for AI coding assistants. The site exposes a full machine-readable surface; see [For Agents](../for_agents.md) for the index.
 
-    - **Comprehensive Guide** (this page): [https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
-    - **Getting Started**: [https://docs.griptapenodes.com/developing_nodes/getting_started/index.md](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
+    - **Comprehensive Guide** (this page): [Markdown](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
+    - **Getting Started**: [Markdown](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
     - **Example Code**: [View Python Example](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/example_control_node.py)
 
     **Usage:** Point your AI assistant to these URLs with instructions like:

--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -2,10 +2,10 @@
 
 !!! tip "For AI Assistants & Coding Agents"
 
-    This guide is available as raw markdown for use with AI coding assistants:
+    This guide is available as post-processed markdown for AI coding assistants. The site exposes a full machine-readable surface; see [For Agents](../for_agents.md) for the index.
 
-    - **Comprehensive Guide**: [Download/View Raw Markdown](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/comprehensive_guide.md)
-    - **Getting Started**: [Download/View Raw Markdown](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/getting_started.md)
+    - **Comprehensive Guide** (this page): [https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
+    - **Getting Started**: [https://docs.griptapenodes.com/developing_nodes/getting_started/index.md](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
     - **Example Code**: [View Python Example](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/example_control_node.py)
 
     **Usage:** Point your AI assistant to these URLs with instructions like:

--- a/docs/developing_nodes/getting_started.md
+++ b/docs/developing_nodes/getting_started.md
@@ -2,10 +2,10 @@
 
 !!! tip "For AI Assistants & Coding Agents"
 
-    This guide is available as raw markdown for use with AI coding assistants:
+    This guide is available as post-processed markdown for AI coding assistants. The site exposes a full machine-readable surface; see [For Agents](../for_agents.md) for the index.
 
-    - **Getting Started** (this page): [Download/View Raw Markdown](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/getting_started.md)
-    - **Comprehensive Guide**: [Download/View Raw Markdown](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/comprehensive_guide.md)
+    - **Getting Started** (this page): [https://docs.griptapenodes.com/developing_nodes/getting_started/index.md](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
+    - **Comprehensive Guide**: [https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
     - **Example Code**: [View Python Example](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/example_control_node.py)
 
     **Usage:** Point your AI assistant to these URLs with instructions like:

--- a/docs/developing_nodes/getting_started.md
+++ b/docs/developing_nodes/getting_started.md
@@ -4,8 +4,8 @@
 
     This guide is available as post-processed markdown for AI coding assistants. The site exposes a full machine-readable surface; see [For Agents](../for_agents.md) for the index.
 
-    - **Getting Started** (this page): [https://docs.griptapenodes.com/developing_nodes/getting_started/index.md](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
-    - **Comprehensive Guide**: [https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
+    - **Getting Started** (this page): [Markdown](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
+    - **Comprehensive Guide**: [Markdown](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
     - **Example Code**: [View Python Example](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/example_control_node.py)
 
     **Usage:** Point your AI assistant to these URLs with instructions like:

--- a/docs/developing_nodes/index.md
+++ b/docs/developing_nodes/index.md
@@ -4,10 +4,10 @@ This section provides comprehensive documentation for developers building custom
 
 !!! tip "For AI Assistants & Coding Agents"
 
-    All documentation in this section is available as raw markdown for use with AI coding assistants:
+    All documentation in this section is available as post-processed markdown for AI coding assistants. The site exposes a full machine-readable surface; see [For Agents](../for_agents.md) for the index.
 
-    - **Getting Started**: [Download/View Raw Markdown](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/getting_started.md)
-    - **Comprehensive Guide**: [Download/View Raw Markdown](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/comprehensive_guide.md)
+    - **Getting Started**: [https://docs.griptapenodes.com/developing_nodes/getting_started/index.md](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
+    - **Comprehensive Guide**: [https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
     - **Example Code**: [View Python Example](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/example_control_node.py)
 
     **Usage:** Point your AI assistant to these URLs with instructions like:

--- a/docs/developing_nodes/index.md
+++ b/docs/developing_nodes/index.md
@@ -6,8 +6,8 @@ This section provides comprehensive documentation for developers building custom
 
     All documentation in this section is available as post-processed markdown for AI coding assistants. The site exposes a full machine-readable surface; see [For Agents](../for_agents.md) for the index.
 
-    - **Getting Started**: [https://docs.griptapenodes.com/developing_nodes/getting_started/index.md](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
-    - **Comprehensive Guide**: [https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
+    - **Getting Started**: [Markdown](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
+    - **Comprehensive Guide**: [Markdown](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
     - **Example Code**: [View Python Example](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/example_control_node.py)
 
     **Usage:** Point your AI assistant to these URLs with instructions like:

--- a/docs/for_agents.md
+++ b/docs/for_agents.md
@@ -1,0 +1,64 @@
+# For Agents
+
+This page documents the machine-readable surface that
+[docs.griptapenodes.com](https://docs.griptapenodes.com/) exposes for AI
+coding agents, MCP skills, and any tool that wants to ground its work in the
+engine's actual API.
+
+The same files that render this site are also published as post-processed
+markdown so an agent can fetch them directly. Snippets, macros, and
+mkdocstrings output are already expanded, which `raw.githubusercontent.com`
+does not give you.
+
+## Surface
+
+- [`/llms.txt`](https://docs.griptapenodes.com/llms.txt) is the curated
+    index per the [llms.txt convention](https://llmstxt.org/). It groups the
+    high-value pages (scripting, the project system, custom node development,
+    MCP integration, and the node reference) under named sections with short
+    descriptions and absolute URLs.
+- [`/llms-full.txt`](https://docs.griptapenodes.com/llms-full.txt) is the
+    full concatenated post-processed markdown of every page in the nav. Use
+    this when you want to drop the entire engine docs into a single context
+    window.
+- Every doc page is also available as standalone markdown next to its HTML
+    rendering. The URL is the rendered page URL with `/index.md` appended,
+    for example
+    [`/developing_nodes/comprehensive_guide/index.md`](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
+    and [`/retained_mode/index.md`](https://docs.griptapenodes.com/retained_mode/index.md).
+    Top-level pages live at `/<page>/index.md`; nested pages mirror the
+    rendered URL.
+
+## When to use which
+
+- Reach for **`/llms.txt`** to discover what's available without pulling the
+    whole corpus. It's small enough to skim and the section descriptions tell
+    you which page covers which topic.
+- Reach for **`/llms-full.txt`** when you want a single-shot grounding
+    document and have the context budget for it. It is the same content as
+    the per-page markdown files, concatenated in the order declared in the
+    llms.txt sections.
+- Reach for **a single per-page `.md`** when you already know which page
+    you need (e.g. you're writing a custom node and want the comprehensive
+    guide, or you're scripting and want `retained_mode.md`).
+
+## High-value pages for engine grounding
+
+If you are pointing an agent at a small set of pages to bootstrap, these
+five cover most of the engine's first-party API surface:
+
+- [Scripting (retained mode)](https://docs.griptapenodes.com/retained_mode/index.md)
+- [Comprehensive node development guide](https://docs.griptapenodes.com/developing_nodes/comprehensive_guide/index.md)
+- [Getting started with node development](https://docs.griptapenodes.com/developing_nodes/getting_started/index.md)
+- [Project system overview](https://docs.griptapenodes.com/projects/index.md)
+- [MCP integration overview](https://docs.griptapenodes.com/how_to/mcp/index.md)
+
+## Stability
+
+- The surface tracks `main` via the existing docs deploy pipeline. There is
+    one live surface; versioned URLs (e.g. `/v0.40/llms.txt`) are not
+    currently published.
+- The set of pages is driven by the `llmstxt` plugin block in `mkdocs.yml`.
+    Adding a new doc page does not automatically include it in `/llms.txt` or
+    `/llms-full.txt`; the page must be added under a section there. Reference
+    pages under `nodes/` are picked up via a glob.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,72 @@ plugins:
           options:
             show_if_no_docstring: true
             heading_level: 3
+  - llmstxt:
+      full_output: llms-full.txt
+      markdown_description: |
+        Documentation for the Griptape Nodes engine: scripting (retained mode),
+        the project system, custom node development, the built-in node
+        reference, and the engine MCP surface. Use these files to ground an
+        agent in the engine's actual API rather than scraping rendered HTML or
+        fetching unrenderered raw markdown from `main`.
+      sections:
+        Overview:
+          - index.md: Top-level introduction to Griptape Nodes
+          - for_agents.md: Hosted machine-readable docs surface (this page)
+          - faq.md: Frequently asked questions
+          - glossary.md: Terms and definitions used throughout the docs
+          - installation.md: Install the engine
+        Configuration and CLI:
+          - configuration.md: Engine configuration (workspace, secrets, libraries)
+          - command_line_interface.md: gtn CLI reference
+        Scripting (retained mode):
+          - retained_mode.md: Engine scripting API for building and running workflows
+        Project system:
+          - projects/index.md: Project system overview
+          - projects/workspace.md: Workspace concepts
+          - projects/projects.md: Projects
+          - projects/macros.md: Macros
+          - projects/directories.md: Directories
+          - projects/situations.md: Situations
+          - projects/environment.md: Environment and built-in variables
+          - projects/file_extension_directories.md: File extension directories
+          - projects/customization.md: Customization guide
+        Custom nodes and scripts:
+          - developing_nodes/index.md: Developing custom nodes overview
+          - developing_nodes/getting_started.md: Beginner-friendly intro to node development
+          - developing_nodes/comprehensive_guide.md: Exhaustive node development reference
+          - how_to/making_custom_nodes.md: Quick start template for building a custom node
+          - how_to/making_custom_scripts.md: Build custom node execution scripts
+        Beginner tutorial (FTUE):
+          - ftue/FTUE.md: Tutorial overview
+          - ftue/00_tour/FTUE_00_tour.md
+          - ftue/01_prompt_an_image/FTUE_01_prompt_an_image.md
+          - ftue/02_coordinating_agents/FTUE_02_coordinating_agents.md
+          - ftue/03_compare_prompts/FTUE_03_compare_prompts.md
+          - ftue/04_photography_team/FTUE_04_photography_team.md
+        External services:
+          - how_to/keys/openai.md
+          - how_to/keys/grok.md
+          - how_to/installs/hugging_face.md
+        MCP integration:
+          - how_to/mcp/index.md: MCP integration overview
+          - how_to/mcp/getting_started.md
+          - how_to/mcp/mcp_task_agents.md
+          - how_to/mcp/advanced_local_models.md
+          - how_to/mcp/connection_types/stdio.md
+          - how_to/mcp/connection_types/sse.md
+          - how_to/mcp/connection_types/streamable_http.md
+          - how_to/mcp/connection_types/websocket.md
+          - how_to/mcp/rules.md
+          - how_to/mcp/servers/index.md
+          - how_to/mcp/servers/blender.md
+          - how_to/mcp/servers/maya.md
+          - how_to/mcp/servers/exa.md
+          - how_to/mcp/servers/fetch.md
+          - how_to/mcp/servers/filesystem.md
+          - how_to/mcp/servers/time.md
+        Node reference:
+          - nodes/*.md
 
 extra_css:
   - assets/css/extra.css
@@ -121,6 +187,7 @@ nav:
                   - Filesystem: how_to/mcp/servers/filesystem.md
                   - Time: how_to/mcp/servers/time.md
   - FAQ: faq.md
+  - For Agents: for_agents.md
   - Nodes Reference:
       - Overview: nodes/overview.md
       - Misc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ docs = [
   "mkdocs>=1.5.2",
   "mkdocstrings[python]>=0.29.1",
   "mkdocs-mermaid2-plugin>=1.2.2",
+  "mkdocs-llmstxt>=0.5.0",
   "pymdown-extensions>=10.17",
 ]
 test = [

--- a/uv.lock
+++ b/uv.lock
@@ -461,6 +461,7 @@ dev = [
 ]
 docs = [
     { name = "mkdocs" },
+    { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -526,6 +527,7 @@ dev = [
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.5.2" },
+    { name = "mkdocs-llmstxt", specifier = ">=0.5.0" },
     { name = "mkdocs-material", specifier = ">=9.6.9" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.2" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
@@ -831,6 +833,19 @@ wheels = [
 ]
 
 [[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -905,14 +920,14 @@ ws = [
 
 [[package]]
 name = "mdformat"
-version = "1.0.0"
+version = "0.7.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
 ]
 
 [[package]]
@@ -970,6 +985,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/25/df38de72a291b96fb7af7549c5285e934267f8f0b269d3ccacda84ef764c/mdformat_mkdocs-5.1.4.tar.gz", hash = "sha256:d3ecf035100328c5ff2b3bd7de87a16ee0484e5c317add9c70022598d15af6a1", size = 28160, upload-time = "2026-01-26T12:12:41.983Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/bf/00ba31df7cd955eb0dbb1b8b0eb388bc6f717f033f807656a12eb8f12a5b/mdformat_mkdocs-5.1.4-py3-none-any.whl", hash = "sha256:6ff339c1023926077c0c598533768433b38981a9eb792ebfe02d2438ba71514d", size = 38377, upload-time = "2026-01-26T12:12:40.326Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
 ]
 
 [[package]]
@@ -1052,6 +1080,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #4575.

Wires the [`mkdocs-llmstxt`](https://github.com/pawamoy/mkdocs-llmstxt) plugin into the existing mkdocs build.

https://griptape-nodes--4578.org.readthedocs.build/en/4578/llms.txt

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4578.org.readthedocs.build/en/4578/

<!-- readthedocs-preview griptape-nodes end -->