### PR TITLE
feat(strict-mode) 04/10: rule reentrant-bus-in-init

### DIFF
--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -1,0 +1,95 @@
+# Strict Mode Reference
+
+Strict mode is a runtime contract for what node code is allowed to do
+across the orchestrator and worker subprocess. When a node violates the
+contract, the framework records a named violation and routes it to the
+node's result payload so the author sees a remediation message in the
+editor instead of a silent no-op, deadlock, or a stack trace that names
+the wrong layer.
+
+Strict mode is always on. There is no config flag, env var, or runtime
+toggle. Severity is picked per-rule: correctness rules fail execution;
+ergonomics rules emit a warning.
+
+## How it surfaces
+
+Violations attach to the `ResultDetails` on the outgoing
+`ResultPayload`. In the editor, the node's output panel shows the rule
+id, severity, and remediation. On the worker side, correctness
+violations elevate a successful `ExecuteNodeResultSuccess` to an
+`ExecuteNodeResultFailure`; ergonomics violations stay non-fatal.
+
+Violations are also logged through the `griptape_nodes.strict_mode`
+logger. Set it to `WARNING` or lower to see every violation in the
+console.
+
+## Rule catalog
+
+Each rule is either a **correctness** rule (fails on both orchestrator
+and worker) or an **ergonomics** rule (warns on orchestrator, escalates
+to a failure on the worker unless the rule opts out).
+
+### Correctness rules (fail execution)
+
+#### `reentrant-bus-in-init`
+
+A node issued an event-bus request from inside its `__init__`. The
+worker library probe runs `__init__` to extract a schema; re-entering
+the bus there deadlocks the worker.
+
+**Remediation**: move the call into `aprocess` (or a lifecycle hook
+that runs after construction).
+
+#### `unknown-payload-type`
+
+A payload type crossing the wire was not registered in
+`PayloadRegistry`. Unknown types cannot be deserialized safely by the
+cattrs converter.
+
+**Remediation**: decorate the payload class with
+`@PayloadRegistry.register` so it can cross the
+worker/orchestrator boundary.
+
+### Ergonomics rules (warnings)
+
+#### `parameter-behaviors-dropped-in-schema`
+
+A `Parameter` attached `converters`, `validators`, or `traits` that
+are not captured in the worker schema. The orchestrator stub cannot
+re-run those behaviors, so UI-side behavior diverges from worker-side
+execution.
+
+**Remediation**: move behavior that needs to run on both sides into
+the worker-side `aprocess`, or accept the divergence as
+orchestrator-only UI sugar.
+
+#### `parameter-mutation-during-aprocess`
+
+A node called `add_parameter` or `remove_parameter_element` during
+`aprocess`. On the worker, these mutations apply to the transient
+node instance and do not sync back to the orchestrator.
+
+Hydration-time mutations made from `before_value_set` /
+`after_value_set` (the standard dynamic-parameter pattern) do
+**not** trip this rule.
+
+**Remediation**: emit an `AddParameterToNodeRequest` or
+`RemoveParameterFromNodeRequest` so the mutation propagates to the
+authoritative orchestrator-side node.
+
+#### `worker-reach-into-orchestrator`
+
+A node running on a worker issued a request whose authoritative state
+lives on the orchestrator (flow graph, connections, parameter
+registry, config, secrets). The request is forwarded across the
+WebSocket bus; each call is a network round-trip and the returned
+view is stale-by-call.
+
+The rule fires for forwarded requests issued anywhere during a
+node's execution -- including from `before_value_set` /
+`after_value_set` during hydration -- not only from `aprocess`.
+
+**Remediation**: if this is an intentional write (e.g. publishing a
+parameter value), ignore the warning. If this is a read of flow /
+connection state, consider whether the data could be passed in via
+parameters instead of fetched per-call.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,5 +346,6 @@ nav:
       - Overview: developing_nodes/index.md
       - Getting Started: developing_nodes/getting_started.md
       - Comprehensive Guide: developing_nodes/comprehensive_guide.md
+      - Strict Mode Reference: developing_nodes/strict_mode.md
       - Example Control Node: developing_nodes/example_control_node.py
   - Glossary: glossary.md

--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -23,6 +23,16 @@ logger = logging.getLogger(__name__)
 class _PendingRequest:
     future: asyncio.Future
     tag: str
+    # When True, EventResultFailure responses resolve the future with
+    # the full payload dict instead of rejecting it with
+    # ``Exception(error_msg)``. The default (False) preserves the
+    # original "failure -> raised exception" contract that
+    # ``request``/``request_to_orchestrator``/``request_batch`` already
+    # rely on. The worker fan-out path opts in so the orchestrator can
+    # cattrs-structure the failure dict back into a real
+    # ``ResultPayloadFailure`` (preserving exception fidelity over the
+    # wire).
+    resolve_failures_as_payload: bool = False
 
 
 class RequestClient:
@@ -303,7 +313,13 @@ class RequestClient:
             logger.debug("Batch of %d requests completed", len(inner_events))
             return results
 
-    async def track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
+    async def track_request(
+        self,
+        request_id: str,
+        tag: str = "",
+        *,
+        resolve_failures_as_payload: bool = False,
+    ) -> asyncio.Future:
         """Register a future for an outgoing request and return it.
 
         Use this when the send path is handled externally (e.g. WorkerManager
@@ -313,11 +329,17 @@ class RequestClient:
         Args:
             request_id: Unique identifier for this request
             tag: Optional tag for grouping related requests (e.g. worker_engine_id)
+            resolve_failures_as_payload: When True, EventResultFailure
+                responses resolve the future with the full payload dict
+                instead of rejecting it with ``Exception(error_msg)``.
+                The worker fan-out path uses this so the orchestrator
+                can structure the failure dict back into a real
+                ``ResultPayloadFailure`` (preserving exception fidelity).
 
         Returns:
             Future that will be resolved when the matching response arrives
         """
-        return await self._track_request(request_id, tag=tag)
+        return await self._track_request(request_id, tag=tag, resolve_failures_as_payload=resolve_failures_as_payload)
 
     async def cancel_requests_by_tag(self, tag: str) -> None:
         """Cancel all pending futures that were registered with the given tag.
@@ -333,12 +355,19 @@ class RequestClient:
                     entry.future.cancel()
                     logger.debug("Cancelled request %s (tag=%s)", rid, tag)
 
-    async def _track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
+    async def _track_request(
+        self,
+        request_id: str,
+        tag: str = "",
+        *,
+        resolve_failures_as_payload: bool = False,
+    ) -> asyncio.Future:
         """Start tracking a request and return a future that will be resolved on response.
 
         Args:
             request_id: Unique identifier for this request
             tag: Optional tag for grouping (e.g. worker_engine_id)
+            resolve_failures_as_payload: See ``track_request``.
 
         Returns:
             Future that will be resolved when response arrives
@@ -352,7 +381,9 @@ class RequestClient:
                 raise ValueError(msg)
 
             future: asyncio.Future = asyncio.Future()
-            self._pending_requests[request_id] = _PendingRequest(future, tag)
+            self._pending_requests[request_id] = _PendingRequest(
+                future, tag, resolve_failures_as_payload=resolve_failures_as_payload
+            )
             logger.debug("Tracking request: %s (tag=%s)", request_id, tag)
             return future
 
@@ -470,11 +501,20 @@ class RequestClient:
             if not request_id or request_id not in self._pending_requests:
                 return False
 
+            entry = self._pending_requests[request_id]
             event_type = payload.get("event_type", "")
             if event_type == "EventResultSuccess":
                 self._resolve_request_unlocked(request_id, payload)
                 return True
             if event_type == "EventResultFailure":
+                # Worker-tracked requests opt in to receiving the full
+                # payload dict so the orchestrator can cattrs-structure
+                # the failure back into a real ResultPayloadFailure
+                # (preserving the exception field). All other callers
+                # keep the legacy "raise Exception(error_msg)" contract.
+                if entry.resolve_failures_as_payload:
+                    self._resolve_request_unlocked(request_id, payload)
+                    return True
                 result = payload.get("result", {})
                 error_msg = str(result.get("result_details") or result.get("exception") or "Unknown error")
                 self._reject_request_unlocked(request_id, Exception(error_msg))

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -31,6 +31,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload,
@@ -202,6 +204,11 @@ class RemoteHandler:
 
     async def __call__(self, request: RequestPayload) -> ResultPayload:
         if self.event_manager.in_node_execution():
+            rule = RULES["worker-reach-into-orchestrator"]
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(request_type=type(request).__name__),
+            )
             event_result = await self.event_manager.forward_to_orchestrator(request, ResultContext())
             return cast("ResultPayload", event_result.result)
         return await call_function(self.original, request)

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -40,7 +40,7 @@ from griptape_nodes.machines.dag_builder import DagBuilder
 from griptape_nodes.node_library.library_registry import Library, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.agent_events import AgentStreamEvent
-from griptape_nodes.retained_mode.events.base_events import ProgressEvent
+from griptape_nodes.retained_mode.events.base_events import ForwardedException, ProgressEvent
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionResultFailure,
     CreateConnectionResultSuccess,
@@ -272,8 +272,9 @@ class NodeExecutor:
                 )
             )
             if not isinstance(result, ExecuteNodeResultSuccess):
-                msg = f"Node '{node.name}' execution failed: {getattr(result, 'result_details', result)}"
-                raise RuntimeError(msg)  # noqa: TRY004
+                exc = getattr(result, "exception", None)
+                msg = self._format_node_failure_message(node.name, result, exc)
+                raise RuntimeError(msg) from exc  # noqa: TRY004
             # Copy outputs back onto the in-memory node. Write directly into
             # parameter_output_values (not through set_parameter_value, which
             # targets parameter_values and re-fires before/after_value_set and
@@ -288,6 +289,31 @@ class NodeExecutor:
                 node.parameter_output_values[name] = value
         finally:
             current_executing_node_name.reset(token)
+
+    @staticmethod
+    def _format_node_failure_message(node_name: str, result: Any, exc: BaseException | None) -> str:
+        """Compose the RuntimeError message for a failed node execution.
+
+        When the worker rebuilt a ``ForwardedException``, surface its
+        ``original_type`` and ``original_traceback`` directly in the
+        message. Chaining via ``from exc`` is not enough on its own:
+        a ForwardedException is constructed (not raised) on the
+        receiving side, so its ``__traceback__`` is None and Python's
+        chained-exception display prints only the cause's
+        ``Type: message`` line with no frames. Interpolating
+        ``original_traceback`` here is what actually puts the worker
+        frames in front of the user.
+        """
+        type_prefix = ""
+        tb_suffix = ""
+        if isinstance(exc, ForwardedException):
+            if exc.original_type:
+                type_prefix = f"[{exc.original_type}] "
+            if exc.original_traceback:
+                tb_suffix = f"\nWorker traceback:\n{exc.original_traceback}"
+        return (
+            f"Node '{node_name}' execution failed: {type_prefix}{getattr(result, 'result_details', result)}{tb_suffix}"
+        )
 
     async def _execute_and_apply_workflow(
         self,

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -41,7 +41,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
-from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
 
 if TYPE_CHECKING:
@@ -122,6 +121,10 @@ def _default_severity_resolver(*, rule_id: str, is_worker: bool) -> StrictModeSe
     historical worker=ERROR / orchestrator=WARNING split so detectors
     can land before the registry entry is added.
     """
+    # Lazy import: strict_mode_checks imports StrictModeSeverity from this
+    # module, so a top-level import would cycle once RULES is non-empty.
+    from griptape_nodes.common.strict_mode_checks import RULES
+
     rule = RULES.get(rule_id)
     if rule is None:
         # A typo'd or unregistered rule_id should not silently produce a

--- a/src/griptape_nodes/common/strict_mode.py
+++ b/src/griptape_nodes/common/strict_mode.py
@@ -41,8 +41,6 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
-from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
-
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
@@ -304,6 +302,13 @@ class StrictModeReporter:
         Each violation becomes a ``StrictModeViolationDetail`` appended
         to the existing list. Mutates ``result``; returns ``None``.
         """
+        # Lazy import: base_events declares the result/violation dataclasses
+        # the framework consumes here, but base_events also imports STRICT_MODE
+        # at its detector sites. Keeping the cycle break in this single
+        # framework method lets every detector module import strict-mode
+        # symbols at the top of the file.
+        from griptape_nodes.retained_mode.events.base_events import ResultDetails, StrictModeViolationDetail
+
         if not scope.violations:
             return
 

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -15,10 +15,9 @@ is a static catalog.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from griptape_nodes.common.strict_mode import StrictModeSeverity
+from griptape_nodes.common.strict_mode import StrictModeSeverity
 
 
 @dataclass(frozen=True)
@@ -46,4 +45,20 @@ class StrictModeRule:
         return self.remediation_template.format(**context)
 
 
-RULES: dict[str, StrictModeRule] = {}
+RULES: dict[str, StrictModeRule] = {
+    "reentrant-bus-in-init": StrictModeRule(
+        rule_id="reentrant-bus-in-init",
+        default_severity=StrictModeSeverity.ERROR,
+        correctness=True,
+        description=(
+            "A node issued an event-bus request from inside its __init__. "
+            "The worker library probe runs __init__ to extract a schema; "
+            "re-entering the bus there deadlocks the worker."
+        ),
+        remediation_template=(
+            "Node class '{node_class}' issued '{request_type}' during __init__. "
+            "Move the call into aprocess (or a lifecycle hook that runs after "
+            "construction)."
+        ),
+    ),
+}

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -7,9 +7,9 @@ escalation), a human description, and a ``str.format``-ready
 remediation template.
 
 Detectors import ``RULES`` to look up their rule and call
-``report_violation(rule_id=..., message=RULES[rid].render(...))`` at
-their own call site. No enforcement logic lives here -- this module
-is a static catalog.
+``STRICT_MODE.report(rule_id=..., message=RULES[rid].render(...))``
+at their own call site. No enforcement logic lives here -- this
+module is a static catalog.
 """
 
 from __future__ import annotations
@@ -60,5 +60,71 @@ RULES: dict[str, StrictModeRule] = {
             "Move the call into aprocess (or a lifecycle hook that runs after "
             "construction)."
         ),
+    ),
+    "parameter-behaviors-dropped-in-schema": StrictModeRule(
+        rule_id="parameter-behaviors-dropped-in-schema",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A Parameter attached converters, validators, or traits that "
+            "are not captured in the worker schema. Orchestrator-side UI "
+            "behavior and worker-side execution diverge."
+        ),
+        remediation_template=(
+            "Parameter '{parameter_name}' carries {dropped_attributes} that "
+            "are not serialized into the worker schema. These will not "
+            "execute on the orchestrator stub; behavior may differ from "
+            "a local-library node."
+        ),
+        # Reported during library load on the worker; escalating to ERROR
+        # would cause the class to be skipped entirely, which is too harsh
+        # for an ergonomics warning.
+        worker_escalation=False,
+    ),
+    "parameter-mutation-during-aprocess": StrictModeRule(
+        rule_id="parameter-mutation-during-aprocess",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node called add_parameter or remove_parameter during "
+            "aprocess. On the worker these changes are local to the "
+            "transient node and do not sync back to the orchestrator."
+        ),
+        remediation_template=(
+            "Node mutated parameter '{parameter_name}' during aprocess via "
+            "{mutation}. Emit AddParameterToNodeRequest or "
+            "RemoveParameterFromNodeRequest to propagate the change to "
+            "the orchestrator."
+        ),
+    ),
+    "worker-reach-into-orchestrator": StrictModeRule(
+        rule_id="worker-reach-into-orchestrator",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node running on a worker issued a request whose "
+            "authoritative state lives on the orchestrator (flow "
+            "graph, connections, parameter registry, config, or "
+            "secrets). The request was forwarded to the orchestrator "
+            "over the WebSocket bus; each call is a network round-"
+            "trip and the returned view is stale-by-call. Events are "
+            "the sanctioned cross-side boundary, but authors are "
+            "often unaware they are paying for it. Detection runs at "
+            "the RemoteHandler dispatch site, which covers both input "
+            "hydration (before/after_value_set) and aprocess. "
+            "Violations issued from library-internal helper threads "
+            "(e.g. ThreadPoolExecutor inside diffusers/transformers) "
+            "are not reported because the strict-mode reporter is "
+            "task-local; the forward still proceeds normally."
+        ),
+        remediation_template=(
+            "Worker-side node issued '{request_type}' during node "
+            "execution. If this is an intentional write (e.g. "
+            "publishing a parameter value), ignore. If this is a read "
+            "of flow / connection state, consider whether the data "
+            "could be passed in via parameters instead of fetched "
+            "per-call."
+        ),
+        worker_escalation=False,
     ),
 }

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -56,7 +56,7 @@ RULES: dict[str, StrictModeRule] = {
             "re-entering the bus there deadlocks the worker."
         ),
         remediation_template=(
-            "Node class '{node_class}' issued '{request_type}' during __init__. "
+            "Issued '{request_type}' during __init__. "
             "Move the call into aprocess (or a lifecycle hook that runs after "
             "construction)."
         ),

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1810,6 +1810,36 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         return validators
 
     @property
+    def has_directly_attached_converters(self) -> bool:
+        """The directly-attached converter list is non-empty.
+
+        Trait-derived converters are merged in by the ``converters``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
+        return bool(self._converters)
+
+    @property
+    def has_directly_attached_validators(self) -> bool:
+        """The directly-attached validator list is non-empty.
+
+        Trait-derived validators are merged in by the ``validators``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
+        return bool(self._validators)
+
+    @property
+    def has_traits(self) -> bool:
+        """Any Trait child is attached.
+
+        Walks ``find_elements_by_type(Trait)`` because traits are stored
+        as child node-elements, not in a flat list. Cheap at probe
+        scale (called once per parameter at library load).
+        """
+        return bool(self.find_elements_by_type(Trait))
+
+    @property
     def on_incoming_connection_removed(self) -> list[Callable[[Parameter, str, str], None]]:
         return self._on_incoming_connection_removed
 

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -4,11 +4,15 @@ import logging
 import threading
 import warnings
 from abc import ABC
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
     ControlParameterInput,
@@ -90,6 +94,56 @@ AsyncResult = Generator[Callable[[], T], T]
 LOCAL_EXECUTION = "Local Execution"
 PRIVATE_EXECUTION = "Private Execution"
 CONTROL_INPUT_PARAMETER = "Control Input Selection"
+
+
+# Per-task flag: when set, parameter mutations on a node are explicitly
+# sanctioned by a request handler (AddParameterToNodeRequest /
+# RemoveParameterFromNodeRequest) and the parameter-mutation-during-aprocess
+# detector should not fire. The handler-side path is the legitimate way to
+# mutate parameters because it propagates the change back to the orchestrator
+# via the request bus; direct add_parameter / remove_parameter_element calls
+# from inside aprocess do not, and that is what the rule catches.
+_sanctioned_mutation: ContextVar[bool] = ContextVar("_node_types_sanctioned_mutation", default=False)
+
+# Per-task flag: True only while ``await node.aprocess()`` is on the stack.
+# The detector uses this to distinguish actual aprocess execution from the
+# surrounding RUNTIME_EXECUTE scope, which also wraps input hydration.
+# Hydration-time set_parameter_value calls run before/after_value_set hooks,
+# and many real nodes (e.g. dynamic-pipeline diffuser nodes) legitimately
+# call add_parameter / remove_parameter_element from those hooks; keying off
+# the broader RUNTIME_EXECUTE scope would false-positive on every such node.
+_in_aprocess: ContextVar[bool] = ContextVar("_node_types_in_aprocess", default=False)
+
+
+@contextmanager
+def sanctioned_parameter_mutation() -> Iterator[None]:
+    """Mark the enclosed block as a request-driven parameter mutation.
+
+    Wraps add_parameter / remove_parameter_element calls inside
+    AddParameterToNodeRequest and RemoveParameterFromNodeRequest handlers
+    so the parameter-mutation-during-aprocess detector skips them.
+    """
+    token = _sanctioned_mutation.set(True)
+    try:
+        yield
+    finally:
+        _sanctioned_mutation.reset(token)
+
+
+@contextmanager
+def aprocess_scope() -> Iterator[None]:
+    """Mark the enclosed block as the actual aprocess() execution.
+
+    The framework wraps ``await node.aprocess()`` with this so the
+    parameter-mutation-during-aprocess detector fires only for mutations
+    that happen inside aprocess itself, not the surrounding hydration
+    pass that also runs under the RUNTIME_EXECUTE strict-mode scope.
+    """
+    token = _in_aprocess.set(True)
+    try:
+        yield
+    finally:
+        _in_aprocess.reset(token)
 
 
 class ImportDependency(NamedTuple):
@@ -588,6 +642,7 @@ class BaseNode(ABC):
 
     def add_parameter(self, param: Parameter) -> None:
         """Adds a Parameter to the Node. Control and Data Parameters are all treated equally."""
+        self._report_parameter_mutation_if_in_aprocess(parameter_name=param.name, mutation="add_parameter")
         if any(char.isspace() for char in param.name):
             msg = f"Failed to add Parameter `{param.name}`. Parameter names cannot currently any whitespace characters. Please see https://github.com/griptape-ai/griptape-nodes/issues/714 to check the status on a remedy for this issue."
             raise ValueError(msg)
@@ -609,6 +664,7 @@ class BaseNode(ABC):
             self.remove_parameter_element(element)
 
     def remove_parameter_element(self, param: BaseNodeElement) -> None:
+        self._report_parameter_mutation_if_in_aprocess(parameter_name=param.name, mutation="remove_parameter_element")
         # Emit event before removal if it's a Parameter
         if isinstance(param, Parameter):
             self._emit_parameter_lifecycle_event(param)
@@ -1344,6 +1400,46 @@ class BaseNode(ABC):
 
         # Use reorder_elements to apply the move
         self.reorder_elements(list(new_order))
+
+    def _report_parameter_mutation_if_in_aprocess(self, *, parameter_name: str, mutation: str) -> None:
+        """Report parameter-mutation-during-aprocess when a node mutates its own params directly.
+
+        Request handlers reach ``add_parameter`` / ``remove_parameter_element``
+        via ``AddParameterToNodeRequest`` / ``RemoveParameterFromNodeRequest``
+        and wrap the call in ``sanctioned_parameter_mutation()``. Any call
+        that arrives here from aprocess without that wrapper is a direct
+        mutation, which does not sync back to the orchestrator when the
+        node runs in a worker subprocess.
+
+        Detection keys off ``_in_aprocess`` (set by ``aprocess_scope()`` only
+        around ``await node.aprocess()``) rather than the broader
+        ``RUNTIME_EXECUTE`` strict-mode scope, because that scope also wraps
+        input hydration. Hydration runs ``set_parameter_value`` ->
+        ``before_value_set`` / ``after_value_set``, and dynamic-pipeline
+        nodes legitimately call ``add_parameter`` from those hooks; keying
+        off ``RUNTIME_EXECUTE`` would false-positive on every such node.
+
+        Nested node construction (a node's ``__init__`` declaring parameters
+        from inside another node's ``aprocess``) is handled by the
+        ``is_constructing_node()`` short-circuit: declarative ``__init__``
+        calls to ``add_parameter`` are not violations even when an outer
+        ``aprocess`` is on the stack.
+        """
+        # Lazy import: library_registry imports BaseNode from this module,
+        # so importing at module load creates a cycle.
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        if _sanctioned_mutation.get():
+            return
+        if LibraryRegistry.is_constructing_node():
+            return
+        if not _in_aprocess.get():
+            return
+        rule = RULES["parameter-mutation-during-aprocess"]
+        STRICT_MODE.report(
+            rule_id=rule.rule_id,
+            message=rule.render(parameter_name=parameter_name, mutation=mutation),
+        )
 
     def _emit_parameter_lifecycle_event(self, parameter: BaseNodeElement, *, remove: bool = False) -> None:
         """Emit an AlterElementEvent for parameter add/remove operations."""

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -222,10 +222,48 @@ class ResultPayloadSuccess(ResultPayload, ABC):
         return True
 
 
+class ForwardedException(Exception):  # noqa: N818
+    """Placeholder for an exception that crossed the worker boundary.
+
+    The converter's Exception hook emits worker-side exceptions as a
+    ``{type, message, traceback}`` dict, then rebuilds them into a
+    ``ForwardedException`` on the receiving side. The placeholder is
+    still an ``Exception`` (so ``raise ... from result.exception``
+    chains) and carries the worker-side class name and formatted
+    traceback so the orchestrator can show both.
+
+    ``NodeExecutor._format_node_failure_message`` is the consumer:
+    it reads ``original_type`` for the ``[builtins.ValueError]``
+    prefix on the user-visible ``RuntimeError`` message, and
+    ``original_traceback`` for the ``Worker traceback:`` block.
+    Without these attributes the chained exception would print only
+    ``Type: message`` with no frames, because the placeholder is
+    constructed (not raised) and so its ``__traceback__`` is ``None``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        original_type: str | None = None,
+        original_traceback: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.original_type = original_type
+        self.original_traceback = original_traceback
+
+
 # Failure result payload abstract base class
 @dataclass(kw_only=True)
 class ResultPayloadFailure(ResultPayload, ABC):
-    """Abstract base class for failure result payloads."""
+    """Abstract base class for failure result payloads.
+
+    ``exception`` is the single source of truth. On the local path it
+    is the live ``Exception``. Across the worker -> orchestrator wire
+    the converter emits it as a structured dict and rebuilds it as a
+    ``ForwardedException`` carrying the original type name and
+    traceback as attributes, so callers can read both paths uniformly.
+    """
 
     result_details: ResultDetails | str
     exception: Exception | None = None

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import traceback
 import types
 from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
@@ -39,10 +40,35 @@ converter.register_unstructure_hook_func(
     lambda obj: obj.isoformat(),
 )
 
-# Exception -> string representation
+
+# Exception -> structured dict.
+#
+# The three dict keys are the wire form of ``ForwardedException``:
+#   ``type``      -> ``ForwardedException.original_type``      -> ``[<type>]`` prefix
+#   ``message``   -> ``ForwardedException.args[0]``            -> message body
+#   ``traceback`` -> ``ForwardedException.original_traceback`` -> ``Worker traceback:`` block
+# ``_structure_exception`` rebuilds the placeholder on the receiving side, and
+# ``NodeExecutor._format_node_failure_message`` renders the prefix and block
+# into the user-visible ``RuntimeError`` message.
+def _unstructure_exception(obj: Exception) -> dict[str, Any]:
+    if obj.__traceback__ is None:
+        tb = None
+    else:
+        try:
+            tb = "".join(traceback.format_exception(type(obj), obj, obj.__traceback__))
+        except Exception:
+            logger.debug("Failed to format traceback for %s", type(obj).__name__, exc_info=True)
+            tb = None
+    return {
+        "type": f"{type(obj).__module__}.{type(obj).__qualname__}",
+        "message": str(obj),
+        "traceback": tb,
+    }
+
+
 converter.register_unstructure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, Exception),
-    str,
+    _unstructure_exception,
 )
 
 # Bare `type` references (e.g. provider_class: type)
@@ -80,10 +106,34 @@ converter.register_structure_hook_func(
     lambda obj, cls: cls.model_validate(obj),
 )
 
-# Exception <- string or dict
+
+# Exception <- structured dict.
+#
+# Rebuilds a ``ForwardedException`` on the receiving side because the
+# worker-side class is rarely importable on the orchestrator. The
+# ``original_type`` and ``original_traceback`` fields are read by
+# ``NodeExecutor._format_node_failure_message`` to render the
+# ``[<type>] ... Worker traceback: ...`` block in the orchestrator's
+# user-visible ``RuntimeError`` message.
+def _structure_exception(obj: Any, _cls: type) -> Exception:
+    # Lazy import to avoid a circular dependency: base_events imports
+    # from this module (event_converter is registered at import time
+    # from base_events), so ForwardedException cannot be imported at
+    # module load.
+    from griptape_nodes.retained_mode.events.base_events import ForwardedException
+
+    if not isinstance(obj, dict):
+        return ForwardedException(str(obj))
+    return ForwardedException(
+        str(obj.get("message", "")),
+        original_type=obj.get("type"),
+        original_traceback=obj.get("traceback"),
+    )
+
+
 converter.register_structure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, Exception),
-    lambda obj, cls: cls(obj) if isinstance(obj, str) else cls(str(obj)),
+    _structure_exception,
 )
 
 

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -314,13 +314,13 @@ class EventManager:
         if not LibraryRegistry.is_constructing_node():
             return
         rule = RULES["reentrant-bus-in-init"]
-        # node_class is not available from the request, but "unknown"
-        # is fine -- the subject attribution comes from the LOAD_PROBE
-        # scope opened by the library manager around the probe, which
-        # already carries the class name.
+        # Subject attribution lives on the violation's ``subject`` field,
+        # set from the surrounding strict-mode scope (class name under
+        # LOAD_PROBE, instance name under RUNTIME_EXECUTE). The message
+        # only needs the request type.
         STRICT_MODE.report(
             rule_id=rule.rule_id,
-            message=rule.render(node_class="<in __init__>", request_type=type(request).__name__),
+            message=rule.render(request_type=type(request).__name__),
         )
 
     def get_manager_for_request_type(self, request_type: type[RP]) -> Callable | None:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING, Any, cast
 from asyncio_thread_runner import ThreadRunner
 from typing_extensions import TypedDict, TypeVar
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
     BaseEvent,
@@ -299,6 +302,27 @@ class EventManager:
         with self._node_execution_lock:
             return self._node_execution_depth > 0
 
+    def _report_reentrant_bus_in_init(self, request: RequestPayload) -> None:
+        """Detect the reentrant-bus-in-init rule.
+
+        A node class that issues an event-bus request from its __init__
+        deadlocks the worker's schema probe, which calls __init__ on
+        the worker thread during library load. LibraryRegistry sets a
+        ContextVar around create_node so every __init__ body in the
+        hierarchy is covered.
+        """
+        if not LibraryRegistry.is_constructing_node():
+            return
+        rule = RULES["reentrant-bus-in-init"]
+        # node_class is not available from the request, but "unknown"
+        # is fine -- the subject attribution comes from the LOAD_PROBE
+        # scope opened by the library manager around the probe, which
+        # already carries the class name.
+        STRICT_MODE.report(
+            rule_id=rule.rule_id,
+            message=rule.render(node_class="<in __init__>", request_type=type(request).__name__),
+        )
+
     def get_manager_for_request_type(self, request_type: type[RP]) -> Callable | None:
         """Return the currently-registered handler callback for a request type, or None."""
         return self._request_type_to_manager.get(request_type)
@@ -471,6 +495,8 @@ class EventManager:
         if result_context is None:
             result_context = ResultContext()
 
+        self._report_reentrant_bus_in_init(request)
+
         # Notify the manager of the event type
         request_type = type(request)
         callback = self._request_type_to_manager.get(request_type)
@@ -515,6 +541,8 @@ class EventManager:
         if result_context is None:
             result_context = ResultContext()
 
+        self._report_reentrant_bus_in_init(request)
+
         # Notify the manager of the event type
         request_type = type(request)
         callback = self._request_type_to_manager.get(request_type)
@@ -531,6 +559,10 @@ class EventManager:
             # loop, so no primitives are shared and the #4469 deadlock shape does not apply.
             # Hop the callback onto the WS loop here and block the caller's thread on the
             # concurrent.futures.Future so RemoteHandler itself stays a plain async callable.
+            #
+            # Lazy import: worker_routing imports ResultContext from this module at
+            # runtime, so a top-level import here would cycle through event_manager
+            # -> worker_routing -> event_manager during module load.
             from griptape_nodes.app.worker_routing import RemoteHandler
 
             if isinstance(callback, RemoteHandler):

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -30,6 +30,11 @@ from rich.text import Text
 from semver import Version
 from xdg_base_dirs import xdg_data_home
 
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+)
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.path_utils import canonicalize_for_identity, canonicalize_for_io, resolve_workspace_path
@@ -3503,6 +3508,31 @@ class LibraryManager:
     # discovery. The instance is discarded after its parameters are read.
     _SCHEMA_PROBE_NODE_NAME: str = "__schema_probe__"
 
+    def _report_parameter_behavior_losses(self, probe: BaseNode) -> None:
+        """Report parameter-behaviors-dropped-in-schema for any probe parameter that has live behaviors.
+
+        ``WorkerParameterSchema`` only carries the scalar-shaped fields of a
+        ``Parameter``. Converters, validators, and traits cannot be
+        serialized across the worker boundary and therefore will not run on
+        the orchestrator stub. If a parameter has any of these attached,
+        report it so the author sees a named warning during library load.
+        """
+        rule = RULES["parameter-behaviors-dropped-in-schema"]
+        for param in probe.parameters:
+            dropped: list[str] = []
+            if param.has_directly_attached_converters:
+                dropped.append("converters")
+            if param.has_directly_attached_validators:
+                dropped.append("validators")
+            if param.has_traits:
+                dropped.append("traits")
+            if not dropped:
+                continue
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(parameter_name=param.name, dropped_attributes=", ".join(dropped)),
+            )
+
     async def _serialize_library_node_schemas(self, library_name: str) -> list[WorkerNodeSchema]:
         """Serialize node parameter schemas for a loaded library.
 
@@ -3520,28 +3550,49 @@ class LibraryManager:
         for class_name in library.get_registered_nodes():
             # The is-constructing flag set inside create_node propagates into
             # the asyncio.to_thread worker via contextvars.copy_context().
-            try:
-                probe = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        LibraryRegistry.create_node,
-                        node_type=class_name,
-                        name=self._SCHEMA_PROBE_NODE_NAME,
-                        specific_library_name=library_name,
-                    ),
-                    timeout=self._SCHEMA_PROBE_TIMEOUT_S,
-                )
-            except TimeoutError:
-                logger.warning(
-                    "Schema probe for node class '%s' in library '%s' timed out after %.1fs; "
-                    "skipping. The node's __init__ likely makes a blocking call that cannot "
-                    "complete during library load.",
-                    class_name,
-                    library_name,
-                    self._SCHEMA_PROBE_TIMEOUT_S,
-                )
-                continue
-            except Exception:
-                logger.debug("Could not probe node class '%s' for schema serialization.", class_name, exc_info=True)
+            probe = None
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject=class_name,
+                library_name=library_name,
+                is_worker=self.is_worker,
+            ) as scope:
+                try:
+                    probe = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            LibraryRegistry.create_node,
+                            node_type=class_name,
+                            name=self._SCHEMA_PROBE_NODE_NAME,
+                            specific_library_name=library_name,
+                        ),
+                        timeout=self._SCHEMA_PROBE_TIMEOUT_S,
+                    )
+                except TimeoutError:
+                    logger.warning(
+                        "Schema probe for node class '%s' in library '%s' timed out after %.1fs; "
+                        "skipping. The node's __init__ likely makes a blocking call that cannot "
+                        "complete during library load.",
+                        class_name,
+                        library_name,
+                        self._SCHEMA_PROBE_TIMEOUT_S,
+                    )
+                    continue
+                except Exception:
+                    logger.debug("Could not probe node class '%s' for schema serialization.", class_name, exc_info=True)
+                    continue
+                # Run the parameter-behavior-drop detector inside the scope so
+                # warnings attach to the same LOAD_PROBE scope that owns the
+                # probe attempt.
+                self._report_parameter_behavior_losses(probe)
+
+            # Drop the class only when a correctness-class rule fired.
+            # Severity is a logging concern; correctness is the lifecycle
+            # signal ("this class is broken enough to exclude from the
+            # schema"). Gating on severity would also drop the class for
+            # any future ergonomics rule whose worker_escalation flag is
+            # left at the True default.
+            blocking_rule_ids = {rid for rid, r in RULES.items() if r.correctness}
+            if any(v.rule_id in blocking_rule_ids for v in scope.violations):
                 continue
 
             param_schemas: list[WorkerParameterSchema] = []

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import logging
 import pickle
@@ -44,6 +45,8 @@ from griptape_nodes.exe_types.node_types import (
     NodeDependencies,
     NodeResolutionState,
     TransformedParameterValue,
+    aprocess_scope,
+    sanctioned_parameter_mutation,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
@@ -64,7 +67,7 @@ from griptape_nodes.retained_mode.events.connection_events import (
     ListConnectionsForNodeResultSuccess,
     OutgoingConnection,
 )
-from griptape_nodes.retained_mode.events.event_converter import safe_unstructure
+from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
 from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     CancelExecuteNodeResultSuccess,
@@ -1545,14 +1548,15 @@ class NodeManager:
             settable=request.settable,
         )
         try:
-            if request.parent_container_name and request.initial_setup:
-                parameter_parent = node.get_parameter_by_name(request.parent_container_name)
-                if parameter_parent is not None:
-                    parameter_parent.add_child(new_param)
-            elif parent_group is not None:
-                parent_group.add_child(new_param)
-            else:
-                node.add_parameter(new_param)
+            with sanctioned_parameter_mutation():
+                if request.parent_container_name and request.initial_setup:
+                    parameter_parent = node.get_parameter_by_name(request.parent_container_name)
+                    if parameter_parent is not None:
+                        parameter_parent.add_child(new_param)
+                elif parent_group is not None:
+                    parent_group.add_child(new_param)
+                else:
+                    node.add_parameter(new_param)
         except Exception as e:
             details = f"Couldn't add parameter with name {request.parameter_name} to Node '{node_name}'. Error: {e}"
             return AddParameterToNodeResultFailure(result_details=details)
@@ -1743,7 +1747,8 @@ class NodeManager:
 
         # Delete the Element itself.
         if element is not None:
-            node.remove_parameter_element(element)
+            with sanctioned_parameter_mutation():
+                node.remove_parameter_element(element)
         else:
             details = f"Attempted to remove Element '{request.parameter_name}' from Node '{node_name}'. Failed because element didn't exist."
 
@@ -2877,9 +2882,16 @@ class NodeManager:
             self._orch_worker_requests.pop(request.node_name, None)
         result_type_name = execute_raw.get("result_type", "")
         result_data = execute_raw.get("result", {})
+        # Route through cattrs structure (not ``**result_data`` spread)
+        # so the registered exception hook rebuilds ``self.exception``
+        # into a ``ForwardedException`` carrying the worker-side type
+        # name and traceback. A bare spread would leave ``exception``
+        # as the raw {type, message, traceback} dict, breaking the
+        # worker-frame surfacing in
+        # ``NodeExecutor._format_node_failure_message``.
         if result_type_name == ExecuteNodeResultSuccess.__name__:
-            return ExecuteNodeResultSuccess(**result_data)
-        return ExecuteNodeResultFailure(**result_data)
+            return cast("ExecuteNodeResultSuccess", converter.structure(result_data, ExecuteNodeResultSuccess))
+        return cast("ExecuteNodeResultFailure", converter.structure(result_data, ExecuteNodeResultFailure))
 
     async def cancel_worker_execution(self, node_name: str) -> None:
         """Dispatch CancelExecuteNodeRequest to the worker running node_name.
@@ -2929,14 +2941,15 @@ class NodeManager:
     async def _hydrate_and_run_node(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         """Hydrate a node's input parameters and execute it.
 
-        Hydration and node.aprocess() both run inside worker_node_execution_scope
-        so that any nested handle_request calls originated from node code (on a
-        worker) forward to the orchestrator. Hydration calls set_parameter_value,
-        which cascades into ListConnectionsForNodeRequest and similar cross-node
-        lookups; those must forward because the worker only owns its single node
-        copy and cannot resolve parent-flow or peer-node state locally. On the
-        orchestrator the scope is a no-op because forwarding is not configured
-        there.
+        On a worker, hydration and node.aprocess() both run inside
+        worker_node_execution_scope so that any nested handle_request calls
+        originated from node code forward to the orchestrator. Hydration calls
+        set_parameter_value, which cascades into ListConnectionsForNodeRequest
+        and similar cross-node lookups; those must forward because the worker
+        only owns its single node copy and cannot resolve parent-flow or peer-
+        node state locally. On the orchestrator we skip the scope entirely --
+        there is no RemoteHandler to read the flag, so opening it there would
+        only bump a refcount nothing observes.
         """
         # Register this aprocess task under its request_id so
         # CancelExecuteNodeRequest can locate it. Only populated when the caller
@@ -2955,7 +2968,15 @@ class NodeManager:
 
     async def _hydrate_and_run_node_inner(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         node_name = request.node_name
-        with GriptapeNodes.EventManager().worker_node_execution_scope():
+        # The node-execution scope only has meaning on a worker: it is what
+        # RemoteHandler consults to decide whether to forward a request to the
+        # orchestrator. On the orchestrator itself there is no RemoteHandler
+        # installed (register_remote_handlers is worker-only), so opening the
+        # scope there would just bump a refcount that nothing reads. Skip it
+        # to keep the depth counter accurate to its name.
+        is_worker = GriptapeNodes.LibraryManager()._is_worker
+        scope_cm = GriptapeNodes.EventManager().worker_node_execution_scope() if is_worker else contextlib.nullcontext()
+        with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
             for param_name, value in parameter_values.items():
@@ -2974,6 +2995,7 @@ class NodeManager:
                 except Exception as e:
                     return ExecuteNodeResultFailure(
                         result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
+                        exception=e,
                     )
             # Materialize parameter defaults into parameter_values so that user
             # process() code reading self.parameter_values[name] directly (rather
@@ -2988,10 +3010,21 @@ class NodeManager:
                     continue
                 node.parameter_values[param.name] = param.default_value
             try:
-                await node.aprocess()
+                with aprocess_scope():
+                    await node.aprocess()
             except Exception as e:
+                # Pass the live exception through ``exception=`` so the
+                # converter can capture worker-side frames into a
+                # ForwardedException on the orchestrator. Without this
+                # the orchestrator only sees the type and message --
+                # PR06's whole reason for the dict wire-format -- and
+                # NodeExecutor._format_node_failure_message would have
+                # nothing to surface. ``__traceback__`` is populated
+                # because ``e`` was actually raised, so the strict-mode
+                # tripwire stays quiet for raise-in-process.
                 return ExecuteNodeResultFailure(
                     result_details=f"Attempted to execute node '{node_name}'. Failed with error: {e}",
+                    exception=e,
                 )
         return ExecuteNodeResultSuccess(
             parameter_output_values=dict(node.parameter_output_values),

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -344,7 +344,16 @@ class WorkerManager:
         returned dict into the appropriate result type.
         """
         request_id = event_request.request_id or str(uuid.uuid4())
-        future = await self._tx.request_client.track_request(request_id, tag=worker_engine_id)
+        # Opt into structured-failure delivery so a worker-side
+        # ResultPayloadFailure arrives as the raw payload dict rather
+        # than being collapsed to a bare ``Exception(error_msg)`` by
+        # ``_try_match``. ``_execute_node_via_worker`` then runs the
+        # dict through ``converter.structure(...)``, which rebuilds
+        # ``self.exception`` into a ForwardedException carrying the
+        # worker-side type name and traceback string.
+        future = await self._tx.request_client.track_request(
+            request_id, tag=worker_engine_id, resolve_failures_as_payload=True
+        )
 
         await self.forward_event_to_worker(
             event_request.model_copy(update={"request_id": request_id}),

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -40,9 +40,13 @@ class _FakeRequestClient:
     def __init__(self) -> None:
         self._pending_requests: dict[str, _PendingRequest] = {}
 
-    async def track_request(self, request_id: str, tag: str = "") -> asyncio.Future:
+    async def track_request(
+        self, request_id: str, tag: str = "", *, resolve_failures_as_payload: bool = False
+    ) -> asyncio.Future:
         future: asyncio.Future = asyncio.Future()
-        self._pending_requests[request_id] = _PendingRequest(future, tag)
+        self._pending_requests[request_id] = _PendingRequest(
+            future, tag, resolve_failures_as_payload=resolve_failures_as_payload
+        )
         return future
 
     async def cancel_requests_by_tag(self, tag: str) -> None:

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -1,0 +1,296 @@
+"""Tests for the worker-reach-into-orchestrator strict-mode tripwire.
+
+RemoteHandler is the single chokepoint where a worker-side ``aprocess``
+reaches into orchestrator-owned state. When it forwards a request back
+to the orchestrator while a strict-mode scope is active, it records a
+``worker-reach-into-orchestrator`` violation. Outside of node execution
+(bootstrap, LOAD_PROBE) the tripwire does not fire because the
+RemoteHandler delegates to the original handler before reaching the
+violation path; outside any strict-mode scope, ``STRICT_MODE.report``
+is a no-op and the handler still forwards without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    FORWARDED_REQUEST_TYPES,
+    RemoteHandler,
+    register_remote_handlers,
+)
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+    StrictModeSeverity,
+)
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultSuccess,
+    RequestPayload,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+
+@dataclass(kw_only=True)
+class _ProbeRequest(RequestPayload):
+    """Minimal request used to exercise RemoteHandler's tripwire."""
+
+    marker: str
+
+
+@dataclass(kw_only=True)
+class _ProbeResult(ResultPayloadSuccess):
+    """Success payload paired with _ProbeRequest."""
+
+    seen_by: str
+
+
+def _make_handler_with_fake_forward(event_manager: EventManager) -> RemoteHandler:
+    async def original(_request: _ProbeRequest) -> _ProbeResult:
+        return _ProbeResult(seen_by="local", result_details="local")
+
+    async def fake_forward(
+        request: RequestPayload,
+        result_context: ResultContext,  # noqa: ARG001
+    ) -> EventResultSuccess:
+        return EventResultSuccess(
+            request=request,
+            result=_ProbeResult(seen_by="orchestrator", result_details="forwarded"),
+        )
+
+    event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+    return RemoteHandler(original=original, event_manager=event_manager)
+
+
+class TestWorkerReachIntoOrchestrator:
+    """The tripwire records one violation per forwarded request while in scope."""
+
+    @pytest.mark.asyncio
+    async def test_in_scope_in_node_execution_records_violation(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await handler(_ProbeRequest(marker="m1"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert violation.severity is StrictModeSeverity.WARNING
+        assert violation.subject == "node-1"
+        assert violation.library_name == "libA"
+        assert "_ProbeRequest" in violation.message
+
+    @pytest.mark.asyncio
+    async def test_in_scope_out_of_node_execution_does_not_record(self) -> None:
+        event_manager = EventManager()
+        local_calls: list[_ProbeRequest] = []
+
+        async def original(request: _ProbeRequest) -> _ProbeResult:
+            local_calls.append(request)
+            return _ProbeResult(seen_by="local", result_details="local")
+
+        handler = RemoteHandler(original=original, event_manager=event_manager)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyClass",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            result = await handler(_ProbeRequest(marker="m2"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "local"
+        assert len(local_calls) == 1
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_no_scope_forwards_without_crashing(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with event_manager.worker_node_execution_scope():
+            result = await handler(_ProbeRequest(marker="m3"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_remediation_message_does_not_claim_from_aprocess(self) -> None:
+        """Regression guard: remediation must not claim "from aprocess".
+
+        The rule's gate is ``worker_node_execution_scope``, which covers
+        both hydration and aprocess. The remediation must not claim "from
+        aprocess" because the rule fires for both. See PR8 for the same
+        factual-claim bug Collin flagged on parameter-mutation.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-r1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="m4"))
+
+        assert len(scope.violations) == 1
+        message = scope.violations[0].message
+        assert "from aprocess" not in message
+        assert "during node execution" in message
+
+    @pytest.mark.asyncio
+    async def test_fires_during_hydration_phase_not_just_aprocess(self) -> None:
+        """The rule's gate is wider than aprocess.
+
+        ``worker_node_execution_scope`` is opened by
+        ``_hydrate_and_run_node_inner`` around BOTH hydration and
+        aprocess. Forwarded requests issued during hydration (e.g.
+        dynamic-pipeline nodes calling ListConnectionsForNodeRequest
+        from before/after_value_set) must trip the rule. This pins
+        down that the gate is intentionally wider than
+        ``aprocess_scope()``.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        # No aprocess_scope() entered. Only the worker_node_execution_scope
+        # (refcount) is active. The rule must still fire.
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-h1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="hydrate"))
+
+        assert len(scope.violations) == 1
+        assert scope.violations[0].rule_id == "worker-reach-into-orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_one_violation_per_call(self) -> None:
+        """Two forwarded requests from the same scope produce two violations."""
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-c1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="first"))
+            await handler(_ProbeRequest(marker="second"))
+
+        expected_violations = 2
+        assert len(scope.violations) == expected_violations
+
+    @pytest.mark.asyncio
+    async def test_forwarded_type_member_through_register_remote_handlers(self) -> None:
+        """End-to-end: a real FORWARDED type goes through the swap and shim.
+
+        ``register_remote_handlers`` swaps a real FORWARDED type's handler
+        for a ``RemoteHandler`` shim, and dispatching that real type
+        directly through the shim records the violation. Locks in the
+        ``FORWARDED_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
+        a future change drops a type from ``FORWARDED_REQUEST_TYPES``,
+        this test stays green only because
+        ``ListConnectionsForNodeRequest`` is still a member.
+        """
+        event_manager = EventManager()
+
+        # Capture what the RemoteHandler shim forwards. Skip going through
+        # event_manager.handle_request because that path requires a configured
+        # WebSocket loop; the rule itself fires inside RemoteHandler.__call__,
+        # which is what we want to exercise.
+        forwarded_calls: list[RequestPayload] = []
+
+        async def fake_forward(
+            request: RequestPayload,
+            result_context: ResultContext,  # noqa: ARG001
+        ) -> EventResultSuccess:
+            forwarded_calls.append(request)
+            return EventResultSuccess(
+                request=request,
+                result=ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="forwarded",
+                ),
+            )
+
+        event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+
+        # register_remote_handlers requires every FORWARDED type to have an
+        # original handler registered first. Stub them all with a trivial
+        # local handler; the swap installs RemoteHandler in their place.
+        for request_type in FORWARDED_REQUEST_TYPES:
+
+            async def stub(_request: RequestPayload) -> ResultPayloadSuccess:
+                return ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="local",
+                )
+
+            event_manager.assign_manager_to_request_type(request_type, stub)
+
+        register_remote_handlers(event_manager)
+
+        # Pull the swapped handler out of the dispatch table and invoke it.
+        # The shim is what production code reaches when the EventManager
+        # dispatches ListConnectionsForNodeRequest on a worker.
+        installed = event_manager.get_manager_for_request_type(ListConnectionsForNodeRequest)
+        assert isinstance(installed, RemoteHandler)
+
+        request = ListConnectionsForNodeRequest(node_name="some-node")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="some-node",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await installed(request)
+
+        assert isinstance(result, ListConnectionsForNodeResultSuccess)
+        assert len(forwarded_calls) == 1
+        assert isinstance(forwarded_calls[0], ListConnectionsForNodeRequest)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert "ListConnectionsForNodeRequest" in violation.message

--- a/tests/unit/common/test_node_executor_helpers.py
+++ b/tests/unit/common/test_node_executor_helpers.py
@@ -265,6 +265,52 @@ class TestExecuteSuccessReturnsNone:
         assert result is None
 
 
+class TestFormatNodeFailureMessage:
+    """Worker-side traceback frames have to land in the RuntimeError message.
+
+    Chaining via ``raise RuntimeError(msg) from exc`` is not enough on
+    its own: a ForwardedException is constructed (not raised) on the
+    receiving side, so its ``__traceback__`` is None and Python's
+    chained-exception display prints only the cause's
+    ``Type: message`` line. The helper interpolates
+    ``original_traceback`` so the worker frames are actually visible.
+    """
+
+    def test_includes_original_type_prefix(self) -> None:
+        from griptape_nodes.retained_mode.events.base_events import ForwardedException
+
+        exc = ForwardedException("rebuilt", original_type="builtins.RuntimeError")
+
+        msg = NodeExecutor._format_node_failure_message("MyNode", MagicMock(result_details="oops"), exc)
+
+        assert "[builtins.RuntimeError]" in msg
+        assert "MyNode" in msg
+
+    def test_appends_worker_traceback_when_present(self) -> None:
+        from griptape_nodes.retained_mode.events.base_events import ForwardedException
+
+        exc = ForwardedException(
+            "rebuilt",
+            original_type="builtins.ValueError",
+            original_traceback='Traceback...\n  File "a.py", line 1, in <module>\nValueError: rebuilt\n',
+        )
+
+        msg = NodeExecutor._format_node_failure_message("MyNode", MagicMock(result_details="oops"), exc)
+
+        assert "Worker traceback:" in msg
+        assert 'File "a.py"' in msg
+
+    def test_omits_worker_block_for_local_exceptions(self) -> None:
+        # Plain Exception (not a ForwardedException) means we're on the
+        # local path. No type prefix, no worker-traceback block.
+        msg = NodeExecutor._format_node_failure_message(
+            "MyNode", MagicMock(result_details="oops"), RuntimeError("local")
+        )
+
+        assert "Worker traceback:" not in msg
+        assert "[" not in msg.split("execution failed:")[1].split(":")[0]
+
+
 class TestControlFlowResolvedEventCattrsRoundTrip:
     """ControlFlowResolvedEvent.unique_parameter_uuid_to_values round-trips through cattrs.
 

--- a/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
+++ b/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
@@ -1,0 +1,197 @@
+"""Tests for the parameter-mutation-during-aprocess strict-mode detector.
+
+The detector lives in ``BaseNode.add_parameter`` and
+``BaseNode.remove_parameter_element``. It fires when a node mutates its
+own parameter list while ``aprocess_scope()`` is active (set only around
+``await node.aprocess()``) and the call is not wrapped by the handler-side
+``sanctioned_parameter_mutation()`` context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import aprocess_scope, sanctioned_parameter_mutation
+from griptape_nodes.node_library.library_registry import _constructing_node
+
+from .mocks import MockNode
+
+
+@pytest.fixture
+def mock_node() -> MockNode:
+    """Return a fresh MockNode for each test."""
+    return MockNode(name="detector_test_node")
+
+
+class TestParameterMutationDetector:
+    def test_no_violation_when_no_scope_active(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p1", type="str")
+        mock_node.add_parameter(param)
+        # Outside a strict-mode scope nothing is tracked.
+        # The add_parameter call should succeed without raising.
+
+    def test_violation_reported_when_adding_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p_added", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "parameter-mutation-during-aprocess"
+        assert "p_added" in violation.message
+        assert "add_parameter" in violation.message
+
+    def test_violation_reported_when_removing_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p_to_remove", type="str")
+        mock_node.add_parameter(param)
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.remove_parameter_element(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "parameter-mutation-during-aprocess"
+        assert "p_to_remove" in violation.message
+        assert "remove_parameter_element" in violation.message
+
+    def test_no_violation_when_handler_sanctions_add(self, mock_node: MockNode) -> None:
+        param = Parameter(name="sanctioned_add", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+            sanctioned_parameter_mutation(),
+        ):
+            mock_node.add_parameter(param)
+        assert scope.violations == []
+
+    def test_no_violation_when_handler_sanctions_remove(self, mock_node: MockNode) -> None:
+        param = Parameter(name="sanctioned_remove", type="str")
+        mock_node.add_parameter(param)
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+            sanctioned_parameter_mutation(),
+        ):
+            mock_node.remove_parameter_element(param)
+        assert scope.violations == []
+
+    def test_worker_scope_escalates_to_error_severity(self, mock_node: MockNode) -> None:
+        param = Parameter(name="worker_add", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=True,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.severity.value == "error"
+
+    def test_no_violation_during_hydration_under_runtime_execute(self, mock_node: MockNode) -> None:
+        """Hydration runs add_parameter under RUNTIME_EXECUTE without aprocess.
+
+        ``_hydrate_and_run_node_inner`` calls ``set_parameter_value``
+        (firing ``before_value_set`` / ``after_value_set``) inside the
+        ``RUNTIME_EXECUTE`` scope but before ``await node.aprocess()``.
+        Real nodes (e.g. dynamic-pipeline diffuser nodes) call
+        ``add_parameter`` from those hooks. The detector must stay silent
+        until the framework enters ``aprocess_scope()``.
+        """
+        param = Parameter(name="hydration_added", type="str")
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject=mock_node.name,
+            library_name=None,
+            is_worker=True,
+        ) as scope:
+            mock_node.add_parameter(param)
+        assert scope.violations == []
+
+    def test_no_violation_when_add_parameter_called_from_init_under_load_probe(self) -> None:
+        """__init__ calls to add_parameter during a LOAD_PROBE scope are not violations.
+
+        LibraryManager._serialize_library_node_schemas instantiates every node
+        class inside a LOAD_PROBE scope. Nodes legitimately declare their
+        parameters by calling self.add_parameter(...) from __init__, so those
+        calls must not report parameter-mutation-during-aprocess. The
+        constructor flag suppresses the rule in this case; the
+        ``_in_aprocess`` flag is also unset because no aprocess is running.
+        """
+
+        class NodeAddsParameterInInit(MockNode):
+            def __init__(self, name: str = "probe_node") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="declared_in_init", type="str"))
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="NodeAddsParameterInInit",
+                library_name="test_library",
+                is_worker=True,
+            ) as scope:
+                NodeAddsParameterInInit(name="__schema_probe__")
+        finally:
+            _constructing_node.reset(token)
+        assert scope.violations == []
+
+    def test_no_violation_for_nested_node_construction_inside_aprocess(self, mock_node: MockNode) -> None:
+        """A node constructed inside aprocess can declare params in __init__.
+
+        ``LibraryRegistry.create_node`` sets the is-constructing flag for the
+        duration of the inner node's ``__init__``. The detector's constructor
+        short-circuit must hold even when ``aprocess_scope()`` is active for
+        the outer node, otherwise creating helper nodes from aprocess would
+        spuriously trip the rule.
+        """
+
+        class InnerNodeWithParam(MockNode):
+            def __init__(self, name: str = "inner") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="inner_p", type="str"))
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            token = _constructing_node.set(True)
+            try:
+                InnerNodeWithParam(name="constructed_during_aprocess")
+            finally:
+                _constructing_node.reset(token)
+        assert scope.violations == []

--- a/tests/unit/retained_mode/events/test_event_converter.py
+++ b/tests/unit/retained_mode/events/test_event_converter.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from griptape_nodes.retained_mode.events.base_events import EventRequest
+from griptape_nodes.retained_mode.events.base_events import EventRequest, ForwardedException
 from griptape_nodes.retained_mode.events.event_converter import (
     _is_json_primitive_union,
     converter,
@@ -145,3 +145,63 @@ class TestSetParameterValueRequestStructuring:
         assert event.request.value["type"] == "ImageUrlArtifact"
         expected_width = 3024
         assert event.request.value["width"] == expected_width
+
+
+class TestExceptionWireForm:
+    """Round-trip coverage for the Exception <-> dict converter pair.
+
+    The unstructure hook emits ``{type, message, traceback}`` and the
+    structure hook rebuilds those into ``ForwardedException``'s
+    ``original_type`` / message / ``original_traceback`` slots. Both
+    halves are load-bearing for the orchestrator-side
+    ``[<type>] ... Worker traceback: ...`` rendering in
+    ``NodeExecutor._format_node_failure_message``.
+    """
+
+    @staticmethod
+    def _raise_and_capture(exc: Exception) -> Exception:
+        try:
+            raise exc  # noqa: TRY301
+        except Exception as e:
+            return e
+
+    def test_unstructure_raised_exception_carries_type_message_and_traceback(self) -> None:
+        e = self._raise_and_capture(ValueError("boom"))
+        payload = converter.unstructure(e, Exception)
+
+        assert payload["type"] == "builtins.ValueError"
+        assert payload["message"] == "boom"
+        assert payload["traceback"] is not None
+        assert "ValueError: boom" in payload["traceback"]
+
+    def test_unstructure_unraised_exception_has_null_traceback(self) -> None:
+        # An exception that was constructed but never raised has
+        # ``__traceback__ is None``; the wire form preserves type and
+        # message but the traceback slot is null.
+        payload = converter.unstructure(ValueError("never raised"), Exception)
+
+        assert payload["type"] == "builtins.ValueError"
+        assert payload["message"] == "never raised"
+        assert payload["traceback"] is None
+
+    def test_round_trip_yields_forwarded_exception_with_worker_fields(self) -> None:
+        e = self._raise_and_capture(RuntimeError("worker boom"))
+        payload = converter.unstructure(e, Exception)
+        rebuilt = converter.structure(payload, Exception)
+
+        assert isinstance(rebuilt, ForwardedException)
+        assert str(rebuilt) == "worker boom"
+        assert rebuilt.original_type == "builtins.RuntimeError"
+        assert rebuilt.original_traceback is not None
+        assert "RuntimeError: worker boom" in rebuilt.original_traceback
+
+    def test_structure_tolerates_non_dict_payload(self) -> None:
+        # Old persisted events on disk may carry a bare-string
+        # ``exception`` field; refusing to structure them would abort
+        # deserialization of the whole enclosing event.
+        rebuilt = converter.structure("legacy stringified error", Exception)
+
+        assert isinstance(rebuilt, ForwardedException)
+        assert str(rebuilt) == "legacy stringified error"
+        assert rebuilt.original_type is None
+        assert rebuilt.original_traceback is None

--- a/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
@@ -1,0 +1,147 @@
+"""Tests for the reentrant-bus-in-init strict-mode tripwire.
+
+EventManager.handle_request / ahandle_request consult
+``LibraryRegistry.is_constructing_node()`` on every dispatch. When that
+flag is set (a node ``__init__`` is currently running on the calling
+task) and a strict-mode scope is open, the manager records a
+``reentrant-bus-in-init`` violation against the active scope. The
+detector is correctness-class: severity is ERROR on both sides.
+
+Outside of node construction, dispatch must not record a violation.
+Outside of any strict-mode scope, ``STRICT_MODE.report`` is a no-op so
+the reentrant call still goes through without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+    StrictModeSeverity,
+)
+from griptape_nodes.node_library.library_registry import _constructing_node
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+
+@dataclass(kw_only=True)
+class _ProbeRequest(RequestPayload):
+    """Minimal request used to exercise the dispatch path."""
+
+    marker: str
+
+
+@dataclass(kw_only=True)
+class _ProbeResult(ResultPayloadSuccess):
+    seen_by: str
+
+
+def _make_event_manager_with_probe_handler() -> EventManager:
+    event_manager = EventManager()
+
+    async def handler(request: _ProbeRequest) -> _ProbeResult:
+        return _ProbeResult(seen_by=request.marker, result_details="ok")
+
+    event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+    return event_manager
+
+
+class TestReentrantBusInInit:
+    """The tripwire records one violation per request dispatched during __init__."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_during_node_init_records_violation(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="MyNodeClass",
+                library_name="libA",
+                is_worker=True,
+            ) as scope:
+                result = await event_manager.ahandle_request(_ProbeRequest(marker="m1"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert result.succeeded()
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "reentrant-bus-in-init"
+        assert violation.severity is StrictModeSeverity.ERROR
+        assert violation.subject == "MyNodeClass"
+        assert violation.library_name == "libA"
+        assert "_ProbeRequest" in violation.message
+
+    def test_sync_dispatch_during_node_init_records_violation(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="MyNodeClass",
+                library_name="libA",
+                is_worker=True,
+            ) as scope:
+                result = event_manager.handle_request(_ProbeRequest(marker="m2"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert result.succeeded()
+        assert len(scope.violations) == 1
+        assert scope.violations[0].rule_id == "reentrant-bus-in-init"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_outside_node_init_records_no_violation(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyNodeClass",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            result = await event_manager.ahandle_request(_ProbeRequest(marker="m3"))
+
+        assert result.succeeded()
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_during_node_init_with_no_scope_does_not_crash(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            result = await event_manager.ahandle_request(_ProbeRequest(marker="m4"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert result.succeeded()
+
+    @pytest.mark.asyncio
+    async def test_severity_is_error_on_orchestrator(self) -> None:
+        """Correctness rules fail on both sides; orchestrator scope still gets ERROR."""
+        event_manager = _make_event_manager_with_probe_handler()
+
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-1",
+                library_name="libA",
+                is_worker=False,
+            ) as scope:
+                await event_manager.ahandle_request(_ProbeRequest(marker="m5"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert scope.violations[0].severity is StrictModeSeverity.ERROR

--- a/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
@@ -23,6 +23,13 @@ from griptape_nodes.common.strict_mode import (
     StrictModeScopeKind,
     StrictModeSeverity,
 )
+
+# Intentional reach into a private module symbol: the public read API is
+# LibraryRegistry.is_constructing_node(), but there is no public setter --
+# the flag is set only inside LibraryRegistry.create_node. Tests need to
+# simulate "we are inside __init__" without calling create_node, so they
+# manipulate the underlying ContextVar directly. Keeping this private
+# avoids growing the registry's public surface for test-only plumbing.
 from griptape_nodes.node_library.library_registry import _constructing_node
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -1,0 +1,212 @@
+"""Probe-level tests for strict-mode routing in _serialize_library_node_schemas.
+
+Uses a fixture probe detector that calls ``STRICT_MODE.report`` from inside a
+node class's ``__init__``. The scope wrapper on the probe loop is then
+responsible for excluding violating classes from the returned schema list.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.exe_types.core_types import Parameter, Trait
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+
+
+@pytest.fixture
+def patched_registry() -> Callable[[dict[str, type]], AbstractContextManager[None]]:
+    """Yield a context-manager factory that patches LibraryRegistry for a probe map.
+
+    Both test classes need the same MagicMock-backed library plus the
+    same ``create_node`` side-effect that constructs an instance from
+    the probe map. Returning a factory keeps the per-test ``nodes``
+    parameter readable at the call site.
+    """
+
+    @contextmanager
+    def _patch(nodes: dict[str, type]) -> Iterator[None]:
+        lib = MagicMock()
+        lib.get_registered_nodes.return_value = list(nodes.keys())
+        lib.get_node_class.side_effect = lambda name: nodes[name]
+
+        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
+            return nodes[node_type](name)
+
+        with patch.multiple(
+            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
+            get_library=MagicMock(return_value=lib),
+            create_node=MagicMock(side_effect=_create_node),
+        ):
+            yield
+
+    return _patch
+
+
+class _CleanProbe:
+    """Node class whose __init__ does nothing interesting."""
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _ViolatingProbe:
+    """Node class whose __init__ triggers a correctness-class violation.
+
+    Uses ``reentrant-bus-in-init`` because it is registered with
+    ``correctness=True``; the LOAD_PROBE skip-on-correctness gate uses
+    that flag to decide whether to drop the class from the schema.
+    """
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        STRICT_MODE.report(
+            rule_id="reentrant-bus-in-init",
+            message="fixture probe violation",
+        )
+
+
+class TestSerializeSchemasStrictMode:
+    @pytest.mark.asyncio
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Clean": _CleanProbe}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["Clean"]
+
+    @pytest.mark.asyncio
+    async def test_violating_class_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        # Violating class dropped from output.
+        assert [s.class_name for s in schemas] == ["Clean"]
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("fixture probe violation" in r.getMessage() for r in errors)
+        assert any("class=Violator" in r.getMessage() for r in errors)
+
+
+class _DummyTrait(Trait):
+    """Minimal concrete Trait used to exercise the trait-detection path."""
+
+    @classmethod
+    def get_trait_keys(cls) -> list[str]:
+        return ["dummy"]
+
+
+class _ProbeWithConverterParam:
+    """Node class whose probe exposes a Parameter with a user-attached converter."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [
+            Parameter(name="p_with_converter", converters=[lambda v: v]),
+        ]
+
+
+class _ProbeWithValidatorParam:
+    """Node class whose probe exposes a Parameter with a user-attached validator."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [
+            Parameter(name="p_with_validator", validators=[lambda _p, _v: None]),
+        ]
+
+
+class _ProbeWithTraitParam:
+    """Node class whose probe exposes a Parameter with a real Trait child."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [
+            Parameter(name="p_with_trait", traits={_DummyTrait()}),
+        ]
+
+
+class _ProbeWithCleanParams:
+    """Node class whose probe parameter has no converters/validators/traits."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.parameters = [Parameter(name="p_clean")]
+
+
+class TestParameterBehaviorsDropped:
+    """#4472: Parameters carrying converters/validators/traits emit a warn violation."""
+
+    @pytest.mark.asyncio
+    async def test_clean_parameters_produce_no_violation(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Clean": _ProbeWithCleanParams}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["Clean"]
+        assert not any("p_clean" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_parameter_with_converter_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        # Warning, not error: the class still yields a schema.
+        assert [s.class_name for s in schemas] == ["WithBehavior"]
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("p_with_converter" in r.getMessage() for r in warnings)
+        assert any("converters" in r.getMessage() for r in warnings)
+        assert any("class=WithBehavior" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_parameter_with_validator_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["WithValidator"]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("p_with_validator" in r.getMessage() for r in warnings)
+        assert any("validators" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_parameter_with_trait_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithTrait": _ProbeWithTraitParam}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["WithTrait"]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("p_with_trait" in r.getMessage() for r in warnings)
+        assert any("traits" in r.getMessage() for r in warnings)

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -1,0 +1,156 @@
+"""Handler-level tests for strict-mode routing in on_execute_node_request.
+
+Uses a fixture runtime detector that calls ``STRICT_MODE.report`` inside
+``node.aprocess`` to simulate a rule firing during execution. The scope
+wrapper on ``on_execute_node_request`` is then responsible for turning
+worker violations into ``ExecuteNodeResultFailure`` and leaving
+orchestrator violations alone.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultFailure,
+    ExecuteNodeResultSuccess,
+    NodeMetadata,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+
+class TestExecuteNodeStrictMode:
+    def _get_node_manager(self) -> NodeManager:
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        return GriptapeNodes.NodeManager()
+
+    def _make_mock_node(self, *, aprocess_reports: bool = False) -> MagicMock:
+        node = MagicMock(spec=BaseNode)
+        node.name = "n"
+        node.parameter_values = {}
+        node.parameter_output_values = {"out": 1}
+        node.metadata = {"library": "libA"}
+        node._cancellation_requested = threading.Event()
+        node.parameters = []
+
+        async def _aprocess() -> None:
+            if aprocess_reports:
+                STRICT_MODE.report(rule_id="fixture-rule", message="fixture violation")
+
+        node.aprocess = AsyncMock(side_effect=_aprocess)
+        return node
+
+    def _make_mock_obj_mgr(self, existing_node: MagicMock) -> MagicMock:
+        m = MagicMock()
+        m.attempt_get_object_by_name_as_type.return_value = existing_node
+        return m
+
+    def _make_mock_library_manager(self, *, is_worker: bool) -> MagicMock:
+        m = MagicMock()
+        m.is_worker = is_worker
+        m._is_worker = is_worker
+        m.get_worker_for_library.return_value = None
+        return m
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_violation_stays_success(self) -> None:
+        node = self._make_mock_node(aprocess_reports=True)
+        obj_mgr = self._make_mock_obj_mgr(existing_node=node)
+        lib_mgr = self._make_mock_library_manager(is_worker=False)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
+                return_value=obj_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
+                return_value=None,
+            ),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await self._get_node_manager().on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_violation_elevates_to_failure(self) -> None:
+        node = self._make_mock_node(aprocess_reports=True)
+        lib_mgr = self._make_mock_library_manager(is_worker=True)
+        node_manager = self._get_node_manager()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        details = str(result.result_details)
+        assert "fixture-rule" in details
+        assert "fixture violation" in details
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_no_violations_unchanged(self) -> None:
+        node = self._make_mock_node(aprocess_reports=False)
+        lib_mgr = self._make_mock_library_manager(is_worker=True)
+        node_manager = self._get_node_manager()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_no_violations_unchanged(self) -> None:
+        node = self._make_mock_node(aprocess_reports=False)
+        obj_mgr = self._make_mock_obj_mgr(existing_node=node)
+        lib_mgr = self._make_mock_library_manager(is_worker=False)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
+                return_value=obj_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
+                return_value=None,
+            ),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await self._get_node_manager().on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()


### PR DESCRIPTION
## Summary

First concrete strict-mode rule. A node that issues an event-bus
request from inside its \`__init__\` deadlocks the worker library
probe (which calls \`__init__\` on the worker thread to extract a
schema).

- Append \`reentrant-bus-in-init\` to \`RULES\`.
- \`EventManager._report_reentrant_bus_in_init\`: checks
  \`in_node_init()\`, called from both \`handle_request\` (async)
  and \`handle_request_in_thread\` (sync).

The framework, the \`node_init_scope\` wrapping, and the
\`__init_subclass__\` propagation all landed in PR 01; this change
just wires up the rule and the call site that consults it.

## Stack

PR 04 of 10. Base: #4672 (PR 03).

## Test plan

- [x] \`make check\` clean
- [x] \`uv run pytest tests/unit\` green (1855 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)