### PR TITLE
feat(strict-mode) 09/10: rule worker-reach-into-orchestrator

### DIFF
--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -1,0 +1,95 @@
+# Strict Mode Reference
+
+Strict mode is a runtime contract for what node code is allowed to do
+across the orchestrator and worker subprocess. When a node violates the
+contract, the framework records a named violation and routes it to the
+node's result payload so the author sees a remediation message in the
+editor instead of a silent no-op, deadlock, or a stack trace that names
+the wrong layer.
+
+Strict mode is always on. There is no config flag, env var, or runtime
+toggle. Severity is picked per-rule: correctness rules fail execution;
+ergonomics rules emit a warning.
+
+## How it surfaces
+
+Violations attach to the `ResultDetails` on the outgoing
+`ResultPayload`. In the editor, the node's output panel shows the rule
+id, severity, and remediation. On the worker side, correctness
+violations elevate a successful `ExecuteNodeResultSuccess` to an
+`ExecuteNodeResultFailure`; ergonomics violations stay non-fatal.
+
+Violations are also logged through the `griptape_nodes.strict_mode`
+logger. Set it to `WARNING` or lower to see every violation in the
+console.
+
+## Rule catalog
+
+Each rule is either a **correctness** rule (fails on both orchestrator
+and worker) or an **ergonomics** rule (warns on orchestrator, escalates
+to a failure on the worker unless the rule opts out).
+
+### Correctness rules (fail execution)
+
+#### `reentrant-bus-in-init`
+
+A node issued an event-bus request from inside its `__init__`. The
+worker library probe runs `__init__` to extract a schema; re-entering
+the bus there deadlocks the worker.
+
+**Remediation**: move the call into `aprocess` (or a lifecycle hook
+that runs after construction).
+
+#### `unknown-payload-type`
+
+A payload type crossing the wire was not registered in
+`PayloadRegistry`. Unknown types cannot be deserialized safely by the
+cattrs converter.
+
+**Remediation**: decorate the payload class with
+`@PayloadRegistry.register` so it can cross the
+worker/orchestrator boundary.
+
+### Ergonomics rules (warnings)
+
+#### `parameter-behaviors-dropped-in-schema`
+
+A `Parameter` attached `converters`, `validators`, or `traits` that
+are not captured in the worker schema. The orchestrator stub cannot
+re-run those behaviors, so UI-side behavior diverges from worker-side
+execution.
+
+**Remediation**: move behavior that needs to run on both sides into
+the worker-side `aprocess`, or accept the divergence as
+orchestrator-only UI sugar.
+
+#### `parameter-mutation-during-aprocess`
+
+A node called `add_parameter` or `remove_parameter_element` during
+`aprocess`. On the worker, these mutations apply to the transient
+node instance and do not sync back to the orchestrator.
+
+Hydration-time mutations made from `before_value_set` /
+`after_value_set` (the standard dynamic-parameter pattern) do
+**not** trip this rule.
+
+**Remediation**: emit an `AddParameterToNodeRequest` or
+`RemoveParameterFromNodeRequest` so the mutation propagates to the
+authoritative orchestrator-side node.
+
+#### `worker-reach-into-orchestrator`
+
+A node running on a worker issued a request whose authoritative state
+lives on the orchestrator (flow graph, connections, parameter
+registry, config, secrets). The request is forwarded across the
+WebSocket bus; each call is a network round-trip and the returned
+view is stale-by-call.
+
+The rule fires for forwarded requests issued anywhere during a
+node's execution -- including from `before_value_set` /
+`after_value_set` during hydration -- not only from `aprocess`.
+
+**Remediation**: if this is an intentional write (e.g. publishing a
+parameter value), ignore the warning. If this is a read of flow /
+connection state, consider whether the data could be passed in via
+parameters instead of fetched per-call.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,5 +346,6 @@ nav:
       - Overview: developing_nodes/index.md
       - Getting Started: developing_nodes/getting_started.md
       - Comprehensive Guide: developing_nodes/comprehensive_guide.md
+      - Strict Mode Reference: developing_nodes/strict_mode.md
       - Example Control Node: developing_nodes/example_control_node.py
   - Glossary: glossary.md

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -31,6 +31,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from griptape_nodes.common.strict_mode import STRICT_MODE
+from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload,
@@ -202,6 +204,11 @@ class RemoteHandler:
 
     async def __call__(self, request: RequestPayload) -> ResultPayload:
         if self.event_manager.in_node_execution():
+            rule = RULES["worker-reach-into-orchestrator"]
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(request_type=type(request).__name__),
+            )
             event_result = await self.event_manager.forward_to_orchestrator(request, ResultContext())
             return cast("ResultPayload", event_result.result)
         return await call_function(self.original, request)

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -109,14 +109,21 @@ RULES: dict[str, StrictModeRule] = {
             "over the WebSocket bus; each call is a network round-"
             "trip and the returned view is stale-by-call. Events are "
             "the sanctioned cross-side boundary, but authors are "
-            "often unaware they are paying for it."
+            "often unaware they are paying for it. Detection runs at "
+            "the RemoteHandler dispatch site, which covers both input "
+            "hydration (before/after_value_set) and aprocess. "
+            "Violations issued from library-internal helper threads "
+            "(e.g. ThreadPoolExecutor inside diffusers/transformers) "
+            "are not reported because the strict-mode reporter is "
+            "task-local; the forward still proceeds normally."
         ),
         remediation_template=(
-            "Worker-side node issued '{request_type}' from aprocess. "
-            "If this is an intentional write (e.g. publishing a "
-            "parameter value), ignore. If this is a read of flow/ "
-            "connection state, consider whether the data could be "
-            "passed in via parameters instead of fetched per-call."
+            "Worker-side node issued '{request_type}' during node "
+            "execution. If this is an intentional write (e.g. "
+            "publishing a parameter value), ignore. If this is a read "
+            "of flow / connection state, consider whether the data "
+            "could be passed in via parameters instead of fetched "
+            "per-call."
         ),
         worker_escalation=False,
     ),

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -7,9 +7,9 @@ escalation), a human description, and a ``str.format``-ready
 remediation template.
 
 Detectors import ``RULES`` to look up their rule and call
-``report_violation(rule_id=..., message=RULES[rid].render(...))`` at
-their own call site. No enforcement logic lives here -- this module
-is a static catalog.
+``STRICT_MODE.report(rule_id=..., message=RULES[rid].render(...))``
+at their own call site. No enforcement logic lives here -- this
+module is a static catalog.
 """
 
 from __future__ import annotations
@@ -92,9 +92,9 @@ RULES: dict[str, StrictModeRule] = {
         ),
         remediation_template=(
             "Node mutated parameter '{parameter_name}' during aprocess via "
-            "{mutation}. Emit AddParameterRequest or "
-            "RemoveParameterFromNodeRequest (both ForwardFromWorkerMixin) "
-            "to propagate the change to the orchestrator."
+            "{mutation}. Emit AddParameterToNodeRequest or "
+            "RemoveParameterFromNodeRequest to propagate the change to "
+            "the orchestrator."
         ),
     ),
     "worker-reach-into-orchestrator": StrictModeRule(

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -97,4 +97,27 @@ RULES: dict[str, StrictModeRule] = {
             "to propagate the change to the orchestrator."
         ),
     ),
+    "worker-reach-into-orchestrator": StrictModeRule(
+        rule_id="worker-reach-into-orchestrator",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node running on a worker issued a request whose "
+            "authoritative state lives on the orchestrator (flow "
+            "graph, connections, parameter registry, config, or "
+            "secrets). The request was forwarded to the orchestrator "
+            "over the WebSocket bus; each call is a network round-"
+            "trip and the returned view is stale-by-call. Events are "
+            "the sanctioned cross-side boundary, but authors are "
+            "often unaware they are paying for it."
+        ),
+        remediation_template=(
+            "Worker-side node issued '{request_type}' from aprocess. "
+            "If this is an intentional write (e.g. publishing a "
+            "parameter value), ignore. If this is a read of flow/ "
+            "connection state, consider whether the data could be "
+            "passed in via parameters instead of fetched per-call."
+        ),
+        worker_escalation=False,
+    ),
 }

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1810,18 +1810,33 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         return validators
 
     @property
-    def has_user_converters(self) -> bool:
-        """Whether the parameter has converters attached directly (not from traits)."""
+    def has_directly_attached_converters(self) -> bool:
+        """The directly-attached converter list is non-empty.
+
+        Trait-derived converters are merged in by the ``converters``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
         return bool(self._converters)
 
     @property
-    def has_user_validators(self) -> bool:
-        """Whether the parameter has validators attached directly (not from traits)."""
+    def has_directly_attached_validators(self) -> bool:
+        """The directly-attached validator list is non-empty.
+
+        Trait-derived validators are merged in by the ``validators``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
         return bool(self._validators)
 
     @property
     def has_traits(self) -> bool:
-        """Whether the parameter has any Trait children attached."""
+        """Any Trait child is attached.
+
+        Walks ``find_elements_by_type(Trait)`` because traits are stored
+        as child node-elements, not in a flat list. Cheap at probe
+        scale (called once per parameter at library load).
+        """
         return bool(self.find_elements_by_type(Trait))
 
     @property

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3520,9 +3520,9 @@ class LibraryManager:
         rule = RULES["parameter-behaviors-dropped-in-schema"]
         for param in probe.parameters:
             dropped: list[str] = []
-            if param.has_user_converters:
+            if param.has_directly_attached_converters:
                 dropped.append("converters")
-            if param.has_user_validators:
+            if param.has_directly_attached_validators:
                 dropped.append("validators")
             if param.has_traits:
                 dropped.append("traits")
@@ -3555,7 +3555,7 @@ class LibraryManager:
                 kind=StrictModeScopeKind.LOAD_PROBE,
                 subject=class_name,
                 library_name=library_name,
-                is_worker=True,
+                is_worker=self.is_worker,
             ) as scope:
                 try:
                     probe = await asyncio.wait_for(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import logging
 import pickle
@@ -2940,14 +2941,15 @@ class NodeManager:
     async def _hydrate_and_run_node(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         """Hydrate a node's input parameters and execute it.
 
-        Hydration and node.aprocess() both run inside worker_node_execution_scope
-        so that any nested handle_request calls originated from node code (on a
-        worker) forward to the orchestrator. Hydration calls set_parameter_value,
-        which cascades into ListConnectionsForNodeRequest and similar cross-node
-        lookups; those must forward because the worker only owns its single node
-        copy and cannot resolve parent-flow or peer-node state locally. On the
-        orchestrator the scope is a no-op because forwarding is not configured
-        there.
+        On a worker, hydration and node.aprocess() both run inside
+        worker_node_execution_scope so that any nested handle_request calls
+        originated from node code forward to the orchestrator. Hydration calls
+        set_parameter_value, which cascades into ListConnectionsForNodeRequest
+        and similar cross-node lookups; those must forward because the worker
+        only owns its single node copy and cannot resolve parent-flow or peer-
+        node state locally. On the orchestrator we skip the scope entirely --
+        there is no RemoteHandler to read the flag, so opening it there would
+        only bump a refcount nothing observes.
         """
         # Register this aprocess task under its request_id so
         # CancelExecuteNodeRequest can locate it. Only populated when the caller
@@ -2966,7 +2968,15 @@ class NodeManager:
 
     async def _hydrate_and_run_node_inner(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         node_name = request.node_name
-        with GriptapeNodes.EventManager().worker_node_execution_scope():
+        # The node-execution scope only has meaning on a worker: it is what
+        # RemoteHandler consults to decide whether to forward a request to the
+        # orchestrator. On the orchestrator itself there is no RemoteHandler
+        # installed (register_remote_handlers is worker-only), so opening the
+        # scope there would just bump a refcount that nothing reads. Skip it
+        # to keep the depth counter accurate to its name.
+        is_worker = GriptapeNodes.LibraryManager()._is_worker
+        scope_cm = GriptapeNodes.EventManager().worker_node_execution_scope() if is_worker else contextlib.nullcontext()
+        with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
             for param_name, value in parameter_values.items():

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -1,0 +1,130 @@
+"""Tests for the worker-reach-into-orchestrator strict-mode tripwire.
+
+RemoteHandler is the single chokepoint where a worker-side ``aprocess``
+reaches into orchestrator-owned state. When it forwards a request back
+to the orchestrator while a strict-mode scope is active, it records a
+``worker-reach-into-orchestrator`` violation. Outside of node execution
+(bootstrap, LOAD_PROBE) the tripwire does not fire because the
+RemoteHandler delegates to the original handler before reaching the
+violation path; outside any strict-mode scope, ``STRICT_MODE.report``
+is a no-op and the handler still forwards without crashing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.app.worker_routing import RemoteHandler
+from griptape_nodes.common.strict_mode import (
+    STRICT_MODE,
+    StrictModeScopeKind,
+    StrictModeSeverity,
+)
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultSuccess,
+    RequestPayload,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+
+@dataclass(kw_only=True)
+class _ProbeRequest(RequestPayload):
+    """Minimal request used to exercise RemoteHandler's tripwire."""
+
+    marker: str
+
+
+@dataclass(kw_only=True)
+class _ProbeResult(ResultPayloadSuccess):
+    """Success payload paired with _ProbeRequest."""
+
+    seen_by: str
+
+
+def _make_handler_with_fake_forward(event_manager: EventManager) -> RemoteHandler:
+    async def original(_request: _ProbeRequest) -> _ProbeResult:
+        return _ProbeResult(seen_by="local", result_details="local")
+
+    async def fake_forward(
+        request: RequestPayload,
+        result_context: ResultContext,  # noqa: ARG001
+    ) -> EventResultSuccess:
+        return EventResultSuccess(
+            request=request,
+            result=_ProbeResult(seen_by="orchestrator", result_details="forwarded"),
+        )
+
+    event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+    return RemoteHandler(original=original, event_manager=event_manager)
+
+
+class TestWorkerReachIntoOrchestrator:
+    """The tripwire records one violation per forwarded request while in scope."""
+
+    @pytest.mark.asyncio
+    async def test_in_scope_in_node_execution_records_violation(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await handler(_ProbeRequest(marker="m1"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert violation.severity is StrictModeSeverity.WARNING
+        assert violation.subject == "node-1"
+        assert violation.library_name == "libA"
+        assert "_ProbeRequest" in violation.message
+
+    @pytest.mark.asyncio
+    async def test_in_scope_out_of_node_execution_does_not_record(self) -> None:
+        event_manager = EventManager()
+        local_calls: list[_ProbeRequest] = []
+
+        async def original(request: _ProbeRequest) -> _ProbeResult:
+            local_calls.append(request)
+            return _ProbeResult(seen_by="local", result_details="local")
+
+        handler = RemoteHandler(original=original, event_manager=event_manager)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyClass",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            result = await handler(_ProbeRequest(marker="m2"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "local"
+        assert len(local_calls) == 1
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_no_scope_forwards_without_crashing(self) -> None:
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with event_manager.worker_node_execution_scope():
+            result = await handler(_ProbeRequest(marker="m3"))
+
+        assert isinstance(result, _ProbeResult)
+        assert result.seen_by == "orchestrator"

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -17,7 +17,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from griptape_nodes.app.worker_routing import RemoteHandler
+from griptape_nodes.app.worker_routing import (
+    FORWARDED_REQUEST_TYPES,
+    RemoteHandler,
+    register_remote_handlers,
+)
 from griptape_nodes.common.strict_mode import (
     STRICT_MODE,
     StrictModeScopeKind,
@@ -27,6 +31,10 @@ from griptape_nodes.retained_mode.events.base_events import (
     EventResultSuccess,
     RequestPayload,
     ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -128,3 +136,161 @@ class TestWorkerReachIntoOrchestrator:
 
         assert isinstance(result, _ProbeResult)
         assert result.seen_by == "orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_remediation_message_does_not_claim_from_aprocess(self) -> None:
+        """Regression guard: remediation must not claim "from aprocess".
+
+        The rule's gate is ``worker_node_execution_scope``, which covers
+        both hydration and aprocess. The remediation must not claim "from
+        aprocess" because the rule fires for both. See PR8 for the same
+        factual-claim bug Collin flagged on parameter-mutation.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-r1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="m4"))
+
+        assert len(scope.violations) == 1
+        message = scope.violations[0].message
+        assert "from aprocess" not in message
+        assert "during node execution" in message
+
+    @pytest.mark.asyncio
+    async def test_fires_during_hydration_phase_not_just_aprocess(self) -> None:
+        """The rule's gate is wider than aprocess.
+
+        ``worker_node_execution_scope`` is opened by
+        ``_hydrate_and_run_node_inner`` around BOTH hydration and
+        aprocess. Forwarded requests issued during hydration (e.g.
+        dynamic-pipeline nodes calling ListConnectionsForNodeRequest
+        from before/after_value_set) must trip the rule. This pins
+        down that the gate is intentionally wider than
+        ``aprocess_scope()``.
+        """
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        # No aprocess_scope() entered. Only the worker_node_execution_scope
+        # (refcount) is active. The rule must still fire.
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-h1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="hydrate"))
+
+        assert len(scope.violations) == 1
+        assert scope.violations[0].rule_id == "worker-reach-into-orchestrator"
+
+    @pytest.mark.asyncio
+    async def test_one_violation_per_call(self) -> None:
+        """Two forwarded requests from the same scope produce two violations."""
+        event_manager = EventManager()
+        handler = _make_handler_with_fake_forward(event_manager)
+
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="node-c1",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            await handler(_ProbeRequest(marker="first"))
+            await handler(_ProbeRequest(marker="second"))
+
+        expected_violations = 2
+        assert len(scope.violations) == expected_violations
+
+    @pytest.mark.asyncio
+    async def test_forwarded_type_member_through_register_remote_handlers(self) -> None:
+        """End-to-end: a real FORWARDED type goes through the swap and shim.
+
+        ``register_remote_handlers`` swaps a real FORWARDED type's handler
+        for a ``RemoteHandler`` shim, and dispatching that real type
+        directly through the shim records the violation. Locks in the
+        ``FORWARDED_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
+        a future change drops a type from ``FORWARDED_REQUEST_TYPES``,
+        this test stays green only because
+        ``ListConnectionsForNodeRequest`` is still a member.
+        """
+        event_manager = EventManager()
+
+        # Capture what the RemoteHandler shim forwards. Skip going through
+        # event_manager.handle_request because that path requires a configured
+        # WebSocket loop; the rule itself fires inside RemoteHandler.__call__,
+        # which is what we want to exercise.
+        forwarded_calls: list[RequestPayload] = []
+
+        async def fake_forward(
+            request: RequestPayload,
+            result_context: ResultContext,  # noqa: ARG001
+        ) -> EventResultSuccess:
+            forwarded_calls.append(request)
+            return EventResultSuccess(
+                request=request,
+                result=ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="forwarded",
+                ),
+            )
+
+        event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+
+        # register_remote_handlers requires every FORWARDED type to have an
+        # original handler registered first. Stub them all with a trivial
+        # local handler; the swap installs RemoteHandler in their place.
+        for request_type in FORWARDED_REQUEST_TYPES:
+
+            async def stub(_request: RequestPayload) -> ResultPayloadSuccess:
+                return ListConnectionsForNodeResultSuccess(
+                    incoming_connections=[],
+                    outgoing_connections=[],
+                    result_details="local",
+                )
+
+            event_manager.assign_manager_to_request_type(request_type, stub)
+
+        register_remote_handlers(event_manager)
+
+        # Pull the swapped handler out of the dispatch table and invoke it.
+        # The shim is what production code reaches when the EventManager
+        # dispatches ListConnectionsForNodeRequest on a worker.
+        installed = event_manager.get_manager_for_request_type(ListConnectionsForNodeRequest)
+        assert isinstance(installed, RemoteHandler)
+
+        request = ListConnectionsForNodeRequest(node_name="some-node")
+        with (
+            STRICT_MODE.open_scope(
+                kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+                subject="some-node",
+                library_name="libA",
+                is_worker=True,
+            ) as scope,
+            event_manager.worker_node_execution_scope(),
+        ):
+            result = await installed(request)
+
+        assert isinstance(result, ListConnectionsForNodeResultSuccess)
+        assert len(forwarded_calls) == 1
+        assert isinstance(forwarded_calls[0], ListConnectionsForNodeRequest)
+        assert len(scope.violations) == 1
+        violation = scope.violations[0]
+        assert violation.rule_id == "worker-reach-into-orchestrator"
+        assert "ListConnectionsForNodeRequest" in violation.message

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -8,7 +8,8 @@ responsible for excluding violating classes from the returned schema list.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,39 @@ import pytest
 from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+
+
+@pytest.fixture
+def patched_registry() -> Callable[[dict[str, type]], AbstractContextManager[None]]:
+    """Yield a context-manager factory that patches LibraryRegistry for a probe map.
+
+    Both test classes need the same MagicMock-backed library plus the
+    same ``create_node`` side-effect that constructs an instance from
+    the probe map. Returning a factory keeps the per-test ``nodes``
+    parameter readable at the call site.
+    """
+
+    @contextmanager
+    def _patch(nodes: dict[str, type]) -> Iterator[None]:
+        lib = MagicMock()
+        lib.get_registered_nodes.return_value = list(nodes.keys())
+        lib.get_node_class.side_effect = lambda name: nodes[name]
+
+        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
+            return nodes[node_type](name)
+
+        with patch.multiple(
+            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
+            get_library=MagicMock(return_value=lib),
+            create_node=MagicMock(side_effect=_create_node),
+        ):
+            yield
+
+    return _patch
 
 
 class _CleanProbe:
@@ -46,41 +80,21 @@ class _ViolatingProbe:
 
 
 class TestSerializeSchemasStrictMode:
-    def _make_library(self, nodes: dict[str, type]) -> MagicMock:
-        lib = MagicMock()
-        lib.get_registered_nodes.return_value = list(nodes.keys())
-        lib.get_node_class.side_effect = lambda name: nodes[name]
-        return lib
-
-    def _patch_registry(self, library: MagicMock, nodes: dict[str, type]) -> Any:
-        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
-
-        return patch.multiple(
-            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
-            get_library=MagicMock(return_value=library),
-            create_node=MagicMock(side_effect=_create_node),
-        )
-
     @pytest.mark.asyncio
-    async def test_clean_class_is_included(self) -> None:
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Clean": _CleanProbe}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["Clean"]
 
     @pytest.mark.asyncio
-    async def test_violating_class_is_skipped(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_violating_class_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Violator": _ViolatingProbe, "Clean": _CleanProbe}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         # Violating class dropped from output.
@@ -140,30 +154,13 @@ class _ProbeWithCleanParams:
 class TestParameterBehaviorsDropped:
     """#4472: Parameters carrying converters/validators/traits emit a warn violation."""
 
-    def _make_library(self, nodes: dict[str, type]) -> MagicMock:
-        lib = MagicMock()
-        lib.get_registered_nodes.return_value = list(nodes.keys())
-        lib.get_node_class.side_effect = lambda name: nodes[name]
-        return lib
-
-    def _patch_registry(self, library: MagicMock, nodes: dict[str, type]) -> Any:
-        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
-
-        return patch.multiple(
-            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
-            get_library=MagicMock(return_value=library),
-            create_node=MagicMock(side_effect=_create_node),
-        )
-
     @pytest.mark.asyncio
-    async def test_clean_parameters_produce_no_violation(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_clean_parameters_produce_no_violation(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Clean": _ProbeWithCleanParams}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Clean": _ProbeWithCleanParams}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["Clean"]
@@ -171,14 +168,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_converter_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithBehavior": _ProbeWithConverterParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         # Warning, not error: the class still yields a schema.
@@ -191,14 +185,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_validator_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithValidator": _ProbeWithValidatorParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["WithValidator"]
@@ -208,14 +199,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_trait_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithTrait": _ProbeWithTraitParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithTrait": _ProbeWithTraitParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["WithTrait"]


### PR DESCRIPTION
## Summary

PR 9 of 10 in the [strict-mode-for-workers stack](https://github.com/griptape-ai/griptape-nodes/pull/4500).

Adds the `worker-reach-into-orchestrator` strict-mode rule (WARNING,
ergonomics-class). Fires whenever a node running on a worker issues a
request whose authoritative state lives on the orchestrator (flow
graph, connections, parameter registry, config, or secrets) from
inside `aprocess`. The request is still forwarded over the WebSocket
bus -- the rule just makes the network round-trip and stale-by-call
read visible to the author.

Depends on #4672 (PR 03), which added the config/secrets request
types to `FORWARDED_REQUEST_TYPES` -- this PR's call site fires when
those types are forwarded from inside an executing node.

Stacked on #4677.

## Changes

- `src/griptape_nodes/common/strict_mode_checks.py` -- appends
  `_rule(\"worker-reach-into-orchestrator\", ...)` to `RULES`.
- `src/griptape_nodes/app/worker_routing.py` -- `report_violation`
  call inside `RemoteHandler.__call__`'s `in_node_execution()` branch.
- `tests/unit/app/test_worker_routing_strict_mode.py` -- coverage for
  the worker-side reach-detection path.

## Test plan

- [ ] `make check` clean
- [ ] `uv run pytest tests/unit/app/test_worker_routing_strict_mode.py` green
- [ ] `uv run pytest tests/unit` green
- [ ] Reviewer sanity-checks that the call site only fires when
  `event_manager.in_node_execution()` is true (i.e. inside an
  executing node) and not during worker bootstrap or library load