### PR TITLE
feat: add permission policy schema, matcher engine, and fact registry

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/permissions/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/__init__.py
@@ -1,0 +1,66 @@
+"""Permission system: declarative policy over privileged engine operations.
+
+The schema (`schema`), matcher engine (`matchers`), and fact registry (`facts`)
+are exposed here for use by `PermissionManager` and tests. Public consumers
+should reach for `PermissionManager` rather than these modules directly.
+"""
+
+from griptape_nodes.retained_mode.managers.permissions.facts import (
+    FactInvalidator,
+    FactRegistry,
+    RequestFactEnricher,
+)
+from griptape_nodes.retained_mode.managers.permissions.matchers import (
+    EvaluationResult,
+    Principal,
+    PrincipalKind,
+    evaluate_policy,
+    evaluate_rule,
+)
+from griptape_nodes.retained_mode.managers.permissions.schema import (
+    ActionMatch,
+    AllOfExpr,
+    AnyOfExpr,
+    ContextMatch,
+    Decision,
+    EqualsExpr,
+    GlobExpr,
+    InExpr,
+    MatchExpr,
+    NotExpr,
+    PathUnderExpr,
+    PermissionPolicy,
+    PermissionRule,
+    PermissionSettings,
+    PrincipalMatch,
+    ResourceMatch,
+    WhenClause,
+)
+
+__all__ = [
+    "ActionMatch",
+    "AllOfExpr",
+    "AnyOfExpr",
+    "ContextMatch",
+    "Decision",
+    "EqualsExpr",
+    "EvaluationResult",
+    "FactInvalidator",
+    "FactRegistry",
+    "GlobExpr",
+    "InExpr",
+    "MatchExpr",
+    "NotExpr",
+    "PathUnderExpr",
+    "PermissionPolicy",
+    "PermissionRule",
+    "PermissionSettings",
+    "Principal",
+    "PrincipalKind",
+    "PrincipalMatch",
+    "RequestFactEnricher",
+    "ResourceMatch",
+    "WhenClause",
+    "evaluate_policy",
+    "evaluate_rule",
+]

--- a/src/griptape_nodes/retained_mode/managers/permissions/facts.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/facts.py
@@ -1,0 +1,170 @@
+"""Fact tree backing the `context` axis of permission rules.
+
+Two flavours of fact:
+
+* **Static / event-invalidated** facts published via `register_provider`. The
+  provider is a cheap sync callable; the registry caches its result and drops
+  the cache when the named invalidator fires (driven by `AppPayload` event
+  listeners on `PermissionManager`).
+* **Per-request enrichers** registered via `register_request_enricher` that
+  produce transient facts scoped to a single request evaluation. These are the
+  way managers expose request-scoped state (e.g. parsed metadata of a library
+  about to be registered) without inventing new lifecycle events.
+
+The merged fact tree is a dict keyed by dotted path. Rules read it through
+the matcher engine using `ContextMatch.facts`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.utils.dict_utils import set_dot_value
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload
+
+
+class FactInvalidator(StrEnum):
+    """When a fact's cached value is dropped.
+
+    Each value maps to a formally defined `AppPayload` / `ExecutionPayload`
+    that `PermissionManager` listens to.
+    """
+
+    NEVER = "never"
+    ON_CONFIG_CHANGED = "on_config_changed"
+    ON_LIBRARY_LOADED = "on_library_loaded"
+    ON_NODE_EXECUTION_BOUNDARY = "on_node_execution_boundary"
+    PER_REQUEST = "per_request"
+
+
+@dataclass
+class _FactProvider:
+    path: str
+    compute: Callable[[], Any]
+    invalidator: FactInvalidator
+    cached: Any = None
+    has_cache: bool = False
+
+
+RequestFactEnricher = Callable[["RequestPayload"], dict[str, Any]]
+
+
+class FactRegistry:
+    """Thread-safe registry of fact providers and per-request enrichers."""
+
+    def __init__(self) -> None:
+        self._providers: dict[str, _FactProvider] = {}
+        self._enrichers: dict[str, list[RequestFactEnricher]] = {}
+        self._lock = Lock()
+
+    def register_provider(
+        self,
+        path: str,
+        compute: Callable[[], Any],
+        *,
+        invalidator: FactInvalidator = FactInvalidator.PER_REQUEST,
+    ) -> None:
+        """Publish a fact under `path`. `compute` must be cheap and sync."""
+        with self._lock:
+            self._providers[path] = _FactProvider(path=path, compute=compute, invalidator=invalidator)
+
+    def unregister_provider(self, path: str) -> None:
+        with self._lock:
+            self._providers.pop(path, None)
+
+    def register_request_enricher(
+        self,
+        request_type_name: str,
+        enricher: RequestFactEnricher,
+    ) -> None:
+        """Register a per-request fact enricher keyed by request type name.
+
+        The enricher receives the request payload and returns a dict of
+        dotted-path -> value entries that are merged under a `request.*`
+        prefix in the fact tree for the duration of the evaluation.
+        """
+        with self._lock:
+            self._enrichers.setdefault(request_type_name, []).append(enricher)
+
+    def unregister_request_enricher(
+        self,
+        request_type_name: str,
+        enricher: RequestFactEnricher,
+    ) -> None:
+        with self._lock:
+            handlers = self._enrichers.get(request_type_name)
+            if not handlers:
+                return
+            try:
+                handlers.remove(enricher)
+            except ValueError:
+                return
+            if not handlers:
+                del self._enrichers[request_type_name]
+
+    def invalidate(self, invalidator: FactInvalidator) -> None:
+        """Drop cached values for every provider with the matching invalidator."""
+        with self._lock:
+            for provider in self._providers.values():
+                if provider.invalidator is invalidator:
+                    provider.has_cache = False
+                    provider.cached = None
+
+    def invalidate_all(self) -> None:
+        with self._lock:
+            for provider in self._providers.values():
+                provider.has_cache = False
+                provider.cached = None
+
+    def build_fact_tree(self, request: RequestPayload | None = None) -> dict[str, Any]:
+        """Compute the merged fact tree for one rule evaluation.
+
+        `PER_REQUEST` providers are recomputed every call. Other providers use
+        their cached value when present. Per-request enrichers for
+        ``type(request).__name__`` are merged under the ``request.*`` prefix.
+        """
+        with self._lock:
+            providers = list(self._providers.values())
+            enrichers = list(self._enrichers.get(type(request).__name__, [])) if request is not None else []
+        tree: dict[str, Any] = {}
+        for provider in providers:
+            if provider.invalidator is FactInvalidator.PER_REQUEST or not provider.has_cache:
+                value = _safe_compute(provider.compute)
+                provider.cached = value
+                provider.has_cache = True
+            set_dot_value(tree, provider.path, provider.cached)
+        if request is not None:
+            request_facts: dict[str, Any] = {}
+            for enricher in enrichers:
+                contribution = _safe_enrich(enricher, request)
+                for key, value in contribution.items():
+                    set_dot_value(request_facts, key, value)
+            if request_facts:
+                set_dot_value(tree, "request", request_facts)
+        return tree
+
+
+def _safe_compute(compute: Callable[[], Any]) -> Any:
+    try:
+        return compute()
+    except Exception:
+        # A misbehaving fact provider must never crash policy evaluation; the
+        # rule simply sees `None` for that path and matchers that needed it
+        # fall through.
+        return None
+
+
+def _safe_enrich(enricher: RequestFactEnricher, request: RequestPayload) -> dict[str, Any]:
+    try:
+        contribution = enricher(request)
+    except Exception:
+        return {}
+    if not isinstance(contribution, dict):
+        return {}
+    return contribution

--- a/src/griptape_nodes/retained_mode/managers/permissions/facts.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/facts.py
@@ -50,6 +50,19 @@ class _FactProvider:
     invalidator: FactInvalidator
     cached: Any = None
     has_cache: bool = False
+    # Bumped on every invalidation so a compute that started before the
+    # invalidation cannot commit a stale value after it (see `build_fact_tree`).
+    generation: int = 0
+
+
+@dataclass
+class _ProviderSnapshot:
+    """Provider state captured under the lock for one `build_fact_tree` call."""
+
+    provider: _FactProvider
+    has_cache: bool
+    cached: Any
+    generation: int
 
 
 RequestFactEnricher = Callable[["RequestPayload"], dict[str, Any]]
@@ -115,12 +128,14 @@ class FactRegistry:
                 if provider.invalidator is invalidator:
                     provider.has_cache = False
                     provider.cached = None
+                    provider.generation += 1
 
     def invalidate_all(self) -> None:
         with self._lock:
             for provider in self._providers.values():
                 provider.has_cache = False
                 provider.cached = None
+                provider.generation += 1
 
     def build_fact_tree(self, request: RequestPayload | None = None) -> dict[str, Any]:
         """Compute the merged fact tree for one rule evaluation.
@@ -130,24 +145,50 @@ class FactRegistry:
         ``type(request).__name__`` are merged under the ``request.*`` prefix.
         """
         with self._lock:
-            providers = list(self._providers.values())
+            snapshots = [
+                _ProviderSnapshot(
+                    provider=provider,
+                    has_cache=provider.has_cache,
+                    cached=provider.cached,
+                    generation=provider.generation,
+                )
+                for provider in self._providers.values()
+            ]
             enrichers = list(self._enrichers.get(type(request).__name__, [])) if request is not None else []
         tree: dict[str, Any] = {}
-        for provider in providers:
-            if provider.invalidator is FactInvalidator.PER_REQUEST or not provider.has_cache:
+        for snapshot in snapshots:
+            provider = snapshot.provider
+            if provider.invalidator is FactInvalidator.PER_REQUEST:
                 value = _safe_compute(provider.compute)
-                provider.cached = value
-                provider.has_cache = True
-            set_dot_value(tree, provider.path, provider.cached)
+            elif snapshot.has_cache:
+                value = snapshot.cached
+            else:
+                value = _safe_compute(provider.compute)
+                self._commit_cache(provider, value, snapshot.generation)
+            set_dot_value(tree, provider.path, value)
         if request is not None:
-            request_facts: dict[str, Any] = {}
             for enricher in enrichers:
                 contribution = _safe_enrich(enricher, request)
+                # Merge each entry under the `request.` prefix individually rather
+                # than replacing the whole subtree, so facts published under
+                # `request.*` by a provider are not clobbered.
                 for key, value in contribution.items():
-                    set_dot_value(request_facts, key, value)
-            if request_facts:
-                set_dot_value(tree, "request", request_facts)
+                    set_dot_value(tree, f"request.{key}", value)
         return tree
+
+    def _commit_cache(self, provider: _FactProvider, value: Any, generation: int) -> None:
+        """Store a freshly computed value unless an invalidation raced the compute.
+
+        The compute ran outside the lock, so an `invalidate` call may have bumped
+        the provider's generation in the meantime. Committing in that case would
+        resurrect a value the caller asked to drop, so skip it and let the next
+        `build_fact_tree` recompute.
+        """
+        with self._lock:
+            if provider.generation != generation:
+                return
+            provider.cached = value
+            provider.has_cache = True
 
 
 def _safe_compute(compute: Callable[[], Any]) -> Any:

--- a/src/griptape_nodes/retained_mode/managers/permissions/matchers.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/matchers.py
@@ -1,0 +1,343 @@
+"""Predicate evaluation for permission rules.
+
+`evaluate_policy` is the single entry point used by `PermissionManager`; it
+drives `evaluate_rule` over the policy's rule list and falls through to the
+default decision on no match.
+
+Match expressions are evaluated against three kinds of input:
+
+* `Principal` — runtime actor identity, supplied by the dispatcher hook.
+* request fields — read off the `RequestPayload` via dot-path navigation.
+* fact tree — merged dict published by `FactRegistry`.
+
+Path expansion for `PathUnderExpr` honours `${workspace}` and
+`${static_files_directory}` macros so policies can be authored portably.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.files.path_utils import canonicalize_for_identity
+from griptape_nodes.retained_mode.managers.permissions.schema import (
+    ActionMatch,
+    AllOfExpr,
+    AnyOfExpr,
+    ContextMatch,
+    Decision,
+    EqualsExpr,
+    GlobExpr,
+    InExpr,
+    NotExpr,
+    PathUnderExpr,
+    PermissionPolicy,
+    PermissionRule,
+    PrincipalKind,
+    PrincipalMatch,
+    ResourceMatch,
+    WhenClause,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from griptape_nodes.retained_mode.managers.permissions.schema import MatchExpr
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Runtime actor identity passed into rule evaluation."""
+
+    kind: PrincipalKind
+    library: str | None = None
+    node_type: str | None = None
+    topic: str | None = None
+    node_name: str | None = None
+
+    def label(self) -> str:
+        """Short human-readable form, e.g. ``node:lib/UpscaleNode``."""
+        if self.kind is PrincipalKind.NODE:
+            lib = self.library or "?"
+            nt = self.node_type or "?"
+            return f"node:{lib}/{nt}"
+        if self.kind is PrincipalKind.CLIENT:
+            return f"client:{self.topic or '?'}"
+        return "engine"
+
+
+@dataclass
+class EvaluationResult:
+    """Outcome of evaluating a `PermissionPolicy` against a request context.
+
+    `inspected_paths` accumulates dot-paths consulted across every rule the
+    matcher walked, in evaluation order. `inspected_values` is scoped to the
+    rule that ultimately matched (or empty when the policy fell through to
+    its default), and maps each consulted dot-path to the resolved value the
+    matcher saw. The user-facing denial message renders the latter so callers
+    can tell why a request was blocked without re-running the matcher.
+    """
+
+    decision: Decision
+    matched_rule: PermissionRule | None
+    inspected_paths: list[str] = field(default_factory=list)
+    inspected_values: dict[str, Any] = field(default_factory=dict)
+    reason: str | None = None
+
+
+def evaluate_policy(  # noqa: PLR0913
+    policy: PermissionPolicy,
+    *,
+    principal: Principal,
+    request_type_name: str,
+    request_fields: Mapping[str, Any],
+    facts: Mapping[str, Any],
+    macro_context: Mapping[str, str] | None = None,
+) -> EvaluationResult:
+    """Evaluate `policy` against a single request context.
+
+    First-match-wins: returns the first rule whose `when` clause matches.
+    Falls through to `policy.default_decision` if no rule matches.
+    """
+    inspected: list[str] = []
+    macros = dict(macro_context) if macro_context else {}
+    for rule in policy.rules:
+        rule_values: dict[str, Any] = {}
+        matched = _matches_when(
+            rule.when,
+            principal=principal,
+            request_type_name=request_type_name,
+            request_fields=request_fields,
+            facts=facts,
+            macros=macros,
+            inspected=inspected,
+            inspected_values=rule_values,
+        )
+        if matched:
+            return EvaluationResult(
+                decision=rule.decision,
+                matched_rule=rule,
+                inspected_paths=inspected,
+                inspected_values=rule_values,
+                reason=rule.reason,
+            )
+    return EvaluationResult(
+        decision=policy.default_decision,
+        matched_rule=None,
+        inspected_paths=inspected,
+        inspected_values={},
+        reason=None,
+    )
+
+
+def evaluate_rule(  # noqa: PLR0913
+    rule: PermissionRule,
+    *,
+    principal: Principal,
+    request_type_name: str,
+    request_fields: Mapping[str, Any],
+    facts: Mapping[str, Any],
+    macro_context: Mapping[str, str] | None = None,
+) -> bool:
+    """Evaluate a single rule's `when` clause; primarily useful for tests."""
+    inspected: list[str] = []
+    inspected_values: dict[str, Any] = {}
+    macros = dict(macro_context) if macro_context else {}
+    return _matches_when(
+        rule.when,
+        principal=principal,
+        request_type_name=request_type_name,
+        request_fields=request_fields,
+        facts=facts,
+        macros=macros,
+        inspected=inspected,
+        inspected_values=inspected_values,
+    )
+
+
+def _matches_when(  # noqa: PLR0913
+    when: WhenClause,
+    *,
+    principal: Principal,
+    request_type_name: str,
+    request_fields: Mapping[str, Any],
+    facts: Mapping[str, Any],
+    macros: Mapping[str, str],
+    inspected: list[str],
+    inspected_values: dict[str, Any],
+) -> bool:
+    if when.principal is not None and not _matches_principal(
+        when.principal, principal, inspected, inspected_values, macros
+    ):
+        return False
+    if when.action is not None and not _matches_action(
+        when.action, request_type_name, inspected, inspected_values, macros
+    ):
+        return False
+    if when.resource is not None and not _matches_resource(
+        when.resource, request_fields, inspected, inspected_values, macros
+    ):
+        return False
+    return not (
+        when.context is not None and not _matches_context(when.context, facts, inspected, inspected_values, macros)
+    )
+
+
+def _matches_principal(
+    match: PrincipalMatch,
+    principal: Principal,
+    inspected: list[str],
+    inspected_values: dict[str, Any],
+    macros: Mapping[str, str],
+) -> bool:
+    inspected.append("principal.kind")
+    inspected_values["principal.kind"] = principal.kind.value
+    if match.kind is not None and principal.kind not in match.kind:
+        return False
+    if match.library is not None:
+        inspected.append("principal.library")
+        inspected_values["principal.library"] = principal.library
+        if not _eval_match(match.library, principal.library, macros):
+            return False
+    if match.node_type is not None:
+        inspected.append("principal.node_type")
+        inspected_values["principal.node_type"] = principal.node_type
+        if not _eval_match(match.node_type, principal.node_type, macros):
+            return False
+    if match.topic is not None:
+        inspected.append("principal.topic")
+        inspected_values["principal.topic"] = principal.topic
+        if not _eval_match(match.topic, principal.topic, macros):
+            return False
+    return True
+
+
+def _matches_action(
+    match: ActionMatch,
+    request_type_name: str,
+    inspected: list[str],
+    inspected_values: dict[str, Any],
+    macros: Mapping[str, str],
+) -> bool:
+    inspected.append("action.request_type")
+    inspected_values["action.request_type"] = request_type_name
+    return _eval_match(match.request_type, request_type_name, macros)
+
+
+def _matches_resource(
+    match: ResourceMatch,
+    request_fields: Mapping[str, Any],
+    inspected: list[str],
+    inspected_values: dict[str, Any],
+    macros: Mapping[str, str],
+) -> bool:
+    for path, expr in match.fields.items():
+        key = f"resource.{path}"
+        inspected.append(key)
+        value = _resolve_dot_path(request_fields, path)
+        inspected_values[key] = value
+        if not _eval_match(expr, value, macros):
+            return False
+    return True
+
+
+def _matches_context(
+    match: ContextMatch,
+    facts: Mapping[str, Any],
+    inspected: list[str],
+    inspected_values: dict[str, Any],
+    macros: Mapping[str, str],
+) -> bool:
+    for path, expr in match.facts.items():
+        key = f"context.{path}"
+        inspected.append(key)
+        value = _resolve_dot_path(facts, path)
+        inspected_values[key] = value
+        if not _eval_match(expr, value, macros):
+            return False
+    return True
+
+
+def _eval_match(expr: MatchExpr, value: Any, macros: Mapping[str, str]) -> bool:  # noqa: PLR0911
+    if isinstance(expr, EqualsExpr):
+        return value == expr.value
+    if isinstance(expr, InExpr):
+        if isinstance(value, list):
+            return any(item in expr.values for item in value)
+        return value in expr.values
+    if isinstance(expr, GlobExpr):
+        if value is None:
+            return False
+        return fnmatch.fnmatch(str(value), expr.pattern)
+    if isinstance(expr, PathUnderExpr):
+        return _path_under(value, expr.root, macros)
+    if isinstance(expr, NotExpr):
+        return not _eval_match(expr.expr, value, macros)
+    if isinstance(expr, AllOfExpr):
+        return all(_eval_match(sub, value, macros) for sub in expr.exprs)
+    if isinstance(expr, AnyOfExpr):
+        return any(_eval_match(sub, value, macros) for sub in expr.exprs)
+    return False
+
+
+def _path_under(value: Any, root_template: str, macros: Mapping[str, str]) -> bool:
+    if value is None:
+        return False
+    target_str = _expand_macros(str(value), macros)
+    root_str = _expand_macros(root_template, macros)
+    try:
+        target = canonicalize_for_identity(target_str)
+        root = canonicalize_for_identity(root_str)
+    except (OSError, ValueError):
+        return False
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _expand_macros(text: str, macros: Mapping[str, str]) -> str:
+    """Replace `${name}` tokens with values from `macros`. Unknown tokens pass through.
+
+    Intentionally simpler than `ParsedMacro`: rules need plain workspace-anchored
+    paths, not the full template engine. If a richer surface is wanted later this
+    function is the only place that needs to change.
+    """
+    if "${" not in text:
+        return text
+    out = text
+    for key, replacement in macros.items():
+        token = "${" + key + "}"
+        if token in out:
+            out = out.replace(token, replacement)
+    return out
+
+
+def _resolve_dot_path(data: Mapping[str, Any], path: str) -> Any:
+    """Walk a dotted key into a nested mapping; returns None on any miss.
+
+    Unlike `dict_utils.get_dot_value`, accepts dataclass-like objects via
+    `getattr` fallback so request payloads can be matched without a manual
+    dict conversion at every call site.
+    """
+    if not path:
+        return None
+    current: Any = data
+    for segment in path.split("."):
+        if current is None:
+            return None
+        if isinstance(current, dict):
+            if segment not in current:
+                return None
+            current = current[segment]
+            continue
+        if hasattr(current, segment):
+            current = getattr(current, segment)
+            continue
+        return None
+    if isinstance(current, Path):
+        return str(current)
+    return current

--- a/src/griptape_nodes/retained_mode/managers/permissions/matchers.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/matchers.py
@@ -270,7 +270,11 @@ def _eval_match(expr: MatchExpr, value: Any, macros: Mapping[str, str]) -> bool:
     if isinstance(expr, GlobExpr):
         if value is None:
             return False
-        return fnmatch.fnmatch(str(value), expr.pattern)
+        # `fnmatchcase` ignores OS path conventions so a policy matches identically
+        # on every platform; plain `fnmatch` would case-fold and rewrite separators
+        # on Windows, silently changing a security decision.
+        pattern = _expand_macros(expr.pattern, macros)
+        return fnmatch.fnmatchcase(str(value), pattern)
     if isinstance(expr, PathUnderExpr):
         return _path_under(value, expr.root, macros)
     if isinstance(expr, NotExpr):
@@ -279,7 +283,11 @@ def _eval_match(expr: MatchExpr, value: Any, macros: Mapping[str, str]) -> bool:
         return all(_eval_match(sub, value, macros) for sub in expr.exprs)
     if isinstance(expr, AnyOfExpr):
         return any(_eval_match(sub, value, macros) for sub in expr.exprs)
-    return False
+    # A discriminated-union member with no handler is a programming error, not a
+    # policy miss. Fail loud rather than silently returning False, which under a
+    # surrounding `NotExpr` would invert into an unconditional allow.
+    msg = f"Unhandled match expression type: {type(expr).__name__}"
+    raise TypeError(msg)
 
 
 def _path_under(value: Any, root_template: str, macros: Mapping[str, str]) -> bool:
@@ -287,9 +295,14 @@ def _path_under(value: Any, root_template: str, macros: Mapping[str, str]) -> bo
         return False
     target_str = _expand_macros(str(value), macros)
     root_str = _expand_macros(root_template, macros)
+    # Anchor relative paths to the workspace, matching how the engine's file
+    # boundary (`OSManager`) resolves request paths. Anchoring to CWD here would
+    # judge a different path than the one actually read/written.
+    workspace = macros.get("workspace")
+    base = Path(workspace) if workspace else None
     try:
-        target = canonicalize_for_identity(target_str)
-        root = canonicalize_for_identity(root_str)
+        target = canonicalize_for_identity(target_str, base=base)
+        root = canonicalize_for_identity(root_str, base=base)
     except (OSError, ValueError):
         return False
     try:

--- a/src/griptape_nodes/retained_mode/managers/permissions/schema.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/schema.py
@@ -1,0 +1,187 @@
+"""Pydantic schema for the permission system.
+
+The data model is principal/action/resource/context: rules describe WHO is
+asking, WHAT they want to do, against WHICH resource, under WHICH ambient
+facts. Each rule resolves to allow/deny/prompt; first-match-wins inside a
+`PermissionPolicy`.
+
+Predicate operators are encoded as a discriminated union (`MatchExpr`) so
+policies round-trip cleanly through JSON config and Pydantic validation
+catches typos at parse time. New operators slot in additively without
+breaking the schema.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EqualsExpr(BaseModel):
+    """Strict equality (`==`)."""
+
+    op: Literal["equals"] = "equals"
+    value: Any
+
+
+class InExpr(BaseModel):
+    """Membership (`value in values`)."""
+
+    op: Literal["in"] = "in"
+    values: list[Any]
+
+
+class GlobExpr(BaseModel):
+    """fnmatch-style glob match against a string field."""
+
+    op: Literal["glob"] = "glob"
+    pattern: str
+
+
+class PathUnderExpr(BaseModel):
+    """Path containment after macro expansion + canonicalisation.
+
+    Both target and `root` are expanded against the active workspace before
+    comparison so policies can be authored in terms of `${workspace}/...`.
+    """
+
+    op: Literal["path_under"] = "path_under"
+    root: str
+
+
+class NotExpr(BaseModel):
+    """Negation."""
+
+    op: Literal["not"] = "not"
+    expr: MatchExpr
+
+
+class AllOfExpr(BaseModel):
+    """Conjunction; matches when every sub-expression matches."""
+
+    op: Literal["all_of"] = "all_of"
+    exprs: list[MatchExpr]
+
+
+class AnyOfExpr(BaseModel):
+    """Disjunction; matches when any sub-expression matches."""
+
+    op: Literal["any_of"] = "any_of"
+    exprs: list[MatchExpr]
+
+
+# `Annotated[X | ..., Field(discriminator="op")]` is Pydantic v2's discriminated-union
+# idiom: each member carries a `op: Literal[...]` tag and Pydantic dispatches on it.
+# Keeps unknown operators from silently parsing as the wrong shape.
+MatchExpr = Annotated[
+    EqualsExpr | InExpr | GlobExpr | PathUnderExpr | NotExpr | AllOfExpr | AnyOfExpr,
+    Field(discriminator="op"),
+]
+
+
+class PrincipalKind(StrEnum):
+    """Categories of actor that can issue a request."""
+
+    ENGINE = "engine"
+    NODE = "node"
+    CLIENT = "client"
+
+
+class PrincipalMatch(BaseModel):
+    """Match the actor that issued the request.
+
+    Populated fields are AND'd; unpopulated fields are wildcards.
+    """
+
+    kind: list[PrincipalKind] | None = None
+    library: MatchExpr | None = None
+    node_type: MatchExpr | None = None
+    topic: MatchExpr | None = None
+
+
+class ActionMatch(BaseModel):
+    """Match by `RequestPayload` class name (must be registered in PayloadRegistry)."""
+
+    request_type: MatchExpr
+
+
+class ResourceMatch(BaseModel):
+    """Match against fields of the request payload via dot-paths.
+
+    Keys are dot-paths into the request dataclass (resolved with the same
+    semantics as `ConfigManager.get_dot_value`). All entries must match (AND).
+    """
+
+    fields: dict[str, MatchExpr] = Field(default_factory=dict)
+
+
+class ContextMatch(BaseModel):
+    """Match against the merged fact tree.
+
+    Keys are dot-paths into the merged facts dict. All entries must match (AND).
+    """
+
+    facts: dict[str, MatchExpr] = Field(default_factory=dict)
+
+
+class WhenClause(BaseModel):
+    """Combined matcher. Populated axes are AND'd; unpopulated axes are wildcards."""
+
+    principal: PrincipalMatch | None = None
+    action: ActionMatch | None = None
+    resource: ResourceMatch | None = None
+    context: ContextMatch | None = None
+
+
+class Decision(StrEnum):
+    """Verdict produced by evaluating a rule or policy."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    PROMPT = "prompt"
+
+
+class PermissionRule(BaseModel):
+    """A single rule. First match wins inside a `PermissionPolicy`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    when: WhenClause = Field(default_factory=WhenClause)
+    decision: Decision
+    reason: str | None = None
+    granted_by: str | None = None
+
+
+class PermissionPolicy(BaseModel):
+    """An ordered list of rules plus a fall-through default decision.
+
+    The default decision is `ALLOW` so an unconfigured engine behaves exactly
+    as it did before this manager existed. Operators ratchet down by adding
+    explicit deny rules, or by setting `default_decision` to `DENY` /`PROMPT`
+    once they have built up an allow list.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rules: list[PermissionRule] = Field(default_factory=list)
+    default_decision: Decision = Decision.ALLOW
+
+
+class PermissionSettings(BaseModel):
+    """Top-level permission settings; merged into `Settings`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    consent_prompts_enabled: bool = True
+    audit_log_max_entries: int = 1000
+    policy: PermissionPolicy = Field(default_factory=PermissionPolicy)
+
+
+# Forward-references for the recursive operators.
+NotExpr.model_rebuild()
+AllOfExpr.model_rebuild()
+AnyOfExpr.model_rebuild()

--- a/src/griptape_nodes/retained_mode/managers/permissions/schema.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/schema.py
@@ -22,6 +22,8 @@ from pydantic import BaseModel, ConfigDict, Field
 class EqualsExpr(BaseModel):
     """Strict equality (`==`)."""
 
+    model_config = ConfigDict(extra="forbid")
+
     op: Literal["equals"] = "equals"
     value: Any
 
@@ -35,6 +37,8 @@ class InExpr(BaseModel):
     not, so prefer per-element rules when every element must be vetted.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     op: Literal["in"] = "in"
     values: list[Any]
 
@@ -47,6 +51,8 @@ class GlobExpr(BaseModel):
     is not collapsed. Use `PathUnderExpr` for filesystem containment checks.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     op: Literal["glob"] = "glob"
     pattern: str
 
@@ -58,12 +64,16 @@ class PathUnderExpr(BaseModel):
     comparison so policies can be authored in terms of `${workspace}/...`.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     op: Literal["path_under"] = "path_under"
     root: str
 
 
 class NotExpr(BaseModel):
     """Negation."""
+
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["not"] = "not"
     expr: MatchExpr
@@ -72,12 +82,16 @@ class NotExpr(BaseModel):
 class AllOfExpr(BaseModel):
     """Conjunction; matches when every sub-expression matches."""
 
+    model_config = ConfigDict(extra="forbid")
+
     op: Literal["all_of"] = "all_of"
     exprs: list[MatchExpr]
 
 
 class AnyOfExpr(BaseModel):
     """Disjunction; matches when any sub-expression matches."""
+
+    model_config = ConfigDict(extra="forbid")
 
     op: Literal["any_of"] = "any_of"
     exprs: list[MatchExpr]
@@ -106,6 +120,8 @@ class PrincipalMatch(BaseModel):
     Populated fields are AND'd; unpopulated fields are wildcards.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     kind: list[PrincipalKind] | None = None
     library: MatchExpr | None = None
     node_type: MatchExpr | None = None
@@ -114,6 +130,8 @@ class PrincipalMatch(BaseModel):
 
 class ActionMatch(BaseModel):
     """Match by `RequestPayload` class name (must be registered in PayloadRegistry)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     request_type: MatchExpr
 
@@ -125,6 +143,8 @@ class ResourceMatch(BaseModel):
     semantics as `ConfigManager.get_dot_value`). All entries must match (AND).
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     fields: dict[str, MatchExpr] = Field(default_factory=dict)
 
 
@@ -134,11 +154,15 @@ class ContextMatch(BaseModel):
     Keys are dot-paths into the merged facts dict. All entries must match (AND).
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     facts: dict[str, MatchExpr] = Field(default_factory=dict)
 
 
 class WhenClause(BaseModel):
     """Combined matcher. Populated axes are AND'd; unpopulated axes are wildcards."""
+
+    model_config = ConfigDict(extra="forbid")
 
     principal: PrincipalMatch | None = None
     action: ActionMatch | None = None

--- a/src/griptape_nodes/retained_mode/managers/permissions/schema.py
+++ b/src/griptape_nodes/retained_mode/managers/permissions/schema.py
@@ -27,14 +27,25 @@ class EqualsExpr(BaseModel):
 
 
 class InExpr(BaseModel):
-    """Membership (`value in values`)."""
+    """Membership (`value in values`).
+
+    Against a list-valued field this uses any-overlap semantics: it matches when
+    any element of the field is in `values`. An allow-list built this way lets a
+    request through as soon as one element qualifies, even if other elements do
+    not, so prefer per-element rules when every element must be vetted.
+    """
 
     op: Literal["in"] = "in"
     values: list[Any]
 
 
 class GlobExpr(BaseModel):
-    """fnmatch-style glob match against a string field."""
+    """Case-sensitive, platform-independent fnmatch glob against a string field.
+
+    `${...}` macros in `pattern` are expanded before matching. This is NOT
+    path-aware: `*` spans `/`, and nothing is canonicalized, so `..` traversal
+    is not collapsed. Use `PathUnderExpr` for filesystem containment checks.
+    """
 
     op: Literal["glob"] = "glob"
     pattern: str

--- a/tests/unit/retained_mode/managers/permissions/test_facts.py
+++ b/tests/unit/retained_mode/managers/permissions/test_facts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.managers.permissions import FactInvalidator, FactRegistry
@@ -89,11 +90,37 @@ class TestFactRegistryProviders:
         registry.build_fact_tree()
         assert counter["n"] == _EXPECTED_TWO
 
+    def test_invalidation_during_compute_is_not_lost(self) -> None:
+        """An invalidate that races a compute must drop the freshly computed value.
+
+        The compute runs outside the registry lock, so a concurrent invalidate can
+        land between the cache-miss check and the cache write. The generation guard
+        means that value is used for the current tree but never committed, so the
+        next build recomputes instead of serving a stale cached value.
+        """
+        registry = FactRegistry()
+        counter = {"n": 0}
+
+        def compute() -> int:
+            counter["n"] += 1
+            if counter["n"] == 1:
+                # Simulate an invalidation landing while this compute is in flight.
+                registry.invalidate(FactInvalidator.ON_LIBRARY_LOADED)
+            return counter["n"]
+
+        registry.register_provider("c", compute, invalidator=FactInvalidator.ON_LIBRARY_LOADED)
+        first = registry.build_fact_tree()
+        second = registry.build_fact_tree()
+        assert first["c"] == 1
+        assert second["c"] == _EXPECTED_TWO
+
 
 class TestFactRegistryEnrichers:
     def test_request_enricher_contributes_under_request_namespace(self) -> None:
         registry = FactRegistry()
-        registry.register_request_enricher("_FakeRequest", lambda r: {"foo": "bar", "len_a": len(r.field_a)})
+        registry.register_request_enricher(
+            "_FakeRequest", lambda r: {"foo": "bar", "len_a": len(cast("_FakeRequest", r).field_a)}
+        )
         tree = registry.build_fact_tree(_FakeRequest(field_a="hello"))
         assert tree == {"request": {"foo": "bar", "len_a": 5}}
 

--- a/tests/unit/retained_mode/managers/permissions/test_facts.py
+++ b/tests/unit/retained_mode/managers/permissions/test_facts.py
@@ -1,0 +1,127 @@
+"""Unit tests for the FactRegistry: providers, invalidation, request enrichers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.events.base_events import RequestPayload
+from griptape_nodes.retained_mode.managers.permissions import FactInvalidator, FactRegistry
+
+_EXPECTED_TWO = 2
+
+
+@dataclass
+class _FakeRequest(RequestPayload):
+    """Bare request payload subclass for enricher tests."""
+
+    field_a: str = ""
+
+
+class TestFactRegistryProviders:
+    def test_per_request_provider_recomputes_each_call(self) -> None:
+        registry = FactRegistry()
+        counter = {"n": 0}
+
+        def compute() -> int:
+            counter["n"] += 1
+            return counter["n"]
+
+        registry.register_provider("counter", compute, invalidator=FactInvalidator.PER_REQUEST)
+
+        first = registry.build_fact_tree()
+        second = registry.build_fact_tree()
+        assert first["counter"] == 1
+        assert second["counter"] == _EXPECTED_TWO
+
+    def test_cached_provider_does_not_recompute_until_invalidated(self) -> None:
+        registry = FactRegistry()
+        counter = {"n": 0}
+
+        def compute() -> int:
+            counter["n"] += 1
+            return counter["n"]
+
+        registry.register_provider("c", compute, invalidator=FactInvalidator.ON_LIBRARY_LOADED)
+        first = registry.build_fact_tree()
+        second = registry.build_fact_tree()
+        assert first["c"] == 1
+        assert second["c"] == 1
+
+        registry.invalidate(FactInvalidator.ON_LIBRARY_LOADED)
+        third = registry.build_fact_tree()
+        assert third["c"] == _EXPECTED_TWO
+
+    def test_dotted_provider_path_nests_into_tree(self) -> None:
+        registry = FactRegistry()
+        registry.register_provider("loaded_libraries.names", lambda: ["lib-a", "lib-b"])
+        tree = registry.build_fact_tree()
+        assert tree == {"loaded_libraries": {"names": ["lib-a", "lib-b"]}}
+
+    def test_misbehaving_provider_yields_none_without_crashing(self) -> None:
+        registry = FactRegistry()
+
+        def bad() -> int:
+            msg = "kaboom"
+            raise RuntimeError(msg)
+
+        registry.register_provider("broken", bad)
+        registry.register_provider("ok", lambda: "yes")
+        tree = registry.build_fact_tree()
+        assert tree == {"broken": None, "ok": "yes"}
+
+    def test_unregister_provider_drops_entry(self) -> None:
+        registry = FactRegistry()
+        registry.register_provider("x", lambda: 1)
+        registry.unregister_provider("x")
+        assert registry.build_fact_tree() == {}
+
+    def test_invalidate_all_clears_every_cache(self) -> None:
+        registry = FactRegistry()
+        counter = {"n": 0}
+
+        def compute() -> int:
+            counter["n"] += 1
+            return counter["n"]
+
+        registry.register_provider("a", compute, invalidator=FactInvalidator.NEVER)
+        registry.build_fact_tree()
+        registry.invalidate_all()
+        registry.build_fact_tree()
+        assert counter["n"] == _EXPECTED_TWO
+
+
+class TestFactRegistryEnrichers:
+    def test_request_enricher_contributes_under_request_namespace(self) -> None:
+        registry = FactRegistry()
+        registry.register_request_enricher("_FakeRequest", lambda r: {"foo": "bar", "len_a": len(r.field_a)})
+        tree = registry.build_fact_tree(_FakeRequest(field_a="hello"))
+        assert tree == {"request": {"foo": "bar", "len_a": 5}}
+
+    def test_request_enricher_only_fires_for_matching_type(self) -> None:
+        registry = FactRegistry()
+        registry.register_request_enricher("_OtherRequest", lambda _: {"x": 1})
+        tree = registry.build_fact_tree(_FakeRequest())
+        assert "request" not in tree
+
+    def test_request_enricher_failure_is_swallowed(self) -> None:
+        registry = FactRegistry()
+
+        def boom(_: RequestPayload) -> dict:
+            msg = "nope"
+            raise RuntimeError(msg)
+
+        registry.register_request_enricher("_FakeRequest", boom)
+        registry.register_request_enricher("_FakeRequest", lambda _: {"x": 1})
+        tree = registry.build_fact_tree(_FakeRequest())
+        assert tree == {"request": {"x": 1}}
+
+    def test_unregister_enricher(self) -> None:
+        registry = FactRegistry()
+
+        def enricher(_: RequestPayload) -> dict:
+            return {"x": 1}
+
+        registry.register_request_enricher("_FakeRequest", enricher)
+        registry.unregister_request_enricher("_FakeRequest", enricher)
+        tree = registry.build_fact_tree(_FakeRequest())
+        assert "request" not in tree

--- a/tests/unit/retained_mode/managers/permissions/test_matchers.py
+++ b/tests/unit/retained_mode/managers/permissions/test_matchers.py
@@ -1,0 +1,313 @@
+"""Unit tests for the permission match expression schema and matcher engine."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.retained_mode.managers.permissions import (
+    AllOfExpr,
+    AnyOfExpr,
+    ContextMatch,
+    Decision,
+    EqualsExpr,
+    GlobExpr,
+    InExpr,
+    MatchExpr,
+    NotExpr,
+    PathUnderExpr,
+    PermissionPolicy,
+    PermissionRule,
+    Principal,
+    PrincipalKind,
+    PrincipalMatch,
+    ResourceMatch,
+    WhenClause,
+    evaluate_policy,
+    evaluate_rule,
+)
+from griptape_nodes.retained_mode.managers.permissions.matchers import ActionMatch
+
+
+class TestMatchExprPrimitives:
+    """Each operator should match what its docstring claims and nothing else."""
+
+    def test_equals(self) -> None:
+        rule = _rule_with_resource("name", EqualsExpr(value="foo"))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "foo"}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"name": "bar"}))
+
+    def test_in(self) -> None:
+        rule = _rule_with_resource("color", InExpr(values=["red", "green"]))
+        assert evaluate_rule(rule, **_ctx(request_fields={"color": "red"}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"color": "blue"}))
+
+    def test_in_against_list_field_uses_any_overlap(self) -> None:
+        rule = _rule_with_resource("tags", InExpr(values=["security", "infra"]))
+        assert evaluate_rule(rule, **_ctx(request_fields={"tags": ["security"]}))
+        assert evaluate_rule(rule, **_ctx(request_fields={"tags": ["random", "infra"]}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"tags": ["random"]}))
+
+    def test_glob(self) -> None:
+        rule = _rule_with_resource("name", GlobExpr(pattern="prefix_*"))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "prefix_thing"}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"name": "thing"}))
+
+    def test_not(self) -> None:
+        rule = _rule_with_resource("name", NotExpr(expr=EqualsExpr(value="foo")))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"name": "foo"}))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "bar"}))
+
+    def test_all_of(self) -> None:
+        rule = _rule_with_resource("name", AllOfExpr(exprs=[GlobExpr(pattern="a*"), GlobExpr(pattern="*z")]))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "a-foo-z"}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"name": "a-foo"}))
+
+    def test_any_of(self) -> None:
+        rule = _rule_with_resource("name", AnyOfExpr(exprs=[EqualsExpr(value="foo"), EqualsExpr(value="bar")]))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "foo"}))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "bar"}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"name": "baz"}))
+
+
+class TestPathUnderExpr:
+    """`path_under` does macro expansion + canonical containment, not string prefix match."""
+
+    @pytest.fixture
+    def workspace(self) -> Path:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "ws"
+            ws.mkdir()
+            yield ws
+
+    def test_inside(self, workspace: Path) -> None:
+        rule = _rule_with_resource("file_path", PathUnderExpr(root="${workspace}"))
+        target = workspace / "outputs" / "image.png"
+        assert evaluate_rule(
+            rule,
+            **_ctx(request_fields={"file_path": str(target)}, macros={"workspace": str(workspace)}),
+        )
+
+    def test_outside(self, workspace: Path) -> None:
+        rule = _rule_with_resource("file_path", PathUnderExpr(root="${workspace}"))
+        target = workspace.parent / "elsewhere.png"
+        assert not evaluate_rule(
+            rule,
+            **_ctx(request_fields={"file_path": str(target)}, macros={"workspace": str(workspace)}),
+        )
+
+    def test_none_value(self, workspace: Path) -> None:
+        rule = _rule_with_resource("file_path", PathUnderExpr(root="${workspace}"))
+        assert not evaluate_rule(
+            rule,
+            **_ctx(request_fields={"file_path": None}, macros={"workspace": str(workspace)}),
+        )
+
+
+class TestPrincipalMatch:
+    """The principal axis matches kind first, then optional library/node_type/topic predicates."""
+
+    def test_kind_filter(self) -> None:
+        rule = _rule_with(
+            principal=PrincipalMatch(kind=[PrincipalKind.NODE]),
+        )
+        assert evaluate_rule(
+            rule,
+            **_ctx(principal=Principal(kind=PrincipalKind.NODE, library="lib", node_type="T")),
+        )
+        assert not evaluate_rule(rule, **_ctx(principal=Principal(kind=PrincipalKind.ENGINE)))
+
+    def test_library_predicate(self) -> None:
+        rule = _rule_with(
+            principal=PrincipalMatch(
+                kind=[PrincipalKind.NODE],
+                library=EqualsExpr(value="my-lib"),
+            ),
+        )
+        assert evaluate_rule(
+            rule,
+            **_ctx(principal=Principal(kind=PrincipalKind.NODE, library="my-lib", node_type="T")),
+        )
+        assert not evaluate_rule(
+            rule,
+            **_ctx(principal=Principal(kind=PrincipalKind.NODE, library="other-lib", node_type="T")),
+        )
+
+
+class TestActionAndContext:
+    def test_action_request_type_match(self) -> None:
+        rule = _rule_with(action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest")))
+        assert evaluate_rule(rule, **_ctx(request_type_name="WriteFileRequest"))
+        assert not evaluate_rule(rule, **_ctx(request_type_name="ReadFileRequest"))
+
+    def test_context_dot_path(self) -> None:
+        rule = _rule_with(
+            context=ContextMatch(facts={"loaded_libraries.names": InExpr(values=["lib-a"])}),
+        )
+        assert evaluate_rule(
+            rule,
+            **_ctx(facts={"loaded_libraries": {"names": ["lib-a", "lib-b"]}}),
+        )
+        assert not evaluate_rule(
+            rule,
+            **_ctx(facts={"loaded_libraries": {"names": ["lib-x"]}}),
+        )
+
+
+class TestInspectedValues:
+    """`EvaluationResult.inspected_values` carries the field=value pairs the matching rule consulted."""
+
+    def test_resource_values_captured_on_match(self) -> None:
+        rule = _rule_with(
+            action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest")),
+            resource=ResourceMatch(fields={"file_path": NotExpr(expr=GlobExpr(pattern="/ws/*"))}),
+        )
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(id="deny-outside", decision=Decision.DENY, when=rule.when),
+            ]
+        )
+        result = evaluate_policy(
+            policy,
+            **_ctx(
+                request_type_name="WriteFileRequest",
+                request_fields={"file_path": "/var/elsewhere.txt"},
+            ),
+        )
+        assert result.matched_rule is not None
+        assert result.matched_rule.id == "deny-outside"
+        assert result.inspected_values["resource.file_path"] == "/var/elsewhere.txt"
+        assert result.inspected_values["action.request_type"] == "WriteFileRequest"
+
+    def test_inspected_values_scoped_to_matching_rule(self) -> None:
+        """Values from earlier non-matching rules do not bleed into the matching rule's map.
+
+        `inspected_paths` deliberately accumulates across every rule the matcher
+        walked, but `inspected_values` is reset per rule so the denial message
+        only shows fields the matching rule actually evaluated.
+        """
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    id="miss",
+                    decision=Decision.ALLOW,
+                    when=WhenClause(resource=ResourceMatch(fields={"name": EqualsExpr(value="never")})),
+                ),
+                PermissionRule(
+                    id="hit",
+                    decision=Decision.DENY,
+                    when=WhenClause(
+                        resource=ResourceMatch(fields={"file_path": GlobExpr(pattern="*.txt")}),
+                    ),
+                ),
+            ]
+        )
+        result = evaluate_policy(
+            policy,
+            **_ctx(
+                request_fields={"name": "actual", "file_path": "/var/x.txt"},
+            ),
+        )
+        assert result.matched_rule is not None
+        assert result.matched_rule.id == "hit"
+        assert "resource.file_path" in result.inspected_values
+        assert result.inspected_values["resource.file_path"] == "/var/x.txt"
+        # The miss rule inspected resource.name; its value must not survive.
+        assert "resource.name" not in result.inspected_values
+        # Inspected paths still carry the cross-rule trace for audit purposes.
+        assert "resource.name" in result.inspected_paths
+        assert "resource.file_path" in result.inspected_paths
+
+    def test_default_fall_through_has_empty_values(self) -> None:
+        policy = PermissionPolicy(default_decision=Decision.DENY)
+        result = evaluate_policy(policy, **_ctx())
+        assert result.matched_rule is None
+        assert result.inspected_values == {}
+
+    def test_context_values_captured(self) -> None:
+        rule = _rule_with(
+            context=ContextMatch(facts={"loaded_libraries.names": InExpr(values=["lib-x"])}),
+        )
+        policy = PermissionPolicy(
+            rules=[PermissionRule(id="hit", decision=Decision.DENY, when=rule.when)],
+        )
+        result = evaluate_policy(
+            policy,
+            **_ctx(facts={"loaded_libraries": {"names": ["lib-x", "lib-y"]}}),
+        )
+        assert result.matched_rule is not None
+        assert result.inspected_values["context.loaded_libraries.names"] == ["lib-x", "lib-y"]
+
+
+class TestPolicyOrdering:
+    """First-match-wins, with fall-through to default_decision."""
+
+    def test_first_match_wins(self) -> None:
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    id="allow-x",
+                    decision=Decision.ALLOW,
+                    when=WhenClause(
+                        action=ActionMatch(request_type=EqualsExpr(value="X")),
+                    ),
+                ),
+                PermissionRule(
+                    id="deny-x",
+                    decision=Decision.DENY,
+                    when=WhenClause(
+                        action=ActionMatch(request_type=EqualsExpr(value="X")),
+                    ),
+                ),
+            ],
+            default_decision=Decision.PROMPT,
+        )
+        result = evaluate_policy(policy, **_ctx(request_type_name="X"))
+        assert result.decision is Decision.ALLOW
+        assert result.matched_rule is not None
+        assert result.matched_rule.id == "allow-x"
+
+    def test_falls_through_to_default(self) -> None:
+        policy = PermissionPolicy(
+            rules=[
+                PermissionRule(
+                    id="allow-x",
+                    decision=Decision.ALLOW,
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="X"))),
+                ),
+            ],
+            default_decision=Decision.DENY,
+        )
+        result = evaluate_policy(policy, **_ctx(request_type_name="Y"))
+        assert result.decision is Decision.DENY
+        assert result.matched_rule is None
+
+
+# ---------------------------------------------------------------------- helpers
+
+
+def _rule_with(**when_kwargs) -> PermissionRule:
+    return PermissionRule(id="r", decision=Decision.ALLOW, when=WhenClause(**when_kwargs))
+
+
+def _rule_with_resource(field_name: str, expr: MatchExpr) -> PermissionRule:
+    return _rule_with(resource=ResourceMatch(fields={field_name: expr}))
+
+
+def _ctx(
+    *,
+    principal: Principal | None = None,
+    request_type_name: str = "TestRequest",
+    request_fields: dict | None = None,
+    facts: dict | None = None,
+    macros: dict | None = None,
+) -> dict:
+    return {
+        "principal": principal or Principal(kind=PrincipalKind.ENGINE),
+        "request_type_name": request_type_name,
+        "request_fields": request_fields or {},
+        "facts": facts or {},
+        "macro_context": macros or {},
+    }

--- a/tests/unit/retained_mode/managers/permissions/test_matchers.py
+++ b/tests/unit/retained_mode/managers/permissions/test_matchers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -28,7 +29,10 @@ from griptape_nodes.retained_mode.managers.permissions import (
     evaluate_policy,
     evaluate_rule,
 )
-from griptape_nodes.retained_mode.managers.permissions.matchers import ActionMatch
+from griptape_nodes.retained_mode.managers.permissions.matchers import ActionMatch, _eval_match
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class TestMatchExprPrimitives:
@@ -55,6 +59,22 @@ class TestMatchExprPrimitives:
         assert evaluate_rule(rule, **_ctx(request_fields={"name": "prefix_thing"}))
         assert not evaluate_rule(rule, **_ctx(request_fields={"name": "thing"}))
 
+    def test_glob_is_case_sensitive_on_every_platform(self) -> None:
+        rule = _rule_with_resource("name", GlobExpr(pattern="Secret_*"))
+        assert evaluate_rule(rule, **_ctx(request_fields={"name": "Secret_x"}))
+        assert not evaluate_rule(rule, **_ctx(request_fields={"name": "secret_x"}))
+
+    def test_glob_expands_macros_in_pattern(self) -> None:
+        rule = _rule_with_resource("name", GlobExpr(pattern="${prefix}_*"))
+        assert evaluate_rule(
+            rule,
+            **_ctx(request_fields={"name": "abc_thing"}, macros={"prefix": "abc"}),
+        )
+        assert not evaluate_rule(
+            rule,
+            **_ctx(request_fields={"name": "xyz_thing"}, macros={"prefix": "abc"}),
+        )
+
     def test_not(self) -> None:
         rule = _rule_with_resource("name", NotExpr(expr=EqualsExpr(value="foo")))
         assert not evaluate_rule(rule, **_ctx(request_fields={"name": "foo"}))
@@ -76,7 +96,7 @@ class TestPathUnderExpr:
     """`path_under` does macro expansion + canonical containment, not string prefix match."""
 
     @pytest.fixture
-    def workspace(self) -> Path:
+    def workspace(self) -> Iterator[Path]:
         with tempfile.TemporaryDirectory() as tmp:
             ws = Path(tmp) / "ws"
             ws.mkdir()
@@ -104,6 +124,25 @@ class TestPathUnderExpr:
             rule,
             **_ctx(request_fields={"file_path": None}, macros={"workspace": str(workspace)}),
         )
+
+    def test_relative_value_anchored_to_workspace(self, workspace: Path) -> None:
+        """A relative target resolves against the workspace, not the process CWD."""
+        rule = _rule_with_resource("file_path", PathUnderExpr(root="${workspace}"))
+        assert evaluate_rule(
+            rule,
+            **_ctx(request_fields={"file_path": "outputs/image.png"}, macros={"workspace": str(workspace)}),
+        )
+
+
+class TestUnhandledOperator:
+    def test_unhandled_expression_raises(self) -> None:
+        """An expression type with no handler must fail loud, not fall through to a miss."""
+
+        class _Bogus:
+            pass
+
+        with pytest.raises(TypeError):
+            _eval_match(cast("MatchExpr", _Bogus()), "anything", {})
 
 
 class TestPrincipalMatch:

--- a/tests/unit/retained_mode/managers/permissions/test_matchers.py
+++ b/tests/unit/retained_mode/managers/permissions/test_matchers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from pydantic import ValidationError
 
 from griptape_nodes.retained_mode.managers.permissions import (
     AllOfExpr,
@@ -143,6 +144,22 @@ class TestUnhandledOperator:
 
         with pytest.raises(TypeError):
             _eval_match(cast("MatchExpr", _Bogus()), "anything", {})
+
+
+class TestSchemaRejectsUnknownKeys:
+    """A typo'd constraint key must raise, not silently drop to a wildcard default."""
+
+    def test_principal_match_rejects_unknown_key(self) -> None:
+        with pytest.raises(ValidationError):
+            PrincipalMatch(kind=[PrincipalKind.NODE], bogus_field=EqualsExpr(value="x"))  # type: ignore[reportCallIssue]
+
+    def test_when_clause_rejects_unknown_key(self) -> None:
+        with pytest.raises(ValidationError):
+            WhenClause(bogus_axis=PrincipalMatch())  # type: ignore[reportCallIssue]
+
+    def test_resource_match_rejects_unknown_key(self) -> None:
+        with pytest.raises(ValidationError):
+            ResourceMatch(bogus_fields={"name": EqualsExpr(value="x")})  # type: ignore[reportCallIssue]
 
 
 class TestPrincipalMatch:


### PR DESCRIPTION
### 📚 Permission Manager stack

Four stacked PRs split by layer. Review and merge bottom-up, starting at the base (#4713). Each PR targets the branch of the PR above it, so its diff shows only that layer.

| Order | PR | Layer | Base |
| --- | --- | --- | --- |
| 1 | #4713 | Pre-dispatch hook chain in `EventManager` | `main` |
| **2** | **#4714 👈 you are here** | **Policy schema, matcher engine, fact registry** | #4713 |
| 3 | #4715 | `PermissionManager` enforcement | #4714 |
| 4 | #4716 | Integrations: `LibraryManager`, MCP server, docs | #4715 |

---

Second slice of the permission-manager stack. Introduces the policy core: the permission policy schema, the matcher engine that evaluates a request against a policy, and the fact registry that supplies the data matchers run against.

Match-axis and expression models forbid unknown keys so malformed policy entries fail loudly instead of being silently ignored. The matcher and fact registry are hardened against the edge cases surfaced in review.

**Previous:** #4713 (the hook seam this plugs into). **Next:** #4715 enforces these policies at dispatch time.

## What the policy language affords

A rule matches across four independent axes (any axis left out is a wildcard): **principal** (who is asking: `engine` / `node` / `client`, plus library and node-type), **action** (the `RequestPayload` type), **resource** (dot-paths into the request payload), and **context** (dot-paths into the merged fact tree). Populated axes are AND'd. Each rule resolves to `allow` / `deny` / `prompt`, **first match wins**, and an unmatched request falls through to `default_decision` (defaults to `allow`, so an unconfigured engine behaves exactly as before).

Predicates are a discriminated union: `equals`, `in`, `glob`, `path_under` (macro-expanded + canonicalized containment), `not`, `all_of`, `any_of`.

### Keep every file write inside the workspace

`path_under` expands `${workspace}` and canonicalizes before comparing, so `..` traversal cannot escape.

```json
{
  "rules": [
    {
      "id": "writes-stay-in-workspace",
      "when": {
        "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
        "resource": {
          "fields": {
            "file_path": { "op": "not", "expr": { "op": "path_under", "root": "${workspace}" } }
          }
        }
      },
      "decision": "deny",
      "reason": "File writes must stay inside the workspace."
    }
  ]
}
```

### Lock the engine down to an allow-list

Flip `default_decision` to `deny` and enumerate what is permitted; prompt on the genuinely dangerous calls.

```json
{
  "default_decision": "deny",
  "rules": [
    {
      "id": "allow-safe-reads",
      "when": {
        "action": { "request_type": { "op": "in", "values": ["ReadFileRequest", "ListDirectoryRequest"] } }
      },
      "decision": "allow"
    },
    {
      "id": "prompt-on-arbitrary-python",
      "when": {
        "action": { "request_type": { "op": "equals", "value": "RunArbitraryPythonStringRequest" } }
      },
      "decision": "prompt",
      "reason": "Running arbitrary Python can touch anything on the host."
    }
  ]
}
```

### Constrain a single untrusted library

The principal axis lets a rule target only requests originating from a specific library or node type. `glob` here matches any file-related request type.

```json
{
  "rules": [
    {
      "id": "untrusted-lib-no-file-io",
      "when": {
        "principal": {
          "kind": ["node"],
          "library": { "op": "equals", "value": "community.untrusted" }
        },
        "action": { "request_type": { "op": "glob", "pattern": "*FileRequest" } }
      },
      "decision": "deny",
      "reason": "The community.untrusted library may not perform file I/O."
    }
  ]
}
```

### Combine axes and conditions

`all_of` / `any_of` nest arbitrarily, and the `context` axis reads the merged fact tree (facts are contributed by providers and per-request enrichers wired up in #4715/#4716). `granted_by` annotates who authorized the rule for the audit trail.

```json
{
  "rules": [
    {
      "id": "client-can-register-vetted-libs",
      "when": {
        "principal": { "kind": ["client"] },
        "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
        "resource": {
          "fields": {
            "file_path": {
              "op": "all_of",
              "exprs": [
                { "op": "path_under", "root": "${workspace}/libraries" },
                { "op": "glob", "pattern": "*/griptape_nodes_library.json" }
              ]
            }
          }
        }
      },
      "decision": "allow",
      "granted_by": "platform-team"
    }
  ]
}
```
