### PR TITLE
feat: integrate permissions with LibraryManager, MCP server, and docs

### DIFF
--- a/.agents/skills/griptape-nodes-permissions/SKILL.md
+++ b/.agents/skills/griptape-nodes-permissions/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: griptape-nodes-permissions
+description: Author and manage permission rules on the engine through its MCP server. Use when the user asks to allow or deny a privileged operation, lock down a library, restrict an MCP client, gate writes to a path, audit recent denials, or revoke an existing rule. Triggers include "set up a permission rule", "block this library at startup", "deny X from doing Y", "allow this library to write to Z", "what's been denied recently", "audit log of permission denials", "lock this engine down", "revoke that rule".
+---
+
+# Griptape Nodes Permission Authoring Guide
+
+This skill covers authoring, applying, and verifying permission rules through the engine's MCP server. The permission system enforces declarative policy at the request dispatcher; rules ride normal engine config and are first-match-wins.
+
+## Mental Model
+
+- **Rules** evaluate four axes: **principal** (who is asking — engine / node / client), **action** (request type), **resource** (fields of the request payload), **context** (ambient facts). Populated axes are AND'd; unpopulated axes are wildcards.
+- **First-match-wins** in policy order. License rules evaluate first, then user rules. If nothing matches, the policy's `default_decision` applies.
+- **License rules trump user rules** and are not editable through MCP. Use them for hard constraints. User rules are the everyday surface and are what `Grant`/`Revoke` operate on.
+- **The dispatcher hook short-circuits with the request's typed failure.** A denied `WriteFileRequest` returns `WriteFileResultFailure` with `failure_reason = PERMISSION_DENIED`, not a generic error.
+- **Default behaviour is `allow`.** An engine with no rules behaves exactly as it always has; ratchet down by adding deny rules or by switching `default_decision` to `deny`.
+
+## MCP Tools
+
+Four MCP tools manage policy. They are exempt from the policy hook so a too-restrictive policy can always be repaired:
+
+| Tool                                            | Purpose                                                                         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| `griptape_nodes_GrantPermissionRuleRequest`     | Append a rule to the user policy (persisted into user config).                  |
+| `griptape_nodes_RevokePermissionRuleRequest`    | Remove a user rule by `id`. License rules cannot be revoked here.               |
+| `griptape_nodes_GetEffectivePolicyRequest`      | Read the merged policy (license rules first, then user rules) for verification. |
+| `griptape_nodes_ListPermissionDecisionsRequest` | Tail the in-memory audit ring buffer (`limit` argument optional).               |
+
+## Rule Shape
+
+```json
+{
+  "id": "user.short-stable-identifier",
+  "decision": "allow" | "deny" | "prompt",
+  "reason": "human-readable explanation, surfaced in failures and audit",
+  "granted_by": "user",
+  "when": {
+    "principal": { ... },
+    "action":    { ... },
+    "resource":  { "fields": { "<dot.path>": <expr> } },
+    "context":   { "facts":  { "<dot.path>": <expr> } }
+  }
+}
+```
+
+`prompt` decisions currently behave as deny with a `prompt-not-implemented` audit tag (consent UI is future work). Default to `allow` or `deny` for now.
+
+## Operator Cheat Sheet
+
+| Operator     | Shape                                    | Use                                                                                               |
+| ------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `equals`     | `{"op": "equals", "value": <any>}`       | Strict equality                                                                                   |
+| `in`         | `{"op": "in", "values": [<any>...]}`     | Membership; against a list-valued field, any-overlap                                              |
+| `glob`       | `{"op": "glob", "pattern": "..."}`       | fnmatch-style glob against a string                                                               |
+| `path_under` | `{"op": "path_under", "root": "<path>"}` | Macro-expanded canonical path containment. `${workspace}` and `${static_files_directory}` expand. |
+| `not`        | `{"op": "not", "expr": <expr>}`          | Negation                                                                                          |
+| `all_of`     | `{"op": "all_of", "exprs": [<expr>...]}` | Conjunction                                                                                       |
+| `any_of`     | `{"op": "any_of", "exprs": [<expr>...]}` | Disjunction                                                                                       |
+
+## Principal Axis
+
+```json
+"principal": {
+  "kind": ["engine"] | ["node"] | ["client"] | <multiple>,
+  "library":   <expr>,   // applies when kind includes "node"
+  "node_type": <expr>,   // applies when kind includes "node"
+  "topic":     <expr>    // applies when kind includes "client"
+}
+```
+
+`engine` covers requests originating inside the engine itself (startup, internal flows). `node` covers requests issued from inside an executing node. `client` covers requests received over the wire from a connected MCP client / editor — `topic` is the response topic of that client.
+
+## Common Resource Fields
+
+Match against fields of the request payload via dot-paths under `resource.fields`. The most common ones:
+
+| Request type                      | Field                   | Notes                                                         |
+| --------------------------------- | ----------------------- | ------------------------------------------------------------- |
+| `WriteFileRequest`                | `file_path`             | Almost always paired with `path_under` against `${workspace}` |
+| `ReadFileRequest`                 | `file_path`             | Same                                                          |
+| `RegisterLibraryFromFileRequest`  | `file_path`             | Path to library JSON or directory                             |
+| `RegisterLibraryFromFileRequest`  | `library_name`          | Optional library name when registering by name                |
+| `RunArbitraryPythonStringRequest` | `python_string`         | Use `glob` or `not.glob` to gate by snippet content           |
+| `CreateNodeRequest`               | `node_type`             | Class name of the node being created                          |
+| `CreateNodeRequest`               | `specific_library_name` | Library scope of the create                                   |
+
+## Common Context Facts
+
+Match ambient state under `context.facts`:
+
+| Path                                            | Type          | Refreshes when              | Notes                                                                                                 |
+| ----------------------------------------------- | ------------- | --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `workspace.path`                                | `str`         | `ConfigChanged`             | Active workspace absolute path                                                                        |
+| `engine.id`                                     | `str`         | never                       | Stable engine session id                                                                              |
+| `loaded_libraries.names`                        | `list[str]`   | `LibraryLoadedNotification` | Names of currently registered libraries                                                               |
+| `current_node.library`                          | `str \| None` | execution boundary          | Library of the node currently executing                                                               |
+| `current_node.node_type`                        | `str \| None` | execution boundary          | Class name of the node currently executing                                                            |
+| `current_node.node_name`                        | `str \| None` | execution boundary          | Instance name of the node currently executing                                                         |
+| `request.metadata.declarations.lifecycle_stage` | `str \| None` | per-request                 | Only set on `RegisterLibraryFromFileRequest`. One of `STABLE`, `BETA`, `ALPHA`, `LABS`, `DEPRECATED`. |
+| `request.metadata.declarations.types`           | `list[str]`   | per-request                 | Only set on `RegisterLibraryFromFileRequest`. Flat list of declaration `type` strings.                |
+| `request.metadata.name`                         | `str \| None` | per-request                 | Library name from the JSON being registered.                                                          |
+
+## Worked Recipes
+
+### Lock writes to the workspace
+
+```json
+{
+  "id": "user.deny-writes-outside-workspace",
+  "decision": "deny",
+  "reason": "writes are scoped to the active workspace",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "resource": {
+      "fields": {
+        "file_path": {
+          "op": "not",
+          "expr": { "op": "path_under", "root": "${workspace}" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Block a specific library at startup
+
+```json
+{
+  "id": "user.deny-experimental-library",
+  "decision": "deny",
+  "reason": "experimental library disabled for this engine",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
+    "resource": {
+      "fields": { "file_path": { "op": "glob", "pattern": "*experimental-library*" } }
+    }
+  }
+}
+```
+
+### Block any LABS-stage library
+
+Uses the per-request enricher that `LibraryManager` ships, so this works against any library whose JSON declares `lifecycle_stage = LABS`.
+
+```json
+{
+  "id": "user.deny-labs-libraries",
+  "decision": "deny",
+  "reason": "labs-stage libraries are not permitted",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
+    "context": {
+      "facts": {
+        "request.metadata.declarations.lifecycle_stage": { "op": "equals", "value": "LABS" }
+      }
+    }
+  }
+}
+```
+
+To block multiple stages: `"op": "in", "values": ["LABS", "ALPHA"]`.
+
+### Block arbitrary Python from external clients
+
+```json
+{
+  "id": "user.deny-arbitrary-python-from-clients",
+  "decision": "deny",
+  "reason": "arbitrary Python execution from external clients is disabled",
+  "when": {
+    "principal": { "kind": ["client"] },
+    "action": { "request_type": { "op": "equals", "value": "RunArbitraryPythonStringRequest" } }
+  }
+}
+```
+
+### Allow a specific library to write to a specific subdirectory
+
+```json
+{
+  "id": "user.allow-image-lib-outputs",
+  "decision": "allow",
+  "when": {
+    "principal": {
+      "kind": ["node"],
+      "library": { "op": "equals", "value": "advanced-image-library" }
+    },
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "resource": {
+      "fields": { "file_path": { "op": "path_under", "root": "${workspace}/outputs" } }
+    }
+  }
+}
+```
+
+### Restrict a library to read-only operations
+
+Two rules in order — earlier rules win. The first allow-lists reads for the named library; the second catches everything else from that library and denies it.
+
+```json
+[
+  {
+    "id": "user.allow-readonly-for-restricted-lib",
+    "decision": "allow",
+    "when": {
+      "principal": {
+        "kind": ["node"],
+        "library": { "op": "equals", "value": "untrusted-library" }
+      },
+      "action": {
+        "request_type": {
+          "op": "in",
+          "values": ["ReadFileRequest", "GetFileInfoRequest", "ListDirectoryRequest"]
+        }
+      }
+    }
+  },
+  {
+    "id": "user.deny-everything-else-for-restricted-lib",
+    "decision": "deny",
+    "reason": "untrusted-library is restricted to read-only operations",
+    "when": {
+      "principal": {
+        "kind": ["node"],
+        "library": { "op": "equals", "value": "untrusted-library" }
+      }
+    }
+  }
+]
+```
+
+### Conditional rule via context facts
+
+```json
+{
+  "id": "user.deny-writes-when-cloud-storage-loaded",
+  "decision": "deny",
+  "reason": "local writes are off when cloud-storage library is active",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "context": {
+      "facts": {
+        "loaded_libraries.names": { "op": "in", "values": ["griptape-cloud-storage"] }
+      }
+    }
+  }
+}
+```
+
+## Author + Verify Recipe
+
+After authoring a rule, always verify before declaring success. Three MCP calls:
+
+```
+1. griptape_nodes_GrantPermissionRuleRequest(rule={ ... })
+   → returns rule_id on success.
+
+2. griptape_nodes_GetEffectivePolicyRequest()
+   → confirm the rule appears in the merged policy, in the position you expect.
+
+3. (optional, after triggering the gated action)
+   griptape_nodes_ListPermissionDecisionsRequest(limit=20)
+   → confirm the rule actually fired. Each entry has rule_id, decision,
+     principal_label, action_request_type, resource_summary, inspected_paths,
+     reason. inspected_paths shows which match paths the rule consulted.
+```
+
+If `Grant` fails with `GrantPermissionRuleResultFailure`, the rule didn't validate. Read the `result_details`; the most common cause is an unknown operator in `op` (only the seven in the cheat sheet are accepted).
+
+## Revoking
+
+```
+griptape_nodes_RevokePermissionRuleRequest(rule_id="user.deny-experimental-library")
+```
+
+Failure reasons:
+
+- `result_details` mentions "no user rule with that id exists" → the id was wrong, or the rule is license-imposed (license rules cannot be revoked through this API).
+
+## Batched authoring
+
+Many rules at once go through `griptape_nodes_EventRequestBatch`. Each inner request is one `GrantPermissionRuleRequest`. Per-slot failure does not abort siblings, so walk the result array and check `ok: true` on every entry:
+
+```json
+{
+  "requests": [
+    {"request_type": "GrantPermissionRuleRequest",
+     "request": {"rule": { "id": "user.allow-readonly", "decision": "allow", "when": { ... } }}},
+    {"request_type": "GrantPermissionRuleRequest",
+     "request": {"rule": { "id": "user.deny-everything-else", "decision": "deny", "when": { ... } }}}
+  ]
+}
+```
+
+## Critical Idioms
+
+- **Stable, prefixed `id`s.** Use a `user.<topic>-<verb>-<scope>` shape (e.g. `user.deny-writes-outside-workspace`). Stable ids let `Revoke` and audit-log filtering work.
+- **Always set `reason`.** It surfaces in the failure message the user sees and in audit entries; debugging policy without it is painful.
+- **First-match-wins means order matters.** When granting allow + deny pairs (e.g. read-only restriction), grant the **allow** first so it wins for permitted ops; the deny then catches everything else.
+- **Verify after every grant.** A mistyped operator silently fails validation; a mistyped field path silently doesn't fire. The dispatcher won't tell you a rule is unreachable. `GetEffectivePolicyRequest` + a probe of the gated action confirm both shape and effect.
+- **Don't ratchet `default_decision` to `deny` casually.** It locks the engine into allow-list mode and you must explicitly allow every privileged op. For most demos, leave it `allow` and add `deny` rules surgically.
+- **Read-only requests usually don't need rules.** `Get*` / `List*` / `Describe*` requests are not state-modifying; default-allow is normally what you want. Focus deny rules on `Write*`, `Delete*`, `Register*`, `Run*`, `Set*`, `Create*`, `Execute*`.
+
+## Gotchas
+
+### Manager request types are exempt from the hook
+
+The four permission tools (`Grant`, `Revoke`, `GetEffectivePolicy`, `ListPermissionDecisions`) bypass policy evaluation by design so the user can always repair a too-restrictive policy. This means a connected MCP client can edit user rules without a policy check. License rules (set via `PermissionManager.set_license_policy()`) are NOT exposed as MCP tools and are the right place for hard constraints.
+
+### Rules do not auto-fire on operations that bypass the dispatcher
+
+The permission hook fires for every `RequestPayload` that flows through `EventManager.handle_request` / `ahandle_request`. Some manager methods are still invoked as plain Python calls inside the engine (audit at `permission_bypass_audit.md`); rules don't fire on those paths. If a rule you wrote isn't firing, confirm the operation actually reaches the dispatcher (check `ListPermissionDecisionsRequest` — if there's no entry for that `action_request_type`, the dispatcher never saw it).
+
+### Persisted into user config
+
+`Grant` writes to `~/.config/griptape_nodes/griptape_nodes_config.json` under the `permissions.policy.rules` key. To inspect or hand-edit, that's the file. License-imposed rules are NOT written there — they live in memory only.
+
+### `path_under` does canonical containment, not string prefix
+
+`/a/b` is not under `/a/b-other`. Symlinks are followed. The macro `${workspace}` resolves to the active workspace's absolute path before comparison, so policies stay portable across machines.
+
+### glob patterns are fnmatch, not regex
+
+`*` matches any sequence; `?` one char; `[abc]` a class. No anchors, no `\d`, no alternation. For more, combine `glob` patterns under `any_of`.
+
+## End-to-End Example: "Block any library in LABS lifecycle stage"
+
+The complete demo flow, end-to-end, with verification:
+
+```
+1. griptape_nodes_GrantPermissionRuleRequest(rule={
+     "id": "user.deny-labs-libraries",
+     "decision": "deny",
+     "reason": "labs-stage libraries are not permitted in this workspace",
+     "granted_by": "user",
+     "when": {
+       "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+       "context": {"facts": {
+         "request.metadata.declarations.lifecycle_stage": {"op": "equals", "value": "LABS"}
+       }}
+     }
+   })
+   → returns rule_id="user.deny-labs-libraries".
+
+2. griptape_nodes_GetEffectivePolicyRequest()
+   → confirm the rule appears in policy.rules.
+
+3. (User restarts the engine, or attempts to register a LABS library.)
+
+4. griptape_nodes_ListPermissionDecisionsRequest(limit=10)
+   → expected: an entry with rule_id="user.deny-labs-libraries",
+     decision="deny", action_request_type="RegisterLibraryFromFileRequest".
+     If absent, the labs library never reached the dispatcher (check for
+     bypass) or the rule didn't match (inspect inspected_paths).
+```
+
+If the user later wants to drop the rule:
+
+```
+griptape_nodes_RevokePermissionRuleRequest(rule_id="user.deny-labs-libraries")
+```
+
+## Further Reading
+
+- [Permissions reference](https://docs.griptapenodes.com/en/stable/permissions/index.md) — full schema, license layer, audit log, settings reference.
+- [Bypass audit](https://docs.griptapenodes.com/en/stable/permissions/index.md#limitations) — current dispatcher coverage gaps.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,3 +201,10 @@ Now when workflows generate media:
 - Local access: Works via the tunnel URL
 - External services: Can fetch media via the ngrok URL
 - CORS: Automatically configured for the tunnel URL
+
+## Permissions
+
+The `permissions` key in any config file holds a declarative policy controlling
+which privileged engine operations are allowed. See [Permissions](permissions.md)
+for the rule schema, operator reference, layered evaluation, the license layer,
+and worked examples.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -474,8 +474,9 @@ The enricher is best-effort: a library with a missing or malformed JSON file
 yields no facts, so the rule simply doesn't fire and registration falls
 through to subsequent rules or the policy default. It also accepts the
 directory form of `file_path` (the path to the folder containing
-`griptape_nodes_library.json`), matching `RegisterLibraryFromFileRequest`'s
-own semantics.
+`griptape_nodes_library.json`) and resolves a `library_name` against the
+engine's tracked libraries, so a registration by name is gated by the same
+rules as a registration by path.
 
 ### Conditional rule via context facts
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -474,9 +474,10 @@ The enricher is best-effort: a library with a missing or malformed JSON file
 yields no facts, so the rule simply doesn't fire and registration falls
 through to subsequent rules or the policy default. It also accepts the
 directory form of `file_path` (the path to the folder containing
-`griptape_nodes_library.json`) and resolves a `library_name` against the
-engine's tracked libraries, so a registration by name is gated by the same
-rules as a registration by path.
+`griptape_nodes_library.json`) and resolves a `library_name` to the JSON the
+loader will read — a tracked library by its known path, or, when the request
+permits discovery, the matching file found by a read-only library scan — so a
+registration by name is gated by the same rules as a registration by path.
 
 ### Conditional rule via context facts
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,785 @@
+# Permissions
+
+The permission system lets you write declarative rules that gate privileged
+engine operations: file IO, library registration, arbitrary Python execution,
+secret access, and any other request that flows through the engine dispatcher.
+Rules live in your normal config file (`griptape_nodes_config.json`) under a
+top-level `permissions` key.
+
+This page covers what rules look like, how they're evaluated, the full operator
+reference, and a catalogue of worked examples you can copy-paste.
+
+## Mental model
+
+Every privileged engine operation is a `RequestPayload` (e.g. `WriteFileRequest`,
+`RegisterLibraryFromFileRequest`, `RunArbitraryPythonStringRequest`) that flows
+through one dispatcher. The permission manager registers a hook on that
+dispatcher. Before any request reaches its handler, the hook evaluates the
+active policy and either lets the request through, denies it (returning the
+request's typed failure with `PERMISSION_DENIED`), or, eventually, prompts the
+user for consent.
+
+Rules are written in a four-axis model borrowed from policy languages like
+Cedar: **principal** (who is asking), **action** (what they want to do),
+**resource** (what is being acted on), **context** (ambient facts about the
+world). Any axis you don't write is a wildcard. Every axis you write must
+match.
+
+## Rule shape
+
+A rule is a JSON object with this structure:
+
+```json
+{
+  "id": "user.allow-workspace-writes",
+  "decision": "allow",
+  "reason": "writes are scoped to the workspace by default",
+  "granted_by": "user",
+  "when": {
+    "principal": { ... },
+    "action": { ... },
+    "resource": { "fields": { "<dot.path>": <match-expr> } },
+    "context": { "facts": { "<dot.path>": <match-expr> } }
+  }
+}
+```
+
+| Field        | Required | Notes                                                                                   |
+| ------------ | -------- | --------------------------------------------------------------------------------------- |
+| `id`         | yes      | Stable identifier; used by `RevokePermissionRuleRequest` and shown in audit entries     |
+| `decision`   | yes      | One of `"allow"`, `"deny"`, `"prompt"`                                                  |
+| `reason`     | no       | Surfaced in failure messages and audit entries                                          |
+| `granted_by` | no       | Free-text origin label (e.g. `"user"`, `"engine-default"`, `"license:enterprise@2026"`) |
+| `when`       | no       | Combined matcher; an empty `when` matches everything                                    |
+
+## Policy and merging
+
+The `permissions` block in your config holds a `policy`:
+
+```json
+{
+  "permissions": {
+    "enabled": true,
+    "consent_prompts_enabled": true,
+    "audit_log_max_entries": 1000,
+    "policy": {
+      "default_decision": "allow",
+      "rules": [ ... ]
+    }
+  }
+}
+```
+
+Rules are evaluated **first-match-wins** in list order. If no rule matches, the
+policy's `default_decision` applies.
+
+The default `default_decision` is `"allow"`, so an unconfigured engine behaves
+exactly as before. To lock down by default, set `"default_decision": "deny"`
+and add explicit allow rules.
+
+Like every other engine setting, the `permissions` block layers across config
+files: built-in defaults → user → project-adjacent → workspace → environment
+variables. The `PermissionManager` reads each layer's `permissions` block
+separately and assembles the active policy at evaluation time:
+
+- Each layer's `policy.rules` are concatenated **highest-priority layer
+    first** (env → workspace → project → user → defaults), so a workspace rule
+    fires ahead of a user rule under first-match-wins.
+- License-imposed rules sit ahead of every config layer in evaluation order.
+- Scalar settings (`enabled`, `consent_prompts_enabled`, `audit_log_max_entries`,
+    `policy.default_decision`) follow the usual layered-config precedence: the
+    highest-priority layer that explicitly sets a value wins; lower layers do
+    not override it. A layer that does not write `default_decision` is treated
+    as silent rather than as setting it to the schema default of `"allow"`.
+- Each rule's `granted_by` is auto-stamped with the layer name (`"user"`,
+    `"workspace"`, `"project"`, `"env"`, `"defaults"`) when the rule did not
+    explicitly carry one, so audit entries identify the source config file.
+- `GrantPermissionRuleRequest` and `RevokePermissionRuleRequest` operate on
+    the user layer only. Rules from other layers are read-only at runtime;
+    edit them by hand in the layer's `griptape_nodes_config.json`.
+
+## Operators
+
+Every matcher value is a small object with an `op` discriminator:
+
+| Operator     | Shape                                          | Meaning                                              |
+| ------------ | ---------------------------------------------- | ---------------------------------------------------- |
+| `equals`     | `{"op": "equals", "value": <any>}`             | Strict equality                                      |
+| `in`         | `{"op": "in", "values": [<any>...]}`           | Membership; against a list-valued field, any-overlap |
+| `glob`       | `{"op": "glob", "pattern": "..."}`             | `fnmatch`-style glob against a string                |
+| `path_under` | `{"op": "path_under", "root": "<path>"}`       | Macro-expanded canonical path containment            |
+| `not`        | `{"op": "not", "expr": <match-expr>}`          | Negation                                             |
+| `all_of`     | `{"op": "all_of", "exprs": [<match-expr>...]}` | Conjunction                                          |
+| `any_of`     | `{"op": "any_of", "exprs": [<match-expr>...]}` | Disjunction                                          |
+
+The `path_under` operator expands `${workspace}` and `${static_files_directory}`
+macros before comparing, so policies stay portable across machines.
+
+## Axes
+
+### Principal — who is asking
+
+```json
+"principal": {
+  "kind": ["node"],
+  "library": { "op": "equals", "value": "advanced-image-library" },
+  "node_type": { "op": "glob", "pattern": "*UpscaleNode*" },
+  "topic": { "op": "equals", "value": "ws://editor" }
+}
+```
+
+`kind` is an array (any-of) of `"engine"`, `"node"`, `"client"`. The other
+fields are predicates and only meaningful for the matching kind:
+
+- `library` and `node_type` apply when `kind` includes `"node"`.
+- `topic` applies when `kind` includes `"client"` (the websocket response
+    topic identifies which connected editor / MCP client issued the request).
+
+### Action — what they want to do
+
+```json
+"action": {
+  "request_type": { "op": "in", "values": ["WriteFileRequest", "DeleteFileRequest"] }
+}
+```
+
+`request_type` is the class name of the `RequestPayload` (e.g.
+`WriteFileRequest`, `RegisterLibraryFromFileRequest`,
+`RunArbitraryPythonStringRequest`, `CreateNodeRequest`).
+
+### Resource — what is being acted on
+
+```json
+"resource": {
+  "fields": {
+    "file_path": { "op": "path_under", "root": "${workspace}" }
+  }
+}
+```
+
+Keys under `fields` are dot-paths into the request payload's dataclass. For
+example, `WriteFileRequest` has a `file_path` field, so `"file_path": ...`
+matches against it. Multiple keys are AND'd.
+
+### Context — ambient facts
+
+```json
+"context": {
+  "facts": {
+    "loaded_libraries.names": { "op": "in", "values": ["advanced-image-library"] }
+  }
+}
+```
+
+Keys under `facts` are dot-paths into the merged fact tree. See
+[Context fact reference](#context-fact-reference) for the complete list of
+built-in facts and per-request enrichers.
+
+## Context fact reference
+
+Facts are values made available to the `context` axis of a rule. Two flavours:
+
+- **Built-in providers** registered by `PermissionManager` and refreshed via
+    formally defined engine events. Available everywhere; cached between
+    evaluations and invalidated when the underlying state changes.
+- **Per-request enrichers** registered by individual managers. Only present
+    while the matching request type is being evaluated; published under the
+    `request.*` namespace.
+
+### Built-in facts
+
+| Path                     | Type          | Refreshes when              | Notes                                                                     |
+| ------------------------ | ------------- | --------------------------- | ------------------------------------------------------------------------- |
+| `workspace.path`         | `str \| None` | `ConfigChanged`             | Resolved absolute path of the active workspace                            |
+| `engine.id`              | `str \| None` | never                       | Stable engine session identifier                                          |
+| `loaded_libraries.names` | `list[str]`   | `LibraryLoadedNotification` | Names of every library currently registered with `LibraryRegistry`        |
+| `current_node.library`   | `str \| None` | node execution boundary     | Library name of the node currently executing, or `None` outside execution |
+| `current_node.node_type` | `str \| None` | node execution boundary     | Class name of the node currently executing                                |
+| `current_node.node_name` | `str \| None` | node execution boundary     | Instance name of the node currently executing                             |
+
+`current_node.*` is populated whenever something has called
+`PermissionManager.push_principal(...)` and not yet popped. The intended
+caller is the node executor at the boundaries of `node.aprocess()`. Outside
+a push/pop block, every `current_node.*` field is `None`, so rules using
+them only fire during node execution.
+
+### Per-request enricher facts
+
+These are published under `request.*` for the duration of one rule
+evaluation, derived from the request payload itself. Available facts depend
+on which manager has registered an enricher for that request type.
+
+| Request type                     | Path                                            | Type          | Notes                                                                                          |
+| -------------------------------- | ----------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------- |
+| `RegisterLibraryFromFileRequest` | `request.metadata.name`                         | `str \| None` | `name` field from the library JSON                                                             |
+| `RegisterLibraryFromFileRequest` | `request.metadata.declarations.lifecycle_stage` | `str \| None` | Stage from a `LifecycleStageLibraryProperty` (`STABLE`, `BETA`, `ALPHA`, `LABS`, `DEPRECATED`) |
+| `RegisterLibraryFromFileRequest` | `request.metadata.declarations.types`           | `list[str]`   | Flat list of declaration `type` strings, useful for `in` matchers                              |
+
+Enrichers are best-effort: missing files, malformed JSON, or unexpected
+shapes yield no facts, so rules that depended on them simply don't fire and
+evaluation falls through.
+
+### Adding your own facts
+
+Managers and library code can publish additional facts through the same
+registry:
+
+```python
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.permissions import FactInvalidator
+
+pm = GriptapeNodes.PermissionManager()
+
+# A static fact
+pm.facts.register_provider(
+    "site.region",
+    lambda: "us-east-1",
+    invalidator=FactInvalidator.NEVER,
+)
+
+# A request-scoped fact for a specific request type
+pm.facts.register_request_enricher(
+    "WriteFileRequest",
+    lambda req: {"size_hint": len(req.content) if isinstance(req.content, (bytes, str)) else 0},
+)
+```
+
+Providers must be cheap and synchronous, and must not themselves issue
+requests through the dispatcher (re-entrancy would deadlock). The
+`FactInvalidator` enum maps each cache invalidator to a real engine event
+so you don't need a separate polling loop.
+
+## Worked examples
+
+### Lock writes to your workspace
+
+```json
+{
+  "permissions": {
+    "policy": {
+      "default_decision": "allow",
+      "rules": [
+        {
+          "id": "user.deny-writes-outside-workspace",
+          "decision": "deny",
+          "reason": "writes are scoped to the active workspace",
+          "when": {
+            "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+            "resource": {
+              "fields": {
+                "file_path": {
+                  "op": "not",
+                  "expr": { "op": "path_under", "root": "${workspace}" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Allows writes anywhere inside the workspace, denies writes anywhere else. Read
+operations are unaffected because the rule only matches `WriteFileRequest`.
+
+### Block a specific library at startup
+
+```json
+{
+  "id": "user.deny-experimental-library",
+  "decision": "deny",
+  "reason": "experimental library disabled",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
+    "resource": {
+      "fields": {
+        "file_path": { "op": "glob", "pattern": "*experimental-library*" }
+      }
+    }
+  }
+}
+```
+
+The engine logs the denial during library load and the library appears as
+`PENDING` in the library status panel. Other libraries load normally.
+
+### Block arbitrary Python from external clients
+
+```json
+{
+  "id": "user.deny-arbitrary-python-from-clients",
+  "decision": "deny",
+  "reason": "arbitrary Python execution from external clients is disabled",
+  "when": {
+    "principal": { "kind": ["client"] },
+    "action": { "request_type": { "op": "equals", "value": "RunArbitraryPythonStringRequest" } }
+  }
+}
+```
+
+`RunArbitraryPythonStringRequest` from the editor or any connected MCP client
+is denied; the engine itself and your own nodes can still call it. This is a
+good default for any setup where the editor talks to a remote engine.
+
+### Allow a specific library to write to a specific subdirectory
+
+```json
+{
+  "id": "user.allow-image-lib-outputs",
+  "decision": "allow",
+  "when": {
+    "principal": {
+      "kind": ["node"],
+      "library": { "op": "equals", "value": "advanced-image-library" }
+    },
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "resource": {
+      "fields": {
+        "file_path": { "op": "path_under", "root": "${workspace}/outputs" }
+      }
+    }
+  }
+}
+```
+
+Combines all four axes: the principal must be a node from the named library,
+the action must be `WriteFileRequest`, and the target path must live under
+`${workspace}/outputs`. Anything else falls through to subsequent rules or the
+policy default.
+
+### Restrict a library to read-only operations
+
+```json
+[
+  {
+    "id": "user.allow-readonly-for-restricted-lib",
+    "decision": "allow",
+    "when": {
+      "principal": {
+        "kind": ["node"],
+        "library": { "op": "equals", "value": "untrusted-library" }
+      },
+      "action": {
+        "request_type": {
+          "op": "in",
+          "values": [
+            "ReadFileRequest",
+            "GetFileInfoRequest",
+            "ListDirectoryRequest"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": "user.deny-everything-else-for-restricted-lib",
+    "decision": "deny",
+    "reason": "untrusted-library is restricted to read-only operations",
+    "when": {
+      "principal": {
+        "kind": ["node"],
+        "library": { "op": "equals", "value": "untrusted-library" }
+      }
+    }
+  }
+]
+```
+
+Two rules in order: the first allow-lists read operations for the named
+library; the second catches everything else and denies it. Other libraries are
+unaffected.
+
+### Allow only known MCP clients
+
+```json
+[
+  {
+    "id": "user.allow-known-mcp-clients",
+    "decision": "allow",
+    "when": {
+      "principal": {
+        "kind": ["client"],
+        "topic": {
+          "op": "any_of",
+          "exprs": [
+            { "op": "glob", "pattern": "*claude-desktop*" },
+            { "op": "glob", "pattern": "*cursor*" }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "id": "user.deny-unknown-clients",
+    "decision": "deny",
+    "reason": "only allow-listed MCP clients are permitted",
+    "when": { "principal": { "kind": ["client"] } }
+  }
+]
+```
+
+External clients are only allowed if their topic matches one of the listed
+patterns. Engine-internal and node-issued requests aren't covered by either
+rule and continue under the policy default.
+
+### Block libraries by lifecycle stage
+
+Libraries authored against schema 0.8.0+ can declare a lifecycle stage
+(`STABLE`, `BETA`, `ALPHA`, `LABS`, `DEPRECATED`). `LibraryManager` parses
+the library's JSON during a `RegisterLibraryFromFileRequest` evaluation and
+publishes the declarations as facts under `request.metadata.declarations.*`,
+so permission rules can match against them directly.
+
+```json
+{
+  "id": "user.deny-labs-libraries",
+  "decision": "deny",
+  "reason": "labs-stage libraries are not permitted in this workspace",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
+    "context": {
+      "facts": {
+        "request.metadata.declarations.lifecycle_stage": { "op": "equals", "value": "LABS" }
+      }
+    }
+  }
+}
+```
+
+With this rule active, any library whose `griptape_nodes_library.json`
+contains a `lifecycle_stage` declaration set to `LABS` is rejected at
+registration time and never reaches the loader. `STABLE`, `BETA`, and so on
+pass through. To block multiple stages at once, swap `equals` for `in`:
+
+```json
+"request.metadata.declarations.lifecycle_stage": {
+  "op": "in",
+  "values": ["LABS", "ALPHA"]
+}
+```
+
+For a coarser "any library that declares a lifecycle stage at all" rule,
+match against the flattened types list:
+
+```json
+"request.metadata.declarations.types": {
+  "op": "in",
+  "values": ["lifecycle_stage"]
+}
+```
+
+The enricher is best-effort: a library with a missing or malformed JSON file
+yields no facts, so the rule simply doesn't fire and registration falls
+through to subsequent rules or the policy default. It also accepts the
+directory form of `file_path` (the path to the folder containing
+`griptape_nodes_library.json`), matching `RegisterLibraryFromFileRequest`'s
+own semantics.
+
+### Conditional rule via context facts
+
+```json
+{
+  "id": "user.deny-writes-when-cloud-storage-loaded",
+  "decision": "deny",
+  "reason": "local writes are off when cloud-storage library is active",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "context": {
+      "facts": {
+        "loaded_libraries.names": {
+          "op": "in",
+          "values": ["griptape-cloud-storage"]
+        }
+      }
+    }
+  }
+}
+```
+
+Active only while `griptape-cloud-storage` is in the loaded library set. As
+soon as that library is unloaded, the rule stops firing.
+
+### Combine matchers with `all_of` / `any_of` / `not`
+
+```json
+{
+  "id": "user.deny-bin-writes-into-workspace-root",
+  "decision": "deny",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "resource": {
+      "fields": {
+        "file_path": {
+          "op": "all_of",
+          "exprs": [
+            { "op": "path_under", "root": "${workspace}" },
+            {
+              "op": "not",
+              "expr": { "op": "path_under", "root": "${workspace}/bin" }
+            },
+            { "op": "glob", "pattern": "*.bin" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+`all_of` expresses "all of these must hold for this field." Operators nest
+freely; `any_of` and `not` work the same way.
+
+### Tighten by switching the default
+
+```json
+{
+  "permissions": {
+    "policy": {
+      "default_decision": "deny",
+      "rules": [
+        {
+          "id": "engine.allow-reads-anywhere",
+          "decision": "allow",
+          "when": {
+            "action": {
+              "request_type": {
+                "op": "in",
+                "values": ["ReadFileRequest", "GetFileInfoRequest", "ListDirectoryRequest"]
+              }
+            }
+          }
+        },
+        {
+          "id": "engine.allow-writes-under-workspace",
+          "decision": "allow",
+          "when": {
+            "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+            "resource": {
+              "fields": { "file_path": { "op": "path_under", "root": "${workspace}" } }
+            }
+          }
+        },
+        {
+          "id": "engine.allow-engine-itself",
+          "decision": "allow",
+          "when": { "principal": { "kind": ["engine"] } }
+        }
+      ]
+    }
+  }
+}
+```
+
+`default_decision: deny` flips the engine into allow-list mode: nothing is
+permitted unless an explicit rule allows it. The three rules above are roughly
+the minimum to keep a development engine functional.
+
+## Programmatic API
+
+Permissions can also be managed at runtime via the request dispatcher (the
+manager's own request types are exempt from the hook so a too-restrictive
+policy can always be repaired):
+
+```python
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.permission_events import (
+    GetEffectivePolicyRequest,
+    GrantPermissionRuleRequest,
+    ListPermissionDecisionsRequest,
+    RevokePermissionRuleRequest,
+)
+
+# Add a rule (persisted into user config)
+GriptapeNodes.handle_request(GrantPermissionRuleRequest(rule={
+    "id": "session.deny-arbitrary-python",
+    "decision": "deny",
+    "when": {
+        "action": {"request_type": {"op": "equals", "value": "RunArbitraryPythonStringRequest"}}
+    },
+}))
+
+# Read the effective policy (license + user, in evaluation order)
+policy = GriptapeNodes.handle_request(GetEffectivePolicyRequest()).policy
+
+# Tail recent decisions
+decisions = GriptapeNodes.handle_request(
+    ListPermissionDecisionsRequest(limit=20)
+).decisions
+
+# Remove a user rule
+GriptapeNodes.handle_request(
+    RevokePermissionRuleRequest(rule_id="session.deny-arbitrary-python")
+)
+```
+
+These four request types are the public surface. Editor UIs build on top of
+them; license and policy automation tools should use them rather than editing
+config files by hand.
+
+### MCP exposure
+
+All four request types are exposed as tools on the engine's MCP server
+(`SUPPORTED_REQUEST_EVENTS` in `src/griptape_nodes/servers/mcp.py`):
+
+- `GetEffectivePolicyRequest`
+- `GrantPermissionRuleRequest`
+- `RevokePermissionRuleRequest`
+- `ListPermissionDecisionsRequest`
+
+This means any MCP client (the editor, an external admin tool, an agent like
+Claude Desktop) can read and edit the user policy through the standard MCP
+toolset. Two things to know:
+
+- **The dispatcher hook does not gate these requests.** They're listed in
+    `PERMISSION_OWN_REQUEST_TYPES` and exempted from policy evaluation, so a
+    too-restrictive policy can always be repaired. That means a connected MCP
+    client can grant or revoke user-policy rules without going through any
+    permission check.
+- **License-imposed rules are not editable through MCP.** They are owned by
+    `PermissionManager.set_license_policy()`, which is not exposed as a request
+    type. `RevokePermissionRuleRequest` against a license rule id fails with a
+    clear reason. Use the license layer for hard constraints that even an MCP
+    client should not be able to disable.
+
+If you expose the MCP server to untrusted clients (remote, unauthenticated),
+gate these tools at the transport layer or place equivalent constraints in
+the license layer. The local-only default (binding to `127.0.0.1`) and the
+fact that the user already controls their own config file mean the standard
+local setup carries no additional risk.
+
+## Audit log and decision events
+
+Every evaluation appends a structured entry to an in-memory ring buffer
+(bounded by `audit_log_max_entries`) and broadcasts a
+`PermissionDecisionEvent` on the standard `AppPayload` event bus. Entry shape:
+
+```json
+{
+  "rule_id": "user.deny-experimental-library",
+  "decision": "deny",
+  "principal_kind": "engine",
+  "principal_label": "engine",
+  "action_request_type": "RegisterLibraryFromFileRequest",
+  "resource_summary": {
+    "library_name": null,
+    "file_path": ".../experimental-library/griptape_nodes_library.json"
+  },
+  "inspected_paths": ["action.request_type", "resource.file_path"],
+  "reason": "experimental library disabled"
+}
+```
+
+`inspected_paths` records which match-paths the rule actually consulted, so
+"why did this fire?" is trivially answerable from the audit alone. To watch
+decisions live, subscribe to `PermissionDecisionEvent`:
+
+```python
+from griptape_nodes.retained_mode.events.permission_events import (
+    PermissionDecisionEvent,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+def on_decision(event: PermissionDecisionEvent) -> None:
+    if event.decision == "deny":
+        print(f"DENY {event.action_request_type} ({event.rule_id}): {event.reason}")
+
+GriptapeNodes.EventManager().add_listener_to_app_event(
+    PermissionDecisionEvent, on_decision
+)
+```
+
+## License layer
+
+Some deployments need rules that the user cannot remove, even by hand-editing
+their config file. The permission manager exposes a separate license layer for
+this purpose:
+
+```python
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.permissions import (
+    PermissionPolicy,
+    PermissionRule,
+    Decision,
+    WhenClause,
+)
+from griptape_nodes.retained_mode.managers.permissions.matchers import ActionMatch
+from griptape_nodes.retained_mode.managers.permissions.schema import EqualsExpr
+
+GriptapeNodes.PermissionManager().set_license_policy(
+    PermissionPolicy(rules=[
+        PermissionRule(
+            id="license.no-arbitrary-python",
+            decision=Decision.DENY,
+            reason="this license forbids arbitrary Python",
+            when=WhenClause(
+                action=ActionMatch(
+                    request_type=EqualsExpr(value="RunArbitraryPythonStringRequest"),
+                ),
+            ),
+        ),
+    ]),
+)
+```
+
+License rules are evaluated **before** user rules and are never persisted to
+user config. A user editing `griptape_nodes_config.json` cannot remove a
+license-imposed rule; `RevokePermissionRuleRequest` against a license rule id
+fails with a clear reason. Calling `clear_license_policy()` drops the entire
+license fragment (used by license revocation paths).
+
+The license layer is intended for whoever loads license files (a future
+`LicenseManager`) to call programmatically; there's no JSON config surface for
+it on purpose.
+
+## Failure shape
+
+When a request is denied, the dispatcher returns the request's typed failure
+payload — not a generic error. For `WriteFileRequest`:
+
+```python
+result = GriptapeNodes.handle_request(WriteFileRequest(...))
+if not result.succeeded():
+    # type(result) is WriteFileResultFailure
+    # result.failure_reason is FileIOFailureReason.PERMISSION_DENIED
+    print(result.result_details)
+    # → "Attempted to dispatch WriteFileRequest. Failed because permission
+    #    was denied by rule 'user.deny-writes-outside-workspace' [deny]
+    #    (writes are scoped to the active workspace)."
+```
+
+This means existing handler-side type assumptions keep working: a caller that
+already does `isinstance(result, WriteFileResultFailure)` doesn't need to
+learn a new failure type for permission denials.
+
+For request types that don't have a typed failure companion, a generic
+`PermissionDeniedResult` is returned instead.
+
+## Settings reference
+
+Top-level keys under the `permissions` block:
+
+| Key                       | Type   | Default   | Description                                                                                |
+| ------------------------- | ------ | --------- | ------------------------------------------------------------------------------------------ |
+| `enabled`                 | bool   | `true`    | When `false`, the dispatcher hook is skipped entirely                                      |
+| `consent_prompts_enabled` | bool   | `true`    | Affects how `prompt` decisions are surfaced (currently treated as deny pending consent UI) |
+| `audit_log_max_entries`   | int    | `1000`    | Bound on the in-memory audit ring buffer                                                   |
+| `policy.rules`            | list   | `[]`      | Ordered rules; first match wins                                                            |
+| `policy.default_decision` | string | `"allow"` | Fall-through when no rule matches; one of `allow`, `deny`, `prompt`                        |
+
+## Limitations
+
+- **`prompt` decisions currently deny** with a `prompt-not-implemented` tag in
+    the audit entry. Consent UI lives behind a future change; until then, treat
+    `prompt` as "deny but mark distinctly so I can find these later."
+- **The dispatcher chokepoint isn't fully closed.** Some manager methods are
+    invoked as plain Python calls inside the engine instead of routed through
+    the dispatcher, which means those specific operations bypass the permission
+    hook today. The audit catalogues them; the fix is mechanical and is being
+    landed incrementally. In the meantime, if a rule you wrote doesn't fire,
+    check whether the operation actually reaches `EventManager.handle_request`.
+- **Fact provider state is lazy by default.** Custom fact providers can opt in
+    to invalidation via `ConfigChanged` and `LibraryLoadedNotification`; the
+    defaults handle these. If you author a provider that derives from other
+    state, declare its invalidator explicitly.

--- a/docs/skills/griptape-nodes-permissions/SKILL.md
+++ b/docs/skills/griptape-nodes-permissions/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: griptape-nodes-permissions
+description: Author and manage permission rules on the engine through its MCP server. Use when the user asks to allow or deny a privileged operation, lock down a library, restrict an MCP client, gate writes to a path, audit recent denials, or revoke an existing rule. Triggers include "set up a permission rule", "block this library at startup", "deny X from doing Y", "allow this library to write to Z", "what's been denied recently", "audit log of permission denials", "lock this engine down", "revoke that rule".
+---
+
+# Griptape Nodes Permission Authoring Guide
+
+This skill covers authoring, applying, and verifying permission rules through the engine's MCP server. The permission system enforces declarative policy at the request dispatcher; rules ride normal engine config and are first-match-wins.
+
+## Mental Model
+
+- **Rules** evaluate four axes: **principal** (who is asking — engine / node / client), **action** (request type), **resource** (fields of the request payload), **context** (ambient facts). Populated axes are AND'd; unpopulated axes are wildcards.
+- **First-match-wins** in policy order. License rules evaluate first, then user rules. If nothing matches, the policy's `default_decision` applies.
+- **License rules trump user rules** and are not editable through MCP. Use them for hard constraints. User rules are the everyday surface and are what `Grant`/`Revoke` operate on.
+- **The dispatcher hook short-circuits with the request's typed failure.** A denied `WriteFileRequest` returns `WriteFileResultFailure` with `failure_reason = PERMISSION_DENIED`, not a generic error.
+- **Default behaviour is `allow`.** An engine with no rules behaves exactly as it always has; ratchet down by adding deny rules or by switching `default_decision` to `deny`.
+
+## MCP Tools
+
+Four MCP tools manage policy. They are exempt from the policy hook so a too-restrictive policy can always be repaired:
+
+| Tool                                            | Purpose                                                                         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| `griptape_nodes_GrantPermissionRuleRequest`     | Append a rule to the user policy (persisted into user config).                  |
+| `griptape_nodes_RevokePermissionRuleRequest`    | Remove a user rule by `id`. License rules cannot be revoked here.               |
+| `griptape_nodes_GetEffectivePolicyRequest`      | Read the merged policy (license rules first, then user rules) for verification. |
+| `griptape_nodes_ListPermissionDecisionsRequest` | Tail the in-memory audit ring buffer (`limit` argument optional).               |
+
+## Rule Shape
+
+```json
+{
+  "id": "user.short-stable-identifier",
+  "decision": "allow" | "deny" | "prompt",
+  "reason": "human-readable explanation, surfaced in failures and audit",
+  "granted_by": "user",
+  "when": {
+    "principal": { ... },
+    "action":    { ... },
+    "resource":  { "fields": { "<dot.path>": <expr> } },
+    "context":   { "facts":  { "<dot.path>": <expr> } }
+  }
+}
+```
+
+`prompt` decisions currently behave as deny with a `prompt-not-implemented` audit tag (consent UI is future work). Default to `allow` or `deny` for now.
+
+## Operator Cheat Sheet
+
+| Operator     | Shape                                    | Use                                                                                               |
+| ------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `equals`     | `{"op": "equals", "value": <any>}`       | Strict equality                                                                                   |
+| `in`         | `{"op": "in", "values": [<any>...]}`     | Membership; against a list-valued field, any-overlap                                              |
+| `glob`       | `{"op": "glob", "pattern": "..."}`       | fnmatch-style glob against a string                                                               |
+| `path_under` | `{"op": "path_under", "root": "<path>"}` | Macro-expanded canonical path containment. `${workspace}` and `${static_files_directory}` expand. |
+| `not`        | `{"op": "not", "expr": <expr>}`          | Negation                                                                                          |
+| `all_of`     | `{"op": "all_of", "exprs": [<expr>...]}` | Conjunction                                                                                       |
+| `any_of`     | `{"op": "any_of", "exprs": [<expr>...]}` | Disjunction                                                                                       |
+
+## Principal Axis
+
+```json
+"principal": {
+  "kind": ["engine"] | ["node"] | ["client"] | <multiple>,
+  "library":   <expr>,   // applies when kind includes "node"
+  "node_type": <expr>,   // applies when kind includes "node"
+  "topic":     <expr>    // applies when kind includes "client"
+}
+```
+
+`engine` covers requests originating inside the engine itself (startup, internal flows). `node` covers requests issued from inside an executing node. `client` covers requests received over the wire from a connected MCP client / editor — `topic` is the response topic of that client.
+
+## Common Resource Fields
+
+Match against fields of the request payload via dot-paths under `resource.fields`. The most common ones:
+
+| Request type                      | Field                   | Notes                                                         |
+| --------------------------------- | ----------------------- | ------------------------------------------------------------- |
+| `WriteFileRequest`                | `file_path`             | Almost always paired with `path_under` against `${workspace}` |
+| `ReadFileRequest`                 | `file_path`             | Same                                                          |
+| `RegisterLibraryFromFileRequest`  | `file_path`             | Path to library JSON or directory                             |
+| `RegisterLibraryFromFileRequest`  | `library_name`          | Optional library name when registering by name                |
+| `RunArbitraryPythonStringRequest` | `python_string`         | Use `glob` or `not.glob` to gate by snippet content           |
+| `CreateNodeRequest`               | `node_type`             | Class name of the node being created                          |
+| `CreateNodeRequest`               | `specific_library_name` | Library scope of the create                                   |
+
+## Common Context Facts
+
+Match ambient state under `context.facts`:
+
+| Path                                            | Type          | Refreshes when              | Notes                                                                                                 |
+| ----------------------------------------------- | ------------- | --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `workspace.path`                                | `str`         | `ConfigChanged`             | Active workspace absolute path                                                                        |
+| `engine.id`                                     | `str`         | never                       | Stable engine session id                                                                              |
+| `loaded_libraries.names`                        | `list[str]`   | `LibraryLoadedNotification` | Names of currently registered libraries                                                               |
+| `current_node.library`                          | `str \| None` | execution boundary          | Library of the node currently executing                                                               |
+| `current_node.node_type`                        | `str \| None` | execution boundary          | Class name of the node currently executing                                                            |
+| `current_node.node_name`                        | `str \| None` | execution boundary          | Instance name of the node currently executing                                                         |
+| `request.metadata.declarations.lifecycle_stage` | `str \| None` | per-request                 | Only set on `RegisterLibraryFromFileRequest`. One of `STABLE`, `BETA`, `ALPHA`, `LABS`, `DEPRECATED`. |
+| `request.metadata.declarations.types`           | `list[str]`   | per-request                 | Only set on `RegisterLibraryFromFileRequest`. Flat list of declaration `type` strings.                |
+| `request.metadata.name`                         | `str \| None` | per-request                 | Library name from the JSON being registered.                                                          |
+
+## Worked Recipes
+
+### Lock writes to the workspace
+
+```json
+{
+  "id": "user.deny-writes-outside-workspace",
+  "decision": "deny",
+  "reason": "writes are scoped to the active workspace",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "resource": {
+      "fields": {
+        "file_path": {
+          "op": "not",
+          "expr": { "op": "path_under", "root": "${workspace}" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Block a specific library at startup
+
+```json
+{
+  "id": "user.deny-experimental-library",
+  "decision": "deny",
+  "reason": "experimental library disabled for this engine",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
+    "resource": {
+      "fields": { "file_path": { "op": "glob", "pattern": "*experimental-library*" } }
+    }
+  }
+}
+```
+
+### Block any LABS-stage library
+
+Uses the per-request enricher that `LibraryManager` ships, so this works against any library whose JSON declares `lifecycle_stage = LABS`.
+
+```json
+{
+  "id": "user.deny-labs-libraries",
+  "decision": "deny",
+  "reason": "labs-stage libraries are not permitted",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "RegisterLibraryFromFileRequest" } },
+    "context": {
+      "facts": {
+        "request.metadata.declarations.lifecycle_stage": { "op": "equals", "value": "LABS" }
+      }
+    }
+  }
+}
+```
+
+To block multiple stages: `"op": "in", "values": ["LABS", "ALPHA"]`.
+
+### Block arbitrary Python from external clients
+
+```json
+{
+  "id": "user.deny-arbitrary-python-from-clients",
+  "decision": "deny",
+  "reason": "arbitrary Python execution from external clients is disabled",
+  "when": {
+    "principal": { "kind": ["client"] },
+    "action": { "request_type": { "op": "equals", "value": "RunArbitraryPythonStringRequest" } }
+  }
+}
+```
+
+### Allow a specific library to write to a specific subdirectory
+
+```json
+{
+  "id": "user.allow-image-lib-outputs",
+  "decision": "allow",
+  "when": {
+    "principal": {
+      "kind": ["node"],
+      "library": { "op": "equals", "value": "advanced-image-library" }
+    },
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "resource": {
+      "fields": { "file_path": { "op": "path_under", "root": "${workspace}/outputs" } }
+    }
+  }
+}
+```
+
+### Restrict a library to read-only operations
+
+Two rules in order — earlier rules win. The first allow-lists reads for the named library; the second catches everything else from that library and denies it.
+
+```json
+[
+  {
+    "id": "user.allow-readonly-for-restricted-lib",
+    "decision": "allow",
+    "when": {
+      "principal": {
+        "kind": ["node"],
+        "library": { "op": "equals", "value": "untrusted-library" }
+      },
+      "action": {
+        "request_type": {
+          "op": "in",
+          "values": ["ReadFileRequest", "GetFileInfoRequest", "ListDirectoryRequest"]
+        }
+      }
+    }
+  },
+  {
+    "id": "user.deny-everything-else-for-restricted-lib",
+    "decision": "deny",
+    "reason": "untrusted-library is restricted to read-only operations",
+    "when": {
+      "principal": {
+        "kind": ["node"],
+        "library": { "op": "equals", "value": "untrusted-library" }
+      }
+    }
+  }
+]
+```
+
+### Conditional rule via context facts
+
+```json
+{
+  "id": "user.deny-writes-when-cloud-storage-loaded",
+  "decision": "deny",
+  "reason": "local writes are off when cloud-storage library is active",
+  "when": {
+    "action": { "request_type": { "op": "equals", "value": "WriteFileRequest" } },
+    "context": {
+      "facts": {
+        "loaded_libraries.names": { "op": "in", "values": ["griptape-cloud-storage"] }
+      }
+    }
+  }
+}
+```
+
+## Author + Verify Recipe
+
+After authoring a rule, always verify before declaring success. Three MCP calls:
+
+```
+1. griptape_nodes_GrantPermissionRuleRequest(rule={ ... })
+   → returns rule_id on success.
+
+2. griptape_nodes_GetEffectivePolicyRequest()
+   → confirm the rule appears in the merged policy, in the position you expect.
+
+3. (optional, after triggering the gated action)
+   griptape_nodes_ListPermissionDecisionsRequest(limit=20)
+   → confirm the rule actually fired. Each entry has rule_id, decision,
+     principal_label, action_request_type, resource_summary, inspected_paths,
+     reason. inspected_paths shows which match paths the rule consulted.
+```
+
+If `Grant` fails with `GrantPermissionRuleResultFailure`, the rule didn't validate. Read the `result_details`; the most common cause is an unknown operator in `op` (only the seven in the cheat sheet are accepted).
+
+## Revoking
+
+```
+griptape_nodes_RevokePermissionRuleRequest(rule_id="user.deny-experimental-library")
+```
+
+Failure reasons:
+
+- `result_details` mentions "no user rule with that id exists" → the id was wrong, or the rule is license-imposed (license rules cannot be revoked through this API).
+
+## Batched authoring
+
+Many rules at once go through `griptape_nodes_EventRequestBatch`. Each inner request is one `GrantPermissionRuleRequest`. Per-slot failure does not abort siblings, so walk the result array and check `ok: true` on every entry:
+
+```json
+{
+  "requests": [
+    {"request_type": "GrantPermissionRuleRequest",
+     "request": {"rule": { "id": "user.allow-readonly", "decision": "allow", "when": { ... } }}},
+    {"request_type": "GrantPermissionRuleRequest",
+     "request": {"rule": { "id": "user.deny-everything-else", "decision": "deny", "when": { ... } }}}
+  ]
+}
+```
+
+## Critical Idioms
+
+- **Stable, prefixed `id`s.** Use a `user.<topic>-<verb>-<scope>` shape (e.g. `user.deny-writes-outside-workspace`). Stable ids let `Revoke` and audit-log filtering work.
+- **Always set `reason`.** It surfaces in the failure message the user sees and in audit entries; debugging policy without it is painful.
+- **First-match-wins means order matters.** When granting allow + deny pairs (e.g. read-only restriction), grant the **allow** first so it wins for permitted ops; the deny then catches everything else.
+- **Verify after every grant.** A mistyped operator silently fails validation; a mistyped field path silently doesn't fire. The dispatcher won't tell you a rule is unreachable. `GetEffectivePolicyRequest` + a probe of the gated action confirm both shape and effect.
+- **Don't ratchet `default_decision` to `deny` casually.** It locks the engine into allow-list mode and you must explicitly allow every privileged op. For most demos, leave it `allow` and add `deny` rules surgically.
+- **Read-only requests usually don't need rules.** `Get*` / `List*` / `Describe*` requests are not state-modifying; default-allow is normally what you want. Focus deny rules on `Write*`, `Delete*`, `Register*`, `Run*`, `Set*`, `Create*`, `Execute*`.
+
+## Gotchas
+
+### Manager request types are exempt from the hook
+
+The four permission tools (`Grant`, `Revoke`, `GetEffectivePolicy`, `ListPermissionDecisions`) bypass policy evaluation by design so the user can always repair a too-restrictive policy. This means a connected MCP client can edit user rules without a policy check. License rules (set via `PermissionManager.set_license_policy()`) are NOT exposed as MCP tools and are the right place for hard constraints.
+
+### Rules do not auto-fire on operations that bypass the dispatcher
+
+The permission hook fires for every `RequestPayload` that flows through `EventManager.handle_request` / `ahandle_request`. Some manager methods are still invoked as plain Python calls inside the engine (audit at `permission_bypass_audit.md`); rules don't fire on those paths. If a rule you wrote isn't firing, confirm the operation actually reaches the dispatcher (check `ListPermissionDecisionsRequest` — if there's no entry for that `action_request_type`, the dispatcher never saw it).
+
+### Persisted into user config
+
+`Grant` writes to `~/.config/griptape_nodes/griptape_nodes_config.json` under the `permissions.policy.rules` key. To inspect or hand-edit, that's the file. License-imposed rules are NOT written there — they live in memory only.
+
+### `path_under` does canonical containment, not string prefix
+
+`/a/b` is not under `/a/b-other`. Symlinks are followed. The macro `${workspace}` resolves to the active workspace's absolute path before comparison, so policies stay portable across machines.
+
+### glob patterns are fnmatch, not regex
+
+`*` matches any sequence; `?` one char; `[abc]` a class. No anchors, no `\d`, no alternation. For more, combine `glob` patterns under `any_of`.
+
+## End-to-End Example: "Block any library in LABS lifecycle stage"
+
+The complete demo flow, end-to-end, with verification:
+
+```
+1. griptape_nodes_GrantPermissionRuleRequest(rule={
+     "id": "user.deny-labs-libraries",
+     "decision": "deny",
+     "reason": "labs-stage libraries are not permitted in this workspace",
+     "granted_by": "user",
+     "when": {
+       "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+       "context": {"facts": {
+         "request.metadata.declarations.lifecycle_stage": {"op": "equals", "value": "LABS"}
+       }}
+     }
+   })
+   → returns rule_id="user.deny-labs-libraries".
+
+2. griptape_nodes_GetEffectivePolicyRequest()
+   → confirm the rule appears in policy.rules.
+
+3. (User restarts the engine, or attempts to register a LABS library.)
+
+4. griptape_nodes_ListPermissionDecisionsRequest(limit=10)
+   → expected: an entry with rule_id="user.deny-labs-libraries",
+     decision="deny", action_request_type="RegisterLibraryFromFileRequest".
+     If absent, the labs library never reached the dispatcher (check for
+     bypass) or the rule didn't match (inspect inspected_paths).
+```
+
+If the user later wants to drop the rule:
+
+```
+griptape_nodes_RevokePermissionRuleRequest(rule_id="user.deny-labs-libraries")
+```
+
+## Further Reading
+
+- [Permissions reference](https://docs.griptapenodes.com/en/stable/permissions/index.md) — full schema, license layer, audit log, settings reference.
+- [Bypass audit](https://docs.griptapenodes.com/en/stable/permissions/index.md#limitations) — current dispatcher coverage gaps.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ plugins:
           - installation.md: Install the engine
         Configuration and CLI:
           - configuration.md: Engine configuration (workspace, secrets, libraries)
+          - permissions.md: Permission policy controlling privileged engine operations
           - command_line_interface.md: gtn CLI reference
         Scripting (retained mode):
           - retained_mode.md: Engine scripting API for building and running workflows
@@ -76,6 +77,7 @@ plugins:
           - how_to/mcp/servers/time.md
         Agent skills:
           - skills/griptape-nodes-workflows/SKILL.md: Build, run, and inspect workflows through the engine's MCP server
+          - skills/griptape-nodes-permissions/SKILL.md: Author and manage permission rules through the engine's MCP server
         Node reference:
           - nodes/*.md
 
@@ -148,6 +150,7 @@ nav:
               - 4. Compare Prompts: ftue/03_compare_prompts/FTUE_03_compare_prompts.md
               - 5. Build a Photography Team: ftue/04_photography_team/FTUE_04_photography_team.md
       - Engine Configuration: configuration.md
+      - Permissions: permissions.md
       - Command Line Interface: command_line_interface.md
       - Scripting: retained_mode.md
       - Project System:

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -164,7 +164,11 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._flow_manager = FlowManager(self._event_manager)
             self._context_manager = ContextManager(self._event_manager)
             self._worker_manager = WorkerManager(griptape_nodes=self, event_manager=self._event_manager)
-            self._library_manager = LibraryManager(self._event_manager, worker_manager=self._worker_manager)
+            self._library_manager = LibraryManager(
+                self._event_manager,
+                worker_manager=self._worker_manager,
+                permission_manager=self._permission_manager,
+            )
             self._model_manager = ModelManager(self._event_manager)
             self._workflow_manager = WorkflowManager(self._event_manager)
             self._workflow_variables_manager = VariablesManager(self._event_manager)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -686,8 +686,10 @@ class LibraryManager:
           ``type`` strings, useful for ``in`` matchers.
 
         The request may reference the library by ``file_path`` or by
-        ``library_name``; the latter is resolved to its tracked library path so
-        a by-name registration is gated by the same rules as a by-path one.
+        ``library_name``; the latter is resolved to its tracked library path, or
+        — when the request permits discovery and the name is not yet tracked —
+        to the matching JSON found by a read-only library scan, so a by-name
+        registration is gated by the same rules as a by-path one.
 
         Best-effort: any failure (missing file, malformed JSON, unexpected
         shape, or an untracked library name) yields an empty contribution so the
@@ -697,11 +699,8 @@ class LibraryManager:
         json_path = self._resolve_register_library_json_path(request)
         if json_path is None:
             return {}
-        try:
-            raw = json.loads(json_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return {}
-        if not isinstance(raw, dict):
+        raw = self._read_library_json_dict(json_path)
+        if raw is None:
             return {}
         metadata = raw.get("metadata")
         declarations = metadata.get("declarations") if isinstance(metadata, dict) else None
@@ -718,27 +717,56 @@ class LibraryManager:
             "metadata.declarations.lifecycle_stage": lifecycle_stage,
         }
 
+    def _read_library_json_dict(self, json_path: Path) -> dict[str, Any] | None:
+        """Read and parse a library JSON file, or None if unreadable/not an object."""
+        try:
+            raw = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(raw, dict):
+            return None
+        return raw
+
     def _resolve_register_library_json_path(self, request: Any) -> Path | None:
         """Resolve a register-library request to the JSON file it will load.
 
         Accepts a ``file_path`` (a JSON file, or a directory whose standard
-        ``griptape_nodes_library.json`` is used) or a ``library_name`` that is
-        already tracked, mirroring how the loader resolves a name to
-        ``LibraryInfo.library_path``. Returns None when neither resolves.
+        ``griptape_nodes_library.json`` is used) or a ``library_name``, mirroring
+        how the loader resolves a name to ``LibraryInfo.library_path``. Returns
+        None when neither resolves.
         """
         file_path = getattr(request, "file_path", None)
         if not file_path:
             library_name = getattr(request, "library_name", None)
             if library_name:
-                library_info = self.get_library_info_by_library_name(library_name)
-                if library_info is not None:
-                    file_path = library_info.library_path
+                file_path = self._resolve_library_path_by_name(library_name, request)
         if not file_path:
             return None
         json_path = Path(file_path)
         if json_path.is_dir():
             json_path = json_path / self.LIBRARY_CONFIG_FILENAME
         return json_path
+
+    def _resolve_library_path_by_name(self, library_name: str, request: Any) -> str | None:
+        """Resolve a library name to the JSON path the loader will read.
+
+        A tracked library resolves to its ``LibraryInfo.library_path``. An
+        untracked name is loadable only when the handler is allowed to run
+        discovery (``perform_discovery_if_not_found``); in that case mirror the
+        loader with a read-only scan of the configured library files so the gate
+        evaluates the same declarations the loader would discover. The scan does
+        not mutate tracking state.
+        """
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is not None:
+            return library_info.library_path
+        if not getattr(request, "perform_discovery_if_not_found", False):
+            return None
+        for entry in self._discover_library_files():
+            raw = self._read_library_json_dict(Path(entry.path))
+            if raw is not None and raw.get("name") == library_name:
+                return entry.path
+        return None
 
     def collate_problems_for_lib_info(self, lib_info: LibraryInfo) -> str | None:
         """Return a collated display string for a LibraryInfo's problems, or None if there are none."""

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -268,51 +268,6 @@ class LibraryUpdateResult(NamedTuple):
     result: ResultPayload
 
 
-def _enrich_register_library_request(request: Any) -> dict[str, Any]:
-    """Publish parsed library metadata as a fact for permission rule evaluation.
-
-    Reads the library JSON if `request.file_path` is set and exposes:
-
-    * ``request.metadata.name`` — library name from the JSON.
-    * ``request.metadata.declarations.lifecycle_stage`` — the stage from a
-      ``LifecycleStageLibraryProperty`` declaration if present, else None.
-    * ``request.metadata.declarations.types`` — flat list of declared
-      ``type`` strings, useful for ``in`` matchers.
-
-    Best-effort: any failure (missing file, malformed JSON, unexpected shape)
-    yields an empty contribution so the rule simply sees ``None`` for those
-    paths and matchers fall through cleanly.
-    """
-    file_path = getattr(request, "file_path", None)
-    if not file_path:
-        return {}
-    json_path = Path(file_path)
-    if json_path.is_dir():
-        # `RegisterLibraryFromFileRequest` accepts a directory containing
-        # `griptape_nodes_library.json`; resolve it to the actual JSON file.
-        json_path = json_path / "griptape_nodes_library.json"
-    try:
-        raw = json.loads(json_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    if not isinstance(raw, dict):
-        return {}
-    metadata = raw.get("metadata")
-    declarations = metadata.get("declarations") if isinstance(metadata, dict) else None
-    if not isinstance(declarations, list):
-        declarations = []
-    declaration_types = [d.get("type") for d in declarations if isinstance(d, dict) and d.get("type")]
-    lifecycle_stage = next(
-        (d.get("stage") for d in declarations if isinstance(d, dict) and d.get("type") == "lifecycle_stage"),
-        None,
-    )
-    return {
-        "metadata.name": raw.get("name"),
-        "metadata.declarations.types": declaration_types,
-        "metadata.declarations.lifecycle_stage": lifecycle_stage,
-    }
-
-
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
     LIBRARY_CONFIG_FILENAME = "griptape_nodes_library.json"
@@ -511,7 +466,7 @@ class LibraryManager:
         if permission_manager is not None:
             permission_manager.facts.register_request_enricher(
                 RegisterLibraryFromFileRequest.__name__,
-                _enrich_register_library_request,
+                self._enrich_register_library_request,
             )
 
         event_manager.add_listener_to_app_event(
@@ -718,6 +673,72 @@ class LibraryManager:
             if library_info.library_name == library_name:
                 return library_info
         return None
+
+    def _enrich_register_library_request(self, request: Any) -> dict[str, Any]:
+        """Publish parsed library metadata as a fact for permission rule evaluation.
+
+        Reads the library JSON the request will load and exposes:
+
+        * ``request.metadata.name`` — library name from the JSON.
+        * ``request.metadata.declarations.lifecycle_stage`` — the stage from a
+          ``lifecycle_stage`` declaration if present, else None.
+        * ``request.metadata.declarations.types`` — flat list of declared
+          ``type`` strings, useful for ``in`` matchers.
+
+        The request may reference the library by ``file_path`` or by
+        ``library_name``; the latter is resolved to its tracked library path so
+        a by-name registration is gated by the same rules as a by-path one.
+
+        Best-effort: any failure (missing file, malformed JSON, unexpected
+        shape, or an untracked library name) yields an empty contribution so the
+        rule simply sees ``None`` for those paths and matchers fall through
+        cleanly.
+        """
+        json_path = self._resolve_register_library_json_path(request)
+        if json_path is None:
+            return {}
+        try:
+            raw = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        metadata = raw.get("metadata")
+        declarations = metadata.get("declarations") if isinstance(metadata, dict) else None
+        if not isinstance(declarations, list):
+            declarations = []
+        declaration_types = [d.get("type") for d in declarations if isinstance(d, dict) and d.get("type")]
+        lifecycle_stage = next(
+            (d.get("stage") for d in declarations if isinstance(d, dict) and d.get("type") == "lifecycle_stage"),
+            None,
+        )
+        return {
+            "metadata.name": raw.get("name"),
+            "metadata.declarations.types": declaration_types,
+            "metadata.declarations.lifecycle_stage": lifecycle_stage,
+        }
+
+    def _resolve_register_library_json_path(self, request: Any) -> Path | None:
+        """Resolve a register-library request to the JSON file it will load.
+
+        Accepts a ``file_path`` (a JSON file, or a directory whose standard
+        ``griptape_nodes_library.json`` is used) or a ``library_name`` that is
+        already tracked, mirroring how the loader resolves a name to
+        ``LibraryInfo.library_path``. Returns None when neither resolves.
+        """
+        file_path = getattr(request, "file_path", None)
+        if not file_path:
+            library_name = getattr(request, "library_name", None)
+            if library_name:
+                library_info = self.get_library_info_by_library_name(library_name)
+                if library_info is not None:
+                    file_path = library_info.library_path
+        if not file_path:
+            return None
+        json_path = Path(file_path)
+        if json_path.is_dir():
+            json_path = json_path / self.LIBRARY_CONFIG_FILENAME
+        return json_path
 
     def collate_problems_for_lib_info(self, lib_info: LibraryInfo) -> str | None:
         """Return a collated display string for a LibraryInfo's problems, or None if there are none."""

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -753,19 +753,24 @@ class LibraryManager:
         A tracked library resolves to its ``LibraryInfo.library_path``. An
         untracked name is loadable only when the handler is allowed to run
         discovery (``perform_discovery_if_not_found``); in that case mirror the
-        loader with a read-only scan of the configured library files so the gate
-        evaluates the same declarations the loader would discover. The scan does
-        not mutate tracking state.
+        loader's ``include_sandbox`` discovery with a read-only scan of the
+        configured library files and the sandbox library so the gate evaluates
+        the same declarations the loader would discover. The scan does not
+        mutate tracking state and does not regenerate the sandbox JSON.
         """
         library_info = self.get_library_info_by_library_name(library_name)
         if library_info is not None:
             return library_info.library_path
         if not getattr(request, "perform_discovery_if_not_found", False):
             return None
-        for entry in self._discover_library_files():
-            raw = self._read_library_json_dict(Path(entry.path))
+        candidate_paths = [Path(entry.path) for entry in self._discover_library_files()]
+        sandbox_directory = self._get_sandbox_directory()
+        if sandbox_directory is not None:
+            candidate_paths.append(sandbox_directory / self.LIBRARY_CONFIG_FILENAME)
+        for candidate in candidate_paths:
+            raw = self._read_library_json_dict(candidate)
             if raw is not None and raw.get("name") == library_name:
-                return entry.path
+                return str(candidate)
         return None
 
     def collate_problems_for_lib_info(self, lib_info: LibraryInfo) -> str | None:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -230,6 +230,7 @@ if TYPE_CHECKING:
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
     from griptape_nodes.retained_mode.events.base_events import Payload, RequestPayload, ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.permission_manager import PermissionManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
 
 logger = logging.getLogger("griptape_nodes")
@@ -265,6 +266,51 @@ class LibraryUpdateResult(NamedTuple):
     old_version: str
     new_version: str
     result: ResultPayload
+
+
+def _enrich_register_library_request(request: Any) -> dict[str, Any]:
+    """Publish parsed library metadata as a fact for permission rule evaluation.
+
+    Reads the library JSON if `request.file_path` is set and exposes:
+
+    * ``request.metadata.name`` — library name from the JSON.
+    * ``request.metadata.declarations.lifecycle_stage`` — the stage from a
+      ``LifecycleStageLibraryProperty`` declaration if present, else None.
+    * ``request.metadata.declarations.types`` — flat list of declared
+      ``type`` strings, useful for ``in`` matchers.
+
+    Best-effort: any failure (missing file, malformed JSON, unexpected shape)
+    yields an empty contribution so the rule simply sees ``None`` for those
+    paths and matchers fall through cleanly.
+    """
+    file_path = getattr(request, "file_path", None)
+    if not file_path:
+        return {}
+    json_path = Path(file_path)
+    if json_path.is_dir():
+        # `RegisterLibraryFromFileRequest` accepts a directory containing
+        # `griptape_nodes_library.json`; resolve it to the actual JSON file.
+        json_path = json_path / "griptape_nodes_library.json"
+    try:
+        raw = json.loads(json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    metadata = raw.get("metadata")
+    declarations = metadata.get("declarations") if isinstance(metadata, dict) else None
+    if not isinstance(declarations, list):
+        declarations = []
+    declaration_types = [d.get("type") for d in declarations if isinstance(d, dict) and d.get("type")]
+    lifecycle_stage = next(
+        (d.get("stage") for d in declarations if isinstance(d, dict) and d.get("type") == "lifecycle_stage"),
+        None,
+    )
+    return {
+        "metadata.name": raw.get("name"),
+        "metadata.declarations.types": declaration_types,
+        "metadata.declarations.lifecycle_stage": lifecycle_stage,
+    }
 
 
 class LibraryManager:
@@ -374,7 +420,13 @@ class LibraryManager:
     # Callbacks invoked immediately before all libraries are reloaded.
     _pre_reload_callbacks: list[Callable[[], Awaitable[None]]]
 
-    def __init__(self, event_manager: EventManager, *, worker_manager: WorkerManager) -> None:
+    def __init__(
+        self,
+        event_manager: EventManager,
+        *,
+        worker_manager: WorkerManager,
+        permission_manager: PermissionManager | None = None,
+    ) -> None:
         self._library_file_path_to_info = {}
         self._dynamic_to_stable_module_mapping = {}
         self._stable_to_dynamic_module_mapping = {}
@@ -451,6 +503,16 @@ class LibraryManager:
         )
         event_manager.assign_manager_to_request_type(SyncLibrariesRequest, self.sync_libraries_request)
         event_manager.assign_manager_to_request_type(InspectLibraryRepoRequest, self.inspect_library_repo_request)
+
+        # Publish parsed library metadata as a per-request fact so permission
+        # rules can match against authored declarations (e.g. lifecycle stage)
+        # without LibraryManager having to know anything about permissions.
+        # Optional dependency: headless tooling can pass None and skip it.
+        if permission_manager is not None:
+            permission_manager.facts.register_request_enricher(
+                RegisterLibraryFromFileRequest.__name__,
+                _enrich_register_library_request,
+            )
 
         event_manager.add_listener_to_app_event(
             LibraryLoadedNotification,
@@ -2793,7 +2855,10 @@ class LibraryManager:
 
     async def _load_and_track_library(self, lib_path: str, index: int, total: int) -> None:
         """Load a single library and emit the corresponding progress event."""
-        load_result = await self.register_library_from_file_request(
+        # Route through the dispatcher so pre-dispatch hooks (PermissionManager,
+        # audit, retained-mode echo) see the request. Calling the handler
+        # method directly would bypass them.
+        load_result = await GriptapeNodes.ahandle_request(
             RegisterLibraryFromFileRequest(
                 file_path=lib_path,
                 load_as_default_library=False,
@@ -4093,7 +4158,10 @@ class LibraryManager:
         total_libraries = len(libraries_to_load)
 
         for current_library_index, lib_path in enumerate(libraries_to_load, start=1):
-            load_result = await self.register_library_from_file_request(
+            # Route through the dispatcher so pre-dispatch hooks (PermissionManager,
+            # audit, retained-mode echo) see the request. Calling the handler
+            # method directly would bypass them.
+            load_result = await GriptapeNodes.ahandle_request(
                 RegisterLibraryFromFileRequest(
                     file_path=lib_path,
                     load_as_default_library=False,

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -74,6 +74,12 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     GetParameterValueRequest,
     SetParameterValueRequest,
 )
+from griptape_nodes.retained_mode.events.permission_events import (
+    GetEffectivePolicyRequest,
+    GrantPermissionRuleRequest,
+    ListPermissionDecisionsRequest,
+    RevokePermissionRuleRequest,
+)
 from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowsRequest,
     RunWorkflowWithCurrentStateRequest,
@@ -130,6 +136,21 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "SetParameterValueRequest": SetParameterValueRequest,
     "GetParameterDetailsRequest": GetParameterDetailsRequest,
     "GetConnectionsForParameterRequest": GetConnectionsForParameterRequest,
+    # Permissions
+    #
+    # These manage the engine's permission policy. They bypass the policy hook
+    # itself by design (so a too-restrictive policy can always be repaired),
+    # which means an MCP client connected here can read and edit the *user*
+    # policy. License-imposed rules are NOT mutable through this surface;
+    # they're owned by `PermissionManager.set_license_policy()` and are not
+    # exposed to MCP at all.
+    #
+    # If you expose this MCP server to untrusted clients, gate these tools at
+    # the transport layer or place equivalent constraints in the license layer.
+    "GetEffectivePolicyRequest": GetEffectivePolicyRequest,
+    "GrantPermissionRuleRequest": GrantPermissionRuleRequest,
+    "RevokePermissionRuleRequest": RevokePermissionRuleRequest,
+    "ListPermissionDecisionsRequest": ListPermissionDecisionsRequest,
 }
 
 # Synthetic MCP tool name for the batch envelope. Not a request payload (and so not a member of

--- a/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
@@ -204,6 +204,43 @@ class TestLibraryDeclarationsEnricher:
         assert not result.succeeded()
         assert "user.deny-labs-libraries" in str(result.result_details)
 
+    def test_library_name_registration_is_gated(self, permission_env: dict) -> None:
+        """A by-name registration is gated by the same declaration rules as a by-path one."""
+        json_path = _write_library_json(
+            permission_env["tmp"] / "named-labs-lib",
+            name="My Named Labs Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "LABS"}],
+        )
+        # Register by path first (no rule active yet) so the LibraryManager
+        # tracks the library and can later resolve it by name.
+        GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(json_path)))
+        assert (
+            permission_env["gn"].LibraryManager().get_library_info_by_library_name("My Named Labs Library") is not None
+        ), "expected the by-path registration to track the library so it is addressable by name"
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "reason": "labs-stage libraries are not permitted",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        # The by-name path must resolve to the tracked JSON and be denied; if the
+        # enricher returned no facts for the name, the deny would not fire.
+        result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(library_name="My Named Labs Library"))
+        assert not result.succeeded()
+        assert "user.deny-labs-libraries" in str(result.result_details)
+
     def test_malformed_library_json_falls_through_cleanly(self, permission_env: dict) -> None:
         """A library file with broken JSON yields empty facts, not a crash."""
         broken = permission_env["tmp"] / "broken-lib"

--- a/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
@@ -20,6 +20,7 @@ import griptape_nodes.retained_mode.managers.config_manager as config_manager_mo
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.permission_events import GrantPermissionRuleRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
 from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
@@ -238,6 +239,48 @@ class TestLibraryDeclarationsEnricher:
         # The by-name path must resolve to the tracked JSON and be denied; if the
         # enricher returned no facts for the name, the deny would not fire.
         result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(library_name="My Named Labs Library"))
+        assert not result.succeeded()
+        assert "user.deny-labs-libraries" in str(result.result_details)
+
+    def test_discoverable_by_name_registration_is_gated(self, permission_env: dict) -> None:
+        """An untracked-but-discoverable library registered by name is gated when discovery is allowed."""
+        json_path = _write_library_json(
+            permission_env["tmp"] / "discoverable-labs-lib",
+            name="Discoverable Labs Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "LABS"}],
+        )
+        # Make the library discoverable via config without pre-tracking it,
+        # mirroring a search path added after startup. The name is unknown to the
+        # manager until the handler runs discovery, which happens after the gate.
+        permission_env["gn"].ConfigManager().set_config_value(LIBRARIES_TO_REGISTER_KEY, [str(json_path)])
+        assert (
+            permission_env["gn"].LibraryManager().get_library_info_by_library_name("Discoverable Labs Library") is None
+        ), "library must be untracked at gate-evaluation time for this test to be meaningful"
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "reason": "labs-stage libraries are not permitted",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        # The gate must resolve the untracked name via a read-only discovery scan
+        # and deny before the handler ever discovers and loads the library.
+        result = GriptapeNodes.handle_request(
+            RegisterLibraryFromFileRequest(
+                library_name="Discoverable Labs Library", perform_discovery_if_not_found=True
+            )
+        )
         assert not result.succeeded()
         assert "user.deny-labs-libraries" in str(result.result_details)
 

--- a/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
@@ -284,6 +284,44 @@ class TestLibraryDeclarationsEnricher:
         assert not result.succeeded()
         assert "user.deny-labs-libraries" in str(result.result_details)
 
+    def test_discoverable_sandbox_by_name_registration_is_gated(self, permission_env: dict) -> None:
+        """An untracked sandbox library registered by name is gated via the read-only sandbox scan."""
+        sandbox_dir = permission_env["tmp"] / "sandbox"
+        _write_library_json(
+            sandbox_dir,
+            name="Sandbox Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "LABS"}],
+        )
+        # The handler discovers the sandbox library (`include_sandbox=True`); the
+        # gate must mirror that without the library being pre-tracked.
+        permission_env["gn"].ConfigManager().set_config_value("sandbox_library_directory", str(sandbox_dir))
+        assert permission_env["gn"].LibraryManager().get_library_info_by_library_name("Sandbox Library") is None, (
+            "sandbox library must be untracked at gate-evaluation time for this test to be meaningful"
+        )
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "reason": "labs-stage libraries are not permitted",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        result = GriptapeNodes.handle_request(
+            RegisterLibraryFromFileRequest(library_name="Sandbox Library", perform_discovery_if_not_found=True)
+        )
+        assert not result.succeeded()
+        assert "user.deny-labs-libraries" in str(result.result_details)
+
     def test_malformed_library_json_falls_through_cleanly(self, permission_env: dict) -> None:
         """A library file with broken JSON yields empty facts, not a crash."""
         broken = permission_env["tmp"] / "broken-lib"

--- a/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
+++ b/tests/integration/retained_mode/permissions/test_library_declarations_enricher_e2e.py
@@ -1,0 +1,242 @@
+"""End-to-end test for the LibraryManager-published declarations fact.
+
+`LibraryManager` registers a request enricher that parses the library JSON
+referenced by a `RegisterLibraryFromFileRequest` and exposes its declarations
+under `request.metadata.declarations.*`. This test verifies that policies can
+match against authored library declarations without any test-side stub.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.permission_events import GrantPermissionRuleRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.utils.metaclasses import SingletonMeta
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def permission_env() -> Generator[dict, None, None]:
+    """Bring up an isolated GriptapeNodes singleton with a clean permissions config."""
+    SingletonMeta._instances.clear()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        config_path = tmp_path / "griptape_nodes_config.json"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "workspace_directory": str(workspace),
+                    "permissions": {
+                        "enabled": True,
+                        "policy": {"rules": [], "default_decision": "allow"},
+                    },
+                }
+            )
+        )
+        with patch.object(config_manager_module, "USER_CONFIG_PATH", config_path):
+            gn = GriptapeNodes()
+            yield {"gn": gn, "tmp": tmp_path}
+        SingletonMeta._instances.clear()
+
+
+def _write_library_json(directory: Path, *, name: str, declarations: list[dict]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    json_path = directory / "griptape_nodes_library.json"
+    json_path.write_text(
+        json.dumps(
+            {
+                "name": name,
+                "library_schema_version": "0.8.0",
+                "metadata": {
+                    "author": "test",
+                    "description": "test",
+                    "library_version": "0.0.1",
+                    "engine_version": "0.85.0",
+                    "tags": [],
+                    "declarations": declarations,
+                },
+                "categories": [],
+                "nodes": [],
+            }
+        )
+    )
+    return json_path
+
+
+def _grant(rule: dict) -> None:
+    GriptapeNodes.handle_request(GrantPermissionRuleRequest(rule=rule))
+
+
+class TestLibraryDeclarationsEnricher:
+    def test_labs_stage_blocks_registration(self, permission_env: dict) -> None:
+        """A library declaring lifecycle_stage = LABS is blocked by a labs-deny rule."""
+        json_path = _write_library_json(
+            permission_env["tmp"] / "labs-lib",
+            name="My Labs Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "LABS"}],
+        )
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "reason": "labs-stage libraries are not permitted",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(json_path)))
+        assert not result.succeeded()
+        assert "user.deny-labs-libraries" in str(result.result_details)
+
+    def test_stable_stage_passes_permission_gate(self, permission_env: dict) -> None:
+        """A library declaring lifecycle_stage = STABLE is not blocked by the labs-deny rule."""
+        json_path = _write_library_json(
+            permission_env["tmp"] / "stable-lib",
+            name="My Stable Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "STABLE"}],
+        )
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        # The library will fail to *load* (no real nodes in the fixture), but the
+        # permission gate must let the request through. Audit-log inspection
+        # tells us cleanly whether perms allowed or denied.
+        GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(json_path)))
+        decisions = [
+            d
+            for d in permission_env["gn"].PermissionManager().list_recent_decisions()
+            if d["action_request_type"] == "RegisterLibraryFromFileRequest"
+        ]
+        assert decisions, "expected at least one decision for the register request"
+        assert decisions[-1]["rule_id"] != "user.deny-labs-libraries"
+
+    def test_block_by_declaration_type_via_in_operator(self, permission_env: dict) -> None:
+        """`in` matcher works against the flattened declaration-types list."""
+        json_path = _write_library_json(
+            permission_env["tmp"] / "labs-lib2",
+            name="My Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "BETA"}],
+        )
+        _grant(
+            {
+                "id": "user.deny-libs-with-lifecycle-decl",
+                "decision": "deny",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.types": {
+                                "op": "in",
+                                "values": ["lifecycle_stage"],
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(json_path)))
+        assert not result.succeeded()
+        assert "user.deny-libs-with-lifecycle-decl" in str(result.result_details)
+
+    def test_directory_path_resolves_to_library_json(self, permission_env: dict) -> None:
+        """The enricher accepts a directory containing griptape_nodes_library.json."""
+        lib_dir = permission_env["tmp"] / "dir-lib"
+        _write_library_json(
+            lib_dir,
+            name="Dir Library",
+            declarations=[{"type": "lifecycle_stage", "stage": "LABS"}],
+        )
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        # Pass the directory, not the JSON path. The enricher resolves it.
+        result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(lib_dir)))
+        assert not result.succeeded()
+        assert "user.deny-labs-libraries" in str(result.result_details)
+
+    def test_malformed_library_json_falls_through_cleanly(self, permission_env: dict) -> None:
+        """A library file with broken JSON yields empty facts, not a crash."""
+        broken = permission_env["tmp"] / "broken-lib"
+        broken.mkdir()
+        (broken / "griptape_nodes_library.json").write_text("{this is not valid json")
+        _grant(
+            {
+                "id": "user.deny-labs-libraries",
+                "decision": "deny",
+                "when": {
+                    "action": {"request_type": {"op": "equals", "value": "RegisterLibraryFromFileRequest"}},
+                    "context": {
+                        "facts": {
+                            "request.metadata.declarations.lifecycle_stage": {
+                                "op": "equals",
+                                "value": "LABS",
+                            }
+                        }
+                    },
+                },
+            }
+        )
+        # The labs-deny rule must NOT match because the enricher gracefully
+        # returned no facts; permission evaluation falls through to the policy
+        # default. The request will fail downstream during actual loading,
+        # but not because of the labs rule.
+        GriptapeNodes.handle_request(
+            RegisterLibraryFromFileRequest(file_path=str(broken / "griptape_nodes_library.json"))
+        )
+        decisions = [
+            d
+            for d in permission_env["gn"].PermissionManager().list_recent_decisions()
+            if d["action_request_type"] == "RegisterLibraryFromFileRequest"
+        ]
+        assert decisions, "expected at least one decision"
+        assert decisions[-1]["rule_id"] != "user.deny-labs-libraries"

--- a/tests/integration/retained_mode/permissions/test_mcp_exposure.py
+++ b/tests/integration/retained_mode/permissions/test_mcp_exposure.py
@@ -1,0 +1,116 @@
+"""Verify the permission-management request types are exposed as MCP tools.
+
+The MCP server uses an explicit allowlist (`SUPPORTED_REQUEST_EVENTS`). These
+tests pin the contract: every permission-management request type appears in
+the allowlist and round-trips correctly through the same construction path
+the MCP server uses (`SUPPORTED_REQUEST_EVENTS[name](**arguments)`).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+from griptape_nodes.retained_mode.events.permission_events import (
+    GetEffectivePolicyRequest,
+    GetEffectivePolicyResultSuccess,
+    GrantPermissionRuleRequest,
+    GrantPermissionRuleResultSuccess,
+    ListPermissionDecisionsRequest,
+    ListPermissionDecisionsResultSuccess,
+    RevokePermissionRuleRequest,
+    RevokePermissionRuleResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.servers.mcp import SUPPORTED_REQUEST_EVENTS
+from griptape_nodes.utils.metaclasses import SingletonMeta
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def permission_env() -> Generator[dict, None, None]:
+    """Bring up an isolated GriptapeNodes singleton for round-trip tests."""
+    SingletonMeta._instances.clear()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        config_path = tmp_path / "griptape_nodes_config.json"
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        config_path.write_text(
+            json.dumps(
+                {
+                    "workspace_directory": str(workspace),
+                    "permissions": {"enabled": True, "policy": {"rules": []}},
+                }
+            )
+        )
+        with patch.object(config_manager_module, "USER_CONFIG_PATH", config_path):
+            GriptapeNodes()
+            yield {}
+        SingletonMeta._instances.clear()
+
+
+class TestPermissionToolsExposed:
+    """All four permission-management request types appear in the MCP allowlist."""
+
+    def test_grant_permission_rule_request_is_exposed(self) -> None:
+        assert SUPPORTED_REQUEST_EVENTS["GrantPermissionRuleRequest"] is GrantPermissionRuleRequest
+
+    def test_revoke_permission_rule_request_is_exposed(self) -> None:
+        assert SUPPORTED_REQUEST_EVENTS["RevokePermissionRuleRequest"] is RevokePermissionRuleRequest
+
+    def test_get_effective_policy_request_is_exposed(self) -> None:
+        assert SUPPORTED_REQUEST_EVENTS["GetEffectivePolicyRequest"] is GetEffectivePolicyRequest
+
+    def test_list_permission_decisions_request_is_exposed(self) -> None:
+        assert SUPPORTED_REQUEST_EVENTS["ListPermissionDecisionsRequest"] is ListPermissionDecisionsRequest
+
+
+class TestPermissionToolsRoundTrip:
+    """Each tool, called the way the MCP server calls it, produces a working result.
+
+    This mirrors `mcp.py:call_tool`: look up the class, construct from a dict of
+    arguments, dispatch through `GriptapeNodes.handle_request`. If the construction
+    or dispatch shape changes, these tests fail before users hit it.
+    """
+
+    def test_grant_then_get_effective_policy(self, permission_env: dict) -> None:  # noqa: ARG002
+        # Arguments shape mirrors what an MCP client would send.
+        grant_args = {
+            "rule": {
+                "id": "mcp.grant-test",
+                "decision": "allow",
+                "when": {"action": {"request_type": {"op": "equals", "value": "WriteFileRequest"}}},
+            }
+        }
+        grant_cls = SUPPORTED_REQUEST_EVENTS["GrantPermissionRuleRequest"]
+        grant_result = GriptapeNodes.handle_request(grant_cls(**grant_args))
+        assert isinstance(grant_result, GrantPermissionRuleResultSuccess)
+        assert grant_result.rule_id == "mcp.grant-test"
+
+        # GetEffectivePolicy also goes through the allowlist.
+        get_cls = SUPPORTED_REQUEST_EVENTS["GetEffectivePolicyRequest"]
+        get_result = GriptapeNodes.handle_request(get_cls())
+        assert isinstance(get_result, GetEffectivePolicyResultSuccess)
+        rule_ids = [r["id"] for r in get_result.policy["rules"]]
+        assert "mcp.grant-test" in rule_ids
+
+    def test_list_decisions(self, permission_env: dict) -> None:  # noqa: ARG002
+        list_cls = SUPPORTED_REQUEST_EVENTS["ListPermissionDecisionsRequest"]
+        result = GriptapeNodes.handle_request(list_cls(limit=5))
+        assert isinstance(result, ListPermissionDecisionsResultSuccess)
+
+    def test_revoke(self, permission_env: dict) -> None:  # noqa: ARG002
+        grant_cls = SUPPORTED_REQUEST_EVENTS["GrantPermissionRuleRequest"]
+        GriptapeNodes.handle_request(grant_cls(rule={"id": "mcp.revoke-target", "decision": "allow"}))
+        revoke_cls = SUPPORTED_REQUEST_EVENTS["RevokePermissionRuleRequest"]
+        revoke_result = GriptapeNodes.handle_request(revoke_cls(rule_id="mcp.revoke-target"))
+        assert isinstance(revoke_result, RevokePermissionRuleResultSuccess)


### PR DESCRIPTION
### 📚 Permission Manager stack

Four stacked PRs split by layer. Review and merge bottom-up, starting at the base (#4713). Each PR targets the branch of the PR above it, so its diff shows only that layer.

| Order | PR | Layer | Base |
| --- | --- | --- | --- |
| 1 | #4713 | Pre-dispatch hook chain in `EventManager` | `main` |
| 2 | #4714 | Policy schema, matcher engine, fact registry | #4713 |
| 3 | #4715 | `PermissionManager` enforcement | #4714 |
| **4** | **#4716 👈 you are here** | **Integrations: `LibraryManager`, MCP server, docs** | #4715 |

---

Final slice of the permission-manager stack. Integrates the permission system with `LibraryManager` and the MCP server, and adds operator-facing documentation plus the `griptape-nodes-permissions` skill.

The library enricher gates by-name registration so a request that names a library it is not allowed to touch is denied before the library loads. This covers the standard, discoverable, and sandbox registration paths.

**Previous:** #4715 (enforcement). This is the top of the stack.
