### PR TITLE
feat(mcp): stabilize MCP server port for external clients

### DIFF
--- a/docs/how_to/mcp/external_clients.md
+++ b/docs/how_to/mcp/external_clients.md
@@ -10,7 +10,7 @@ By default the engine listens on:
 http://localhost:8125/mcp/
 ```
 
-The trailing slash matters. The transport is **Streamable HTTP**.
+The transport is **Streamable HTTP**. The trailing slash is recommended; the server redirects `/mcp` to `/mcp/` for clients that drop it.
 
 When the engine starts, it logs the actual bound address, for example:
 
@@ -102,10 +102,19 @@ Claude Desktop's `claude_desktop_config.json` only supports `stdio` servers. To 
 
 ## Verifying the connection
 
-With the engine running, list the tools the MCP server exposes from the command line:
+The simplest non-interactive check is the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) CLI. The engine speaks Streamable HTTP, so pass `--transport http`:
 
 ```bash
-npx @modelcontextprotocol/inspector http://localhost:8125/mcp/
+npx -y @modelcontextprotocol/inspector --cli http://localhost:8125/mcp/ \
+  --transport http --method tools/list
 ```
 
-You should see the engine's request tools (`CreateNodeRequest`, `RunWorkflowWithCurrentStateRequest`, etc.).
+Without `--transport http` the inspector defaults to SSE and you'll see `SSE error: Non-200 status code (400)`, which is the engine refusing an SSE-style GET without an MCP session.
+
+The inspector also has a browser UI:
+
+```bash
+npx -y @modelcontextprotocol/inspector
+```
+
+Paste `http://localhost:8125/mcp/` into the URL field and pick **Streamable HTTP** as the transport. If the connection fails with `TypeError: NetworkError when attempting to fetch resource`, it's almost always CORS: the engine's MCP server does not currently emit `Access-Control-Allow-Origin` headers, so cross-origin browser fetches are blocked. Use the CLI command above instead, or run the inspector with browser security relaxed.

--- a/docs/how_to/mcp/external_clients.md
+++ b/docs/how_to/mcp/external_clients.md
@@ -1,0 +1,111 @@
+# Connect External MCP Clients to Griptape Nodes
+
+Griptape Nodes runs its own MCP server so external agents (Claude Desktop, Claude Code, Cursor, VS Code, etc.) can drive the engine. This page is the inverse of the rest of this section: instead of Griptape Nodes consuming external MCP servers, here we expose Griptape Nodes itself as an MCP server.
+
+## URL
+
+By default the engine listens on:
+
+```
+http://localhost:8125/mcp/
+```
+
+The trailing slash matters. The transport is **Streamable HTTP**.
+
+When the engine starts, it logs the actual bound address, for example:
+
+```
+INFO MCP server listening at http://127.0.0.1:8125/mcp/
+```
+
+## Overrides
+
+The host and port are controlled by environment variables:
+
+| Variable                   | Default     | Description                                                              |
+| -------------------------- | ----------- | ------------------------------------------------------------------------ |
+| `GTN_MCP_SERVER_HOST`      | `localhost` | Interface to bind. Use `127.0.0.1` to be explicit, or `0.0.0.0` for LAN. |
+| `GTN_MCP_SERVER_PORT`      | `8125`      | TCP port. Set to `0` to let the OS assign a free port.                   |
+| `GTN_MCP_SERVER_LOG_LEVEL` | `ERROR`     | uvicorn log level for the MCP server.                                    |
+
+If the configured port is already in use, the engine falls back to an OS-assigned port. Check the startup log to see the actual URL.
+
+!!! warning "Local-only by default"
+
+    The engine binds to `localhost`, which means only processes on the same machine can reach it. The MCP server has no authentication. Do not bind to `0.0.0.0` or expose the port to the network unless you fully trust everything that can reach it.
+
+## Client configuration
+
+### Claude Code
+
+Add to `~/.claude.json` (or use `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "griptape-nodes": {
+      "type": "streamable-http",
+      "url": "http://localhost:8125/mcp/"
+    }
+  }
+}
+```
+
+### Cursor
+
+Create `~/.cursor/mcp.json` for global access, or `.cursor/mcp.json` in a workspace:
+
+```json
+{
+  "mcpServers": {
+    "griptape-nodes": {
+      "url": "http://localhost:8125/mcp/"
+    }
+  }
+}
+```
+
+### VS Code
+
+Create `.vscode/mcp.json` in your workspace, or open the user file via **MCP: Open User Configuration**:
+
+```json
+{
+  "servers": {
+    "griptape-nodes": {
+      "type": "http",
+      "url": "http://localhost:8125/mcp/"
+    }
+  }
+}
+```
+
+Note that VS Code uses `servers` (not `mcpServers`) and `"type": "http"`.
+
+### Claude Desktop
+
+Claude Desktop's `claude_desktop_config.json` only supports `stdio` servers. To connect to a remote/HTTP MCP server, either:
+
+- Use **Settings → Connectors → Add custom connector** in the app and paste `http://localhost:8125/mcp/`, or
+- Wrap the URL with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) in the config file:
+
+```json
+{
+  "mcpServers": {
+    "griptape-nodes": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:8125/mcp/"]
+    }
+  }
+}
+```
+
+## Verifying the connection
+
+With the engine running, list the tools the MCP server exposes from the command line:
+
+```bash
+npx @modelcontextprotocol/inspector http://localhost:8125/mcp/
+```
+
+You should see the engine's request tools (`CreateNodeRequest`, `RunWorkflowWithCurrentStateRequest`, etc.).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
               - Getting Started: how_to/mcp/getting_started.md
               - Using MCPTask with Agents: how_to/mcp/mcp_task_agents.md
               - "Local Models with Agents": how_to/mcp/advanced_local_models.md
+              - Connect External MCP Clients: how_to/mcp/external_clients.md
               - Connection Types:
                   - Local Process (stdio): how_to/mcp/connection_types/stdio.md
                   - Server-Sent Events (SSE): how_to/mcp/connection_types/sse.md

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -126,8 +126,10 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
 }
 
 GTN_MCP_SERVER_HOST = os.getenv("GTN_MCP_SERVER_HOST", "localhost")
-# Port of the MCP server (where uvicorn binds). 0 means the OS assigns a free port automatically.
-GTN_MCP_SERVER_PORT = int(os.getenv("GTN_MCP_SERVER_PORT", "0"))
+# Port of the MCP server (where uvicorn binds). Stable by default so external MCP clients
+# (Claude Desktop, Cursor, VS Code, ...) can hard-code the URL in their config files.
+# Set to 0 to let the OS assign a free port; set to any other value to pin the port.
+GTN_MCP_SERVER_PORT = int(os.getenv("GTN_MCP_SERVER_PORT", "8125"))
 GTN_MCP_SERVER_LOG_LEVEL = os.getenv("GTN_MCP_SERVER_LOG_LEVEL", "ERROR").lower()
 
 config_manager = ConfigManager()
@@ -187,7 +189,8 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
     this function. Using a pre-bound socket avoids race conditions when discovering
     the actual port assigned by the OS.
     """
-    mcp_server_logger.debug("Starting MCP GTN server...")
+    bound_host, bound_port = sock.getsockname()[:2]
+    mcp_server_logger.info("MCP server listening at http://%s:%d/mcp/", bound_host, bound_port)
 
     app = Server("mcp-gtn")
 

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -15,7 +15,6 @@ from mcp.types import (
     Tool,
 )
 from pydantic import TypeAdapter
-from rich.logging import RichHandler
 from starlette.types import Receive, Scope, Send
 
 from griptape_nodes.api_client import Client, RequestClient
@@ -136,7 +135,6 @@ config_manager = ConfigManager()
 secrets_manager = SecretsManager(config_manager)
 
 mcp_server_logger = logging.getLogger("griptape_nodes_mcp_server")
-mcp_server_logger.addHandler(RichHandler(show_time=True, show_path=False, markup=True, rich_tracebacks=True))
 mcp_server_logger.setLevel(logging.INFO)
 
 


### PR DESCRIPTION
Closes #3851

The engine's MCP server bound to an OS-assigned port by default, so external MCP clients had no stable URL to put in their config files and the actual port was never surfaced anywhere a user could find it. Pinning `GTN_MCP_SERVER_PORT` to `8125` (mirroring `STATIC_SERVER_PORT`'s `8124` neighbor) gives external clients something to hard-code; the env var still allows `0` for users who want OS-assigned, and `bind_free_socket`'s existing fallback handles port collisions. The startup INFO log reads the bound address from `sock.getsockname()` rather than the configured value so it stays accurate when that fallback fires.

The new `external_clients.md` page covers the inverse direction from the rest of the MCP docs (engine-as-server instead of engine-as-client) and includes paste-ready snippets for the four clients we expect users to reach for. Claude Desktop gets the `mcp-remote` shim treatment because its config file is still stdio-only; the others connect natively over Streamable HTTP.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4579.org.readthedocs.build/en/4579/

<!-- readthedocs-preview griptape-nodes end -->