### PR TITLE
fix(mcp): dispatch requests in-process instead of over a second WebSocket

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -219,10 +219,9 @@ class AgentManager:
             )
 
     def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
         sock = bind_free_socket(GTN_MCP_SERVER_HOST, GTN_MCP_SERVER_PORT)
         self._mcp_server_port = sock.getsockname()[1]
-        threading.Thread(target=start_mcp_server, args=(api_key, sock), daemon=True, name="mcp-server").start()
+        threading.Thread(target=start_mcp_server, args=(sock,), daemon=True, name="mcp-server").start()
 
     async def on_handle_run_agent_request(self, request: RunAgentRequest) -> ResultPayload:
         try:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -131,6 +131,15 @@ class EventManager:
             raise ValueError(msg)
         return self._event_queue
 
+    @property
+    def event_loop(self) -> asyncio.AbstractEventLoop | None:
+        """The event loop that owns request handling, or None before the queue is initialized.
+
+        In-process callers running on another thread (e.g. the bundled MCP server) use this to
+        dispatch coroutines onto the engine loop via asyncio.run_coroutine_threadsafe.
+        """
+        return self._event_loop
+
     def should_suppress_event(self, event: BaseEvent | ProgressEvent) -> bool:
         """Check if events should be suppressed from being sent to websockets.
 

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -18,8 +18,11 @@ from mcp.types import (
 from pydantic import TypeAdapter
 from starlette.types import Receive, Scope, Send
 
-from griptape_nodes.api_client import Client, RequestClient
-from griptape_nodes.retained_mode.events.base_events import RequestPayload
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
+    EventResultSuccess,
+    RequestPayload,
+)
 from griptape_nodes.retained_mode.events.config_events import (
     GetConfigValueRequest,
     GetWorkspaceRequest,
@@ -78,6 +81,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowsRequest,
     RunWorkflowWithCurrentStateRequest,
 )
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
@@ -133,7 +137,7 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
 }
 
 # Synthetic MCP tool name for the batch envelope. Not a request payload (and so not a member of
-# SUPPORTED_REQUEST_EVENTS); the call_tool dispatch special-cases it onto manager.request_batch.
+# SUPPORTED_REQUEST_EVENTS); the call_tool dispatch special-cases it onto _dispatch_batch_to_engine.
 EVENT_REQUEST_BATCH_TOOL_NAME = "EventRequestBatch"
 EVENT_REQUEST_BATCH_DESCRIPTION = (
     "Send N requests in a single round trip and gather their responses.\n\n"
@@ -339,7 +343,63 @@ def _trim_batch_results(raw_results: list[Any]) -> list[dict[str, Any]]:
     return trimmed
 
 
-def start_mcp_server(api_key: str, sock: socket.socket) -> None:
+async def _handle_request_on_engine_loop(request_payload: RequestPayload) -> dict[str, Any]:
+    """Handle a request on the engine loop and serialize the result to the wire shape.
+
+    Must be scheduled onto the engine's event loop (see _dispatch_to_engine). GriptapeNodes.
+    ahandle_request is the same in-memory entry point the engine's own inbound path uses: it
+    dispatches to the assigned manager and broadcasts the result so connected clients (e.g. the
+    editor) still observe the change. The returned ResultPayload is wrapped back into an
+    EventResult purely to reuse its wire serializer, producing the same dict shape the WebSocket
+    transport delivered, which _trim_response already knows how to collapse.
+    """
+    result_payload = await GriptapeNodes.ahandle_request(request_payload)
+    if result_payload.succeeded():
+        result_event: EventResultSuccess | EventResultFailure = EventResultSuccess(
+            request=request_payload, result=result_payload
+        )
+    else:
+        result_event = EventResultFailure(request=request_payload, result=result_payload)
+    return json.loads(result_event.json())
+
+
+async def _dispatch_to_engine(request_payload: RequestPayload, timeout_ms: int | None = None) -> dict[str, Any]:
+    """Dispatch a request from the MCP server's loop onto the engine loop and await the result.
+
+    The MCP server runs uvicorn on its own event loop in a daemon thread, so `call_tool` is not
+    on the engine's loop and cannot simply `await ahandle_request` (that would run the handler
+    on uvicorn's loop, concurrent with the engine instead of serialized onto it). run_coroutine_
+    threadsafe schedules the work on the engine loop; wrap_future binds the cross-thread future
+    back to the MCP server's loop so it can be awaited and timed out here without blocking.
+    """
+    engine_loop = GriptapeNodes.EventManager().event_loop
+    if engine_loop is None:
+        msg = (
+            "Attempted to dispatch an MCP request to the engine. "
+            "Failed because the engine event loop is not running yet."
+        )
+        raise RuntimeError(msg)
+    response_future = asyncio.wrap_future(
+        asyncio.run_coroutine_threadsafe(_handle_request_on_engine_loop(request_payload), engine_loop)
+    )
+    if timeout_ms:
+        return await asyncio.wait_for(response_future, timeout=timeout_ms / 1000)
+    return await response_future
+
+
+async def _dispatch_batch_to_engine(pairs: list[tuple[str, dict[str, Any]]], timeout_ms: int) -> list[Any]:
+    """Dispatch a batch of (request_type, payload) pairs concurrently onto the engine loop.
+
+    Mirrors the single-request path but gathers the per-request futures. Failures are returned
+    in their slot (return_exceptions semantics) so one bad inner request does not abort the rest;
+    _trim_batch_results maps those exceptions to ok=false responses.
+    """
+    coros = [_dispatch_to_engine(SUPPORTED_REQUEST_EVENTS[request_type](**payload)) for request_type, payload in pairs]
+    gather = asyncio.gather(*coros, return_exceptions=True)
+    return await asyncio.wait_for(gather, timeout=timeout_ms / 1000)
+
+
+def start_mcp_server(sock: socket.socket) -> None:
     """Synchronous version of main entry point for the Griptape Nodes MCP server.
 
     The socket should already be bound to the desired address and port before calling
@@ -350,9 +410,6 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
     mcp_server_logger.info("MCP server listening at http://%s:%d/mcp/", bound_host, bound_port)
 
     app = Server("mcp-gtn")
-
-    # Manager reference to be set in lifespan
-    manager: RequestClient | None = None
 
     @app.list_tools()
     async def list_tools() -> list[Tool]:
@@ -369,14 +426,10 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
 
     @app.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
-        if manager is None:
-            msg = "Request manager not initialized"
-            raise RuntimeError(msg)
-
         if name == EVENT_REQUEST_BATCH_TOOL_NAME:
             pairs = _build_batch_pairs(arguments.get("requests"))
             timeout_ms = _resolve_batch_timeout_ms(arguments.get("timeout_ms"), len(pairs))
-            raw_results = await manager.request_batch(pairs, timeout_ms=timeout_ms, return_exceptions=True)
+            raw_results = await _dispatch_batch_to_engine(pairs, timeout_ms)
             mcp_server_logger.debug("Got %d batch results", len(raw_results))
             return [TextContent(type="text", text=json.dumps(_trim_batch_results(raw_results)))]
 
@@ -385,10 +438,7 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
             raise ValueError(msg)
 
         request_payload = SUPPORTED_REQUEST_EVENTS[name](**arguments)
-
-        result = await manager.request(
-            request_payload.__class__.__name__, dict(request_payload.__dict__), timeout_ms=30000
-        )
+        result = await _dispatch_to_engine(request_payload, timeout_ms=30000)
         mcp_server_logger.debug("Got result: %s", result)
 
         return [TextContent(type="text", text=json.dumps(_trim_response(result)))]
@@ -400,20 +450,17 @@ def start_mcp_server(api_key: str, sock: socket.socket) -> None:
 
     @contextlib.asynccontextmanager
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-        """Context manager for managing session manager and WebSocket client lifecycle."""
-        nonlocal manager
+        """Run the StreamableHTTP session manager for the lifetime of the FastAPI app.
 
-        async with Client(api_key=api_key) as ws_client, RequestClient(client=ws_client) as req_manager:
-            manager = req_manager
-            mcp_server_logger.debug("Request manager initialized")
-
-            async with session_manager.run():
-                mcp_server_logger.debug("GTN MCP server started with StreamableHTTP session manager!")
-                try:
-                    yield
-                finally:
-                    mcp_server_logger.debug("GTN MCP server shutting down...")
-                    manager = None
+        Requests are dispatched straight into the engine's event loop (see _dispatch_to_engine),
+        so there is no transport client to set up or tear down here.
+        """
+        async with session_manager.run():
+            mcp_server_logger.debug("GTN MCP server started with StreamableHTTP session manager!")
+            try:
+                yield
+            finally:
+                mcp_server_logger.debug("GTN MCP server shutting down...")
 
     mcp_server_app = FastAPI(lifespan=lifespan)
 


### PR DESCRIPTION
Closes #4757

The MCP server lives in a daemon thread inside the engine process, yet it reached the engine by opening a second WebSocket back to the Nodes API and round-tripping every request through it. That made MCP availability depend on an outbound connection the engine does not otherwise need to serve those requests, so a slow or unreachable Nodes API failed uvicorn's lifespan startup and took the whole MCP server down.

This swaps that transport for in-process dispatch. Tool calls now hand their request straight to the engine's in-memory handler via `GriptapeNodes.ahandle_request`. Since `call_tool` runs on uvicorn's own loop in the daemon thread rather than the engine loop, the request is scheduled onto the engine loop with `run_coroutine_threadsafe` and awaited back on the MCP loop with `wrap_future`, which keeps every MCP request serialized onto the engine loop exactly like WebSocket-delivered requests. The result is wrapped back into an `EventResult` only to reuse its existing wire serializer, so the response-trimming layer is untouched.

The cross-thread hop is kept rather than co-hosting uvicorn on the engine loop on purpose: the engine loop can be blocked by synchronous node execution (`await node.aprocess()`), and a separate thread keeps the HTTP server responsive and isolated, and avoids uvicorn installing signal handlers on the main thread.

`EventManager` gains an `event_loop` property so off-loop callers can find the loop to dispatch onto, mirroring the existing thread-safe `put_event`/`aput_event` pattern.
