### PR TITLE
feat(strict-mode) 08/10: rule parameter-mutation-during-aprocess

### DIFF
--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -1,0 +1,95 @@
+# Strict Mode Reference
+
+Strict mode is a runtime contract for what node code is allowed to do
+across the orchestrator and worker subprocess. When a node violates the
+contract, the framework records a named violation and routes it to the
+node's result payload so the author sees a remediation message in the
+editor instead of a silent no-op, deadlock, or a stack trace that names
+the wrong layer.
+
+Strict mode is always on. There is no config flag, env var, or runtime
+toggle. Severity is picked per-rule: correctness rules fail execution;
+ergonomics rules emit a warning.
+
+## How it surfaces
+
+Violations attach to the `ResultDetails` on the outgoing
+`ResultPayload`. In the editor, the node's output panel shows the rule
+id, severity, and remediation. On the worker side, correctness
+violations elevate a successful `ExecuteNodeResultSuccess` to an
+`ExecuteNodeResultFailure`; ergonomics violations stay non-fatal.
+
+Violations are also logged through the `griptape_nodes.strict_mode`
+logger. Set it to `WARNING` or lower to see every violation in the
+console.
+
+## Rule catalog
+
+Each rule is either a **correctness** rule (fails on both orchestrator
+and worker) or an **ergonomics** rule (warns on orchestrator, escalates
+to a failure on the worker unless the rule opts out).
+
+### Correctness rules (fail execution)
+
+#### `reentrant-bus-in-init`
+
+A node issued an event-bus request from inside its `__init__`. The
+worker library probe runs `__init__` to extract a schema; re-entering
+the bus there deadlocks the worker.
+
+**Remediation**: move the call into `aprocess` (or a lifecycle hook
+that runs after construction).
+
+#### `unknown-payload-type`
+
+A payload type crossing the wire was not registered in
+`PayloadRegistry`. Unknown types cannot be deserialized safely by the
+cattrs converter.
+
+**Remediation**: decorate the payload class with
+`@PayloadRegistry.register` so it can cross the
+worker/orchestrator boundary.
+
+### Ergonomics rules (warnings)
+
+#### `parameter-behaviors-dropped-in-schema`
+
+A `Parameter` attached `converters`, `validators`, or `traits` that
+are not captured in the worker schema. The orchestrator stub cannot
+re-run those behaviors, so UI-side behavior diverges from worker-side
+execution.
+
+**Remediation**: move behavior that needs to run on both sides into
+the worker-side `aprocess`, or accept the divergence as
+orchestrator-only UI sugar.
+
+#### `parameter-mutation-during-aprocess`
+
+A node called `add_parameter` or `remove_parameter_element` during
+`aprocess`. On the worker, these mutations apply to the transient
+node instance and do not sync back to the orchestrator.
+
+Hydration-time mutations made from `before_value_set` /
+`after_value_set` (the standard dynamic-parameter pattern) do
+**not** trip this rule.
+
+**Remediation**: emit an `AddParameterToNodeRequest` or
+`RemoveParameterFromNodeRequest` so the mutation propagates to the
+authoritative orchestrator-side node.
+
+#### `worker-reach-into-orchestrator`
+
+A node running on a worker issued a request whose authoritative state
+lives on the orchestrator (flow graph, connections, parameter
+registry, config, secrets). The request is forwarded across the
+WebSocket bus; each call is a network round-trip and the returned
+view is stale-by-call.
+
+The rule fires for forwarded requests issued anywhere during a
+node's execution -- including from `before_value_set` /
+`after_value_set` during hydration -- not only from `aprocess`.
+
+**Remediation**: if this is an intentional write (e.g. publishing a
+parameter value), ignore the warning. If this is a read of flow /
+connection state, consider whether the data could be passed in via
+parameters instead of fetched per-call.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,5 +346,6 @@ nav:
       - Overview: developing_nodes/index.md
       - Getting Started: developing_nodes/getting_started.md
       - Comprehensive Guide: developing_nodes/comprehensive_guide.md
+      - Strict Mode Reference: developing_nodes/strict_mode.md
       - Example Control Node: developing_nodes/example_control_node.py
   - Glossary: glossary.md

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -31,6 +31,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload,
@@ -202,6 +204,11 @@ class RemoteHandler:
 
     async def __call__(self, request: RequestPayload) -> ResultPayload:
         if self.event_manager.in_node_execution():
+            rule = RULES["worker-reach-into-orchestrator"]
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(request_type=type(request).__name__),
+            )
             event_result = await self.event_manager.forward_to_orchestrator(request, ResultContext())
             return cast("ResultPayload", event_result.result)
         return await call_function(self.original, request)

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -7,9 +7,9 @@ escalation), a human description, and a ``str.format``-ready
 remediation template.
 
 Detectors import ``RULES`` to look up their rule and call
-``report_violation(rule_id=..., message=RULES[rid].render(...))`` at
-their own call site. No enforcement logic lives here -- this module
-is a static catalog.
+``STRICT_MODE.report(rule_id=..., message=RULES[rid].render(...))``
+at their own call site. No enforcement logic lives here -- this
+module is a static catalog.
 """
 
 from __future__ import annotations
@@ -92,9 +92,39 @@ RULES: dict[str, StrictModeRule] = {
         ),
         remediation_template=(
             "Node mutated parameter '{parameter_name}' during aprocess via "
-            "{mutation}. Emit AddParameterRequest or "
-            "RemoveParameterFromNodeRequest (both ForwardFromWorkerMixin) "
-            "to propagate the change to the orchestrator."
+            "{mutation}. Emit AddParameterToNodeRequest or "
+            "RemoveParameterFromNodeRequest to propagate the change to "
+            "the orchestrator."
         ),
+    ),
+    "worker-reach-into-orchestrator": StrictModeRule(
+        rule_id="worker-reach-into-orchestrator",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node running on a worker issued a request whose "
+            "authoritative state lives on the orchestrator (flow "
+            "graph, connections, parameter registry, config, or "
+            "secrets). The request was forwarded to the orchestrator "
+            "over the WebSocket bus; each call is a network round-"
+            "trip and the returned view is stale-by-call. Events are "
+            "the sanctioned cross-side boundary, but authors are "
+            "often unaware they are paying for it. Detection runs at "
+            "the RemoteHandler dispatch site, which covers both input "
+            "hydration (before/after_value_set) and aprocess. "
+            "Violations issued from library-internal helper threads "
+            "(e.g. ThreadPoolExecutor inside diffusers/transformers) "
+            "are not reported because the strict-mode reporter is "
+            "task-local; the forward still proceeds normally."
+        ),
+        remediation_template=(
+            "Worker-side node issued '{request_type}' during node "
+            "execution. If this is an intentional write (e.g. "
+            "publishing a parameter value), ignore. If this is a read "
+            "of flow / connection state, consider whether the data "
+            "could be passed in via parameters instead of fetched "
+            "per-call."
+        ),
+        worker_escalation=False,
     ),
 }

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -81,4 +81,20 @@ RULES: dict[str, StrictModeRule] = {
         # for an ergonomics warning.
         worker_escalation=False,
     ),
+    "parameter-mutation-during-aprocess": StrictModeRule(
+        rule_id="parameter-mutation-during-aprocess",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node called add_parameter or remove_parameter during "
+            "aprocess. On the worker these changes are local to the "
+            "transient node and do not sync back to the orchestrator."
+        ),
+        remediation_template=(
+            "Node mutated parameter '{parameter_name}' during aprocess via "
+            "{mutation}. Emit AddParameterRequest or "
+            "RemoveParameterFromNodeRequest (both ForwardFromWorkerMixin) "
+            "to propagate the change to the orchestrator."
+        ),
+    ),
 }

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1810,18 +1810,33 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         return validators
 
     @property
-    def has_user_converters(self) -> bool:
-        """Whether the parameter has converters attached directly (not from traits)."""
+    def has_directly_attached_converters(self) -> bool:
+        """The directly-attached converter list is non-empty.
+
+        Trait-derived converters are merged in by the ``converters``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
         return bool(self._converters)
 
     @property
-    def has_user_validators(self) -> bool:
-        """Whether the parameter has validators attached directly (not from traits)."""
+    def has_directly_attached_validators(self) -> bool:
+        """The directly-attached validator list is non-empty.
+
+        Trait-derived validators are merged in by the ``validators``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
         return bool(self._validators)
 
     @property
     def has_traits(self) -> bool:
-        """Whether the parameter has any Trait children attached."""
+        """Any Trait child is attached.
+
+        Walks ``find_elements_by_type(Trait)`` because traits are stored
+        as child node-elements, not in a flat list. Cheap at probe
+        scale (called once per parameter at library load).
+        """
         return bool(self.find_elements_by_type(Trait))
 
     @property

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -4,11 +4,15 @@ import logging
 import threading
 import warnings
 from abc import ABC
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
+from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
     ControlParameterInput,
@@ -90,6 +94,31 @@ AsyncResult = Generator[Callable[[], T], T]
 LOCAL_EXECUTION = "Local Execution"
 PRIVATE_EXECUTION = "Private Execution"
 CONTROL_INPUT_PARAMETER = "Control Input Selection"
+
+
+# Per-task flag: when set, parameter mutations on a node are explicitly
+# sanctioned by a request handler (AddParameterToNodeRequest /
+# RemoveParameterFromNodeRequest) and the parameter-mutation-during-aprocess
+# detector should not fire. The handler-side path is the legitimate way to
+# mutate parameters because it propagates the change back to the orchestrator
+# via the request bus; direct add_parameter / remove_parameter_element calls
+# from inside aprocess do not, and that is what the rule catches.
+_sanctioned_mutation: ContextVar[bool] = ContextVar("_node_types_sanctioned_mutation", default=False)
+
+
+@contextmanager
+def sanctioned_parameter_mutation() -> Iterator[None]:
+    """Mark the enclosed block as a request-driven parameter mutation.
+
+    Wraps add_parameter / remove_parameter_element calls inside
+    AddParameterToNodeRequest and RemoveParameterFromNodeRequest handlers
+    so the parameter-mutation-during-aprocess detector skips them.
+    """
+    token = _sanctioned_mutation.set(True)
+    try:
+        yield
+    finally:
+        _sanctioned_mutation.reset(token)
 
 
 class ImportDependency(NamedTuple):
@@ -588,6 +617,7 @@ class BaseNode(ABC):
 
     def add_parameter(self, param: Parameter) -> None:
         """Adds a Parameter to the Node. Control and Data Parameters are all treated equally."""
+        self._report_parameter_mutation_if_in_aprocess(parameter_name=param.name, mutation="add_parameter")
         if any(char.isspace() for char in param.name):
             msg = f"Failed to add Parameter `{param.name}`. Parameter names cannot currently any whitespace characters. Please see https://github.com/griptape-ai/griptape-nodes/issues/714 to check the status on a remedy for this issue."
             raise ValueError(msg)
@@ -609,6 +639,7 @@ class BaseNode(ABC):
             self.remove_parameter_element(element)
 
     def remove_parameter_element(self, param: BaseNodeElement) -> None:
+        self._report_parameter_mutation_if_in_aprocess(parameter_name=param.name, mutation="remove_parameter_element")
         # Emit event before removal if it's a Parameter
         if isinstance(param, Parameter):
             self._emit_parameter_lifecycle_event(param)
@@ -1344,6 +1375,39 @@ class BaseNode(ABC):
 
         # Use reorder_elements to apply the move
         self.reorder_elements(list(new_order))
+
+    def _report_parameter_mutation_if_in_aprocess(self, *, parameter_name: str, mutation: str) -> None:
+        """Report parameter-mutation-during-aprocess when a node mutates its own params directly.
+
+        Request handlers reach ``add_parameter`` / ``remove_parameter_element``
+        via ``AddParameterToNodeRequest`` / ``RemoveParameterFromNodeRequest``
+        and wrap the call in ``sanctioned_parameter_mutation()``. Any call
+        that arrives here from aprocess without that wrapper is a direct
+        mutation, which does not sync back to the orchestrator when the
+        node runs in a worker subprocess.
+
+        ``LibraryManager._serialize_library_node_schemas`` instantiates every
+        node class inside a ``LOAD_PROBE`` scope to extract its schema. Nodes
+        routinely call ``self.add_parameter(...)`` from ``__init__``, which
+        is the intended way to declare parameters, so calls made from inside
+        a constructor are not a violation of this rule.
+        """
+        # Lazy import: library_registry imports BaseNode from this module,
+        # so importing at module load creates a cycle.
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        if _sanctioned_mutation.get():
+            return
+        if LibraryRegistry.is_constructing_node():
+            return
+        scope = STRICT_MODE.current_scope()
+        if scope is None or scope.kind is not StrictModeScopeKind.RUNTIME_EXECUTE:
+            return
+        rule = RULES["parameter-mutation-during-aprocess"]
+        STRICT_MODE.report(
+            rule_id=rule.rule_id,
+            message=rule.render(parameter_name=parameter_name, mutation=mutation),
+        )
 
     def _emit_parameter_lifecycle_event(self, parameter: BaseNodeElement, *, remove: bool = False) -> None:
         """Emit an AlterElementEvent for parameter add/remove operations."""

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
-from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
+from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
@@ -105,6 +105,15 @@ CONTROL_INPUT_PARAMETER = "Control Input Selection"
 # from inside aprocess do not, and that is what the rule catches.
 _sanctioned_mutation: ContextVar[bool] = ContextVar("_node_types_sanctioned_mutation", default=False)
 
+# Per-task flag: True only while ``await node.aprocess()`` is on the stack.
+# The detector uses this to distinguish actual aprocess execution from the
+# surrounding RUNTIME_EXECUTE scope, which also wraps input hydration.
+# Hydration-time set_parameter_value calls run before/after_value_set hooks,
+# and many real nodes (e.g. dynamic-pipeline diffuser nodes) legitimately
+# call add_parameter / remove_parameter_element from those hooks; keying off
+# the broader RUNTIME_EXECUTE scope would false-positive on every such node.
+_in_aprocess: ContextVar[bool] = ContextVar("_node_types_in_aprocess", default=False)
+
 
 @contextmanager
 def sanctioned_parameter_mutation() -> Iterator[None]:
@@ -119,6 +128,22 @@ def sanctioned_parameter_mutation() -> Iterator[None]:
         yield
     finally:
         _sanctioned_mutation.reset(token)
+
+
+@contextmanager
+def aprocess_scope() -> Iterator[None]:
+    """Mark the enclosed block as the actual aprocess() execution.
+
+    The framework wraps ``await node.aprocess()`` with this so the
+    parameter-mutation-during-aprocess detector fires only for mutations
+    that happen inside aprocess itself, not the surrounding hydration
+    pass that also runs under the RUNTIME_EXECUTE strict-mode scope.
+    """
+    token = _in_aprocess.set(True)
+    try:
+        yield
+    finally:
+        _in_aprocess.reset(token)
 
 
 class ImportDependency(NamedTuple):
@@ -1386,11 +1411,19 @@ class BaseNode(ABC):
         mutation, which does not sync back to the orchestrator when the
         node runs in a worker subprocess.
 
-        ``LibraryManager._serialize_library_node_schemas`` instantiates every
-        node class inside a ``LOAD_PROBE`` scope to extract its schema. Nodes
-        routinely call ``self.add_parameter(...)`` from ``__init__``, which
-        is the intended way to declare parameters, so calls made from inside
-        a constructor are not a violation of this rule.
+        Detection keys off ``_in_aprocess`` (set by ``aprocess_scope()`` only
+        around ``await node.aprocess()``) rather than the broader
+        ``RUNTIME_EXECUTE`` strict-mode scope, because that scope also wraps
+        input hydration. Hydration runs ``set_parameter_value`` ->
+        ``before_value_set`` / ``after_value_set``, and dynamic-pipeline
+        nodes legitimately call ``add_parameter`` from those hooks; keying
+        off ``RUNTIME_EXECUTE`` would false-positive on every such node.
+
+        Nested node construction (a node's ``__init__`` declaring parameters
+        from inside another node's ``aprocess``) is handled by the
+        ``is_constructing_node()`` short-circuit: declarative ``__init__``
+        calls to ``add_parameter`` are not violations even when an outer
+        ``aprocess`` is on the stack.
         """
         # Lazy import: library_registry imports BaseNode from this module,
         # so importing at module load creates a cycle.
@@ -1400,8 +1433,7 @@ class BaseNode(ABC):
             return
         if LibraryRegistry.is_constructing_node():
             return
-        scope = STRICT_MODE.current_scope()
-        if scope is None or scope.kind is not StrictModeScopeKind.RUNTIME_EXECUTE:
+        if not _in_aprocess.get():
             return
         rule = RULES["parameter-mutation-during-aprocess"]
         STRICT_MODE.report(

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3520,9 +3520,9 @@ class LibraryManager:
         rule = RULES["parameter-behaviors-dropped-in-schema"]
         for param in probe.parameters:
             dropped: list[str] = []
-            if param.has_user_converters:
+            if param.has_directly_attached_converters:
                 dropped.append("converters")
-            if param.has_user_validators:
+            if param.has_directly_attached_validators:
                 dropped.append("validators")
             if param.has_traits:
                 dropped.append("traits")
@@ -3555,7 +3555,7 @@ class LibraryManager:
                 kind=StrictModeScopeKind.LOAD_PROBE,
                 subject=class_name,
                 library_name=library_name,
-                is_worker=True,
+                is_worker=self.is_worker,
             ) as scope:
                 try:
                     probe = await asyncio.wait_for(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -44,6 +44,7 @@ from griptape_nodes.exe_types.node_types import (
     NodeDependencies,
     NodeResolutionState,
     TransformedParameterValue,
+    aprocess_scope,
     sanctioned_parameter_mutation,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
@@ -2999,7 +3000,8 @@ class NodeManager:
                     continue
                 node.parameter_values[param.name] = param.default_value
             try:
-                await node.aprocess()
+                with aprocess_scope():
+                    await node.aprocess()
             except Exception as e:
                 # Pass the live exception through ``exception=`` so the
                 # converter can capture worker-side frames into a

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -44,6 +44,7 @@ from griptape_nodes.exe_types.node_types import (
     NodeDependencies,
     NodeResolutionState,
     TransformedParameterValue,
+    sanctioned_parameter_mutation,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
@@ -1545,14 +1546,15 @@ class NodeManager:
             settable=request.settable,
         )
         try:
-            if request.parent_container_name and request.initial_setup:
-                parameter_parent = node.get_parameter_by_name(request.parent_container_name)
-                if parameter_parent is not None:
-                    parameter_parent.add_child(new_param)
-            elif parent_group is not None:
-                parent_group.add_child(new_param)
-            else:
-                node.add_parameter(new_param)
+            with sanctioned_parameter_mutation():
+                if request.parent_container_name and request.initial_setup:
+                    parameter_parent = node.get_parameter_by_name(request.parent_container_name)
+                    if parameter_parent is not None:
+                        parameter_parent.add_child(new_param)
+                elif parent_group is not None:
+                    parent_group.add_child(new_param)
+                else:
+                    node.add_parameter(new_param)
         except Exception as e:
             details = f"Couldn't add parameter with name {request.parameter_name} to Node '{node_name}'. Error: {e}"
             return AddParameterToNodeResultFailure(result_details=details)
@@ -1743,7 +1745,8 @@ class NodeManager:
 
         # Delete the Element itself.
         if element is not None:
-            node.remove_parameter_element(element)
+            with sanctioned_parameter_mutation():
+                node.remove_parameter_element(element)
         else:
             details = f"Attempted to remove Element '{request.parameter_name}' from Node '{node_name}'. Failed because element didn't exist."
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import logging
 import pickle
@@ -2940,14 +2941,15 @@ class NodeManager:
     async def _hydrate_and_run_node(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         """Hydrate a node's input parameters and execute it.
 
-        Hydration and node.aprocess() both run inside worker_node_execution_scope
-        so that any nested handle_request calls originated from node code (on a
-        worker) forward to the orchestrator. Hydration calls set_parameter_value,
-        which cascades into ListConnectionsForNodeRequest and similar cross-node
-        lookups; those must forward because the worker only owns its single node
-        copy and cannot resolve parent-flow or peer-node state locally. On the
-        orchestrator the scope is a no-op because forwarding is not configured
-        there.
+        On a worker, hydration and node.aprocess() both run inside
+        worker_node_execution_scope so that any nested handle_request calls
+        originated from node code forward to the orchestrator. Hydration calls
+        set_parameter_value, which cascades into ListConnectionsForNodeRequest
+        and similar cross-node lookups; those must forward because the worker
+        only owns its single node copy and cannot resolve parent-flow or peer-
+        node state locally. On the orchestrator we skip the scope entirely --
+        there is no RemoteHandler to read the flag, so opening it there would
+        only bump a refcount nothing observes.
         """
         # Register this aprocess task under its request_id so
         # CancelExecuteNodeRequest can locate it. Only populated when the caller
@@ -2966,7 +2968,15 @@ class NodeManager:
 
     async def _hydrate_and_run_node_inner(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         node_name = request.node_name
-        with GriptapeNodes.EventManager().worker_node_execution_scope():
+        # The node-execution scope only has meaning on a worker: it is what
+        # RemoteHandler consults to decide whether to forward a request to the
+        # orchestrator. On the orchestrator itself there is no RemoteHandler
+        # installed (register_remote_handlers is worker-only), so opening the
+        # scope there would just bump a refcount that nothing reads. Skip it
+        # to keep the depth counter accurate to its name.
+        is_worker = GriptapeNodes.LibraryManager()._is_worker
+        scope_cm = GriptapeNodes.EventManager().worker_node_execution_scope() if is_worker else contextlib.nullcontext()
+        with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
             for param_name, value in parameter_values.items():

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -1,0 +1,296 @@
+"""Tests for the worker-reach-into-orchestrator strict-mode tripwire.
+
+RemoteHandler is the single chokepoint where a worker-side ``aprocess``
+reaches into orchestrator-owned state. When it forwards a request back
+to the orchestrator while a strict-mode scope is active, it records a
+``worker-reach-into-orchestrator`` violation. Outside of node execution
+(bootstrap, LOAD_PROBE) the tripwire does not fire because the
+RemoteHandler delegates to the original handler before reaching the
+violation path; outside any strict-mode scope, ``STRICT_MODE.report``
+is a no-op and the handler still forwards without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    FORWARDED_REQUEST_TYPES,
+    RemoteHandler,
+    register_remote_handlers,
+)
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+    StrictModeSeverity,
+)
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultSuccess,
+    RequestPayload,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+
+@dataclass(kw_only=True)
+class _ProbeRequest(RequestPayload):
+    """Minimal request used to exercise RemoteHandler's tripwire."""
+
+    marker: str
+
+
+@dataclass(kw_only=True)
+class _ProbeResult(ResultPayloadSuccess):
+    """Success payload paired with _ProbeRequest."""
+
+    seen_by: str
+
+
+def _make_handler_with_fake_forward(event_manager: EventManager) -> RemoteHandler:
+    async def original(_request: _ProbeRequest) -> _ProbeResult:
+        return _ProbeResult(seen_by="local", result_details="local")
+
+    async def fake_forward(
+        request: RequestPayload,
+        result_context: ResultContext,  # noqa: ARG001
+    ) -> EventResultSuccess:
+        return EventResultSuccess(
+            request=request,
+            result=_ProbeResult(seen_by="orchestrator", result_details="forwarded"),
+        )
+
+    event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+    return RemoteHandler(original=original, event_manager=event_manager)
+
+
+class TestWorkerReachIntoOrchestrator:
+    """The tripwire records one violation per forwarded request while in scope."""
+
+    @pytest.mark.asyncio
+    async def test_in_scope_in_node_execution_records_violation(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await handler(_ProbeRequest(marker="m1"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert violation.severity is StrictModeSeverity.WARNING
+        assert violation.subject == "node-1"
+        assert violation.library_name == "libA"
+        assert "_ProbeRequest" in violation.message
+
+    @pytest.mark.asyncio
+    async def test_in_scope_out_of_node_execution_does_not_record(self) -> None:
+        event_manager = EventManager()
+        local_calls: list[_ProbeRequest] = []
+
+        async def original(request: _ProbeRequest) -> _ProbeResult:
+            local_calls.append(request)
+            return _ProbeResult(seen_by="local", result_details="local")
+
+        handler = RemoteHandler(original=original, event_manager=event_manager)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyClass",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            result = await handler(_ProbeRequest(marker="m2"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "local"
+        assert len(local_calls) == 1
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_no_scope_forwards_without_crashing(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with event_manager.worker_node_execution_scope():
+            result = await handler(_ProbeRequest(marker="m3"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_remediation_message_does_not_claim_from_aprocess(self) -> None:
+        """Regression guard: remediation must not claim "from aprocess".
+
+        The rule's gate is ``worker_node_execution_scope``, which covers
+        both hydration and aprocess. The remediation must not claim "from
+        aprocess" because the rule fires for both. See PR8 for the same
+        factual-claim bug Collin flagged on parameter-mutation.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-r1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="m4"))
+
+        assert len(scope.violations) == 1
+        message = scope.violations[0].message
+        assert "from aprocess" not in message
+        assert "during node execution" in message
+
+    @pytest.mark.asyncio
+    async def test_fires_during_hydration_phase_not_just_aprocess(self) -> None:
+        """The rule's gate is wider than aprocess.
+
+        ``worker_node_execution_scope`` is opened by
+        ``_hydrate_and_run_node_inner`` around BOTH hydration and
+        aprocess. Forwarded requests issued during hydration (e.g.
+        dynamic-pipeline nodes calling ListConnectionsForNodeRequest
+        from before/after_value_set) must trip the rule. This pins
+        down that the gate is intentionally wider than
+        ``aprocess_scope()``.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        # No aprocess_scope() entered. Only the worker_node_execution_scope
+        # (refcount) is active. The rule must still fire.
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-h1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="hydrate"))
+
+        assert len(scope.violations) == 1
+        assert scope.violations[0].rule_id == "worker-reach-into-orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_one_violation_per_call(self) -> None:
+        """Two forwarded requests from the same scope produce two violations."""
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-c1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="first"))
+            await handler(_ProbeRequest(marker="second"))
+
+        expected_violations = 2
+        assert len(scope.violations) == expected_violations
+
+    @pytest.mark.asyncio
+    async def test_forwarded_type_member_through_register_remote_handlers(self) -> None:
+        """End-to-end: a real FORWARDED type goes through the swap and shim.
+
+        ``register_remote_handlers`` swaps a real FORWARDED type's handler
+        for a ``RemoteHandler`` shim, and dispatching that real type
+        directly through the shim records the violation. Locks in the
+        ``FORWARDED_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
+        a future change drops a type from ``FORWARDED_REQUEST_TYPES``,
+        this test stays green only because
+        ``ListConnectionsForNodeRequest`` is still a member.
+        """
+        event_manager = EventManager()
+
+        # Capture what the RemoteHandler shim forwards. Skip going through
+        # event_manager.handle_request because that path requires a configured
+        # WebSocket loop; the rule itself fires inside RemoteHandler.__call__,
+        # which is what we want to exercise.
+        forwarded_calls: list[RequestPayload] = []
+
+        async def fake_forward(
+            request: RequestPayload,
+            result_context: ResultContext,  # noqa: ARG001
+        ) -> EventResultSuccess:
+            forwarded_calls.append(request)
+            return EventResultSuccess(
+                request=request,
+                result=ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="forwarded",
+                ),
+            )
+
+        event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+
+        # register_remote_handlers requires every FORWARDED type to have an
+        # original handler registered first. Stub them all with a trivial
+        # local handler; the swap installs RemoteHandler in their place.
+        for request_type in FORWARDED_REQUEST_TYPES:
+
+            async def stub(_request: RequestPayload) -> ResultPayloadSuccess:
+                return ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="local",
+                )
+
+            event_manager.assign_manager_to_request_type(request_type, stub)
+
+        register_remote_handlers(event_manager)
+
+        # Pull the swapped handler out of the dispatch table and invoke it.
+        # The shim is what production code reaches when the EventManager
+        # dispatches ListConnectionsForNodeRequest on a worker.
+        installed = event_manager.get_manager_for_request_type(ListConnectionsForNodeRequest)
+        assert isinstance(installed, RemoteHandler)
+
+        request = ListConnectionsForNodeRequest(node_name="some-node")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="some-node",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await installed(request)
+
+        assert isinstance(result, ListConnectionsForNodeResultSuccess)
+        assert len(forwarded_calls) == 1
+        assert isinstance(forwarded_calls[0], ListConnectionsForNodeRequest)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert "ListConnectionsForNodeRequest" in violation.message

--- a/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
+++ b/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
@@ -1,0 +1,136 @@
+"""Tests for the parameter-mutation-during-aprocess strict-mode detector.
+
+The detector lives in ``BaseNode.add_parameter`` and
+``BaseNode.remove_parameter_element``. It fires when a node mutates its
+own parameter list while a RUNTIME_EXECUTE strict-mode scope is active
+and the call is not wrapped by the handler-side
+``sanctioned_parameter_mutation()`` context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import sanctioned_parameter_mutation
+from griptape_nodes.node_library.library_registry import _constructing_node
+
+from .mocks import MockNode
+
+
+@pytest.fixture
+def mock_node() -> MockNode:
+    """Return a fresh MockNode for each test."""
+    return MockNode(name="detector_test_node")
+
+
+class TestParameterMutationDetector:
+    def test_no_violation_when_no_scope_active(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p1", type="str")
+        mock_node.add_parameter(param)
+        # Outside a strict-mode scope nothing is tracked.
+        # The add_parameter call should succeed without raising.
+
+    def test_violation_reported_when_adding_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p_added", type="str")
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject=mock_node.name,
+            library_name=None,
+            is_worker=False,
+        ) as scope:
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "parameter-mutation-during-aprocess"
+        assert "p_added" in violation.message
+        assert "add_parameter" in violation.message
+
+    def test_violation_reported_when_removing_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
+        param = Parameter(name="p_to_remove", type="str")
+        mock_node.add_parameter(param)
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject=mock_node.name,
+            library_name=None,
+            is_worker=False,
+        ) as scope:
+            mock_node.remove_parameter_element(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "parameter-mutation-during-aprocess"
+        assert "p_to_remove" in violation.message
+        assert "remove_parameter_element" in violation.message
+
+    def test_no_violation_when_handler_sanctions_add(self, mock_node: MockNode) -> None:
+        param = Parameter(name="sanctioned_add", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            sanctioned_parameter_mutation(),
+        ):
+            mock_node.add_parameter(param)
+        assert scope.violations == []
+
+    def test_no_violation_when_handler_sanctions_remove(self, mock_node: MockNode) -> None:
+        param = Parameter(name="sanctioned_remove", type="str")
+        mock_node.add_parameter(param)
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            sanctioned_parameter_mutation(),
+        ):
+            mock_node.remove_parameter_element(param)
+        assert scope.violations == []
+
+    def test_worker_scope_escalates_to_error_severity(self, mock_node: MockNode) -> None:
+        param = Parameter(name="worker_add", type="str")
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject=mock_node.name,
+            library_name=None,
+            is_worker=True,
+        ) as scope:
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.severity.value == "error"
+
+    def test_no_violation_when_add_parameter_called_from_init_under_load_probe(self) -> None:
+        """__init__ calls to add_parameter during a LOAD_PROBE scope are not violations.
+
+        LibraryManager._serialize_library_node_schemas instantiates every node
+        class inside a LOAD_PROBE scope. Nodes legitimately declare their
+        parameters by calling self.add_parameter(...) from __init__, so those
+        calls must not report parameter-mutation-during-aprocess.
+        """
+
+        class NodeAddsParameterInInit(MockNode):
+            def __init__(self, name: str = "probe_node") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="declared_in_init", type="str"))
+
+        # LOAD_PROBE construction sets the is-constructing flag in
+        # LibraryRegistry.create_node; the detector reads it via
+        # LibraryRegistry.is_constructing_node().
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.LOAD_PROBE,
+                subject="NodeAddsParameterInInit",
+                library_name="test_library",
+                is_worker=True,
+            ) as scope:
+                NodeAddsParameterInInit(name="__schema_probe__")
+        finally:
+            _constructing_node.reset(token)
+        assert scope.violations == []

--- a/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
+++ b/tests/unit/exe_types/test_parameter_mutation_strict_mode.py
@@ -2,8 +2,8 @@
 
 The detector lives in ``BaseNode.add_parameter`` and
 ``BaseNode.remove_parameter_element``. It fires when a node mutates its
-own parameter list while a RUNTIME_EXECUTE strict-mode scope is active
-and the call is not wrapped by the handler-side
+own parameter list while ``aprocess_scope()`` is active (set only around
+``await node.aprocess()``) and the call is not wrapped by the handler-side
 ``sanctioned_parameter_mutation()`` context.
 """
 
@@ -13,7 +13,7 @@ import pytest
 
 from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import sanctioned_parameter_mutation
+from griptape_nodes.exe_types.node_types import aprocess_scope, sanctioned_parameter_mutation
 from griptape_nodes.node_library.library_registry import _constructing_node
 
 from .mocks import MockNode
@@ -34,12 +34,15 @@ class TestParameterMutationDetector:
 
     def test_violation_reported_when_adding_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
         param = Parameter(name="p_added", type="str")
-        with STRICT_MODE.open_scope(
-            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
-            subject=mock_node.name,
-            library_name=None,
-            is_worker=False,
-        ) as scope:
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
             mock_node.add_parameter(param)
         assert len(scope.violations) == 1
         violation = scope.violations[0]
@@ -50,12 +53,15 @@ class TestParameterMutationDetector:
     def test_violation_reported_when_removing_parameter_inside_aprocess_scope(self, mock_node: MockNode) -> None:
         param = Parameter(name="p_to_remove", type="str")
         mock_node.add_parameter(param)
-        with STRICT_MODE.open_scope(
-            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
-            subject=mock_node.name,
-            library_name=None,
-            is_worker=False,
-        ) as scope:
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
             mock_node.remove_parameter_element(param)
         assert len(scope.violations) == 1
         violation = scope.violations[0]
@@ -72,6 +78,7 @@ class TestParameterMutationDetector:
                 library_name=None,
                 is_worker=False,
             ) as scope,
+            aprocess_scope(),
             sanctioned_parameter_mutation(),
         ):
             mock_node.add_parameter(param)
@@ -87,6 +94,7 @@ class TestParameterMutationDetector:
                 library_name=None,
                 is_worker=False,
             ) as scope,
+            aprocess_scope(),
             sanctioned_parameter_mutation(),
         ):
             mock_node.remove_parameter_element(param)
@@ -94,6 +102,31 @@ class TestParameterMutationDetector:
 
     def test_worker_scope_escalates_to_error_severity(self, mock_node: MockNode) -> None:
         param = Parameter(name="worker_add", type="str")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=True,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            mock_node.add_parameter(param)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.severity.value == "error"
+
+    def test_no_violation_during_hydration_under_runtime_execute(self, mock_node: MockNode) -> None:
+        """Hydration runs add_parameter under RUNTIME_EXECUTE without aprocess.
+
+        ``_hydrate_and_run_node_inner`` calls ``set_parameter_value``
+        (firing ``before_value_set`` / ``after_value_set``) inside the
+        ``RUNTIME_EXECUTE`` scope but before ``await node.aprocess()``.
+        Real nodes (e.g. dynamic-pipeline diffuser nodes) call
+        ``add_parameter`` from those hooks. The detector must stay silent
+        until the framework enters ``aprocess_scope()``.
+        """
+        param = Parameter(name="hydration_added", type="str")
         with STRICT_MODE.open_scope(
             kind=StrictModeScopeKind.RUNTIME_EXECUTE,
             subject=mock_node.name,
@@ -101,9 +134,7 @@ class TestParameterMutationDetector:
             is_worker=True,
         ) as scope:
             mock_node.add_parameter(param)
-        assert len(scope.violations) == 1
-        violation = scope.violations[0]
-        assert violation.severity.value == "error"
+        assert scope.violations == []
 
     def test_no_violation_when_add_parameter_called_from_init_under_load_probe(self) -> None:
         """__init__ calls to add_parameter during a LOAD_PROBE scope are not violations.
@@ -111,7 +142,9 @@ class TestParameterMutationDetector:
         LibraryManager._serialize_library_node_schemas instantiates every node
         class inside a LOAD_PROBE scope. Nodes legitimately declare their
         parameters by calling self.add_parameter(...) from __init__, so those
-        calls must not report parameter-mutation-during-aprocess.
+        calls must not report parameter-mutation-during-aprocess. The
+        constructor flag suppresses the rule in this case; the
+        ``_in_aprocess`` flag is also unset because no aprocess is running.
         """
 
         class NodeAddsParameterInInit(MockNode):
@@ -119,9 +152,6 @@ class TestParameterMutationDetector:
                 super().__init__(name=name)
                 self.add_parameter(Parameter(name="declared_in_init", type="str"))
 
-        # LOAD_PROBE construction sets the is-constructing flag in
-        # LibraryRegistry.create_node; the detector reads it via
-        # LibraryRegistry.is_constructing_node().
         token = _constructing_node.set(True)
         try:
             with STRICT_MODE.open_scope(
@@ -133,4 +163,35 @@ class TestParameterMutationDetector:
                 NodeAddsParameterInInit(name="__schema_probe__")
         finally:
             _constructing_node.reset(token)
+        assert scope.violations == []
+
+    def test_no_violation_for_nested_node_construction_inside_aprocess(self, mock_node: MockNode) -> None:
+        """A node constructed inside aprocess can declare params in __init__.
+
+        ``LibraryRegistry.create_node`` sets the is-constructing flag for the
+        duration of the inner node's ``__init__``. The detector's constructor
+        short-circuit must hold even when ``aprocess_scope()`` is active for
+        the outer node, otherwise creating helper nodes from aprocess would
+        spuriously trip the rule.
+        """
+
+        class InnerNodeWithParam(MockNode):
+            def __init__(self, name: str = "inner") -> None:
+                super().__init__(name=name)
+                self.add_parameter(Parameter(name="inner_p", type="str"))
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject=mock_node.name,
+                library_name=None,
+                is_worker=False,
+            ) as scope,
+            aprocess_scope(),
+        ):
+            token = _constructing_node.set(True)
+            try:
+                InnerNodeWithParam(name="constructed_during_aprocess")
+            finally:
+                _constructing_node.reset(token)
         assert scope.violations == []

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -8,7 +8,8 @@ responsible for excluding violating classes from the returned schema list.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,39 @@ import pytest
 from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+
+
+@pytest.fixture
+def patched_registry() -> Callable[[dict[str, type]], AbstractContextManager[None]]:
+    """Yield a context-manager factory that patches LibraryRegistry for a probe map.
+
+    Both test classes need the same MagicMock-backed library plus the
+    same ``create_node`` side-effect that constructs an instance from
+    the probe map. Returning a factory keeps the per-test ``nodes``
+    parameter readable at the call site.
+    """
+
+    @contextmanager
+    def _patch(nodes: dict[str, type]) -> Iterator[None]:
+        lib = MagicMock()
+        lib.get_registered_nodes.return_value = list(nodes.keys())
+        lib.get_node_class.side_effect = lambda name: nodes[name]
+
+        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
+            return nodes[node_type](name)
+
+        with patch.multiple(
+            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
+            get_library=MagicMock(return_value=lib),
+            create_node=MagicMock(side_effect=_create_node),
+        ):
+            yield
+
+    return _patch
 
 
 class _CleanProbe:
@@ -46,41 +80,21 @@ class _ViolatingProbe:
 
 
 class TestSerializeSchemasStrictMode:
-    def _make_library(self, nodes: dict[str, type]) -> MagicMock:
-        lib = MagicMock()
-        lib.get_registered_nodes.return_value = list(nodes.keys())
-        lib.get_node_class.side_effect = lambda name: nodes[name]
-        return lib
-
-    def _patch_registry(self, library: MagicMock, nodes: dict[str, type]) -> Any:
-        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
-
-        return patch.multiple(
-            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
-            get_library=MagicMock(return_value=library),
-            create_node=MagicMock(side_effect=_create_node),
-        )
-
     @pytest.mark.asyncio
-    async def test_clean_class_is_included(self) -> None:
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Clean": _CleanProbe}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["Clean"]
 
     @pytest.mark.asyncio
-    async def test_violating_class_is_skipped(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_violating_class_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Violator": _ViolatingProbe, "Clean": _CleanProbe}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         # Violating class dropped from output.
@@ -140,30 +154,13 @@ class _ProbeWithCleanParams:
 class TestParameterBehaviorsDropped:
     """#4472: Parameters carrying converters/validators/traits emit a warn violation."""
 
-    def _make_library(self, nodes: dict[str, type]) -> MagicMock:
-        lib = MagicMock()
-        lib.get_registered_nodes.return_value = list(nodes.keys())
-        lib.get_node_class.side_effect = lambda name: nodes[name]
-        return lib
-
-    def _patch_registry(self, library: MagicMock, nodes: dict[str, type]) -> Any:
-        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
-
-        return patch.multiple(
-            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
-            get_library=MagicMock(return_value=library),
-            create_node=MagicMock(side_effect=_create_node),
-        )
-
     @pytest.mark.asyncio
-    async def test_clean_parameters_produce_no_violation(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_clean_parameters_produce_no_violation(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Clean": _ProbeWithCleanParams}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Clean": _ProbeWithCleanParams}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["Clean"]
@@ -171,14 +168,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_converter_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithBehavior": _ProbeWithConverterParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         # Warning, not error: the class still yields a schema.
@@ -191,14 +185,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_validator_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithValidator": _ProbeWithValidatorParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["WithValidator"]
@@ -208,14 +199,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_trait_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithTrait": _ProbeWithTraitParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithTrait": _ProbeWithTraitParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["WithTrait"]

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -1,0 +1,156 @@
+"""Handler-level tests for strict-mode routing in on_execute_node_request.
+
+Uses a fixture runtime detector that calls ``STRICT_MODE.report`` inside
+``node.aprocess`` to simulate a rule firing during execution. The scope
+wrapper on ``on_execute_node_request`` is then responsible for turning
+worker violations into ``ExecuteNodeResultFailure`` and leaving
+orchestrator violations alone.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultFailure,
+    ExecuteNodeResultSuccess,
+    NodeMetadata,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+
+class TestExecuteNodeStrictMode:
+    def _get_node_manager(self) -> NodeManager:
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        return GriptapeNodes.NodeManager()
+
+    def _make_mock_node(self, *, aprocess_reports: bool = False) -> MagicMock:
+        node = MagicMock(spec=BaseNode)
+        node.name = "n"
+        node.parameter_values = {}
+        node.parameter_output_values = {"out": 1}
+        node.metadata = {"library": "libA"}
+        node._cancellation_requested = threading.Event()
+        node.parameters = []
+
+        async def _aprocess() -> None:
+            if aprocess_reports:
+                STRICT_MODE.report(rule_id="fixture-rule", message="fixture violation")
+
+        node.aprocess = AsyncMock(side_effect=_aprocess)
+        return node
+
+    def _make_mock_obj_mgr(self, existing_node: MagicMock) -> MagicMock:
+        m = MagicMock()
+        m.attempt_get_object_by_name_as_type.return_value = existing_node
+        return m
+
+    def _make_mock_library_manager(self, *, is_worker: bool) -> MagicMock:
+        m = MagicMock()
+        m.is_worker = is_worker
+        m._is_worker = is_worker
+        m.get_worker_for_library.return_value = None
+        return m
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_violation_stays_success(self) -> None:
+        node = self._make_mock_node(aprocess_reports=True)
+        obj_mgr = self._make_mock_obj_mgr(existing_node=node)
+        lib_mgr = self._make_mock_library_manager(is_worker=False)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
+                return_value=obj_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
+                return_value=None,
+            ),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await self._get_node_manager().on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_violation_elevates_to_failure(self) -> None:
+        node = self._make_mock_node(aprocess_reports=True)
+        lib_mgr = self._make_mock_library_manager(is_worker=True)
+        node_manager = self._get_node_manager()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        details = str(result.result_details)
+        assert "fixture-rule" in details
+        assert "fixture violation" in details
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_no_violations_unchanged(self) -> None:
+        node = self._make_mock_node(aprocess_reports=False)
+        lib_mgr = self._make_mock_library_manager(is_worker=True)
+        node_manager = self._get_node_manager()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await node_manager.on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_no_violations_unchanged(self) -> None:
+        node = self._make_mock_node(aprocess_reports=False)
+        obj_mgr = self._make_mock_obj_mgr(existing_node=node)
+        lib_mgr = self._make_mock_library_manager(is_worker=False)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
+                return_value=obj_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
+                return_value=lib_mgr,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
+                return_value=None,
+            ),
+        ):
+            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+            result = await self._get_node_manager().on_execute_node_request(request)
+
+        assert isinstance(result, ExecuteNodeResultSuccess)
+        node.aprocess.assert_awaited_once()


### PR DESCRIPTION
## Summary

Detect direct \`add_parameter\` / \`remove_parameter_element\`
calls made from inside \`aprocess\`. On a worker, these mutations
apply to the transient node and never propagate back to the
authoritative orchestrator-side instance.

- Append \`parameter-mutation-during-aprocess\` to \`RULES\`.
- \`BaseNode._report_parameter_mutation_if_in_aprocess\` called
  from both \`add_parameter\` and \`remove_parameter_element\`.
  Short-circuits when a) inside \`sanctioned_parameter_mutation()\`,
  b) inside a node \`__init__\` (LOAD_PROBE schemas legitimately
  call \`self.add_parameter(...)\`), or c) no scope is active.
- \`NodeManager.AddParameterToNodeRequest\` and
  \`RemoveParameterFromNodeRequest\` handlers wrap their
  mutations in \`sanctioned_parameter_mutation()\` so legitimate
  request-driven edits bypass the detector.
- New tests under \`exe_types/test_parameter_mutation_strict_mode.py\`
  exercise the rule call sites; new tests under
  \`retained_mode/managers/test_node_manager_strict_mode.py\`
  exercise the handler escalation path with a fixture rule.

## Stack

PR 08 of 10. Base: #4676 (PR 07).

## Test plan

- [x] \`make check\` clean
- [x] \`uv run pytest tests/unit\` green (1870 tests, +11 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)