### PR TITLE
feat: add on_each per-iteration control output to BaseIterativeNodeGroup

### DIFF
--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -2042,6 +2042,26 @@ class NodeExecutor:
 
         return sources
 
+    def _resolve_on_each_entry(self, node: SubflowNodeGroup) -> tuple[str | None, str | None]:
+        """Return (entry_node_name, entry_param_name) from on_each connection, or (None, None)."""
+        if not (isinstance(node, BaseIterativeNodeGroup) and hasattr(node, "on_each")):
+            return None, None
+        flow_manager = GriptapeNodes.FlowManager()
+        connections = flow_manager.get_connections()
+        on_each_conns = connections.outgoing_index.get(node.name, {}).get("on_each", [])
+        if not on_each_conns:
+            return None, None
+        first_conn = connections.connections[on_each_conns[0]]
+        if first_conn.target_node.name == node.name:
+            proxy_param = first_conn.target_parameter
+            proxy_conns = connections.outgoing_index.get(node.name, {}).get(proxy_param.name, [])
+            if proxy_conns:
+                internal_conn = connections.connections[proxy_conns[0]]
+                if internal_conn.is_node_group_internal:
+                    return internal_conn.target_node.name, internal_conn.target_parameter.name
+            return None, None
+        return first_conn.target_node.name, first_conn.target_parameter.name
+
     async def _package_subflow_group_body(
         self, node: SubflowNodeGroup, label: str
     ) -> PackageNodesAsSerializedFlowResultSuccess | None:
@@ -2075,6 +2095,8 @@ class NodeExecutor:
         sanitized_node_name = node.name.replace(" ", "_")
         output_parameter_prefix = f"{sanitized_node_name}_{label}_"
 
+        entry_control_node_name, entry_control_parameter_name = self._resolve_on_each_entry(node)
+
         request = PackageNodesAsSerializedFlowRequest(
             node_names=node_names,
             start_node_type=workflow_start_end_nodes.start_flow_node_type,
@@ -2082,8 +2104,8 @@ class NodeExecutor:
             start_node_library_name=workflow_start_end_nodes.start_flow_node_library_name,
             end_node_library_name=workflow_start_end_nodes.end_flow_node_library_name,
             output_parameter_prefix=output_parameter_prefix,
-            entry_control_node_name=None,
-            entry_control_parameter_name=None,
+            entry_control_node_name=entry_control_node_name,
+            entry_control_parameter_name=entry_control_parameter_name,
             node_group_name=node.name,
         )
 

--- a/src/griptape_nodes/exe_types/node_groups/base_iterative_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_iterative_node_group.py
@@ -81,6 +81,17 @@ class BaseIterativeNodeGroup(SubflowNodeGroup):
             self.metadata[LEFT_PARAMETERS_KEY] = []
         self.metadata[LEFT_PARAMETERS_KEY].insert(0, "exec_in")
 
+        # Per-iteration control output — pairs visually with exec_in on the LEFT rail.
+        # Connect this to the first body node to make that node each iteration's entry point.
+        # If unconnected, executor falls back to implicit child-discovery.
+        self.on_each = ControlParameterOutput(
+            tooltip="Fired at the start of each iteration. Connect to the first node in the loop body.",
+            name="on_each",
+        )
+        self.on_each.ui_options = {"display_name": "On Each"}
+        self.add_parameter(self.on_each)
+        self.metadata[LEFT_PARAMETERS_KEY].append("on_each")
+
         self.exec_out = ControlParameterOutput(
             tooltip="Fired after all iterations complete",
             name="exec_out",


### PR DESCRIPTION
## Summary
- Adds an `on_each` `ControlParameterOutput` on the left rail of `BaseIterativeNodeGroup` (inherited by `ForLoopGroupNode` and `ForEachGroupNode`)
- When `on_each` is wired to a body node, the executor uses that node as the iteration entry point; when unconnected, falls back to implicit child-discovery so existing workflows keep running
- Adds `_resolve_on_each_entry` helper to `NodeExecutor` and updates `_package_subflow_group_body` to pass the resolved entry through

## Test Plan
- [ ] Wire `on_each` to a body node inside a ForLoopGroupNode — confirm execution enters at that node each iteration
- [ ] Leave `on_each` unconnected on an existing iterative group — confirm workflow runs unchanged (backward compat)
- [ ] Wire `on_each` inside a ForEachGroupNode and verify per-iteration entry behavior

Stacked on #4571