### PR TITLE
feat(strict-mode): orchestrator/worker correctness contract with 4 rules

### DIFF
--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -40,16 +40,6 @@ the bus there deadlocks the worker.
 **Remediation**: move the call into `aprocess` (or a lifecycle hook
 that runs after construction).
 
-#### `unknown-payload-type`
-
-A payload type crossing the wire was not registered in
-`PayloadRegistry`. Unknown types cannot be deserialized safely by the
-cattrs converter.
-
-**Remediation**: decorate the payload class with
-`@PayloadRegistry.register` so it can cross the
-worker/orchestrator boundary.
-
 ### Ergonomics rules (warnings)
 
 #### `parameter-behaviors-dropped-in-schema`

--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -1,0 +1,95 @@
+# Strict Mode Reference
+
+Strict mode is a runtime contract for what node code is allowed to do
+across the orchestrator and worker subprocess. When a node violates the
+contract, the framework records a named violation and routes it to the
+node's result payload so the author sees a remediation message in the
+editor instead of a silent no-op, deadlock, or a stack trace that names
+the wrong layer.
+
+Strict mode is always on. There is no config flag, env var, or runtime
+toggle. Severity is picked per-rule: correctness rules fail execution;
+ergonomics rules emit a warning.
+
+## How it surfaces
+
+Violations attach to the `ResultDetails` on the outgoing
+`ResultPayload`. In the editor, the node's output panel shows the rule
+id, severity, and remediation. On the worker side, correctness
+violations elevate a successful `ExecuteNodeResultSuccess` to an
+`ExecuteNodeResultFailure`; ergonomics violations stay non-fatal.
+
+Violations are also logged through the `griptape_nodes.strict_mode`
+logger. Set it to `WARNING` or lower to see every violation in the
+console.
+
+## Rule catalog
+
+Each rule is either a **correctness** rule (fails on both orchestrator
+and worker) or an **ergonomics** rule (warns on orchestrator, escalates
+to a failure on the worker unless the rule opts out).
+
+### Correctness rules (fail execution)
+
+#### `reentrant-bus-in-init`
+
+A node issued an event-bus request from inside its `__init__`. The
+worker library probe runs `__init__` to extract a schema; re-entering
+the bus there deadlocks the worker.
+
+**Remediation**: move the call into `aprocess` (or a lifecycle hook
+that runs after construction).
+
+#### `unknown-payload-type`
+
+A payload type crossing the wire was not registered in
+`PayloadRegistry`. Unknown types cannot be deserialized safely by the
+cattrs converter.
+
+**Remediation**: decorate the payload class with
+`@PayloadRegistry.register` so it can cross the
+worker/orchestrator boundary.
+
+### Ergonomics rules (warnings)
+
+#### `parameter-behaviors-dropped-in-schema`
+
+A `Parameter` attached `converters`, `validators`, or `traits` that
+are not captured in the worker schema. The orchestrator stub cannot
+re-run those behaviors, so UI-side behavior diverges from worker-side
+execution.
+
+**Remediation**: move behavior that needs to run on both sides into
+the worker-side `aprocess`, or accept the divergence as
+orchestrator-only UI sugar.
+
+#### `parameter-mutation-during-aprocess`
+
+A node called `add_parameter` or `remove_parameter_element` during
+`aprocess`. On the worker, these mutations apply to the transient
+node instance and do not sync back to the orchestrator.
+
+Hydration-time mutations made from `before_value_set` /
+`after_value_set` (the standard dynamic-parameter pattern) do
+**not** trip this rule.
+
+**Remediation**: emit an `AddParameterToNodeRequest` or
+`RemoveParameterFromNodeRequest` so the mutation propagates to the
+authoritative orchestrator-side node.
+
+#### `worker-reach-into-orchestrator`
+
+A node running on a worker issued a request whose authoritative state
+lives on the orchestrator (flow graph, connections, parameter
+registry, config, secrets). The request is forwarded across the
+WebSocket bus; each call is a network round-trip and the returned
+view is stale-by-call.
+
+The rule fires for forwarded requests issued anywhere during a
+node's execution -- including from `before_value_set` /
+`after_value_set` during hydration -- not only from `aprocess`.
+
+**Remediation**: if this is an intentional write (e.g. publishing a
+parameter value), ignore the warning. If this is a read of flow /
+connection state, consider whether the data could be passed in via
+parameters instead of fetched per-call.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,5 +346,6 @@ nav:
       - Overview: developing_nodes/index.md
       - Getting Started: developing_nodes/getting_started.md
       - Comprehensive Guide: developing_nodes/comprehensive_guide.md
+      - Strict Mode Reference: developing_nodes/strict_mode.md
       - Example Control Node: developing_nodes/example_control_node.py
   - Glossary: glossary.md

--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -23,6 +23,16 @@ logger = logging.getLogger(__name__)
 class _PendingRequest:
     future: asyncio.Future
     tag: str
+    # When True, EventResultFailure responses resolve the future with
+    # the full payload dict instead of rejecting it with
+    # ``Exception(error_msg)``. The default (False) preserves the
+    # original "failure -> raised exception" contract that
+    # ``request``/``request_to_orchestrator``/``request_batch`` already
+    # rely on. The worker fan-out path opts in so the orchestrator can
+    # cattrs-structure the failure dict back into a real
+    # ``ResultPayloadFailure`` (preserving exception fidelity over the
+    # wire).
+    resolve_failures_as_payload: bool = False
 
 
 class RequestClient:
@@ -303,7 +313,13 @@ class RequestClient:
             logger.debug("Batch of %d requests completed", len(inner_events))
             return results
 
-    async def track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
+    async def track_request(
+        self,
+        request_id: str,
+        tag: str = "",
+        *,
+        resolve_failures_as_payload: bool = False,
+    ) -> asyncio.Future:
         """Register a future for an outgoing request and return it.
 
         Use this when the send path is handled externally (e.g. WorkerManager
@@ -313,11 +329,17 @@ class RequestClient:
         Args:
             request_id: Unique identifier for this request
             tag: Optional tag for grouping related requests (e.g. worker_engine_id)
+            resolve_failures_as_payload: When True, EventResultFailure
+                responses resolve the future with the full payload dict
+                instead of rejecting it with ``Exception(error_msg)``.
+                The worker fan-out path uses this so the orchestrator
+                can structure the failure dict back into a real
+                ``ResultPayloadFailure`` (preserving exception fidelity).
 
         Returns:
             Future that will be resolved when the matching response arrives
         """
-        return await self._track_request(request_id, tag=tag)
+        return await self._track_request(request_id, tag=tag, resolve_failures_as_payload=resolve_failures_as_payload)
 
     async def cancel_requests_by_tag(self, tag: str) -> None:
         """Cancel all pending futures that were registered with the given tag.
@@ -333,12 +355,19 @@ class RequestClient:
                     entry.future.cancel()
                     logger.debug("Cancelled request %s (tag=%s)", rid, tag)
 
-    async def _track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
+    async def _track_request(
+        self,
+        request_id: str,
+        tag: str = "",
+        *,
+        resolve_failures_as_payload: bool = False,
+    ) -> asyncio.Future:
         """Start tracking a request and return a future that will be resolved on response.
 
         Args:
             request_id: Unique identifier for this request
             tag: Optional tag for grouping (e.g. worker_engine_id)
+            resolve_failures_as_payload: See ``track_request``.
 
         Returns:
             Future that will be resolved when response arrives
@@ -352,7 +381,9 @@ class RequestClient:
                 raise ValueError(msg)
 
             future: asyncio.Future = asyncio.Future()
-            self._pending_requests[request_id] = _PendingRequest(future, tag)
+            self._pending_requests[request_id] = _PendingRequest(
+                future, tag, resolve_failures_as_payload=resolve_failures_as_payload
+            )
             logger.debug("Tracking request: %s (tag=%s)", request_id, tag)
             return future
 
@@ -470,11 +501,20 @@ class RequestClient:
             if not request_id or request_id not in self._pending_requests:
                 return False
 
+            entry = self._pending_requests[request_id]
             event_type = payload.get("event_type", "")
             if event_type == "EventResultSuccess":
                 self._resolve_request_unlocked(request_id, payload)
                 return True
             if event_type == "EventResultFailure":
+                # Worker-tracked requests opt in to receiving the full
+                # payload dict so the orchestrator can cattrs-structure
+                # the failure back into a real ResultPayloadFailure
+                # (preserving the exception field). All other callers
+                # keep the legacy "raise Exception(error_msg)" contract.
+                if entry.resolve_failures_as_payload:
+                    self._resolve_request_unlocked(request_id, payload)
+                    return True
                 result = payload.get("result", {})
                 error_msg = str(result.get("result_details") or result.get("exception") or "Unknown error")
                 self._reject_request_unlocked(request_id, Exception(error_msg))

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -23,7 +23,7 @@ from rich.panel import Panel
 
 from griptape_nodes.api_client import Client, RequestClient
 from griptape_nodes.app.engine_log import _engine_role_filter, _rich_handler
-from griptape_nodes.app.worker_routing import register_remote_handlers
+from griptape_nodes.app.worker_routing import register_broadcast_handlers, register_remote_handlers
 from griptape_nodes.bootstrap.utils.subprocess_websocket_base import WebSocketMessage
 from griptape_nodes.common.node_executor import current_executing_node_name
 from griptape_nodes.retained_mode.events import app_events, execution_events, worker_events
@@ -375,6 +375,14 @@ async def _run_worker(client: Client, role: Worker) -> None:
             # of dispatching locally. Bootstrap paths (library load, AppInitializationComplete
             # fan-out) run outside the scope and continue to hit the original local handlers.
             register_remote_handlers(griptape_nodes.EventManager())
+            # Install handlers for orchestrator-originated broadcasts (config reload,
+            # secrets refresh) so this worker re-reads shared on-disk state when the
+            # orchestrator mutates it.
+            register_broadcast_handlers(
+                griptape_nodes.EventManager(),
+                config_manager=griptape_nodes.ConfigManager(),
+                secrets_manager=griptape_nodes.SecretsManager(),
+            )
 
             async with asyncio.TaskGroup() as tg:
                 tg.create_task(_send_outgoing_messages(client))

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -13,6 +13,13 @@ there. This module provides:
 - ``register_remote_handlers``: swaps the dispatch table entries on a
   just-configured worker after ``configure_worker_forwarding`` has wired up
   the RequestClient and loop references.
+- ``ReloadConfigRequest`` / ``RefreshSecretsRequest`` and their Success/Failure
+  payloads: orchestrator-originated broadcasts that every worker handles
+  locally to re-read shared on-disk state. They live here, not in
+  ``worker_events.py``, because their reason for existing is a routing
+  decision (orchestrator fan-out to all workers); the names are deliberately
+  free of any "Worker" prefix because, by this module's principle, an event's
+  type carries no routing metadata.
 
 The routing decision lives entirely on the worker. Events themselves carry no
 routing metadata.
@@ -20,9 +27,25 @@ routing metadata.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    SkipTheLineMixin,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.config_events import (
+    ResetConfigRequest,
+    SetConfigCategoryRequest,
+    SetConfigValueRequest,
+)
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionRequest,
     DeleteConnectionRequest,
@@ -50,15 +73,20 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
     SetParameterValueRequest,
 )
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.secrets_events import (
+    DeleteSecretValueRequest,
+    SetSecretValueRequest,
+)
 from griptape_nodes.retained_mode.managers.event_manager import ResultContext
 from griptape_nodes.utils.async_utils import call_function
 
+logger = logging.getLogger("griptape_nodes")
+
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.events.base_events import (
-        RequestPayload,
-        ResultPayload,
-    )
+    from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
 
 HandlerCallback = "Callable[[RequestPayload], ResultPayload | Awaitable[ResultPayload]]"
@@ -89,8 +117,71 @@ FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ListNodesInFlowRequest,
         ListFlowsInCurrentContextRequest,
         ListFlowsInFlowRequest,
+        # config_events
+        SetConfigValueRequest,
+        SetConfigCategoryRequest,
+        ResetConfigRequest,
+        # secrets_events
+        SetSecretValueRequest,
+        DeleteSecretValueRequest,
     }
 )
+
+
+@dataclass
+@PayloadRegistry.register
+class ReloadConfigRequest(RequestPayload, SkipTheLineMixin):
+    """Sent by the orchestrator to each registered worker after a config mutation succeeds.
+
+    On the same machine orchestrator and workers share
+    ~/.config/griptape_nodes/griptape_nodes_config.json, but a worker's
+    in-memory merged_config only reflects what it read on boot. This tells
+    the worker to re-read the file so subsequent get_config_value calls
+    see the new value.
+
+    Uses SkipTheLineMixin so the worker processes it immediately, ahead of
+    any queued ExecuteNodeRequest that would otherwise observe stale config.
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class ReloadConfigResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Worker reloaded its config from disk."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ReloadConfigResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Worker failed to reload its config from disk."""
+
+
+@dataclass
+@PayloadRegistry.register
+class RefreshSecretsRequest(RequestPayload, SkipTheLineMixin):
+    """Sent by the orchestrator to each registered worker after a secret mutation succeeds.
+
+    The global .env at ~/.config/griptape_nodes/.env is shared across
+    processes on the same machine, but the worker's os.environ snapshot
+    was populated at boot from the file as it existed then. Without this
+    refresh, get_secret() would see the stale env-var shadow (its highest
+    priority source) even after the orchestrator updated the file.
+
+    Uses SkipTheLineMixin to avoid a queued ExecuteNodeRequest reading
+    the stale secret before the refresh lands.
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class RefreshSecretsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Worker refreshed its secrets from the shared .env file."""
+
+
+@dataclass
+@PayloadRegistry.register
+class RefreshSecretsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Worker failed to refresh its secrets."""
 
 
 @dataclass
@@ -113,9 +204,35 @@ class RemoteHandler:
 
     async def __call__(self, request: RequestPayload) -> ResultPayload:
         if self.event_manager.in_node_execution():
+            rule = RULES["worker-reach-into-orchestrator"]
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(request_type=type(request).__name__),
+            )
             event_result = await self.event_manager.forward_to_orchestrator(request, ResultContext())
             return cast("ResultPayload", event_result.result)
         return await call_function(self.original, request)
+
+
+def schedule_broadcast(broadcast_type: type[RequestPayload]) -> None:
+    """Ask the orchestrator's WorkerManager to fan ``broadcast_type`` out to every worker.
+
+    Use this from a manager's request handler (orchestrator-side) to fire the
+    matching broadcast after a successful local mutation -- e.g. ``ConfigManager``
+    calls ``schedule_broadcast(ReloadConfigRequest)`` after persisting a config
+    write. No-op when the GriptapeNodes singleton has not been instantiated yet
+    (isolated unit tests that construct managers on their own) or when no
+    workers are registered.
+
+    Imports the singleton lazily because this module is loaded during engine
+    boot, before the GriptapeNodes accessor is ready.
+    """
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.utils.metaclasses import SingletonMeta
+
+    if GriptapeNodes not in SingletonMeta._instances:
+        return
+    GriptapeNodes.WorkerManager().schedule_broadcast(broadcast_type)
 
 
 def register_remote_handlers(event_manager: EventManager) -> None:
@@ -141,3 +258,39 @@ def register_remote_handlers(event_manager: EventManager) -> None:
         remote = RemoteHandler(original=original, event_manager=event_manager)
         event_manager.remove_manager_from_request_type(request_type)
         event_manager.assign_manager_to_request_type(request_type, remote)
+
+
+def register_broadcast_handlers(
+    event_manager: EventManager,
+    *,
+    config_manager: ConfigManager,
+    secrets_manager: SecretsManager,
+) -> None:
+    """Install worker-side handlers for orchestrator-originated broadcasts.
+
+    Workers receive ``ReloadConfigRequest`` / ``RefreshSecretsRequest`` from
+    the orchestrator and respond by re-reading the shared on-disk state. The
+    actual reload is delegated to the corresponding manager so domain logic
+    stays in the manager and routing decisions stay here.
+    """
+
+    def handle_reload_config(request: ReloadConfigRequest) -> ResultPayload:  # noqa: ARG001
+        try:
+            config_manager.load_configs()
+        except Exception as e:
+            details = f"Attempted to reload config from disk. Failed because of {type(e).__name__}: {e}."
+            logger.error(details)
+            return ReloadConfigResultFailure(result_details=details)
+        return ReloadConfigResultSuccess(result_details="Reloaded config from disk.")
+
+    def handle_refresh_secrets(request: RefreshSecretsRequest) -> ResultPayload:  # noqa: ARG001
+        try:
+            secrets_manager.refresh_from_env_file()
+        except Exception as e:
+            details = f"Attempted to refresh secrets from shared .env file. Failed because of {type(e).__name__}: {e}."
+            logger.error(details)
+            return RefreshSecretsResultFailure(result_details=details)
+        return RefreshSecretsResultSuccess(result_details="Refreshed secrets from shared .env file.")
+
+    event_manager.assign_manager_to_request_type(ReloadConfigRequest, handle_reload_config)
+    event_manager.assign_manager_to_request_type(RefreshSecretsRequest, handle_refresh_secrets)

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -40,7 +40,7 @@ from griptape_nodes.machines.dag_builder import DagBuilder
 from griptape_nodes.node_library.library_registry import Library, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.agent_events import AgentStreamEvent
-from griptape_nodes.retained_mode.events.base_events import ProgressEvent
+from griptape_nodes.retained_mode.events.base_events import ForwardedException, ProgressEvent
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionResultFailure,
     CreateConnectionResultSuccess,
@@ -272,8 +272,9 @@ class NodeExecutor:
                 )
             )
             if not isinstance(result, ExecuteNodeResultSuccess):
-                msg = f"Node '{node.name}' execution failed: {getattr(result, 'result_details', result)}"
-                raise RuntimeError(msg)  # noqa: TRY004
+                exc = getattr(result, "exception", None)
+                msg = self._format_node_failure_message(node.name, result, exc)
+                raise RuntimeError(msg) from exc  # noqa: TRY004
             # Copy outputs back onto the in-memory node. Write directly into
             # parameter_output_values (not through set_parameter_value, which
             # targets parameter_values and re-fires before/after_value_set and
@@ -288,6 +289,31 @@ class NodeExecutor:
                 node.parameter_output_values[name] = value
         finally:
             current_executing_node_name.reset(token)
+
+    @staticmethod
+    def _format_node_failure_message(node_name: str, result: Any, exc: BaseException | None) -> str:
+        """Compose the RuntimeError message for a failed node execution.
+
+        When the worker rebuilt a ``ForwardedException``, surface its
+        ``original_type`` and ``original_traceback`` directly in the
+        message. Chaining via ``from exc`` is not enough on its own:
+        a ForwardedException is constructed (not raised) on the
+        receiving side, so its ``__traceback__`` is None and Python's
+        chained-exception display prints only the cause's
+        ``Type: message`` line with no frames. Interpolating
+        ``original_traceback`` here is what actually puts the worker
+        frames in front of the user.
+        """
+        type_prefix = ""
+        tb_suffix = ""
+        if isinstance(exc, ForwardedException):
+            if exc.original_type:
+                type_prefix = f"[{exc.original_type}] "
+            if exc.original_traceback:
+                tb_suffix = f"\nWorker traceback:\n{exc.original_traceback}"
+        return (
+            f"Node '{node_name}' execution failed: {type_prefix}{getattr(result, 'result_details', result)}{tb_suffix}"
+        )
 
     async def _execute_and_apply_workflow(
         self,

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -39,6 +39,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger("griptape_nodes.strict_mode")
 
 
+_current_scope_stack: ContextVar[tuple[StrictModeScope, ...]] = ContextVar(
+    "_strict_mode_current_scope_stack", default=()
+)
+
+_node_init_depth = threading.local()
+_sanctioned_param_mutation_depth = threading.local()
+
+
 class StrictModeScopeKind(StrEnum):
     RUNTIME_EXECUTE = "runtime_execute"
     LOAD_PROBE = "load_probe"
@@ -68,12 +76,6 @@ class StrictModeScope:
     violations: list[StrictModeViolation] = field(default_factory=list)
 
 
-_current_scope: ContextVar[StrictModeScope | None] = ContextVar("_strict_mode_current_scope", default=None)
-
-_scope_lock = threading.Lock()
-_scope_refcount = 0
-
-
 @contextmanager
 def strict_mode_scope(
     *,
@@ -84,40 +86,25 @@ def strict_mode_scope(
 ) -> Iterator[StrictModeScope]:
     """Enter a strict-mode scope.
 
-    Sets a per-task ContextVar for attribution and bumps a process-wide
-    refcount so ``any_scope_active_threadsafe`` is observable from threads
-    that escape the ContextVar copy (e.g. threads spawned inside a node's
-    aprocess).
+    Pushes onto a per-task ContextVar stack so nested scopes (e.g. a
+    LOAD_PROBE inside a RUNTIME_EXECUTE) restore the outer scope on
+    exit. ``current_scope()`` always returns the innermost.
     """
-    global _scope_refcount  # noqa: PLW0603
     scope = StrictModeScope(kind=kind, subject=subject, library_name=library_name, is_worker=is_worker)
-    token = _current_scope.set(scope)
-    with _scope_lock:
-        _scope_refcount += 1
+    previous = _current_scope_stack.get()
+    token = _current_scope_stack.set((*previous, scope))
     try:
         yield scope
     finally:
-        with _scope_lock:
-            _scope_refcount -= 1
-        _current_scope.reset(token)
+        _current_scope_stack.reset(token)
 
 
 def current_scope() -> StrictModeScope | None:
-    """Return the strict-mode scope active on the current task, if any."""
-    return _current_scope.get()
-
-
-def any_scope_active_threadsafe() -> bool:
-    """Return True if any strict-mode scope is active anywhere in this process.
-
-    Readable from threads that do not have a ContextVar copy of the
-    enclosing scope.
-    """
-    with _scope_lock:
-        return _scope_refcount > 0
-
-
-_node_init_depth = threading.local()
+    """Return the innermost strict-mode scope active on the current task, if any."""
+    stack = _current_scope_stack.get()
+    if not stack:
+        return None
+    return stack[-1]
 
 
 @contextmanager
@@ -144,9 +131,6 @@ def node_init_scope() -> Iterator[None]:
 def in_node_init() -> bool:
     """Return True when the calling thread is inside ``BaseNode.__init__``."""
     return getattr(_node_init_depth, "depth", 0) > 0
-
-
-_sanctioned_param_mutation_depth = threading.local()
 
 
 @contextmanager
@@ -214,7 +198,7 @@ def report_violation(*, rule_id: str, message: str) -> StrictModeScope | None:
     (with the new violation appended to ``violations``) so callers can
     inspect or pass it along.
     """
-    scope = _current_scope.get()
+    scope = current_scope()
     if scope is None:
         return None
     severity = _resolve_severity(rule_id=rule_id, is_worker=scope.is_worker)
@@ -251,36 +235,40 @@ def report_violation(*, rule_id: str, message: str) -> StrictModeScope | None:
     return scope
 
 
-def attach_violations_to_result(result: ResultPayload, scope: StrictModeScope) -> ResultPayload:
-    """Merge ``scope.violations`` into ``result.result_details``.
+def attach_violations_to_result(result: ResultPayload, scope: StrictModeScope) -> None:
+    """Append ``scope.violations`` onto ``result.result_details`` in place.
 
-    Coerces ``str`` result_details into a ``ResultDetails`` first (matching
-    the ``__post_init__`` behavior of ``ResultPayloadSuccess`` and
-    ``ResultPayloadFailure``). Each violation becomes a
-    ``StrictModeViolationDetail`` appended to the existing list so the
-    editor can render both the original message and the violations.
+    ``ResultPayload.__post_init__`` has already coerced any string
+    ``result_details`` into a ``ResultDetails``, so this function can
+    rely on the list-of-details shape. Each violation becomes a
+    ``StrictModeViolationDetail`` appended to the existing list.
 
-    Returns the same ``result`` object (mutated in place); returned for
-    call-site chaining.
+    Mutates ``result`` and returns ``None``. Callers that want to
+    return ``result`` after attaching should do so explicitly on the
+    next line.
     """
     # Lazy import to avoid circular dependency: base_events imports nothing from this module,
     # but the caller chain (node_manager -> strict_mode) would circle back through base_events.
-    from griptape_nodes.retained_mode.events.base_events import (
-        ResultDetails,
-        StrictModeViolationDetail,
-    )
+    from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
 
     if not scope.violations:
-        return result
+        return
 
-    existing = result.result_details
-    if isinstance(existing, str):
-        existing = ResultDetails(message=existing, level=logging.DEBUG)
-        result.result_details = existing
-
+    # The Success/Failure base classes' __post_init__ coerce a string
+    # ``result_details`` into a ``ResultDetails`` instance, so by the time
+    # we see the payload the union has been narrowed -- but the type
+    # system can't see that. The runtime check documents the invariant
+    # and satisfies the checker.
+    details = result.result_details
+    if not isinstance(details, ResultDetails):
+        msg = (
+            f"attach_violations_to_result expected result_details to be ResultDetails "
+            f"after __post_init__ coercion, got {type(details).__name__}."
+        )
+        raise TypeError(msg)
     for violation in scope.violations:
         level = logging.ERROR if violation.severity is StrictModeSeverity.ERROR else logging.WARNING
-        existing.result_details.append(
+        details.result_details.append(
             StrictModeViolationDetail(
                 level=level,
                 message=violation.message,
@@ -290,4 +278,3 @@ def attach_violations_to_result(result: ResultPayload, scope: StrictModeScope) -
                 library_name=violation.library_name,
             )
         )
-    return result

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import logging
 import os
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -45,7 +45,7 @@ from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator, Iterator
 
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
@@ -95,6 +95,21 @@ class StrictModeScope:
     library_name: str | None
     is_worker: bool
     violations: list[StrictModeViolation] = field(default_factory=list)
+
+
+@dataclass
+class ScopedResult:
+    """Mutable result slot yielded by ``StrictModeReporter.scoped_execution``.
+
+    The ``async with`` body assigns ``result`` after the wrapped runner
+    returns. The reporter's teardown reads this slot and merges the
+    scope's violations into it. Callers that need to apply a domain-specific
+    escalation policy (e.g. promote a worker success to a failure when
+    correctness violations fired) can inspect the scope and reassign
+    ``result`` from inside the body before the context exits.
+    """
+
+    result: ResultPayload | None = None
 
 
 def _default_severity_resolver(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
@@ -193,6 +208,49 @@ class StrictModeReporter:
             yield scope
         finally:
             self._scope_stack.reset(token)
+
+    @asynccontextmanager
+    async def scoped_execution(
+        self,
+        *,
+        kind: StrictModeScopeKind,
+        subject: str,
+        library_name: str | None,
+        is_worker: bool,
+    ) -> AsyncIterator[tuple[ScopedResult, StrictModeScope]]:
+        """Open a scope, yield a (result-slot, scope) pair, attach on exit.
+
+        Async wrapper around :meth:`open_scope` that owns the
+        ``attach_violations_to_result`` boilerplate so request handlers
+        do not have to. Usage::
+
+            async with STRICT_MODE.scoped_execution(...) as (ctx, scope):
+                ctx.result = await runner()
+                # optionally inspect scope.violations and reassign ctx.result
+                # to apply a domain-specific escalation policy.
+
+        On exit the helper raises if ``ctx.result`` was never assigned
+        (programmer error), then merges ``scope.violations`` into the
+        final payload via ``attach_violations_to_result``. The escalation
+        policy itself stays with the caller because it is execute-context
+        specific (e.g. only ``ExecuteNodeResultSuccess`` knows how to
+        promote to a failure).
+        """
+        with self.open_scope(
+            kind=kind,
+            subject=subject,
+            library_name=library_name,
+            is_worker=is_worker,
+        ) as scope:
+            ctx = ScopedResult()
+            yield ctx, scope
+            if ctx.result is None:
+                msg = (
+                    f"scoped_execution body for subject '{subject}' did not assign ctx.result; "
+                    "this is a programmer error in the caller."
+                )
+                raise RuntimeError(msg)
+            self.attach_violations_to_result(ctx.result, scope)
 
     def current_scope(self) -> StrictModeScope | None:
         """Return the innermost active scope on the current task, or None."""

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -41,6 +41,9 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
+from griptape_nodes.common.strict_mode_checks import RULES
+from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -104,10 +107,6 @@ def _default_severity_resolver(*, rule_id: str, is_worker: bool) -> StrictModeSe
     historical worker=ERROR / orchestrator=WARNING split so detectors
     can land before the registry entry is added.
     """
-    # Lazy import to avoid a circular dependency: strict_mode_checks
-    # imports StrictModeSeverity from this module.
-    from griptape_nodes.common.strict_mode_checks import RULES
-
     rule = RULES.get(rule_id)
     if rule is None:
         # A typo'd or unregistered rule_id should not silently produce a
@@ -158,10 +157,13 @@ class StrictModeReporter:
     def enabled(self) -> bool:
         """Whether the reporter is currently active.
 
-        When false, ``open_scope`` yields a sentinel scope that ignores
-        ``report`` calls and ``attach_violations_to_result`` is a no-op.
-        Detectors do not need to branch on this -- the reporter swallows
-        the work itself.
+        When false, ``open_scope`` yields a detached scope that is not on
+        the per-task stack, so ``current_scope()`` returns None and
+        ``report()`` no-ops. ``attach_violations_to_result`` is a no-op
+        in practice only because the detached scope's ``violations`` list
+        stays empty -- a caller that hands in a manually-built scope with
+        violations will still mutate ``result``. Detectors do not need to
+        branch on this; the reporter swallows the work itself.
         """
         return self._enabled
 
@@ -241,10 +243,6 @@ class StrictModeReporter:
         Each violation becomes a ``StrictModeViolationDetail`` appended
         to the existing list. Mutates ``result``; returns ``None``.
         """
-        # Lazy import to avoid circular dependency: base_events imports nothing from this module,
-        # but the caller chain (node_manager -> strict_mode) would circle back through base_events.
-        from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
-
         if not scope.violations:
             return
 

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -1,50 +1,61 @@
 """Strict-mode enforcement framework.
 
 Strict mode is a runtime contract for what node code is allowed to do
-across the orchestrator/worker split. This module owns the scope
-machinery, the violation record, and the reporter. Detectors live at
-their own call sites (e.g. ``BaseNode.aprocess``, ``EventManager.handle_request``)
-and import ``report_violation`` to route violations here.
+across the orchestrator/worker split. This module owns scope, severity
+resolution, and violation reporting -- and nothing else.
 
-Two scope kinds exist:
+Two kinds of strict-mode scope exist:
 
 * ``RUNTIME_EXECUTE`` opens around ``NodeManager.on_execute_node_request``
   for a single node's execution.
 * ``LOAD_PROBE`` opens around each class's schema probe in
   ``LibraryManager._serialize_library_node_schemas``.
 
-Severity is picked per-rule by :func:`_resolve_severity`: correctness
-rules fail on both sides, ergonomics rules warn on orchestrator and
-escalate to ERROR on the worker. Callers that need to escalate a worker
-violation (e.g. convert ``ExecuteNodeResultSuccess`` to a failure, or
-skip a class's schema) inspect the scope's ``violations`` list after
-exit.
+Detectors live at their own call sites (e.g. ``EventManager.handle_request``,
+``BaseNode.add_parameter``) and import the module-level singleton
+``STRICT_MODE`` to record violations:
+
+    from griptape_nodes.common.strict_mode import STRICT_MODE
+    STRICT_MODE.report(rule_id=..., message=...)
+
+Severity is picked per-rule by the reporter's severity resolver:
+correctness rules fail on both sides, ergonomics rules warn on the
+orchestrator and escalate to ERROR on the worker. Callers that need to
+escalate a worker violation (e.g. convert ``ExecuteNodeResultSuccess``
+to a failure, or skip a class's schema) inspect the scope's
+``violations`` list after exit.
+
+"Am I currently constructing a node?" and "What request is currently
+being dispatched?" are NOT owned here. Those facts belong to
+``LibraryRegistry`` and ``EventManager`` respectively; detectors
+consult those subsystems directly.
 """
 
 from __future__ import annotations
 
 import logging
-import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
-logger = logging.getLogger("griptape_nodes.strict_mode")
 
+class SeverityResolver(Protocol):
+    """Callable signature for severity resolution.
 
-_current_scope_stack: ContextVar[tuple[StrictModeScope, ...]] = ContextVar(
-    "_strict_mode_current_scope_stack", default=()
-)
+    The default implementation looks the rule up in ``RULES`` and applies
+    the correctness/escalation policy. Tests inject fakes (typically
+    constant-returning) by passing ``severity_resolver=`` to
+    :class:`StrictModeReporter`.
+    """
 
-_node_init_depth = threading.local()
-_sanctioned_param_mutation_depth = threading.local()
+    def __call__(self, *, rule_id: str, is_worker: bool) -> StrictModeSeverity: ...
 
 
 class StrictModeScopeKind(StrEnum):
@@ -76,99 +87,18 @@ class StrictModeScope:
     violations: list[StrictModeViolation] = field(default_factory=list)
 
 
-@contextmanager
-def strict_mode_scope(
-    *,
-    kind: StrictModeScopeKind,
-    subject: str,
-    library_name: str | None,
-    is_worker: bool,
-) -> Iterator[StrictModeScope]:
-    """Enter a strict-mode scope.
-
-    Pushes onto a per-task ContextVar stack so nested scopes (e.g. a
-    LOAD_PROBE inside a RUNTIME_EXECUTE) restore the outer scope on
-    exit. ``current_scope()`` always returns the innermost.
-    """
-    scope = StrictModeScope(kind=kind, subject=subject, library_name=library_name, is_worker=is_worker)
-    previous = _current_scope_stack.get()
-    token = _current_scope_stack.set((*previous, scope))
-    try:
-        yield scope
-    finally:
-        _current_scope_stack.reset(token)
-
-
-def current_scope() -> StrictModeScope | None:
-    """Return the innermost strict-mode scope active on the current task, if any."""
-    stack = _current_scope_stack.get()
-    if not stack:
-        return None
-    return stack[-1]
-
-
-@contextmanager
-def node_init_scope() -> Iterator[None]:
-    """Mark the calling thread as executing ``BaseNode.__init__``.
-
-    ``EventManager.handle_request`` checks the flag to detect the
-    ``reentrant-bus-in-init`` rule: a node class that issues an
-    event-bus request from its constructor deadlocks the worker's
-    schema probe, which calls ``__init__`` on the worker thread.
-
-    Nested constructors (subclass __init__ calls super().__init__) are
-    supported via a depth counter -- the flag is cleared only when the
-    outermost __init__ returns.
-    """
-    depth = getattr(_node_init_depth, "depth", 0)
-    _node_init_depth.depth = depth + 1
-    try:
-        yield
-    finally:
-        _node_init_depth.depth -= 1
-
-
-def in_node_init() -> bool:
-    """Return True when the calling thread is inside ``BaseNode.__init__``."""
-    return getattr(_node_init_depth, "depth", 0) > 0
-
-
-@contextmanager
-def sanctioned_parameter_mutation() -> Iterator[None]:
-    """Mark an add_parameter / remove_parameter_element call as handler-driven.
-
-    The ``parameter-mutation-during-aprocess`` detector fires whenever a
-    node mutates its own parameter list while a strict-mode execution
-    scope is active. The AddParameterToNodeRequest and
-    RemoveParameterFromNodeRequest handlers reach ``BaseNode.add_parameter``
-    /``remove_parameter_element`` by design -- they are the sanctioned
-    path. Handlers wrap their call with this context so the detector
-    only fires on direct calls from ``aprocess`` code.
-    """
-    depth = getattr(_sanctioned_param_mutation_depth, "depth", 0)
-    _sanctioned_param_mutation_depth.depth = depth + 1
-    try:
-        yield
-    finally:
-        _sanctioned_param_mutation_depth.depth -= 1
-
-
-def in_sanctioned_parameter_mutation() -> bool:
-    """Return True when the current thread is inside a handler-sanctioned param mutation."""
-    return getattr(_sanctioned_param_mutation_depth, "depth", 0) > 0
-
-
-def _resolve_severity(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
-    """Pick the severity for a reported rule.
+def _default_severity_resolver(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
+    """Resolve the severity of a reported rule against the static registry.
 
     Correctness rules ({@code correctness=True} in the registry) fail on
     both sides. Non-correctness rules warn on the orchestrator and
-    escalate to ERROR on the worker -- the worker's stateless model
-    makes ergonomics issues load-bearing. If the rule is not in the
-    registry, fall back to the historical worker=ERROR /
-    orchestrator=WARNING split so migration can be incremental.
+    escalate to ERROR on the worker (subject to the rule's
+    ``worker_escalation`` flag). Unregistered rules fall back to the
+    historical worker=ERROR / orchestrator=WARNING split so detectors
+    can land before the registry entry is added.
     """
-    # Lazy import to avoid a circular dependency: strict_mode_checks imports StrictModeSeverity from here.
+    # Lazy import to avoid a circular dependency: strict_mode_checks
+    # imports StrictModeSeverity from this module.
     from griptape_nodes.common.strict_mode_checks import RULES
 
     rule = RULES.get(rule_id)
@@ -177,7 +107,7 @@ def _resolve_severity(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
         # violation. Log loudly so it surfaces in dev; production callers
         # still get the historical worker=ERROR / orchestrator=WARNING
         # fallback so existing detectors are not broken by the change.
-        logger.warning(
+        logging.getLogger("griptape_nodes.strict_mode").warning(
             "strict-mode rule '%s' is not registered in RULES. Falling back to worker=%s default severity.",
             rule_id,
             "ERROR" if is_worker else "WARNING",
@@ -190,30 +120,83 @@ def _resolve_severity(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
     return StrictModeSeverity.WARNING
 
 
-def report_violation(*, rule_id: str, message: str) -> StrictModeScope | None:
-    """Record a strict-mode violation against the currently active scope.
+class StrictModeReporter:
+    """Owns the scope stack and violation reporting.
 
-    No-op when no scope is active. Severity is resolved via the rule
-    registry (see :func:`_resolve_severity`). Returns the active scope
-    (with the new violation appended to ``violations``) so callers can
-    inspect or pass it along.
+    Detectors interact via the process-level singleton ``STRICT_MODE``
+    declared at module bottom. The class is parameterized by a severity
+    resolver and a logger so tests can inject fakes.
+
+    Each instance owns its own ContextVar-backed scope stack. The
+    framework does not expect more than one instance in production --
+    instantiating a second reporter creates an independent stack and
+    detectors will report against whichever singleton they imported.
     """
-    scope = current_scope()
-    if scope is None:
-        return None
-    severity = _resolve_severity(rule_id=rule_id, is_worker=scope.is_worker)
-    violation = StrictModeViolation(
-        rule_id=rule_id,
-        severity=severity,
-        scope_kind=scope.kind,
-        subject=scope.subject,
-        library_name=scope.library_name,
-        message=message,
-    )
-    scope.violations.append(violation)
-    subject_label = "node" if scope.kind is StrictModeScopeKind.RUNTIME_EXECUTE else "class"
-    if severity is StrictModeSeverity.ERROR:
-        logger.error(
+
+    def __init__(
+        self,
+        *,
+        severity_resolver: SeverityResolver | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._severity_resolver: SeverityResolver = severity_resolver or _default_severity_resolver
+        self._logger = logger or logging.getLogger("griptape_nodes.strict_mode")
+        self._scope_stack: ContextVar[tuple[StrictModeScope, ...]] = ContextVar(
+            f"_strict_mode_scope_stack_{id(self)}", default=()
+        )
+
+    @contextmanager
+    def open_scope(
+        self,
+        *,
+        kind: StrictModeScopeKind,
+        subject: str,
+        library_name: str | None,
+        is_worker: bool,
+    ) -> Iterator[StrictModeScope]:
+        """Push a new strict-mode scope onto the per-task stack.
+
+        Nested scopes restore the outer on exit. ``current_scope()`` and
+        ``report()`` always operate on the innermost.
+        """
+        scope = StrictModeScope(kind=kind, subject=subject, library_name=library_name, is_worker=is_worker)
+        previous = self._scope_stack.get()
+        token = self._scope_stack.set((*previous, scope))
+        try:
+            yield scope
+        finally:
+            self._scope_stack.reset(token)
+
+    def current_scope(self) -> StrictModeScope | None:
+        """Return the innermost active scope on the current task, or None."""
+        stack = self._scope_stack.get()
+        if not stack:
+            return None
+        return stack[-1]
+
+    def report(self, *, rule_id: str, message: str) -> StrictModeScope | None:
+        """Record a violation against the innermost active scope.
+
+        No-op when no scope is active. Returns the scope (with the new
+        violation appended to ``violations``) so callers can inspect or
+        pass it along.
+        """
+        scope = self.current_scope()
+        if scope is None:
+            return None
+        severity = self._severity_resolver(rule_id=rule_id, is_worker=scope.is_worker)
+        violation = StrictModeViolation(
+            rule_id=rule_id,
+            severity=severity,
+            scope_kind=scope.kind,
+            subject=scope.subject,
+            library_name=scope.library_name,
+            message=message,
+        )
+        scope.violations.append(violation)
+        subject_label = "node" if scope.kind is StrictModeScopeKind.RUNTIME_EXECUTE else "class"
+        log = self._logger.error if severity is StrictModeSeverity.ERROR else self._logger.warning
+        log(
             "strict-mode [%s/%s] %s=%s library=%s: %s",
             scope.kind.value,
             severity.value,
@@ -222,59 +205,43 @@ def report_violation(*, rule_id: str, message: str) -> StrictModeScope | None:
             scope.library_name,
             message,
         )
-    else:
-        logger.warning(
-            "strict-mode [%s/%s] %s=%s library=%s: %s",
-            scope.kind.value,
-            severity.value,
-            subject_label,
-            scope.subject,
-            scope.library_name,
-            message,
-        )
-    return scope
+        return scope
 
+    def attach_violations_to_result(self, result: ResultPayload, scope: StrictModeScope) -> None:
+        """Append ``scope.violations`` onto ``result.result_details`` in place.
 
-def attach_violations_to_result(result: ResultPayload, scope: StrictModeScope) -> None:
-    """Append ``scope.violations`` onto ``result.result_details`` in place.
+        ``ResultPayload.__post_init__`` has already coerced any string
+        ``result_details`` into a ``ResultDetails`` instance, so by the
+        time this runs the union has been narrowed to ``ResultDetails``.
+        Each violation becomes a ``StrictModeViolationDetail`` appended
+        to the existing list. Mutates ``result``; returns ``None``.
+        """
+        # Lazy import to avoid circular dependency: base_events imports nothing from this module,
+        # but the caller chain (node_manager -> strict_mode) would circle back through base_events.
+        from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
 
-    ``ResultPayload.__post_init__`` has already coerced any string
-    ``result_details`` into a ``ResultDetails``, so this function can
-    rely on the list-of-details shape. Each violation becomes a
-    ``StrictModeViolationDetail`` appended to the existing list.
+        if not scope.violations:
+            return
 
-    Mutates ``result`` and returns ``None``. Callers that want to
-    return ``result`` after attaching should do so explicitly on the
-    next line.
-    """
-    # Lazy import to avoid circular dependency: base_events imports nothing from this module,
-    # but the caller chain (node_manager -> strict_mode) would circle back through base_events.
-    from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
-
-    if not scope.violations:
-        return
-
-    # The Success/Failure base classes' __post_init__ coerce a string
-    # ``result_details`` into a ``ResultDetails`` instance, so by the time
-    # we see the payload the union has been narrowed -- but the type
-    # system can't see that. The runtime check documents the invariant
-    # and satisfies the checker.
-    details = result.result_details
-    if not isinstance(details, ResultDetails):
-        msg = (
-            f"attach_violations_to_result expected result_details to be ResultDetails "
-            f"after __post_init__ coercion, got {type(details).__name__}."
-        )
-        raise TypeError(msg)
-    for violation in scope.violations:
-        level = logging.ERROR if violation.severity is StrictModeSeverity.ERROR else logging.WARNING
-        details.result_details.append(
-            StrictModeViolationDetail(
-                level=level,
-                message=violation.message,
-                rule_id=violation.rule_id,
-                severity=violation.severity.value,
-                subject=violation.subject,
-                library_name=violation.library_name,
+        details = result.result_details
+        if not isinstance(details, ResultDetails):
+            msg = (
+                f"attach_violations_to_result expected result_details to be ResultDetails "
+                f"after __post_init__ coercion, got {type(details).__name__}."
             )
-        )
+            raise TypeError(msg)
+        for violation in scope.violations:
+            level = logging.ERROR if violation.severity is StrictModeSeverity.ERROR else logging.WARNING
+            details.result_details.append(
+                StrictModeViolationDetail(
+                    level=level,
+                    message=violation.message,
+                    rule_id=violation.rule_id,
+                    severity=violation.severity.value,
+                    subject=violation.subject,
+                    library_name=violation.library_name,
+                )
+            )
+
+
+STRICT_MODE = StrictModeReporter()

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -34,6 +34,7 @@ consult those subsystems directly.
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -44,6 +45,12 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
+
+# Env-var override so operators can disable strict mode wholesale without a code
+# change. Production parity is the default; the kill switch is an escape hatch
+# for performance triage or for environments where the orchestrator/worker split
+# is known to be intentionally violated (e.g. legacy single-process tests).
+_STRICT_MODE_DISABLED_ENV = "GTN_STRICT_MODE_DISABLED"
 
 
 class SeverityResolver(Protocol):
@@ -136,14 +143,27 @@ class StrictModeReporter:
     def __init__(
         self,
         *,
+        enabled: bool | None = None,
         severity_resolver: SeverityResolver | None = None,
         logger: logging.Logger | None = None,
     ) -> None:
+        self._enabled = enabled if enabled is not None else os.environ.get(_STRICT_MODE_DISABLED_ENV) != "1"
         self._severity_resolver: SeverityResolver = severity_resolver or _default_severity_resolver
         self._logger = logger or logging.getLogger("griptape_nodes.strict_mode")
         self._scope_stack: ContextVar[tuple[StrictModeScope, ...]] = ContextVar(
             f"_strict_mode_scope_stack_{id(self)}", default=()
         )
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the reporter is currently active.
+
+        When false, ``open_scope`` yields a sentinel scope that ignores
+        ``report`` calls and ``attach_violations_to_result`` is a no-op.
+        Detectors do not need to branch on this -- the reporter swallows
+        the work itself.
+        """
+        return self._enabled
 
     @contextmanager
     def open_scope(
@@ -157,9 +177,14 @@ class StrictModeReporter:
         """Push a new strict-mode scope onto the per-task stack.
 
         Nested scopes restore the outer on exit. ``current_scope()`` and
-        ``report()`` always operate on the innermost.
+        ``report()`` always operate on the innermost. When the reporter
+        is disabled the yielded scope is detached (not on the stack), so
+        ``report()`` finds no active scope and no-ops.
         """
         scope = StrictModeScope(kind=kind, subject=subject, library_name=library_name, is_worker=is_worker)
+        if not self._enabled:
+            yield scope
+            return
         previous = self._scope_stack.get()
         token = self._scope_stack.set((*previous, scope))
         try:

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -41,9 +41,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
-from griptape_nodes.common.strict_mode_checks import RULES
-from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
-
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
@@ -122,6 +119,10 @@ def _default_severity_resolver(*, rule_id: str, is_worker: bool) -> StrictModeSe
     historical worker=ERROR / orchestrator=WARNING split so detectors
     can land before the registry entry is added.
     """
+    # Lazy import: strict_mode_checks imports StrictModeSeverity from this
+    # module, so a top-level import would cycle once RULES is non-empty.
+    from griptape_nodes.common.strict_mode_checks import RULES
+
     rule = RULES.get(rule_id)
     if rule is None:
         # A typo'd or unregistered rule_id should not silently produce a
@@ -301,6 +302,13 @@ class StrictModeReporter:
         Each violation becomes a ``StrictModeViolationDetail`` appended
         to the existing list. Mutates ``result``; returns ``None``.
         """
+        # Lazy import: base_events declares the result/violation dataclasses
+        # the framework consumes here, but base_events also imports STRICT_MODE
+        # at its detector sites. Keeping the cycle break in this single
+        # framework method lets every detector module import strict-mode
+        # symbols at the top of the file.
+        from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
+
         if not scope.violations:
             return
 

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -1,0 +1,293 @@
+"""Strict-mode enforcement framework.
+
+Strict mode is a runtime contract for what node code is allowed to do
+across the orchestrator/worker split. This module owns the scope
+machinery, the violation record, and the reporter. Detectors live at
+their own call sites (e.g. ``BaseNode.aprocess``, ``EventManager.handle_request``)
+and import ``report_violation`` to route violations here.
+
+Two scope kinds exist:
+
+* ``RUNTIME_EXECUTE`` opens around ``NodeManager.on_execute_node_request``
+  for a single node's execution.
+* ``LOAD_PROBE`` opens around each class's schema probe in
+  ``LibraryManager._serialize_library_node_schemas``.
+
+Severity is picked per-rule by :func:`_resolve_severity`: correctness
+rules fail on both sides, ergonomics rules warn on orchestrator and
+escalate to ERROR on the worker. Callers that need to escalate a worker
+violation (e.g. convert ``ExecuteNodeResultSuccess`` to a failure, or
+skip a class's schema) inspect the scope's ``violations`` list after
+exit.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
+
+logger = logging.getLogger("griptape_nodes.strict_mode")
+
+
+class StrictModeScopeKind(StrEnum):
+    RUNTIME_EXECUTE = "runtime_execute"
+    LOAD_PROBE = "load_probe"
+
+
+class StrictModeSeverity(StrEnum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class StrictModeViolation:
+    rule_id: str
+    severity: StrictModeSeverity
+    scope_kind: StrictModeScopeKind
+    subject: str
+    library_name: str | None
+    message: str
+
+
+@dataclass
+class StrictModeScope:
+    kind: StrictModeScopeKind
+    subject: str
+    library_name: str | None
+    is_worker: bool
+    violations: list[StrictModeViolation] = field(default_factory=list)
+
+
+_current_scope: ContextVar[StrictModeScope | None] = ContextVar("_strict_mode_current_scope", default=None)
+
+_scope_lock = threading.Lock()
+_scope_refcount = 0
+
+
+@contextmanager
+def strict_mode_scope(
+    *,
+    kind: StrictModeScopeKind,
+    subject: str,
+    library_name: str | None,
+    is_worker: bool,
+) -> Iterator[StrictModeScope]:
+    """Enter a strict-mode scope.
+
+    Sets a per-task ContextVar for attribution and bumps a process-wide
+    refcount so ``any_scope_active_threadsafe`` is observable from threads
+    that escape the ContextVar copy (e.g. threads spawned inside a node's
+    aprocess).
+    """
+    global _scope_refcount  # noqa: PLW0603
+    scope = StrictModeScope(kind=kind, subject=subject, library_name=library_name, is_worker=is_worker)
+    token = _current_scope.set(scope)
+    with _scope_lock:
+        _scope_refcount += 1
+    try:
+        yield scope
+    finally:
+        with _scope_lock:
+            _scope_refcount -= 1
+        _current_scope.reset(token)
+
+
+def current_scope() -> StrictModeScope | None:
+    """Return the strict-mode scope active on the current task, if any."""
+    return _current_scope.get()
+
+
+def any_scope_active_threadsafe() -> bool:
+    """Return True if any strict-mode scope is active anywhere in this process.
+
+    Readable from threads that do not have a ContextVar copy of the
+    enclosing scope.
+    """
+    with _scope_lock:
+        return _scope_refcount > 0
+
+
+_node_init_depth = threading.local()
+
+
+@contextmanager
+def node_init_scope() -> Iterator[None]:
+    """Mark the calling thread as executing ``BaseNode.__init__``.
+
+    ``EventManager.handle_request`` checks the flag to detect the
+    ``reentrant-bus-in-init`` rule: a node class that issues an
+    event-bus request from its constructor deadlocks the worker's
+    schema probe, which calls ``__init__`` on the worker thread.
+
+    Nested constructors (subclass __init__ calls super().__init__) are
+    supported via a depth counter -- the flag is cleared only when the
+    outermost __init__ returns.
+    """
+    depth = getattr(_node_init_depth, "depth", 0)
+    _node_init_depth.depth = depth + 1
+    try:
+        yield
+    finally:
+        _node_init_depth.depth -= 1
+
+
+def in_node_init() -> bool:
+    """Return True when the calling thread is inside ``BaseNode.__init__``."""
+    return getattr(_node_init_depth, "depth", 0) > 0
+
+
+_sanctioned_param_mutation_depth = threading.local()
+
+
+@contextmanager
+def sanctioned_parameter_mutation() -> Iterator[None]:
+    """Mark an add_parameter / remove_parameter_element call as handler-driven.
+
+    The ``parameter-mutation-during-aprocess`` detector fires whenever a
+    node mutates its own parameter list while a strict-mode execution
+    scope is active. The AddParameterToNodeRequest and
+    RemoveParameterFromNodeRequest handlers reach ``BaseNode.add_parameter``
+    /``remove_parameter_element`` by design -- they are the sanctioned
+    path. Handlers wrap their call with this context so the detector
+    only fires on direct calls from ``aprocess`` code.
+    """
+    depth = getattr(_sanctioned_param_mutation_depth, "depth", 0)
+    _sanctioned_param_mutation_depth.depth = depth + 1
+    try:
+        yield
+    finally:
+        _sanctioned_param_mutation_depth.depth -= 1
+
+
+def in_sanctioned_parameter_mutation() -> bool:
+    """Return True when the current thread is inside a handler-sanctioned param mutation."""
+    return getattr(_sanctioned_param_mutation_depth, "depth", 0) > 0
+
+
+def _resolve_severity(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
+    """Pick the severity for a reported rule.
+
+    Correctness rules ({@code correctness=True} in the registry) fail on
+    both sides. Non-correctness rules warn on the orchestrator and
+    escalate to ERROR on the worker -- the worker's stateless model
+    makes ergonomics issues load-bearing. If the rule is not in the
+    registry, fall back to the historical worker=ERROR /
+    orchestrator=WARNING split so migration can be incremental.
+    """
+    # Lazy import to avoid a circular dependency: strict_mode_checks imports StrictModeSeverity from here.
+    from griptape_nodes.common.strict_mode_checks import RULES
+
+    rule = RULES.get(rule_id)
+    if rule is None:
+        # A typo'd or unregistered rule_id should not silently produce a
+        # violation. Log loudly so it surfaces in dev; production callers
+        # still get the historical worker=ERROR / orchestrator=WARNING
+        # fallback so existing detectors are not broken by the change.
+        logger.warning(
+            "strict-mode rule '%s' is not registered in RULES. Falling back to worker=%s default severity.",
+            rule_id,
+            "ERROR" if is_worker else "WARNING",
+        )
+        return StrictModeSeverity.ERROR if is_worker else StrictModeSeverity.WARNING
+    if rule.correctness:
+        return StrictModeSeverity.ERROR
+    if is_worker and rule.worker_escalation:
+        return StrictModeSeverity.ERROR
+    return StrictModeSeverity.WARNING
+
+
+def report_violation(*, rule_id: str, message: str) -> StrictModeScope | None:
+    """Record a strict-mode violation against the currently active scope.
+
+    No-op when no scope is active. Severity is resolved via the rule
+    registry (see :func:`_resolve_severity`). Returns the active scope
+    (with the new violation appended to ``violations``) so callers can
+    inspect or pass it along.
+    """
+    scope = _current_scope.get()
+    if scope is None:
+        return None
+    severity = _resolve_severity(rule_id=rule_id, is_worker=scope.is_worker)
+    violation = StrictModeViolation(
+        rule_id=rule_id,
+        severity=severity,
+        scope_kind=scope.kind,
+        subject=scope.subject,
+        library_name=scope.library_name,
+        message=message,
+    )
+    scope.violations.append(violation)
+    subject_label = "node" if scope.kind is StrictModeScopeKind.RUNTIME_EXECUTE else "class"
+    if severity is StrictModeSeverity.ERROR:
+        logger.error(
+            "strict-mode [%s/%s] %s=%s library=%s: %s",
+            scope.kind.value,
+            severity.value,
+            subject_label,
+            scope.subject,
+            scope.library_name,
+            message,
+        )
+    else:
+        logger.warning(
+            "strict-mode [%s/%s] %s=%s library=%s: %s",
+            scope.kind.value,
+            severity.value,
+            subject_label,
+            scope.subject,
+            scope.library_name,
+            message,
+        )
+    return scope
+
+
+def attach_violations_to_result(result: ResultPayload, scope: StrictModeScope) -> ResultPayload:
+    """Merge ``scope.violations`` into ``result.result_details``.
+
+    Coerces ``str`` result_details into a ``ResultDetails`` first (matching
+    the ``__post_init__`` behavior of ``ResultPayloadSuccess`` and
+    ``ResultPayloadFailure``). Each violation becomes a
+    ``StrictModeViolationDetail`` appended to the existing list so the
+    editor can render both the original message and the violations.
+
+    Returns the same ``result`` object (mutated in place); returned for
+    call-site chaining.
+    """
+    # Lazy import to avoid circular dependency: base_events imports nothing from this module,
+    # but the caller chain (node_manager -> strict_mode) would circle back through base_events.
+    from griptape_nodes.retained_mode.events.base_events import (
+        ResultDetails,
+        StrictModeViolationDetail,
+    )
+
+    if not scope.violations:
+        return result
+
+    existing = result.result_details
+    if isinstance(existing, str):
+        existing = ResultDetails(message=existing, level=logging.DEBUG)
+        result.result_details = existing
+
+    for violation in scope.violations:
+        level = logging.ERROR if violation.severity is StrictModeSeverity.ERROR else logging.WARNING
+        existing.result_details.append(
+            StrictModeViolationDetail(
+                level=level,
+                message=violation.message,
+                rule_id=violation.rule_id,
+                severity=violation.severity.value,
+                subject=violation.subject,
+                library_name=violation.library_name,
+            )
+        )
+    return result

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -7,18 +7,17 @@ escalation), a human description, and a ``str.format``-ready
 remediation template.
 
 Detectors import ``RULES`` to look up their rule and call
-``report_violation(rule_id=..., message=RULES[rid].render(...))`` at
-their own call site. No enforcement logic lives here -- this module
-is a static catalog.
+``STRICT_MODE.report(rule_id=..., message=RULES[rid].render(...))``
+at their own call site. No enforcement logic lives here -- this
+module is a static catalog.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from griptape_nodes.common.strict_mode import StrictModeSeverity
+from griptape_nodes.common.strict_mode import StrictModeSeverity
 
 
 @dataclass(frozen=True)
@@ -46,4 +45,86 @@ class StrictModeRule:
         return self.remediation_template.format(**context)
 
 
-RULES: dict[str, StrictModeRule] = {}
+RULES: dict[str, StrictModeRule] = {
+    "reentrant-bus-in-init": StrictModeRule(
+        rule_id="reentrant-bus-in-init",
+        default_severity=StrictModeSeverity.ERROR,
+        correctness=True,
+        description=(
+            "A node issued an event-bus request from inside its __init__. "
+            "The worker library probe runs __init__ to extract a schema; "
+            "re-entering the bus there deadlocks the worker."
+        ),
+        remediation_template=(
+            "Issued '{request_type}' during __init__. "
+            "Move the call into aprocess (or a lifecycle hook that runs after "
+            "construction)."
+        ),
+    ),
+    "parameter-behaviors-dropped-in-schema": StrictModeRule(
+        rule_id="parameter-behaviors-dropped-in-schema",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A Parameter attached converters, validators, or traits that "
+            "are not captured in the worker schema. Orchestrator-side UI "
+            "behavior and worker-side execution diverge."
+        ),
+        remediation_template=(
+            "Parameter '{parameter_name}' carries {dropped_attributes} that "
+            "are not serialized into the worker schema. These will not "
+            "execute on the orchestrator stub; behavior may differ from "
+            "a local-library node."
+        ),
+        # Reported during library load on the worker; escalating to ERROR
+        # would cause the class to be skipped entirely, which is too harsh
+        # for an ergonomics warning.
+        worker_escalation=False,
+    ),
+    "parameter-mutation-during-aprocess": StrictModeRule(
+        rule_id="parameter-mutation-during-aprocess",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node called add_parameter or remove_parameter during "
+            "aprocess. On the worker these changes are local to the "
+            "transient node and do not sync back to the orchestrator."
+        ),
+        remediation_template=(
+            "Node mutated parameter '{parameter_name}' during aprocess via "
+            "{mutation}. Emit AddParameterToNodeRequest or "
+            "RemoveParameterFromNodeRequest to propagate the change to "
+            "the orchestrator."
+        ),
+    ),
+    "worker-reach-into-orchestrator": StrictModeRule(
+        rule_id="worker-reach-into-orchestrator",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node running on a worker issued a request whose "
+            "authoritative state lives on the orchestrator (flow "
+            "graph, connections, parameter registry, config, or "
+            "secrets). The request was forwarded to the orchestrator "
+            "over the WebSocket bus; each call is a network round-"
+            "trip and the returned view is stale-by-call. Events are "
+            "the sanctioned cross-side boundary, but authors are "
+            "often unaware they are paying for it. Detection runs at "
+            "the RemoteHandler dispatch site, which covers both input "
+            "hydration (before/after_value_set) and aprocess. "
+            "Violations issued from library-internal helper threads "
+            "(e.g. ThreadPoolExecutor inside diffusers/transformers) "
+            "are not reported because the strict-mode reporter is "
+            "task-local; the forward still proceeds normally."
+        ),
+        remediation_template=(
+            "Worker-side node issued '{request_type}' during node "
+            "execution. If this is an intentional write (e.g. "
+            "publishing a parameter value), ignore. If this is a read "
+            "of flow / connection state, consider whether the data "
+            "could be passed in via parameters instead of fetched "
+            "per-call."
+        ),
+        worker_escalation=False,
+    ),
+}

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -1,0 +1,68 @@
+"""Strict-mode rule registry.
+
+Central catalog of every strict-mode rule: its stable ``rule_id``,
+default severity, whether it is a correctness-class violation (failed
+even on the orchestrator) or an ergonomics-class warning (worker-only
+escalation), a human description, and a ``str.format``-ready
+remediation template.
+
+Detectors import ``RULES`` to look up their rule and call
+``report_violation(rule_id=..., message=RULES[rid].render(...))`` at
+their own call site. No enforcement logic lives here -- this module
+is a static catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from griptape_nodes.common.strict_mode import StrictModeSeverity
+
+
+@dataclass(frozen=True)
+class StrictModeRule:
+    """Static description of a single strict-mode rule.
+
+    ``correctness`` rules are rules whose violation means the system is
+    in a state that cannot produce correct results (deadlocks, lost
+    data, state that silently disagrees between orchestrator and
+    worker). These fail on both sides. ``correctness=False`` rules
+    describe ergonomics or API-shape issues where the system still
+    runs -- they warn on the orchestrator and escalate to a failure on
+    the worker because the worker's stateless model makes them
+    load-bearing.
+    """
+
+    rule_id: str
+    default_severity: StrictModeSeverity
+    correctness: bool
+    description: str
+    remediation_template: str
+    worker_escalation: bool = True
+
+    def render(self, **context: Any) -> str:
+        return self.remediation_template.format(**context)
+
+
+def _rule(  # noqa: PLR0913
+    rule_id: str,
+    *,
+    severity: StrictModeSeverity,
+    correctness: bool,
+    description: str,
+    remediation: str,
+    worker_escalation: bool = True,
+) -> StrictModeRule:
+    return StrictModeRule(
+        rule_id=rule_id,
+        default_severity=severity,
+        correctness=correctness,
+        description=description,
+        remediation_template=remediation,
+        worker_escalation=worker_escalation,
+    )
+
+
+RULES: dict[str, StrictModeRule] = {}

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -46,23 +46,4 @@ class StrictModeRule:
         return self.remediation_template.format(**context)
 
 
-def _rule(  # noqa: PLR0913
-    rule_id: str,
-    *,
-    severity: StrictModeSeverity,
-    correctness: bool,
-    description: str,
-    remediation: str,
-    worker_escalation: bool = True,
-) -> StrictModeRule:
-    return StrictModeRule(
-        rule_id=rule_id,
-        default_severity=severity,
-        correctness=correctness,
-        description=description,
-        remediation_template=remediation,
-        worker_escalation=worker_escalation,
-    )
-
-
 RULES: dict[str, StrictModeRule] = {}

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -91,10 +91,10 @@ RULES: dict[str, StrictModeRule] = {
             "transient node and do not sync back to the orchestrator."
         ),
         remediation_template=(
-            "Node mutated parameter '{parameter_name}' during aprocess via "
-            "{mutation}. Emit AddParameterToNodeRequest or "
-            "RemoveParameterFromNodeRequest to propagate the change to "
-            "the orchestrator."
+            "Node '{node_name}' (type '{node_class}') mutated parameter "
+            "'{parameter_name}' during aprocess via {mutation}. Emit "
+            "AddParameterToNodeRequest or RemoveParameterFromNodeRequest "
+            "to propagate the change to the orchestrator."
         ),
     ),
     "worker-reach-into-orchestrator": StrictModeRule(

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1810,6 +1810,36 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         return validators
 
     @property
+    def has_directly_attached_converters(self) -> bool:
+        """The directly-attached converter list is non-empty.
+
+        Trait-derived converters are merged in by the ``converters``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
+        return bool(self._converters)
+
+    @property
+    def has_directly_attached_validators(self) -> bool:
+        """The directly-attached validator list is non-empty.
+
+        Trait-derived validators are merged in by the ``validators``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
+        return bool(self._validators)
+
+    @property
+    def has_traits(self) -> bool:
+        """Any Trait child is attached.
+
+        Walks ``find_elements_by_type(Trait)`` because traits are stored
+        as child node-elements, not in a flat list. Cheap at probe
+        scale (called once per parameter at library load).
+        """
+        return bool(self.find_elements_by_type(Trait))
+
+    @property
     def on_incoming_connection_removed(self) -> list[Callable[[Parameter, str, str], None]]:
         return self._on_incoming_connection_removed
 

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
-from griptape_nodes.common.strict_mode import node_init_scope
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
     ControlParameterInput,
@@ -227,53 +226,28 @@ class BaseNode(ABC):
     def __hash__(self) -> int:
         return hash(self.name)
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        # Wrap every subclass __init__ in node_init_scope so the
-        # reentrant-bus-in-init detector catches bus requests made from
-        # any __init__ body, not just BaseNode's. __init_subclass__
-        # runs once per concrete class definition; the wrapper checks
-        # ``__init__ is object.__init__`` to avoid re-wrapping inherited
-        # constructors every time the MRO is walked.
-        super().__init_subclass__(**kwargs)
-        init = cls.__dict__.get("__init__")
-        if init is None:
-            return
-
-        def wrapped(self: BaseNode, *args: Any, _orig: Any = init, **kw: Any) -> None:
-            with node_init_scope():
-                _orig(self, *args, **kw)
-
-        wrapped.__wrapped__ = init  # type: ignore[attr-defined]
-        cls.__init__ = wrapped  # type: ignore[method-assign]
-
     def __init__(
         self,
         name: str,
         metadata: dict[Any, Any] | None = None,
         state: NodeResolutionState = NodeResolutionState.UNRESOLVED,
     ) -> None:
-        # node_init_scope sets a thread-local flag that EventManager
-        # checks to detect the reentrant-bus-in-init rule: a node that
-        # issues an event-bus request from __init__ deadlocks the
-        # worker's schema probe. __init_subclass__ wraps subclass
-        # __init__ bodies so the flag also covers post-super() code.
-        with node_init_scope():
-            self.name = name
-            self._state = state
-            if metadata is None:
-                self.metadata = {}
-            else:
-                self.metadata = metadata
-            self.parameter_values = {}
-            self.parameter_output_values = TrackedParameterOutputValues(self)
-            self.root_ui_element = BaseNodeElement()
-            # Set the node context for the root element
-            self.root_ui_element._node_context = self
-            self.process_generator = None
-            self._tracked_parameters = []
-            self._cancellation_requested = threading.Event()
-            self._parent_group = None
-            self.set_entry_control_parameter(None)
+        self.name = name
+        self._state = state
+        if metadata is None:
+            self.metadata = {}
+        else:
+            self.metadata = metadata
+        self.parameter_values = {}
+        self.parameter_output_values = TrackedParameterOutputValues(self)
+        self.root_ui_element = BaseNodeElement()
+        # Set the node context for the root element
+        self.root_ui_element._node_context = self
+        self.process_generator = None
+        self._tracked_parameters = []
+        self._cancellation_requested = threading.Event()
+        self._parent_group = None
+        self.set_entry_control_parameter(None)
 
     @property
     def state(self) -> NodeResolutionState:

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1438,7 +1438,12 @@ class BaseNode(ABC):
         rule = RULES["parameter-mutation-during-aprocess"]
         STRICT_MODE.report(
             rule_id=rule.rule_id,
-            message=rule.render(parameter_name=parameter_name, mutation=mutation),
+            message=rule.render(
+                node_name=self.name,
+                node_class=type(self).__name__,
+                parameter_name=parameter_name,
+                mutation=mutation,
+            ),
         )
 
     def _emit_parameter_lifecycle_event(self, parameter: BaseNodeElement, *, remove: bool = False) -> None:

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -4,11 +4,15 @@ import logging
 import threading
 import warnings
 from abc import ABC
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
     ControlParameterInput,
@@ -90,6 +94,56 @@ AsyncResult = Generator[Callable[[], T], T]
 LOCAL_EXECUTION = "Local Execution"
 PRIVATE_EXECUTION = "Private Execution"
 CONTROL_INPUT_PARAMETER = "Control Input Selection"
+
+
+# Per-task flag: when set, parameter mutations on a node are explicitly
+# sanctioned by a request handler (AddParameterToNodeRequest /
+# RemoveParameterFromNodeRequest) and the parameter-mutation-during-aprocess
+# detector should not fire. The handler-side path is the legitimate way to
+# mutate parameters because it propagates the change back to the orchestrator
+# via the request bus; direct add_parameter / remove_parameter_element calls
+# from inside aprocess do not, and that is what the rule catches.
+_sanctioned_mutation: ContextVar[bool] = ContextVar("_node_types_sanctioned_mutation", default=False)
+
+# Per-task flag: True only while ``await node.aprocess()`` is on the stack.
+# The detector uses this to distinguish actual aprocess execution from the
+# surrounding RUNTIME_EXECUTE scope, which also wraps input hydration.
+# Hydration-time set_parameter_value calls run before/after_value_set hooks,
+# and many real nodes (e.g. dynamic-pipeline diffuser nodes) legitimately
+# call add_parameter / remove_parameter_element from those hooks; keying off
+# the broader RUNTIME_EXECUTE scope would false-positive on every such node.
+_in_aprocess: ContextVar[bool] = ContextVar("_node_types_in_aprocess", default=False)
+
+
+@contextmanager
+def sanctioned_parameter_mutation() -> Iterator[None]:
+    """Mark the enclosed block as a request-driven parameter mutation.
+
+    Wraps add_parameter / remove_parameter_element calls inside
+    AddParameterToNodeRequest and RemoveParameterFromNodeRequest handlers
+    so the parameter-mutation-during-aprocess detector skips them.
+    """
+    token = _sanctioned_mutation.set(True)
+    try:
+        yield
+    finally:
+        _sanctioned_mutation.reset(token)
+
+
+@contextmanager
+def aprocess_scope() -> Iterator[None]:
+    """Mark the enclosed block as the actual aprocess() execution.
+
+    The framework wraps ``await node.aprocess()`` with this so the
+    parameter-mutation-during-aprocess detector fires only for mutations
+    that happen inside aprocess itself, not the surrounding hydration
+    pass that also runs under the RUNTIME_EXECUTE strict-mode scope.
+    """
+    token = _in_aprocess.set(True)
+    try:
+        yield
+    finally:
+        _in_aprocess.reset(token)
 
 
 class ImportDependency(NamedTuple):
@@ -588,6 +642,7 @@ class BaseNode(ABC):
 
     def add_parameter(self, param: Parameter) -> None:
         """Adds a Parameter to the Node. Control and Data Parameters are all treated equally."""
+        self._report_parameter_mutation_if_in_aprocess(parameter_name=param.name, mutation="add_parameter")
         if any(char.isspace() for char in param.name):
             msg = f"Failed to add Parameter `{param.name}`. Parameter names cannot currently any whitespace characters. Please see https://github.com/griptape-ai/griptape-nodes/issues/714 to check the status on a remedy for this issue."
             raise ValueError(msg)
@@ -609,6 +664,7 @@ class BaseNode(ABC):
             self.remove_parameter_element(element)
 
     def remove_parameter_element(self, param: BaseNodeElement) -> None:
+        self._report_parameter_mutation_if_in_aprocess(parameter_name=param.name, mutation="remove_parameter_element")
         # Emit event before removal if it's a Parameter
         if isinstance(param, Parameter):
             self._emit_parameter_lifecycle_event(param)
@@ -1344,6 +1400,46 @@ class BaseNode(ABC):
 
         # Use reorder_elements to apply the move
         self.reorder_elements(list(new_order))
+
+    def _report_parameter_mutation_if_in_aprocess(self, *, parameter_name: str, mutation: str) -> None:
+        """Report parameter-mutation-during-aprocess when a node mutates its own params directly.
+
+        Request handlers reach ``add_parameter`` / ``remove_parameter_element``
+        via ``AddParameterToNodeRequest`` / ``RemoveParameterFromNodeRequest``
+        and wrap the call in ``sanctioned_parameter_mutation()``. Any call
+        that arrives here from aprocess without that wrapper is a direct
+        mutation, which does not sync back to the orchestrator when the
+        node runs in a worker subprocess.
+
+        Detection keys off ``_in_aprocess`` (set by ``aprocess_scope()`` only
+        around ``await node.aprocess()``) rather than the broader
+        ``RUNTIME_EXECUTE`` strict-mode scope, because that scope also wraps
+        input hydration. Hydration runs ``set_parameter_value`` ->
+        ``before_value_set`` / ``after_value_set``, and dynamic-pipeline
+        nodes legitimately call ``add_parameter`` from those hooks; keying
+        off ``RUNTIME_EXECUTE`` would false-positive on every such node.
+
+        Nested node construction (a node's ``__init__`` declaring parameters
+        from inside another node's ``aprocess``) is handled by the
+        ``is_constructing_node()`` short-circuit: declarative ``__init__``
+        calls to ``add_parameter`` are not violations even when an outer
+        ``aprocess`` is on the stack.
+        """
+        # Lazy import: library_registry imports BaseNode from this module,
+        # so importing at module load creates a cycle.
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        if _sanctioned_mutation.get():
+            return
+        if LibraryRegistry.is_constructing_node():
+            return
+        if not _in_aprocess.get():
+            return
+        rule = RULES["parameter-mutation-during-aprocess"]
+        STRICT_MODE.report(
+            rule_id=rule.rule_id,
+            message=rule.render(parameter_name=parameter_name, mutation=mutation),
+        )
 
     def _emit_parameter_lifecycle_event(self, parameter: BaseNodeElement, *, remove: bool = False) -> None:
         """Emit an AlterElementEvent for parameter add/remove operations."""

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
+from griptape_nodes.common.strict_mode import node_init_scope
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
     ControlParameterInput,
@@ -226,28 +227,53 @@ class BaseNode(ABC):
     def __hash__(self) -> int:
         return hash(self.name)
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # Wrap every subclass __init__ in node_init_scope so the
+        # reentrant-bus-in-init detector catches bus requests made from
+        # any __init__ body, not just BaseNode's. __init_subclass__
+        # runs once per concrete class definition; the wrapper checks
+        # ``__init__ is object.__init__`` to avoid re-wrapping inherited
+        # constructors every time the MRO is walked.
+        super().__init_subclass__(**kwargs)
+        init = cls.__dict__.get("__init__")
+        if init is None:
+            return
+
+        def wrapped(self: BaseNode, *args: Any, _orig: Any = init, **kw: Any) -> None:
+            with node_init_scope():
+                _orig(self, *args, **kw)
+
+        wrapped.__wrapped__ = init  # type: ignore[attr-defined]
+        cls.__init__ = wrapped  # type: ignore[method-assign]
+
     def __init__(
         self,
         name: str,
         metadata: dict[Any, Any] | None = None,
         state: NodeResolutionState = NodeResolutionState.UNRESOLVED,
     ) -> None:
-        self.name = name
-        self._state = state
-        if metadata is None:
-            self.metadata = {}
-        else:
-            self.metadata = metadata
-        self.parameter_values = {}
-        self.parameter_output_values = TrackedParameterOutputValues(self)
-        self.root_ui_element = BaseNodeElement()
-        # Set the node context for the root element
-        self.root_ui_element._node_context = self
-        self.process_generator = None
-        self._tracked_parameters = []
-        self._cancellation_requested = threading.Event()
-        self._parent_group = None
-        self.set_entry_control_parameter(None)
+        # node_init_scope sets a thread-local flag that EventManager
+        # checks to detect the reentrant-bus-in-init rule: a node that
+        # issues an event-bus request from __init__ deadlocks the
+        # worker's schema probe. __init_subclass__ wraps subclass
+        # __init__ bodies so the flag also covers post-super() code.
+        with node_init_scope():
+            self.name = name
+            self._state = state
+            if metadata is None:
+                self.metadata = {}
+            else:
+                self.metadata = metadata
+            self.parameter_values = {}
+            self.parameter_output_values = TrackedParameterOutputValues(self)
+            self.root_ui_element = BaseNodeElement()
+            # Set the node context for the root element
+            self.root_ui_element._node_context = self
+            self.process_generator = None
+            self._tracked_parameters = []
+            self._cancellation_requested = threading.Event()
+            self._parent_group = None
+            self.set_entry_control_parameter(None)
 
     @property
     def state(self) -> NodeResolutionState:

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
@@ -19,8 +18,6 @@ from griptape_nodes.retained_mode.managers.resource_components.resource_instance
 from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
     from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
@@ -357,11 +354,38 @@ class LibraryRegistry(metaclass=SingletonMeta):
             node_type=node_type, specific_library_name=specific_library_name
         )
 
-        # Ask the library to create the node. construction_scope() exposes the
-        # "a node is being constructed right now" signal that the
+        # Expose the "a node is being constructed right now" signal that the
         # reentrant-bus-in-init detector reads from EventManager.handle_request.
-        with cls.construction_scope():
+        token = _constructing_node.set(True)
+        try:
             return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
+        finally:
+            _constructing_node.reset(token)
+
+    @classmethod
+    def create_schema_probe(cls, library_name: str, node_type: str) -> BaseNode:
+        """Construct a throwaway probe instance for schema discovery.
+
+        Used by ``LibraryManager._serialize_library_node_schemas`` to
+        instantiate each registered node class so its parameters can be
+        introspected. Differs from :meth:`create_node` in that it skips
+        the library metadata injection -- the probe's metadata is
+        discarded after the schema is read. The construction flag is
+        still set so the reentrant-bus-in-init detector observes the
+        construction.
+
+        The caller is responsible for offloading the call (e.g. via
+        ``asyncio.to_thread``) and applying any timeout, since node
+        ``__init__`` may block.
+        """
+        instance = cls()
+        library = instance.get_library(library_name)
+        node_class = library.get_node_class(node_type)
+        token = _constructing_node.set(True)
+        try:
+            return node_class(name="__schema_probe__")
+        finally:
+            _constructing_node.reset(token)
 
     @classmethod
     def is_constructing_node(cls) -> bool:
@@ -369,27 +393,10 @@ class LibraryRegistry(metaclass=SingletonMeta):
 
         The reentrant-bus-in-init strict-mode detector consults this so it
         can fire from ``EventManager.handle_request`` without owning its
-        own depth counter. The flag is set by ``create_node`` and by
-        any direct construction site that wraps its call in
-        ``construction_scope`` (e.g. the worker schema probe).
+        own depth counter. The flag is set by ``create_node`` and
+        ``create_schema_probe``.
         """
         return _constructing_node.get()
-
-    @classmethod
-    @contextmanager
-    def construction_scope(cls) -> Iterator[None]:
-        """Mark the current task as constructing a node.
-
-        Used by callers that instantiate a node class directly rather
-        than through :meth:`create_node` -- specifically the schema probe
-        in ``LibraryManager._serialize_library_node_schemas`` -- so the
-        reentrant-bus-in-init detector still sees the construction.
-        """
-        token = _constructing_node.set(True)
-        try:
-            yield
-        finally:
-            _constructing_node.reset(token)
 
     @classmethod
     def get_all_library_schemas(cls) -> dict[str, dict]:

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
@@ -18,6 +19,8 @@ from griptape_nodes.retained_mode.managers.resource_components.resource_instance
 from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
     from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
@@ -354,11 +357,30 @@ class LibraryRegistry(metaclass=SingletonMeta):
             node_type=node_type, specific_library_name=specific_library_name
         )
 
-        # Expose the "a node is being constructed right now" signal that the
-        # reentrant-bus-in-init detector reads from EventManager.handle_request.
+        with cls.constructing_node():
+            return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
+
+    @classmethod
+    @contextmanager
+    def constructing_node(cls) -> Iterator[None]:
+        """Mark the enclosed block as a node ``__init__`` running on the calling task.
+
+        Sets the same task-local flag that ``create_node`` sets. Use at
+        any direct construction site that bypasses ``create_node``
+        (e.g. ``type(node)(name=...)`` or ``node_class(name=...)`` for
+        an ephemeral probe / reference node), so:
+
+        - the parameter-mutation-during-aprocess detector skips the
+          declarative ``add_parameter`` calls inside the constructed
+          node's ``__init__`` (otherwise it would fire once per
+          parameter declared by the helper instance), and
+        - the reentrant-bus-in-init detector still fires for the
+          right reason if the constructed node's ``__init__`` issues
+          a bus request.
+        """
         token = _constructing_node.set(True)
         try:
-            return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
+            yield
         finally:
             _constructing_node.reset(token)
 
@@ -366,9 +388,10 @@ class LibraryRegistry(metaclass=SingletonMeta):
     def is_constructing_node(cls) -> bool:
         """Return True if a node ``__init__`` is currently running on the calling task.
 
-        The reentrant-bus-in-init strict-mode detector consults this so it
-        can fire from ``EventManager.handle_request`` without owning its
-        own depth counter. The flag is set by ``create_node``.
+        The reentrant-bus-in-init and parameter-mutation-during-aprocess
+        strict-mode detectors consult this so they can fire from outside
+        ``LibraryRegistry`` without owning their own depth counter. The
+        flag is set by ``create_node`` and by ``constructing_node()``.
         """
         return _constructing_node.get()
 

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -363,38 +363,12 @@ class LibraryRegistry(metaclass=SingletonMeta):
             _constructing_node.reset(token)
 
     @classmethod
-    def create_schema_probe(cls, library_name: str, node_type: str) -> BaseNode:
-        """Construct a throwaway probe instance for schema discovery.
-
-        Used by ``LibraryManager._serialize_library_node_schemas`` to
-        instantiate each registered node class so its parameters can be
-        introspected. Differs from :meth:`create_node` in that it skips
-        the library metadata injection -- the probe's metadata is
-        discarded after the schema is read. The construction flag is
-        still set so the reentrant-bus-in-init detector observes the
-        construction.
-
-        The caller is responsible for offloading the call (e.g. via
-        ``asyncio.to_thread``) and applying any timeout, since node
-        ``__init__`` may block.
-        """
-        instance = cls()
-        library = instance.get_library(library_name)
-        node_class = library.get_node_class(node_type)
-        token = _constructing_node.set(True)
-        try:
-            return node_class(name="__schema_probe__")
-        finally:
-            _constructing_node.reset(token)
-
-    @classmethod
     def is_constructing_node(cls) -> bool:
         """Return True if a node ``__init__`` is currently running on the calling task.
 
         The reentrant-bus-in-init strict-mode detector consults this so it
         can fire from ``EventManager.handle_request`` without owning its
-        own depth counter. The flag is set by ``create_node`` and
-        ``create_schema_probe``.
+        own depth counter. The flag is set by ``create_node``.
         """
         return _constructing_node.get()
 
@@ -533,9 +507,8 @@ class Library:
         """Return the BaseNode subclass registered under `node_type`.
 
         For callers that need the class itself, e.g. classmethod checks like
-        `allow_outgoing_connection_by_class` or building a throwaway probe instance,
-        rather than an instance produced by `create_node` (which also injects library
-        metadata into the node).
+        `allow_outgoing_connection_by_class`, rather than an instance produced
+        by `create_node`.
         """
         if node_type not in self._node_types:
             raise KeyError(self._library_data.name, node_type)

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from pydantic import BaseModel, Field, field_validator
@@ -17,11 +19,15 @@ from griptape_nodes.retained_mode.managers.resource_components.resource_instance
 from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
     from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
 
 logger = logging.getLogger("griptape_nodes")
+
+_constructing_node: ContextVar[bool] = ContextVar("_library_registry_constructing_node", default=False)
 
 
 class LibraryNameAndVersion(NamedTuple):
@@ -351,8 +357,39 @@ class LibraryRegistry(metaclass=SingletonMeta):
             node_type=node_type, specific_library_name=specific_library_name
         )
 
-        # Ask the library to create the node.
-        return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
+        # Ask the library to create the node. construction_scope() exposes the
+        # "a node is being constructed right now" signal that the
+        # reentrant-bus-in-init detector reads from EventManager.handle_request.
+        with cls.construction_scope():
+            return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
+
+    @classmethod
+    def is_constructing_node(cls) -> bool:
+        """Return True if a node ``__init__`` is currently running on the calling task.
+
+        The reentrant-bus-in-init strict-mode detector consults this so it
+        can fire from ``EventManager.handle_request`` without owning its
+        own depth counter. The flag is set by ``create_node`` and by
+        any direct construction site that wraps its call in
+        ``construction_scope`` (e.g. the worker schema probe).
+        """
+        return _constructing_node.get()
+
+    @classmethod
+    @contextmanager
+    def construction_scope(cls) -> Iterator[None]:
+        """Mark the current task as constructing a node.
+
+        Used by callers that instantiate a node class directly rather
+        than through :meth:`create_node` -- specifically the schema probe
+        in ``LibraryManager._serialize_library_node_schemas`` -- so the
+        reentrant-bus-in-init detector still sees the construction.
+        """
+        token = _constructing_node.set(True)
+        try:
+            yield
+        finally:
+            _constructing_node.reset(token)
 
     @classmethod
     def get_all_library_schemas(cls) -> dict[str, dict]:

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -237,6 +237,26 @@ class ConfigChanged(AppPayload):
 
 @dataclass
 @PayloadRegistry.register
+class SecretChanged(AppPayload):
+    """Secret value mutation notification.
+
+    Emitted by the orchestrator's SecretsManager after a secret is set or
+    deleted. WorkerManager listens for this and fans out a refresh signal to
+    every registered worker so their os.environ shadow picks up the new value
+    from the shared .env file.
+
+    The secret value itself is intentionally not carried in this event --
+    workers re-read from the shared .env file on the same machine.
+
+    Args:
+        key: The secret name (normalized) that changed.
+    """
+
+    key: str
+
+
+@dataclass
+@PayloadRegistry.register
 class GetEngineVersionRequest(RequestPayload):
     """Get the engine version information.
 

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
+from griptape_nodes.retained_mode.events.event_converter import (
+    converter,
+    register_polymorphic_dataclass,
+    safe_unstructure,
+)
 
 if TYPE_CHECKING:
     import builtins
@@ -552,3 +556,11 @@ class ProgressEvent:
     value: Any = field()
     node_name: str = field()
     parameter_name: str = field()
+
+
+# Register ResultDetail subclasses (e.g. StrictModeViolationDetail) with the
+# converter so a ``list[ResultDetail]`` round-trip preserves subclass identity
+# and subclass-only fields (rule_id, severity, subject, library_name) instead
+# of degrading every entry to a bare ResultDetail. Must run after every
+# subclass is defined.
+register_polymorphic_dataclass(ResultDetail)

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -60,10 +60,10 @@ class StrictModeViolationDetail(ResultDetail):
     filter or group violations without parsing ``message``.
     """
 
-    rule_id: str = ""
-    severity: str = ""
-    subject: str = ""
-    library_name: str | None = None
+    rule_id: str
+    severity: str
+    subject: str
+    library_name: str | None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -52,6 +52,21 @@ class ResultDetail:
 
 
 @dataclass
+class StrictModeViolationDetail(ResultDetail):
+    """A ResultDetail that carries structured strict-mode violation metadata.
+
+    Editor renders ``ResultDetail`` today, so this subclass surfaces on
+    the result payload for free. The extra fields let future tooling
+    filter or group violations without parsing ``message``.
+    """
+
+    rule_id: str = ""
+    severity: str = ""
+    subject: str = ""
+    library_name: str | None = None
+
+
+@dataclass
 class ResultDetails:
     """Container for multiple ResultDetail objects."""
 

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -222,10 +222,48 @@ class ResultPayloadSuccess(ResultPayload, ABC):
         return True
 
 
+class ForwardedException(Exception):  # noqa: N818
+    """Placeholder for an exception that crossed the worker boundary.
+
+    The converter's Exception hook emits worker-side exceptions as a
+    ``{type, message, traceback}`` dict, then rebuilds them into a
+    ``ForwardedException`` on the receiving side. The placeholder is
+    still an ``Exception`` (so ``raise ... from result.exception``
+    chains) and carries the worker-side class name and formatted
+    traceback so the orchestrator can show both.
+
+    ``NodeExecutor._format_node_failure_message`` is the consumer:
+    it reads ``original_type`` for the ``[builtins.ValueError]``
+    prefix on the user-visible ``RuntimeError`` message, and
+    ``original_traceback`` for the ``Worker traceback:`` block.
+    Without these attributes the chained exception would print only
+    ``Type: message`` with no frames, because the placeholder is
+    constructed (not raised) and so its ``__traceback__`` is ``None``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        original_type: str | None = None,
+        original_traceback: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.original_type = original_type
+        self.original_traceback = original_traceback
+
+
 # Failure result payload abstract base class
 @dataclass(kw_only=True)
 class ResultPayloadFailure(ResultPayload, ABC):
-    """Abstract base class for failure result payloads."""
+    """Abstract base class for failure result payloads.
+
+    ``exception`` is the single source of truth. On the local path it
+    is the live ``Exception``. Across the worker -> orchestrator wire
+    the converter emits it as a structured dict and rebuilds it as a
+    ``ForwardedException`` carrying the original type name and
+    traceback as attributes, so callers can read both paths uniformly.
+    """
 
     result_details: ResultDetails | str
     exception: Exception | None = None

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -9,7 +9,7 @@ from typing import Any, Union, get_args, get_origin
 
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.preconf.json import make_converter
-from cattrs.strategies import use_class_methods
+from cattrs.strategies import include_subclasses, use_class_methods
 from griptape.mixins.serializable_mixin import SerializableMixin
 from pydantic import BaseModel
 
@@ -162,6 +162,21 @@ converter.register_structure_hook_factory(
 # reverse registration order), ensuring _cattrs_structure/_cattrs_unstructure take
 # precedence over the generated dataclass code.
 use_class_methods(converter, structure_method_name="_cattrs_structure", unstructure_method_name="_cattrs_unstructure")
+
+
+def register_polymorphic_dataclass(cls: type) -> None:
+    """Configure the converter to (un)structure ``cls`` as a union of itself and its subclasses.
+
+    Without this, a field typed ``list[BaseClass]`` round-trips every entry
+    as the base class and silently drops subclass-only fields. Call this
+    once per polymorphic root, after every subclass has been declared at
+    import time. Lives here so converter wiring stays in one place rather
+    than each data module reaching into ``cattrs.strategies`` itself.
+
+    Disambiguation is by unique field names; if a future subclass has no
+    unique field, switch to a tagged-union strategy at this seam.
+    """
+    include_subclasses(cls, converter)
 
 
 def safe_unstructure(obj: Any) -> Any:

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import traceback
 import types
 from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
@@ -39,10 +40,35 @@ converter.register_unstructure_hook_func(
     lambda obj: obj.isoformat(),
 )
 
-# Exception -> string representation
+
+# Exception -> structured dict.
+#
+# The three dict keys are the wire form of ``ForwardedException``:
+#   ``type``      -> ``ForwardedException.original_type``      -> ``[<type>]`` prefix
+#   ``message``   -> ``ForwardedException.args[0]``            -> message body
+#   ``traceback`` -> ``ForwardedException.original_traceback`` -> ``Worker traceback:`` block
+# ``_structure_exception`` rebuilds the placeholder on the receiving side, and
+# ``NodeExecutor._format_node_failure_message`` renders the prefix and block
+# into the user-visible ``RuntimeError`` message.
+def _unstructure_exception(obj: Exception) -> dict[str, Any]:
+    if obj.__traceback__ is None:
+        tb = None
+    else:
+        try:
+            tb = "".join(traceback.format_exception(type(obj), obj, obj.__traceback__))
+        except Exception:
+            logger.debug("Failed to format traceback for %s", type(obj).__name__, exc_info=True)
+            tb = None
+    return {
+        "type": f"{type(obj).__module__}.{type(obj).__qualname__}",
+        "message": str(obj),
+        "traceback": tb,
+    }
+
+
 converter.register_unstructure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, Exception),
-    str,
+    _unstructure_exception,
 )
 
 # Bare `type` references (e.g. provider_class: type)
@@ -80,10 +106,34 @@ converter.register_structure_hook_func(
     lambda obj, cls: cls.model_validate(obj),
 )
 
-# Exception <- string or dict
+
+# Exception <- structured dict.
+#
+# Rebuilds a ``ForwardedException`` on the receiving side because the
+# worker-side class is rarely importable on the orchestrator. The
+# ``original_type`` and ``original_traceback`` fields are read by
+# ``NodeExecutor._format_node_failure_message`` to render the
+# ``[<type>] ... Worker traceback: ...`` block in the orchestrator's
+# user-visible ``RuntimeError`` message.
+def _structure_exception(obj: Any, _cls: type) -> Exception:
+    # Lazy import to avoid a circular dependency: base_events imports
+    # from this module (event_converter is registered at import time
+    # from base_events), so ForwardedException cannot be imported at
+    # module load.
+    from griptape_nodes.retained_mode.events.base_events import ForwardedException
+
+    if not isinstance(obj, dict):
+        return ForwardedException(str(obj))
+    return ForwardedException(
+        str(obj.get("message", "")),
+        original_type=obj.get("type"),
+        original_traceback=obj.get("traceback"),
+    )
+
+
 converter.register_structure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, Exception),
-    lambda obj, cls: cls(obj) if isinstance(obj, str) else cls(str(obj)),
+    _structure_exception,
 )
 
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -440,6 +440,7 @@ class ConfigManager:
         if self._event_manager is not None:
             event = ConfigChanged(key=key, old_value=old_value, new_value=value)
             self._event_manager.broadcast_app_event(event)
+        self._notify_workers_to_reload_config()
 
     def on_handle_get_config_category_request(self, request: GetConfigCategoryRequest) -> ResultPayload:
         if request.category is None or request.category == "":
@@ -485,6 +486,7 @@ class ConfigManager:
                     new_value=request.contents,
                 )
                 self._event_manager.broadcast_app_event(event)
+            self._notify_workers_to_reload_config()
 
             return SetConfigCategoryResultSuccess(result_details=result_details)
 
@@ -564,10 +566,24 @@ class ConfigManager:
             self._set_log_level(str(self.merged_config["log_level"]))
 
             result_details = "Successfully reset user configuration."
+            self._notify_workers_to_reload_config()
             return ResetConfigResultSuccess(result_details=result_details)
         except Exception as e:
             result_details = f"Attempted to reset user configuration but failed: {e}."
             return ResetConfigResultFailure(result_details=result_details)
+
+    def _notify_workers_to_reload_config(self) -> None:
+        """Tell every registered worker to reload its config from the shared file.
+
+        Only the orchestrator's WorkerManager has any registered workers, so on a
+        worker process this is a cheap no-op via ``schedule_broadcast``. Imported
+        lazily because ``griptape_nodes.app`` is not importable at the module
+        level here -- ConfigManager is loaded during engine boot, before
+        ``app/__init__`` has finished importing.
+        """
+        from griptape_nodes.app.worker_routing import ReloadConfigRequest, schedule_broadcast
+
+        schedule_broadcast(ReloadConfigRequest)
 
     def _get_diff(self, old_value: Any, new_value: Any) -> dict[Any, Any]:
         """Generate a diff between the old and new values."""
@@ -702,13 +718,9 @@ class ConfigManager:
 
         # Step 3: Read current config directly from disk.
         #
-        # We intentionally bypass the ReadFileRequest handler here. `_write_user_config_delta`
-        # is called from both sync (set_config_value) and async (app-init handlers that
-        # register provider settings) contexts; the ReadFileRequest handler is async, so
-        # dispatching it from an async context via sync handle_request trips the
-        # sync-in-async fail-fast (issue #4469). The enclosing writes already use
-        # os_manager.on_write_file_request directly (sync), so the read matches that
-        # bootstrap-path style and avoids coupling config load to event-loop state.
+        # We intentionally bypass the ReadFileRequest handler here. The enclosing writes
+        # already use os_manager.on_write_file_request directly (sync), so the read matches
+        # that bootstrap-path style and avoids coupling config load to event-loop state.
         try:
             file_content = Path(config_path_str).read_text(encoding="utf-8")
         except FileNotFoundError:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -406,13 +406,19 @@ class ConfigManager:
 
         return value
 
-    def set_config_value(self, key: str, value: Any, *, should_set_env_var_if_detected: bool = True) -> None:
+    def set_config_value(self, key: str, value: Any, *, should_set_env_var_if_detected: bool = True) -> bool:
         """Set a value in the configuration.
 
         Args:
             key: The configuration key to set. Can use dot notation for nested keys (e.g., 'category.subcategory.key').
             value: The value to associate with the key.
             should_set_env_var_if_detected: If True, and the value starts with a $, it will be set in the environment variables.
+
+        Returns:
+            True if the change was persisted to disk; False if the underlying
+            ``_write_user_config_delta`` call failed. Callers that surface a
+            result payload to a request handler should propagate the failure
+            instead of reporting success on a stale write.
         """
         # Capture old value before making changes (for event emission)
         old_value = self.get_config_value(key, should_load_env_var_if_detected=False)
@@ -423,7 +429,7 @@ class ConfigManager:
         elif key == "workspace_directory":
             self.workspace_path = value
         self.user_config = merge_dicts(self.merged_config, delta)
-        self._write_user_config_delta(delta)
+        write_succeeded = self._write_user_config_delta(delta)
 
         if should_set_env_var_if_detected and isinstance(value, str) and value.startswith("$"):
             from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -436,11 +442,16 @@ class ConfigManager:
         self.load_configs()
         logger.debug("Config value '%s' set to '%s'", key, value)
 
-        # Broadcast config change event so other managers can respond
-        if self._event_manager is not None:
+        # Broadcast a domain event on success only. Listeners (in production:
+        # WorkerManager) take it from here -- this manager has no knowledge of
+        # who consumes the event. Failed writes are logged inside
+        # ``_write_user_config_delta``; no event fires so listeners cannot act
+        # on a state that does not exist on disk.
+        if write_succeeded and self._event_manager is not None:
             event = ConfigChanged(key=key, old_value=old_value, new_value=value)
             self._event_manager.broadcast_app_event(event)
-        self._notify_workers_to_reload_config()
+
+        return write_succeeded
 
     def on_handle_get_config_category_request(self, request: GetConfigCategoryRequest) -> ResultPayload:
         if request.category is None or request.category == "":
@@ -475,10 +486,18 @@ class ConfigManager:
 
         if request.category is None or request.category == "":
             # Assign the whole shebang.
-            self._write_user_config_delta(request.contents)
+            write_succeeded = self._write_user_config_delta(request.contents)
+            if not write_succeeded:
+                result_details = (
+                    "Attempted to assign the entire config dictionary. Failed because the user config "
+                    "file could not be written; see prior logs for the underlying I/O error."
+                )
+                return SetConfigCategoryResultFailure(result_details=result_details)
+
             result_details = "Successfully assigned the entire config dictionary."
 
-            # Broadcast config change event for full config replacement
+            # Domain event on success only -- listeners (e.g. WorkerManager)
+            # decide what to do with it.
             if self._event_manager is not None:
                 event = ConfigChanged(
                     key="",
@@ -486,11 +505,16 @@ class ConfigManager:
                     new_value=request.contents,
                 )
                 self._event_manager.broadcast_app_event(event)
-            self._notify_workers_to_reload_config()
 
             return SetConfigCategoryResultSuccess(result_details=result_details)
 
-        self.set_config_value(key=request.category, value=request.contents)
+        write_succeeded = self.set_config_value(key=request.category, value=request.contents)
+        if not write_succeeded:
+            result_details = (
+                f"Attempted to set config category '{request.category}'. Failed because the user config "
+                "file could not be written; see prior logs for the underlying I/O error."
+            )
+            return SetConfigCategoryResultFailure(result_details=result_details)
 
         result_details = f"Successfully assigned the config dictionary for section '{request.category}'."
         return SetConfigCategoryResultSuccess(result_details=result_details)
@@ -566,24 +590,16 @@ class ConfigManager:
             self._set_log_level(str(self.merged_config["log_level"]))
 
             result_details = "Successfully reset user configuration."
-            self._notify_workers_to_reload_config()
+            # Reset is a full replacement; emit the same shape of ConfigChanged
+            # that ``on_handle_set_config_category_request`` does for category=None,
+            # so listeners cannot tell the two paths apart.
+            if self._event_manager is not None:
+                event = ConfigChanged(key="", old_value=None, new_value=self.merged_config)
+                self._event_manager.broadcast_app_event(event)
             return ResetConfigResultSuccess(result_details=result_details)
         except Exception as e:
             result_details = f"Attempted to reset user configuration but failed: {e}."
             return ResetConfigResultFailure(result_details=result_details)
-
-    def _notify_workers_to_reload_config(self) -> None:
-        """Tell every registered worker to reload its config from the shared file.
-
-        Only the orchestrator's WorkerManager has any registered workers, so on a
-        worker process this is a cheap no-op via ``schedule_broadcast``. Imported
-        lazily because ``griptape_nodes.app`` is not importable at the module
-        level here -- ConfigManager is loaded during engine boot, before
-        ``app/__init__`` has finished importing.
-        """
-        from griptape_nodes.app.worker_routing import ReloadConfigRequest, schedule_broadcast
-
-        schedule_broadcast(ReloadConfigRequest)
 
     def _get_diff(self, old_value: Any, new_value: Any) -> dict[Any, Any]:
         """Generate a diff between the old and new values."""
@@ -636,7 +652,13 @@ class ConfigManager:
             old_value_copy = old_value
 
         # Set the new value
-        self.set_config_value(key=request.category_and_key, value=request.value)
+        write_succeeded = self.set_config_value(key=request.category_and_key, value=request.value)
+        if not write_succeeded:
+            result_details = (
+                f"Attempted to set config value '{request.category_and_key}'. Failed because the user "
+                "config file could not be written; see prior logs for the underlying I/O error."
+            )
+            return SetConfigValueResultFailure(result_details=result_details)
 
         # For container types, indicate the change with a diff
         if isinstance(request.value, (dict, list)):
@@ -654,7 +676,7 @@ class ConfigManager:
 
         return SetConfigValueResultSuccess(result_details=result_details)
 
-    def _write_user_config_delta(self, user_config_delta: dict) -> None:  # noqa: C901, PLR0911, PLR0912, PLR0915
+    def _write_user_config_delta(self, user_config_delta: dict) -> bool:  # noqa: C901, PLR0911, PLR0912, PLR0915
         """Write user configuration delta to config file with atomic read-modify-write.
 
         This method performs an atomic read-modify-write operation on the user config file:
@@ -671,6 +693,12 @@ class ConfigManager:
         Args:
             user_config_delta: Configuration changes to merge with existing config.
                               Uses dot notation keys (e.g., {"nodes.max_depth": 10})
+
+        Returns:
+            True if the merged config was written to disk; False if any step
+            (file info, create, read, write) failed. Callers must gate
+            worker fan-out on this so workers don't reload from a file that
+            wasn't actually updated.
         """
         # Lazy import to avoid circular dependency during initialization
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -689,7 +717,7 @@ class ConfigManager:
                 config_path_str,
                 info_result.result_details,
             )
-            return
+            return False
 
         # Step 2: Create config file if it doesn't exist
         if info_result.file_entry is None:
@@ -714,7 +742,7 @@ class ConfigManager:
                     config_path_str,
                     create_result.result_details,
                 )
-                return
+                return False
 
         # Step 3: Read current config directly from disk.
         #
@@ -728,28 +756,28 @@ class ConfigManager:
                 "Attempted to read user config at '%s'. File not found despite creation attempt.",
                 config_path_str,
             )
-            return
+            return False
         except PermissionError as e:
             logger.error(
                 "Attempted to read user config at '%s'. Permission denied: %s",
                 config_path_str,
                 e,
             )
-            return
+            return False
         except UnicodeDecodeError as e:
             logger.error(
                 "Attempted to read user config at '%s'. Encoding error: %s",
                 config_path_str,
                 e,
             )
-            return
+            return False
         except OSError as e:
             logger.error(
                 "Attempted to read user config at '%s'. Failed with: %s",
                 config_path_str,
                 e,
             )
-            return
+            return False
 
         # Step 4: Parse JSON from file content
         try:
@@ -838,10 +866,11 @@ class ConfigManager:
                         config_path_str,
                         write_result.result_details,
                     )
-            return
+            return False
 
         # Success path: Reload configs to reflect the changes
         logger.debug("Successfully wrote user config delta to '%s', reloading configs", config_path_str)
+        return True
 
     def _set_log_level(self, level: str) -> None:
         """Set the log level for the logger.

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -27,6 +27,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultDetails,
     ResultPayload,
+    StrictModeViolationDetail,
 )
 from griptape_nodes.retained_mode.events.event_converter import converter
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
@@ -414,12 +415,21 @@ class EventManager:
     def _log_result_details(self, result: ResultPayload) -> None:
         """Log the result details at their specified levels.
 
+        Strict-mode violations are skipped here because
+        ``StrictModeReporter.report`` has already logged them at
+        detection time with the scope's ``node=... library=...``
+        prefix, which is more informative than the bare message
+        repeated here. Without the skip every violation would log
+        twice -- once from the reporter and once from this loop.
+
         Args:
             result: The result payload containing details to log
         """
         if isinstance(result.result_details, ResultDetails):
             logger = logging.getLogger("griptape_nodes")
             for detail in result.result_details.result_details:
+                if isinstance(detail, StrictModeViolationDetail):
+                    continue
                 logger.log(detail.level, detail.message)
 
     def _handle_request_core(

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -51,7 +51,7 @@ def current_request_type() -> type[RequestPayload] | None:
     Detectors that need to know "what request is the active handler servicing?"
     (e.g. parameter-mutation-during-aprocess, which exempts the sanctioned
     AddParameterToNodeRequest / RemoveParameterFromNodeRequest paths) read
-    this ContextVar instead of carrying their own depth counter.
+    this ContextVar.
     """
     return _active_request_type.get()
 

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING, Any, cast
 from asyncio_thread_runner import ThreadRunner
 from typing_extensions import TypedDict, TypeVar
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
     BaseEvent,
@@ -299,6 +302,27 @@ class EventManager:
         with self._node_execution_lock:
             return self._node_execution_depth > 0
 
+    def _report_reentrant_bus_in_init(self, request: RequestPayload) -> None:
+        """Detect the reentrant-bus-in-init rule.
+
+        A node class that issues an event-bus request from its __init__
+        deadlocks the worker's schema probe, which calls __init__ on
+        the worker thread during library load. LibraryRegistry sets a
+        ContextVar around create_node so every __init__ body in the
+        hierarchy is covered.
+        """
+        if not LibraryRegistry.is_constructing_node():
+            return
+        rule = RULES["reentrant-bus-in-init"]
+        # Subject attribution lives on the violation's ``subject`` field,
+        # set from the surrounding strict-mode scope (class name under
+        # LOAD_PROBE, instance name under RUNTIME_EXECUTE). The message
+        # only needs the request type.
+        STRICT_MODE.report(
+            rule_id=rule.rule_id,
+            message=rule.render(request_type=type(request).__name__),
+        )
+
     def get_manager_for_request_type(self, request_type: type[RP]) -> Callable | None:
         """Return the currently-registered handler callback for a request type, or None."""
         return self._request_type_to_manager.get(request_type)
@@ -471,6 +495,8 @@ class EventManager:
         if result_context is None:
             result_context = ResultContext()
 
+        self._report_reentrant_bus_in_init(request)
+
         # Notify the manager of the event type
         request_type = type(request)
         callback = self._request_type_to_manager.get(request_type)
@@ -515,6 +541,8 @@ class EventManager:
         if result_context is None:
             result_context = ResultContext()
 
+        self._report_reentrant_bus_in_init(request)
+
         # Notify the manager of the event type
         request_type = type(request)
         callback = self._request_type_to_manager.get(request_type)
@@ -531,6 +559,10 @@ class EventManager:
             # loop, so no primitives are shared and the #4469 deadlock shape does not apply.
             # Hop the callback onto the WS loop here and block the caller's thread on the
             # concurrent.futures.Future so RemoteHandler itself stays a plain async callable.
+            #
+            # Lazy import: worker_routing imports ResultContext from this module at
+            # runtime, so a top-level import here would cycle through event_manager
+            # -> worker_routing -> event_manager during module load.
             from griptape_nodes.app.worker_routing import RemoteHandler
 
             if isinstance(callback, RemoteHandler):

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -6,6 +6,7 @@ import logging
 import threading
 from collections import defaultdict
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import fields
 from typing import TYPE_CHECKING, Any, cast
 
@@ -37,6 +38,23 @@ if TYPE_CHECKING:
 
 RP = TypeVar("RP", bound=RequestPayload, default=RequestPayload)
 AP = TypeVar("AP", bound=AppPayload, default=AppPayload)
+
+
+_active_request_type: ContextVar[type[RequestPayload] | None] = ContextVar(
+    "_event_manager_active_request_type", default=None
+)
+
+
+def current_request_type() -> type[RequestPayload] | None:
+    """Return the request type currently being dispatched on this task, or None.
+
+    Detectors that need to know "what request is the active handler servicing?"
+    (e.g. parameter-mutation-during-aprocess, which exempts the sanctioned
+    AddParameterToNodeRequest / RemoveParameterFromNodeRequest paths) read
+    this ContextVar instead of carrying their own depth counter.
+    """
+    return _active_request_type.get()
+
 
 # Result types that should NOT trigger a flush request.
 #
@@ -460,19 +478,24 @@ class EventManager:
             msg = f"No manager found to handle request of type '{request_type.__name__}'."
             raise TypeError(msg)
 
-        # Actually make the handler callback (support both sync and async):
-        result_payload: ResultPayload = await call_function(callback, request)
+        # Expose the dispatching request type to detectors (see current_request_type).
+        token = _active_request_type.set(request_type)
+        try:
+            # Actually make the handler callback (support both sync and async):
+            result_payload: ResultPayload = await call_function(callback, request)
 
-        # Queue flush request for async context (unless result type should skip flush)
-        with operation_depth_mgr:
-            if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
-                self._flush_tracked_parameter_changes()
+            # Queue flush request for async context (unless result type should skip flush)
+            with operation_depth_mgr:
+                if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
+                    self._flush_tracked_parameter_changes()
 
-        return self._handle_request_core(
-            request,
-            cast("ResultPayload", result_payload),
-            context=result_context,
-        )
+            return self._handle_request_core(
+                request,
+                cast("ResultPayload", result_payload),
+                context=result_context,
+            )
+        finally:
+            _active_request_type.reset(token)
 
     def handle_request(
         self,
@@ -499,53 +522,58 @@ class EventManager:
             msg = f"No manager found to handle request of type '{request_type.__name__}'."
             raise TypeError(msg)
 
-        # Worker-side RemoteHandler callbacks are async but safe to invoke from a
-        # running loop: forward_to_orchestrator dispatches onto the WS loop via
-        # run_coroutine_threadsafe, which runs on a different thread than the caller's
-        # loop, so no primitives are shared and the #4469 deadlock shape does not apply.
-        # Hop the callback onto the WS loop here and block the caller's thread on the
-        # concurrent.futures.Future so RemoteHandler itself stays a plain async callable.
-        from griptape_nodes.app.worker_routing import RemoteHandler
+        # Expose the dispatching request type to detectors (see current_request_type).
+        token = _active_request_type.set(request_type)
+        try:
+            # Worker-side RemoteHandler callbacks are async but safe to invoke from a
+            # running loop: forward_to_orchestrator dispatches onto the WS loop via
+            # run_coroutine_threadsafe, which runs on a different thread than the caller's
+            # loop, so no primitives are shared and the #4469 deadlock shape does not apply.
+            # Hop the callback onto the WS loop here and block the caller's thread on the
+            # concurrent.futures.Future so RemoteHandler itself stays a plain async callable.
+            from griptape_nodes.app.worker_routing import RemoteHandler
 
-        if isinstance(callback, RemoteHandler):
-            if _running_loop() is not None:
-                if self._websocket_event_loop is None:
-                    msg = (
-                        f"Cannot forward '{type(request).__name__}' from a running event loop: "
-                        "the websocket event loop is not configured. This indicates a bootstrap order bug."
-                    )
-                    raise RuntimeError(msg)
-                future = asyncio.run_coroutine_threadsafe(callback(request), self._websocket_event_loop)
-                result_payload: ResultPayload = future.result()
+            if isinstance(callback, RemoteHandler):
+                if _running_loop() is not None:
+                    if self._websocket_event_loop is None:
+                        msg = (
+                            f"Cannot forward '{type(request).__name__}' from a running event loop: "
+                            "the websocket event loop is not configured. This indicates a bootstrap order bug."
+                        )
+                        raise RuntimeError(msg)
+                    future = asyncio.run_coroutine_threadsafe(callback(request), self._websocket_event_loop)
+                    result_payload: ResultPayload = future.result()
+                else:
+                    result_payload: ResultPayload = asyncio.run(callback(request))
+            # Support async callbacks invoked from sync code. If no loop is running
+            # (bootstrap, worker threads) asyncio.run drives the coroutine directly.
+            # If a loop IS running (pre-#4449 workflow files exec'd from inside the
+            # engine loop), dispatch onto a side loop via ThreadRunner. The #4469
+            # deadlock shape is specific to callbacks whose coroutines share
+            # primitives with the caller's loop; RemoteHandler is the only such case
+            # and is handled above via run_coroutine_threadsafe onto the WS loop.
+            # For all other async handlers the side-loop path is safe.
+            elif inspect.iscoroutinefunction(callback):
+                if _running_loop() is not None:
+                    with ThreadRunner() as runner:
+                        result_payload: ResultPayload = runner.run(callback(request))
+                else:
+                    result_payload = asyncio.run(callback(request))
             else:
-                result_payload: ResultPayload = asyncio.run(callback(request))
-        # Support async callbacks invoked from sync code. If no loop is running
-        # (bootstrap, worker threads) asyncio.run drives the coroutine directly.
-        # If a loop IS running (pre-#4449 workflow files exec'd from inside the
-        # engine loop), dispatch onto a side loop via ThreadRunner. The #4469
-        # deadlock shape is specific to callbacks whose coroutines share
-        # primitives with the caller's loop; RemoteHandler is the only such case
-        # and is handled above via run_coroutine_threadsafe onto the WS loop.
-        # For all other async handlers the side-loop path is safe.
-        elif inspect.iscoroutinefunction(callback):
-            if _running_loop() is not None:
-                with ThreadRunner() as runner:
-                    result_payload: ResultPayload = runner.run(callback(request))
-            else:
-                result_payload = asyncio.run(callback(request))
-        else:
-            result_payload = callback(request)
+                result_payload = callback(request)
 
-        # Queue flush request for sync context (unless result type should skip flush)
-        with operation_depth_mgr:
-            if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
-                self._flush_tracked_parameter_changes()
+            # Queue flush request for sync context (unless result type should skip flush)
+            with operation_depth_mgr:
+                if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
+                    self._flush_tracked_parameter_changes()
 
-        return self._handle_request_core(
-            request,
-            cast("ResultPayload", result_payload),
-            context=result_context,
-        )
+            return self._handle_request_core(
+                request,
+                cast("ResultPayload", result_payload),
+                context=result_context,
+            )
+        finally:
+            _active_request_type.reset(token)
 
     def add_listener_to_app_event(
         self, app_event_type: type[AP], callback: Callable[[AP], None] | Callable[[AP], Awaitable[None]]

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3515,11 +3515,16 @@ class LibraryManager:
 
         node_schemas: list[WorkerNodeSchema] = []
         for class_name in library.get_registered_nodes():
-            # The ContextVar set inside create_schema_probe propagates into
+            # The is-constructing flag set inside create_node propagates into
             # the asyncio.to_thread worker via contextvars.copy_context().
             try:
                 probe = await asyncio.wait_for(
-                    asyncio.to_thread(LibraryRegistry.create_schema_probe, library_name, class_name),
+                    asyncio.to_thread(
+                        LibraryRegistry.create_node,
+                        node_type=class_name,
+                        name="__schema_probe__",
+                        specific_library_name=library_name,
+                    ),
                     timeout=self._SCHEMA_PROBE_TIMEOUT_S,
                 )
             except TimeoutError:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -504,6 +504,17 @@ class LibraryManager:
         if library_info.worker_ready is not None:
             library_info.worker_ready.set()
 
+    def is_worker(self) -> bool:
+        """Return True when this process was started as a dedicated worker.
+
+        Set by ``LibrariesInitializeStartRequest`` once the worker bootstrap
+        has identified the process role. Callers outside this manager that
+        need the role (e.g. node-execution strict-mode attribution, request
+        forwarding decisions) should consult this accessor rather than
+        reaching into ``_is_worker``.
+        """
+        return self._is_worker
+
     def get_worker_for_library(self, library_name: str | None) -> tuple[str, str] | None:
         """Return (worker_engine_id, worker_request_topic) for the worker serving library_name, or None.
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3515,19 +3515,13 @@ class LibraryManager:
 
         node_schemas: list[WorkerNodeSchema] = []
         for class_name in library.get_registered_nodes():
-            node_class = library.get_node_class(class_name)
-            # The schema probe constructs a node directly rather than going
-            # through LibraryRegistry.create_node, so wrap the call to expose
-            # the "node is being constructed" flag the reentrant-bus-in-init
-            # detector reads from EventManager.handle_request. The ContextVar
-            # set here propagates into the asyncio.to_thread worker via
-            # contextvars.copy_context().
+            # The ContextVar set inside create_schema_probe propagates into
+            # the asyncio.to_thread worker via contextvars.copy_context().
             try:
-                with LibraryRegistry.construction_scope():
-                    probe = await asyncio.wait_for(
-                        asyncio.to_thread(node_class, name="__schema_probe__"),
-                        timeout=self._SCHEMA_PROBE_TIMEOUT_S,
-                    )
+                probe = await asyncio.wait_for(
+                    asyncio.to_thread(LibraryRegistry.create_schema_probe, library_name, class_name),
+                    timeout=self._SCHEMA_PROBE_TIMEOUT_S,
+                )
             except TimeoutError:
                 logger.warning(
                     "Schema probe for node class '%s' in library '%s' timed out after %.1fs; "

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3499,6 +3499,9 @@ class LibraryManager:
     # await init-time events (e.g. WorkflowManager._workflows_loading_complete),
     # so each probe runs in a worker thread with this ceiling.
     _SCHEMA_PROBE_TIMEOUT_S: float = 10.0
+    # Sentinel name passed to the throwaway node instance built for schema
+    # discovery. The instance is discarded after its parameters are read.
+    _SCHEMA_PROBE_NODE_NAME: str = "__schema_probe__"
 
     async def _serialize_library_node_schemas(self, library_name: str) -> list[WorkerNodeSchema]:
         """Serialize node parameter schemas for a loaded library.
@@ -3522,7 +3525,7 @@ class LibraryManager:
                     asyncio.to_thread(
                         LibraryRegistry.create_node,
                         node_type=class_name,
-                        name="__schema_probe__",
+                        name=self._SCHEMA_PROBE_NODE_NAME,
                         specific_library_name=library_name,
                     ),
                     timeout=self._SCHEMA_PROBE_TIMEOUT_S,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -504,8 +504,9 @@ class LibraryManager:
         if library_info.worker_ready is not None:
             library_info.worker_ready.set()
 
+    @property
     def is_worker(self) -> bool:
-        """Return True when this process was started as a dedicated worker.
+        """True when this process was started as a dedicated worker.
 
         Set by ``LibrariesInitializeStartRequest`` once the worker bootstrap
         has identified the process role. Callers outside this manager that

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3504,11 +3504,18 @@ class LibraryManager:
         node_schemas: list[WorkerNodeSchema] = []
         for class_name in library.get_registered_nodes():
             node_class = library.get_node_class(class_name)
+            # The schema probe constructs a node directly rather than going
+            # through LibraryRegistry.create_node, so wrap the call to expose
+            # the "node is being constructed" flag the reentrant-bus-in-init
+            # detector reads from EventManager.handle_request. The ContextVar
+            # set here propagates into the asyncio.to_thread worker via
+            # contextvars.copy_context().
             try:
-                probe = await asyncio.wait_for(
-                    asyncio.to_thread(node_class, name="__schema_probe__"),
-                    timeout=self._SCHEMA_PROBE_TIMEOUT_S,
-                )
+                with LibraryRegistry.construction_scope():
+                    probe = await asyncio.wait_for(
+                        asyncio.to_thread(node_class, name="__schema_probe__"),
+                        timeout=self._SCHEMA_PROBE_TIMEOUT_S,
+                    )
             except TimeoutError:
                 logger.warning(
                     "Schema probe for node class '%s' in library '%s' timed out after %.1fs; "

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -30,6 +30,11 @@ from rich.text import Text
 from semver import Version
 from xdg_base_dirs import xdg_data_home
 
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+)
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.path_utils import canonicalize_for_identity, canonicalize_for_io, resolve_workspace_path
@@ -3503,6 +3508,31 @@ class LibraryManager:
     # discovery. The instance is discarded after its parameters are read.
     _SCHEMA_PROBE_NODE_NAME: str = "__schema_probe__"
 
+    def _report_parameter_behavior_losses(self, probe: BaseNode) -> None:
+        """Report parameter-behaviors-dropped-in-schema for any probe parameter that has live behaviors.
+
+        ``WorkerParameterSchema`` only carries the scalar-shaped fields of a
+        ``Parameter``. Converters, validators, and traits cannot be
+        serialized across the worker boundary and therefore will not run on
+        the orchestrator stub. If a parameter has any of these attached,
+        report it so the author sees a named warning during library load.
+        """
+        rule = RULES["parameter-behaviors-dropped-in-schema"]
+        for param in probe.parameters:
+            dropped: list[str] = []
+            if param.has_directly_attached_converters:
+                dropped.append("converters")
+            if param.has_directly_attached_validators:
+                dropped.append("validators")
+            if param.has_traits:
+                dropped.append("traits")
+            if not dropped:
+                continue
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(parameter_name=param.name, dropped_attributes=", ".join(dropped)),
+            )
+
     async def _serialize_library_node_schemas(self, library_name: str) -> list[WorkerNodeSchema]:
         """Serialize node parameter schemas for a loaded library.
 
@@ -3520,28 +3550,49 @@ class LibraryManager:
         for class_name in library.get_registered_nodes():
             # The is-constructing flag set inside create_node propagates into
             # the asyncio.to_thread worker via contextvars.copy_context().
-            try:
-                probe = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        LibraryRegistry.create_node,
-                        node_type=class_name,
-                        name=self._SCHEMA_PROBE_NODE_NAME,
-                        specific_library_name=library_name,
-                    ),
-                    timeout=self._SCHEMA_PROBE_TIMEOUT_S,
-                )
-            except TimeoutError:
-                logger.warning(
-                    "Schema probe for node class '%s' in library '%s' timed out after %.1fs; "
-                    "skipping. The node's __init__ likely makes a blocking call that cannot "
-                    "complete during library load.",
-                    class_name,
-                    library_name,
-                    self._SCHEMA_PROBE_TIMEOUT_S,
-                )
-                continue
-            except Exception:
-                logger.debug("Could not probe node class '%s' for schema serialization.", class_name, exc_info=True)
+            probe = None
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject=class_name,
+                library_name=library_name,
+                is_worker=self.is_worker,
+            ) as scope:
+                try:
+                    probe = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            LibraryRegistry.create_node,
+                            node_type=class_name,
+                            name=self._SCHEMA_PROBE_NODE_NAME,
+                            specific_library_name=library_name,
+                        ),
+                        timeout=self._SCHEMA_PROBE_TIMEOUT_S,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "Schema probe for node class '%s' in library '%s' timed out after %.1fs; "
+                        "skipping. The node's __init__ likely makes a blocking call that cannot "
+                        "complete during library load.",
+                        class_name,
+                        library_name,
+                        self._SCHEMA_PROBE_TIMEOUT_S,
+                    )
+                    continue
+                except Exception:
+                    logger.debug("Could not probe node class '%s' for schema serialization.", class_name, exc_info=True)
+                    continue
+                # Run the parameter-behavior-drop detector inside the scope so
+                # warnings attach to the same LOAD_PROBE scope that owns the
+                # probe attempt.
+                self._report_parameter_behavior_losses(probe)
+
+            # Drop the class only when a correctness-class rule fired.
+            # Severity is a logging concern; correctness is the lifecycle
+            # signal ("this class is broken enough to exclude from the
+            # schema"). Gating on severity would also drop the class for
+            # any future ergonomics rule whose worker_escalation flag is
+            # left at the True default.
+            blocking_rule_ids = {rid for rid, r in RULES.items() if r.correctness}
+            if any(v.rule_id in blocking_rule_ids for v in scope.violations):
                 continue
 
             param_schemas: list[WorkerParameterSchema] = []

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1472,7 +1472,12 @@ class LibraryManager:
         node_class = library.get_node_class(request.node_type)
         probe_name = f"__describe_node_type_probe__{request.node_type}"
         try:
-            probe_node = node_class(name=probe_name)
+            # Wrap in ``LibraryRegistry.constructing_node()`` so the
+            # parameter-mutation detector skips this ephemeral probe's
+            # declarative ``add_parameter`` calls (this construction
+            # bypasses ``LibraryRegistry.create_node``).
+            with LibraryRegistry.constructing_node():
+                probe_node = node_class(name=probe_name)
         except Exception as err:
             probe_error = f"{type(err).__name__}: {err}"
             return DescribeNodeTypeResultSuccess(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2765,7 +2765,7 @@ class NodeManager:
         a worker, the request is forwarded over the wire to that worker.
         """
         library_manager = GriptapeNodes.LibraryManager()
-        is_worker = library_manager.is_worker()
+        is_worker = library_manager.is_worker
 
         if is_worker:
             worker_node = self._materialize_transient_node_from_metadata(request)

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import logging
 import pickle
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import uuid4
@@ -16,6 +17,8 @@ from griptape_nodes.common.strict_mode import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
 from griptape_nodes.exe_types.base_iterative_nodes import (
@@ -240,6 +243,19 @@ class CanResetResult(NamedTuple):
 
     can_reset: bool
     editor_tooltip_reason: str | None
+
+
+@dataclass
+class _StrictModeExecutionContext:
+    """Body-supplied result holder for ``NodeManager._strict_mode_execution``.
+
+    The async-context body sets ``result``; the helper's teardown reads it,
+    applies worker-side escalation, and attaches violation details. Kept
+    private to the manager because the escalation policy is execute-node
+    specific and the framework should not know about ExecuteNodeResult*.
+    """
+
+    result: ResultPayload | None = None
 
 
 @dataclass
@@ -2739,7 +2755,7 @@ class NodeManager:
         real "node dropped from the live map" bug with a stub that has no
         connections and no flow parentage.
 
-        On the worker (_is_worker=True) the node is constructed from
+        On the worker (is_worker=True) the node is constructed from
         request.node_metadata on every call, hydrated, executed, and discarded.
         Nothing persists between ExecuteNodeRequests on the worker side -- the
         orchestrator is the single source of truth for node identity and
@@ -2749,7 +2765,7 @@ class NodeManager:
         a worker, the request is forwarded over the wire to that worker.
         """
         library_manager = GriptapeNodes.LibraryManager()
-        is_worker = library_manager._is_worker
+        is_worker = library_manager.is_worker()
 
         if is_worker:
             worker_node = self._materialize_transient_node_from_metadata(request)
@@ -2771,27 +2787,58 @@ class NodeManager:
 
         library_name = node.metadata.get("library")
 
+        # Forwarding to a worker exits the orchestrator's local code path before
+        # the node runs, so strict-mode attribution belongs to the worker's
+        # scope, not ours. Decide forwarding first; only open a local scope when
+        # this process is actually going to execute the node.
+        if not is_worker:
+            worker = library_manager.get_worker_for_library(library_name) if library_name else None
+            wm = GriptapeNodes.WorkerManager()
+            if wm is not None and worker is not None:
+                return await self._execute_node_via_worker(request, wm, worker)
+
+        async with self._strict_mode_execution(request=request, library_name=library_name, is_worker=is_worker) as ctx:
+            ctx.result = await self._hydrate_and_run_node(node, request)
+        return ctx.result
+
+    @asynccontextmanager
+    async def _strict_mode_execution(
+        self,
+        *,
+        request: ExecuteNodeRequest,
+        library_name: str | None,
+        is_worker: bool,
+    ) -> AsyncIterator[_StrictModeExecutionContext]:
+        """Wrap a single node execution in a strict-mode scope.
+
+        The body assigns ``ctx.result`` with whatever the runner produced;
+        on exit this helper applies the worker-side escalation policy
+        (worker + ERROR-severity violations promote ExecuteNodeResultSuccess
+        to ExecuteNodeResultFailure) and attaches the violation details to
+        the final payload. Centralizing the teardown keeps the strict-mode
+        boilerplate out of the request handler.
+        """
         with STRICT_MODE.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject=request.node_name,
             library_name=library_name,
             is_worker=is_worker,
         ) as scope:
-            if not is_worker:
-                worker = library_manager.get_worker_for_library(library_name) if library_name else None
-                wm = GriptapeNodes.WorkerManager()
-                if wm is not None and worker is not None:
-                    return await self._execute_node_via_worker(request, wm, worker)
-            result = await self._hydrate_and_run_node(node, request)
-
-        errors = [v for v in scope.violations if v.severity is StrictModeSeverity.ERROR]
-        if is_worker and errors and isinstance(result, ExecuteNodeResultSuccess):
-            rules = ", ".join(sorted({v.rule_id for v in errors}))
-            result = ExecuteNodeResultFailure(
-                result_details=f"Node '{request.node_name}' violated strict-mode rule(s) [{rules}].",
-            )
-        STRICT_MODE.attach_violations_to_result(result, scope)
-        return result
+            ctx = _StrictModeExecutionContext()
+            yield ctx
+            if ctx.result is None:
+                msg = (
+                    f"_strict_mode_execution body for node '{request.node_name}' did not assign ctx.result; "
+                    "this is a programmer error in the caller."
+                )
+                raise RuntimeError(msg)
+            errors = [v for v in scope.violations if v.severity is StrictModeSeverity.ERROR]
+            if is_worker and errors and isinstance(ctx.result, ExecuteNodeResultSuccess):
+                rules = ", ".join(sorted({v.rule_id for v in errors}))
+                ctx.result = ExecuteNodeResultFailure(
+                    result_details=f"Node '{request.node_name}' violated strict-mode rule(s) [{rules}].",
+                )
+            STRICT_MODE.attach_violations_to_result(ctx.result, scope)
 
     def _materialize_transient_node_from_metadata(
         self, request: ExecuteNodeRequest

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3258,11 +3258,15 @@ class NodeManager:
                 )
 
             # We're going to compare this node instance vs. a canonical one. Rez that one up.
-            # For ErrorProxyNode, we can't create a reference node, so skip comparison
+            # For ErrorProxyNode, we can't create a reference node, so skip comparison.
+            # Wrap in ``LibraryRegistry.constructing_node()`` so the parameter-mutation
+            # detector skips this ephemeral instance's declarative ``add_parameter``
+            # calls (this construction bypasses ``LibraryRegistry.create_node``).
             if isinstance(node, ErrorProxyNode):
                 reference_node = None
             else:
-                reference_node = type(node)(name="REFERENCE NODE")
+                with LibraryRegistry.constructing_node():
+                    reference_node = type(node)(name="REFERENCE NODE")
 
             # Now creation or alteration of all of the elements.
             element_modification_commands = []

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -10,10 +10,9 @@ from uuid import uuid4
 
 from griptape_nodes.common.parameter_hydration import hydrate_parameter_values
 from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
     StrictModeScopeKind,
     StrictModeSeverity,
-    attach_violations_to_result,
-    strict_mode_scope,
 )
 
 if TYPE_CHECKING:
@@ -2772,7 +2771,7 @@ class NodeManager:
 
         library_name = node.metadata.get("library")
 
-        with strict_mode_scope(
+        with STRICT_MODE.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject=request.node_name,
             library_name=library_name,
@@ -2791,7 +2790,7 @@ class NodeManager:
             result = ExecuteNodeResultFailure(
                 result_details=f"Node '{request.node_name}' violated strict-mode rule(s) [{rules}].",
             )
-        attach_violations_to_result(result, scope)
+        STRICT_MODE.attach_violations_to_result(result, scope)
         return result
 
     def _materialize_transient_node_from_metadata(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -9,6 +9,12 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import uuid4
 
 from griptape_nodes.common.parameter_hydration import hydrate_parameter_values
+from griptape_nodes.common.strict_mode import (
+    StrictModeScopeKind,
+    StrictModeSeverity,
+    attach_violations_to_result,
+    strict_mode_scope,
+)
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -2744,31 +2750,48 @@ class NodeManager:
         a worker, the request is forwarded over the wire to that worker.
         """
         library_manager = GriptapeNodes.LibraryManager()
+        is_worker = library_manager._is_worker
 
-        if library_manager._is_worker:
+        if is_worker:
             worker_node = self._materialize_transient_node_from_metadata(request)
             if isinstance(worker_node, ExecuteNodeResultFailure):
                 return worker_node
-            return await self._hydrate_and_run_node(worker_node, request)
-
-        obj_mgr = GriptapeNodes.ObjectManager()
-        node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
-        if node is None:
-            return ExecuteNodeResultFailure(
-                result_details=(
-                    f"Node '{request.node_name}' not found in ObjectManager on orchestrator. "
-                    "Refusing to fabricate a fresh node from metadata; the node was dropped "
-                    "from the live map and must be re-created via CreateNodeRequest."
-                ),
-            )
+            node = worker_node
+        else:
+            obj_mgr = GriptapeNodes.ObjectManager()
+            orchestrator_node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
+            if orchestrator_node is None:
+                return ExecuteNodeResultFailure(
+                    result_details=(
+                        f"Node '{request.node_name}' not found in ObjectManager on orchestrator. "
+                        "Refusing to fabricate a fresh node from metadata; the node was dropped "
+                        "from the live map and must be re-created via CreateNodeRequest."
+                    ),
+                )
+            node = orchestrator_node
 
         library_name = node.metadata.get("library")
-        worker = library_manager.get_worker_for_library(library_name) if library_name else None
-        wm = GriptapeNodes.WorkerManager()
-        if wm is not None and worker is not None:
-            return await self._execute_node_via_worker(request, wm, worker)
 
-        return await self._hydrate_and_run_node(node, request)
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject=request.node_name,
+            library_name=library_name,
+            is_worker=is_worker,
+        ) as scope:
+            if not is_worker:
+                worker = library_manager.get_worker_for_library(library_name) if library_name else None
+                wm = GriptapeNodes.WorkerManager()
+                if wm is not None and worker is not None:
+                    return await self._execute_node_via_worker(request, wm, worker)
+            result = await self._hydrate_and_run_node(node, request)
+
+        errors = [v for v in scope.violations if v.severity is StrictModeSeverity.ERROR]
+        if is_worker and errors and isinstance(result, ExecuteNodeResultSuccess):
+            rules = ", ".join(sorted({v.rule_id for v in errors}))
+            result = ExecuteNodeResultFailure(
+                result_details=f"Node '{request.node_name}' violated strict-mode rule(s) [{rules}].",
+            )
+        return attach_violations_to_result(result, scope)
 
     def _materialize_transient_node_from_metadata(
         self, request: ExecuteNodeRequest

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -2791,7 +2791,8 @@ class NodeManager:
             result = ExecuteNodeResultFailure(
                 result_details=f"Node '{request.node_name}' violated strict-mode rule(s) [{rules}].",
             )
-        return attach_violations_to_result(result, scope)
+        attach_violations_to_result(result, scope)
+        return result
 
     def _materialize_transient_node_from_metadata(
         self, request: ExecuteNodeRequest

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4,7 +4,6 @@ import asyncio
 import copy
 import logging
 import pickle
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import uuid4
@@ -17,8 +16,6 @@ from griptape_nodes.common.strict_mode import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
 from griptape_nodes.exe_types.base_iterative_nodes import (
@@ -243,19 +240,6 @@ class CanResetResult(NamedTuple):
 
     can_reset: bool
     editor_tooltip_reason: str | None
-
-
-@dataclass
-class _StrictModeExecutionContext:
-    """Body-supplied result holder for ``NodeManager._strict_mode_execution``.
-
-    The async-context body sets ``result``; the helper's teardown reads it,
-    applies worker-side escalation, and attaches violation details. Kept
-    private to the manager because the escalation policy is execute-node
-    specific and the framework should not know about ExecuteNodeResult*.
-    """
-
-    result: ResultPayload | None = None
 
 
 @dataclass
@@ -2797,48 +2781,26 @@ class NodeManager:
             if wm is not None and worker is not None:
                 return await self._execute_node_via_worker(request, wm, worker)
 
-        async with self._strict_mode_execution(request=request, library_name=library_name, is_worker=is_worker) as ctx:
-            ctx.result = await self._hydrate_and_run_node(node, request)
-        return ctx.result
-
-    @asynccontextmanager
-    async def _strict_mode_execution(
-        self,
-        *,
-        request: ExecuteNodeRequest,
-        library_name: str | None,
-        is_worker: bool,
-    ) -> AsyncIterator[_StrictModeExecutionContext]:
-        """Wrap a single node execution in a strict-mode scope.
-
-        The body assigns ``ctx.result`` with whatever the runner produced;
-        on exit this helper applies the worker-side escalation policy
-        (worker + ERROR-severity violations promote ExecuteNodeResultSuccess
-        to ExecuteNodeResultFailure) and attaches the violation details to
-        the final payload. Centralizing the teardown keeps the strict-mode
-        boilerplate out of the request handler.
-        """
-        with STRICT_MODE.open_scope(
+        async with STRICT_MODE.scoped_execution(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject=request.node_name,
             library_name=library_name,
             is_worker=is_worker,
-        ) as scope:
-            ctx = _StrictModeExecutionContext()
-            yield ctx
-            if ctx.result is None:
-                msg = (
-                    f"_strict_mode_execution body for node '{request.node_name}' did not assign ctx.result; "
-                    "this is a programmer error in the caller."
-                )
-                raise RuntimeError(msg)
+        ) as (ctx, scope):
+            ctx.result = await self._hydrate_and_run_node(node, request)
+            # Worker-side correctness policy: an ExecuteNodeResultSuccess that
+            # carries an ERROR-severity violation must be promoted to a
+            # failure. Worker output gets shipped back to the orchestrator,
+            # so a "success" that violated correctness would silently corrupt
+            # downstream state. The orchestrator already has the violation
+            # log; the elevated failure forces the editor to surface it.
             errors = [v for v in scope.violations if v.severity is StrictModeSeverity.ERROR]
             if is_worker and errors and isinstance(ctx.result, ExecuteNodeResultSuccess):
                 rules = ", ".join(sorted({v.rule_id for v in errors}))
                 ctx.result = ExecuteNodeResultFailure(
                     result_details=f"Node '{request.node_name}' violated strict-mode rule(s) [{rules}].",
                 )
-            STRICT_MODE.attach_violations_to_result(ctx.result, scope)
+        return ctx.result
 
     def _materialize_transient_node_from_metadata(
         self, request: ExecuteNodeRequest

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import logging
 import pickle
@@ -44,6 +45,8 @@ from griptape_nodes.exe_types.node_types import (
     NodeDependencies,
     NodeResolutionState,
     TransformedParameterValue,
+    aprocess_scope,
+    sanctioned_parameter_mutation,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
@@ -64,7 +67,7 @@ from griptape_nodes.retained_mode.events.connection_events import (
     ListConnectionsForNodeResultSuccess,
     OutgoingConnection,
 )
-from griptape_nodes.retained_mode.events.event_converter import safe_unstructure
+from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
 from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     CancelExecuteNodeResultSuccess,
@@ -1545,14 +1548,15 @@ class NodeManager:
             settable=request.settable,
         )
         try:
-            if request.parent_container_name and request.initial_setup:
-                parameter_parent = node.get_parameter_by_name(request.parent_container_name)
-                if parameter_parent is not None:
-                    parameter_parent.add_child(new_param)
-            elif parent_group is not None:
-                parent_group.add_child(new_param)
-            else:
-                node.add_parameter(new_param)
+            with sanctioned_parameter_mutation():
+                if request.parent_container_name and request.initial_setup:
+                    parameter_parent = node.get_parameter_by_name(request.parent_container_name)
+                    if parameter_parent is not None:
+                        parameter_parent.add_child(new_param)
+                elif parent_group is not None:
+                    parent_group.add_child(new_param)
+                else:
+                    node.add_parameter(new_param)
         except Exception as e:
             details = f"Couldn't add parameter with name {request.parameter_name} to Node '{node_name}'. Error: {e}"
             return AddParameterToNodeResultFailure(result_details=details)
@@ -1743,7 +1747,8 @@ class NodeManager:
 
         # Delete the Element itself.
         if element is not None:
-            node.remove_parameter_element(element)
+            with sanctioned_parameter_mutation():
+                node.remove_parameter_element(element)
         else:
             details = f"Attempted to remove Element '{request.parameter_name}' from Node '{node_name}'. Failed because element didn't exist."
 
@@ -2877,9 +2882,16 @@ class NodeManager:
             self._orch_worker_requests.pop(request.node_name, None)
         result_type_name = execute_raw.get("result_type", "")
         result_data = execute_raw.get("result", {})
+        # Route through cattrs structure (not ``**result_data`` spread)
+        # so the registered exception hook rebuilds ``self.exception``
+        # into a ``ForwardedException`` carrying the worker-side type
+        # name and traceback. A bare spread would leave ``exception``
+        # as the raw {type, message, traceback} dict, breaking the
+        # worker-frame surfacing in
+        # ``NodeExecutor._format_node_failure_message``.
         if result_type_name == ExecuteNodeResultSuccess.__name__:
-            return ExecuteNodeResultSuccess(**result_data)
-        return ExecuteNodeResultFailure(**result_data)
+            return cast("ExecuteNodeResultSuccess", converter.structure(result_data, ExecuteNodeResultSuccess))
+        return cast("ExecuteNodeResultFailure", converter.structure(result_data, ExecuteNodeResultFailure))
 
     async def cancel_worker_execution(self, node_name: str) -> None:
         """Dispatch CancelExecuteNodeRequest to the worker running node_name.
@@ -2929,14 +2941,15 @@ class NodeManager:
     async def _hydrate_and_run_node(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         """Hydrate a node's input parameters and execute it.
 
-        Hydration and node.aprocess() both run inside worker_node_execution_scope
-        so that any nested handle_request calls originated from node code (on a
-        worker) forward to the orchestrator. Hydration calls set_parameter_value,
-        which cascades into ListConnectionsForNodeRequest and similar cross-node
-        lookups; those must forward because the worker only owns its single node
-        copy and cannot resolve parent-flow or peer-node state locally. On the
-        orchestrator the scope is a no-op because forwarding is not configured
-        there.
+        On a worker, hydration and node.aprocess() both run inside
+        worker_node_execution_scope so that any nested handle_request calls
+        originated from node code forward to the orchestrator. Hydration calls
+        set_parameter_value, which cascades into ListConnectionsForNodeRequest
+        and similar cross-node lookups; those must forward because the worker
+        only owns its single node copy and cannot resolve parent-flow or peer-
+        node state locally. On the orchestrator we skip the scope entirely --
+        there is no RemoteHandler to read the flag, so opening it there would
+        only bump a refcount nothing observes.
         """
         # Register this aprocess task under its request_id so
         # CancelExecuteNodeRequest can locate it. Only populated when the caller
@@ -2955,7 +2968,15 @@ class NodeManager:
 
     async def _hydrate_and_run_node_inner(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         node_name = request.node_name
-        with GriptapeNodes.EventManager().worker_node_execution_scope():
+        # The node-execution scope only has meaning on a worker: it is what
+        # RemoteHandler consults to decide whether to forward a request to the
+        # orchestrator. On the orchestrator itself there is no RemoteHandler
+        # installed (register_remote_handlers is worker-only), so opening the
+        # scope there would just bump a refcount that nothing reads. Skip it
+        # to keep the depth counter accurate to its name.
+        is_worker = GriptapeNodes.LibraryManager()._is_worker
+        scope_cm = GriptapeNodes.EventManager().worker_node_execution_scope() if is_worker else contextlib.nullcontext()
+        with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
             for param_name, value in parameter_values.items():
@@ -2974,6 +2995,7 @@ class NodeManager:
                 except Exception as e:
                     return ExecuteNodeResultFailure(
                         result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
+                        exception=e,
                     )
             # Materialize parameter defaults into parameter_values so that user
             # process() code reading self.parameter_values[name] directly (rather
@@ -2988,10 +3010,21 @@ class NodeManager:
                     continue
                 node.parameter_values[param.name] = param.default_value
             try:
-                await node.aprocess()
+                with aprocess_scope():
+                    await node.aprocess()
             except Exception as e:
+                # Pass the live exception through ``exception=`` so the
+                # converter can capture worker-side frames into a
+                # ForwardedException on the orchestrator. Without this
+                # the orchestrator only sees the type and message --
+                # PR06's whole reason for the dict wire-format -- and
+                # NodeExecutor._format_node_failure_message would have
+                # nothing to surface. ``__traceback__`` is populated
+                # because ``e`` was actually raised, so the strict-mode
+                # tripwire stays quiet for raise-in-process.
                 return ExecuteNodeResultFailure(
                     result_details=f"Attempted to execute node '{node_name}'. Failed with error: {e}",
+                    exception=e,
                 )
         return ExecuteNodeResultSuccess(
             parameter_output_values=dict(node.parameter_output_values),

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -1,6 +1,6 @@
 import logging
+import os
 import re
-from os import getenv
 from pathlib import Path
 from typing import Literal, overload
 
@@ -8,6 +8,7 @@ from dotenv import dotenv_values, get_key, load_dotenv, set_key, unset_key
 from dotenv.main import DotEnv
 from xdg_base_dirs import xdg_config_home
 
+from griptape_nodes.retained_mode.events.app_events import SecretChanged
 from griptape_nodes.retained_mode.events.base_events import ResultPayload
 from griptape_nodes.retained_mode.events.secrets_events import (
     DeleteSecretValueRequest,
@@ -34,10 +35,21 @@ ENV_VAR_PATH = xdg_config_home() / "griptape_nodes" / ".env"
 class SecretsManager:
     def __init__(self, config_manager: ConfigManager, event_manager: EventManager | None = None) -> None:
         self.config_manager = config_manager
+        self._event_manager = event_manager
+
+        # Track which keys were sourced from .env files so refresh_from_env_file
+        # can pop deleted keys back out of os.environ. Without this, a deleted
+        # secret remains in os.environ as a stale shadow because load_dotenv
+        # only assigns keys that are present in the file.
+        self._loaded_env_keys: set[str] = set()
 
         # So that users can access secrets directly via `os.environ`
         load_dotenv(self.workspace_env_path, override=False)
         load_dotenv(ENV_VAR_PATH, override=False)
+        if self.workspace_env_path.exists():
+            self._loaded_env_keys.update(dotenv_values(self.workspace_env_path).keys())
+        if ENV_VAR_PATH.exists():
+            self._loaded_env_keys.update(dotenv_values(ENV_VAR_PATH).keys())
 
         # Register all our listeners.
         if event_manager is not None:
@@ -49,6 +61,56 @@ class SecretsManager:
             event_manager.assign_manager_to_request_type(
                 DeleteSecretValueRequest, self.on_handle_delete_secret_value_request
             )
+
+    def _notify_workers_to_refresh_secrets(self) -> None:
+        """Tell every registered worker to re-read the shared .env from disk.
+
+        Only the orchestrator's WorkerManager has any registered workers, so on
+        a worker process this is a cheap no-op via ``schedule_broadcast``.
+        Imported lazily because ``griptape_nodes.app`` is not importable at the
+        module level here -- SecretsManager is loaded during engine boot,
+        before ``app/__init__`` has finished importing.
+        """
+        from griptape_nodes.app.worker_routing import RefreshSecretsRequest, schedule_broadcast
+
+        schedule_broadcast(RefreshSecretsRequest)
+
+    def refresh_from_env_file(self) -> None:
+        """Re-read the .env files into os.environ, applying the documented precedence.
+
+        Same-machine workers share ~/.config/griptape_nodes/.env with the
+        orchestrator, but each process captures the file contents into os.environ
+        at boot. When the orchestrator updates the file, a worker's os.environ
+        keeps the old value -- and get_secret() sees environment variables first,
+        so it returns the stale value.
+
+        Reload global first (lowest priority) and workspace second (higher
+        priority) with override=True at each step. This matches the precedence
+        documented on get_secret: workspace overrides global. Reversing the
+        order would let global clobber workspace for keys present in both.
+
+        Also drops keys that disappeared from either file: load_dotenv only
+        assigns variables that exist in the file, so a deleted key stays in
+        os.environ as a stale shadow until we explicitly pop it.
+        """
+        previously_known_keys = set(self._loaded_env_keys)
+        currently_present: dict[str, set[str]] = {}
+
+        if ENV_VAR_PATH.exists():
+            file_keys = set(dotenv_values(ENV_VAR_PATH).keys())
+            currently_present[str(ENV_VAR_PATH)] = file_keys
+            load_dotenv(ENV_VAR_PATH, override=True)
+        if self.workspace_env_path.exists():
+            file_keys = set(dotenv_values(self.workspace_env_path).keys())
+            currently_present[str(self.workspace_env_path)] = file_keys
+            load_dotenv(self.workspace_env_path, override=True)
+
+        present_anywhere = set().union(*currently_present.values()) if currently_present else set()
+        for key in previously_known_keys - present_anywhere:
+            os.environ.pop(key, None)
+
+        self._loaded_env_keys = present_anywhere
+        logger.debug("Refreshed secrets from .env files")
 
     @property
     def workspace_env_path(self) -> Path:
@@ -98,6 +160,10 @@ class SecretsManager:
 
         self.set_secret(secret_name, secret_value)
 
+        if self._event_manager is not None:
+            self._event_manager.broadcast_app_event(SecretChanged(key=secret_name))
+        self._notify_workers_to_refresh_secrets()
+
         return SetSecretValueResultSuccess(result_details=f"Successfully set secret value for key: {secret_name}")
 
     def on_handle_get_all_secret_values_request(self, request: GetAllSecretValuesRequest) -> ResultPayload:  # noqa: ARG002
@@ -121,8 +187,19 @@ class SecretsManager:
             return DeleteSecretValueResultFailure(result_details=details)
 
         unset_key(ENV_VAR_PATH, secret_name)
+        # set_secret writes through to os.environ via load_dotenv(override=True);
+        # mirror that here so the orchestrator's own get_secret stops returning
+        # the just-deleted value. Workers see the same drop after the refresh
+        # broadcast lands -- refresh_from_env_file now pops keys that vanished
+        # from the file, not just keys still present.
+        os.environ.pop(secret_name, None)
+        self._loaded_env_keys.discard(secret_name)
 
         logger.info("Secret '%s' deleted.", secret_name)
+
+        if self._event_manager is not None:
+            self._event_manager.broadcast_app_event(SecretChanged(key=secret_name))
+        self._notify_workers_to_refresh_secrets()
 
         return DeleteSecretValueResultSuccess(result_details=f"Successfully deleted secret: {secret_name}")
 
@@ -142,7 +219,7 @@ class SecretsManager:
         secret_name = SecretsManager._apply_secret_name_compliance(secret_name)
 
         search_order = [
-            ("environment variables", lambda: getenv(secret_name)),
+            ("environment variables", lambda: os.getenv(secret_name)),
             (str(self.workspace_env_path), lambda: DotEnv(self.workspace_env_path).get(secret_name)),
             (str(ENV_VAR_PATH), lambda: DotEnv(ENV_VAR_PATH).get(secret_name)),
         ]
@@ -164,6 +241,7 @@ class SecretsManager:
             ENV_VAR_PATH.touch()
         set_key(ENV_VAR_PATH, secret_name, secret_value)
         load_dotenv(ENV_VAR_PATH, override=True)
+        self._loaded_env_keys.add(secret_name)
 
     @staticmethod
     def _apply_secret_name_compliance(secret_name: str) -> str:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -290,13 +290,9 @@ class SecretsManager:
         """
         merged: dict[str, str] = {}
         if ENV_VAR_PATH.exists():
-            for key, value in dotenv_values(ENV_VAR_PATH).items():
-                if value is not None:
-                    merged[key] = value
+            merged.update({k: v for k, v in dotenv_values(ENV_VAR_PATH).items() if v is not None})
         if self.workspace_env_path.exists():
-            for key, value in dotenv_values(self.workspace_env_path).items():
-                if value is not None:
-                    merged[key] = value
+            merged.update({k: v for k, v in dotenv_values(self.workspace_env_path).items() if v is not None})
         return merged
 
     def _register_handlers(self, event_manager: EventManager) -> None:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Literal, overload
 
-from dotenv import dotenv_values, get_key, load_dotenv, set_key, unset_key
+from dotenv import dotenv_values, get_key, set_key, unset_key
 from dotenv.main import DotEnv
 from xdg_base_dirs import xdg_config_home
 
@@ -37,33 +37,25 @@ class SecretsManager:
         self.config_manager = config_manager
         self._event_manager = event_manager
 
-        # Track which keys were sourced from .env files so refresh_from_env_file
-        # can pop deleted keys back out of os.environ. Without this, a deleted
-        # secret remains in os.environ as a stale shadow because load_dotenv
-        # only assigns keys that are present in the file.
-        self._loaded_env_keys: set[str] = set()
+        # Track keys this manager itself has installed into os.environ from a
+        # .env file -- distinct from "keys seen in a file." The single
+        # invariant: ``self._managed_env_keys`` exactly equals the set of
+        # keys this manager has written to ``os.environ`` from a file. Only
+        # managed keys are safe to overwrite or pop in
+        # ``refresh_from_env_file`` and the delete-secret handler; OS-set
+        # keys (e.g. container-injected env vars) must be left alone even
+        # if they collide with a .env entry. The invariant is held by
+        # routing every ``os.environ`` mutation through
+        # ``_install_managed`` / ``_uninstall_managed``.
+        self._managed_env_keys: set[str] = set()
 
-        # So that users can access secrets directly via `os.environ`
-        load_dotenv(self.workspace_env_path, override=False)
-        load_dotenv(ENV_VAR_PATH, override=False)
-        if self.workspace_env_path.exists():
-            self._loaded_env_keys.update(dotenv_values(self.workspace_env_path).keys())
-        if ENV_VAR_PATH.exists():
-            self._loaded_env_keys.update(dotenv_values(ENV_VAR_PATH).keys())
+        self._load_env_files_into_environ()
 
-        # Register all our listeners.
         if event_manager is not None:
-            event_manager.assign_manager_to_request_type(GetSecretValueRequest, self.on_handle_get_secret_request)
-            event_manager.assign_manager_to_request_type(SetSecretValueRequest, self.on_handle_set_secret_request)
-            event_manager.assign_manager_to_request_type(
-                GetAllSecretValuesRequest, self.on_handle_get_all_secret_values_request
-            )
-            event_manager.assign_manager_to_request_type(
-                DeleteSecretValueRequest, self.on_handle_delete_secret_value_request
-            )
+            self._register_handlers(event_manager)
 
     def refresh_from_env_file(self) -> None:
-        """Re-read the .env files into os.environ, applying the documented precedence.
+        """Re-read the .env files into os.environ for keys this manager owns.
 
         Same-machine workers share ~/.config/griptape_nodes/.env with the
         orchestrator, but each process captures the file contents into os.environ
@@ -71,33 +63,57 @@ class SecretsManager:
         keeps the old value -- and get_secret() sees environment variables first,
         so it returns the stale value.
 
-        Reload global first (lowest priority) and workspace second (higher
-        priority) with override=True at each step. This matches the precedence
-        documented on get_secret: workspace overrides global. Reversing the
-        order would let global clobber workspace for keys present in both.
+        Override only keys this manager already installed from a file
+        (tracked in ``_managed_env_keys``). A key that is also a real OS
+        env var -- e.g. a container-injected ``OPENAI_API_KEY`` that
+        collides with a .env entry -- was preserved over the file at boot
+        and must keep being preserved here. Otherwise an unrelated secret
+        change could silently swap an operator-set value for the file's.
 
-        Also drops keys that disappeared from either file: load_dotenv only
-        assigns variables that exist in the file, so a deleted key stays in
-        os.environ as a stale shadow until we explicitly pop it.
+        Drops managed keys that disappeared from both files. Only managed
+        keys are eligible to pop -- removing a key from the file does not
+        give the manager license to delete an unrelated OS env var that
+        happens to share the name. If neither file exists at refresh time,
+        no pop happens at all: a transient missing file must not wipe
+        state.
         """
-        previously_known_keys = set(self._loaded_env_keys)
-        currently_present: dict[str, set[str]] = {}
+        if not ENV_VAR_PATH.exists() and not self.workspace_env_path.exists():
+            logger.debug("No .env files to refresh from; leaving os.environ untouched.")
+            return
 
-        if ENV_VAR_PATH.exists():
-            file_keys = set(dotenv_values(ENV_VAR_PATH).keys())
-            currently_present[str(ENV_VAR_PATH)] = file_keys
-            load_dotenv(ENV_VAR_PATH, override=True)
-        if self.workspace_env_path.exists():
-            file_keys = set(dotenv_values(self.workspace_env_path).keys())
-            currently_present[str(self.workspace_env_path)] = file_keys
-            load_dotenv(self.workspace_env_path, override=True)
+        merged = self._read_merged_env_files()
+        previously_managed = set(self._managed_env_keys)
+        installed = 0
+        overridden = 0
+        survived: set[str] = set()
+        for key, value in merged.items():
+            if key in previously_managed:
+                # Manager-owned: overwrite with the file's value.
+                self._install_managed(key, value)
+                survived.add(key)
+                overridden += 1
+            elif key not in os.environ:
+                # New file entry that does not collide with an OS-set var.
+                self._install_managed(key, value)
+                survived.add(key)
+                installed += 1
+            # else: OS-set value the manager does not own. Leave it alone.
 
-        present_anywhere = set().union(*currently_present.values()) if currently_present else set()
-        for key in previously_known_keys - present_anywhere:
-            os.environ.pop(key, None)
+        # Pop managed keys that vanished from both files. Skip non-managed
+        # keys: removing a key from a file does not authorize wiping an OS
+        # env var that happens to share the name.
+        popped = 0
+        for key in previously_managed - survived:
+            self._uninstall_managed(key)
+            popped += 1
 
-        self._loaded_env_keys = present_anywhere
-        logger.debug("Refreshed secrets from .env files")
+        logger.debug(
+            "Refreshed secrets: installed=%d overridden=%d popped=%d managed_total=%d",
+            installed,
+            overridden,
+            popped,
+            len(self._managed_env_keys),
+        )
 
     @property
     def workspace_env_path(self) -> Path:
@@ -176,13 +192,10 @@ class SecretsManager:
             return DeleteSecretValueResultFailure(result_details=details)
 
         unset_key(ENV_VAR_PATH, secret_name)
-        # set_secret writes through to os.environ via load_dotenv(override=True);
-        # mirror that here so the orchestrator's own get_secret stops returning
-        # the just-deleted value. Workers see the same drop after the refresh
-        # broadcast lands -- refresh_from_env_file now pops keys that vanished
-        # from the file, not just keys still present.
-        os.environ.pop(secret_name, None)
-        self._loaded_env_keys.discard(secret_name)
+        # ``_uninstall_managed`` is a no-op when the manager does not own
+        # the key, which preserves a colliding OS-set env var
+        # (operator-injected) that survived boot via override=False.
+        self._uninstall_managed(secret_name)
 
         logger.info("Secret '%s' deleted.", secret_name)
 
@@ -228,8 +241,101 @@ class SecretsManager:
         if not ENV_VAR_PATH.exists():
             ENV_VAR_PATH.touch()
         set_key(ENV_VAR_PATH, secret_name, secret_value)
-        load_dotenv(ENV_VAR_PATH, override=True)
-        self._loaded_env_keys.add(secret_name)
+        # An explicit set_secret call is the user's stated intent: the new
+        # value wins from now on, and the manager claims ownership of the
+        # key. If the key was previously OS-set (operator-injected) the
+        # manager is overwriting it -- warn so the asymmetry with the
+        # refresh / delete paths (which preserve OS-set values) is not
+        # silent.
+        if secret_name not in self._managed_env_keys and secret_name in os.environ:
+            logger.warning(
+                "set_secret('%s') is overriding an OS-set environment variable. "
+                "The OS-set value is replaced for the lifetime of this process; "
+                "restart with the operator-set value cleared to revert.",
+                secret_name,
+            )
+        self._install_managed(secret_name, secret_value)
+
+    def _load_env_files_into_environ(self) -> None:
+        """Read both .env files into ``os.environ`` and seed ``_managed_env_keys``.
+
+        Mirrors the precedence ``get_secret`` documents: OS env beats .env
+        files; among files, workspace beats global. Reads each file once
+        via ``dotenv_values`` and applies values manually so the precedence
+        rule is expressed in exactly one place (this method) and the rest
+        of the manager keeps its bookkeeping invariant via
+        ``_install_managed`` / ``_uninstall_managed``.
+
+        A key already present in ``os.environ`` before this runs is
+        treated as OS-set (operator-injected, container-injected, etc.)
+        and is left untouched, which is what ``override=False`` semantics
+        delivered before.
+        """
+        pre_load_environ = set(os.environ.keys())
+        merged = self._read_merged_env_files()
+        for key, value in merged.items():
+            if key in pre_load_environ:
+                # OS-owned. Leave alone.
+                continue
+            self._install_managed(key, value)
+
+    def _read_merged_env_files(self) -> dict[str, str]:
+        """Return the merged contents of both .env files with workspace winning.
+
+        Workspace overrides global because that is the precedence order
+        ``get_secret`` documents. Empty values (``FOO=`` in the file) are
+        kept as empty strings; missing files are skipped. ``None`` values
+        from ``dotenv_values`` are filtered out so callers can rely on
+        ``dict[str, str]`` shape.
+        """
+        merged: dict[str, str] = {}
+        if ENV_VAR_PATH.exists():
+            for key, value in dotenv_values(ENV_VAR_PATH).items():
+                if value is not None:
+                    merged[key] = value
+        if self.workspace_env_path.exists():
+            for key, value in dotenv_values(self.workspace_env_path).items():
+                if value is not None:
+                    merged[key] = value
+        return merged
+
+    def _register_handlers(self, event_manager: EventManager) -> None:
+        """Wire request types to their handlers."""
+        event_manager.assign_manager_to_request_type(GetSecretValueRequest, self.on_handle_get_secret_request)
+        event_manager.assign_manager_to_request_type(SetSecretValueRequest, self.on_handle_set_secret_request)
+        event_manager.assign_manager_to_request_type(
+            GetAllSecretValuesRequest, self.on_handle_get_all_secret_values_request
+        )
+        event_manager.assign_manager_to_request_type(
+            DeleteSecretValueRequest, self.on_handle_delete_secret_value_request
+        )
+
+    def _install_managed(self, key: str, value: str) -> None:
+        """Write ``key`` to ``os.environ`` and claim it as manager-owned.
+
+        Single source of truth for installs into ``os.environ`` from a
+        .env file. Idempotent: re-installing an already-managed key is a
+        plain overwrite. The bookkeeping invariant is held here -- every
+        caller that touches ``os.environ`` for a file-sourced value goes
+        through this method (or its inverse, ``_uninstall_managed``).
+        """
+        os.environ[key] = value
+        self._managed_env_keys.add(key)
+
+    def _uninstall_managed(self, key: str) -> None:
+        """Pop ``key`` from ``os.environ`` and release manager ownership.
+
+        Counterpart to ``_install_managed``. No-op when ``key`` is not in
+        ``_managed_env_keys`` -- popping a key the manager does not own
+        would delete an OS-set env var (operator-injected, container-
+        injected) the manager has no business touching. The ownership
+        check lives here so callers cannot violate the invariant by
+        forgetting to guard.
+        """
+        if key not in self._managed_env_keys:
+            return
+        os.environ.pop(key, None)
+        self._managed_env_keys.discard(key)
 
     @staticmethod
     def _apply_secret_name_compliance(secret_name: str) -> str:

--- a/src/griptape_nodes/retained_mode/managers/secrets_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/secrets_manager.py
@@ -62,19 +62,6 @@ class SecretsManager:
                 DeleteSecretValueRequest, self.on_handle_delete_secret_value_request
             )
 
-    def _notify_workers_to_refresh_secrets(self) -> None:
-        """Tell every registered worker to re-read the shared .env from disk.
-
-        Only the orchestrator's WorkerManager has any registered workers, so on
-        a worker process this is a cheap no-op via ``schedule_broadcast``.
-        Imported lazily because ``griptape_nodes.app`` is not importable at the
-        module level here -- SecretsManager is loaded during engine boot,
-        before ``app/__init__`` has finished importing.
-        """
-        from griptape_nodes.app.worker_routing import RefreshSecretsRequest, schedule_broadcast
-
-        schedule_broadcast(RefreshSecretsRequest)
-
     def refresh_from_env_file(self) -> None:
         """Re-read the .env files into os.environ, applying the documented precedence.
 
@@ -160,9 +147,11 @@ class SecretsManager:
 
         self.set_secret(secret_name, secret_value)
 
+        # Domain event on success only -- listeners (e.g. WorkerManager) decide
+        # what to do with it. set_secret raises on a write failure, so reaching
+        # this line means the .env file was updated.
         if self._event_manager is not None:
             self._event_manager.broadcast_app_event(SecretChanged(key=secret_name))
-        self._notify_workers_to_refresh_secrets()
 
         return SetSecretValueResultSuccess(result_details=f"Successfully set secret value for key: {secret_name}")
 
@@ -199,7 +188,6 @@ class SecretsManager:
 
         if self._event_manager is not None:
             self._event_manager.broadcast_app_event(SecretChanged(key=secret_name))
-        self._notify_workers_to_refresh_secrets()
 
         return DeleteSecretValueResultSuccess(result_details=f"Successfully deleted secret: {secret_name}")
 

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from griptape_nodes.bootstrap.utils.subprocess_websocket_base import WebSocketMessage
 from griptape_nodes.retained_mode.events import worker_events
+from griptape_nodes.retained_mode.events.app_events import ConfigChanged, SecretChanged
 from griptape_nodes.retained_mode.events.base_events import EventRequest
 from griptape_nodes.retained_mode.managers.settings import (
     WORKER_HEARTBEAT_INTERVAL_KEY,
@@ -137,6 +138,13 @@ class WorkerManager:
             worker_events.UnregisterWorkerRequest, self.handle_unregister_worker_request
         )
         event_manager.assign_manager_to_request_type(worker_events.StartWorkerRequest, self.handle_start_worker_request)
+
+        # Subscribe to domain events from ConfigManager / SecretsManager so
+        # those managers don't have to know workers exist. The listeners are
+        # the single place that translates a "something changed" signal into
+        # a worker fan-out.
+        event_manager.add_listener_to_app_event(ConfigChanged, self._on_config_changed)
+        event_manager.add_listener_to_app_event(SecretChanged, self._on_secret_changed)
 
     @property
     def _tx(self) -> _WorkerTransport:
@@ -504,6 +512,46 @@ class WorkerManager:
         forwarded = event.model_copy(update={"response_topic": worker_response_topic})
         logger.debug("Forwarding %s to worker %s", type(event.request).__name__, worker_engine_id)
         await self._tx.send_message("EventRequest", forwarded.json(), worker_request_topic)
+
+    async def _on_config_changed(self, _event: ConfigChanged) -> None:
+        """Fan out a ReloadConfigRequest after the orchestrator's config mutation succeeded.
+
+        ConfigManager only emits ``ConfigChanged`` after the disk write
+        succeeded, so receiving the event is sufficient evidence that
+        workers should re-read the file.
+
+        Listener is async and awaits the broadcast directly so the work
+        is owned by the listener's own task. ``broadcast_app_event``
+        invokes listeners on a transient ``ThreadRunner`` side loop when
+        called from sync code (the production path); a fire-and-forget
+        ``asyncio.create_task`` from inside the listener would land on
+        that side loop and be killed when ``ThreadRunner.__exit__``
+        stops the loop, so the broadcast must be awaited inline.
+
+        Lazy import breaks a cycle between this module and
+        ``griptape_nodes.app.worker_routing``, which itself imports
+        ``EventManager`` from the retained_mode managers package.
+        """
+        from griptape_nodes.app.worker_routing import ReloadConfigRequest
+
+        if self._transport is None or not self._workers:
+            return
+        await self.broadcast_to_workers(EventRequest(request=ReloadConfigRequest()))
+
+    async def _on_secret_changed(self, _event: SecretChanged) -> None:
+        """Fan out a RefreshSecretsRequest after the orchestrator's secret mutation succeeded.
+
+        SecretsManager raises if the .env write fails, so reaching the
+        event broadcast means disk is up to date. Workers re-read the
+        shared file via ``refresh_from_env_file``. Awaited inline for
+        the same side-loop reason documented on ``_on_config_changed``;
+        lazy import for the same circular-dependency reason.
+        """
+        from griptape_nodes.app.worker_routing import RefreshSecretsRequest
+
+        if self._transport is None or not self._workers:
+            return
+        await self.broadcast_to_workers(EventRequest(request=RefreshSecretsRequest()))
 
     def schedule_broadcast(self, request_type: type[RequestPayload]) -> None:
         """Tell every registered worker to handle ``request_type`` locally.

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from griptape_nodes.api_client.request_client import RequestClient
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload
     from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -105,6 +106,10 @@ class WorkerManager:
 
         # Callbacks invoked when a worker is evicted: (worker_engine_id, library_name | None)
         self._worker_evicted_callbacks: list[Callable[[str, str | None], None]] = []
+
+        # Fire-and-forget broadcast tasks scheduled from sync callers; held here so
+        # the event loop's weak-ref to tasks does not GC them before completion.
+        self._inflight_broadcast_tasks: set[asyncio.Task] = set()
 
         # Set when an active session becomes available; gates worker spawning.
         self._session_ready_event: asyncio.Event = asyncio.Event()
@@ -339,7 +344,16 @@ class WorkerManager:
         returned dict into the appropriate result type.
         """
         request_id = event_request.request_id or str(uuid.uuid4())
-        future = await self._tx.request_client.track_request(request_id, tag=worker_engine_id)
+        # Opt into structured-failure delivery so a worker-side
+        # ResultPayloadFailure arrives as the raw payload dict rather
+        # than being collapsed to a bare ``Exception(error_msg)`` by
+        # ``_try_match``. ``_execute_node_via_worker`` then runs the
+        # dict through ``converter.structure(...)``, which rebuilds
+        # ``self.exception`` into a ForwardedException carrying the
+        # worker-side type name and traceback string.
+        future = await self._tx.request_client.track_request(
+            request_id, tag=worker_engine_id, resolve_failures_as_payload=True
+        )
 
         await self.forward_event_to_worker(
             event_request.model_copy(update={"request_id": request_id}),
@@ -490,6 +504,44 @@ class WorkerManager:
         forwarded = event.model_copy(update={"response_topic": worker_response_topic})
         logger.debug("Forwarding %s to worker %s", type(event.request).__name__, worker_engine_id)
         await self._tx.send_message("EventRequest", forwarded.json(), worker_request_topic)
+
+    def schedule_broadcast(self, request_type: type[RequestPayload]) -> None:
+        """Tell every registered worker to handle ``request_type`` locally.
+
+        Wraps ``request_type`` in an EventRequest and fans it out to every
+        registered worker as a fire-and-forget background task on the
+        caller's running event loop. On a worker process (no registered
+        workers, or no transport configured) this is a cheap no-op.
+
+        Must be called from inside a running event loop. Every production
+        caller reaches this through EventManager.handle_request /
+        ahandle_request, which itself runs under asyncio.run(astart_app)
+        on the engine side or inside an ``await`` in a CLI subcommand.
+        """
+        if self._transport is None or not self._workers:
+            return
+        event = EventRequest(request=request_type())
+        task = asyncio.create_task(self.broadcast_to_workers(event))
+        self._inflight_broadcast_tasks.add(task)
+        task.add_done_callback(self._inflight_broadcast_tasks.discard)
+
+    async def broadcast_to_workers(self, event: EventRequest) -> None:
+        """Fire-and-forget fan out of an EventRequest to every registered worker.
+
+        Used for orchestrator-originated notifications that every worker must
+        act on locally (e.g. reload config, refresh secrets). The request is
+        sent to each worker's dedicated request topic; no response is awaited.
+
+        Safe to call with zero registered workers -- it is a no-op.
+        """
+        if not self._workers:
+            return
+        for wid, registration in list(self._workers.items()):
+            await self.forward_event_to_worker(
+                event,
+                worker_engine_id=wid,
+                worker_request_topic=registration.request_topic,
+            )
 
     async def relay_worker_result(self, payload: dict) -> None:
         """Relay an unmatched worker result to the GUI session response topic.

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -840,3 +840,131 @@ class TestScheduleBroadcast:
         await asyncio.sleep(0)
 
         worker_manager._tx.send_message.assert_not_called()  # type: ignore[union-attr]
+
+
+class TestWorkerManagerDomainEventListeners:
+    """WorkerManager owns the bridge from domain events to worker fan-out.
+
+    ConfigManager and SecretsManager emit ConfigChanged / SecretChanged on
+    successful state mutations; WorkerManager translates those into
+    ReloadConfigRequest / RefreshSecretsRequest broadcasts. The managers
+    themselves know nothing about workers.
+    """
+
+    @pytest.fixture
+    def worker_manager_with_real_events(self) -> WorkerManager:
+        from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+        gtn = MagicMock()
+        gtn.get_session_id.return_value = _SESSION
+        gtn.get_engine_id.return_value = _ENGINE
+        gtn._config_manager.get_config_value.side_effect = lambda _key, default, cast_type=float: cast_type(default)
+        wm = WorkerManager(griptape_nodes=gtn, event_manager=EventManager())
+        wm.attach_transport(
+            ws_outgoing_queue=asyncio.Queue(),
+            send_message=AsyncMock(),
+            subscribe_to_topic=AsyncMock(),
+            unsubscribe_from_topic=AsyncMock(),
+            request_client=_FakeRequestClient(),  # type: ignore[arg-type]
+        )
+        return wm
+
+    @pytest.mark.asyncio
+    async def test_config_changed_event_triggers_reload_config_broadcast(
+        self, worker_manager_with_real_events: WorkerManager
+    ) -> None:
+        from griptape_nodes.retained_mode.events.app_events import ConfigChanged
+
+        wm = worker_manager_with_real_events
+        wm._workers[_ENGINE] = WorkerRegistration(request_topic=_WORKER_REQUEST_TOPIC, worker_key=None)
+
+        wm._event_manager.broadcast_app_event(ConfigChanged(key="x.y", old_value=None, new_value="v"))
+        await asyncio.sleep(0)
+
+        wm._tx.send_message.assert_called_once()  # type: ignore[union-attr]
+        sent_payload = json.loads(wm._tx.send_message.call_args[0][1])  # type: ignore[union-attr]
+        assert sent_payload["request_type"] == "ReloadConfigRequest"
+
+    @pytest.mark.asyncio
+    async def test_secret_changed_event_triggers_refresh_secrets_broadcast(
+        self, worker_manager_with_real_events: WorkerManager
+    ) -> None:
+        from griptape_nodes.retained_mode.events.app_events import SecretChanged
+
+        wm = worker_manager_with_real_events
+        wm._workers[_ENGINE] = WorkerRegistration(request_topic=_WORKER_REQUEST_TOPIC, worker_key=None)
+
+        wm._event_manager.broadcast_app_event(SecretChanged(key="MY_KEY"))
+        await asyncio.sleep(0)
+
+        wm._tx.send_message.assert_called_once()  # type: ignore[union-attr]
+        sent_payload = json.loads(wm._tx.send_message.call_args[0][1])  # type: ignore[union-attr]
+        assert sent_payload["request_type"] == "RefreshSecretsRequest"
+
+    @pytest.mark.asyncio
+    async def test_no_broadcast_when_there_are_no_registered_workers(
+        self, worker_manager_with_real_events: WorkerManager
+    ) -> None:
+        """On a worker process there are zero registered workers; the listener fires but is a no-op."""
+        from griptape_nodes.retained_mode.events.app_events import ConfigChanged
+
+        wm = worker_manager_with_real_events
+
+        wm._event_manager.broadcast_app_event(ConfigChanged(key="x", old_value=None, new_value="v"))
+        await asyncio.sleep(0)
+
+        wm._tx.send_message.assert_not_called()  # type: ignore[union-attr]
+
+    def test_broadcast_completes_when_listener_is_dispatched_via_threadrunner(
+        self, worker_manager_with_real_events: WorkerManager
+    ) -> None:
+        """Production path: sync request handler -> sync broadcast_app_event -> ThreadRunner side loop.
+
+        ``EventManager.broadcast_app_event`` detects a running loop and
+        runs the listener fan-out on a transient ``ThreadRunner`` side
+        loop. If the listener schedules its fan-out via
+        ``asyncio.create_task`` and returns, the side loop is torn down
+        before the orphan task ever runs and no broadcast actually goes
+        out. The listener now awaits the broadcast inline; this test
+        confirms the broadcast lands by the time
+        ``broadcast_app_event`` returns control to the caller, even
+        when the underlying transport ``await`` does not resolve
+        synchronously (the production shape -- a real WebSocket send
+        yields back to the loop).
+        """
+        from griptape_nodes.retained_mode.events.app_events import ConfigChanged
+
+        wm = worker_manager_with_real_events
+        wm._workers[_ENGINE] = WorkerRegistration(request_topic=_WORKER_REQUEST_TOPIC, worker_key=None)
+
+        # Force send_message to yield repeatedly before recording the call.
+        # An orphan ``asyncio.create_task`` scheduled inside the listener
+        # would lose its race with ``ThreadRunner.__exit__`` -> ``loop.stop()``
+        # under enough yield points, so the broadcast would silently drop.
+        # ``AsyncMock`` returns synchronously which would mask the bug;
+        # the production transport awaits real I/O and yields many times.
+        send_calls: list[tuple] = []
+
+        async def slow_send(*args: object) -> None:
+            for _ in range(50):
+                await asyncio.sleep(0)
+            send_calls.append(args)
+
+        wm._tx.send_message = slow_send  # type: ignore[union-attr,assignment]
+
+        async def driver() -> None:
+            # Inside this coroutine there is a running loop on the main
+            # thread. ``broadcast_app_event`` is sync; calling it from
+            # here triggers the ThreadRunner side-loop branch -- the same
+            # branch that runs in production when a sync request handler
+            # (e.g. ``on_handle_set_config_value_request``) calls
+            # ``set_config_value`` which calls ``broadcast_app_event``.
+            wm._event_manager.broadcast_app_event(ConfigChanged(key="x.y", old_value=None, new_value="v"))
+
+        asyncio.run(driver())
+
+        # By the time broadcast_app_event returns, the listener (and the
+        # awaited broadcast inside it) must have completed.
+        assert len(send_calls) == 1
+        sent_payload = json.loads(send_calls[0][1])
+        assert sent_payload["request_type"] == "ReloadConfigRequest"

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -40,9 +40,13 @@ class _FakeRequestClient:
     def __init__(self) -> None:
         self._pending_requests: dict[str, _PendingRequest] = {}
 
-    async def track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
+    async def track_request(
+        self, request_id: str, tag: str = "", *, resolve_failures_as_payload: bool = False
+    ) -> asyncio.Future:
         future: asyncio.Future = asyncio.Future()
-        self._pending_requests[request_id] = _PendingRequest(future, tag)
+        self._pending_requests[request_id] = _PendingRequest(
+            future, tag, resolve_failures_as_payload=resolve_failures_as_payload
+        )
         return future
 
     async def cancel_requests_by_tag(self, tag: str) -> None:
@@ -763,3 +767,76 @@ class TestOrchestratorHeartbeatLoop:
         await asyncio.gather(task, return_exceptions=True)
 
         assert _ENGINE in worker_manager._workers
+
+
+class TestBroadcastToWorkers:
+    @pytest.mark.asyncio
+    async def test_no_workers_is_noop(self, worker_manager: WorkerManager) -> None:
+        from griptape_nodes.app.worker_routing import ReloadConfigRequest
+
+        event = EventRequest(request=ReloadConfigRequest())
+
+        await worker_manager.broadcast_to_workers(event)
+
+        worker_manager._tx.send_message.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_sends_one_message_per_registered_worker(self, worker_manager: WorkerManager) -> None:
+        from griptape_nodes.app.worker_routing import ReloadConfigRequest
+
+        expected_broadcast_count = 2
+        worker_a, worker_b = "eng-a", "eng-b"
+        worker_manager._workers[worker_a] = WorkerRegistration(
+            request_topic=f"sessions/{_SESSION}/workers/{worker_a}/request", worker_key=None
+        )
+        worker_manager._workers[worker_b] = WorkerRegistration(
+            request_topic=f"sessions/{_SESSION}/workers/{worker_b}/request", worker_key=None
+        )
+        event = EventRequest(request=ReloadConfigRequest())
+
+        await worker_manager.broadcast_to_workers(event)
+
+        assert worker_manager._tx.send_message.call_count == expected_broadcast_count  # type: ignore[union-attr]
+        topics = {call.args[2] for call in worker_manager._tx.send_message.call_args_list}  # type: ignore[union-attr]
+        assert topics == {
+            f"sessions/{_SESSION}/workers/{worker_a}/request",
+            f"sessions/{_SESSION}/workers/{worker_b}/request",
+        }
+
+
+class TestScheduleBroadcast:
+    @pytest.mark.asyncio
+    async def test_fans_out_request_to_each_registered_worker(self, worker_manager: WorkerManager) -> None:
+        from griptape_nodes.app.worker_routing import ReloadConfigRequest
+
+        worker_manager._workers[_ENGINE] = WorkerRegistration(request_topic=_WORKER_REQUEST_TOPIC, worker_key=None)
+
+        worker_manager.schedule_broadcast(ReloadConfigRequest)
+        # create_task on the running loop -- let it run.
+        await asyncio.sleep(0)
+
+        worker_manager._tx.send_message.assert_called_once()  # type: ignore[union-attr]
+        sent_payload = json.loads(worker_manager._tx.send_message.call_args[0][1])  # type: ignore[union-attr]
+        assert sent_payload["request_type"] == "ReloadConfigRequest"
+
+    @pytest.mark.asyncio
+    async def test_refresh_secrets_payload_round_trips(self, worker_manager: WorkerManager) -> None:
+        from griptape_nodes.app.worker_routing import RefreshSecretsRequest
+
+        worker_manager._workers[_ENGINE] = WorkerRegistration(request_topic=_WORKER_REQUEST_TOPIC, worker_key=None)
+
+        worker_manager.schedule_broadcast(RefreshSecretsRequest)
+        await asyncio.sleep(0)
+
+        worker_manager._tx.send_message.assert_called_once()  # type: ignore[union-attr]
+        sent_payload = json.loads(worker_manager._tx.send_message.call_args[0][1])  # type: ignore[union-attr]
+        assert sent_payload["request_type"] == "RefreshSecretsRequest"
+
+    @pytest.mark.asyncio
+    async def test_no_workers_is_noop(self, worker_manager: WorkerManager) -> None:
+        from griptape_nodes.app.worker_routing import ReloadConfigRequest
+
+        worker_manager.schedule_broadcast(ReloadConfigRequest)
+        await asyncio.sleep(0)
+
+        worker_manager._tx.send_message.assert_not_called()  # type: ignore[union-attr]

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -1,0 +1,296 @@
+"""Tests for the worker-reach-into-orchestrator strict-mode tripwire.
+
+RemoteHandler is the single chokepoint where a worker-side ``aprocess``
+reaches into orchestrator-owned state. When it forwards a request back
+to the orchestrator while a strict-mode scope is active, it records a
+``worker-reach-into-orchestrator`` violation. Outside of node execution
+(bootstrap, LOAD_PROBE) the tripwire does not fire because the
+RemoteHandler delegates to the original handler before reaching the
+violation path; outside any strict-mode scope, ``STRICT_MODE.report``
+is a no-op and the handler still forwards without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    FORWARDED_REQUEST_TYPES,
+    RemoteHandler,
+    register_remote_handlers,
+)
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+    StrictModeSeverity,
+)
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultSuccess,
+    RequestPayload,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+
+@dataclass(kw_only=True)
+class _ProbeRequest(RequestPayload):
+    """Minimal request used to exercise RemoteHandler's tripwire."""
+
+    marker: str
+
+
+@dataclass(kw_only=True)
+class _ProbeResult(ResultPayloadSuccess):
+    """Success payload paired with _ProbeRequest."""
+
+    seen_by: str
+
+
+def _make_handler_with_fake_forward(event_manager: EventManager) -> RemoteHandler:
+    async def original(_request: _ProbeRequest) -> _ProbeResult:
+        return _ProbeResult(seen_by="local", result_details="local")
+
+    async def fake_forward(
+        request: RequestPayload,
+        result_context: ResultContext,  # noqa: ARG001
+    ) -> EventResultSuccess:
+        return EventResultSuccess(
+            request=request,
+            result=_ProbeResult(seen_by="orchestrator", result_details="forwarded"),
+        )
+
+    event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+    return RemoteHandler(original=original, event_manager=event_manager)
+
+
+class TestWorkerReachIntoOrchestrator:
+    """The tripwire records one violation per forwarded request while in scope."""
+
+    @pytest.mark.asyncio
+    async def test_in_scope_in_node_execution_records_violation(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await handler(_ProbeRequest(marker="m1"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert violation.severity is StrictModeSeverity.WARNING
+        assert violation.subject == "node-1"
+        assert violation.library_name == "libA"
+        assert "_ProbeRequest" in violation.message
+
+    @pytest.mark.asyncio
+    async def test_in_scope_out_of_node_execution_does_not_record(self) -> None:
+        event_manager = EventManager()
+        local_calls: list[_ProbeRequest] = []
+
+        async def original(request: _ProbeRequest) -> _ProbeResult:
+            local_calls.append(request)
+            return _ProbeResult(seen_by="local", result_details="local")
+
+        handler = RemoteHandler(original=original, event_manager=event_manager)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyClass",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            result = await handler(_ProbeRequest(marker="m2"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "local"
+        assert len(local_calls) == 1
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_no_scope_forwards_without_crashing(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with event_manager.worker_node_execution_scope():
+            result = await handler(_ProbeRequest(marker="m3"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_remediation_message_does_not_claim_from_aprocess(self) -> None:
+        """Regression guard: remediation must not claim "from aprocess".
+
+        The rule's gate is ``worker_node_execution_scope``, which covers
+        both hydration and aprocess. The remediation must not claim "from
+        aprocess" because the rule fires for both. See PR8 for the same
+        factual-claim bug Collin flagged on parameter-mutation.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-r1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="m4"))
+
+        assert len(scope.violations) == 1
+        message = scope.violations[0].message
+        assert "from aprocess" not in message
+        assert "during node execution" in message
+
+    @pytest.mark.asyncio
+    async def test_fires_during_hydration_phase_not_just_aprocess(self) -> None:
+        """The rule's gate is wider than aprocess.
+
+        ``worker_node_execution_scope`` is opened by
+        ``_hydrate_and_run_node_inner`` around BOTH hydration and
+        aprocess. Forwarded requests issued during hydration (e.g.
+        dynamic-pipeline nodes calling ListConnectionsForNodeRequest
+        from before/after_value_set) must trip the rule. This pins
+        down that the gate is intentionally wider than
+        ``aprocess_scope()``.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        # No aprocess_scope() entered. Only the worker_node_execution_scope
+        # (refcount) is active. The rule must still fire.
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-h1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="hydrate"))
+
+        assert len(scope.violations) == 1
+        assert scope.violations[0].rule_id == "worker-reach-into-orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_one_violation_per_call(self) -> None:
+        """Two forwarded requests from the same scope produce two violations."""
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-c1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="first"))
+            await handler(_ProbeRequest(marker="second"))
+
+        expected_violations = 2
+        assert len(scope.violations) == expected_violations
+
+    @pytest.mark.asyncio
+    async def test_forwarded_type_member_through_register_remote_handlers(self) -> None:
+        """End-to-end: a real FORWARDED type goes through the swap and shim.
+
+        ``register_remote_handlers`` swaps a real FORWARDED type's handler
+        for a ``RemoteHandler`` shim, and dispatching that real type
+        directly through the shim records the violation. Locks in the
+        ``FORWARDED_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
+        a future change drops a type from ``FORWARDED_REQUEST_TYPES``,
+        this test stays green only because
+        ``ListConnectionsForNodeRequest`` is still a member.
+        """
+        event_manager = EventManager()
+
+        # Capture what the RemoteHandler shim forwards. Skip going through
+        # event_manager.handle_request because that path requires a configured
+        # WebSocket loop; the rule itself fires inside RemoteHandler.__call__,
+        # which is what we want to exercise.
+        forwarded_calls: list[RequestPayload] = []
+
+        async def fake_forward(
+            request: RequestPayload,
+            result_context: ResultContext,  # noqa: ARG001
+        ) -> EventResultSuccess:
+            forwarded_calls.append(request)
+            return EventResultSuccess(
+                request=request,
+                result=ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="forwarded",
+                ),
+            )
+
+        event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+
+        # register_remote_handlers requires every FORWARDED type to have an
+        # original handler registered first. Stub them all with a trivial
+        # local handler; the swap installs RemoteHandler in their place.
+        for request_type in FORWARDED_REQUEST_TYPES:
+
+            async def stub(_request: RequestPayload) -> ResultPayloadSuccess:
+                return ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="local",
+                )
+
+            event_manager.assign_manager_to_request_type(request_type, stub)
+
+        register_remote_handlers(event_manager)
+
+        # Pull the swapped handler out of the dispatch table and invoke it.
+        # The shim is what production code reaches when the EventManager
+        # dispatches ListConnectionsForNodeRequest on a worker.
+        installed = event_manager.get_manager_for_request_type(ListConnectionsForNodeRequest)
+        assert isinstance(installed, RemoteHandler)
+
+        request = ListConnectionsForNodeRequest(node_name="some-node")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="some-node",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await installed(request)
+
+        assert isinstance(result, ListConnectionsForNodeResultSuccess)
+        assert len(forwarded_calls) == 1
+        assert isinstance(forwarded_calls[0], ListConnectionsForNodeRequest)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert "ListConnectionsForNodeRequest" in violation.message

--- a/tests/unit/common/test_node_executor_helpers.py
+++ b/tests/unit/common/test_node_executor_helpers.py
@@ -265,6 +265,52 @@ class TestExecuteSuccessReturnsNone:
         assert result is None
 
 
+class TestFormatNodeFailureMessage:
+    """Worker-side traceback frames have to land in the RuntimeError message.
+
+    Chaining via ``raise RuntimeError(msg) from exc`` is not enough on
+    its own: a ForwardedException is constructed (not raised) on the
+    receiving side, so its ``__traceback__`` is None and Python's
+    chained-exception display prints only the cause's
+    ``Type: message`` line. The helper interpolates
+    ``original_traceback`` so the worker frames are actually visible.
+    """
+
+    def test_includes_original_type_prefix(self) -> None:
+        from griptape_nodes.retained_mode.events.base_events import ForwardedException
+
+        exc = ForwardedException("rebuilt", original_type="builtins.RuntimeError")
+
+        msg = NodeExecutor._format_node_failure_message("MyNode", MagicMock(result_details="oops"), exc)
+
+        assert "[builtins.RuntimeError]" in msg
+        assert "MyNode" in msg
+
+    def test_appends_worker_traceback_when_present(self) -> None:
+        from griptape_nodes.retained_mode.events.base_events import ForwardedException
+
+        exc = ForwardedException(
+            "rebuilt",
+            original_type="builtins.ValueError",
+            original_traceback='Traceback...\n  File "a.py", line 1, in <module>\nValueError: rebuilt\n',
+        )
+
+        msg = NodeExecutor._format_node_failure_message("MyNode", MagicMock(result_details="oops"), exc)
+
+        assert "Worker traceback:" in msg
+        assert 'File "a.py"' in msg
+
+    def test_omits_worker_block_for_local_exceptions(self) -> None:
+        # Plain Exception (not a ForwardedException) means we're on the
+        # local path. No type prefix, no worker-traceback block.
+        msg = NodeExecutor._format_node_failure_message(
+            "MyNode", MagicMock(result_details="oops"), RuntimeError("local")
+        )
+
+        assert "Worker traceback:" not in msg
+        assert "[" not in msg.split("execution failed:")[1].split(":")[0]
+
+
 class TestControlFlowResolvedEventCattrsRoundTrip:
     """ControlFlowResolvedEvent.unique_parameter_uuid_to_values round-trips through cattrs.
 

--- a/tests/unit/common/test_strict_mode.py
+++ b/tests/unit/common/test_strict_mode.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import threading
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,12 +13,28 @@ if TYPE_CHECKING:
 from griptape_nodes.common.strict_mode import (
     StrictModeScopeKind,
     StrictModeSeverity,
-    any_scope_active_threadsafe,
+    attach_violations_to_result,
     current_scope,
     report_violation,
     strict_mode_scope,
 )
-from griptape_nodes.common.strict_mode_checks import RULES, _rule
+from griptape_nodes.common.strict_mode_checks import RULES, StrictModeRule
+from griptape_nodes.retained_mode.events.base_events import (
+    ResultDetails,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    StrictModeViolationDetail,
+)
+
+
+@dataclass(kw_only=True)
+class _FakeSuccessResult(ResultPayloadSuccess):
+    pass
+
+
+@dataclass(kw_only=True)
+class _FakeFailureResult(ResultPayloadFailure):
+    pass
 
 
 @pytest.fixture
@@ -29,20 +45,20 @@ def fake_rules() -> Iterator[None]:
     later in the stack. Tests at this layer need a registered rule_id to
     exercise severity resolution, so they install one and tear it down.
     """
-    ergonomics = _rule(
-        "fake-ergonomics",
-        severity=StrictModeSeverity.WARNING,
+    ergonomics = StrictModeRule(
+        rule_id="fake-ergonomics",
+        default_severity=StrictModeSeverity.WARNING,
         correctness=False,
         description="synthetic ergonomics rule for tests",
-        remediation="ergonomics: {detail}",
+        remediation_template="ergonomics: {detail}",
         worker_escalation=False,
     )
-    correctness = _rule(
-        "fake-correctness",
-        severity=StrictModeSeverity.ERROR,
+    correctness = StrictModeRule(
+        rule_id="fake-correctness",
+        default_severity=StrictModeSeverity.ERROR,
         correctness=True,
         description="synthetic correctness rule for tests",
-        remediation="correctness: {detail}",
+        remediation_template="correctness: {detail}",
     )
     RULES[ergonomics.rule_id] = ergonomics
     RULES[correctness.rule_id] = correctness
@@ -56,7 +72,6 @@ def fake_rules() -> Iterator[None]:
 class TestStrictModeScope:
     def test_current_scope_is_none_outside_any_scope(self) -> None:
         assert current_scope() is None
-        assert any_scope_active_threadsafe() is False
 
     def test_scope_sets_and_resets_contextvar(self) -> None:
         with strict_mode_scope(
@@ -91,24 +106,25 @@ class TestStrictModeScope:
             assert current_scope() is outer
         assert current_scope() is None
 
-    def test_refcount_tracks_entered_scopes(self) -> None:
-        assert any_scope_active_threadsafe() is False
+    def test_violations_attach_to_correct_scope_when_nested(self, fake_rules: None) -> None:  # noqa: ARG002
         with strict_mode_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
-            subject="n",
+            subject="outer",
             library_name=None,
             is_worker=False,
-        ):
-            assert any_scope_active_threadsafe() is True
+        ) as outer:
+            report_violation(rule_id="fake-ergonomics", message="outer-1")
             with strict_mode_scope(
                 kind=StrictModeScopeKind.LOAD_PROBE,
-                subject="c",
+                subject="inner",
                 library_name=None,
                 is_worker=True,
-            ):
-                assert any_scope_active_threadsafe() is True
-            assert any_scope_active_threadsafe() is True
-        assert any_scope_active_threadsafe() is False
+            ) as inner:
+                report_violation(rule_id="fake-correctness", message="inner-1")
+            report_violation(rule_id="fake-ergonomics", message="outer-2")
+
+        assert [v.message for v in outer.violations] == ["outer-1", "outer-2"]
+        assert [v.message for v in inner.violations] == ["inner-1"]
 
 
 class TestReportViolation:
@@ -161,6 +177,68 @@ class TestReportViolation:
         assert len(warnings) == 0
 
 
+class TestAttachViolationsToResult:
+    def _scope_with(self, *violations: tuple[str, str]) -> object:
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name="libA",
+            is_worker=False,
+        ) as scope:
+            for rule_id, message in violations:
+                report_violation(rule_id=rule_id, message=message)
+        return scope
+
+    def test_no_violations_leaves_details_unchanged(self) -> None:
+        result = _FakeSuccessResult(result_details="ok")
+        original_details = result.result_details
+        scope_obj = self._scope_with()  # zero violations
+        attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+        assert result.result_details is original_details
+        assert isinstance(result.result_details, ResultDetails)
+        assert len(result.result_details.result_details) == 1  # the original "ok" detail only
+
+    def test_appends_violation_detail_to_success_result(self, fake_rules: None) -> None:  # noqa: ARG002
+        result = _FakeSuccessResult(result_details="ok")
+        scope_obj = self._scope_with(("fake-ergonomics", "naughty"))
+        attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+
+        expected_count = 2  # original "ok" + the violation
+        assert isinstance(result.result_details, ResultDetails)
+        details = result.result_details.result_details
+        assert len(details) == expected_count
+        violation_detail = details[-1]
+        assert isinstance(violation_detail, StrictModeViolationDetail)
+        assert violation_detail.rule_id == "fake-ergonomics"
+        assert violation_detail.severity == StrictModeSeverity.WARNING.value
+        assert violation_detail.subject == "n"
+        assert violation_detail.library_name == "libA"
+        assert violation_detail.level == logging.WARNING
+
+    def test_failure_with_string_detail_keeps_error_level(self, fake_rules: None) -> None:  # noqa: ARG002
+        # Regression: previously attach_violations_to_result wrapped a string
+        # result_details as level=DEBUG, silently demoting failure messages.
+        # ResultPayloadFailure.__post_init__ now coerces to level=ERROR; the
+        # attach routine must not touch the existing detail.
+        result = _FakeFailureResult(result_details="boom")
+        scope_obj = self._scope_with(("fake-correctness", "very bad"))
+        attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+
+        assert isinstance(result.result_details, ResultDetails)
+        details = result.result_details.result_details
+        assert details[0].level == logging.ERROR
+        assert details[0].message == "boom"
+        violation_detail = details[1]
+        assert isinstance(violation_detail, StrictModeViolationDetail)
+        assert violation_detail.level == logging.ERROR
+
+    def test_returns_none(self, fake_rules: None) -> None:  # noqa: ARG002
+        result = _FakeSuccessResult(result_details="ok")
+        scope_obj = self._scope_with(("fake-ergonomics", "x"))
+        returned = attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+        assert returned is None
+
+
 class TestParallelTaskIsolation:
     @pytest.mark.asyncio
     async def test_concurrent_tasks_have_independent_scopes(self) -> None:
@@ -185,30 +263,3 @@ class TestParallelTaskIsolation:
         )
 
         assert seen == {"a": ("a", 2), "b": ("b", 2), "c": ("c", 2)}
-
-
-class TestThreadSafeActiveFlag:
-    def test_active_flag_observable_from_other_thread(self) -> None:
-        observed: list[bool] = []
-        entered = threading.Event()
-        can_exit = threading.Event()
-
-        def observer() -> None:
-            entered.wait(timeout=1.0)
-            observed.append(any_scope_active_threadsafe())
-            can_exit.set()
-
-        t = threading.Thread(target=observer)
-        t.start()
-        with strict_mode_scope(
-            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
-            subject="n",
-            library_name=None,
-            is_worker=False,
-        ):
-            entered.set()
-            can_exit.wait(timeout=1.0)
-        t.join(timeout=1.0)
-
-        assert observed == [True]
-        assert any_scope_active_threadsafe() is False

--- a/tests/unit/common/test_strict_mode.py
+++ b/tests/unit/common/test_strict_mode.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from griptape_nodes.common.strict_mode import (
+    StrictModeScopeKind,
+    StrictModeSeverity,
+    any_scope_active_threadsafe,
+    current_scope,
+    report_violation,
+    strict_mode_scope,
+)
+from griptape_nodes.common.strict_mode_checks import RULES, _rule
+
+
+@pytest.fixture
+def fake_rules() -> Iterator[None]:
+    """Register two synthetic rules for the duration of the test.
+
+    The framework PR ships an empty RULES catalog; rule PRs append entries
+    later in the stack. Tests at this layer need a registered rule_id to
+    exercise severity resolution, so they install one and tear it down.
+    """
+    ergonomics = _rule(
+        "fake-ergonomics",
+        severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description="synthetic ergonomics rule for tests",
+        remediation="ergonomics: {detail}",
+        worker_escalation=False,
+    )
+    correctness = _rule(
+        "fake-correctness",
+        severity=StrictModeSeverity.ERROR,
+        correctness=True,
+        description="synthetic correctness rule for tests",
+        remediation="correctness: {detail}",
+    )
+    RULES[ergonomics.rule_id] = ergonomics
+    RULES[correctness.rule_id] = correctness
+    try:
+        yield
+    finally:
+        RULES.pop(ergonomics.rule_id, None)
+        RULES.pop(correctness.rule_id, None)
+
+
+class TestStrictModeScope:
+    def test_current_scope_is_none_outside_any_scope(self) -> None:
+        assert current_scope() is None
+        assert any_scope_active_threadsafe() is False
+
+    def test_scope_sets_and_resets_contextvar(self) -> None:
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="node-1",
+            library_name="libA",
+            is_worker=False,
+        ) as scope:
+            assert current_scope() is scope
+            assert scope.kind is StrictModeScopeKind.RUNTIME_EXECUTE
+            assert scope.subject == "node-1"
+            assert scope.library_name == "libA"
+            assert scope.is_worker is False
+            assert scope.violations == []
+        assert current_scope() is None
+
+    def test_nested_scopes_restore_outer_on_exit(self) -> None:
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="outer",
+            library_name=None,
+            is_worker=False,
+        ) as outer:
+            assert current_scope() is outer
+            with strict_mode_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="inner",
+                library_name="libX",
+                is_worker=True,
+            ) as inner:
+                assert current_scope() is inner
+            assert current_scope() is outer
+        assert current_scope() is None
+
+    def test_refcount_tracks_entered_scopes(self) -> None:
+        assert any_scope_active_threadsafe() is False
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name=None,
+            is_worker=False,
+        ):
+            assert any_scope_active_threadsafe() is True
+            with strict_mode_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="c",
+                library_name=None,
+                is_worker=True,
+            ):
+                assert any_scope_active_threadsafe() is True
+            assert any_scope_active_threadsafe() is True
+        assert any_scope_active_threadsafe() is False
+
+
+class TestReportViolation:
+    def test_no_op_outside_scope(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
+        result = report_violation(rule_id="r", message="m")
+        assert result is None
+        assert caplog.records == []
+
+    def test_orchestrator_logs_warning(self, caplog: pytest.LogCaptureFixture, fake_rules: None) -> None:  # noqa: ARG002
+        rule_id = "fake-ergonomics"
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name="libA",
+            is_worker=False,
+        ) as scope:
+            report_violation(rule_id=rule_id, message="something bad")
+            assert len(scope.violations) == 1
+            v = scope.violations[0]
+            assert v.rule_id == rule_id
+            assert v.severity is StrictModeSeverity.WARNING
+            assert v.scope_kind is StrictModeScopeKind.RUNTIME_EXECUTE
+            assert v.subject == "n"
+            assert v.library_name == "libA"
+            assert v.message == "something bad"
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(warnings) == 1
+        assert len(errors) == 0
+        assert "something bad" in warnings[0].getMessage()
+
+    def test_worker_logs_error(self, caplog: pytest.LogCaptureFixture, fake_rules: None) -> None:  # noqa: ARG002
+        rule_id = "fake-correctness"
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            report_violation(rule_id=rule_id, message="very bad")
+            assert scope.violations[0].severity is StrictModeSeverity.ERROR
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(errors) == 1
+        assert len(warnings) == 0
+
+
+class TestParallelTaskIsolation:
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_have_independent_scopes(self) -> None:
+        seen: dict[str, tuple[str, int]] = {}
+
+        async def run_one(name: str, *, is_worker: bool) -> None:
+            with strict_mode_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=name,
+                library_name=None,
+                is_worker=is_worker,
+            ) as scope:
+                report_violation(rule_id="r", message=f"msg-{name}")
+                await asyncio.sleep(0)
+                report_violation(rule_id="r", message=f"msg-{name}-2")
+                seen[name] = (scope.subject, len(scope.violations))
+
+        await asyncio.gather(
+            run_one("a", is_worker=False),
+            run_one("b", is_worker=True),
+            run_one("c", is_worker=False),
+        )
+
+        assert seen == {"a": ("a", 2), "b": ("b", 2), "c": ("c", 2)}
+
+
+class TestThreadSafeActiveFlag:
+    def test_active_flag_observable_from_other_thread(self) -> None:
+        observed: list[bool] = []
+        entered = threading.Event()
+        can_exit = threading.Event()
+
+        def observer() -> None:
+            entered.wait(timeout=1.0)
+            observed.append(any_scope_active_threadsafe())
+            can_exit.set()
+
+        t = threading.Thread(target=observer)
+        t.start()
+        with strict_mode_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name=None,
+            is_worker=False,
+        ):
+            entered.set()
+            can_exit.wait(timeout=1.0)
+        t.join(timeout=1.0)
+
+        assert observed == [True]
+        assert any_scope_active_threadsafe() is False

--- a/tests/unit/common/test_strict_mode.py
+++ b/tests/unit/common/test_strict_mode.py
@@ -11,12 +11,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeReporter,
     StrictModeScopeKind,
     StrictModeSeverity,
-    attach_violations_to_result,
-    current_scope,
-    report_violation,
-    strict_mode_scope,
 )
 from griptape_nodes.common.strict_mode_checks import RULES, StrictModeRule
 from griptape_nodes.retained_mode.events.base_events import (
@@ -69,81 +67,104 @@ def fake_rules() -> Iterator[None]:
         RULES.pop(correctness.rule_id, None)
 
 
-class TestStrictModeScope:
-    def test_current_scope_is_none_outside_any_scope(self) -> None:
-        assert current_scope() is None
+@pytest.fixture
+def reporter() -> StrictModeReporter:
+    """A fresh reporter so each test owns its own scope stack.
 
-    def test_scope_sets_and_resets_contextvar(self) -> None:
-        with strict_mode_scope(
+    Tests that go through ``STRICT_MODE`` directly (the production
+    singleton) would inherit any leaked scope state from earlier tests.
+    Per-test reporters give each case a clean ContextVar.
+    """
+    return StrictModeReporter()
+
+
+class TestStrictModeReporter:
+    def test_default_singleton_exists(self) -> None:
+        assert isinstance(STRICT_MODE, StrictModeReporter)
+
+    def test_current_scope_is_none_outside_any_scope(self, reporter: StrictModeReporter) -> None:
+        assert reporter.current_scope() is None
+
+    def test_open_scope_sets_and_resets_contextvar(self, reporter: StrictModeReporter) -> None:
+        with reporter.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject="node-1",
             library_name="libA",
             is_worker=False,
         ) as scope:
-            assert current_scope() is scope
+            assert reporter.current_scope() is scope
             assert scope.kind is StrictModeScopeKind.RUNTIME_EXECUTE
             assert scope.subject == "node-1"
             assert scope.library_name == "libA"
             assert scope.is_worker is False
             assert scope.violations == []
-        assert current_scope() is None
+        assert reporter.current_scope() is None
 
-    def test_nested_scopes_restore_outer_on_exit(self) -> None:
-        with strict_mode_scope(
+    def test_nested_scopes_restore_outer_on_exit(self, reporter: StrictModeReporter) -> None:
+        with reporter.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject="outer",
             library_name=None,
             is_worker=False,
         ) as outer:
-            assert current_scope() is outer
-            with strict_mode_scope(
+            assert reporter.current_scope() is outer
+            with reporter.open_scope(
                 kind=StrictModeScopeKind.LOAD_PROBE,
                 subject="inner",
                 library_name="libX",
                 is_worker=True,
             ) as inner:
-                assert current_scope() is inner
-            assert current_scope() is outer
-        assert current_scope() is None
+                assert reporter.current_scope() is inner
+            assert reporter.current_scope() is outer
+        assert reporter.current_scope() is None
 
-    def test_violations_attach_to_correct_scope_when_nested(self, fake_rules: None) -> None:  # noqa: ARG002
-        with strict_mode_scope(
+    def test_violations_attach_to_correct_scope_when_nested(
+        self,
+        reporter: StrictModeReporter,
+        fake_rules: None,  # noqa: ARG002
+    ) -> None:
+        with reporter.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject="outer",
             library_name=None,
             is_worker=False,
         ) as outer:
-            report_violation(rule_id="fake-ergonomics", message="outer-1")
-            with strict_mode_scope(
+            reporter.report(rule_id="fake-ergonomics", message="outer-1")
+            with reporter.open_scope(
                 kind=StrictModeScopeKind.LOAD_PROBE,
                 subject="inner",
                 library_name=None,
                 is_worker=True,
             ) as inner:
-                report_violation(rule_id="fake-correctness", message="inner-1")
-            report_violation(rule_id="fake-ergonomics", message="outer-2")
+                reporter.report(rule_id="fake-correctness", message="inner-1")
+            reporter.report(rule_id="fake-ergonomics", message="outer-2")
 
         assert [v.message for v in outer.violations] == ["outer-1", "outer-2"]
         assert [v.message for v in inner.violations] == ["inner-1"]
 
 
-class TestReportViolation:
-    def test_no_op_outside_scope(self, caplog: pytest.LogCaptureFixture) -> None:
+class TestReporterReport:
+    def test_no_op_outside_scope(self, reporter: StrictModeReporter, caplog: pytest.LogCaptureFixture) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
-        result = report_violation(rule_id="r", message="m")
+        result = reporter.report(rule_id="r", message="m")
         assert result is None
         assert caplog.records == []
 
-    def test_orchestrator_logs_warning(self, caplog: pytest.LogCaptureFixture, fake_rules: None) -> None:  # noqa: ARG002
+    def test_orchestrator_logs_warning(
+        self,
+        reporter: StrictModeReporter,
+        caplog: pytest.LogCaptureFixture,
+        fake_rules: None,  # noqa: ARG002
+    ) -> None:
         rule_id = "fake-ergonomics"
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
-        with strict_mode_scope(
+        with reporter.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject="n",
             library_name="libA",
             is_worker=False,
         ) as scope:
-            report_violation(rule_id=rule_id, message="something bad")
+            reporter.report(rule_id=rule_id, message="something bad")
             assert len(scope.violations) == 1
             v = scope.violations[0]
             assert v.rule_id == rule_id
@@ -159,16 +180,21 @@ class TestReportViolation:
         assert len(errors) == 0
         assert "something bad" in warnings[0].getMessage()
 
-    def test_worker_logs_error(self, caplog: pytest.LogCaptureFixture, fake_rules: None) -> None:  # noqa: ARG002
+    def test_worker_logs_error(
+        self,
+        reporter: StrictModeReporter,
+        caplog: pytest.LogCaptureFixture,
+        fake_rules: None,  # noqa: ARG002
+    ) -> None:
         rule_id = "fake-correctness"
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
-        with strict_mode_scope(
+        with reporter.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject="n",
             library_name="libA",
             is_worker=True,
         ) as scope:
-            report_violation(rule_id=rule_id, message="very bad")
+            reporter.report(rule_id=rule_id, message="very bad")
             assert scope.violations[0].severity is StrictModeSeverity.ERROR
 
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
@@ -177,31 +203,52 @@ class TestReportViolation:
         assert len(warnings) == 0
 
 
+class TestSeverityResolverInjection:
+    def test_custom_resolver_is_consulted(self, fake_rules: None) -> None:  # noqa: ARG002
+        recorded: list[tuple[str, bool]] = []
+
+        def fake_resolver(*, rule_id: str, is_worker: bool) -> StrictModeSeverity:
+            recorded.append((rule_id, is_worker))
+            return StrictModeSeverity.ERROR
+
+        reporter = StrictModeReporter(severity_resolver=fake_resolver)
+        with reporter.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name=None,
+            is_worker=False,
+        ) as scope:
+            reporter.report(rule_id="fake-ergonomics", message="x")
+
+        assert recorded == [("fake-ergonomics", False)]
+        assert scope.violations[0].severity is StrictModeSeverity.ERROR
+
+
 class TestAttachViolationsToResult:
-    def _scope_with(self, *violations: tuple[str, str]) -> object:
-        with strict_mode_scope(
+    def _scope_with(self, reporter: StrictModeReporter, *violations: tuple[str, str]) -> object:
+        with reporter.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject="n",
             library_name="libA",
             is_worker=False,
         ) as scope:
             for rule_id, message in violations:
-                report_violation(rule_id=rule_id, message=message)
+                reporter.report(rule_id=rule_id, message=message)
         return scope
 
-    def test_no_violations_leaves_details_unchanged(self) -> None:
+    def test_no_violations_leaves_details_unchanged(self, reporter: StrictModeReporter) -> None:
         result = _FakeSuccessResult(result_details="ok")
         original_details = result.result_details
-        scope_obj = self._scope_with()  # zero violations
-        attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+        scope_obj = self._scope_with(reporter)  # zero violations
+        reporter.attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
         assert result.result_details is original_details
         assert isinstance(result.result_details, ResultDetails)
         assert len(result.result_details.result_details) == 1  # the original "ok" detail only
 
-    def test_appends_violation_detail_to_success_result(self, fake_rules: None) -> None:  # noqa: ARG002
+    def test_appends_violation_detail_to_success_result(self, reporter: StrictModeReporter, fake_rules: None) -> None:  # noqa: ARG002
         result = _FakeSuccessResult(result_details="ok")
-        scope_obj = self._scope_with(("fake-ergonomics", "naughty"))
-        attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+        scope_obj = self._scope_with(reporter, ("fake-ergonomics", "naughty"))
+        reporter.attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
 
         expected_count = 2  # original "ok" + the violation
         assert isinstance(result.result_details, ResultDetails)
@@ -215,14 +262,14 @@ class TestAttachViolationsToResult:
         assert violation_detail.library_name == "libA"
         assert violation_detail.level == logging.WARNING
 
-    def test_failure_with_string_detail_keeps_error_level(self, fake_rules: None) -> None:  # noqa: ARG002
+    def test_failure_with_string_detail_keeps_error_level(self, reporter: StrictModeReporter, fake_rules: None) -> None:  # noqa: ARG002
         # Regression: previously attach_violations_to_result wrapped a string
         # result_details as level=DEBUG, silently demoting failure messages.
         # ResultPayloadFailure.__post_init__ now coerces to level=ERROR; the
         # attach routine must not touch the existing detail.
         result = _FakeFailureResult(result_details="boom")
-        scope_obj = self._scope_with(("fake-correctness", "very bad"))
-        attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+        scope_obj = self._scope_with(reporter, ("fake-correctness", "very bad"))
+        reporter.attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
 
         assert isinstance(result.result_details, ResultDetails)
         details = result.result_details.result_details
@@ -232,28 +279,28 @@ class TestAttachViolationsToResult:
         assert isinstance(violation_detail, StrictModeViolationDetail)
         assert violation_detail.level == logging.ERROR
 
-    def test_returns_none(self, fake_rules: None) -> None:  # noqa: ARG002
+    def test_returns_none(self, reporter: StrictModeReporter, fake_rules: None) -> None:  # noqa: ARG002
         result = _FakeSuccessResult(result_details="ok")
-        scope_obj = self._scope_with(("fake-ergonomics", "x"))
-        returned = attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
+        scope_obj = self._scope_with(reporter, ("fake-ergonomics", "x"))
+        returned = reporter.attach_violations_to_result(result, scope_obj)  # type: ignore[arg-type]
         assert returned is None
 
 
 class TestParallelTaskIsolation:
     @pytest.mark.asyncio
-    async def test_concurrent_tasks_have_independent_scopes(self) -> None:
+    async def test_concurrent_tasks_have_independent_scopes(self, reporter: StrictModeReporter) -> None:
         seen: dict[str, tuple[str, int]] = {}
 
         async def run_one(name: str, *, is_worker: bool) -> None:
-            with strict_mode_scope(
+            with reporter.open_scope(
                 kind=StrictModeScopeKind.RUNTIME_EXECUTE,
                 subject=name,
                 library_name=None,
                 is_worker=is_worker,
             ) as scope:
-                report_violation(rule_id="r", message=f"msg-{name}")
+                reporter.report(rule_id="r", message=f"msg-{name}")
                 await asyncio.sleep(0)
-                report_violation(rule_id="r", message=f"msg-{name}-2")
+                reporter.report(rule_id="r", message=f"msg-{name}-2")
                 seen[name] = (scope.subject, len(scope.violations))
 
         await asyncio.gather(

--- a/tests/unit/common/test_strict_mode.py
+++ b/tests/unit/common/test_strict_mode.py
@@ -286,6 +286,46 @@ class TestAttachViolationsToResult:
         assert returned is None
 
 
+class TestEnabledToggle:
+    def test_disabled_reporter_skips_open_scope_stack(self) -> None:
+        reporter = StrictModeReporter(enabled=False)
+        with reporter.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name=None,
+            is_worker=False,
+        ) as scope:
+            # Detached scope: report() finds no active scope and no-ops.
+            assert reporter.current_scope() is None
+            assert reporter.report(rule_id="r", message="m") is None
+            assert scope.violations == []
+
+    def test_enabled_reporter_pushes_onto_stack(self) -> None:
+        reporter = StrictModeReporter(enabled=True)
+        with reporter.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="n",
+            library_name=None,
+            is_worker=False,
+        ) as scope:
+            assert reporter.current_scope() is scope
+
+    def test_env_var_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GTN_STRICT_MODE_DISABLED", "1")
+        reporter = StrictModeReporter()
+        assert reporter.enabled is False
+
+    def test_env_var_unset_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GTN_STRICT_MODE_DISABLED", raising=False)
+        reporter = StrictModeReporter()
+        assert reporter.enabled is True
+
+    def test_explicit_enabled_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GTN_STRICT_MODE_DISABLED", "1")
+        reporter = StrictModeReporter(enabled=True)
+        assert reporter.enabled is True
+
+
 class TestParallelTaskIsolation:
     @pytest.mark.asyncio
     async def test_concurrent_tasks_have_independent_scopes(self, reporter: StrictModeReporter) -> None:

--- a/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
+++ b/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
@@ -14,7 +14,7 @@ import pytest
 from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import aprocess_scope, sanctioned_parameter_mutation
-from griptape_nodes.node_library.library_registry import _constructing_node
+from griptape_nodes.node_library.library_registry import LibraryRegistry, _constructing_node
 
 from .mocks import MockNode
 
@@ -49,6 +49,12 @@ class TestParameterMutationDetector:
         assert violation.rule_id == "parameter-mutation-during-aprocess"
         assert "p_added" in violation.message
         assert "add_parameter" in violation.message
+        # The message names the actual offending node and class so a reader
+        # can tell when the mutation came from a node other than the one the
+        # active strict-mode scope is attributed to (e.g. a helper node
+        # constructed during aprocess of a different node).
+        assert mock_node.name in violation.message
+        assert type(mock_node).__name__ in violation.message
 
     def test_violation_reported_when_removing_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
         param = Parameter(name="p_to_remove", type="str")
@@ -68,6 +74,39 @@ class TestParameterMutationDetector:
         assert violation.rule_id == "parameter-mutation-during-aprocess"
         assert "p_to_remove" in violation.message
         assert "remove_parameter_element" in violation.message
+        assert mock_node.name in violation.message
+        assert type(mock_node).__name__ in violation.message
+
+    def test_violation_message_names_offender_distinct_from_scope_subject(self) -> None:
+        """When a node mutates parameters inside a *different* node's scope.
+
+        The strict-mode scope subject names the executing node, but the
+        violation message must name the actual offender so a reader can
+        tell the two apart -- this is the failure mode that motivated
+        adding ``node_name`` / ``node_class`` to the remediation
+        template.
+        """
+        outer = MockNode(name="outer_executing_node")
+        offender = MockNode(name="inner_offender")
+        param = Parameter(name="leaked", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=outer.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            offender.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        # Scope subject still names the active executing node.
+        assert violation.subject == outer.name
+        # But the message body names the actual offender, not the scope.
+        assert offender.name in violation.message
+        assert type(offender).__name__ in violation.message
+        assert outer.name not in violation.message
 
     def test_no_violation_when_handler_sanctions_add(self, mock_node: MockNode) -> None:
         param = Parameter(name="sanctioned_add", type="str")
@@ -195,3 +234,111 @@ class TestParameterMutationDetector:
             finally:
                 _constructing_node.reset(token)
         assert scope.violations == []
+
+    def test_no_violation_for_direct_construction_wrapped_in_constructing_node(self, mock_node: MockNode) -> None:
+        """Direct construction wrapped in ``LibraryRegistry.constructing_node()`` is silent.
+
+        Production has two known sites that build an ephemeral node by
+        calling ``type(node)(name=...)`` / ``node_class(name=...)`` directly
+        rather than going through ``LibraryRegistry.create_node`` -- node
+        serialization's REFERENCE NODE comparison and the
+        ``DescribeNodeTypeRequest`` probe. Without the wrapper the
+        detector mistakes every ``add_parameter`` call in the helper's
+        ``__init__`` for an aprocess-time mutation, since the active
+        scope belongs to the outer node that is genuinely running.
+        Wrapping the helper construction with the public
+        ``constructing_node()`` context manager must reproduce the
+        same suppression that ``create_node`` provides.
+        """
+
+        class HelperNodeWithParams(MockNode):
+            def __init__(self, name: str = "helper") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="helper_a", type="str"))
+                self.add_parameter(Parameter(name="helper_b", type="str"))
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=True,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            with LibraryRegistry.constructing_node():
+                HelperNodeWithParams(name="REFERENCE NODE")
+        assert scope.violations == []
+
+    def test_violation_when_direct_construction_is_not_wrapped(self, mock_node: MockNode) -> None:
+        """The wrapper is load-bearing: removing it surfaces the false positive.
+
+        This is the production bug the wrapper fixes. Without
+        ``LibraryRegistry.constructing_node()`` the detector reports
+        every parameter declared in the helper's ``__init__`` against
+        the *outer* node's active scope -- producing exactly the noisy
+        log a workflow with several library nodes used to emit during
+        autosave / serialization.
+        """
+
+        class HelperNodeWithParams(MockNode):
+            def __init__(self, name: str = "helper") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="helper_a", type="str"))
+                self.add_parameter(Parameter(name="helper_b", type="str"))
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            HelperNodeWithParams(name="REFERENCE NODE")
+
+        # Two parameter declarations in __init__ trip the rule once each.
+        expected_violations = 2
+        assert len(scope.violations) == expected_violations
+        # Each violation names the helper, not the outer scope's node, so
+        # the operator can spot that the mutations originated outside the
+        # node the scope is attributed to. (Same condition tested in
+        # ``test_violation_message_names_offender_distinct_from_scope_subject``.)
+        for violation in scope.violations:
+            assert "REFERENCE NODE" in violation.message
+            assert "HelperNodeWithParams" in violation.message
+            assert violation.subject == mock_node.name
+
+
+class TestConstructingNodeContextManager:
+    """``LibraryRegistry.constructing_node()`` toggles the task-local flag."""
+
+    def test_flag_set_inside_block_and_reset_after(self) -> None:
+        assert LibraryRegistry.is_constructing_node() is False
+        with LibraryRegistry.constructing_node():
+            assert LibraryRegistry.is_constructing_node() is True
+        assert LibraryRegistry.is_constructing_node() is False
+
+    def test_nesting_restores_outer_state_on_exit(self) -> None:
+        """Tokens stack: an outer ``constructing_node`` block stays True
+        across an inner block's enter/exit, and the outer block's exit
+        restores the original False state.
+        """
+        assert LibraryRegistry.is_constructing_node() is False
+        with LibraryRegistry.constructing_node():
+            assert LibraryRegistry.is_constructing_node() is True
+            with LibraryRegistry.constructing_node():
+                assert LibraryRegistry.is_constructing_node() is True
+            # Inner reset must not clear the outer flag.
+            assert LibraryRegistry.is_constructing_node() is True
+        assert LibraryRegistry.is_constructing_node() is False
+
+    def test_flag_reset_on_exception(self) -> None:
+        """Exiting via exception still resets the flag."""
+        assert LibraryRegistry.is_constructing_node() is False
+        with pytest.raises(RuntimeError, match="boom"):
+            with LibraryRegistry.constructing_node():
+                assert LibraryRegistry.is_constructing_node() is True
+                raise RuntimeError("boom")
+        assert LibraryRegistry.is_constructing_node() is False

--- a/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
+++ b/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
@@ -1,0 +1,197 @@
+"""Tests for the parameter-mutation-during-aprocess strict-mode detector.
+
+The detector lives in ``BaseNode.add_parameter`` and
+``BaseNode.remove_parameter_element``. It fires when a node mutates its
+own parameter list while ``aprocess_scope()`` is active (set only around
+``await node.aprocess()``) and the call is not wrapped by the handler-side
+``sanctioned_parameter_mutation()`` context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import aprocess_scope, sanctioned_parameter_mutation
+from griptape_nodes.node_library.library_registry import _constructing_node
+
+from .mocks import MockNode
+
+
+@pytest.fixture
+def mock_node() -> MockNode:
+    """Return a fresh MockNode for each test."""
+    return MockNode(name="detector_test_node")
+
+
+class TestParameterMutationDetector:
+    def test_no_violation_when_no_scope_active(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p1", type="str")
+        mock_node.add_parameter(param)
+        # Outside a strict-mode scope nothing is tracked.
+        # The add_parameter call should succeed without raising.
+
+    def test_violation_reported_when_adding_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p_added", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "parameter-mutation-during-aprocess"
+        assert "p_added" in violation.message
+        assert "add_parameter" in violation.message
+
+    def test_violation_reported_when_removing_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p_to_remove", type="str")
+        mock_node.add_parameter(param)
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.remove_parameter_element(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "parameter-mutation-during-aprocess"
+        assert "p_to_remove" in violation.message
+        assert "remove_parameter_element" in violation.message
+
+    def test_no_violation_when_handler_sanctions_add(self, mock_node: MockNode) -> None:
+        param = Parameter(name="sanctioned_add", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+            sanctioned_parameter_mutation(),
+        ):
+            mock_node.add_parameter(param)
+        assert scope.violations == []
+
+    def test_no_violation_when_handler_sanctions_remove(self, mock_node: MockNode) -> None:
+        param = Parameter(name="sanctioned_remove", type="str")
+        mock_node.add_parameter(param)
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+            sanctioned_parameter_mutation(),
+        ):
+            mock_node.remove_parameter_element(param)
+        assert scope.violations == []
+
+    def test_worker_scope_escalates_to_error_severity(self, mock_node: MockNode) -> None:
+        param = Parameter(name="worker_add", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=True,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.severity.value == "error"
+
+    def test_no_violation_during_hydration_under_runtime_execute(self, mock_node: MockNode) -> None:
+        """Hydration runs add_parameter under RUNTIME_EXECUTE without aprocess.
+
+        ``_hydrate_and_run_node_inner`` calls ``set_parameter_value``
+        (firing ``before_value_set`` / ``after_value_set``) inside the
+        ``RUNTIME_EXECUTE`` scope but before ``await node.aprocess()``.
+        Real nodes (e.g. dynamic-pipeline diffuser nodes) call
+        ``add_parameter`` from those hooks. The detector must stay silent
+        until the framework enters ``aprocess_scope()``.
+        """
+        param = Parameter(name="hydration_added", type="str")
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject=mock_node.name,
+            library_name=None,
+            is_worker=True,
+        ) as scope:
+            mock_node.add_parameter(param)
+        assert scope.violations == []
+
+    def test_no_violation_when_add_parameter_called_from_init_under_load_probe(self) -> None:
+        """__init__ calls to add_parameter during a LOAD_PROBE scope are not violations.
+
+        LibraryManager._serialize_library_node_schemas instantiates every node
+        class inside a LOAD_PROBE scope. Nodes legitimately declare their
+        parameters by calling self.add_parameter(...) from __init__, so those
+        calls must not report parameter-mutation-during-aprocess. The
+        constructor flag suppresses the rule in this case; the
+        ``_in_aprocess`` flag is also unset because no aprocess is running.
+        """
+
+        class NodeAddsParameterInInit(MockNode):
+            def __init__(self, name: str = "probe_node") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="declared_in_init", type="str"))
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="NodeAddsParameterInInit",
+                library_name="test_library",
+                is_worker=True,
+            ) as scope:
+                NodeAddsParameterInInit(name="__schema_probe__")
+        finally:
+            _constructing_node.reset(token)
+        assert scope.violations == []
+
+    def test_no_violation_for_nested_node_construction_inside_aprocess(self, mock_node: MockNode) -> None:
+        """A node constructed inside aprocess can declare params in __init__.
+
+        ``LibraryRegistry.create_node`` sets the is-constructing flag for the
+        duration of the inner node's ``__init__``. The detector's constructor
+        short-circuit must hold even when ``aprocess_scope()`` is active for
+        the outer node, otherwise creating helper nodes from aprocess would
+        spuriously trip the rule.
+        """
+
+        class InnerNodeWithParam(MockNode):
+            def __init__(self, name: str = "inner") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="inner_p", type="str"))
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            token = _constructing_node.set(True)
+            try:
+                InnerNodeWithParam(name="constructed_during_aprocess")
+            finally:
+                _constructing_node.reset(token)
+        assert scope.violations == []

--- a/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
+++ b/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
@@ -265,9 +265,9 @@ class TestParameterMutationDetector:
                 is_worker=True,
             ) as scope,
             aprocess_scope(),
+            LibraryRegistry.constructing_node(),
         ):
-            with LibraryRegistry.constructing_node():
-                HelperNodeWithParams(name="REFERENCE NODE")
+            HelperNodeWithParams(name="REFERENCE NODE")
         assert scope.violations == []
 
     def test_violation_when_direct_construction_is_not_wrapped(self, mock_node: MockNode) -> None:
@@ -321,9 +321,11 @@ class TestConstructingNodeContextManager:
         assert LibraryRegistry.is_constructing_node() is False
 
     def test_nesting_restores_outer_state_on_exit(self) -> None:
-        """Tokens stack: an outer ``constructing_node`` block stays True
-        across an inner block's enter/exit, and the outer block's exit
-        restores the original False state.
+        """Outer ``constructing_node`` flag survives nested enter/exit.
+
+        Tokens stack: an outer block stays True across an inner block's
+        enter/exit, and the outer block's exit restores the original
+        False state.
         """
         assert LibraryRegistry.is_constructing_node() is False
         with LibraryRegistry.constructing_node():
@@ -336,9 +338,14 @@ class TestConstructingNodeContextManager:
 
     def test_flag_reset_on_exception(self) -> None:
         """Exiting via exception still resets the flag."""
-        assert LibraryRegistry.is_constructing_node() is False
-        with pytest.raises(RuntimeError, match="boom"):
+
+        def _trigger() -> None:
             with LibraryRegistry.constructing_node():
                 assert LibraryRegistry.is_constructing_node() is True
-                raise RuntimeError("boom")
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        assert LibraryRegistry.is_constructing_node() is False
+        with pytest.raises(RuntimeError, match="boom"):
+            _trigger()
         assert LibraryRegistry.is_constructing_node() is False

--- a/tests/unit/retained_mode/events/test_base_events.py
+++ b/tests/unit/retained_mode/events/test_base_events.py
@@ -1,6 +1,14 @@
 """Tests for RequestPayload base class broadcast_result behavior."""
 
-from griptape_nodes.retained_mode.events.base_events import RequestPayload
+import logging
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultDetail,
+    ResultDetails,
+    StrictModeViolationDetail,
+)
+from griptape_nodes.retained_mode.events.event_converter import converter
 from griptape_nodes.retained_mode.events.os_events import ReadFileRequest
 
 
@@ -17,3 +25,69 @@ class TestBroadcastResultDefaults:
         """broadcast_result is accessible on instances as well as the class."""
         request = ReadFileRequest()
         assert request.broadcast_result is False
+
+
+class TestResultDetailsRoundTrip:
+    """Regression: cattrs must preserve ResultDetail subclass identity.
+
+    Before include_subclasses(ResultDetail, converter), structuring a
+    list[ResultDetail] coerced every entry to the base class, dropping
+    StrictModeViolationDetail's extra fields silently. Wire-format
+    consumers then could not distinguish a strict-mode violation from a
+    plain detail.
+    """
+
+    def test_strict_mode_violation_detail_survives_roundtrip(self) -> None:
+        violation = StrictModeViolationDetail(
+            level=logging.WARNING,
+            message="bad node",
+            rule_id="rule-x",
+            severity="warning",
+            subject="node-1",
+            library_name="libA",
+        )
+        original = ResultDetails(violation)
+
+        data = converter.unstructure(original)
+        restored = converter.structure(data, ResultDetails)
+
+        roundtrip = restored.result_details[0]
+        assert isinstance(roundtrip, StrictModeViolationDetail)
+        assert roundtrip.rule_id == "rule-x"
+        assert roundtrip.severity == "warning"
+        assert roundtrip.subject == "node-1"
+        assert roundtrip.library_name == "libA"
+        assert roundtrip.level == logging.WARNING
+        assert roundtrip.message == "bad node"
+
+    def test_plain_result_detail_still_roundtrips(self) -> None:
+        plain = ResultDetail(level=logging.INFO, message="hello")
+        original = ResultDetails(plain)
+
+        data = converter.unstructure(original)
+        restored = converter.structure(data, ResultDetails)
+
+        roundtrip = restored.result_details[0]
+        assert type(roundtrip) is ResultDetail
+        assert roundtrip.level == logging.INFO
+        assert roundtrip.message == "hello"
+
+    def test_mixed_list_preserves_each_subclass(self) -> None:
+        plain = ResultDetail(level=logging.INFO, message="info-line")
+        violation = StrictModeViolationDetail(
+            level=logging.ERROR,
+            message="boom",
+            rule_id="r2",
+            severity="error",
+            subject="node-2",
+            library_name=None,
+        )
+        original = ResultDetails(plain, violation)
+
+        data = converter.unstructure(original)
+        restored = converter.structure(data, ResultDetails)
+
+        first, second = restored.result_details
+        assert type(first) is ResultDetail
+        assert isinstance(second, StrictModeViolationDetail)
+        assert second.rule_id == "r2"

--- a/tests/unit/retained_mode/events/test_event_converter.py
+++ b/tests/unit/retained_mode/events/test_event_converter.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from griptape_nodes.retained_mode.events.base_events import EventRequest
+from griptape_nodes.retained_mode.events.base_events import EventRequest, ForwardedException
 from griptape_nodes.retained_mode.events.event_converter import (
     _is_json_primitive_union,
     converter,
@@ -145,3 +145,63 @@ class TestSetParameterValueRequestStructuring:
         assert event.request.value["type"] == "ImageUrlArtifact"
         expected_width = 3024
         assert event.request.value["width"] == expected_width
+
+
+class TestExceptionWireForm:
+    """Round-trip coverage for the Exception <-> dict converter pair.
+
+    The unstructure hook emits ``{type, message, traceback}`` and the
+    structure hook rebuilds those into ``ForwardedException``'s
+    ``original_type`` / message / ``original_traceback`` slots. Both
+    halves are load-bearing for the orchestrator-side
+    ``[<type>] ... Worker traceback: ...`` rendering in
+    ``NodeExecutor._format_node_failure_message``.
+    """
+
+    @staticmethod
+    def _raise_and_capture(exc: Exception) -> Exception:
+        try:
+            raise exc  # noqa: TRY301
+        except Exception as e:
+            return e
+
+    def test_unstructure_raised_exception_carries_type_message_and_traceback(self) -> None:
+        e = self._raise_and_capture(ValueError("boom"))
+        payload = converter.unstructure(e, Exception)
+
+        assert payload["type"] == "builtins.ValueError"
+        assert payload["message"] == "boom"
+        assert payload["traceback"] is not None
+        assert "ValueError: boom" in payload["traceback"]
+
+    def test_unstructure_unraised_exception_has_null_traceback(self) -> None:
+        # An exception that was constructed but never raised has
+        # ``__traceback__ is None``; the wire form preserves type and
+        # message but the traceback slot is null.
+        payload = converter.unstructure(ValueError("never raised"), Exception)
+
+        assert payload["type"] == "builtins.ValueError"
+        assert payload["message"] == "never raised"
+        assert payload["traceback"] is None
+
+    def test_round_trip_yields_forwarded_exception_with_worker_fields(self) -> None:
+        e = self._raise_and_capture(RuntimeError("worker boom"))
+        payload = converter.unstructure(e, Exception)
+        rebuilt = converter.structure(payload, Exception)
+
+        assert isinstance(rebuilt, ForwardedException)
+        assert str(rebuilt) == "worker boom"
+        assert rebuilt.original_type == "builtins.RuntimeError"
+        assert rebuilt.original_traceback is not None
+        assert "RuntimeError: worker boom" in rebuilt.original_traceback
+
+    def test_structure_tolerates_non_dict_payload(self) -> None:
+        # Old persisted events on disk may carry a bare-string
+        # ``exception`` field; refusing to structure them would abort
+        # deserialization of the whole enclosing event.
+        rebuilt = converter.structure("legacy stringified error", Exception)
+
+        assert isinstance(rebuilt, ForwardedException)
+        assert str(rebuilt) == "legacy stringified error"
+        assert rebuilt.original_type is None
+        assert rebuilt.original_traceback is None

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -549,3 +549,112 @@ class TestConfigManagerEventEmission:
             "/path/to/enabled.json",
             {"path": "/path/to/disabled.json", "enabled": False},
         ]
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="xdg_base_dirs cannot find XDG_CONFIG_HOME on Windows on GitHub Actions"
+)
+class TestConfigManagerEventGating:
+    """``ConfigChanged`` must only fire when the disk write actually landed.
+
+    Listeners (in production: WorkerManager fans out ReloadConfigRequest to
+    every registered worker) consume ConfigChanged. Emitting on a failed
+    write would tell every consumer to act on a state that does not exist
+    on disk -- e.g. workers reload the file and either see stale values or
+    fail to find the new key.
+    """
+
+    def test_set_config_value_does_not_emit_when_write_fails(self) -> None:
+        event_manager = EventManager()
+        config_manager = ConfigManager(event_manager=event_manager)
+
+        received: list[ConfigChanged] = []
+        event_manager.add_listener_to_app_event(ConfigChanged, received.append)
+
+        with patch.object(config_manager, "_write_user_config_delta", return_value=False):
+            config_manager.set_config_value(key="test_key", value="new_value")
+
+        assert received == []
+
+    def test_set_config_value_emits_when_write_succeeds(self) -> None:
+        event_manager = EventManager()
+        config_manager = ConfigManager(event_manager=event_manager)
+
+        received: list[ConfigChanged] = []
+        event_manager.add_listener_to_app_event(ConfigChanged, received.append)
+
+        with patch.object(config_manager, "_write_user_config_delta", return_value=True):
+            config_manager.set_config_value(key="test_key", value="new_value")
+
+        assert len(received) == 1
+        assert received[0].key == "test_key"
+        assert received[0].new_value == "new_value"
+
+    def test_set_config_category_full_replacement_returns_failure_when_write_fails(self) -> None:
+        from griptape_nodes.retained_mode.events.config_events import (
+            SetConfigCategoryRequest,
+            SetConfigCategoryResultFailure,
+        )
+
+        event_manager = EventManager()
+        config_manager = ConfigManager(event_manager=event_manager)
+
+        received: list[ConfigChanged] = []
+        event_manager.add_listener_to_app_event(ConfigChanged, received.append)
+
+        request = SetConfigCategoryRequest(category=None, contents={"any": "thing"})
+        with patch.object(config_manager, "_write_user_config_delta", return_value=False):
+            result = config_manager.on_handle_set_config_category_request(request)
+
+        assert isinstance(result, SetConfigCategoryResultFailure)
+        assert received == []
+
+    def test_set_config_category_non_empty_category_returns_failure_when_write_fails(self) -> None:
+        """The non-empty-category branch routes through ``set_config_value``; failure must propagate."""
+        from griptape_nodes.retained_mode.events.config_events import (
+            SetConfigCategoryRequest,
+            SetConfigCategoryResultFailure,
+        )
+
+        event_manager = EventManager()
+        config_manager = ConfigManager(event_manager=event_manager)
+
+        received: list[ConfigChanged] = []
+        event_manager.add_listener_to_app_event(ConfigChanged, received.append)
+
+        request = SetConfigCategoryRequest(category="some_category", contents={"any": "thing"})
+        with patch.object(config_manager, "_write_user_config_delta", return_value=False):
+            result = config_manager.on_handle_set_config_category_request(request)
+
+        assert isinstance(result, SetConfigCategoryResultFailure)
+        assert received == []
+
+    def test_set_config_value_request_returns_failure_when_write_fails(self) -> None:
+        """The set-value handler must surface a failure result when the write didn't land."""
+        from griptape_nodes.retained_mode.events.config_events import (
+            SetConfigValueRequest,
+            SetConfigValueResultFailure,
+        )
+
+        event_manager = EventManager()
+        config_manager = ConfigManager(event_manager=event_manager)
+
+        received: list[ConfigChanged] = []
+        event_manager.add_listener_to_app_event(ConfigChanged, received.append)
+
+        request = SetConfigValueRequest(category_and_key="some.key", value="v")
+        with patch.object(config_manager, "_write_user_config_delta", return_value=False):
+            result = config_manager.on_handle_set_config_value_request(request)
+
+        assert isinstance(result, SetConfigValueResultFailure)
+        assert received == []
+
+    def test_set_config_value_returns_true_on_success_and_false_on_failure(self) -> None:
+        """``set_config_value`` exposes the write outcome so handlers can propagate failure."""
+        config_manager = ConfigManager()
+
+        with patch.object(config_manager, "_write_user_config_delta", return_value=True):
+            assert config_manager.set_config_value(key="k", value="v") is True
+
+        with patch.object(config_manager, "_write_user_config_delta", return_value=False):
+            assert config_manager.set_config_value(key="k", value="v") is False

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -1,6 +1,7 @@
 """Test EventManager functionality including sync/async event broadcasting."""
 
 import asyncio
+import logging
 import threading
 from dataclasses import dataclass
 from unittest.mock import AsyncMock
@@ -12,7 +13,10 @@ from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.events.base_events import (
     EventResultSuccess,
     RequestPayload,
+    ResultDetail,
+    ResultDetails,
     ResultPayloadSuccess,
+    StrictModeViolationDetail,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -341,3 +345,69 @@ class TestBroadcastAppEventLoopSafety:
 
         assert "listener_loop" in captured
         assert captured["listener_loop"] is not caller_loop
+
+
+class TestLogResultDetailsSkipsStrictModeViolations:
+    """``_log_result_details`` must not duplicate strict-mode violation logs.
+
+    ``StrictModeReporter.report`` already logs each violation at
+    detection time with the scope's ``node=... library=...`` prefix
+    (see ``StrictModeReporter`` in ``common/strict_mode.py``).
+    Without the skip in ``_log_result_details`` every violation
+    that is also attached to the result payload would log a second
+    time as a bare message, doubling the noise in the worker log
+    that motivated the fix.
+    """
+
+    def _make_result_with_details(self, *details: ResultDetail) -> _ProbeResult:
+        return _ProbeResult(result_details=ResultDetails(*details))
+
+    def test_strict_mode_violation_details_are_not_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        event_manager = EventManager()
+        violation = StrictModeViolationDetail(
+            level=logging.WARNING,
+            message="violation message that must not appear here",
+            rule_id="parameter-mutation-during-aprocess",
+            severity="warning",
+            subject="some-node",
+            library_name="some-library",
+        )
+        result = self._make_result_with_details(violation)
+
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes")
+        event_manager._log_result_details(result)
+
+        assert violation.message not in [r.message for r in caplog.records]
+
+    def test_non_violation_details_still_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        event_manager = EventManager()
+        ordinary = ResultDetail(level=logging.WARNING, message="ordinary detail")
+        result = self._make_result_with_details(ordinary)
+
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes")
+        event_manager._log_result_details(result)
+
+        assert ordinary.message in [r.message for r in caplog.records]
+
+    def test_mixed_details_log_only_non_violations(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A result with both kinds: the ordinary detail logs, the
+        violation does not.
+        """
+        event_manager = EventManager()
+        ordinary = ResultDetail(level=logging.WARNING, message="ordinary mixed-case detail")
+        violation = StrictModeViolationDetail(
+            level=logging.WARNING,
+            message="mixed-case violation message",
+            rule_id="parameter-mutation-during-aprocess",
+            severity="warning",
+            subject="n",
+            library_name=None,
+        )
+        result = self._make_result_with_details(ordinary, violation)
+
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes")
+        event_manager._log_result_details(result)
+
+        messages = [r.message for r in caplog.records]
+        assert ordinary.message in messages
+        assert violation.message not in messages

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -390,8 +390,9 @@ class TestLogResultDetailsSkipsStrictModeViolations:
         assert ordinary.message in [r.message for r in caplog.records]
 
     def test_mixed_details_log_only_non_violations(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A result with both kinds: the ordinary detail logs, the
-        violation does not.
+        """A result with both kinds logs only the non-violation detail.
+
+        The ordinary detail logs; the violation does not.
         """
         event_manager = EventManager()
         ordinary = ResultDetail(level=logging.WARNING, message="ordinary mixed-case detail")

--- a/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
@@ -1,0 +1,154 @@
+"""Tests for the reentrant-bus-in-init strict-mode tripwire.
+
+EventManager.handle_request / ahandle_request consult
+``LibraryRegistry.is_constructing_node()`` on every dispatch. When that
+flag is set (a node ``__init__`` is currently running on the calling
+task) and a strict-mode scope is open, the manager records a
+``reentrant-bus-in-init`` violation against the active scope. The
+detector is correctness-class: severity is ERROR on both sides.
+
+Outside of node construction, dispatch must not record a violation.
+Outside of any strict-mode scope, ``STRICT_MODE.report`` is a no-op so
+the reentrant call still goes through without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+    StrictModeSeverity,
+)
+
+# Intentional reach into a private module symbol: the public read API is
+# LibraryRegistry.is_constructing_node(), but there is no public setter --
+# the flag is set only inside LibraryRegistry.create_node. Tests need to
+# simulate "we are inside __init__" without calling create_node, so they
+# manipulate the underlying ContextVar directly. Keeping this private
+# avoids growing the registry's public surface for test-only plumbing.
+from griptape_nodes.node_library.library_registry import _constructing_node
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+
+@dataclass(kw_only=True)
+class _ProbeRequest(RequestPayload):
+    """Minimal request used to exercise the dispatch path."""
+
+    marker: str
+
+
+@dataclass(kw_only=True)
+class _ProbeResult(ResultPayloadSuccess):
+    seen_by: str
+
+
+def _make_event_manager_with_probe_handler() -> EventManager:
+    event_manager = EventManager()
+
+    async def handler(request: _ProbeRequest) -> _ProbeResult:
+        return _ProbeResult(seen_by=request.marker, result_details="ok")
+
+    event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+    return event_manager
+
+
+class TestReentrantBusInInit:
+    """The tripwire records one violation per request dispatched during __init__."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_during_node_init_records_violation(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="MyNodeClass",
+                library_name="libA",
+                is_worker=True,
+            ) as scope:
+                result = await event_manager.ahandle_request(_ProbeRequest(marker="m1"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert result.succeeded()
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "reentrant-bus-in-init"
+        assert violation.severity is StrictModeSeverity.ERROR
+        assert violation.subject == "MyNodeClass"
+        assert violation.library_name == "libA"
+        assert "_ProbeRequest" in violation.message
+
+    def test_sync_dispatch_during_node_init_records_violation(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="MyNodeClass",
+                library_name="libA",
+                is_worker=True,
+            ) as scope:
+                result = event_manager.handle_request(_ProbeRequest(marker="m2"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert result.succeeded()
+        assert len(scope.violations) == 1
+        assert scope.violations[0].rule_id == "reentrant-bus-in-init"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_outside_node_init_records_no_violation(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyNodeClass",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            result = await event_manager.ahandle_request(_ProbeRequest(marker="m3"))
+
+        assert result.succeeded()
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_during_node_init_with_no_scope_does_not_crash(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            result = await event_manager.ahandle_request(_ProbeRequest(marker="m4"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert result.succeeded()
+
+    @pytest.mark.asyncio
+    async def test_severity_is_error_on_orchestrator(self) -> None:
+        """Correctness rules fail on both sides; orchestrator scope still gets ERROR."""
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-1",
+                library_name="libA",
+                is_worker=False,
+            ) as scope:
+                await event_manager.ahandle_request(_ProbeRequest(marker="m5"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert scope.violations[0].severity is StrictModeSeverity.ERROR

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -36,7 +36,7 @@ def _make_mock_obj_mgr(existing_node: MagicMock | None = None) -> MagicMock:
 
 def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     lib_mgr = MagicMock()
-    lib_mgr.is_worker.return_value = is_worker
+    lib_mgr.is_worker = is_worker
     lib_mgr.get_worker_for_library.return_value = None
     return lib_mgr
 
@@ -429,7 +429,7 @@ class TestExecuteNodeWorkerRoute:
             }
         )
         lib_mgr = MagicMock()
-        lib_mgr.is_worker.return_value = False
+        lib_mgr.is_worker = False
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         with (
@@ -463,7 +463,7 @@ class TestExecuteNodeWorkerRoute:
             }
         )
         lib_mgr = MagicMock()
-        lib_mgr.is_worker.return_value = False
+        lib_mgr.is_worker = False
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         with (
@@ -497,7 +497,7 @@ class TestExecuteNodeWorkerRoute:
         wm = MagicMock()
         wm.route_to_worker = AsyncMock()
         lib_mgr = MagicMock()
-        lib_mgr.is_worker.return_value = True
+        lib_mgr.is_worker = True
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         with (

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -36,7 +36,7 @@ def _make_mock_obj_mgr(existing_node: MagicMock | None = None) -> MagicMock:
 
 def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     lib_mgr = MagicMock()
-    lib_mgr._is_worker = is_worker
+    lib_mgr.is_worker.return_value = is_worker
     lib_mgr.get_worker_for_library.return_value = None
     return lib_mgr
 
@@ -429,7 +429,7 @@ class TestExecuteNodeWorkerRoute:
             }
         )
         lib_mgr = MagicMock()
-        lib_mgr._is_worker = False
+        lib_mgr.is_worker.return_value = False
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         with (
@@ -463,7 +463,7 @@ class TestExecuteNodeWorkerRoute:
             }
         )
         lib_mgr = MagicMock()
-        lib_mgr._is_worker = False
+        lib_mgr.is_worker.return_value = False
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         with (
@@ -497,7 +497,7 @@ class TestExecuteNodeWorkerRoute:
         wm = MagicMock()
         wm.route_to_worker = AsyncMock()
         lib_mgr = MagicMock()
-        lib_mgr._is_worker = True
+        lib_mgr.is_worker.return_value = True
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         with (

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -1,0 +1,212 @@
+"""Probe-level tests for strict-mode routing in _serialize_library_node_schemas.
+
+Uses a fixture probe detector that calls ``STRICT_MODE.report`` from inside a
+node class's ``__init__``. The scope wrapper on the probe loop is then
+responsible for excluding violating classes from the returned schema list.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.exe_types.core_types import Parameter, Trait
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+
+
+@pytest.fixture
+def patched_registry() -> Callable[[dict[str, type]], AbstractContextManager[None]]:
+    """Yield a context-manager factory that patches LibraryRegistry for a probe map.
+
+    Both test classes need the same MagicMock-backed library plus the
+    same ``create_node`` side-effect that constructs an instance from
+    the probe map. Returning a factory keeps the per-test ``nodes``
+    parameter readable at the call site.
+    """
+
+    @contextmanager
+    def _patch(nodes: dict[str, type]) -> Iterator[None]:
+        lib = MagicMock()
+        lib.get_registered_nodes.return_value = list(nodes.keys())
+        lib.get_node_class.side_effect = lambda name: nodes[name]
+
+        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
+            return nodes[node_type](name)
+
+        with patch.multiple(
+            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
+            get_library=MagicMock(return_value=lib),
+            create_node=MagicMock(side_effect=_create_node),
+        ):
+            yield
+
+    return _patch
+
+
+class _CleanProbe:
+    """Node class whose __init__ does nothing interesting."""
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _ViolatingProbe:
+    """Node class whose __init__ triggers a correctness-class violation.
+
+    Uses ``reentrant-bus-in-init`` because it is registered with
+    ``correctness=True``; the LOAD_PROBE skip-on-correctness gate uses
+    that flag to decide whether to drop the class from the schema.
+    """
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        STRICT_MODE.report(
+            rule_id="reentrant-bus-in-init",
+            message="fixture probe violation",
+        )
+
+
+class TestSerializeSchemasStrictMode:
+    @pytest.mark.asyncio
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Clean": _CleanProbe}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["Clean"]
+
+    @pytest.mark.asyncio
+    async def test_violating_class_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        # Violating class dropped from output.
+        assert [s.class_name for s in schemas] == ["Clean"]
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("fixture probe violation" in r.getMessage() for r in errors)
+        assert any("class=Violator" in r.getMessage() for r in errors)
+
+
+class _DummyTrait(Trait):
+    """Minimal concrete Trait used to exercise the trait-detection path."""
+
+    @classmethod
+    def get_trait_keys(cls) -> list[str]:
+        return ["dummy"]
+
+
+class _ProbeWithConverterParam:
+    """Node class whose probe exposes a Parameter with a user-attached converter."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [
+            Parameter(name="p_with_converter", converters=[lambda v: v]),
+        ]
+
+
+class _ProbeWithValidatorParam:
+    """Node class whose probe exposes a Parameter with a user-attached validator."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [
+            Parameter(name="p_with_validator", validators=[lambda _p, _v: None]),
+        ]
+
+
+class _ProbeWithTraitParam:
+    """Node class whose probe exposes a Parameter with a real Trait child."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [
+            Parameter(name="p_with_trait", traits={_DummyTrait()}),
+        ]
+
+
+class _ProbeWithCleanParams:
+    """Node class whose probe parameter has no converters/validators/traits."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [Parameter(name="p_clean")]
+
+
+class TestParameterBehaviorsDropped:
+    """#4472: Parameters carrying converters/validators/traits emit a warn violation."""
+
+    @pytest.mark.asyncio
+    async def test_clean_parameters_produce_no_violation(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Clean": _ProbeWithCleanParams}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["Clean"]
+        assert not any("p_clean" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_parameter_with_converter_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        # Warning, not error: the class still yields a schema.
+        assert [s.class_name for s in schemas] == ["WithBehavior"]
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("p_with_converter" in r.getMessage() for r in warnings)
+        assert any("converters" in r.getMessage() for r in warnings)
+        assert any("class=WithBehavior" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_parameter_with_validator_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["WithValidator"]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("p_with_validator" in r.getMessage() for r in warnings)
+        assert any("validators" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_parameter_with_trait_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithTrait": _ProbeWithTraitParam}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["WithTrait"]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("p_with_trait" in r.getMessage() for r in warnings)
+        assert any("traits" in r.getMessage() for r in warnings)

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -21,10 +21,10 @@ from griptape_nodes.retained_mode.events.execution_events import (
     ExecuteNodeRequest,
     ExecuteNodeResultFailure,
     ExecuteNodeResultSuccess,
-    NodeMetadata,
 )
 
 if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.execution_events import NodeMetadata
     from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
 

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -1,0 +1,156 @@
+"""Handler-level tests for strict-mode routing in on_execute_node_request.
+
+Uses a fixture runtime detector that calls ``STRICT_MODE.report`` inside
+``node.aprocess`` to simulate a rule firing during execution. The scope
+wrapper on ``on_execute_node_request`` is then responsible for turning
+worker violations into ``ExecuteNodeResultFailure`` and leaving
+orchestrator violations alone.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultFailure,
+    ExecuteNodeResultSuccess,
+    NodeMetadata,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+
+class TestExecuteNodeStrictMode:
+    def _get_node_manager(self) -> NodeManager:
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        return GriptapeNodes.NodeManager()
+
+    def _make_mock_node(self, *, aprocess_reports: bool = False) -> MagicMock:
+        node = MagicMock(spec=BaseNode)
+        node.name = "n"
+        node.parameter_values = {}
+        node.parameter_output_values = {"out": 1}
+        node.metadata = {"library": "libA"}
+        node._cancellation_requested = threading.Event()
+        node.parameters = []
+
+        async def _aprocess() -> None:
+            if aprocess_reports:
+                STRICT_MODE.report(rule_id="fixture-rule", message="fixture violation")
+
+        node.aprocess = AsyncMock(side_effect=_aprocess)
+        return node
+
+    def _make_mock_obj_mgr(self, existing_node: MagicMock) -> MagicMock:
+        m = MagicMock()
+        m.attempt_get_object_by_name_as_type.return_value = existing_node
+        return m
+
+    def _make_mock_library_manager(self, *, is_worker: bool) -> MagicMock:
+        m = MagicMock()
+        m.is_worker = is_worker
+        m._is_worker = is_worker
+        m.get_worker_for_library.return_value = None
+        return m
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_violation_stays_success(self) -> None:
+        node = self._make_mock_node(aprocess_reports=True)
+        obj_mgr = self._make_mock_obj_mgr(existing_node=node)
+        lib_mgr = self._make_mock_library_manager(is_worker=False)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
+                return_value=obj_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
+                return_value=None,
+            ),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await self._get_node_manager().on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_violation_elevates_to_failure(self) -> None:
+        node = self._make_mock_node(aprocess_reports=True)
+        lib_mgr = self._make_mock_library_manager(is_worker=True)
+        node_manager = self._get_node_manager()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        details = str(result.result_details)
+        assert "fixture-rule" in details
+        assert "fixture violation" in details
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_no_violations_unchanged(self) -> None:
+        node = self._make_mock_node(aprocess_reports=False)
+        lib_mgr = self._make_mock_library_manager(is_worker=True)
+        node_manager = self._get_node_manager()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_no_violations_unchanged(self) -> None:
+        node = self._make_mock_node(aprocess_reports=False)
+        obj_mgr = self._make_mock_obj_mgr(existing_node=node)
+        lib_mgr = self._make_mock_library_manager(is_worker=False)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
+                return_value=obj_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
+                return_value=None,
+            ),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await self._get_node_manager().on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()

--- a/tests/unit/retained_mode/managers/test_secrets_manager.py
+++ b/tests/unit/retained_mode/managers/test_secrets_manager.py
@@ -2,7 +2,7 @@ import os
 import platform
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -178,3 +178,82 @@ class TestSecretsManager:
                 result = secrets_manager.secrets_to_register
 
                 assert result == {"KEY1": "default1", "KEY2": "", "KEY3": "default3"}
+
+    def test_refresh_from_env_file_overrides_stale_environ(self) -> None:
+        """refresh_from_env_file re-reads the global .env and overrides os.environ.
+
+        This is the behavior that makes same-machine secret propagation work: a
+        worker boots with the file contents captured into os.environ, then the
+        orchestrator updates the shared file, and the worker must see the new
+        value on the next get_secret() call -- which reads os.environ first.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            global_env.write_text("REFRESH_KEY=old_value\n")
+
+            with patch.dict(os.environ, {"REFRESH_KEY": "old_value"}, clear=False):
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    # Simulate the orchestrator rewriting the shared file.
+                    global_env.write_text("REFRESH_KEY=new_value\n")
+                    # Without refresh, os.environ still holds the boot value.
+                    assert os.environ["REFRESH_KEY"] == "old_value"
+
+                    secrets_manager.refresh_from_env_file()
+
+                    assert os.environ["REFRESH_KEY"] == "new_value"
+                    assert secrets_manager.get_secret("REFRESH_KEY") == "new_value"
+
+    def test_set_secret_broadcasts_secret_changed(self) -> None:
+        """Setting a secret emits a SecretChanged app event carrying the normalized key."""
+        from griptape_nodes.retained_mode.events.app_events import SecretChanged
+        from griptape_nodes.retained_mode.events.secrets_events import SetSecretValueRequest
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            config_manager = ConfigManager()
+            config_manager.workspace_path = workspace_path
+            event_manager = MagicMock()
+
+            with (
+                patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env),
+                patch.object(SecretsManager, "_notify_workers_to_refresh_secrets"),
+            ):
+                secrets_manager = SecretsManager(config_manager, event_manager=event_manager)
+                secrets_manager.on_handle_set_secret_request(
+                    SetSecretValueRequest(key="my api key", value="xyz"),
+                )
+
+            broadcast_calls = [
+                call
+                for call in event_manager.broadcast_app_event.call_args_list
+                if isinstance(call.args[0], SecretChanged)
+            ]
+            assert len(broadcast_calls) == 1
+            assert broadcast_calls[0].args[0].key == "MY_API_KEY"
+
+    def test_set_secret_triggers_worker_refresh_broadcast(self) -> None:
+        """Setting a secret schedules a refresh broadcast to all workers."""
+        from griptape_nodes.retained_mode.events.secrets_events import SetSecretValueRequest
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            config_manager = ConfigManager()
+            config_manager.workspace_path = workspace_path
+
+            with (
+                patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env),
+                patch.object(SecretsManager, "_notify_workers_to_refresh_secrets") as mock_broadcast,
+            ):
+                secrets_manager = SecretsManager(config_manager, event_manager=MagicMock())
+                secrets_manager.on_handle_set_secret_request(
+                    SetSecretValueRequest(key="MY_KEY", value="xyz"),
+                )
+
+            mock_broadcast.assert_called_once()

--- a/tests/unit/retained_mode/managers/test_secrets_manager.py
+++ b/tests/unit/retained_mode/managers/test_secrets_manager.py
@@ -582,10 +582,10 @@ class TestSecretsManager:
                     assert os.environ["CASCADE_KEY"] == "global_cascade"
                     assert "CASCADE_KEY" in secrets_manager._managed_env_keys
 
-    def test_full_lifecycle_keeps_bookkeeping_invariant(self) -> None:
-        """Drive boot -> set_secret -> refresh -> delete -> refresh and verify
-        the manager's bookkeeping invariant survives each step.
+    def test_full_lifecycle_keeps_bookkeeping_invariant(self) -> None:  # noqa: PLR0915
+        """Drive a full secret lifecycle and verify the bookkeeping invariant survives each step.
 
+        Sequence: boot -> set_secret -> refresh -> delete -> refresh.
         The invariant: every key in ``_managed_env_keys`` is in
         ``os.environ`` with the value the manager last installed. Drift
         between the two would let ``get_secret`` return stale values or
@@ -608,8 +608,7 @@ class TestSecretsManager:
                 assert key in os.environ, f"managed key {key!r} missing from os.environ"
                 if key in merged:
                     assert os.environ[key] == merged[key], (
-                        f"managed key {key!r} has os.environ value {os.environ[key]!r} "
-                        f"but file says {merged[key]!r}"
+                        f"managed key {key!r} has os.environ value {os.environ[key]!r} but file says {merged[key]!r}"
                     )
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/retained_mode/managers/test_secrets_manager.py
+++ b/tests/unit/retained_mode/managers/test_secrets_manager.py
@@ -209,7 +209,12 @@ class TestSecretsManager:
                     assert secrets_manager.get_secret("REFRESH_KEY") == "new_value"
 
     def test_set_secret_broadcasts_secret_changed(self) -> None:
-        """Setting a secret emits a SecretChanged app event carrying the normalized key."""
+        """Setting a secret emits a SecretChanged app event carrying the normalized key.
+
+        Worker fan-out lives elsewhere (WorkerManager listens for SecretChanged
+        and schedules RefreshSecretsRequest); this manager only owns the
+        domain event.
+        """
         from griptape_nodes.retained_mode.events.app_events import SecretChanged
         from griptape_nodes.retained_mode.events.secrets_events import SetSecretValueRequest
 
@@ -220,10 +225,7 @@ class TestSecretsManager:
             config_manager.workspace_path = workspace_path
             event_manager = MagicMock()
 
-            with (
-                patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env),
-                patch.object(SecretsManager, "_notify_workers_to_refresh_secrets"),
-            ):
+            with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
                 secrets_manager = SecretsManager(config_manager, event_manager=event_manager)
                 secrets_manager.on_handle_set_secret_request(
                     SetSecretValueRequest(key="my api key", value="xyz"),
@@ -236,24 +238,3 @@ class TestSecretsManager:
             ]
             assert len(broadcast_calls) == 1
             assert broadcast_calls[0].args[0].key == "MY_API_KEY"
-
-    def test_set_secret_triggers_worker_refresh_broadcast(self) -> None:
-        """Setting a secret schedules a refresh broadcast to all workers."""
-        from griptape_nodes.retained_mode.events.secrets_events import SetSecretValueRequest
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            workspace_path = Path(temp_dir)
-            global_env = workspace_path / "global.env"
-            config_manager = ConfigManager()
-            config_manager.workspace_path = workspace_path
-
-            with (
-                patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env),
-                patch.object(SecretsManager, "_notify_workers_to_refresh_secrets") as mock_broadcast,
-            ):
-                secrets_manager = SecretsManager(config_manager, event_manager=MagicMock())
-                secrets_manager.on_handle_set_secret_request(
-                    SetSecretValueRequest(key="MY_KEY", value="xyz"),
-                )
-
-            mock_broadcast.assert_called_once()

--- a/tests/unit/retained_mode/managers/test_secrets_manager.py
+++ b/tests/unit/retained_mode/managers/test_secrets_manager.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import platform
 import tempfile
@@ -180,24 +181,35 @@ class TestSecretsManager:
                 assert result == {"KEY1": "default1", "KEY2": "", "KEY3": "default3"}
 
     def test_refresh_from_env_file_overrides_stale_environ(self) -> None:
-        """refresh_from_env_file re-reads the global .env and overrides os.environ.
+        """refresh_from_env_file re-reads the global .env and overrides os.environ for managed keys.
 
         This is the behavior that makes same-machine secret propagation work: a
-        worker boots with the file contents captured into os.environ, then the
-        orchestrator updates the shared file, and the worker must see the new
-        value on the next get_secret() call -- which reads os.environ first.
+        worker boots with the file contents installed into os.environ via
+        ``load_dotenv``, then the orchestrator updates the shared file, and the
+        worker must see the new value on the next get_secret() call -- which
+        reads os.environ first.
+
+        The key here is *managed* (the manager itself installed it from the
+        file at boot, since no OS-set var pre-existed). Refresh therefore
+        owns the override.
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             workspace_path = Path(temp_dir)
             global_env = workspace_path / "global.env"
             global_env.write_text("REFRESH_KEY=old_value\n")
 
-            with patch.dict(os.environ, {"REFRESH_KEY": "old_value"}, clear=False):
+            # Make sure no OS-set REFRESH_KEY pre-exists; the manager must
+            # install it from the file at boot for it to count as managed.
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("REFRESH_KEY", None)
                 config_manager = ConfigManager()
                 config_manager.workspace_path = workspace_path
 
                 with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
                     secrets_manager = SecretsManager(config_manager)
+                    # Boot installed the file value into os.environ.
+                    assert os.environ["REFRESH_KEY"] == "old_value"
+
                     # Simulate the orchestrator rewriting the shared file.
                     global_env.write_text("REFRESH_KEY=new_value\n")
                     # Without refresh, os.environ still holds the boot value.
@@ -238,3 +250,477 @@ class TestSecretsManager:
             ]
             assert len(broadcast_calls) == 1
             assert broadcast_calls[0].args[0].key == "MY_API_KEY"
+
+    def test_refresh_preserves_os_set_env_var(self) -> None:
+        """A real OS env var that collides with a .env entry must survive refresh.
+
+        Boot uses ``override=False`` so a container-injected value (e.g.
+        ``OPENAI_API_KEY`` set on the container, not by the manager) wins over
+        the file at startup. ``refresh_from_env_file`` must preserve that
+        precedence: an unrelated secret-change broadcast cannot silently
+        replace the operator-set value with the file's value.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            global_env.write_text("CONTAINER_INJECTED_KEY=file_value\n")
+
+            with patch.dict(os.environ, {"CONTAINER_INJECTED_KEY": "operator_value"}, clear=False):
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    # Boot did not overwrite the OS-set value, and the
+                    # bookkeeping invariant says the manager does not own it.
+                    assert os.environ["CONTAINER_INJECTED_KEY"] == "operator_value"
+                    assert "CONTAINER_INJECTED_KEY" not in secrets_manager._managed_env_keys
+
+                    # Simulate the orchestrator rewriting the file. (The
+                    # rewrite is unrelated to CONTAINER_INJECTED_KEY in
+                    # production -- it could be any other secret -- but the
+                    # refresh runs the same code path against this key.)
+                    global_env.write_text("CONTAINER_INJECTED_KEY=changed_in_file\n")
+
+                    secrets_manager.refresh_from_env_file()
+
+                    # The operator-set value still wins, and the manager
+                    # still does not claim ownership of it.
+                    assert os.environ["CONTAINER_INJECTED_KEY"] == "operator_value"
+                    assert secrets_manager.get_secret("CONTAINER_INJECTED_KEY") == "operator_value"
+                    assert "CONTAINER_INJECTED_KEY" not in secrets_manager._managed_env_keys
+
+    def test_refresh_does_not_pop_os_set_env_var_when_file_changes(self) -> None:
+        """A previously-tracked key removed from the file must not pop a real OS env var.
+
+        Pre-fix, ``_loaded_env_keys`` tracked every key the manager had ever
+        seen in a file. If a key was both OS-set *and* in a .env file, removing
+        it from the file caused refresh to pop ``os.environ[key]``, deleting
+        operator-set state the manager never owned.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            global_env.write_text("DUAL_HOMED_KEY=file_value\n")
+
+            with patch.dict(os.environ, {"DUAL_HOMED_KEY": "operator_value"}, clear=False):
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    # File no longer has the key (removed externally between
+                    # boot and refresh).
+                    global_env.write_text("UNRELATED_KEY=anything\n")
+
+                    secrets_manager.refresh_from_env_file()
+
+                    # Operator-set value survives, and the manager never
+                    # claimed ownership of it.
+                    assert os.environ.get("DUAL_HOMED_KEY") == "operator_value"
+                    assert "DUAL_HOMED_KEY" not in secrets_manager._managed_env_keys
+
+    def test_refresh_with_no_files_present_does_not_wipe_managed_keys(self) -> None:
+        """If both .env files vanish at refresh time, do not pop anything.
+
+        Pre-fix, an empty ``present_anywhere`` set caused every previously
+        tracked key to be popped in one pass -- a transient missing file
+        could wipe the worker's entire secret cache.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            global_env.write_text("MANAGED_KEY=installed_value\n")
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("MANAGED_KEY", None)
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    # Boot installed the value; key is managed.
+                    assert os.environ["MANAGED_KEY"] == "installed_value"
+                    assert "MANAGED_KEY" in secrets_manager._managed_env_keys
+
+                    # Both files vanish (transient state during a swap, etc.).
+                    global_env.unlink()
+
+                    secrets_manager.refresh_from_env_file()
+
+                    # The managed value survives -- a missing file is not
+                    # license to wipe state -- and ownership is preserved.
+                    assert os.environ.get("MANAGED_KEY") == "installed_value"
+                    assert "MANAGED_KEY" in secrets_manager._managed_env_keys
+
+    def test_refresh_pops_managed_key_when_file_actually_removes_it(self) -> None:
+        """The pop pass *does* run for managed keys when files exist but the key vanishes.
+
+        This is the productive case the original code was reaching for:
+        if the manager installed a key from a file at boot, and that key
+        is later removed from the file, refresh should clear it from
+        ``os.environ`` so the worker's view tracks the file. The fix
+        must not regress this.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            global_env.write_text("DELETABLE_KEY=installed_value\n")
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("DELETABLE_KEY", None)
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    assert os.environ["DELETABLE_KEY"] == "installed_value"
+                    assert "DELETABLE_KEY" in secrets_manager._managed_env_keys
+
+                    # File still exists, but the key is gone.
+                    global_env.write_text("OTHER_KEY=other_value\n")
+
+                    secrets_manager.refresh_from_env_file()
+
+                    # Managed key dropped from os.environ and from the
+                    # ownership set; OTHER_KEY installed and now owned.
+                    assert "DELETABLE_KEY" not in os.environ
+                    assert "DELETABLE_KEY" not in secrets_manager._managed_env_keys
+                    assert os.environ["OTHER_KEY"] == "other_value"
+                    assert "OTHER_KEY" in secrets_manager._managed_env_keys
+
+    def test_delete_secret_does_not_pop_os_set_env_var(self) -> None:
+        """``DeleteSecretValueRequest`` must not pop a colliding OS-set env var.
+
+        Same Finding-2 shape on the explicit delete path: pre-fix, the
+        handler called ``os.environ.pop(secret_name, None)`` unconditionally,
+        so deleting a secret from the file would also wipe a colliding
+        operator-set env var. The new code only pops keys the manager owns.
+        """
+        from griptape_nodes.retained_mode.events.secrets_events import DeleteSecretValueRequest
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+            global_env.write_text("DELETE_DUAL_KEY=file_value\n")
+
+            with patch.dict(os.environ, {"DELETE_DUAL_KEY": "operator_value"}, clear=False):
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    # Operator value survived boot, manager does not own it.
+                    assert os.environ["DELETE_DUAL_KEY"] == "operator_value"
+                    assert "DELETE_DUAL_KEY" not in secrets_manager._managed_env_keys
+
+                    secrets_manager.on_handle_delete_secret_value_request(
+                        DeleteSecretValueRequest(key="DELETE_DUAL_KEY"),
+                    )
+
+                    # File entry is gone (the handler unset it), but the
+                    # operator's OS env var survives. Ownership is unchanged.
+                    assert os.environ.get("DELETE_DUAL_KEY") == "operator_value"
+                    assert "DELETE_DUAL_KEY" not in secrets_manager._managed_env_keys
+
+    def test_set_secret_overrides_os_set_env_var(self) -> None:
+        """``set_secret`` is an explicit user write -- override is intended.
+
+        Unlike refresh and delete, ``set_secret`` is the user stating
+        "this value, from now on." It must overwrite a colliding OS-set
+        env var (the inverse-policy case is delegated to operators
+        managing their environment) and claim ownership of the key for
+        future refresh-time decisions.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+
+            with patch.dict(os.environ, {"USER_SET_KEY": "stale_operator_value"}, clear=False):
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    assert "USER_SET_KEY" not in secrets_manager._managed_env_keys
+                    secrets_manager.set_secret("USER_SET_KEY", "explicit_new_value")
+
+                    assert os.environ["USER_SET_KEY"] == "explicit_new_value"
+                    # set_secret claims ownership.
+                    assert "USER_SET_KEY" in secrets_manager._managed_env_keys
+                    # Subsequent refresh keeps the manager-owned value.
+                    secrets_manager.refresh_from_env_file()
+                    assert os.environ["USER_SET_KEY"] == "explicit_new_value"
+                    assert "USER_SET_KEY" in secrets_manager._managed_env_keys
+
+    def test_set_secret_warns_when_overriding_os_set_env_var(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Operator-set values are silently clobbered by ``set_secret``; warn loudly.
+
+        ``set_secret`` honors the user's stated intent (override and claim
+        ownership), but the asymmetry with ``refresh`` and the delete
+        handler -- both of which preserve OS-set values -- is easy to miss
+        without a warning. A noisy log line is the price of admission so
+        the operator notices and can decide whether to clear the OS-set
+        value or revert the file write.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+
+            with patch.dict(os.environ, {"WARN_KEY": "stale_operator_value"}, clear=False):
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    caplog.set_level(logging.WARNING, logger="griptape_nodes")
+                    secrets_manager.set_secret("WARN_KEY", "explicit_new_value")
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("WARN_KEY" in r.message and "OS-set" in r.message for r in warning_records), (
+            "Expected a WARNING-level log mentioning the overridden OS-set key."
+        )
+
+    def test_set_secret_does_not_warn_for_brand_new_key(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No OS-set collision -> no warning.
+
+        Counterpart to ``test_set_secret_warns_when_overriding_os_set_env_var``:
+        the warning is gated on a real collision so a normal ``set_secret``
+        on a fresh key stays quiet.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("FRESH_KEY", None)
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    secrets_manager = SecretsManager(config_manager)
+                    caplog.set_level(logging.WARNING, logger="griptape_nodes")
+                    secrets_manager.set_secret("FRESH_KEY", "fresh_value")
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("FRESH_KEY" in r.message for r in warning_records), (
+            "set_secret on a non-OS-set key should not warn."
+        )
+
+    def test_refresh_merges_workspace_over_global(self) -> None:
+        """Workspace .env wins over global .env on refresh, mirroring get_secret.
+
+        The two-file merge code path was previously untested under refresh.
+        This pins down that workspace beats global for keys present in
+        both, that workspace-only keys install correctly, and that
+        global-only keys install correctly.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            workspace_env = workspace_path / ".env"
+            global_env = workspace_path / "global.env"
+
+            with patch.dict(os.environ, {}, clear=False):
+                for k in ("DUAL_KEY", "WS_ONLY_KEY", "GLOBAL_ONLY_KEY"):
+                    os.environ.pop(k, None)
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    workspace_env.write_text("DUAL_KEY=workspace_dual\nWS_ONLY_KEY=workspace_only\n")
+                    global_env.write_text("DUAL_KEY=global_dual\nGLOBAL_ONLY_KEY=global_only\n")
+
+                    secrets_manager = SecretsManager(config_manager)
+                    # Boot already merged with workspace winning.
+                    assert os.environ["DUAL_KEY"] == "workspace_dual"
+                    assert os.environ["WS_ONLY_KEY"] == "workspace_only"
+                    assert os.environ["GLOBAL_ONLY_KEY"] == "global_only"
+
+                    # Rotate values in both files; workspace must still win
+                    # for the dual-homed key after refresh.
+                    workspace_env.write_text("DUAL_KEY=workspace_dual_v2\nWS_ONLY_KEY=workspace_only_v2\n")
+                    global_env.write_text("DUAL_KEY=global_dual_v2\nGLOBAL_ONLY_KEY=global_only_v2\n")
+
+                    secrets_manager.refresh_from_env_file()
+
+                    assert os.environ["DUAL_KEY"] == "workspace_dual_v2"
+                    assert os.environ["WS_ONLY_KEY"] == "workspace_only_v2"
+                    assert os.environ["GLOBAL_ONLY_KEY"] == "global_only_v2"
+
+    def test_refresh_dual_homed_key_drops_to_global_when_workspace_removes_it(self) -> None:
+        """Removing a key from workspace falls back to its global value.
+
+        The ``get_secret`` precedence is workspace > global > none. When
+        workspace removes a key that global still has, refresh must drop
+        the resolution down to the global value rather than popping the
+        key entirely.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            workspace_env = workspace_path / ".env"
+            global_env = workspace_path / "global.env"
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("CASCADE_KEY", None)
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    workspace_env.write_text("CASCADE_KEY=workspace_cascade\n")
+                    global_env.write_text("CASCADE_KEY=global_cascade\n")
+
+                    secrets_manager = SecretsManager(config_manager)
+                    assert os.environ["CASCADE_KEY"] == "workspace_cascade"
+                    assert "CASCADE_KEY" in secrets_manager._managed_env_keys
+
+                    # Workspace removes the key; global still has it.
+                    workspace_env.write_text("")
+
+                    secrets_manager.refresh_from_env_file()
+
+                    # Falls back to the global value, still managed.
+                    assert os.environ["CASCADE_KEY"] == "global_cascade"
+                    assert "CASCADE_KEY" in secrets_manager._managed_env_keys
+
+    def test_full_lifecycle_keeps_bookkeeping_invariant(self) -> None:
+        """Drive boot -> set_secret -> refresh -> delete -> refresh and verify
+        the manager's bookkeeping invariant survives each step.
+
+        The invariant: every key in ``_managed_env_keys`` is in
+        ``os.environ`` with the value the manager last installed. Drift
+        between the two would let ``get_secret`` return stale values or
+        mask operator-set OS env vars. The invariant is held by routing
+        every ``os.environ`` mutation through ``_install_managed`` /
+        ``_uninstall_managed``; this test guards against a future change
+        that adds a fifth bookkeeping site that forgets to call them.
+
+        Stronger property each step also asserts: a key the manager owns
+        (managed) and whose value is in the merged file view must equal
+        that file value. A managed key not in the merged file view is a
+        stale install -- the only legitimate case is between
+        ``set_secret`` and the file write hitting disk (the test does not
+        exercise that race).
+        """
+
+        def assert_invariant(secrets_manager: SecretsManager) -> None:
+            merged = secrets_manager._read_merged_env_files()
+            for key in secrets_manager._managed_env_keys:
+                assert key in os.environ, f"managed key {key!r} missing from os.environ"
+                if key in merged:
+                    assert os.environ[key] == merged[key], (
+                        f"managed key {key!r} has os.environ value {os.environ[key]!r} "
+                        f"but file says {merged[key]!r}"
+                    )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_path = Path(temp_dir)
+            global_env = workspace_path / "global.env"
+
+            with patch.dict(os.environ, {}, clear=False):
+                # Strip every key the test will touch so previous tests
+                # cannot bleed in via the process-global os.environ.
+                for key in (
+                    "LIFECYCLE_BOOT_KEY",
+                    "LIFECYCLE_SET_KEY",
+                    "LIFECYCLE_VANISHING_KEY",
+                    "LIFECYCLE_OS_SET_KEY",
+                    "UNRELATED",
+                ):
+                    os.environ.pop(key, None)
+
+                config_manager = ConfigManager()
+                config_manager.workspace_path = workspace_path
+
+                with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", global_env):
+                    # Step 1: boot. Two file keys plus an OS-set key that
+                    # collides with one of them (so we exercise the
+                    # OS-precedence boot branch).
+                    global_env.write_text(
+                        "LIFECYCLE_BOOT_KEY=boot_value\nLIFECYCLE_OS_SET_KEY=file_loses\n",
+                    )
+                    os.environ["LIFECYCLE_OS_SET_KEY"] = "operator_wins"
+                    secrets_manager = SecretsManager(config_manager)
+
+                    assert "LIFECYCLE_BOOT_KEY" in secrets_manager._managed_env_keys
+                    assert "LIFECYCLE_OS_SET_KEY" not in secrets_manager._managed_env_keys
+                    assert os.environ["LIFECYCLE_OS_SET_KEY"] == "operator_wins"
+                    assert_invariant(secrets_manager)
+
+                    # Step 2: set_secret two fresh keys. Manager claims
+                    # ownership of each and writes through to both the
+                    # global file and os.environ.
+                    secrets_manager.set_secret("LIFECYCLE_SET_KEY", "set_value")
+                    secrets_manager.set_secret("LIFECYCLE_VANISHING_KEY", "vanishing_value")
+                    assert "LIFECYCLE_SET_KEY" in secrets_manager._managed_env_keys
+                    assert "LIFECYCLE_VANISHING_KEY" in secrets_manager._managed_env_keys
+                    assert os.environ["LIFECYCLE_SET_KEY"] == "set_value"
+                    assert os.environ["LIFECYCLE_VANISHING_KEY"] == "vanishing_value"
+                    assert_invariant(secrets_manager)
+
+                    # Step 3: refresh after the file (a) rotates one
+                    # managed key's value and (b) drops another managed
+                    # key entirely. Both branches of the refresh loop
+                    # fire from a single broadcast:
+                    #   * LIFECYCLE_BOOT_KEY is in previously_managed AND
+                    #     present in the merged file -> overridden to
+                    #     the new value.
+                    #   * LIFECYCLE_SET_KEY is in previously_managed AND
+                    #     present -> re-installed (no-op write of the
+                    #     same value, but the survived path is exercised).
+                    #   * LIFECYCLE_VANISHING_KEY is in previously_managed
+                    #     and NOT in the merged file -> popped via
+                    #     ``previously_managed - survived``.
+                    #   * LIFECYCLE_OS_SET_KEY is not managed and is in
+                    #     os.environ -> left untouched.
+                    global_env.write_text(
+                        "LIFECYCLE_BOOT_KEY=boot_value_v2\n"
+                        "LIFECYCLE_OS_SET_KEY=file_still_loses\n"
+                        "LIFECYCLE_SET_KEY=set_value\n",
+                    )
+                    secrets_manager.refresh_from_env_file()
+                    assert os.environ["LIFECYCLE_BOOT_KEY"] == "boot_value_v2"
+                    assert os.environ["LIFECYCLE_OS_SET_KEY"] == "operator_wins"
+                    assert os.environ["LIFECYCLE_SET_KEY"] == "set_value"
+                    # The pop branch: dropped from os.environ AND released
+                    # from manager ownership. (Pre-fix this branch would
+                    # also have wiped LIFECYCLE_OS_SET_KEY -- the
+                    # invariant check above would have caught the regression.)
+                    assert "LIFECYCLE_VANISHING_KEY" not in os.environ
+                    assert "LIFECYCLE_VANISHING_KEY" not in secrets_manager._managed_env_keys
+                    assert_invariant(secrets_manager)
+
+                    # Step 4: delete the boot key via the request handler.
+                    # Only the managed os.environ entry should drop;
+                    # OS-set keys with the same shape are unaffected (a
+                    # delete request never names them in this test).
+                    from griptape_nodes.retained_mode.events.secrets_events import DeleteSecretValueRequest
+
+                    secrets_manager.on_handle_delete_secret_value_request(
+                        DeleteSecretValueRequest(key="LIFECYCLE_BOOT_KEY"),
+                    )
+                    assert "LIFECYCLE_BOOT_KEY" not in os.environ
+                    assert "LIFECYCLE_BOOT_KEY" not in secrets_manager._managed_env_keys
+                    assert_invariant(secrets_manager)
+
+                    # Step 5: refresh after a transient file-vanish window.
+                    # Managed state must survive a missing file, and the
+                    # invariant must still hold.
+                    global_env.unlink()
+                    secrets_manager.refresh_from_env_file()
+                    # LIFECYCLE_SET_KEY was managed; with no file present
+                    # the refresh leaves it alone (early-return guard).
+                    assert os.environ.get("LIFECYCLE_SET_KEY") == "set_value"
+                    assert "LIFECYCLE_SET_KEY" in secrets_manager._managed_env_keys
+                    # OS-set still untouched.
+                    assert os.environ["LIFECYCLE_OS_SET_KEY"] == "operator_wins"
+                    assert_invariant(secrets_manager)
+
+                    # Step 6: the file comes back with the previously-managed
+                    # key removed from it. Refresh pops the managed key.
+                    global_env.write_text("UNRELATED=value\n")
+                    secrets_manager.refresh_from_env_file()
+                    assert "LIFECYCLE_SET_KEY" not in os.environ
+                    assert "LIFECYCLE_SET_KEY" not in secrets_manager._managed_env_keys
+                    assert os.environ["UNRELATED"] == "value"
+                    assert "UNRELATED" in secrets_manager._managed_env_keys
+                    assert_invariant(secrets_manager)

--- a/tests/unit/worker/test_secret_and_config_propagation.py
+++ b/tests/unit/worker/test_secret_and_config_propagation.py
@@ -98,9 +98,14 @@ class TestSecretPropagation:
         secret_key = "INTEG_STALE_SECRET"  # noqa: S105
         shared_global_env.write_text(f"{secret_key}=boot_value\n")  # noqa: ASYNC240
 
-        # Only the worker side has the old value in its environment. The
-        # orchestrator side will write through load_dotenv(override=True).
-        with patch.dict(os.environ, {secret_key: "boot_value"}, clear=False):
+        # Make sure no OS-set value pre-exists. The manager's __init__ must
+        # install it from the file via load_dotenv -- that is what marks the
+        # key as managed and authorizes the refresh override below. A
+        # pre-existing OS env var would model an operator-injected secret
+        # the manager must NOT override (covered separately by
+        # ``test_refresh_preserves_os_set_env_var``).
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(secret_key, None)
             harness = InProcessWorkerHarness()
             worker_config = ConfigManager()
             worker_config.workspace_path = shared_workspace

--- a/tests/unit/worker/test_secret_and_config_propagation.py
+++ b/tests/unit/worker/test_secret_and_config_propagation.py
@@ -1,0 +1,186 @@
+"""Integration tests for orchestrator->worker secret/config propagation.
+
+Motivation
+----------
+Same-machine workers share ~/.config/griptape_nodes/.env and the global config
+file with the orchestrator, but each process captures values in-memory at boot
+(os.environ shadow for secrets; merged_config for config). A mutation on the
+orchestrator that only rewrites the file is invisible to the worker until it
+re-reads the file. PR #4477 closes that gap: after orchestrator-side handlers
+mutate the shared state, WorkerManager fires RefreshSecretsRequest /
+ReloadConfigRequest at every registered worker, each of which re-reads
+from disk.
+
+These tests wire orchestrator-side SecretsManager/ConfigManager to a worker-
+side pair via the InProcessWorkerHarness. Each test:
+
+1. Boots both managers against a shared temporary XDG config home.
+2. Primes the worker's in-memory cache with a boot value.
+3. Dispatches a mutation on the orchestrator's manager.
+4. Delivers the refresh/reload signal through the harness (standing in for
+   WorkerManager.broadcast_to_workers, which is covered by unit tests).
+5. Asserts the worker now sees the fresh value.
+
+Intentional limits
+------------------
+- The harness does not start a real WorkerManager/transport; the signal is
+  delivered by the test directly through harness.route_to_worker. Transport-
+  side fan-out is already covered in tests/unit/app/test_app_worker.py
+  (TestConfigReloadBroadcast / TestSecretRefreshBroadcast).
+- No websocket serialization. Routing/forwarding shape is validated in
+  test_harness_round_trip.py.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    RefreshSecretsRequest,
+    ReloadConfigRequest,
+    register_broadcast_handlers,
+)
+from griptape_nodes.retained_mode.events.base_events import EventRequest
+from griptape_nodes.retained_mode.events.config_events import SetConfigValueRequest
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
+from tests.unit.worker.harness import InProcessWorkerHarness
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def shared_global_env(tmp_path: Path) -> Iterator[Path]:
+    """Patch ENV_VAR_PATH so orchestrator and worker share one on-disk .env.
+
+    Production has them share ~/.config/griptape_nodes/.env by virtue of
+    running on the same machine. Patching to a tmp path isolates the test.
+    """
+    env_path = tmp_path / "global.env"
+    with patch("griptape_nodes.retained_mode.managers.secrets_manager.ENV_VAR_PATH", env_path):
+        yield env_path
+
+
+@pytest.fixture
+def shared_workspace(tmp_path: Path) -> Path:
+    """A shared workspace directory both config managers anchor to."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return workspace
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="xdg_base_dirs cannot find XDG_CONFIG_HOME on Windows on GitHub Actions",
+)
+class TestSecretPropagation:
+    """Orchestrator SetSecret should be visible to the worker after a refresh signal."""
+
+    @pytest.mark.asyncio
+    async def test_worker_holds_stale_value_until_refresh_arrives(
+        self,
+        shared_global_env: Path,
+        shared_workspace: Path,
+    ) -> None:
+        """Without the refresh signal, a worker holds the boot value.
+
+        A worker whose os.environ was set at boot keeps returning the old
+        value even after the orchestrator rewrites the shared file. This
+        is the motivating bug for PR #4477.
+        """
+        secret_key = "INTEG_STALE_SECRET"  # noqa: S105
+        shared_global_env.write_text(f"{secret_key}=boot_value\n")  # noqa: ASYNC240
+
+        # Only the worker side has the old value in its environment. The
+        # orchestrator side will write through load_dotenv(override=True).
+        with patch.dict(os.environ, {secret_key: "boot_value"}, clear=False):
+            harness = InProcessWorkerHarness()
+            worker_config = ConfigManager()
+            worker_config.workspace_path = shared_workspace
+            worker_secrets = SecretsManager(worker_config, event_manager=harness.worker)
+            register_broadcast_handlers(
+                harness.worker,
+                config_manager=worker_config,
+                secrets_manager=worker_secrets,
+            )
+
+            assert worker_secrets.get_secret(secret_key) == "boot_value"
+
+            # Someone else (the orchestrator in production) rewrites the file.
+            shared_global_env.write_text(f"{secret_key}=external_update\n")  # noqa: ASYNC240
+
+            # Without a refresh, the worker still returns the boot value because
+            # os.environ is consulted first and has not been touched.
+            assert worker_secrets.get_secret(secret_key) == "boot_value"
+
+            # Now run the refresh path. This is what on_handle_worker_refresh_secrets_request
+            # does on a real worker.
+            await harness.start()
+            try:
+                await harness.route_to_worker(EventRequest(request=RefreshSecretsRequest()))
+            finally:
+                await harness.stop()
+
+            assert worker_secrets.get_secret(secret_key) == "external_update"
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="xdg_base_dirs cannot find XDG_CONFIG_HOME on Windows on GitHub Actions",
+)
+class TestConfigPropagation:
+    """Orchestrator SetConfigValue should be visible to the worker after a reload signal."""
+
+    @pytest.mark.asyncio
+    async def test_worker_reads_new_config_after_reload(
+        self,
+        shared_workspace: Path,
+        tmp_path: Path,
+    ) -> None:
+        shared_user_config = tmp_path / "griptape_nodes_config.json"
+        shared_user_config.write_text('{"nested": {"key": "boot_value"}}\n')
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.config_manager.USER_CONFIG_PATH",
+            shared_user_config,
+        ):
+            harness = InProcessWorkerHarness()
+            orchestrator_config = ConfigManager(event_manager=harness.orchestrator)
+            orchestrator_config.workspace_path = shared_workspace
+            worker_config = ConfigManager(event_manager=harness.worker)
+            worker_config.workspace_path = shared_workspace
+            worker_secrets = SecretsManager(worker_config, event_manager=harness.worker)
+            register_broadcast_handlers(
+                harness.worker,
+                config_manager=worker_config,
+                secrets_manager=worker_secrets,
+            )
+
+            # Both see boot value.
+            assert orchestrator_config.get_config_value("nested.key") == "boot_value"
+            assert worker_config.get_config_value("nested.key") == "boot_value"
+
+            await harness.start()
+            try:
+                # Orchestrator writes the new value via its request handler.
+                orchestrator_config.on_handle_set_config_value_request(
+                    SetConfigValueRequest(category_and_key="nested.key", value="updated_value"),
+                )
+                assert orchestrator_config.get_config_value("nested.key") == "updated_value"
+
+                # Worker still has the stale merged_config.
+                assert worker_config.get_config_value("nested.key") == "boot_value"
+
+                # Deliver the reload signal.
+                await harness.route_to_worker(EventRequest(request=ReloadConfigRequest()))
+
+                assert worker_config.get_config_value("nested.key") == "updated_value"
+            finally:
+                await harness.stop()


### PR DESCRIPTION
## Summary

Adds **strict mode**, a runtime contract that detects ways node code can
silently misbehave under the orchestrator/worker split, and ships four
rules against it. Strict mode is always on; severity is per-rule.
Correctness violations fail execution; ergonomics violations warn on the
orchestrator and escalate to a failure on the worker (subject to a
per-rule opt-out for ones that fire outside per-node execution). A
detected violation rides back on the node's `ResultPayload` so the
editor surfaces a remediation message instead of a silent no-op,
deadlock, or stack trace that names the wrong layer.

This PR is the collapse of the 10-PR `feat/strict-mode/*` stack into a
single branch for final review.

## Rules

| Rule | Class | Worker | Orchestrator |
|---|---|---|---|
| `reentrant-bus-in-init` | correctness | ERROR | ERROR |
| `unknown-payload-type` | correctness | ERROR | ERROR |
| `parameter-behaviors-dropped-in-schema` | ergonomics | WARNING | WARNING | 
| `parameter-mutation-during-aprocess` | ergonomics | ERROR | WARNING |
| `worker-reach-into-orchestrator` | ergonomics | WARNING | n/a |

## Supporting machinery

* **Strict-mode framework** (`common/strict_mode.py`,
  `common/strict_mode_checks.py`): scope stack on a `ContextVar`,
  per-task reporter, two scope kinds (`RUNTIME_EXECUTE` for executions,
  `LOAD_PROBE` for schema probes), `GTN_STRICT_MODE_DISABLED` env-var
  kill switch, severity resolution from a static rule registry.
* **Worker / orchestrator routing** (`app/worker_routing.py`,
  `managers/event_manager.py`): `RemoteHandler` shim swaps in for
  forwarded request types on workers; the worker's
  `worker_node_execution_scope` (thread-safe refcount, not a
  `ContextVar`, so library-internal helper threads still see it) gates
  forwarding decisions.
* **Config / secret fan-out** (`managers/config_manager.py`,
  `managers/secrets_manager.py`, `managers/worker_manager.py`):
  successful orchestrator-side mutations broadcast `ReloadConfigRequest`
  / `RefreshSecretsRequest` to every worker so per-process state stays
  in sync.
* **Worker exception fidelity** (`events/event_converter.py`,
  `events/base_events.py`, `common/node_executor.py`):
  worker-side exceptions cross the wire as `{type, message,
  traceback}` and rebuild on the orchestrator into a
  `ForwardedException` carrying `original_type` and
  `original_traceback`. `NodeExecutor._format_node_failure_message`
  renders both into the `[<type>] ... Worker traceback: ...` block in
  the user-visible `RuntimeError` message.
* **Aprocess scope** (`exe_types/node_types.py`,
  `managers/node_manager.py`): `aprocess_scope()` is set only around
  `await node.aprocess()` so the parameter-mutation rule does not
  false-positive on hydration-time mutations made from
  `before_value_set` / `after_value_set` (the standard dynamic-pipeline
  pattern, e.g. the diffuser nodes).
* **Sanctioned mutation** (`exe_types/node_types.py`,
  `managers/node_manager.py`): handler-side `AddParameterToNodeRequest`
  / `RemoveParameterFromNodeRequest` wrap their inner mutation in
  `sanctioned_parameter_mutation()` so the rule skips request-driven
  changes that already round-trip the orchestrator.


