### PR TITLE
feat: add PermissionManager enforcement with layered config and license policy

### DIFF
--- a/src/griptape_nodes/retained_mode/events/permission_events.py
+++ b/src/griptape_nodes/retained_mode/events/permission_events.py
@@ -1,0 +1,121 @@
+"""Events for the permission system.
+
+`PermissionDecisionEvent` is broadcast for every evaluation; audit log
+listeners and editor UIs subscribe to it. The request types let callers
+read the effective policy, tail recent decisions, and grant/revoke rules
+through the standard request dispatcher.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from griptape_nodes.retained_mode.events.base_events import (
+    AppPayload,
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+@dataclass
+@PayloadRegistry.register
+class PermissionDecisionEvent(AppPayload):
+    """Broadcast after every `PermissionManager` evaluation. Informational.
+
+    `rule_id` is None when the policy fell through to its default decision.
+    `inspected_paths` records which match-paths the rule actually consulted,
+    making "explain why this fired" trivially debuggable. `inspected_values`
+    is scoped to the matching rule (empty on default fall-through) and maps
+    each consulted path to the resolved value the matcher saw, so consumers
+    can render "why" without re-running the matcher.
+    """
+
+    rule_id: str | None
+    decision: str
+    principal_kind: str
+    principal_label: str
+    action_request_type: str
+    resource_summary: dict[str, Any] = field(default_factory=dict)
+    inspected_paths: list[str] = field(default_factory=list)
+    inspected_values: dict[str, Any] = field(default_factory=dict)
+    reason: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEffectivePolicyRequest(RequestPayload):
+    """Read the merged permission policy as seen by the engine."""
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEffectivePolicyResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    policy: dict[str, Any]
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEffectivePolicyResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class ListPermissionDecisionsRequest(RequestPayload):
+    """Read recent permission decisions from the in-memory ring buffer."""
+
+    limit: int | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class ListPermissionDecisionsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    decisions: list[dict[str, Any]]
+
+
+@dataclass
+@PayloadRegistry.register
+class ListPermissionDecisionsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class GrantPermissionRuleRequest(RequestPayload):
+    """Append a rule to the active policy."""
+
+    rule: dict[str, Any]
+
+
+@dataclass
+@PayloadRegistry.register
+class GrantPermissionRuleResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    rule_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GrantPermissionRuleResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    pass
+
+
+@dataclass
+@PayloadRegistry.register
+class RevokePermissionRuleRequest(RequestPayload):
+    """Remove a rule by id from the active policy."""
+
+    rule_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class RevokePermissionRuleResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    rule_id: str
+
+
+@dataclass
+@PayloadRegistry.register
+class RevokePermissionRuleResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    pass

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
         OperationDepthManager,
     )
     from griptape_nodes.retained_mode.managers.os_manager import OSManager
+    from griptape_nodes.retained_mode.managers.permission_manager import PermissionManager
     from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
     from griptape_nodes.retained_mode.managers.resource_manager import ResourceManager
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -98,6 +99,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
     _session_manager: SessionManager
     _engine_identity_manager: EngineIdentityManager
     _mcp_manager: MCPManager
+    _permission_manager: PermissionManager
     _resource_manager: ResourceManager
     _sync_manager: SyncManager
     _user_manager: UserManager
@@ -125,6 +127,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
             OperationDepthManager,
         )
         from griptape_nodes.retained_mode.managers.os_manager import OSManager
+        from griptape_nodes.retained_mode.managers.permission_manager import PermissionManager
         from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
         from griptape_nodes.retained_mode.managers.resource_manager import ResourceManager
         from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -150,6 +153,10 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._event_manager = EventManager()
             self._resource_manager = ResourceManager(self._event_manager)
             self._config_manager = ConfigManager(self._event_manager)
+            # PermissionManager registers a pre-dispatch hook on EventManager and
+            # listens to ConfigChanged. It must exist before any other manager
+            # registers handlers, so that those handlers run behind the policy.
+            self._permission_manager = PermissionManager(self._event_manager, self._config_manager)
             self._os_manager = OSManager(self._event_manager)
             self._secrets_manager = SecretsManager(self._config_manager, self._event_manager)
             self._object_manager = ObjectManager(self._event_manager)
@@ -336,6 +343,10 @@ class GriptapeNodes(metaclass=SingletonMeta):
     @classmethod
     def MCPManager(cls) -> MCPManager:
         return GriptapeNodes.get_instance()._mcp_manager
+
+    @classmethod
+    def PermissionManager(cls) -> PermissionManager:
+        return GriptapeNodes.get_instance()._permission_manager
 
     @classmethod
     def EngineIdentityManager(cls) -> EngineIdentityManager:

--- a/src/griptape_nodes/retained_mode/managers/permission_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/permission_manager.py
@@ -135,11 +135,13 @@ class PermissionManager:
         self._audit: deque[dict[str, Any]] = deque(maxlen=self._audit_max_entries)
         self._node_stack_lock = Lock()
         self._node_stack: list[dict[str, str | None]] = []
-        # Re-entrancy guard so a request issued while the policy is being
-        # evaluated does not recurse through the hook (would be the case if a
-        # fact provider or audit listener accidentally dispatched a request).
-        self._evaluating = False
-        self._evaluating_lock = Lock()
+        # Re-entrancy is handled by `EventManager`, which guards the hook chain
+        # with a thread-local flag: a fact provider or audit listener that
+        # re-enters `handle_request` on the evaluating thread bypasses the
+        # chain instead of recursing. A manager-level flag here would have to be
+        # thread-local to match, and a shared one would fail open by skipping
+        # evaluation for requests dispatched concurrently on other threads, so
+        # we deliberately keep no such flag.
 
         self._reload_settings()
 
@@ -445,16 +447,8 @@ class PermissionManager:
             return None
         if not self._enabled:
             return None
-        with self._evaluating_lock:
-            if self._evaluating:
-                return None
-            self._evaluating = True
-        try:
-            principal = self._infer_principal(context=context)
-            result = self.evaluate(request, principal=principal, context=context)
-        finally:
-            with self._evaluating_lock:
-                self._evaluating = False
+        principal = self._infer_principal(context=context)
+        result = self.evaluate(request, principal=principal, context=context)
         if result.decision is Decision.ALLOW:
             return None
         if result.decision is Decision.PROMPT:
@@ -566,8 +560,23 @@ class PermissionManager:
         # cannot remove a license-imposed deny by hand.
         with self._policy_lock:
             slot = self._layer_settings.get(self._USER_LAYER_NAME)
-            settings = slot.model_copy(deep=True) if slot is not None else PermissionSettings()
-        self._config_manager.set_config_value("permissions", settings.model_dump(mode="json"))
+            rules = list(slot.policy.rules) if slot is not None else []
+            default_explicit = slot is not None and self._USER_LAYER_NAME in self._explicit_defaults
+            default_decision = slot.policy.default_decision if slot is not None else PermissionPolicy().default_decision
+        rule_payload = [rule.model_dump(mode="json") for rule in rules]
+        policy_payload: dict[str, Any] = {"rules": rule_payload}
+        # Only carry `default_decision` when the user layer actually set one.
+        # `set_config_value` merges this delta into the user config file, and
+        # `merge_dicts` replaces the `rules` list while preserving every other
+        # key the user already set. Dumping a fully-populated `PermissionSettings`
+        # instead would write schema defaults (`enabled`,
+        # `consent_prompts_enabled`, `audit_log_max_entries`, and a defaulted
+        # `policy.default_decision`) that `_reload_settings` would then treat as
+        # explicit operator intent, e.g. promoting a defaulted `allow` over a
+        # lower layer's explicit `deny`.
+        if default_explicit:
+            policy_payload["default_decision"] = default_decision.value
+        self._config_manager.set_config_value("permissions", {"policy": policy_payload})
 
     def _infer_principal(self, context: ResultContext | None) -> Principal:
         with self._node_stack_lock:
@@ -724,20 +733,25 @@ def _resource_summary(request: RequestPayload) -> dict[str, Any]:
 _SUMMARY_PRIMITIVES = (str, int, float, bool, type(None))
 _SUMMARY_MAX_STR = 256
 _SUMMARY_MAX_LIST = 8
+_SUMMARY_MAX_DEPTH = 6
 
 
-def _summarise(value: Any) -> Any:
+def _summarise(value: Any, depth: int = 0) -> Any:
     if isinstance(value, _SUMMARY_PRIMITIVES):
         if isinstance(value, str) and len(value) > _SUMMARY_MAX_STR:
             return value[:_SUMMARY_MAX_STR] + "..."
         return value
     if isinstance(value, (bytes, bytearray)):
         return f"<{len(value)} bytes>"
-    if isinstance(value, dict):
-        return {k: _summarise(v) for k, v in list(value.items())[:_SUMMARY_MAX_LIST]}
-    if isinstance(value, (list, tuple, set, frozenset)):
+    # Bound recursion so a deeply nested or self-referential payload can't raise
+    # RecursionError here and turn an audit record into a denied request. Past
+    # the depth bound, fall through to the repr summary below.
+    within_depth = depth < _SUMMARY_MAX_DEPTH
+    if within_depth and isinstance(value, dict):
+        return {k: _summarise(v, depth + 1) for k, v in list(value.items())[:_SUMMARY_MAX_LIST]}
+    if within_depth and isinstance(value, (list, tuple, set, frozenset)):
         items = list(value)[:_SUMMARY_MAX_LIST]
-        return [_summarise(item) for item in items]
+        return [_summarise(item, depth + 1) for item in items]
     return repr(value)[:_SUMMARY_MAX_STR]
 
 

--- a/src/griptape_nodes/retained_mode/managers/permission_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/permission_manager.py
@@ -360,6 +360,11 @@ class PermissionManager:
             entries = list(self._audit)
         if limit is None:
             return entries
+        # `entries[-0:]` is the whole list and a negative limit slices from the
+        # front, both of which would over-share an audit tail, so treat any
+        # non-positive limit as "no entries".
+        if limit <= 0:
+            return []
         return entries[-limit:]
 
     # ------------------------------------------------------------------ request handlers
@@ -404,7 +409,14 @@ class PermissionManager:
             slot.policy.rules.append(rule)
         # Persist outside the lock; set_config_value broadcasts ConfigChanged
         # synchronously, and our listener re-acquires _policy_lock.
-        self._persist_policy()
+        if not self._persist_policy():
+            return GrantPermissionRuleResultFailure(
+                result_details=(
+                    f"Attempted to grant permission rule '{rule.id}'. Failed because the rule could "
+                    "not be persisted to the user config, so it is not active. Check the engine log "
+                    "for the underlying write error."
+                )
+            )
         return GrantPermissionRuleResultSuccess(
             rule_id=rule.id,
             result_details=f"Granted permission rule '{rule.id}'.",
@@ -431,7 +443,14 @@ class PermissionManager:
                     "and defaults layers, plus license-imposed rules, are read-only at runtime."
                 )
             )
-        self._persist_policy()
+        if not self._persist_policy():
+            return RevokePermissionRuleResultFailure(
+                result_details=(
+                    f"Attempted to revoke permission rule '{request.rule_id}'. Failed because the "
+                    "change could not be persisted to the user config, so the rule is still active. "
+                    "Check the engine log for the underlying write error."
+                )
+            )
         return RevokePermissionRuleResultSuccess(
             rule_id=request.rule_id,
             result_details=f"Revoked permission rule '{request.rule_id}'.",
@@ -553,7 +572,7 @@ class PermissionManager:
             default_decision=default_decision if default_decision is not None else Decision.ALLOW,
         )
 
-    def _persist_policy(self) -> None:
+    def _persist_policy(self) -> bool:
         # Only the user-layer settings are persisted. Project / workspace / env
         # / defaults layers are owned by their own config files; license rules
         # live in memory only so a user editing `griptape_nodes_config.json`
@@ -563,6 +582,7 @@ class PermissionManager:
             rules = list(slot.policy.rules) if slot is not None else []
             default_explicit = slot is not None and self._USER_LAYER_NAME in self._explicit_defaults
             default_decision = slot.policy.default_decision if slot is not None else PermissionPolicy().default_decision
+        expected_ids = [rule.id for rule in rules]
         rule_payload = [rule.model_dump(mode="json") for rule in rules]
         policy_payload: dict[str, Any] = {"rules": rule_payload}
         # Only carry `default_decision` when the user layer actually set one.
@@ -577,6 +597,16 @@ class PermissionManager:
         if default_explicit:
             policy_payload["default_decision"] = default_decision.value
         self._config_manager.set_config_value("permissions", {"policy": policy_payload})
+        # set_config_value reloads _layer_settings from disk synchronously via the
+        # ConfigChanged broadcast, but _write_user_config_delta swallows disk
+        # errors (logs and returns). Compare the reloaded user-layer rule ids
+        # against what we intended to persist so a silently-dropped write is
+        # reported as failure instead of a false success that leaves the operator
+        # believing a rule is active.
+        with self._policy_lock:
+            reloaded = self._layer_settings.get(self._USER_LAYER_NAME)
+            reloaded_ids = [rule.id for rule in reloaded.policy.rules] if reloaded is not None else []
+        return reloaded_ids == expected_ids
 
     def _infer_principal(self, context: ResultContext | None) -> Principal:
         with self._node_stack_lock:

--- a/src/griptape_nodes/retained_mode/managers/permission_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/permission_manager.py
@@ -1,0 +1,842 @@
+"""PermissionManager: declarative policy over privileged engine operations.
+
+Single chokepoint: a pre-dispatch hook on `EventManager` is the only place
+verdicts are enforced. Everything else here exists to feed that hook with
+fresh, well-typed inputs (principal identity, resolved fields, fact tree)
+and to surface the resulting decisions over the existing event channels.
+
+State is kept current by listening to formally defined `AppPayload` and
+`ExecutionPayload` events, never by polling. Cache invalidation is driven
+by the same broadcasts the rest of the engine already emits.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections import deque
+from dataclasses import dataclass, fields, is_dataclass
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from griptape_nodes.retained_mode.events.app_events import ConfigChanged, LibraryLoadedNotification
+from griptape_nodes.retained_mode.events.base_events import (
+    Payload,
+    RequestPayload,
+    ResultPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.permission_events import (
+    GetEffectivePolicyRequest,
+    GetEffectivePolicyResultSuccess,
+    GrantPermissionRuleRequest,
+    GrantPermissionRuleResultFailure,
+    GrantPermissionRuleResultSuccess,
+    ListPermissionDecisionsRequest,
+    ListPermissionDecisionsResultSuccess,
+    PermissionDecisionEvent,
+    RevokePermissionRuleRequest,
+    RevokePermissionRuleResultFailure,
+    RevokePermissionRuleResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.permissions.facts import FactInvalidator, FactRegistry
+from griptape_nodes.retained_mode.managers.permissions.matchers import (
+    EvaluationResult,
+    Principal,
+    PrincipalKind,
+    evaluate_policy,
+)
+from griptape_nodes.retained_mode.managers.permissions.schema import (
+    Decision,
+    PermissionPolicy,
+    PermissionRule,
+    PermissionSettings,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager, ResultContext
+
+logger = logging.getLogger("griptape_nodes")
+
+
+PERMISSION_OWN_REQUEST_TYPES: frozenset[str] = frozenset(
+    {
+        GetEffectivePolicyRequest.__name__,
+        GrantPermissionRuleRequest.__name__,
+        ListPermissionDecisionsRequest.__name__,
+        RevokePermissionRuleRequest.__name__,
+    }
+)
+
+
+@dataclass
+@PayloadRegistry.register
+class PermissionDeniedResult(ResultPayloadFailure):
+    """Generic permission-denied result.
+
+    Used when no typed failure payload can be auto-wired for the original
+    request. The dispatcher prefers a request-specific failure class when one
+    exists (e.g. `WriteFileResultFailure`) so handler-side type assumptions
+    keep working; this class is the fall-through.
+    """
+
+
+class PermissionManager:
+    """Enforce permission policy over `RequestPayload` dispatch."""
+
+    # Per-layer settings are read straight off `ConfigManager`, ordered
+    # highest-priority first so first-match-wins evaluation gives the right
+    # precedence: env, then workspace, then project, then user, then
+    # defaults. License rules sit ahead of every config layer at evaluation
+    # time and are never persisted through this slot.
+    _LAYER_ATTRS: tuple[tuple[str, str], ...] = (
+        ("env", "env_config"),
+        ("workspace", "workspace_config"),
+        ("project", "project_config"),
+        ("user", "user_config"),
+        ("defaults", "default_config"),
+    )
+    _USER_LAYER_NAME: str = "user"
+
+    def __init__(
+        self,
+        event_manager: EventManager,
+        config_manager: ConfigManager,
+    ) -> None:
+        self._event_manager = event_manager
+        self._config_manager = config_manager
+        self._facts = FactRegistry()
+        self._policy_lock = Lock()
+        # Per-layer settings populated by `_reload_settings`. Each layer's
+        # `policy.rules` carry their `granted_by` stamp (auto-applied at load
+        # time when not explicitly set) so audit messages identify the source
+        # config file.
+        self._layer_settings: dict[str, PermissionSettings] = {}
+        # Layer names whose `policy.default_decision` should be honored at
+        # merge time. A layer is "explicit" when its config block actually
+        # contains a `policy.default_decision` key, distinguishing
+        # "workspace deliberately set ALLOW" from "workspace's policy was
+        # silent and inherited the schema default of ALLOW."
+        self._explicit_defaults: set[str] = set()
+        # License rules sit ahead of every config layer in evaluation order;
+        # set via `set_license_policy()`, never persisted to config.
+        self._license_policy: PermissionPolicy = PermissionPolicy(default_decision=Decision.ALLOW)
+        self._enabled = True
+        self._consent_prompts_enabled = True
+        self._audit_max_entries = 1000
+        self._audit_lock = Lock()
+        self._audit: deque[dict[str, Any]] = deque(maxlen=self._audit_max_entries)
+        self._node_stack_lock = Lock()
+        self._node_stack: list[dict[str, str | None]] = []
+        # Re-entrancy guard so a request issued while the policy is being
+        # evaluated does not recurse through the hook (would be the case if a
+        # fact provider or audit listener accidentally dispatched a request).
+        self._evaluating = False
+        self._evaluating_lock = Lock()
+
+        self._reload_settings()
+
+        # Wire the dispatcher hook before any request can be handled.
+        event_manager.add_pre_dispatch_hook(self._on_pre_dispatch)
+
+        # Subscribe to formally defined `AppPayload` event types for cache
+        # invalidation / policy reloads. NodeStart/Finish principal tracking is
+        # done through the explicit push_principal/pop_principal API; the engine
+        # does not currently broadcast those execution events through this bus,
+        # and we'd rather have the caller be explicit than have a silently-inert
+        # listener.
+        event_manager.add_listener_to_app_event(ConfigChanged, self._on_config_changed)
+        event_manager.add_listener_to_app_event(LibraryLoadedNotification, self._on_library_loaded)
+
+        # Manager-owned request handlers (introspection + grant/revoke).
+        event_manager.assign_manager_to_request_type(GetEffectivePolicyRequest, self.on_get_effective_policy_request)
+        event_manager.assign_manager_to_request_type(
+            ListPermissionDecisionsRequest, self.on_list_permission_decisions_request
+        )
+        event_manager.assign_manager_to_request_type(GrantPermissionRuleRequest, self.on_grant_permission_rule_request)
+        event_manager.assign_manager_to_request_type(
+            RevokePermissionRuleRequest, self.on_revoke_permission_rule_request
+        )
+
+        # Built-in fact providers. Each maps to a stable, formally defined piece
+        # of engine state and uses the appropriate invalidator so providers don't
+        # poll. New providers register themselves through `facts.register_provider`
+        # the same way.
+        self._register_builtin_fact_providers()
+
+    def _register_builtin_fact_providers(self) -> None:
+        """Register the facts that ship with the permission system.
+
+        Each provider returns a JSON-serializable value and declares an
+        invalidator that maps to a real engine event. The fact tree paths are
+        documented in the Permissions reference; new built-ins should be
+        added here so they round-trip with the documentation.
+        """
+        self._facts.register_provider(
+            "workspace.path",
+            self._fact_workspace_path,
+            invalidator=FactInvalidator.ON_CONFIG_CHANGED,
+        )
+        self._facts.register_provider(
+            "engine.id",
+            self._fact_engine_id,
+            invalidator=FactInvalidator.NEVER,
+        )
+        self._facts.register_provider(
+            "loaded_libraries.names",
+            self._fact_loaded_library_names,
+            invalidator=FactInvalidator.ON_LIBRARY_LOADED,
+        )
+        self._facts.register_provider(
+            "current_node.library",
+            lambda: self._current_node_field("library"),
+            invalidator=FactInvalidator.ON_NODE_EXECUTION_BOUNDARY,
+        )
+        self._facts.register_provider(
+            "current_node.node_type",
+            lambda: self._current_node_field("node_type"),
+            invalidator=FactInvalidator.ON_NODE_EXECUTION_BOUNDARY,
+        )
+        self._facts.register_provider(
+            "current_node.node_name",
+            lambda: self._current_node_field("node_name"),
+            invalidator=FactInvalidator.ON_NODE_EXECUTION_BOUNDARY,
+        )
+
+    def _fact_workspace_path(self) -> str | None:
+        try:
+            return str(self._config_manager.workspace_path)
+        except Exception:
+            return None
+
+    def _fact_engine_id(self) -> str | None:
+        # Lazy import: EngineIdentityManager imports through the GriptapeNodes
+        # singleton chain that this manager itself participates in.
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        try:
+            return GriptapeNodes.EngineIdentityManager().active_engine_id
+        except Exception:
+            return None
+
+    def _fact_loaded_library_names(self) -> list[str]:
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        try:
+            return list(LibraryRegistry.list_libraries())
+        except Exception:
+            return []
+
+    def _current_node_field(self, key: str) -> str | None:
+        with self._node_stack_lock:
+            top = self._node_stack[-1] if self._node_stack else None
+        if top is None:
+            return None
+        return top.get(key)
+
+    # ------------------------------------------------------------------ public API
+
+    @property
+    def facts(self) -> FactRegistry:
+        """Fact registry. Managers publish providers / enrichers through this."""
+        return self._facts
+
+    @property
+    def policy(self) -> PermissionPolicy:
+        """Merged view of license + per-layer config rules in evaluation order.
+
+        License rules fire first, followed by config layers in priority order:
+        env, then workspace, then project, then user, then defaults. The
+        fall-through default is whichever layer's `policy.default_decision` was
+        explicitly set first, defaulting to ALLOW; licenses deliberately have
+        no default of their own.
+        """
+        return self._build_merged_policy()
+
+    @property
+    def user_policy(self) -> PermissionPolicy:
+        """User-layer policy fragment as loaded from `ConfigManager.user_config`.
+
+        Returns a deep copy. To mutate, go through `GrantPermissionRuleRequest`
+        / `RevokePermissionRuleRequest`, or reach for `_user_policy` from
+        within tests where in-place mutation is the intended interface.
+        """
+        with self._policy_lock:
+            slot = self._layer_settings.get(self._USER_LAYER_NAME)
+        if slot is None:
+            return PermissionPolicy()
+        return slot.policy.model_copy(deep=True)
+
+    @property
+    def _user_policy(self) -> PermissionPolicy:
+        """Live user-layer policy slot. Internal use; mutation is in-place.
+
+        Created on first access if the user config didn't carry a
+        `permissions` block, so callers can mutate `default_decision` /
+        `rules` without preloading config. Mutating `default_decision`
+        through this handle also flags the user layer as having an explicit
+        default so the merged policy honours it at evaluation time.
+        """
+        with self._policy_lock:
+            slot = self._layer_settings.setdefault(self._USER_LAYER_NAME, PermissionSettings())
+            self._explicit_defaults.add(self._USER_LAYER_NAME)
+            return slot.policy
+
+    @property
+    def license_policy(self) -> PermissionPolicy:
+        """License-imposed policy fragment as set via `set_license_policy`."""
+        with self._policy_lock:
+            return self._license_policy.model_copy(deep=True)
+
+    def set_license_policy(self, policy: PermissionPolicy) -> None:
+        """Replace the license-imposed policy fragment.
+
+        Whatever loads license files (a future `LicenseManager`) calls this
+        with the parsed policy. Rules are stamped with `granted_by =
+        "license"` if the caller did not already tag them; this keeps the
+        audit log honest about origin without forcing license loaders to
+        repeat themselves.
+
+        License rules are held in memory only and are never persisted into
+        user config, so a user editing `griptape_nodes_config.json` cannot
+        edit a license-imposed `deny` out of existence.
+        """
+        stamped = policy.model_copy(deep=True)
+        for rule in stamped.rules:
+            if not rule.granted_by:
+                rule.granted_by = "license"
+        with self._policy_lock:
+            self._license_policy = stamped
+        # Audit cache stays valid; only the rule set changed.
+
+    def clear_license_policy(self) -> None:
+        """Drop all license-imposed rules. Used by license revocation paths."""
+        with self._policy_lock:
+            self._license_policy = PermissionPolicy(default_decision=Decision.ALLOW)
+
+    def reload(self) -> None:
+        """Re-read settings + policy from `ConfigManager`."""
+        self._reload_settings()
+
+    def evaluate(
+        self,
+        request: RequestPayload,
+        *,
+        principal: Principal | None = None,
+        macro_context: dict[str, str] | None = None,
+        context: ResultContext | None = None,
+    ) -> EvaluationResult:
+        """Evaluate the active policy against `request`. Used by the hook and tests."""
+        actor = principal if principal is not None else self._infer_principal(context=context)
+        request_fields_dict = _request_fields(request)
+        facts = self._facts.build_fact_tree(request)
+        macros = macro_context if macro_context is not None else self._macro_context()
+        # License rules win by being evaluated first; config layers follow in
+        # priority order. Things outside any explicit rule fall through to the
+        # merged default decision.
+        merged = self._build_merged_policy()
+        result = evaluate_policy(
+            merged,
+            principal=actor,
+            request_type_name=type(request).__name__,
+            request_fields=request_fields_dict,
+            facts=facts,
+            macro_context=macros,
+        )
+        self._record_decision(request, actor, result)
+        return result
+
+    def list_recent_decisions(self, limit: int | None = None) -> list[dict[str, Any]]:
+        with self._audit_lock:
+            entries = list(self._audit)
+        if limit is None:
+            return entries
+        return entries[-limit:]
+
+    # ------------------------------------------------------------------ request handlers
+
+    def on_get_effective_policy_request(self, _: GetEffectivePolicyRequest) -> ResultPayload:
+        policy_dict = self._build_merged_policy().model_dump(mode="json")
+        return GetEffectivePolicyResultSuccess(
+            policy=policy_dict,
+            result_details=(
+                "Returned active permission policy (license rules first, then config layers "
+                "in priority order: env, workspace, project, user, defaults)."
+            ),
+        )
+
+    def on_list_permission_decisions_request(
+        self,
+        request: ListPermissionDecisionsRequest,
+    ) -> ResultPayload:
+        decisions = self.list_recent_decisions(request.limit)
+        return ListPermissionDecisionsResultSuccess(
+            decisions=decisions,
+            result_details=f"Returned {len(decisions)} recent permission decision(s).",
+        )
+
+    def on_grant_permission_rule_request(self, request: GrantPermissionRuleRequest) -> ResultPayload:
+        try:
+            rule = PermissionRule.model_validate(request.rule)
+        except ValidationError as e:
+            return GrantPermissionRuleResultFailure(
+                exception=e,
+                result_details=f"Attempted to grant permission rule. Failed because rule is invalid: {e}",
+            )
+        # User-authored rule. Stamp `granted_by` if absent so audit entries
+        # round-trip with provenance even after a config reload. License rules
+        # use set_license_policy(), which is not exposed as a request type by
+        # design; project / workspace / env / defaults rules are read-only at
+        # runtime and edited by hand in their respective config files.
+        if not rule.granted_by:
+            rule = rule.model_copy(update={"granted_by": self._USER_LAYER_NAME})
+        with self._policy_lock:
+            slot = self._layer_settings.setdefault(self._USER_LAYER_NAME, PermissionSettings())
+            slot.policy.rules.append(rule)
+        # Persist outside the lock; set_config_value broadcasts ConfigChanged
+        # synchronously, and our listener re-acquires _policy_lock.
+        self._persist_policy()
+        return GrantPermissionRuleResultSuccess(
+            rule_id=rule.id,
+            result_details=f"Granted permission rule '{rule.id}'.",
+        )
+
+    def on_revoke_permission_rule_request(self, request: RevokePermissionRuleRequest) -> ResultPayload:
+        # Revoke targets the user layer only. Rules from project, workspace,
+        # env, and defaults layers are read-only at runtime and edited in their
+        # config files; license-imposed rules come and go via set_license_policy
+        # / clear_license_policy on the LicenseManager side.
+        with self._policy_lock:
+            slot = self._layer_settings.get(self._USER_LAYER_NAME)
+            if slot is None:
+                removed = 0
+            else:
+                before = len(slot.policy.rules)
+                slot.policy.rules = [r for r in slot.policy.rules if r.id != request.rule_id]
+                removed = before - len(slot.policy.rules)
+        if not removed:
+            return RevokePermissionRuleResultFailure(
+                result_details=(
+                    f"Attempted to revoke permission rule '{request.rule_id}'. Failed because no "
+                    "user-layer rule with that id exists. Rules from project, workspace, env, "
+                    "and defaults layers, plus license-imposed rules, are read-only at runtime."
+                )
+            )
+        self._persist_policy()
+        return RevokePermissionRuleResultSuccess(
+            rule_id=request.rule_id,
+            result_details=f"Revoked permission rule '{request.rule_id}'.",
+        )
+
+    # ------------------------------------------------------------------ event listeners
+
+    def _on_pre_dispatch(self, request: RequestPayload, context: ResultContext) -> ResultPayload | None:
+        # The manager's own request types are exempt: denying GetEffectivePolicy
+        # would be an unhelpful loop, and the grant/revoke path is itself the
+        # tool used to repair a too-restrictive policy.
+        if type(request).__name__ in PERMISSION_OWN_REQUEST_TYPES:
+            return None
+        if not self._enabled:
+            return None
+        with self._evaluating_lock:
+            if self._evaluating:
+                return None
+            self._evaluating = True
+        try:
+            principal = self._infer_principal(context=context)
+            result = self.evaluate(request, principal=principal, context=context)
+        finally:
+            with self._evaluating_lock:
+                self._evaluating = False
+        if result.decision is Decision.ALLOW:
+            return None
+        if result.decision is Decision.PROMPT:
+            mode = "prompt-not-implemented" if self._consent_prompts_enabled else "prompt-disabled"
+            return _build_failure_for_request(request, _denied_message(request, result, mode))
+        return _build_failure_for_request(request, _denied_message(request, result, "deny"))
+
+    def _on_config_changed(self, event: ConfigChanged) -> None:
+        if event.key != "permissions" and not event.key.startswith("permissions."):
+            self._facts.invalidate(FactInvalidator.ON_CONFIG_CHANGED)
+            return
+        self._reload_settings()
+        self._facts.invalidate(FactInvalidator.ON_CONFIG_CHANGED)
+
+    def _on_library_loaded(self, _: LibraryLoadedNotification) -> None:
+        self._facts.invalidate(FactInvalidator.ON_LIBRARY_LOADED)
+
+    # ------------------------------------------------------------------ helpers
+
+    def _reload_settings(self) -> None:
+        cm = self._config_manager
+        layer_settings: dict[str, PermissionSettings] = {}
+        explicit_defaults: set[str] = set()
+        enabled: bool = True
+        consent_prompts_enabled: bool = True
+        audit_max: int = 1000
+        enabled_set = consent_set = audit_set = False
+
+        for layer_name, attr in self._LAYER_ATTRS:
+            layer = getattr(cm, attr, None)
+            if not isinstance(layer, dict):
+                continue
+            block = layer.get("permissions")
+            if not isinstance(block, dict):
+                continue
+            try:
+                settings = PermissionSettings.model_validate(block)
+            except ValidationError:
+                logger.exception("Permission settings in '%s' layer failed validation; skipping.", layer_name)
+                continue
+
+            # Stamp `granted_by` on rules that didn't carry one so audit entries
+            # attribute decisions back to the layer's config file. Round-trip
+            # the policy with the stamped rules so subsequent reads see them.
+            stamped_rules = [
+                rule if rule.granted_by else rule.model_copy(update={"granted_by": layer_name})
+                for rule in settings.policy.rules
+            ]
+            settings.policy = PermissionPolicy(
+                rules=stamped_rules,
+                default_decision=settings.policy.default_decision,
+            )
+            layer_settings[layer_name] = settings
+
+            # Highest-priority layer that explicitly set a scalar wins. Lower
+            # layers don't override a value already chosen by a higher layer.
+            # Presence is checked against the raw block so the schema default
+            # (e.g. enabled=True) is treated as "unset" rather than an override.
+            if not enabled_set and "enabled" in block:
+                enabled, enabled_set = settings.enabled, True
+            if not consent_set and "consent_prompts_enabled" in block:
+                consent_prompts_enabled, consent_set = settings.consent_prompts_enabled, True
+            if not audit_set and "audit_log_max_entries" in block:
+                audit_max, audit_set = max(1, settings.audit_log_max_entries), True
+            policy_block = block.get("policy")
+            if isinstance(policy_block, dict) and "default_decision" in policy_block:
+                explicit_defaults.add(layer_name)
+
+        with self._policy_lock:
+            self._layer_settings = layer_settings
+            self._explicit_defaults = explicit_defaults
+        self._enabled = enabled
+        self._consent_prompts_enabled = consent_prompts_enabled
+        with self._audit_lock:
+            if audit_max != self._audit.maxlen:
+                self._audit = deque(self._audit, maxlen=audit_max)
+            self._audit_max_entries = audit_max
+
+    def _build_merged_policy(self) -> PermissionPolicy:
+        """Assemble the active policy: license rules + per-layer rules + default.
+
+        License rules go first so a license-imposed deny wins over a config
+        allow. Config layers concatenate in priority order so first-match-wins
+        gives "more-specific layer's rule fires before less-specific layer's
+        rule". The default decision is whichever layer's
+        `policy.default_decision` was explicitly set first; falls back to
+        ALLOW so an unconfigured engine behaves as it did before this manager
+        existed.
+        """
+        with self._policy_lock:
+            rules: list[PermissionRule] = list(self._license_policy.rules)
+            default_decision: Decision | None = None
+            for layer_name, _ in self._LAYER_ATTRS:
+                slot = self._layer_settings.get(layer_name)
+                if slot is None:
+                    continue
+                rules.extend(slot.policy.rules)
+                if default_decision is None and layer_name in self._explicit_defaults:
+                    default_decision = slot.policy.default_decision
+        return PermissionPolicy(
+            rules=rules,
+            default_decision=default_decision if default_decision is not None else Decision.ALLOW,
+        )
+
+    def _persist_policy(self) -> None:
+        # Only the user-layer settings are persisted. Project / workspace / env
+        # / defaults layers are owned by their own config files; license rules
+        # live in memory only so a user editing `griptape_nodes_config.json`
+        # cannot remove a license-imposed deny by hand.
+        with self._policy_lock:
+            slot = self._layer_settings.get(self._USER_LAYER_NAME)
+            settings = slot.model_copy(deep=True) if slot is not None else PermissionSettings()
+        self._config_manager.set_config_value("permissions", settings.model_dump(mode="json"))
+
+    def _infer_principal(self, context: ResultContext | None) -> Principal:
+        with self._node_stack_lock:
+            top = self._node_stack[-1] if self._node_stack else None
+        if top is not None:
+            return Principal(
+                kind=PrincipalKind.NODE,
+                library=top.get("library"),
+                node_type=top.get("node_type"),
+                node_name=top.get("node_name"),
+            )
+        topic = (context or {}).get("response_topic") if context else None
+        if topic:
+            return Principal(kind=PrincipalKind.CLIENT, topic=str(topic))
+        return Principal(kind=PrincipalKind.ENGINE)
+
+    def push_principal(self, *, library: str | None, node_type: str | None, node_name: str | None) -> None:
+        """Install a NODE principal on the stack.
+
+        Callers (NodeManager / NodeExecutor / tests) bracket node execution with
+        push/pop. This is the single entry point for principal tracking; nothing
+        listens for execution events directly because the engine does not
+        currently broadcast them through the AppPayload bus.
+        """
+        with self._node_stack_lock:
+            self._node_stack.append({"library": library, "node_type": node_type, "node_name": node_name})
+        self._facts.invalidate(FactInvalidator.ON_NODE_EXECUTION_BOUNDARY)
+
+    def pop_principal(self) -> None:
+        """Undo `push_principal`."""
+        with self._node_stack_lock:
+            if self._node_stack:
+                self._node_stack.pop()
+        self._facts.invalidate(FactInvalidator.ON_NODE_EXECUTION_BOUNDARY)
+
+    def _lookup_node_identity(self, node_name: str) -> dict[str, str | None]:
+        """Resolve `(library, node_type)` for a live node by name.
+
+        Reserved for the eventual NodeManager integration that brackets node
+        execution with `push_principal`. Not currently called inside the
+        manager but kept here so the integration is a one-line wiring change.
+        """
+        # Lazy import to avoid bootstrap-time circular imports (NodeManager's
+        # transitive imports include ConfigManager / Settings, which is the same
+        # graph this manager participates in via GriptapeNodes).
+        from griptape_nodes.exe_types.node_types import BaseNode
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        try:
+            object_manager = GriptapeNodes.ObjectManager()
+            node = object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
+        except Exception:
+            node = None
+        if node is None:
+            return {"library": None, "node_type": None, "node_name": node_name}
+        metadata = getattr(node, "metadata", {}) or {}
+        return {
+            "library": metadata.get("library"),
+            "node_type": metadata.get("node_type"),
+            "node_name": node_name,
+        }
+
+    def _macro_context(self) -> dict[str, str]:
+        config = self._config_manager
+        macros: dict[str, str] = {}
+        try:
+            workspace = str(config.workspace_path)
+        except Exception:
+            workspace = ""
+        if workspace:
+            macros["workspace"] = workspace
+        static_dir = config.get_config_value("static_files_directory")
+        if isinstance(static_dir, str) and static_dir:
+            macros["static_files_directory"] = static_dir
+        return macros
+
+    def _record_decision(
+        self,
+        request: RequestPayload,
+        principal: Principal,
+        result: EvaluationResult,
+    ) -> None:
+        rule_id = result.matched_rule.id if result.matched_rule else None
+        inspected_values = {key: _summarise(value) for key, value in result.inspected_values.items()}
+        entry = {
+            "rule_id": rule_id,
+            "decision": result.decision.value,
+            "principal_kind": principal.kind.value,
+            "principal_label": principal.label(),
+            "action_request_type": type(request).__name__,
+            "resource_summary": _resource_summary(request),
+            "inspected_paths": list(result.inspected_paths),
+            "inspected_values": inspected_values,
+            "reason": result.reason,
+        }
+        with self._audit_lock:
+            self._audit.append(entry)
+        try:
+            self._event_manager.broadcast_app_event(
+                PermissionDecisionEvent(
+                    rule_id=rule_id,
+                    decision=result.decision.value,
+                    principal_kind=principal.kind.value,
+                    principal_label=principal.label(),
+                    action_request_type=type(request).__name__,
+                    resource_summary=entry["resource_summary"],
+                    inspected_paths=list(result.inspected_paths),
+                    inspected_values=dict(inspected_values),
+                    reason=result.reason,
+                )
+            )
+        except Exception:
+            # Never let an event-broadcast failure perturb the dispatcher.
+            logger.exception("Failed to broadcast PermissionDecisionEvent.")
+
+
+# ---------------------------------------------------------------------- module-level helpers
+
+
+def _request_fields(request: RequestPayload) -> dict[str, Any]:
+    """Convert a request payload to a dict for matcher lookups."""
+    if is_dataclass(request) and not isinstance(request, type):
+        try:
+            return dataclasses.asdict(request)
+        except (TypeError, ValueError):
+            pass
+    out: dict[str, Any] = {}
+    if hasattr(request, "__dict__"):
+        out.update({k: v for k, v in vars(request).items() if not k.startswith("_")})
+    return out
+
+
+def _resource_summary(request: RequestPayload) -> dict[str, Any]:
+    """Cheap, JSON-safe summary of request fields for audit/event payloads.
+
+    Trims long collections and stringifies non-primitive values so the audit
+    ring buffer stays small and serialisable.
+    """
+    summary: dict[str, Any] = {}
+    if is_dataclass(request) and not isinstance(request, type):
+        for field_def in fields(request):
+            if field_def.metadata.get("omit_from_result"):
+                continue
+            value = getattr(request, field_def.name, None)
+            summary[field_def.name] = _summarise(value)
+    else:
+        for key, value in vars(request).items():
+            if key.startswith("_"):
+                continue
+            summary[key] = _summarise(value)
+    return summary
+
+
+_SUMMARY_PRIMITIVES = (str, int, float, bool, type(None))
+_SUMMARY_MAX_STR = 256
+_SUMMARY_MAX_LIST = 8
+
+
+def _summarise(value: Any) -> Any:
+    if isinstance(value, _SUMMARY_PRIMITIVES):
+        if isinstance(value, str) and len(value) > _SUMMARY_MAX_STR:
+            return value[:_SUMMARY_MAX_STR] + "..."
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return f"<{len(value)} bytes>"
+    if isinstance(value, dict):
+        return {k: _summarise(v) for k, v in list(value.items())[:_SUMMARY_MAX_LIST]}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        items = list(value)[:_SUMMARY_MAX_LIST]
+        return [_summarise(item) for item in items]
+    return repr(value)[:_SUMMARY_MAX_STR]
+
+
+def _denied_message(request: RequestPayload, result: EvaluationResult, mode: str) -> str:
+    rule_label = f"rule '{result.matched_rule.id}'" if result.matched_rule else "default policy"
+    qualifier = f"{mode}: {result.reason}" if result.reason else mode
+    details = _format_inspected_values(result.inspected_values)
+    suffix = f" Inspected: {details}" if details else ""
+    # Bracket-free format: the engine's RichHandler runs with markup=True, and
+    # `[deny]` / `[resource.file_path=...]` would be parsed as Rich tags and
+    # silently elided in the rendered log line. Parens + an `Inspected:`
+    # prefix render the same in plain text and survive Rich markup unchanged.
+    return (
+        f"Attempted to dispatch {type(request).__name__}. "
+        f"Failed because permission was denied by {rule_label} ({qualifier}).{suffix}"
+    )
+
+
+# Principal/action axes are tautological in the denial message: the request
+# type is already named, and the principal axis is rarely the surprising
+# reason a request was blocked. Resource and context fields carry the
+# request- and environment-specific values the user usually needs to debug
+# "why was this blocked".
+_DENIAL_MESSAGE_AXES: tuple[str, ...] = ("resource.", "context.")
+
+
+def _format_inspected_values(inspected_values: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in inspected_values.items():
+        if not key.startswith(_DENIAL_MESSAGE_AXES):
+            continue
+        parts.append(f"{key}={_summarise(value)}")
+    return ", ".join(parts)
+
+
+def _build_failure_for_request(request: RequestPayload, message: str) -> ResultPayload:
+    """Synthesise a failure result of the type the request's manager would have returned.
+
+    Resolves the response type from the corresponding `*ResultFailure` naming
+    convention. Falls back to `PermissionDeniedResult` when no companion class
+    exists or when a required field cannot be defaulted.
+    """
+    candidate = _find_failure_companion(type(request))
+    if candidate is not None:
+        instance = _instantiate_failure(candidate, message)
+        if instance is not None:
+            return instance
+    return PermissionDeniedResult(result_details=message)
+
+
+def _find_failure_companion(request_class: type[Payload]) -> type[ResultPayloadFailure] | None:
+    """Find `<Foo>ResultFailure` for `<Foo>Request` in the same module."""
+    name = request_class.__name__
+    if not name.endswith("Request"):
+        return None
+    target_name = name.removesuffix("Request") + "ResultFailure"
+    module = __import__(request_class.__module__, fromlist=[target_name])
+    candidate = getattr(module, target_name, None)
+    if candidate is None or not isinstance(candidate, type):
+        return None
+    if not issubclass(candidate, ResultPayloadFailure):
+        return None
+    if issubclass(candidate, ResultPayloadSuccess):
+        return None
+    return candidate
+
+
+def _instantiate_failure(failure_class: type[ResultPayloadFailure], message: str) -> ResultPayloadFailure | None:
+    """Best-effort construct a failure with sensible defaults for required fields."""
+    kwargs: dict[str, Any] = {"result_details": message}
+    if is_dataclass(failure_class):
+        for field_def in fields(failure_class):
+            if field_def.name in kwargs:
+                continue
+            if field_def.default is not dataclasses.MISSING:
+                continue
+            if field_def.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+                continue
+            default = _default_for_failure_field(field_def.name)
+            if default is _UNSET:
+                return None
+            kwargs[field_def.name] = default
+    try:
+        return failure_class(**kwargs)
+    except TypeError:
+        return None
+
+
+_UNSET: Any = object()
+
+
+def _default_for_failure_field(name: str) -> Any:
+    """Provide sensible defaults for a small set of well-known required fields.
+
+    Anything outside this list returns `_UNSET`, which causes the dispatcher to
+    fall back to `PermissionDeniedResult` rather than guess.
+    """
+    if name == "failure_reason":
+        from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+
+        return FileIOFailureReason.PERMISSION_DENIED
+    return _UNSET

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -39,6 +39,7 @@ MCP_SERVERS = Category(name="MCP Servers", description="Model Context Protocol s
 PROJECTS = Category(name="Projects", description="Project template configurations and registrations")
 STATIC_SERVER = Category(name="Static Server", description="Static file server configuration for serving media assets")
 ARTIFACTS = Category(name="Artifacts", description="Settings for artifact providers and preview generation")
+PERMISSIONS = Category(name="Permissions", description="Permission policy controlling privileged engine operations")
 
 
 def Field(category: str | Category = "General", **kwargs) -> Any:
@@ -329,4 +330,9 @@ class Settings(BaseModel):
         category=PROJECTS,
         default_factory=dict,
         description="Mapping of project file paths to workspace directory overrides. When a project is loaded, if its resolved path matches a key here, the corresponding value is used as the workspace directory instead of the project-adjacent config or auto-default.",
+    )
+    permissions: dict[str, Any] = Field(
+        category=PERMISSIONS,
+        default_factory=dict,
+        description="Permission policy controlling privileged engine operations. Validated against PermissionSettings at PermissionManager startup.",
     )

--- a/tests/integration/retained_mode/permissions/test_builtin_facts_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_builtin_facts_e2e.py
@@ -1,0 +1,148 @@
+"""Built-in fact providers shipped by PermissionManager.
+
+`workspace.path`, `engine.id`, `loaded_libraries.names`, and `current_node.*`
+are documented in `docs/permissions.md` and must round-trip with the docs.
+These tests pin the contract: presence, shape, and invalidation behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+from griptape_nodes.retained_mode.events.permission_events import GrantPermissionRuleRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.utils.metaclasses import SingletonMeta
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def permission_env() -> Generator[dict, None, None]:
+    """Bring up an isolated GriptapeNodes singleton with a clean permissions config."""
+    SingletonMeta._instances.clear()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        config_path = tmp_path / "griptape_nodes_config.json"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "workspace_directory": str(workspace),
+                    "permissions": {
+                        "enabled": True,
+                        "policy": {"rules": [], "default_decision": "allow"},
+                    },
+                }
+            )
+        )
+        with patch.object(config_manager_module, "USER_CONFIG_PATH", config_path):
+            gn = GriptapeNodes()
+            yield {"gn": gn, "workspace": workspace}
+        SingletonMeta._instances.clear()
+
+
+class TestBuiltinFactPresence:
+    """Every documented built-in fact appears in the tree."""
+
+    def test_all_documented_facts_present(self, permission_env: dict) -> None:
+        pm = permission_env["gn"].PermissionManager()
+        tree = pm.facts.build_fact_tree()
+        # Workspace
+        assert "workspace" in tree
+        assert isinstance(tree["workspace"]["path"], str)
+        assert tree["workspace"]["path"].endswith("ws")
+        # Engine
+        assert "engine" in tree
+        assert tree["engine"]["id"] is None or isinstance(tree["engine"]["id"], str)
+        # Loaded libraries
+        assert "loaded_libraries" in tree
+        assert isinstance(tree["loaded_libraries"]["names"], list)
+        # Current node (None outside a push_principal block)
+        assert "current_node" in tree
+        assert tree["current_node"] == {
+            "library": None,
+            "node_type": None,
+            "node_name": None,
+        }
+
+
+class TestBuiltinFactInvalidation:
+    """Cached facts refresh in response to the right events."""
+
+    def test_current_node_updates_with_push_principal(self, permission_env: dict) -> None:
+        pm = permission_env["gn"].PermissionManager()
+        pm.push_principal(library="lib-a", node_type="NodeT", node_name="n1")
+        try:
+            tree = pm.facts.build_fact_tree()
+        finally:
+            pm.pop_principal()
+        assert tree["current_node"] == {
+            "library": "lib-a",
+            "node_type": "NodeT",
+            "node_name": "n1",
+        }
+        cleared = pm.facts.build_fact_tree()
+        assert cleared["current_node"]["library"] is None
+
+
+class TestRuleAgainstBuiltinFact:
+    """A real rule using a built-in fact path fires correctly via the dispatcher."""
+
+    def test_engine_principal_blocked_when_in_node_context(self, permission_env: dict) -> None:
+        from griptape_nodes.retained_mode.events.os_events import (
+            ExistingFilePolicy,
+            WriteFileRequest,
+            WriteFileResultFailure,
+            WriteFileResultSuccess,
+        )
+
+        gn = permission_env["gn"]
+        pm = gn.PermissionManager()
+
+        # Rule: deny WriteFileRequest while a node from "untrusted-lib" is on top.
+        GriptapeNodes.handle_request(
+            GrantPermissionRuleRequest(
+                rule={
+                    "id": "user.deny-untrusted-node-writes",
+                    "decision": "deny",
+                    "when": {
+                        "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                        "context": {"facts": {"current_node.library": {"op": "equals", "value": "untrusted-lib"}}},
+                    },
+                }
+            )
+        )
+        target = permission_env["workspace"] / "ok.txt"
+        # Outside any node context: rule does not fire.
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultSuccess)
+        # Inside a matching node context: rule fires.
+        pm.push_principal(library="untrusted-lib", node_type="X", node_name="x1")
+        try:
+            target2 = permission_env["workspace"] / "blocked.txt"
+            result2 = GriptapeNodes.handle_request(
+                WriteFileRequest(
+                    file_path=str(target2),
+                    content="hi",
+                    existing_file_policy=ExistingFilePolicy.OVERWRITE,
+                )
+            )
+        finally:
+            pm.pop_principal()
+        assert isinstance(result2, WriteFileResultFailure)
+        assert "user.deny-untrusted-node-writes" in str(result2.result_details)

--- a/tests/integration/retained_mode/permissions/test_license_layer_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_license_layer_e2e.py
@@ -1,0 +1,339 @@
+"""End-to-end tests for license-imposed policy that trumps user-set rules.
+
+License rules live in a separate in-memory layer that's evaluated before user
+rules. They're never persisted into user config, so a user editing
+`griptape_nodes_config.json` cannot remove a license-imposed deny.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+from griptape_nodes.retained_mode.events.os_events import (
+    ExistingFilePolicy,
+    WriteFileRequest,
+    WriteFileResultFailure,
+    WriteFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.permission_events import (
+    GetEffectivePolicyRequest,
+    GetEffectivePolicyResultSuccess,
+    GrantPermissionRuleRequest,
+    GrantPermissionRuleResultSuccess,
+    RevokePermissionRuleRequest,
+    RevokePermissionRuleResultFailure,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.permissions import (
+    Decision,
+    PermissionPolicy,
+    PermissionRule,
+    WhenClause,
+)
+from griptape_nodes.retained_mode.managers.permissions.matchers import ActionMatch
+from griptape_nodes.retained_mode.managers.permissions.schema import (
+    EqualsExpr,
+    GlobExpr,
+)
+from griptape_nodes.utils.metaclasses import SingletonMeta
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def permission_env() -> Generator[dict, None, None]:
+    """Bring up an isolated GriptapeNodes singleton with a clean permissions config."""
+    SingletonMeta._instances.clear()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        config_path = tmp_path / "griptape_nodes_config.json"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "workspace_directory": str(workspace),
+                    "permissions": {
+                        "enabled": True,
+                        "policy": {"rules": [], "default_decision": "allow"},
+                    },
+                }
+            )
+        )
+        with patch.object(config_manager_module, "USER_CONFIG_PATH", config_path):
+            gn = GriptapeNodes()
+            yield {
+                "gn": gn,
+                "permission_manager": gn.PermissionManager(),
+                "workspace": workspace,
+                "tmp": tmp_path,
+                "config_path": config_path,
+            }
+        SingletonMeta._instances.clear()
+
+
+def _grant_user_rule(rule: dict) -> str:
+    result = GriptapeNodes.handle_request(GrantPermissionRuleRequest(rule=rule))
+    assert isinstance(result, GrantPermissionRuleResultSuccess), result.result_details
+    return result.rule_id
+
+
+def _license_policy(*rules: PermissionRule) -> PermissionPolicy:
+    return PermissionPolicy(rules=list(rules), default_decision=Decision.ALLOW)
+
+
+class TestLicenseTrumpsUser:
+    """A license rule that fires before any user rule wins."""
+
+    def test_license_deny_overrides_user_allow(self, permission_env: dict) -> None:
+        """User says allow-everything; license says deny-WriteFile. License wins."""
+        pm = permission_env["permission_manager"]
+        _grant_user_rule(
+            {
+                "id": "user.allow-anything",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.no-writes",
+                    decision=Decision.DENY,
+                    reason="this license forbids writes",
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest"))),
+                )
+            )
+        )
+        target = permission_env["workspace"] / "blocked-by-license.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        assert "license.no-writes" in str(result.result_details)
+        assert not target.exists()
+
+    def test_license_allow_overrides_user_deny(self, permission_env: dict) -> None:
+        """User says deny-WriteFile; license says allow-WriteFile. License wins."""
+        pm = permission_env["permission_manager"]
+        _grant_user_rule(
+            {
+                "id": "user.deny-writes",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.allow-writes",
+                    decision=Decision.ALLOW,
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest"))),
+                )
+            )
+        )
+        target = permission_env["workspace"] / "allowed-by-license.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+        assert target.read_text() == "hi"
+
+    def test_license_silent_falls_through_to_user(self, permission_env: dict) -> None:
+        """License has no rule for this action; user rules apply normally."""
+        pm = permission_env["permission_manager"]
+        _grant_user_rule(
+            {
+                "id": "user.deny-writes",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.cares-about-something-else",
+                    decision=Decision.ALLOW,
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="ReadFileRequest"))),
+                )
+            )
+        )
+        target = permission_env["workspace"] / "user-deny.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        # User's deny rule is what blocked it, not the license's allow.
+        assert "user.deny-writes" in str(result.result_details)
+
+
+class TestLicensePersistenceIsolation:
+    """License rules must never round-trip through user config."""
+
+    def test_license_rules_never_persist_to_user_config(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.no-writes",
+                    decision=Decision.DENY,
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest"))),
+                )
+            )
+        )
+        # Trigger a persist by issuing a user grant.
+        _grant_user_rule(
+            {
+                "id": "user.something",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        # Read the on-disk user config: must not contain the license rule id.
+        on_disk = json.loads(permission_env["config_path"].read_text())
+        rule_ids = [r["id"] for r in on_disk["permissions"]["policy"]["rules"]]
+        assert "user.something" in rule_ids
+        assert "license.no-writes" not in rule_ids
+
+    def test_user_grant_does_not_drop_license_rules(self, permission_env: dict) -> None:
+        """A user adding a rule must not remove license rules from the live policy."""
+        pm = permission_env["permission_manager"]
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.locked",
+                    decision=Decision.DENY,
+                    when=WhenClause(action=ActionMatch(request_type=GlobExpr(pattern="Forbidden*"))),
+                )
+            )
+        )
+        _grant_user_rule(
+            {
+                "id": "user.something",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        license_rule_ids = [r.id for r in pm.license_policy.rules]
+        assert "license.locked" in license_rule_ids
+
+    def test_revoke_cannot_remove_license_rules(self, permission_env: dict) -> None:
+        """RevokePermissionRuleRequest only operates on user rules."""
+        pm = permission_env["permission_manager"]
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.locked",
+                    decision=Decision.DENY,
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest"))),
+                )
+            )
+        )
+        # Attempt to revoke the license rule via the public API.
+        result = GriptapeNodes.handle_request(RevokePermissionRuleRequest(rule_id="license.locked"))
+        assert isinstance(result, RevokePermissionRuleResultFailure)
+        # And the rule is still active.
+        assert any(r.id == "license.locked" for r in pm.license_policy.rules)
+
+    def test_clear_license_policy_drops_only_license_rules(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        _grant_user_rule(
+            {
+                "id": "user.keep-me",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.transient",
+                    decision=Decision.DENY,
+                    when=WhenClause(action=ActionMatch(request_type=EqualsExpr(value="WriteFileRequest"))),
+                )
+            )
+        )
+        pm.clear_license_policy()
+        assert pm.license_policy.rules == []
+        assert any(r.id == "user.keep-me" for r in pm.user_policy.rules)
+
+
+class TestLicenseAuditTrail:
+    """Decisions stamped with the originating layer via `granted_by`."""
+
+    def test_license_rules_auto_stamp_granted_by(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.unstamped",
+                    decision=Decision.DENY,
+                    when=WhenClause(action=ActionMatch(request_type=GlobExpr(pattern="*"))),
+                )
+            )
+        )
+        active = pm.license_policy.rules[0]
+        assert active.granted_by == "license"
+
+    def test_caller_supplied_granted_by_is_preserved(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.tagged",
+                    decision=Decision.DENY,
+                    granted_by="license:enterprise@2026.05",
+                    when=WhenClause(action=ActionMatch(request_type=GlobExpr(pattern="*"))),
+                )
+            )
+        )
+        active = pm.license_policy.rules[0]
+        assert active.granted_by == "license:enterprise@2026.05"
+
+
+class TestEffectivePolicyView:
+    """`GetEffectivePolicyRequest` returns the merged view in evaluation order."""
+
+    def test_merged_view_lists_license_rules_first(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        _grant_user_rule(
+            {
+                "id": "user.one",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        pm.set_license_policy(
+            _license_policy(
+                PermissionRule(
+                    id="license.first",
+                    decision=Decision.DENY,
+                    when=WhenClause(action=ActionMatch(request_type=GlobExpr(pattern="*"))),
+                )
+            )
+        )
+        result = GriptapeNodes.handle_request(GetEffectivePolicyRequest())
+        assert isinstance(result, GetEffectivePolicyResultSuccess)
+        rule_ids = [r["id"] for r in result.policy["rules"]]
+        # License rules come first in the merged view.
+        assert rule_ids == ["license.first", "user.one"]

--- a/tests/integration/retained_mode/permissions/test_permission_manager_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_permission_manager_e2e.py
@@ -1,0 +1,870 @@
+"""End-to-end tests for the permission system.
+
+These tests run the full request dispatcher (`GriptapeNodes.handle_request`)
+with a `PermissionManager` enforcing policy via the pre-dispatch hook. They
+exercise the worked-policy examples from the design doc end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+from griptape_nodes.retained_mode.events.os_events import (
+    ExistingFilePolicy,
+    FileIOFailureReason,
+    ListDirectoryRequest,
+    ReadFileRequest,
+    WriteFileRequest,
+    WriteFileResultFailure,
+    WriteFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.permission_events import (
+    GetEffectivePolicyRequest,
+    GetEffectivePolicyResultSuccess,
+    GrantPermissionRuleRequest,
+    GrantPermissionRuleResultFailure,
+    GrantPermissionRuleResultSuccess,
+    ListPermissionDecisionsRequest,
+    ListPermissionDecisionsResultSuccess,
+    PermissionDecisionEvent,
+    RevokePermissionRuleRequest,
+    RevokePermissionRuleResultFailure,
+    RevokePermissionRuleResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.permissions import (
+    Decision,
+)
+from griptape_nodes.utils.metaclasses import SingletonMeta
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+_EXPECTED_THREE = 3
+
+# ----------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def permission_env() -> Generator[dict, None, None]:
+    """Bring up an isolated GriptapeNodes singleton + workspace + permissions config.
+
+    Sets workspace through the real config setter so set_config_value calls in
+    tests don't reset workspace_path back to the default.
+    """
+    SingletonMeta._instances.clear()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        config_path = tmp_path / "griptape_nodes_config.json"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "workspace_directory": str(workspace),
+                    "permissions": {
+                        "enabled": True,
+                        "consent_prompts_enabled": True,
+                        "audit_log_max_entries": 100,
+                        "policy": {"rules": [], "default_decision": "allow"},
+                    },
+                }
+            )
+        )
+        with patch.object(config_manager_module, "USER_CONFIG_PATH", config_path):
+            gn = GriptapeNodes()
+            yield {
+                "gn": gn,
+                "permission_manager": gn.PermissionManager(),
+                "workspace": workspace,
+                "tmp": tmp_path,
+                "config_path": config_path,
+            }
+        SingletonMeta._instances.clear()
+
+
+# ----------------------------------------------------------------------- helpers
+
+
+def _grant(rule: dict) -> str:
+    result = GriptapeNodes.handle_request(GrantPermissionRuleRequest(rule=rule))
+    assert isinstance(result, GrantPermissionRuleResultSuccess), result.result_details
+    return result.rule_id
+
+
+# ----------------------------------------------------------------------- tests
+
+
+class TestEnforcedDispatch:
+    """The dispatcher hook denies, allows, and short-circuits with typed failures."""
+
+    def test_engine_default_allow_passes_through(self, permission_env: dict) -> None:
+        """With default_decision=allow and no rules, requests succeed normally."""
+        target = permission_env["workspace"] / "out.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hello",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+        assert target.read_text() == "hello"
+
+    def test_deny_rule_short_circuits_with_typed_failure(self, permission_env: dict) -> None:
+        """A matching deny rule returns the request's typed failure with PERMISSION_DENIED."""
+        _grant(
+            {
+                "id": "deny-all-writes",
+                "decision": "deny",
+                "reason": "writes are blocked in this test",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        target = permission_env["workspace"] / "blocked.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="nope",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        assert result.failure_reason is FileIOFailureReason.PERMISSION_DENIED
+        assert "deny-all-writes" in str(result.result_details)
+        assert not target.exists()
+
+    def test_allow_rule_lets_request_through(self, permission_env: dict) -> None:
+        """An earlier allow rule beats a later catch-all deny."""
+        _grant(
+            {
+                "id": "allow-workspace-write",
+                "decision": "allow",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "resource": {"fields": {"file_path": {"op": "path_under", "root": "${workspace}"}}},
+                },
+            }
+        )
+        _grant(
+            {
+                "id": "deny-everything-else",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        inside = permission_env["workspace"] / "ok.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(inside),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+        assert inside.read_text() == "hi"
+
+    def test_path_under_denies_writes_outside_workspace(self, permission_env: dict) -> None:
+        """`path_under` distinguishes writes inside vs outside the workspace."""
+        _grant(
+            {
+                "id": "allow-workspace-write",
+                "decision": "allow",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "resource": {"fields": {"file_path": {"op": "path_under", "root": "${workspace}"}}},
+                },
+            }
+        )
+        _grant(
+            {
+                "id": "deny-non-workspace-writes",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        outside = permission_env["tmp"] / "elsewhere.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(outside),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        assert result.failure_reason is FileIOFailureReason.PERMISSION_DENIED
+        assert not outside.exists()
+
+    def test_denial_message_includes_inspected_field_value(self, permission_env: dict) -> None:
+        """Denial messages name the field=value the matching rule consulted.
+
+        Surfacing the resolved value lets callers see *why* a request was
+        blocked (e.g. "file_path=/tmp/elsewhere.txt") without diving into the
+        audit log or re-running the matcher.
+        """
+        _grant(
+            {
+                "id": "deny-outside-workspace",
+                "decision": "deny",
+                "reason": "writes outside the workspace are blocked",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "resource": {
+                        "fields": {
+                            "file_path": {"op": "not", "expr": {"op": "path_under", "root": "${workspace}"}},
+                        }
+                    },
+                },
+            }
+        )
+        outside = permission_env["tmp"] / "elsewhere.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(outside),
+                content="nope",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        details = str(result.result_details)
+        assert "deny-outside-workspace" in details
+        assert "writes outside the workspace are blocked" in details
+        assert f"resource.file_path={outside}" in details
+        assert not outside.exists()
+
+    def test_read_only_requests_unaffected_by_write_deny(self, permission_env: dict) -> None:
+        """A WriteFileRequest-targeted deny does not block ReadFileRequest."""
+        target = permission_env["workspace"] / "input.txt"
+        target.write_text("abc")
+        _grant(
+            {
+                "id": "deny-writes",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        result = GriptapeNodes.handle_request(ReadFileRequest(file_path=str(target)))
+        # Read should succeed (we're only denying writes).
+        assert result.succeeded(), result.result_details
+
+    def test_list_directory_unaffected(self, permission_env: dict) -> None:
+        _grant(
+            {
+                "id": "deny-writes",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        result = GriptapeNodes.handle_request(ListDirectoryRequest(directory_path=str(permission_env["workspace"])))
+        assert result.succeeded()
+
+
+class TestPrincipalAxis:
+    """`PrincipalKind` matching: engine, node, client."""
+
+    def test_node_principal_passes_when_library_matches(self, permission_env: dict) -> None:
+        """While `push_principal` is active, the actor presents as `node:<lib>/<type>`."""
+        pm = permission_env["permission_manager"]
+        _grant(
+            {
+                "id": "allow-when-image-lib",
+                "decision": "allow",
+                "when": {
+                    "principal": {
+                        "kind": ["node"],
+                        "library": {"op": "equals", "value": "advanced-image-library"},
+                    },
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                },
+            }
+        )
+        _grant(
+            {
+                "id": "deny-everything-else-w",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        target = permission_env["workspace"] / "node-output.txt"
+
+        # Without principal: denied
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="x",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+
+        # With matching node principal: allowed
+        pm.push_principal(library="advanced-image-library", node_type="UpscaleNode", node_name="up_1")
+        try:
+            result = GriptapeNodes.handle_request(
+                WriteFileRequest(
+                    file_path=str(target),
+                    content="x",
+                    existing_file_policy=ExistingFilePolicy.OVERWRITE,
+                )
+            )
+        finally:
+            pm.pop_principal()
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+        assert target.read_text() == "x"
+
+    def test_node_principal_with_wrong_library_still_denied(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        _grant(
+            {
+                "id": "allow-only-image-lib",
+                "decision": "allow",
+                "when": {
+                    "principal": {
+                        "kind": ["node"],
+                        "library": {"op": "equals", "value": "advanced-image-library"},
+                    },
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                },
+            }
+        )
+        _grant(
+            {
+                "id": "deny-other-writes",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        target = permission_env["workspace"] / "x.txt"
+        pm.push_principal(library="other-library", node_type="OtherNode", node_name="o_1")
+        try:
+            result = GriptapeNodes.handle_request(
+                WriteFileRequest(
+                    file_path=str(target),
+                    content="x",
+                    existing_file_policy=ExistingFilePolicy.OVERWRITE,
+                )
+            )
+        finally:
+            pm.pop_principal()
+        assert isinstance(result, WriteFileResultFailure)
+
+
+class TestContextFactsAndEnrichers:
+    """Rules that match against the fact tree (loaded libraries, request enrichers)."""
+
+    def test_loaded_libraries_provider_drives_context_match(self, permission_env: dict) -> None:
+        pm = permission_env["permission_manager"]
+        loaded = ["lib-a"]
+        pm.facts.register_provider("loaded_libraries.names", lambda: list(loaded))
+        _grant(
+            {
+                "id": "deny-when-lib-a-loaded",
+                "decision": "deny",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "context": {"facts": {"loaded_libraries.names": {"op": "in", "values": ["lib-a"]}}},
+                },
+            }
+        )
+        target = permission_env["workspace"] / "y.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="x",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        loaded.clear()
+        loaded.append("lib-z")
+        # Force a re-read of the fact (provider is PER_REQUEST by default)
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="x",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+
+    def test_request_enricher_publishes_per_request_facts(self, permission_env: dict) -> None:
+        """A manager can publish facts derived from the request being evaluated."""
+        pm = permission_env["permission_manager"]
+
+        def enricher(request: WriteFileRequest) -> dict:
+            return {"content_kind": "binary" if isinstance(request.content, bytes) else "text"}
+
+        pm.facts.register_request_enricher(WriteFileRequest.__name__, enricher)
+        _grant(
+            {
+                "id": "deny-binary-writes",
+                "decision": "deny",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "context": {"facts": {"request.content_kind": {"op": "equals", "value": "binary"}}},
+                },
+            }
+        )
+        # Text write: allowed (default_decision=allow, no matching rule)
+        text_target = permission_env["workspace"] / "text.txt"
+        text_result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(text_target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(text_result, WriteFileResultSuccess), text_result.result_details
+
+        # Binary write: blocked by the enricher-driven rule
+        bin_target = permission_env["workspace"] / "bin.bin"
+        bin_result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(bin_target),
+                content=b"\x00\x01\x02",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(bin_result, WriteFileResultFailure)
+        assert not bin_target.exists()
+
+
+class TestAuditAndDecisionEvents:
+    """The audit ring buffer and `PermissionDecisionEvent` carry the same data."""
+
+    def test_decisions_appear_in_ring_buffer(self, permission_env: dict) -> None:
+        _grant(
+            {
+                "id": "deny-everything",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        target = permission_env["workspace"] / "z.txt"
+        for _ in range(3):
+            GriptapeNodes.handle_request(
+                WriteFileRequest(
+                    file_path=str(target),
+                    content="z",
+                    existing_file_policy=ExistingFilePolicy.OVERWRITE,
+                )
+            )
+        result = GriptapeNodes.handle_request(ListPermissionDecisionsRequest(limit=10))
+        assert isinstance(result, ListPermissionDecisionsResultSuccess)
+        write_decisions = [d for d in result.decisions if d["action_request_type"] == "WriteFileRequest"]
+        assert len(write_decisions) == _EXPECTED_THREE
+        for entry in write_decisions:
+            assert entry["decision"] == Decision.DENY.value
+            assert entry["rule_id"] == "deny-everything"
+            assert "action.request_type" in entry["inspected_paths"]
+        assert len(write_decisions) == _EXPECTED_THREE
+
+    def test_decision_event_broadcast(self, permission_env: dict) -> None:
+        gn = permission_env["gn"]
+        events: list[PermissionDecisionEvent] = []
+        gn.EventManager().add_listener_to_app_event(PermissionDecisionEvent, events.append)
+        _grant(
+            {
+                "id": "deny-writes-evt",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        target = permission_env["workspace"] / "ev.txt"
+        GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        write_events = [e for e in events if e.action_request_type == "WriteFileRequest"]
+        assert any(e.decision == Decision.DENY.value and e.rule_id == "deny-writes-evt" for e in write_events)
+
+
+class TestPolicyManagementRequests:
+    """Grant / revoke / read-effective-policy round-trip through the dispatcher.
+
+    These requests are exempt from the hook so a too-restrictive policy can
+    always be repaired.
+    """
+
+    def test_grant_accepts_well_formed_rule(self, permission_env: dict) -> None:  # noqa: ARG002
+        rid = _grant(
+            {
+                "id": "ok-rule",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        assert rid == "ok-rule"
+
+    def test_grant_rejects_invalid_operator(self, permission_env: dict) -> None:  # noqa: ARG002
+        result = GriptapeNodes.handle_request(
+            GrantPermissionRuleRequest(
+                rule={
+                    "id": "bad",
+                    "decision": "allow",
+                    "when": {"action": {"request_type": {"op": "regex", "pattern": ".*"}}},
+                }
+            )
+        )
+        assert isinstance(result, GrantPermissionRuleResultFailure)
+
+    def test_revoke_removes_rule_and_no_op_failure_otherwise(self, permission_env: dict) -> None:  # noqa: ARG002
+        _grant(
+            {
+                "id": "to-remove",
+                "decision": "deny",
+                "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+            }
+        )
+        revoke = GriptapeNodes.handle_request(RevokePermissionRuleRequest(rule_id="to-remove"))
+        assert isinstance(revoke, RevokePermissionRuleResultSuccess)
+        # Second revoke is a no-op failure with a clear reason.
+        again = GriptapeNodes.handle_request(RevokePermissionRuleRequest(rule_id="to-remove"))
+        assert isinstance(again, RevokePermissionRuleResultFailure)
+
+    def test_get_effective_policy_returns_active_rules(self, permission_env: dict) -> None:  # noqa: ARG002
+        _grant({"id": "one", "decision": "allow", "when": {}})
+        _grant({"id": "two", "decision": "deny", "when": {}})
+        result = GriptapeNodes.handle_request(GetEffectivePolicyRequest())
+        assert isinstance(result, GetEffectivePolicyResultSuccess)
+        rule_ids = [r["id"] for r in result.policy["rules"]]
+        assert rule_ids == ["one", "two"]
+
+
+class TestWorkedExampleFromDesignDoc:
+    """Reproduce the merged-policy example given in the design doc end to end."""
+
+    def _install_worked_example(self) -> None:
+        for rule in [
+            {
+                "id": "engine-default.read-anywhere",
+                "granted_by": "engine-default",
+                "decision": "allow",
+                "when": {
+                    "action": {
+                        "request_type": {
+                            "op": "in",
+                            "values": [
+                                "ReadFileRequest",
+                                "GetFileInfoRequest",
+                                "ListDirectoryRequest",
+                            ],
+                        }
+                    }
+                },
+            },
+            {
+                "id": "engine-default.write-under-workspace",
+                "granted_by": "engine-default",
+                "decision": "allow",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "resource": {"fields": {"file_path": {"op": "path_under", "root": "${workspace}"}}},
+                },
+            },
+            {
+                "id": "engine-default.deny-arbitrary-python-from-clients",
+                "granted_by": "engine-default",
+                "decision": "deny",
+                "reason": "Arbitrary Python execution from external clients is disabled by default.",
+                "when": {
+                    "principal": {"kind": ["client"]},
+                    "action": {
+                        "request_type": {
+                            "op": "equals",
+                            "value": "RunArbitraryPythonStringRequest",
+                        }
+                    },
+                },
+            },
+            {
+                "id": "user.allow-image-lib-write-outputs",
+                "granted_by": "user",
+                "decision": "allow",
+                "when": {
+                    "principal": {
+                        "kind": ["node"],
+                        "library": {"op": "equals", "value": "advanced-image-library"},
+                    },
+                    "action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}},
+                    "resource": {"fields": {"file_path": {"op": "path_under", "root": "${workspace}/outputs"}}},
+                },
+            },
+            {
+                "id": "user.deny-labs-stage-libraries",
+                "granted_by": "user",
+                "decision": "deny",
+                "reason": "Labs-stage libraries are not permitted in this workspace.",
+                "when": {
+                    "action": {
+                        "request_type": {
+                            "op": "equals",
+                            "value": "RegisterLibraryFromFileRequest",
+                        }
+                    },
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            },
+        ]:
+            _grant(rule)
+
+    def test_engine_defaults_block_writes_outside_workspace(self, permission_env: dict) -> None:
+        # Tighten default to deny so engine-default rules are the only allow path.
+        permission_env["permission_manager"]._user_policy.default_decision = Decision.DENY
+        self._install_worked_example()
+        outside = permission_env["tmp"] / "elsewhere.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(outside),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        assert not outside.exists()
+
+    def test_engine_defaults_allow_writes_under_workspace(self, permission_env: dict) -> None:
+        permission_env["permission_manager"]._user_policy.default_decision = Decision.DENY
+        self._install_worked_example()
+        target = permission_env["workspace"] / "out.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+
+    def test_image_lib_node_writes_to_outputs_subdir(self, permission_env: dict) -> None:
+        permission_env["permission_manager"]._user_policy.default_decision = Decision.DENY
+        self._install_worked_example()
+        outputs_dir = permission_env["workspace"] / "outputs"
+        outputs_dir.mkdir()
+        target = outputs_dir / "render.png"
+        pm = permission_env["permission_manager"]
+        pm.push_principal(library="advanced-image-library", node_type="UpscaleNode", node_name="u1")
+        try:
+            result = GriptapeNodes.handle_request(
+                WriteFileRequest(
+                    file_path=str(target),
+                    content=b"\x89PNG",
+                    existing_file_policy=ExistingFilePolicy.OVERWRITE,
+                )
+            )
+        finally:
+            pm.pop_principal()
+        assert isinstance(result, WriteFileResultSuccess), result.result_details
+
+    def test_labs_lifecycle_blocks_register_library(self, permission_env: dict) -> None:
+        """Use a request enricher to publish parsed declarations and gate registration."""
+        permission_env["permission_manager"]._user_policy.default_decision = Decision.DENY
+        self._install_worked_example()
+        pm = permission_env["permission_manager"]
+        # Stand-in for what LibraryManager will eventually publish: parsed
+        # declarations of the library being registered, namespaced under
+        # request.metadata.declarations.
+        pm.facts.register_request_enricher(
+            "RegisterLibraryFromFileRequest",
+            lambda _: {"metadata.declarations.lifecycle_stage": "LABS"},
+        )
+        # Allow the registration request type so only the labs rule can deny.
+        _grant(
+            {
+                "id": "engine-default.allow-register",
+                "decision": "allow",
+                "when": {
+                    "action": {
+                        "request_type": {
+                            "op": "equals",
+                            "value": "RegisterLibraryFromFileRequest",
+                        }
+                    }
+                },
+            }
+        )
+        from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+
+        result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path="/nonexistent.json"))
+        # The denial happens at the dispatcher hook before the library manager
+        # ever sees the request, so the failure carries our deny reason rather
+        # than a "file not found" reason.
+        assert not result.succeeded()
+        assert "labs-stage" in str(result.result_details).lower() or "LABS" in str(result.result_details)
+
+
+class TestLayeredConfig:
+    """Per-layer reading: project / workspace / env contribute rules ahead of user."""
+
+    @staticmethod
+    def _install_workspace_permissions(permission_env: dict, block: dict) -> None:
+        """Write a workspace `griptape_nodes_config.json` and reload.
+
+        Goes through `cm.load_workspace_config` so the layer survives any
+        subsequent `cm.load_configs()` triggered by config writes elsewhere.
+        """
+        workspace = permission_env["workspace"]
+        (workspace / "griptape_nodes_config.json").write_text(json.dumps({"permissions": block}))
+        cm = permission_env["permission_manager"]._config_manager
+        cm.load_workspace_config(workspace)
+        permission_env["permission_manager"].reload()
+
+    def test_workspace_layer_rule_fires_ahead_of_user_layer(self, permission_env: dict) -> None:
+        """A workspace-layer deny beats a user-layer allow under first-match-wins."""
+        # User's allow-everything rule is loaded first via the public grant API
+        # so it lives in the user layer specifically.
+        _grant(
+            {
+                "id": "user.allow-writes",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        )
+        # Workspace is higher-priority than user; its deny should fire first.
+        self._install_workspace_permissions(
+            permission_env,
+            {
+                "policy": {
+                    "rules": [
+                        {
+                            "id": "workspace.deny-writes",
+                            "decision": "deny",
+                            "reason": "studio policy: writes blocked at workspace layer",
+                            "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+                        }
+                    ]
+                }
+            },
+        )
+
+        target = permission_env["workspace"] / "blocked.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(target),
+                content="nope",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        assert isinstance(result, WriteFileResultFailure)
+        assert "workspace.deny-writes" in str(result.result_details)
+        assert not target.exists()
+
+    def test_workspace_layer_rules_auto_stamp_granted_by(self, permission_env: dict) -> None:
+        """Rules loaded from a config layer get `granted_by` stamped with the layer name."""
+        self._install_workspace_permissions(
+            permission_env,
+            {
+                "policy": {
+                    "rules": [
+                        {
+                            "id": "workspace.tag-me",
+                            "decision": "deny",
+                            "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+                        }
+                    ]
+                }
+            },
+        )
+
+        result = GriptapeNodes.handle_request(GetEffectivePolicyRequest())
+        assert isinstance(result, GetEffectivePolicyResultSuccess)
+        rules = result.policy["rules"]
+        match = next(r for r in rules if r["id"] == "workspace.tag-me")
+        assert match["granted_by"] == "workspace"
+
+    def test_explicit_default_decision_in_workspace_overrides_user(self, permission_env: dict) -> None:
+        """A workspace layer that explicitly sets default_decision wins over user."""
+        self._install_workspace_permissions(
+            permission_env,
+            {"policy": {"default_decision": "deny", "rules": []}},
+        )
+
+        outside = permission_env["tmp"] / "elsewhere.txt"
+        result = GriptapeNodes.handle_request(
+            WriteFileRequest(
+                file_path=str(outside),
+                content="hi",
+                existing_file_policy=ExistingFilePolicy.OVERWRITE,
+            )
+        )
+        # Workspace's explicit deny default fires; user layer's silent ALLOW
+        # default is treated as unset and does not override.
+        assert isinstance(result, WriteFileResultFailure)
+        assert not outside.exists()
+
+    def test_grant_only_persists_user_layer_rules(self, permission_env: dict) -> None:
+        """Granting a rule writes to user config, not workspace/project layers."""
+        self._install_workspace_permissions(
+            permission_env,
+            {
+                "policy": {
+                    "rules": [
+                        {
+                            "id": "workspace.read-only",
+                            "decision": "deny",
+                            "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+                        }
+                    ]
+                }
+            },
+        )
+
+        # Granting a user rule should land only in the user config file; the
+        # workspace rule must remain in memory because it lives outside the
+        # persisted user file.
+        _grant(
+            {
+                "id": "user.added",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "equals", "value": "ReadFileRequest"}}},
+            }
+        )
+        on_disk = json.loads(permission_env["config_path"].read_text())
+        rule_ids = [r["id"] for r in on_disk["permissions"]["policy"]["rules"]]
+        assert rule_ids == ["user.added"]
+        merged = GriptapeNodes.handle_request(GetEffectivePolicyRequest())
+        assert isinstance(merged, GetEffectivePolicyResultSuccess)
+        merged_ids = [r["id"] for r in merged.policy["rules"]]
+        assert "workspace.read-only" in merged_ids
+        assert "user.added" in merged_ids
+
+    def test_revoke_refuses_non_user_layer_rule_id(self, permission_env: dict) -> None:
+        """Revoke targets only the user layer; workspace-layer rule ids are read-only."""
+        self._install_workspace_permissions(
+            permission_env,
+            {
+                "policy": {
+                    "rules": [
+                        {
+                            "id": "workspace.locked",
+                            "decision": "deny",
+                            "when": {"action": {"request_type": {"op": "glob", "pattern": "*"}}},
+                        }
+                    ]
+                }
+            },
+        )
+
+        result = GriptapeNodes.handle_request(RevokePermissionRuleRequest(rule_id="workspace.locked"))
+        assert isinstance(result, RevokePermissionRuleResultFailure)
+        # And the rule is still active.
+        merged = GriptapeNodes.handle_request(GetEffectivePolicyRequest())
+        assert isinstance(merged, GetEffectivePolicyResultSuccess)
+        assert any(r["id"] == "workspace.locked" for r in merged.policy["rules"])


### PR DESCRIPTION
### 📚 Permission Manager stack

Four stacked PRs split by layer. Review and merge bottom-up, starting at the base (#4713). Each PR targets the branch of the PR above it, so its diff shows only that layer.

| Order | PR | Layer | Base |
| --- | --- | --- | --- |
| 1 | #4713 | Pre-dispatch hook chain in `EventManager` | `main` |
| 2 | #4714 | Policy schema, matcher engine, fact registry | #4713 |
| **3** | **#4715 👈 you are here** | **`PermissionManager` enforcement** | #4714 |
| 4 | #4716 | Integrations: `LibraryManager`, MCP server, docs | #4715 |

---

Third slice of the permission-manager stack. Adds `PermissionManager`, which wires the policy core into the dispatch hook and enforces decisions, with layered configuration and a license-derived policy.

Persistence is hardened: a concurrent fail-open window is closed, and when a decision fails to persist the manager reports failure rather than dropping it. The decision tail is bound so the audit trail stays consistent.

**Previous:** #4714 (policy core). **Next:** #4716 integrates enforcement with the rest of the engine.
