### PR TITLE
fix: reconcile DISABLED libraries on refresh

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3902,11 +3902,20 @@ class LibraryManager:
 
         Loads metadata if possible and creates the entry in the appropriate lifecycle state.
         When `enabled` is False, the entry is created in the DISABLED terminal state and
-        is skipped by load_all_libraries_from_config. Only creates the entry if it doesn't
-        already exist in tracking.
+        is skipped by load_all_libraries_from_config.
+
+        If an entry already exists for this path, it is preserved unless the requested
+        `enabled` flag disagrees with the existing lifecycle state (DISABLED vs. anything
+        else). In that case the stale entry is dropped so a fresh one can be created,
+        which is what lets a refresh pick up libraries the user has just toggled in
+        libraries_to_register.
         """
-        if file_path_str in self._library_file_path_to_info:
-            return
+        existing = self._library_file_path_to_info.get(file_path_str)
+        if existing is not None:
+            existing_is_disabled = existing.lifecycle_state == LibraryManager.LibraryLifecycleState.DISABLED
+            if existing_is_disabled == (not enabled):
+                return
+            del self._library_file_path_to_info[file_path_str]
 
         metadata_result = self.load_library_metadata_from_file_request(
             LoadLibraryMetadataFromFileRequest(file_path=file_path_str)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3913,8 +3913,12 @@ class LibraryManager:
         existing = self._library_file_path_to_info.get(file_path_str)
         if existing is not None:
             existing_is_disabled = existing.lifecycle_state == LibraryManager.LibraryLifecycleState.DISABLED
-            if existing_is_disabled == (not enabled):
+            requested_is_disabled = not enabled
+            if existing_is_disabled == requested_is_disabled:
+                # Already in the right state; keep the existing entry as-is.
                 return
+            # The user toggled enabled in libraries_to_register; drop the stale entry so
+            # the block below recreates it with the new lifecycle.
             del self._library_file_path_to_info[file_path_str]
 
         metadata_result = self.load_library_metadata_from_file_request(

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -232,6 +232,44 @@ class TestLibraryManagerDisabledEntries:
         warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert any("libraries_to_register" in m for m in warnings)
 
+    def test_rediscovery_reconciles_toggled_enabled_flag(
+        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+    ) -> None:
+        """Re-running discovery after a refresh updates lifecycle when the user toggles enabled.
+
+        Refreshing libraries (ReloadAllLibrariesRequest) does not unload entries that were
+        never registered with LibraryRegistry, such as DISABLED entries. The follow-up
+        discovery must therefore reconcile the lifecycle state itself; otherwise a library
+        flipped from disabled to enabled (or back) would never get picked up.
+        """
+        from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesRequest
+        from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+        library_manager = griptape_nodes.LibraryManager()
+        first_lib, second_lib = lib_files
+        # Reset tracking so this test does not depend on prior state.
+        library_manager._library_file_path_to_info = {}
+
+        # Initial discovery: first_lib enabled, second_lib disabled.
+        initial_config = [str(first_lib), {"path": str(second_lib), "enabled": False}]
+        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=initial_config):
+            library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
+
+        first_state = library_manager._library_file_path_to_info[str(first_lib)].lifecycle_state
+        second_state = library_manager._library_file_path_to_info[str(second_lib)].lifecycle_state
+        assert first_state != LibraryManager.LibraryLifecycleState.DISABLED
+        assert second_state == LibraryManager.LibraryLifecycleState.DISABLED
+
+        # User flips the config: first_lib disabled, second_lib enabled, then triggers refresh.
+        toggled_config = [{"path": str(first_lib), "enabled": False}, str(second_lib)]
+        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=toggled_config):
+            library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
+
+        first_state_after = library_manager._library_file_path_to_info[str(first_lib)].lifecycle_state
+        second_state_after = library_manager._library_file_path_to_info[str(second_lib)].lifecycle_state
+        assert first_state_after == LibraryManager.LibraryLifecycleState.DISABLED
+        assert second_state_after != LibraryManager.LibraryLifecycleState.DISABLED
+
 
 class TestLibraryManagerMigrateOldXdgPaths:
     """Test the _migrate_old_xdg_library_paths functionality in LibraryManager."""


### PR DESCRIPTION
Disabled entries in `libraries_to_register` are tracked in `LibraryManager._library_file_path_to_info` but never registered with `LibraryRegistry`, so the unload pass in `ReloadAllLibrariesRequest` skips them. Re-discovery then short-circuited on the existing entry and left the stale `DISABLED` lifecycle in place, which meant the user had to restart the engine to pick up an enable/disable toggle. The same hole affected entries that had loaded metadata but never reached `LOADED`.

Discovery is now authoritative for the `DISABLED` vs. non-`DISABLED` distinction: when `_create_library_info_entry` finds an existing entry whose state disagrees with the requested `enabled` flag, it drops the stale entry so the existing recreation logic produces a fresh `LibraryInfo`. Matching state still short-circuits, so steady-state refreshes do no extra work.

Found while testing griptape-ai/griptape-vsl-gui#2267.

Closes #4580
