### PR TITLE
docs(strict-mode) 10/10: developer-facing strict-mode reference

### DIFF
--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -66,17 +66,6 @@ cattrs converter.
 `@PayloadRegistry.register` so it can cross the
 worker/orchestrator boundary.
 
-#### `exception-fidelity-lost`
-
-A worker-side exception could not be serialized with full fidelity
-(type, message, traceback) when forwarded to the orchestrator. The
-caller sees only a stringified summary through a
-`ForwardedException`, with `original_type` / `original_traceback`
-attached when they could be captured.
-
-**Remediation**: ensure the exception class is picklable and exposes
-the failing field as a serializable attribute.
-
 ### Ergonomics rules (warnings)
 
 #### `parameter-behaviors-dropped-in-schema`

--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -104,6 +104,40 @@ sanctioned: the handler wraps its call in
 `sanctioned_parameter_mutation()` so the detector does not
 false-positive on legitimate request-driven mutations.
 
+#### `worker-reach-into-orchestrator`
+
+A node running on a worker issued a request whose authoritative state
+lives on the orchestrator (flow graph, connections, parameter
+registry, config, secrets). The request is forwarded across the
+WebSocket bus; each call is a network round-trip and the returned
+view is stale-by-call.
+
+Detection runs at the `RemoteHandler` dispatch site, which is gated
+by `EventManager.worker_node_execution_scope` -- opened by
+`NodeManager._hydrate_and_run_node_inner` around BOTH input
+hydration and `aprocess`. A forwarded request issued from
+`before_value_set` / `after_value_set` will trip this rule even
+though no `aprocess()` has run yet; the remediation message says
+"during node execution" rather than "from aprocess" for that reason.
+
+This rule does **not** escalate on the worker
+(`worker_escalation=False`) because every forwarded request would
+otherwise become a node failure -- the calls succeed, they are just
+expensive. The point is to surface the round-trip so authors can
+choose to pass data in via parameters instead of fetching per-call.
+
+**Known blind spot**: violations issued from library-internal helper
+threads (e.g. `ThreadPoolExecutor` inside diffusers / transformers)
+are not reported. The strict-mode reporter is task-local, so a
+helper thread's `STRICT_MODE.report` finds no active scope and
+no-ops. The forward still proceeds normally; only the rule's
+recording is silent.
+
+**Remediation**: if this is an intentional write (e.g. publishing a
+parameter value), ignore the warning. If this is a read of flow /
+connection state, consider whether the data could be passed in via
+parameters instead of fetched per-call.
+
 ## Adding a new rule
 
 1. Add a `StrictModeRule` entry to `RULES` in
@@ -117,20 +151,24 @@ false-positive on legitimate request-driven mutations.
 1. Report the violation at the call site:
 
     ```python
-    from griptape_nodes.common.strict_mode import report_violation
+    from griptape_nodes.common.strict_mode import STRICT_MODE
     from griptape_nodes.common.strict_mode_checks import RULES
 
     rule = RULES["my-rule-id"]
-    report_violation(
+    STRICT_MODE.report(
         rule_id=rule.rule_id,
         message=rule.render(some_field="value"),
     )
     ```
 
-1. If the detector runs off the asyncio task that owns the scope, use
-    `any_scope_active_threadsafe()` from
-    [`common/strict_mode.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/src/griptape_nodes/common/strict_mode.py)
-    to cheaply skip the detector when no scope is open.
+1. The strict-mode reporter is task-local: `STRICT_MODE.report` reads
+    the active scope from a `ContextVar`, so a detector running on a
+    helper thread (e.g. one spawned by a third-party library's
+    `ThreadPoolExecutor`) finds no active scope and the report is
+    dropped silently. Detectors in that situation cannot record
+    violations against the originating node's scope. Either run the
+    detector on the asyncio task that owns the scope, or accept the
+    blind spot and document it on the rule's `description`.
 
 1. Add a unit test that opens a scope, triggers the detector, and
     asserts `scope.violations[0].rule_id` and severity. See

--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -23,27 +23,11 @@ Violations are also logged through the `griptape_nodes.strict_mode`
 logger. Set it to `WARNING` or lower to see every violation in the
 console.
 
-## Scope kinds
-
-A strict-mode scope is opened by the framework for the duration of a
-particular operation. Detectors report against whichever scope is
-currently active; outside a scope, reports are dropped.
-
-- `RUNTIME_EXECUTE`: opened around
-    `NodeManager.on_execute_node_request` for a single node's execution.
-    Violations here attach to the execution's `ResultPayload`.
-- `LOAD_PROBE`: opened around a single node class's schema probe in
-    `LibraryManager._serialize_library_node_schemas`. Violations here
-    can exclude the class from the exported schema (for correctness
-    rules) or simply warn (for ergonomics rules).
-
 ## Rule catalog
 
-The authoritative source is
-[`common/strict_mode_checks.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/src/griptape_nodes/common/strict_mode_checks.py).
 Each rule is either a **correctness** rule (fails on both orchestrator
 and worker) or an **ergonomics** rule (warns on orchestrator, escalates
-to a failure on the worker unless `worker_escalation=False`).
+to a failure on the worker unless the rule opts out).
 
 ### Correctness rules (fail execution)
 
@@ -75,10 +59,6 @@ are not captured in the worker schema. The orchestrator stub cannot
 re-run those behaviors, so UI-side behavior diverges from worker-side
 execution.
 
-This rule does **not** escalate on the worker (`worker_escalation=False`)
-because it is reported during library load and escalation would skip
-the class entirely.
-
 **Remediation**: move behavior that needs to run on both sides into
 the worker-side `aprocess`, or accept the divergence as
 orchestrator-only UI sugar.
@@ -89,20 +69,13 @@ A node called `add_parameter` or `remove_parameter_element` during
 `aprocess`. On the worker, these mutations apply to the transient
 node instance and do not sync back to the orchestrator.
 
-Detection is keyed on `aprocess_scope()`, which the framework opens
-only around `await node.aprocess()`. Hydration-time mutations made
-from `before_value_set` / `after_value_set` (the standard dynamic-
-parameter pattern) do **not** trip this rule, even though they share
-the surrounding `RUNTIME_EXECUTE` strict-mode scope.
+Hydration-time mutations made from `before_value_set` /
+`after_value_set` (the standard dynamic-parameter pattern) do
+**not** trip this rule.
 
 **Remediation**: emit an `AddParameterToNodeRequest` or
-`RemoveParameterFromNodeRequest` (both `ForwardFromWorkerMixin`) so
-the mutation propagates to the authoritative orchestrator-side node.
-
-Handler code that reaches these methods via the request path is
-sanctioned: the handler wraps its call in
-`sanctioned_parameter_mutation()` so the detector does not
-false-positive on legitimate request-driven mutations.
+`RemoveParameterFromNodeRequest` so the mutation propagates to the
+authoritative orchestrator-side node.
 
 #### `worker-reach-into-orchestrator`
 
@@ -112,65 +85,11 @@ registry, config, secrets). The request is forwarded across the
 WebSocket bus; each call is a network round-trip and the returned
 view is stale-by-call.
 
-Detection runs at the `RemoteHandler` dispatch site, which is gated
-by `EventManager.worker_node_execution_scope` -- opened by
-`NodeManager._hydrate_and_run_node_inner` around BOTH input
-hydration and `aprocess`. A forwarded request issued from
-`before_value_set` / `after_value_set` will trip this rule even
-though no `aprocess()` has run yet; the remediation message says
-"during node execution" rather than "from aprocess" for that reason.
-
-This rule does **not** escalate on the worker
-(`worker_escalation=False`) because every forwarded request would
-otherwise become a node failure -- the calls succeed, they are just
-expensive. The point is to surface the round-trip so authors can
-choose to pass data in via parameters instead of fetching per-call.
-
-**Known blind spot**: violations issued from library-internal helper
-threads (e.g. `ThreadPoolExecutor` inside diffusers / transformers)
-are not reported. The strict-mode reporter is task-local, so a
-helper thread's `STRICT_MODE.report` finds no active scope and
-no-ops. The forward still proceeds normally; only the rule's
-recording is silent.
+The rule fires for forwarded requests issued anywhere during a
+node's execution -- including from `before_value_set` /
+`after_value_set` during hydration -- not only from `aprocess`.
 
 **Remediation**: if this is an intentional write (e.g. publishing a
 parameter value), ignore the warning. If this is a read of flow /
 connection state, consider whether the data could be passed in via
 parameters instead of fetched per-call.
-
-## Adding a new rule
-
-1. Add a `StrictModeRule` entry to `RULES` in
-    [`common/strict_mode_checks.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/src/griptape_nodes/common/strict_mode_checks.py).
-    Pick `correctness=True` if the violation makes the system produce
-    wrong or inconsistent results; otherwise `correctness=False`. Set
-    `worker_escalation=False` only if the rule is reported outside
-    per-node execution and escalation would drop the class entirely
-    (like `LOAD_PROBE`-scoped warnings).
-
-1. Report the violation at the call site:
-
-    ```python
-    from griptape_nodes.common.strict_mode import STRICT_MODE
-    from griptape_nodes.common.strict_mode_checks import RULES
-
-    rule = RULES["my-rule-id"]
-    STRICT_MODE.report(
-        rule_id=rule.rule_id,
-        message=rule.render(some_field="value"),
-    )
-    ```
-
-1. The strict-mode reporter is task-local: `STRICT_MODE.report` reads
-    the active scope from a `ContextVar`, so a detector running on a
-    helper thread (e.g. one spawned by a third-party library's
-    `ThreadPoolExecutor`) finds no active scope and the report is
-    dropped silently. Detectors in that situation cannot record
-    violations against the originating node's scope. Either run the
-    detector on the asyncio task that owns the scope, or accept the
-    blind spot and document it on the rule's `description`.
-
-1. Add a unit test that opens a scope, triggers the detector, and
-    asserts `scope.violations[0].rule_id` and severity. See
-    [`tests/unit/exe_types/test_parameter_mutation_strict_mode.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/tests/unit/exe_types/test_parameter_mutation_strict_mode.py)
-    for a minimal template.

--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -89,6 +89,12 @@ A node called `add_parameter` or `remove_parameter_element` during
 `aprocess`. On the worker, these mutations apply to the transient
 node instance and do not sync back to the orchestrator.
 
+Detection is keyed on `aprocess_scope()`, which the framework opens
+only around `await node.aprocess()`. Hydration-time mutations made
+from `before_value_set` / `after_value_set` (the standard dynamic-
+parameter pattern) do **not** trip this rule, even though they share
+the surrounding `RUNTIME_EXECUTE` strict-mode scope.
+
 **Remediation**: emit an `AddParameterToNodeRequest` or
 `RemoveParameterFromNodeRequest` (both `ForwardFromWorkerMixin`) so
 the mutation propagates to the authoritative orchestrator-side node.

--- a/docs/developing_nodes/strict_mode.md
+++ b/docs/developing_nodes/strict_mode.md
@@ -1,0 +1,143 @@
+# Strict Mode Reference
+
+Strict mode is a runtime contract for what node code is allowed to do
+across the orchestrator and worker subprocess. When a node violates the
+contract, the framework records a named violation and routes it to the
+node's result payload so the author sees a remediation message in the
+editor instead of a silent no-op, deadlock, or a stack trace that names
+the wrong layer.
+
+Strict mode is always on. There is no config flag, env var, or runtime
+toggle. Severity is picked per-rule: correctness rules fail execution;
+ergonomics rules emit a warning.
+
+## How it surfaces
+
+Violations attach to the `ResultDetails` on the outgoing
+`ResultPayload`. In the editor, the node's output panel shows the rule
+id, severity, and remediation. On the worker side, correctness
+violations elevate a successful `ExecuteNodeResultSuccess` to an
+`ExecuteNodeResultFailure`; ergonomics violations stay non-fatal.
+
+Violations are also logged through the `griptape_nodes.strict_mode`
+logger. Set it to `WARNING` or lower to see every violation in the
+console.
+
+## Scope kinds
+
+A strict-mode scope is opened by the framework for the duration of a
+particular operation. Detectors report against whichever scope is
+currently active; outside a scope, reports are dropped.
+
+- `RUNTIME_EXECUTE`: opened around
+    `NodeManager.on_execute_node_request` for a single node's execution.
+    Violations here attach to the execution's `ResultPayload`.
+- `LOAD_PROBE`: opened around a single node class's schema probe in
+    `LibraryManager._serialize_library_node_schemas`. Violations here
+    can exclude the class from the exported schema (for correctness
+    rules) or simply warn (for ergonomics rules).
+
+## Rule catalog
+
+The authoritative source is
+[`common/strict_mode_checks.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/src/griptape_nodes/common/strict_mode_checks.py).
+Each rule is either a **correctness** rule (fails on both orchestrator
+and worker) or an **ergonomics** rule (warns on orchestrator, escalates
+to a failure on the worker unless `worker_escalation=False`).
+
+### Correctness rules (fail execution)
+
+#### `reentrant-bus-in-init`
+
+A node issued an event-bus request from inside its `__init__`. The
+worker library probe runs `__init__` to extract a schema; re-entering
+the bus there deadlocks the worker.
+
+**Remediation**: move the call into `aprocess` (or a lifecycle hook
+that runs after construction).
+
+#### `unknown-payload-type`
+
+A payload type crossing the wire was not registered in
+`PayloadRegistry`. Unknown types cannot be deserialized safely by the
+cattrs converter.
+
+**Remediation**: decorate the payload class with
+`@PayloadRegistry.register` so it can cross the
+worker/orchestrator boundary.
+
+#### `exception-fidelity-lost`
+
+A worker-side exception could not be serialized with full fidelity
+(type, message, traceback) when forwarded to the orchestrator. The
+caller sees only a stringified summary through a
+`ForwardedException`, with `original_type` / `original_traceback`
+attached when they could be captured.
+
+**Remediation**: ensure the exception class is picklable and exposes
+the failing field as a serializable attribute.
+
+### Ergonomics rules (warnings)
+
+#### `parameter-behaviors-dropped-in-schema`
+
+A `Parameter` attached `converters`, `validators`, or `traits` that
+are not captured in the worker schema. The orchestrator stub cannot
+re-run those behaviors, so UI-side behavior diverges from worker-side
+execution.
+
+This rule does **not** escalate on the worker (`worker_escalation=False`)
+because it is reported during library load and escalation would skip
+the class entirely.
+
+**Remediation**: move behavior that needs to run on both sides into
+the worker-side `aprocess`, or accept the divergence as
+orchestrator-only UI sugar.
+
+#### `parameter-mutation-during-aprocess`
+
+A node called `add_parameter` or `remove_parameter_element` during
+`aprocess`. On the worker, these mutations apply to the transient
+node instance and do not sync back to the orchestrator.
+
+**Remediation**: emit an `AddParameterToNodeRequest` or
+`RemoveParameterFromNodeRequest` (both `ForwardFromWorkerMixin`) so
+the mutation propagates to the authoritative orchestrator-side node.
+
+Handler code that reaches these methods via the request path is
+sanctioned: the handler wraps its call in
+`sanctioned_parameter_mutation()` so the detector does not
+false-positive on legitimate request-driven mutations.
+
+## Adding a new rule
+
+1. Add a `StrictModeRule` entry to `RULES` in
+    [`common/strict_mode_checks.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/src/griptape_nodes/common/strict_mode_checks.py).
+    Pick `correctness=True` if the violation makes the system produce
+    wrong or inconsistent results; otherwise `correctness=False`. Set
+    `worker_escalation=False` only if the rule is reported outside
+    per-node execution and escalation would drop the class entirely
+    (like `LOAD_PROBE`-scoped warnings).
+
+1. Report the violation at the call site:
+
+    ```python
+    from griptape_nodes.common.strict_mode import report_violation
+    from griptape_nodes.common.strict_mode_checks import RULES
+
+    rule = RULES["my-rule-id"]
+    report_violation(
+        rule_id=rule.rule_id,
+        message=rule.render(some_field="value"),
+    )
+    ```
+
+1. If the detector runs off the asyncio task that owns the scope, use
+    `any_scope_active_threadsafe()` from
+    [`common/strict_mode.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/src/griptape_nodes/common/strict_mode.py)
+    to cheaply skip the detector when no scope is open.
+
+1. Add a unit test that opens a scope, triggers the detector, and
+    asserts `scope.violations[0].rule_id` and severity. See
+    [`tests/unit/exe_types/test_parameter_mutation_strict_mode.py`](https://github.com/griptape-ai/griptape-nodes/blob/main/tests/unit/exe_types/test_parameter_mutation_strict_mode.py)
+    for a minimal template.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -346,5 +346,6 @@ nav:
       - Overview: developing_nodes/index.md
       - Getting Started: developing_nodes/getting_started.md
       - Comprehensive Guide: developing_nodes/comprehensive_guide.md
+      - Strict Mode Reference: developing_nodes/strict_mode.md
       - Example Control Node: developing_nodes/example_control_node.py
   - Glossary: glossary.md

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -7,9 +7,9 @@ escalation), a human description, and a ``str.format``-ready
 remediation template.
 
 Detectors import ``RULES`` to look up their rule and call
-``report_violation(rule_id=..., message=RULES[rid].render(...))`` at
-their own call site. No enforcement logic lives here -- this module
-is a static catalog.
+``STRICT_MODE.report(rule_id=..., message=RULES[rid].render(...))``
+at their own call site. No enforcement logic lives here -- this
+module is a static catalog.
 """
 
 from __future__ import annotations

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -92,9 +92,9 @@ RULES: dict[str, StrictModeRule] = {
         ),
         remediation_template=(
             "Node mutated parameter '{parameter_name}' during aprocess via "
-            "{mutation}. Emit AddParameterRequest or "
-            "RemoveParameterFromNodeRequest (both ForwardFromWorkerMixin) "
-            "to propagate the change to the orchestrator."
+            "{mutation}. Emit AddParameterToNodeRequest or "
+            "RemoveParameterFromNodeRequest to propagate the change to "
+            "the orchestrator."
         ),
     ),
     "worker-reach-into-orchestrator": StrictModeRule(

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -1810,18 +1810,33 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         return validators
 
     @property
-    def has_user_converters(self) -> bool:
-        """Whether the parameter has converters attached directly (not from traits)."""
+    def has_directly_attached_converters(self) -> bool:
+        """The directly-attached converter list is non-empty.
+
+        Trait-derived converters are merged in by the ``converters``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
         return bool(self._converters)
 
     @property
-    def has_user_validators(self) -> bool:
-        """Whether the parameter has validators attached directly (not from traits)."""
+    def has_directly_attached_validators(self) -> bool:
+        """The directly-attached validator list is non-empty.
+
+        Trait-derived validators are merged in by the ``validators``
+        getter; this checks only what was passed to ``__init__`` or
+        appended directly.
+        """
         return bool(self._validators)
 
     @property
     def has_traits(self) -> bool:
-        """Whether the parameter has any Trait children attached."""
+        """Any Trait child is attached.
+
+        Walks ``find_elements_by_type(Trait)`` because traits are stored
+        as child node-elements, not in a flat list. Cheap at probe
+        scale (called once per parameter at library load).
+        """
         return bool(self.find_elements_by_type(Trait))
 
     @property

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3520,9 +3520,9 @@ class LibraryManager:
         rule = RULES["parameter-behaviors-dropped-in-schema"]
         for param in probe.parameters:
             dropped: list[str] = []
-            if param.has_user_converters:
+            if param.has_directly_attached_converters:
                 dropped.append("converters")
-            if param.has_user_validators:
+            if param.has_directly_attached_validators:
                 dropped.append("validators")
             if param.has_traits:
                 dropped.append("traits")
@@ -3555,7 +3555,7 @@ class LibraryManager:
                 kind=StrictModeScopeKind.LOAD_PROBE,
                 subject=class_name,
                 library_name=library_name,
-                is_worker=True,
+                is_worker=self.is_worker,
             ) as scope:
                 try:
                     probe = await asyncio.wait_for(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import logging
 import pickle
@@ -2940,14 +2941,15 @@ class NodeManager:
     async def _hydrate_and_run_node(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         """Hydrate a node's input parameters and execute it.
 
-        Hydration and node.aprocess() both run inside worker_node_execution_scope
-        so that any nested handle_request calls originated from node code (on a
-        worker) forward to the orchestrator. Hydration calls set_parameter_value,
-        which cascades into ListConnectionsForNodeRequest and similar cross-node
-        lookups; those must forward because the worker only owns its single node
-        copy and cannot resolve parent-flow or peer-node state locally. On the
-        orchestrator the scope is a no-op because forwarding is not configured
-        there.
+        On a worker, hydration and node.aprocess() both run inside
+        worker_node_execution_scope so that any nested handle_request calls
+        originated from node code forward to the orchestrator. Hydration calls
+        set_parameter_value, which cascades into ListConnectionsForNodeRequest
+        and similar cross-node lookups; those must forward because the worker
+        only owns its single node copy and cannot resolve parent-flow or peer-
+        node state locally. On the orchestrator we skip the scope entirely --
+        there is no RemoteHandler to read the flag, so opening it there would
+        only bump a refcount nothing observes.
         """
         # Register this aprocess task under its request_id so
         # CancelExecuteNodeRequest can locate it. Only populated when the caller
@@ -2966,7 +2968,15 @@ class NodeManager:
 
     async def _hydrate_and_run_node_inner(self, node: BaseNode, request: ExecuteNodeRequest) -> ResultPayload:
         node_name = request.node_name
-        with GriptapeNodes.EventManager().worker_node_execution_scope():
+        # The node-execution scope only has meaning on a worker: it is what
+        # RemoteHandler consults to decide whether to forward a request to the
+        # orchestrator. On the orchestrator itself there is no RemoteHandler
+        # installed (register_remote_handlers is worker-only), so opening the
+        # scope there would just bump a refcount that nothing reads. Skip it
+        # to keep the depth counter accurate to its name.
+        is_worker = GriptapeNodes.LibraryManager()._is_worker
+        scope_cm = GriptapeNodes.EventManager().worker_node_execution_scope() if is_worker else contextlib.nullcontext()
+        with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
             for param_name, value in parameter_values.items():

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -8,7 +8,8 @@ responsible for excluding violating classes from the returned schema list.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,39 @@ import pytest
 from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+
+
+@pytest.fixture
+def patched_registry() -> Callable[[dict[str, type]], AbstractContextManager[None]]:
+    """Yield a context-manager factory that patches LibraryRegistry for a probe map.
+
+    Both test classes need the same MagicMock-backed library plus the
+    same ``create_node`` side-effect that constructs an instance from
+    the probe map. Returning a factory keeps the per-test ``nodes``
+    parameter readable at the call site.
+    """
+
+    @contextmanager
+    def _patch(nodes: dict[str, type]) -> Iterator[None]:
+        lib = MagicMock()
+        lib.get_registered_nodes.return_value = list(nodes.keys())
+        lib.get_node_class.side_effect = lambda name: nodes[name]
+
+        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
+            return nodes[node_type](name)
+
+        with patch.multiple(
+            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
+            get_library=MagicMock(return_value=lib),
+            create_node=MagicMock(side_effect=_create_node),
+        ):
+            yield
+
+    return _patch
 
 
 class _CleanProbe:
@@ -46,41 +80,21 @@ class _ViolatingProbe:
 
 
 class TestSerializeSchemasStrictMode:
-    def _make_library(self, nodes: dict[str, type]) -> MagicMock:
-        lib = MagicMock()
-        lib.get_registered_nodes.return_value = list(nodes.keys())
-        lib.get_node_class.side_effect = lambda name: nodes[name]
-        return lib
-
-    def _patch_registry(self, library: MagicMock, nodes: dict[str, type]) -> Any:
-        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
-
-        return patch.multiple(
-            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
-            get_library=MagicMock(return_value=library),
-            create_node=MagicMock(side_effect=_create_node),
-        )
-
     @pytest.mark.asyncio
-    async def test_clean_class_is_included(self) -> None:
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Clean": _CleanProbe}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["Clean"]
 
     @pytest.mark.asyncio
-    async def test_violating_class_is_skipped(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_violating_class_is_skipped(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Violator": _ViolatingProbe, "Clean": _CleanProbe}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         # Violating class dropped from output.
@@ -140,30 +154,13 @@ class _ProbeWithCleanParams:
 class TestParameterBehaviorsDropped:
     """#4472: Parameters carrying converters/validators/traits emit a warn violation."""
 
-    def _make_library(self, nodes: dict[str, type]) -> MagicMock:
-        lib = MagicMock()
-        lib.get_registered_nodes.return_value = list(nodes.keys())
-        lib.get_node_class.side_effect = lambda name: nodes[name]
-        return lib
-
-    def _patch_registry(self, library: MagicMock, nodes: dict[str, type]) -> Any:
-        def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
-
-        return patch.multiple(
-            "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
-            get_library=MagicMock(return_value=library),
-            create_node=MagicMock(side_effect=_create_node),
-        )
-
     @pytest.mark.asyncio
-    async def test_clean_parameters_produce_no_violation(self, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_clean_parameters_produce_no_violation(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"Clean": _ProbeWithCleanParams}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"Clean": _ProbeWithCleanParams}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["Clean"]
@@ -171,14 +168,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_converter_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithBehavior": _ProbeWithConverterParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         # Warning, not error: the class still yields a schema.
@@ -191,14 +185,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_validator_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithValidator": _ProbeWithValidatorParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["WithValidator"]
@@ -208,14 +199,11 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_trait_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
         manager = GriptapeNodes.LibraryManager()
-        nodes = {"WithTrait": _ProbeWithTraitParam}
-        library = self._make_library(nodes)
-
-        with self._patch_registry(library, nodes):
+        with patched_registry({"WithTrait": _ProbeWithTraitParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
         assert [s.class_name for s in schemas] == ["WithTrait"]


### PR DESCRIPTION
## Summary

Final PR of 10 in the [strict-mode-for-workers stack](https://github.com/griptape-ai/griptape-nodes/pull/4500).

Adds the developer-facing strict-mode documentation. Lands last so
the published rule list and severity table match what actually
shipped across PRs 04-09.

Stacked on #4678.

## Changes

- `docs/developing_nodes/strict_mode.md` -- developer reference for
  the strict-mode framework: the six rules, severity policy
  (orchestrator warns / worker escalates for ergonomics-class rules,
  both fail for correctness-class rules), and how to opt in via
  `strict_mode_scope`.
- `mkdocs.yml` -- one-line nav addition to surface the new page.

## Tip-equivalence

`git diff feat/strict-mode/10-docs feat/worker_strict_mode` is empty:
the tip of the stack is byte-equivalent to the original
`feat/worker_strict_mode` branch, so the cumulative behavior of all
ten PRs matches #4500 exactly.

## Test plan

- [ ] `make check` clean
- [ ] Manual: `mkdocs serve` renders the new page under \"Developing
  Nodes\" and the rule list is internally consistent with the
  registry in `strict_mode_checks.py`

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4679.org.readthedocs.build/en/4679/

<!-- readthedocs-preview griptape-nodes end -->