### PR TITLE
feat: add pre-dispatch hook chain to EventManager

### DIFF
--- a/src/griptape_nodes/retained_mode/events/generic_events.py
+++ b/src/griptape_nodes/retained_mode/events/generic_events.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.events.base_events import (
+    ResultPayloadFailure,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+@dataclass
+@PayloadRegistry.register
+class GenericResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Failure result not tied to a specific request type.
+
+    Returned when the dispatcher must fail a request before (or instead of) its
+    manager callback runs, so there is no request-specific failure type to use --
+    for example when a pre-dispatch hook raises. Unlike the abstract
+    ``ResultPayloadFailure`` base, this is concrete and registered, so it
+    round-trips through ``PayloadRegistry`` on the worker-forward path instead of
+    raising "result_type is not registered".
+    """

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -27,10 +27,10 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultDetails,
     ResultPayload,
-    ResultPayloadFailure,
     StrictModeViolationDetail,
 )
 from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.generic_events import GenericResultFailure
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.utils.async_utils import call_function
 
@@ -301,7 +301,7 @@ class EventManager:
                         f"'{getattr(hook, '__name__', hook)}' raised {type(exc).__name__}: {exc}"
                     )
                     logging.getLogger("griptape_nodes").exception(msg)
-                    return ResultPayloadFailure(exception=exc, result_details=msg)
+                    return GenericResultFailure(exception=exc, result_details=msg)
                 if short_circuit is not None:
                     return short_circuit
             return None

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -67,6 +67,15 @@ def current_request_type() -> type[RequestPayload] | None:
 RESULT_TYPES_THAT_SKIP_FLUSH = {}
 
 
+class PreDispatchHookError(RuntimeError):
+    """Raised when a pre-dispatch hook errors.
+
+    The hook chain is an enforcement boundary, so a hook that raises denies the
+    request (fail closed) rather than letting it fall through to its manager
+    callback.
+    """
+
+
 def _running_loop() -> asyncio.AbstractEventLoop | None:
     """Return the currently running event loop, or None if not inside one."""
     try:
@@ -111,10 +120,17 @@ class EventManager:
         self._node_execution_depth: int = 0
         self._node_execution_lock = threading.Lock()
         # Pre-dispatch hook chain consulted before every request callback. Each
-        # hook returns either None (fall through to the next) or a ResultPayload
-        # to short-circuit the dispatcher. Used by PermissionManager to enforce
-        # policy without instrumenting every manager.
+        # hook returns None (fall through) or a ResultPayload (short-circuit the
+        # dispatcher). Lets PermissionManager enforce policy without instrumenting
+        # every manager.
         self._pre_dispatch_hooks: list[Callable[[RequestPayload, ResultContext], ResultPayload | None]] = []
+        # handle_request runs on arbitrary threads, so guard the list and snapshot
+        # it before iteration.
+        self._pre_dispatch_hooks_lock = threading.Lock()
+        # Thread-local flag: if a hook re-enters handle_request on this thread, the
+        # chain is skipped so the hook can't keep re-triggering itself into
+        # unbounded recursion.
+        self._hook_evaluation = threading.local()
 
     @property
     def event_queue(self) -> asyncio.Queue:
@@ -238,38 +254,65 @@ class EventManager:
         Returning a ResultPayload short-circuits the dispatcher with that result;
         returning None lets dispatch continue.
 
-        Hooks must be cheap, sync, and must not themselves issue requests through
-        `handle_request` -- doing so risks unbounded recursion. Subscribe to
-        AppPayload events for state instead.
+        Hooks should be cheap and sync. A hook that re-enters `handle_request`
+        (directly or transitively) is bypassed on the re-entrant call rather
+        than recursing, but subscribing to AppPayload events for state is still
+        preferred. Registering the same hook twice is a no-op.
         """
-        self._pre_dispatch_hooks.append(hook)
+        with self._pre_dispatch_hooks_lock:
+            if hook not in self._pre_dispatch_hooks:
+                self._pre_dispatch_hooks.append(hook)
 
     def remove_pre_dispatch_hook(
         self,
         hook: Callable[[RequestPayload, ResultContext], ResultPayload | None],
     ) -> None:
-        try:
-            self._pre_dispatch_hooks.remove(hook)
-        except ValueError:
-            return
+        with self._pre_dispatch_hooks_lock:
+            try:
+                self._pre_dispatch_hooks.remove(hook)
+            except ValueError:
+                return
 
     def _run_pre_dispatch_hooks(
         self,
         request: RequestPayload,
         context: ResultContext,
     ) -> ResultPayload | None:
-        for hook in self._pre_dispatch_hooks:
-            try:
-                short_circuit = hook(request, context)
-            except Exception:
-                logging.getLogger("griptape_nodes").exception(
-                    "Pre-dispatch hook raised while evaluating %s; treating as no-op.",
-                    type(request).__name__,
-                )
-                continue
-            if short_circuit is not None:
-                return short_circuit
-        return None
+        # Bypass the chain when a hook is already running on this thread. A hook
+        # that re-enters handle_request would otherwise re-trigger itself and
+        # recurse without bound.
+        if getattr(self._hook_evaluation, "active", False):
+            return None
+
+        # Snapshot under the lock so concurrent add/remove on another thread
+        # cannot mutate the list mid-iteration.
+        with self._pre_dispatch_hooks_lock:
+            hooks = list(self._pre_dispatch_hooks)
+
+        if not hooks:
+            return None
+
+        self._hook_evaluation.active = True
+        try:
+            for hook in hooks:
+                try:
+                    short_circuit = hook(request, context)
+                except Exception as exc:
+                    # Fail closed: the chain is an enforcement boundary, so a
+                    # hook that errors must deny the request rather than let it
+                    # fall through to its manager callback.
+                    msg = (
+                        f"Attempted to evaluate pre-dispatch hooks for request "
+                        f"'{type(request).__name__}'. Failed because hook "
+                        f"'{getattr(hook, '__name__', hook)}' raised {type(exc).__name__}: {exc}"
+                    )
+                    logging.getLogger("griptape_nodes").exception(msg)
+                    raise PreDispatchHookError(msg) from exc
+                if short_circuit is not None:
+                    return short_circuit
+            return None
+        finally:
+            self._hook_evaluation.active = False
 
     def assign_manager_to_request_type(
         self,

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -110,6 +110,11 @@ class EventManager:
         # library-internal ThreadPoolExecutors ran node-emitted requests.
         self._node_execution_depth: int = 0
         self._node_execution_lock = threading.Lock()
+        # Pre-dispatch hook chain consulted before every request callback. Each
+        # hook returns either None (fall through to the next) or a ResultPayload
+        # to short-circuit the dispatcher. Used by PermissionManager to enforce
+        # policy without instrumenting every manager.
+        self._pre_dispatch_hooks: list[Callable[[RequestPayload, ResultContext], ResultPayload | None]] = []
 
     @property
     def event_queue(self) -> asyncio.Queue:
@@ -222,6 +227,49 @@ class EventManager:
         else:
             # We're on the same thread as the event loop or no loop thread tracked, use async method
             await self._event_queue.put(event)
+
+    def add_pre_dispatch_hook(
+        self,
+        hook: Callable[[RequestPayload, ResultContext], ResultPayload | None],
+    ) -> None:
+        """Register a pre-dispatch hook.
+
+        Hooks run in registration order before the request's manager callback.
+        Returning a ResultPayload short-circuits the dispatcher with that result;
+        returning None lets dispatch continue.
+
+        Hooks must be cheap, sync, and must not themselves issue requests through
+        `handle_request` -- doing so risks unbounded recursion. Subscribe to
+        AppPayload events for state instead.
+        """
+        self._pre_dispatch_hooks.append(hook)
+
+    def remove_pre_dispatch_hook(
+        self,
+        hook: Callable[[RequestPayload, ResultContext], ResultPayload | None],
+    ) -> None:
+        try:
+            self._pre_dispatch_hooks.remove(hook)
+        except ValueError:
+            return
+
+    def _run_pre_dispatch_hooks(
+        self,
+        request: RequestPayload,
+        context: ResultContext,
+    ) -> ResultPayload | None:
+        for hook in self._pre_dispatch_hooks:
+            try:
+                short_circuit = hook(request, context)
+            except Exception:
+                logging.getLogger("griptape_nodes").exception(
+                    "Pre-dispatch hook raised while evaluating %s; treating as no-op.",
+                    type(request).__name__,
+                )
+                continue
+            if short_circuit is not None:
+                return short_circuit
+        return None
 
     def assign_manager_to_request_type(
         self,
@@ -514,6 +562,16 @@ class EventManager:
             msg = f"No manager found to handle request of type '{request_type.__name__}'."
             raise TypeError(msg)
 
+        # Pre-dispatch hooks (e.g. PermissionManager) may short-circuit before
+        # the manager callback runs.
+        short_circuit = self._run_pre_dispatch_hooks(request, result_context)
+        if short_circuit is not None:
+            return self._handle_request_core(
+                request,
+                short_circuit,
+                context=result_context,
+            )
+
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
@@ -533,7 +591,7 @@ class EventManager:
         finally:
             _active_request_type.reset(token)
 
-    def handle_request(
+    def handle_request(  # noqa: PLR0912
         self,
         request: RP,
         *,
@@ -559,6 +617,16 @@ class EventManager:
         if not callback:
             msg = f"No manager found to handle request of type '{request_type.__name__}'."
             raise TypeError(msg)
+
+        # Pre-dispatch hooks (e.g. PermissionManager) may short-circuit before
+        # the manager callback runs.
+        short_circuit = self._run_pre_dispatch_hooks(request, result_context)
+        if short_circuit is not None:
+            return self._handle_request_core(
+                request,
+                short_circuit,
+                context=result_context,
+            )
 
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -27,6 +27,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultDetails,
     ResultPayload,
+    ResultPayloadFailure,
     StrictModeViolationDetail,
 )
 from griptape_nodes.retained_mode.events.event_converter import converter
@@ -65,15 +66,6 @@ def current_request_type() -> type[RequestPayload] | None:
 # Add result types to this set if they should never trigger a flush (typically because they ARE
 # the flush operation itself, or other internal operations that don't modify workflow state).
 RESULT_TYPES_THAT_SKIP_FLUSH = {}
-
-
-class PreDispatchHookError(RuntimeError):
-    """Raised when a pre-dispatch hook errors.
-
-    The hook chain is an enforcement boundary, so a hook that raises denies the
-    request (fail closed) rather than letting it fall through to its manager
-    callback.
-    """
 
 
 def _running_loop() -> asyncio.AbstractEventLoop | None:
@@ -299,15 +291,17 @@ class EventManager:
                     short_circuit = hook(request, context)
                 except Exception as exc:
                     # Fail closed: the chain is an enforcement boundary, so a
-                    # hook that errors must deny the request rather than let it
-                    # fall through to its manager callback.
+                    # hook that errors denies the request. Return a failure
+                    # result rather than raising, so the dispatcher still
+                    # delivers an EventResultFailure to the caller instead of
+                    # leaving its response future to hang.
                     msg = (
                         f"Attempted to evaluate pre-dispatch hooks for request "
                         f"'{type(request).__name__}'. Failed because hook "
                         f"'{getattr(hook, '__name__', hook)}' raised {type(exc).__name__}: {exc}"
                     )
                     logging.getLogger("griptape_nodes").exception(msg)
-                    raise PreDispatchHookError(msg) from exc
+                    return ResultPayloadFailure(exception=exc, result_details=msg)
                 if short_circuit is not None:
                     return short_circuit
             return None

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -19,7 +19,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     ResultPayloadSuccess,
     StrictModeViolationDetail,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager, PreDispatchHookError
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 
 class TestEventManagerBroadcasting:
@@ -509,10 +509,10 @@ class TestPreDispatchHooks:
 
         event_manager.add_pre_dispatch_hook(hook)
 
-        with pytest.raises(PreDispatchHookError):
-            event_manager.handle_request(_ProbeRequest())
+        event = event_manager.handle_request(_ProbeRequest())
 
-        # Fail closed: the manager callback must never run when a hook errors.
+        # Fail closed: deny with a failure result, and never run the callback.
+        assert event.result.failed()
         assert handler_calls == []
 
     def test_reentrant_hook_is_bypassed_not_recursive(self) -> None:
@@ -544,7 +544,7 @@ class TestPreDispatchHooks:
         # Handler ran for both the re-entrant and the outer dispatch.
         assert len(handler_calls) == 2  # noqa: PLR2004
 
-    def test_hook_evaluation_flag_reset_after_raise(self) -> None:
+    def test_hook_error_does_not_wedge_later_dispatch(self) -> None:
         event_manager = EventManager()
 
         def handler(_request: _ProbeRequest) -> _ProbeResult:
@@ -562,13 +562,14 @@ class TestPreDispatchHooks:
 
         event_manager.add_pre_dispatch_hook(hook)
 
-        with pytest.raises(PreDispatchHookError):
-            event_manager.handle_request(_ProbeRequest())
+        # First dispatch is denied by the erroring hook...
+        first = event_manager.handle_request(_ProbeRequest())
+        assert first.result.failed()
 
-        # The thread-local guard must be cleared on the raising path so later
-        # dispatches still evaluate the chain.
-        event = event_manager.handle_request(_ProbeRequest())
-        assert event.result.succeeded()
+        # ...and the thread-local guard is cleared, so the next dispatch still
+        # evaluates the chain and succeeds.
+        second = event_manager.handle_request(_ProbeRequest())
+        assert second.result.succeeded()
         assert len(calls) == 2  # noqa: PLR2004
 
     def test_add_pre_dispatch_hook_dedupes(self) -> None:

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -19,6 +19,8 @@ from griptape_nodes.retained_mode.events.base_events import (
     ResultPayloadSuccess,
     StrictModeViolationDetail,
 )
+from griptape_nodes.retained_mode.events.generic_events import GenericResultFailure
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 
@@ -514,6 +516,10 @@ class TestPreDispatchHooks:
         # Fail closed: deny with a failure result, and never run the callback.
         assert event.result.failed()
         assert handler_calls == []
+        # The denial must use a concrete, registered failure type so it can
+        # round-trip on the worker-forward path (PayloadRegistry.get_type).
+        assert isinstance(event.result, GenericResultFailure)
+        assert PayloadRegistry.get_type(type(event.result).__name__) is GenericResultFailure
 
     def test_reentrant_hook_is_bypassed_not_recursive(self) -> None:
         event_manager = EventManager()

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -15,10 +15,11 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultDetail,
     ResultDetails,
+    ResultPayloadFailure,
     ResultPayloadSuccess,
     StrictModeViolationDetail,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager
+from griptape_nodes.retained_mode.managers.event_manager import EventManager, PreDispatchHookError
 
 
 class TestEventManagerBroadcasting:
@@ -412,3 +413,230 @@ class TestLogResultDetailsSkipsStrictModeViolations:
         messages = [r.message for r in caplog.records]
         assert ordinary.message in messages
         assert violation.message not in messages
+
+
+@dataclass(kw_only=True)
+class _DeniedResult(ResultPayloadFailure):
+    """Minimal failure payload a pre-dispatch hook can use to short-circuit dispatch."""
+
+
+class TestPreDispatchHooks:
+    """Pre-dispatch hooks gate request dispatch before the manager callback runs."""
+
+    def test_hook_returning_none_falls_through_to_callback(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        hook_calls: list[RequestPayload] = []
+
+        def hook(request: RequestPayload, _context: object) -> None:
+            hook_calls.append(request)
+
+        event_manager.add_pre_dispatch_hook(hook)
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert event.result.succeeded()
+        assert len(hook_calls) == 1
+        assert len(handler_calls) == 1
+
+    def test_hook_short_circuits_before_callback(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        def hook(_request: RequestPayload, _context: object) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager.add_pre_dispatch_hook(hook)
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert event.result.failed()
+        assert "denied" in str(event.result.result_details)
+        assert handler_calls == []
+
+    def test_hooks_run_in_registration_order_and_first_result_wins(self) -> None:
+        event_manager = EventManager()
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        order: list[str] = []
+
+        def first(_request: RequestPayload, _context: object) -> _DeniedResult:
+            order.append("first")
+            return _DeniedResult(result_details="first")
+
+        def second(_request: RequestPayload, _context: object) -> _DeniedResult:
+            order.append("second")
+            return _DeniedResult(result_details="second")
+
+        event_manager.add_pre_dispatch_hook(first)
+        event_manager.add_pre_dispatch_hook(second)
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert order == ["first"]
+        assert "first" in str(event.result.result_details)
+
+    def test_hook_raising_fails_closed(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        def hook(_request: RequestPayload, _context: object) -> None:
+            msg = "boom"
+            raise ValueError(msg)
+
+        event_manager.add_pre_dispatch_hook(hook)
+
+        with pytest.raises(PreDispatchHookError):
+            event_manager.handle_request(_ProbeRequest())
+
+        # Fail closed: the manager callback must never run when a hook errors.
+        assert handler_calls == []
+
+    def test_reentrant_hook_is_bypassed_not_recursive(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        hook_calls: list[RequestPayload] = []
+
+        def hook(request: RequestPayload, _context: object) -> None:
+            hook_calls.append(request)
+            # Re-enter the dispatcher from inside a hook. The nested call must
+            # bypass the chain rather than re-trigger this hook and recurse.
+            if len(hook_calls) == 1:
+                event_manager.handle_request(_ProbeRequest())
+
+        event_manager.add_pre_dispatch_hook(hook)
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert event.result.succeeded()
+        # Hook ran only for the outer request; the re-entrant dispatch skipped it.
+        assert len(hook_calls) == 1
+        # Handler ran for both the re-entrant and the outer dispatch.
+        assert len(handler_calls) == 2  # noqa: PLR2004
+
+    def test_hook_evaluation_flag_reset_after_raise(self) -> None:
+        event_manager = EventManager()
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        calls: list[int] = []
+
+        def hook(_request: RequestPayload, _context: object) -> None:
+            calls.append(1)
+            if len(calls) == 1:
+                msg = "boom"
+                raise ValueError(msg)
+
+        event_manager.add_pre_dispatch_hook(hook)
+
+        with pytest.raises(PreDispatchHookError):
+            event_manager.handle_request(_ProbeRequest())
+
+        # The thread-local guard must be cleared on the raising path so later
+        # dispatches still evaluate the chain.
+        event = event_manager.handle_request(_ProbeRequest())
+        assert event.result.succeeded()
+        assert len(calls) == 2  # noqa: PLR2004
+
+    def test_add_pre_dispatch_hook_dedupes(self) -> None:
+        event_manager = EventManager()
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        hook_calls: list[RequestPayload] = []
+
+        def hook(request: RequestPayload, _context: object) -> None:
+            hook_calls.append(request)
+
+        event_manager.add_pre_dispatch_hook(hook)
+        event_manager.add_pre_dispatch_hook(hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(hook_calls) == 1
+
+    def test_remove_pre_dispatch_hook_stops_evaluation(self) -> None:
+        event_manager = EventManager()
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        hook_calls: list[RequestPayload] = []
+
+        def hook(request: RequestPayload, _context: object) -> None:
+            hook_calls.append(request)
+
+        event_manager.add_pre_dispatch_hook(hook)
+        event_manager.remove_pre_dispatch_hook(hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert hook_calls == []
+
+    def test_remove_unregistered_hook_is_noop(self) -> None:
+        event_manager = EventManager()
+
+        def hook(_request: RequestPayload, _context: object) -> None:
+            return None
+
+        # Removing a hook that was never registered must not raise.
+        event_manager.remove_pre_dispatch_hook(hook)
+
+    @pytest.mark.asyncio
+    async def test_async_dispatch_short_circuits_on_hook_result(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        async def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        def hook(_request: RequestPayload, _context: object) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager.add_pre_dispatch_hook(hook)
+
+        event = await event_manager.ahandle_request(_ProbeRequest())
+
+        assert event.result.failed()
+        assert handler_calls == []


### PR DESCRIPTION
Adds a pre-dispatch hook chain to `EventManager` so that requests can be blocked before reaching their callback. Griptape Nodes App will wire up a pre-dispatch hook that checks policies.