### PR TITLE
fix: specify encoding="utf-8" on all text file reads/writes to prevent cp949 UnicodeDecodeError

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -201,8 +201,8 @@ class ConfigManager:
             logger.debug("No %s config file loaded", label)
             return {}
         try:
-            return json.loads(path.read_text())
-        except json.JSONDecodeError as e:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
             logger.error("Error parsing %s config file: %s", label, e)
             return {}
 

--- a/src/griptape_nodes/retained_mode/managers/engine_identity_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/engine_identity_manager.py
@@ -245,11 +245,11 @@ class EngineIdentityManager:
 
         if engine_data_file.exists():
             try:
-                with engine_data_file.open("r") as f:
+                with engine_data_file.open("r", encoding="utf-8") as f:
                     data = json.load(f)
                     if isinstance(data, dict) and "engines" in data:
                         return EnginesStorage.model_validate(data)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 pass
 
         return EnginesStorage(engines=[], default_engine_id=None)
@@ -264,7 +264,7 @@ class EngineIdentityManager:
         engine_data_dir.mkdir(parents=True, exist_ok=True)
 
         engine_data_file = self._get_engine_data_file()
-        with engine_data_file.open("w") as f:
+        with engine_data_file.open("w", encoding="utf-8") as f:
             json.dump(engines_data.model_dump(exclude_none=True), f, indent=2)
 
         # Update in-memory copy

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -4680,7 +4680,7 @@ class LibraryManager:
             return DownloadLibraryResultFailure(result_details=details)
 
         try:
-            content = await anyio.Path(library_json_path).read_text()
+            content = await anyio.Path(library_json_path).read_text(encoding="utf-8")
             library_data = json.loads(content)
         except json.JSONDecodeError as e:
             details = f"Failed to parse griptape_nodes_library.json from downloaded library: {e}"

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -879,7 +879,7 @@ class ModelManager:
             return None
 
         try:
-            with status_file.open() as f:
+            with status_file.open(encoding="utf-8") as f:
                 data = json.load(f)
 
             # Get byte counts from status file
@@ -923,7 +923,7 @@ class ModelManager:
         statuses = []
         for status_file in status_dir.glob("*.json"):
             try:
-                with status_file.open() as f:
+                with status_file.open(encoding="utf-8") as f:
                     data = json.load(f)
 
                 model_id = data.get("model_id", "")
@@ -952,7 +952,7 @@ class ModelManager:
         unfinished_models = []
         for status_file in status_dir.glob("*.json"):
             try:
-                with status_file.open() as f:
+                with status_file.open(encoding="utf-8") as f:
                     data = json.load(f)
 
                 status = data.get("status", "")

--- a/src/griptape_nodes/retained_mode/managers/session_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/session_manager.py
@@ -245,11 +245,11 @@ class SessionManager:
 
         if session_state_file.exists():
             try:
-                with session_state_file.open("r") as f:
+                with session_state_file.open("r", encoding="utf-8") as f:
                     data = json.load(f)
                     if isinstance(data, dict) and "sessions" in data:
                         return SessionsStorage.model_validate(data)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 pass
 
         return SessionsStorage(sessions=[])
@@ -265,7 +265,7 @@ class SessionManager:
         session_state_dir.mkdir(parents=True, exist_ok=True)
 
         session_state_file = self._get_session_state_file(engine_id)
-        with session_state_file.open("w") as f:
+        with session_state_file.open("w", encoding="utf-8") as f:
             json.dump(sessions_data.model_dump(exclude_none=True), f, indent=2)
 
         # Update in-memory copy

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -1046,7 +1046,7 @@ def _extract_library_version_from_json(json_path: Path, remote_url: str) -> str:
     import json
 
     try:
-        with json_path.open() as f:
+        with json_path.open(encoding="utf-8") as f:
             library_data = json.load(f)
     except json.JSONDecodeError as e:
         msg = f"JSON decode error reading library metadata from {remote_url}: {e}"
@@ -1111,7 +1111,7 @@ def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> tuple[str, str, 
                 "*/griptape-nodes-library.json",
                 "*/*/griptape-nodes-library.json",
             ]
-            sparse_checkout_file.write_text("\n".join(patterns))
+            sparse_checkout_file.write_text("\n".join(patterns), encoding="utf-8")
 
             # Fetch with depth 1 (shallow clone)
             _run_git_command(
@@ -1142,7 +1142,7 @@ def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> tuple[str, str, 
 
             # Read the JSON data before temp directory is deleted
             try:
-                with library_json_path.open() as f:
+                with library_json_path.open(encoding="utf-8") as f:
                     library_data = json.load(f)
             except (OSError, json.JSONDecodeError) as e:
                 msg = f"Failed to read library file from {remote_url}: {e}"
@@ -1221,7 +1221,7 @@ def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> tuple[str, str, dic
 
             # Read the JSON data before temp directory is deleted
             try:
-                with library_json_path.open() as f:
+                with library_json_path.open(encoding="utf-8") as f:
                     library_data = json.load(f)
             except (OSError, json.JSONDecodeError) as e:
                 msg = f"Failed to read library file from {remote_url}: {e}"

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import tempfile
@@ -549,3 +550,28 @@ class TestConfigManagerEventEmission:
             "/path/to/enabled.json",
             {"path": "/path/to/disabled.json", "enabled": False},
         ]
+
+
+class TestConfigManagerUtf8:
+    """_load_config_from_file must read UTF-8 regardless of the platform locale."""
+
+    def test_reads_utf8_config_when_locale_is_cp949(self, tmp_path: Path) -> None:
+        config_data = {"workspace": "C:\\Users\\한국어\\griptape"}
+        config_file = tmp_path / "griptape_nodes_config.json"
+        config_file.write_text(json.dumps(config_data), encoding="utf-8")
+
+        manager = ConfigManager.__new__(ConfigManager)
+
+        with patch("locale.getpreferredencoding", return_value="cp949"):
+            result = manager._load_config_from_file(config_file, "test")
+
+        assert result == config_data
+
+    def test_returns_empty_dict_on_unicode_decode_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "griptape_nodes_config.json"
+        config_file.write_bytes(b'{"key": "\xb9\xd9"}')  # cp949-encoded bytes, not valid UTF-8
+
+        manager = ConfigManager.__new__(ConfigManager)
+        result = manager._load_config_from_file(config_file, "test")
+
+        assert result == {}

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -659,3 +659,28 @@ class TestConfigManagerEventGating:
 
         with patch.object(config_manager, "_write_user_config_delta", return_value=False):
             assert config_manager.set_config_value(key="k", value="v") is False
+
+
+class TestConfigManagerUtf8:
+    """_load_config_from_file must read UTF-8 regardless of the platform locale."""
+
+    def test_reads_utf8_config_when_locale_is_cp949(self, tmp_path: Path) -> None:
+        config_data = {"workspace": "C:\\Users\\한국어\\griptape"}
+        config_file = tmp_path / "griptape_nodes_config.json"
+        config_file.write_text(json.dumps(config_data), encoding="utf-8")
+
+        manager = ConfigManager.__new__(ConfigManager)
+
+        with patch("locale.getpreferredencoding", return_value="cp949"):
+            result = manager._load_config_from_file(config_file, "test")
+
+        assert result == config_data
+
+    def test_returns_empty_dict_on_unicode_decode_error(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "griptape_nodes_config.json"
+        config_file.write_bytes(b'{"key": "\xb9\xd9"}')  # cp949-encoded bytes, not valid UTF-8
+
+        manager = ConfigManager.__new__(ConfigManager)
+        result = manager._load_config_from_file(config_file, "test")
+
+        assert result == {}


### PR DESCRIPTION
## Summary

- Fixes #4709 — workflow execution crashes on Windows with a Korean (cp949) locale when reading UTF-8 files containing non-ASCII bytes
- Adds `encoding="utf-8"` to 13 text I/O call sites across 6 files where the platform default encoding was being inherited
- Widens 3 exception handlers (`config_manager`, `session_manager`, `engine_identity_manager`) to catch `UnicodeDecodeError` so an existing cp949-encoded state file triggers the normal "start fresh" recovery path instead of propagating
- Adds a regression test (`TestConfigManagerUtf8`) that proves `_load_config_from_file` correctly reads UTF-8 content (e.g. Korean workspace paths) and gracefully handles files that are genuinely not UTF-8

## Files changed

- `src/griptape_nodes/retained_mode/managers/config_manager.py`
- `src/griptape_nodes/retained_mode/managers/library_manager.py`
- `src/griptape_nodes/retained_mode/managers/session_manager.py`
- `src/griptape_nodes/retained_mode/managers/engine_identity_manager.py`
- `src/griptape_nodes/retained_mode/managers/model_manager.py`
- `src/griptape_nodes/utils/git_utils.py`
- `tests/unit/retained_mode/managers/test_config_manager.py`

## Test plan

- [ ] All existing unit tests pass (`uv run pytest tests/unit/retained_mode/managers/ tests/unit/utils/test_git_utils.py -q`)
- [ ] New `TestConfigManagerUtf8` tests pass
- [ ] `make check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)