### PR TITLE
feat: use badges instead of ParameterMessage for HuggingFace model download status

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -2,9 +2,10 @@ import logging
 import re
 from abc import ABC, abstractmethod
 
-from griptape_nodes.exe_types.core_types import BadgeData, ParameterMode
+from griptape_nodes.exe_types.core_types import BadgeData, NodeMessageResult, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
@@ -82,7 +83,15 @@ class HuggingFaceModelParameter(ABC):
             name=self._parameter_name,
             default_value=default_value,
             display_name=self._parameter_name,
-            traits={Options(choices=display_choices)},
+            traits={
+                Options(choices=display_choices),
+                Button(
+                    icon="list-restart",
+                    size="icon",
+                    variant="secondary",
+                    on_click=self._on_refresh_click,
+                ),
+            },
             tooltip=self._parameter_name,
             allowed_modes={ParameterMode.PROPERTY},
             accept_any=False,
@@ -94,6 +103,10 @@ class HuggingFaceModelParameter(ABC):
 
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
+
+    def _on_refresh_click(self, _button: Button, _button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:
+        self.refresh_parameters()
+        return None
 
     def get_choices(self) -> list[str]:
         # Ensure the latest repo revisions are fetched
@@ -160,18 +173,17 @@ class HuggingFaceModelParameter(ABC):
 
         model_lines = []
         for model in download_models:
+            hf_link = f"[↗](https://huggingface.co/{model})"
             if model in downloaded_repo_ids:
-                model_lines.append(f"✓ {model}")
+                model_lines.append(f"✓ {model} {hf_link}")
             else:
-                model_lines.append(f"[{model}](#model-management?search={model})")
+                model_lines.append(f"[↓ {model}](#model-management?search={model}) {hf_link}")
 
         message = (
             "Model download required to continue.\n\n"
-            "To download models:\n\n"
-            "- Navigate to **Settings → Model Management**\n\n"
-            "-Search for the model(s) you need and click the download button:\n\n"
+            "Click a model name below to open it in Model Management, then click the download button:\n\n"
             + "\n\n".join(model_lines)
-            + "\n\nAfter completing these steps, a dropdown with available models will appear."
+            + "\n\nAfter downloading, a dropdown with available models will appear."
         )
 
         return BadgeData(

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -2,11 +2,14 @@ import logging
 import re
 from abc import ABC, abstractmethod
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.core_types import BadgeData, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
+
+_NO_MODELS_PLACEHOLDER = "No models downloaded — see badge"
 
 
 class HuggingFaceModelParameter(ABC):
@@ -41,57 +44,56 @@ class HuggingFaceModelParameter(ABC):
             return
 
         choices = self.get_choices()
-        if not choices:
-            return
 
-        current_value = self._node.get_parameter_value(self._parameter_name)
-        if current_value in choices:
-            default_value = current_value
-        else:
+        if choices:
             default_value = choices[0]
+            display_choices = choices
+        else:
+            default_value = _NO_MODELS_PLACEHOLDER
+            display_choices = [_NO_MODELS_PLACEHOLDER]
 
         if parameter.find_elements_by_type(Options):
-            self._node._update_option_choices(self._parameter_name, choices, default_value)
+            self._node._update_option_choices(self._parameter_name, display_choices, default_value)
         else:
-            parameter.add_trait(Options(choices=choices))
+            parameter.add_trait(Options(choices=display_choices))
+
+        self._node.set_parameter_value(self._parameter_name, default_value)
+
+        badge = self._build_model_badge()
+        if badge is None:
+            parameter.clear_badge()
+        else:
+            parameter.set_badge(
+                variant=badge.variant,
+                title=badge.title,
+                message=badge.message,
+                icon=badge.icon,
+                hide_clear_button=badge.hide_clear_button,
+            )
 
     def add_input_parameters(self) -> None:
         choices = self.get_choices()
+        badge = self._build_model_badge()
 
-        if not choices:
-            self._node.add_node_element(
-                ParameterMessage(
-                    name=f"huggingface_repo_parameter_message_{self._parameter_name}",
-                    title="Huggingface Model Download Required",
-                    variant="warning",
-                    value=self.get_help_message(),
-                    button_link=f"#model-management?search={self.get_download_models()[0]}",
-                    button_text="Model Management",
-                    button_icon="hard-drive",
-                )
-            )
-            return
+        display_choices = choices or [_NO_MODELS_PLACEHOLDER]
+        default_value = choices[0] if choices else _NO_MODELS_PLACEHOLDER
 
-        self._node.add_parameter(
-            Parameter(
-                name=self._parameter_name,
-                default_value=choices[0] if choices else None,
-                input_types=["str"],
-                type="str",
-                ui_options={"display_name": self._parameter_name, "show_search": True},
-                traits={
-                    Options(
-                        choices=choices,
-                    )
-                },
-                tooltip=self._parameter_name,
-                allowed_modes={ParameterMode.PROPERTY},
-            )
+        parameter = ParameterString(
+            name=self._parameter_name,
+            default_value=default_value,
+            display_name=self._parameter_name,
+            traits={Options(choices=display_choices)},
+            tooltip=self._parameter_name,
+            allowed_modes={ParameterMode.PROPERTY},
+            accept_any=False,
+            badge=badge,
         )
+
+        self._node.add_parameter(parameter)
+        self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
 
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
-        self._node.remove_parameter_element_by_name(f"huggingface_repo_parameter_message_{self._parameter_name}")
 
     def get_choices(self) -> list[str]:
         # Ensure the latest repo revisions are fetched
@@ -148,16 +150,36 @@ class HuggingFaceModelParameter(ABC):
         # If revision was provided, return it directly
         return repo_id, revision
 
-    def get_help_message(self) -> str:
-        download_models = "\n".join([f"  {model}" for model in self.get_download_models()])
+    def _build_model_badge(self) -> BadgeData | None:
+        download_models = self.get_download_models()
+        downloaded_repo_ids = {repo_id for repo_id, _ in self.list_repo_revisions()}
 
-        return (
+        missing = [m for m in download_models if m not in downloaded_repo_ids]
+        if not missing:
+            return None
+
+        model_lines = []
+        for model in download_models:
+            if model in downloaded_repo_ids:
+                model_lines.append(f"✓ {model}")
+            else:
+                model_lines.append(f"[{model}](#model-management?search={model})")
+
+        message = (
             "Model download required to continue.\n\n"
             "To download models:\n\n"
-            "1. Navigate to Settings -> Model Management\n\n"
-            "2. Search for the model(s) you need and click the download button:\n"
-            f"{download_models}\n\n"
-            "After completing these steps, a dropdown menu with available models will appear."
+            "- Navigate to **Settings → Model Management**\n\n"
+            "-Search for the model(s) you need and click the download button:\n\n"
+            + "\n\n".join(model_lines)
+            + "\n\nAfter completing these steps, a dropdown with available models will appear."
+        )
+
+        return BadgeData(
+            variant="warning",
+            title="Download Required",
+            message=message,
+            icon="hard-drive",
+            hide_clear_button=True,
         )
 
     @abstractmethod

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -104,10 +104,6 @@ class HuggingFaceModelParameter(ABC):
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
 
-    def _on_refresh_click(self, _button: Button, _button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:
-        self.refresh_parameters()
-        return None
-
     def get_choices(self) -> list[str]:
         # Ensure the latest repo revisions are fetched
         self._repo_revisions = self.fetch_repo_revisions()
@@ -162,6 +158,12 @@ class HuggingFaceModelParameter(ABC):
 
         # If revision was provided, return it directly
         return repo_id, revision
+
+    def _on_refresh_click(
+        self, _button: Button, _button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:
+        self.refresh_parameters()
+        return None
 
     def _build_model_badge(self) -> BadgeData | None:
         download_models = self.get_download_models()

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -57,6 +57,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
         # Get all cached models
         all_choices = self.get_choices()
         if not all_choices:
+            super().refresh_parameters()
             return
 
         # Get current value - use value_being_set if provided (during after_value_set)
@@ -74,8 +75,9 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             if not is_deprecated or choice == current_value:
                 filtered_choices.append(choice)
 
-        # If no choices after filtering, include all (initial state)
+        # If no choices after filtering, fall back to base behaviour
         if not filtered_choices:
+            super().refresh_parameters()
             return
 
         # Determine default value
@@ -88,6 +90,19 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             self._node._update_option_choices(self._parameter_name, filtered_choices, default_value)
         else:
             parameter.add_trait(Options(choices=filtered_choices))
+
+        # Update badge to reflect current download status
+        badge = self._build_model_badge()
+        if badge is None:
+            parameter.clear_badge()
+        else:
+            parameter.set_badge(
+                variant=badge.variant,
+                title=badge.title,
+                message=badge.message,
+                icon=badge.icon,
+                hide_clear_button=badge.hide_clear_button,
+            )
 
     def add_input_parameters(self) -> None:
         """Override to apply deprecated model filtering after parameter creation."""

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -75,7 +75,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             if not is_deprecated or choice == current_value:
                 filtered_choices.append(choice)
 
-        # If no choices after filtering, fall back to base behaviour
+        # If no choices after filtering, include all (initial state)
         if not filtered_choices:
             super().refresh_parameters()
             return


### PR DESCRIPTION
Fixes: https://github.com/griptape-ai/griptape-nodes/issues/4586

## Summary

- Replaces the conditional `ParameterMessage` warning block (which hid the model dropdown entirely when no models were downloaded) with a badge on the `model` parameter that appears only when one or more required models are missing
- The model dropdown is now always visible: when no models are downloaded it shows a placeholder `"No models downloaded — see badge"`; once models are available it shows the real choices
- Adds a refresh button (`list-restart` icon) to the model parameter so users can update the list after downloading a model without reloading the node
- Badge message renders markdown with per-model status — `✓ model-name [↗](huggingface link)` for downloaded models and `↓ [model-name](model-management link) [↗](huggingface link)` for missing ones, so users can click directly to either download or browse the model
- Fixes `HuggingFaceRepoParameter.refresh_parameters` early-return bug: when all choices were empty (e.g. after deleting a downloaded model) the method returned without updating the UI, making the refresh button appear non-functional. It now delegates to `super().refresh_parameters()` so the placeholder and badge are correctly restored
- Adds badge updating to the filtered (non-empty) path in `HuggingFaceRepoParameter.refresh_parameters`, which previously never updated the badge after the initial render

## Before

Node showed massive ParameterMessage when there was 1 or more missing models:
<img width="482" height="549" alt="image" src="https://github.com/user-attachments/assets/c0b1cdf5-d1ea-4817-9513-244c9d088dfd" />

But if at least one of the models were downloaded, the Parameter message went away _even if the user could pick more models_

<img width="477" height="354" alt="image" src="https://github.com/user-attachments/assets/280eb9bd-3901-467c-a1ad-be4e039f1a5f" />

## Current

Now the node will show a Badge if there are missing models, and a message:

<img width="564" height="384" alt="image" src="https://github.com/user-attachments/assets/6c9caa65-99ad-456e-9b21-ceb2f59cfbd2" />

if the user clicks the badge, the see all the available models

<img width="824" height="446" alt="image" src="https://github.com/user-attachments/assets/91a64b1c-a503-4986-bf7b-f77e843cbdd9" />

If the user has at least one missing model downloaded, they still see the badge

<img width="569" height="291" alt="image" src="https://github.com/user-attachments/assets/7c431f8a-ce4a-4c72-be24-10201ba6e8c2" />

and in the badge itself, they can see which models they've downloaded and which are missing:

<img width="273" height="266" alt="image" src="https://github.com/user-attachments/assets/7ca41712-c999-4078-8c8d-f2020fe40fa5" />


Every model also has a link to the hugging face page by clicking on the arrow.

If all the models are downloaded, the badge goes away

<img width="557" height="318" alt="image" src="https://github.com/user-attachments/assets/648dfe22-e591-46c2-9364-9388804aad4c" />

There's also a refresh button the user can use to reload the list if the models change and they want to update the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)