### PR TITLE
fix: handle blob, serialized, and error artifacts in PublicArtifactUrlParameter

### DIFF
--- a/src/griptape_nodes/common/parameter_hydration.py
+++ b/src/griptape_nodes/common/parameter_hydration.py
@@ -35,11 +35,18 @@ def hydrate_parameter_values(values: dict[str, Any]) -> dict[str, Any]:
     element-wise so parameters like ``list[VideoUrlArtifact]`` work.
     Non-matching values pass through unchanged.
     """
-    return {name: _hydrate(value) for name, value in values.items()}
+    return {name: hydrate_value(value) for name, value in values.items()}
 
 
 # TODO: This is hacky and needs to be solved for non-griptape artifacts as well: https://github.com/griptape-ai/griptape-nodes/issues/4475
-def _hydrate(value: Any) -> Any:
+def hydrate_value(value: Any) -> Any:
+    """Reconstitute a single serialized artifact value.
+
+    Replaces a value that looks like a serialized SerializableMixin (dict with
+    a ``"type"`` key that resolves to an artifact subclass) with the
+    reconstituted object. Lists are walked element-wise. Non-matching values
+    pass through unchanged.
+    """
     if isinstance(value, dict) and "type" in value:
         try:
             return BaseArtifact.from_dict(value)
@@ -47,5 +54,5 @@ def _hydrate(value: Any) -> Any:
             logger.debug("Could not hydrate value as artifact; passing through.", exc_info=True)
             return value
     if isinstance(value, list):
-        return [_hydrate(item) for item in value]
+        return [hydrate_value(item) for item in value]
     return value

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 from pathlib import Path
 from typing import Any, ClassVar
@@ -5,10 +6,13 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
+from griptape.artifacts.blob_artifact import BlobArtifact
+from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.artifacts.image_url_artifact import ImageUrlArtifact
 from griptape.artifacts.url_artifact import UrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 
+from griptape_nodes.common.parameter_hydration import hydrate_value
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
@@ -116,8 +120,40 @@ class PublicArtifactUrlParameter:
         )
 
     def get_public_url_for_parameter(self) -> str:
-        parameter_value = self._node.get_parameter_value(self._parameter.name)
-        url = parameter_value.value if isinstance(parameter_value, UrlArtifact) else parameter_value
+        # Parameter values that crossed a JSON boundary (orchestrator <-> worker, workflow load)
+        # arrive as serialized artifact dicts; rehydrate them back into artifacts first.
+        parameter_value = hydrate_value(self._node.get_parameter_value(self._parameter.name))
+
+        # An upstream failure propagates as an ErrorArtifact. Surface the original error
+        # instead of masking it with an AttributeError further down.
+        if isinstance(parameter_value, ErrorArtifact):
+            msg = (
+                f"Attempted to generate a public URL for parameter '{self._parameter.name}' on node "
+                f"'{self._node.name}'. Failed because the upstream value is an error: {parameter_value.value}"
+            )
+            raise RuntimeError(msg)  # noqa: TRY004 the upstream failure is a runtime error, not a type error.
+
+        # Bytes-bearing artifacts (ImageArtifact, AudioArtifact, ...) are exactly what this upload
+        # path exists for: upload the raw bytes directly rather than treating them as a URL.
+        if isinstance(parameter_value, BlobArtifact):
+            return self._upload_bytes(
+                file_content=parameter_value.to_bytes(),
+                filename=self._filename_for_blob_artifact(parameter_value),
+            )
+
+        # UrlArtifact carries the URL in .value; a bare string is already a URL or path.
+        if isinstance(parameter_value, UrlArtifact):
+            url = parameter_value.value
+        elif isinstance(parameter_value, str):
+            url = parameter_value
+        else:
+            msg = (
+                f"Attempted to generate a public URL for parameter '{self._parameter.name}' on node "
+                f"'{self._node.name}'. Failed because the value is of unsupported type "
+                f"'{type(parameter_value).__name__}'. Expected a URL string, a UrlArtifact, or a "
+                f"BlobArtifact carrying bytes."
+            )
+            raise TypeError(msg)
 
         # check if the URL is already public
         if url.startswith(("http://", "https://")) and "localhost" not in url:
@@ -127,15 +163,23 @@ class PublicArtifactUrlParameter:
 
         file_contents = File(url).read_bytes()
         filename = Path(urlparse(url).path).name
-
-        self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
-
-        # upload to Griptape Cloud and get a public URL
-        public_url = self._storage_driver.upload_file(path=self.gtc_file_path, file_content=file_contents)
-
-        return public_url
+        return self._upload_bytes(file_content=file_contents, filename=filename)
 
     def delete_uploaded_artifact(self) -> None:
         if not self.gtc_file_path:
             return
         self._storage_driver.delete_file(self.gtc_file_path)
+
+    def _upload_bytes(self, *, file_content: bytes, filename: str) -> str:
+        self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
+        return self._storage_driver.upload_file(path=self.gtc_file_path, file_content=file_content)
+
+    @staticmethod
+    def _filename_for_blob_artifact(artifact: BlobArtifact) -> str:
+        # Strip any path separators the artifact name might carry so it stays a single
+        # filename segment, matching how the URL branch derives its filename.
+        name = Path(artifact.name).name
+        if Path(name).suffix:
+            return name
+        extension = mimetypes.guess_extension(artifact.mime_type) or ""
+        return f"{name}{extension}"

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,4 +1,3 @@
-import mimetypes
 import os
 from pathlib import Path
 from typing import Any, ClassVar
@@ -6,7 +5,6 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
-from griptape.artifacts.blob_artifact import BlobArtifact
 from griptape.artifacts.error_artifact import ErrorArtifact
 from griptape.artifacts.image_url_artifact import ImageUrlArtifact
 from griptape.artifacts.url_artifact import UrlArtifact
@@ -133,27 +131,7 @@ class PublicArtifactUrlParameter:
             )
             raise RuntimeError(msg)  # noqa: TRY004 the upstream failure is a runtime error, not a type error.
 
-        # Bytes-bearing artifacts (ImageArtifact, AudioArtifact, ...) are exactly what this upload
-        # path exists for: upload the raw bytes directly rather than treating them as a URL.
-        if isinstance(parameter_value, BlobArtifact):
-            return self._upload_bytes(
-                file_content=parameter_value.to_bytes(),
-                filename=self._filename_for_blob_artifact(parameter_value),
-            )
-
-        # UrlArtifact carries the URL in .value; a bare string is already a URL or path.
-        if isinstance(parameter_value, UrlArtifact):
-            url = parameter_value.value
-        elif isinstance(parameter_value, str):
-            url = parameter_value
-        else:
-            msg = (
-                f"Attempted to generate a public URL for parameter '{self._parameter.name}' on node "
-                f"'{self._node.name}'. Failed because the value is of unsupported type "
-                f"'{type(parameter_value).__name__}'. Expected a URL string, a UrlArtifact, or a "
-                f"BlobArtifact carrying bytes."
-            )
-            raise TypeError(msg)
+        url = parameter_value.value if isinstance(parameter_value, UrlArtifact) else parameter_value
 
         # check if the URL is already public
         if url.startswith(("http://", "https://")) and "localhost" not in url:
@@ -163,23 +141,15 @@ class PublicArtifactUrlParameter:
 
         file_contents = File(url).read_bytes()
         filename = Path(urlparse(url).path).name
-        return self._upload_bytes(file_content=file_contents, filename=filename)
+
+        self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
+
+        # upload to Griptape Cloud and get a public URL
+        public_url = self._storage_driver.upload_file(path=self.gtc_file_path, file_content=file_contents)
+
+        return public_url
 
     def delete_uploaded_artifact(self) -> None:
         if not self.gtc_file_path:
             return
         self._storage_driver.delete_file(self.gtc_file_path)
-
-    def _upload_bytes(self, *, file_content: bytes, filename: str) -> str:
-        self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
-        return self._storage_driver.upload_file(path=self.gtc_file_path, file_content=file_content)
-
-    @staticmethod
-    def _filename_for_blob_artifact(artifact: BlobArtifact) -> str:
-        # Strip any path separators the artifact name might carry so it stays a single
-        # filename segment, matching how the URL branch derives its filename.
-        name = Path(artifact.name).name
-        if Path(name).suffix:
-            return name
-        extension = mimetypes.guess_extension(artifact.mime_type) or ""
-        return f"{name}{extension}"

--- a/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
+++ b/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
@@ -1,16 +1,16 @@
 """Tests for PublicArtifactUrlParameter.get_public_url_for_parameter input handling.
 
 These cover the artifact shapes that reach the component in practice -- serialized
-artifact dicts (orchestrator <-> worker JSON boundary), raw BlobArtifact bytes, and
-ErrorArtifact propagated from an upstream failure -- in addition to the original
-UrlArtifact / bare-string paths. See griptape-ai/griptape-nodes-engine#4688.
+artifact dicts (orchestrator <-> worker JSON boundary) and ErrorArtifact propagated
+from an upstream failure -- in addition to the original UrlArtifact / bare-string
+paths. See griptape-ai/griptape-nodes-engine#4688.
 """
 
 from typing import Any, NamedTuple
 from unittest.mock import Mock
 
 import pytest
-from griptape.artifacts import AudioArtifact, BlobArtifact, ErrorArtifact, ImageArtifact
+from griptape.artifacts import ErrorArtifact
 from griptape.artifacts.image_url_artifact import ImageUrlArtifact
 
 from griptape_nodes.exe_types.core_types import Parameter
@@ -65,31 +65,6 @@ class TestGetPublicUrlForParameter:
         assert component.get_public_url_for_parameter() == "https://example.com/img.png"
         driver.upload_file.assert_not_called()
 
-    def test_blob_artifact_uploads_bytes(self) -> None:
-        component, driver = _make_component(ImageArtifact(value=b"\x89PNG", format="png", width=1, height=1))
-
-        assert component.get_public_url_for_parameter() == PUBLIC_URL
-        _, kwargs = driver.upload_file.call_args
-        assert kwargs["file_content"] == b"\x89PNG"
-        assert component.gtc_file_path is not None
-        assert component.gtc_file_path.suffix == ".png"
-
-    def test_serialized_blob_artifact_dict_uploads_bytes(self) -> None:
-        component, driver = _make_component(ImageArtifact(value=b"\x89PNG", format="png", width=1, height=1).to_dict())
-
-        assert component.get_public_url_for_parameter() == PUBLIC_URL
-        _, kwargs = driver.upload_file.call_args
-        assert kwargs["file_content"] == b"\x89PNG"
-
-    def test_audio_blob_artifact_uploads_bytes(self) -> None:
-        component, driver = _make_component(
-            AudioArtifact(value=b"ID3audio", format="mp3"), param_type="AudioUrlArtifact"
-        )
-
-        assert component.get_public_url_for_parameter() == PUBLIC_URL
-        _, kwargs = driver.upload_file.call_args
-        assert kwargs["file_content"] == b"ID3audio"
-
     def test_error_artifact_raises_with_upstream_message(self) -> None:
         component, driver = _make_component(ErrorArtifact(value="upstream blew up"))
 
@@ -99,28 +74,3 @@ class TestGetPublicUrlForParameter:
         # The error should name the parameter so the editor points at the real cause.
         assert "image" in str(excinfo.value)
         driver.upload_file.assert_not_called()
-
-    def test_unsupported_type_raises_type_error(self) -> None:
-        component, driver = _make_component(42)
-
-        with pytest.raises(TypeError, match="unsupported type"):
-            component.get_public_url_for_parameter()
-        driver.upload_file.assert_not_called()
-
-
-class TestFilenameForBlobArtifact:
-    def test_keeps_name_with_extension(self) -> None:
-        artifact = ImageArtifact(value=b"\x89PNG", format="png", width=1, height=1)
-
-        filename = PublicArtifactUrlParameter._filename_for_blob_artifact(artifact)
-
-        assert filename == artifact.name
-        assert filename.endswith(".png")
-
-    def test_appends_extension_from_mime_type_when_missing(self) -> None:
-        artifact = BlobArtifact(value=b"abc", name="nameless")
-
-        filename = PublicArtifactUrlParameter._filename_for_blob_artifact(artifact)
-
-        # BlobArtifact defaults to application/octet-stream -> .bin
-        assert filename == "nameless.bin"

--- a/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
+++ b/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
@@ -1,0 +1,126 @@
+"""Tests for PublicArtifactUrlParameter.get_public_url_for_parameter input handling.
+
+These cover the artifact shapes that reach the component in practice -- serialized
+artifact dicts (orchestrator <-> worker JSON boundary), raw BlobArtifact bytes, and
+ErrorArtifact propagated from an upstream failure -- in addition to the original
+UrlArtifact / bare-string paths. See griptape-ai/griptape-nodes-engine#4688.
+"""
+
+from typing import Any, NamedTuple
+from unittest.mock import Mock
+
+import pytest
+from griptape.artifacts import AudioArtifact, BlobArtifact, ErrorArtifact, ImageArtifact
+from griptape.artifacts.image_url_artifact import ImageUrlArtifact
+
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from tests.unit.exe_types.mocks import MockNode
+
+PUBLIC_URL = "https://cloud.example/public/artifact.png"
+
+
+class ComponentFixture(NamedTuple):
+    component: PublicArtifactUrlParameter
+    driver: Mock
+
+
+def _make_component(value: Any, *, param_type: str = "ImageUrlArtifact") -> ComponentFixture:
+    """Build a component without running __init__ (which performs network calls)."""
+    node = MockNode()
+    parameter = Parameter(name="image", type=param_type, tooltip="t")
+    node.add_parameter(parameter)
+    node.parameter_values["image"] = value
+
+    driver = Mock()
+    driver.upload_file.return_value = PUBLIC_URL
+
+    component = PublicArtifactUrlParameter.__new__(PublicArtifactUrlParameter)
+    component._node = node
+    component._parameter = parameter
+    component._storage_driver = driver
+    component.gtc_file_path = None
+    return ComponentFixture(component=component, driver=driver)
+
+
+class TestGetPublicUrlForParameter:
+    def test_already_public_string_passes_through(self) -> None:
+        component, driver = _make_component("https://example.com/img.png")
+
+        assert component.get_public_url_for_parameter() == "https://example.com/img.png"
+        driver.upload_file.assert_not_called()
+
+    def test_url_artifact_with_public_url_passes_through(self) -> None:
+        component, driver = _make_component(ImageUrlArtifact(value="https://example.com/img.png"))
+
+        assert component.get_public_url_for_parameter() == "https://example.com/img.png"
+        driver.upload_file.assert_not_called()
+
+    def test_serialized_url_artifact_dict_is_hydrated(self) -> None:
+        # A value that crossed a JSON boundary arrives as a dict, not an artifact.
+        component, driver = _make_component(ImageUrlArtifact(value="https://example.com/img.png").to_dict())
+
+        assert component.get_public_url_for_parameter() == "https://example.com/img.png"
+        driver.upload_file.assert_not_called()
+
+    def test_blob_artifact_uploads_bytes(self) -> None:
+        component, driver = _make_component(ImageArtifact(value=b"\x89PNG", format="png", width=1, height=1))
+
+        assert component.get_public_url_for_parameter() == PUBLIC_URL
+        _, kwargs = driver.upload_file.call_args
+        assert kwargs["file_content"] == b"\x89PNG"
+        assert component.gtc_file_path is not None
+        assert component.gtc_file_path.suffix == ".png"
+
+    def test_serialized_blob_artifact_dict_uploads_bytes(self) -> None:
+        component, driver = _make_component(ImageArtifact(value=b"\x89PNG", format="png", width=1, height=1).to_dict())
+
+        assert component.get_public_url_for_parameter() == PUBLIC_URL
+        _, kwargs = driver.upload_file.call_args
+        assert kwargs["file_content"] == b"\x89PNG"
+
+    def test_audio_blob_artifact_uploads_bytes(self) -> None:
+        component, driver = _make_component(
+            AudioArtifact(value=b"ID3audio", format="mp3"), param_type="AudioUrlArtifact"
+        )
+
+        assert component.get_public_url_for_parameter() == PUBLIC_URL
+        _, kwargs = driver.upload_file.call_args
+        assert kwargs["file_content"] == b"ID3audio"
+
+    def test_error_artifact_raises_with_upstream_message(self) -> None:
+        component, driver = _make_component(ErrorArtifact(value="upstream blew up"))
+
+        with pytest.raises(RuntimeError, match="upstream blew up") as excinfo:
+            component.get_public_url_for_parameter()
+
+        # The error should name the parameter so the editor points at the real cause.
+        assert "image" in str(excinfo.value)
+        driver.upload_file.assert_not_called()
+
+    def test_unsupported_type_raises_type_error(self) -> None:
+        component, driver = _make_component(42)
+
+        with pytest.raises(TypeError, match="unsupported type"):
+            component.get_public_url_for_parameter()
+        driver.upload_file.assert_not_called()
+
+
+class TestFilenameForBlobArtifact:
+    def test_keeps_name_with_extension(self) -> None:
+        artifact = ImageArtifact(value=b"\x89PNG", format="png", width=1, height=1)
+
+        filename = PublicArtifactUrlParameter._filename_for_blob_artifact(artifact)
+
+        assert filename == artifact.name
+        assert filename.endswith(".png")
+
+    def test_appends_extension_from_mime_type_when_missing(self) -> None:
+        artifact = BlobArtifact(value=b"abc", name="nameless")
+
+        filename = PublicArtifactUrlParameter._filename_for_blob_artifact(artifact)
+
+        # BlobArtifact defaults to application/octet-stream -> .bin
+        assert filename == "nameless.bin"


### PR DESCRIPTION
Closes #4688

`PublicArtifactUrlParameter.get_public_url_for_parameter` assumed every wrapped value was either a `UrlArtifact` or a bare `str`. Any other shape was passed straight to `str.startswith`, which raised an opaque `AttributeError` that pointed at a string method rather than the parameter, node, or upstream failure that actually caused it. Two shapes hit this in practice: serialized artifact dicts that arrive after a value crosses a JSON boundary (so even a valid `UrlArtifact` blows up once it has been round-tripped through JSON), and `ErrorArtifact` propagated from an upstream node failure.

The value is now rehydrated before inspection so a serialized dict becomes a real artifact again, and an upstream `ErrorArtifact` is surfaced as an error that names the parameter and node instead of masking the original failure. Everything else keeps its existing behavior.

The private `_hydrate` helper in `parameter_hydration` is promoted to a public `hydrate_value` so a single value can be rehydrated without wrapping it in a dict; `hydrate_parameter_values` delegates to it.