### PR TITLE
Coerce file extension to match bytes on save

### DIFF
--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -171,53 +171,10 @@ _EXTENSION_ALIASES: dict[str, str] = {
 }
 
 
-def _canonical_extension(ext: str) -> str:
+def canonical_extension(ext: str) -> str:
     """Return the canonical form of an on-disk extension for equivalence checks."""
     lowered = ext.lstrip(".").lower()
     return _EXTENSION_ALIASES.get(lowered, lowered)
-
-
-def _validate_extension_matches_bytes(file_path: str, content: str | bytes) -> None:
-    """Raise ValueError if `content`'s sniffed extension disagrees with the path suffix.
-
-    The actual sniffing is delegated to
-    ``GriptapeNodes.ArtifactManager().sniff_extension``, which dispatches to
-    each registered artifact provider's ``detect_format``. Validation is
-    skipped when:
-    - `content` is text (not bytes),
-    - the path has no extension,
-    - the bytes can't be identified by any provider (a warning is logged).
-
-    Args:
-        file_path: The resolved on-disk path the bytes will be written to.
-        content: The bytes (or text) being written.
-
-    Raises:
-        ValueError: If the sniffed canonical extension disagrees with the
-            extension on `file_path`.
-    """
-    if not isinstance(content, bytes):
-        return
-
-    suffix = Path(file_path).suffix.lstrip(".").lower()
-    if not suffix:
-        return
-
-    sniffed = GriptapeNodes.ArtifactManager().sniff_extension(content)
-    if sniffed is None:
-        logger.warning(
-            "Could not identify byte content for '%s'; writing through without extension validation.",
-            file_path,
-        )
-        return
-
-    if _canonical_extension(suffix) != _canonical_extension(sniffed):
-        msg = (
-            f"Refusing to write {sniffed.upper()} bytes to '{file_path}' "
-            f"(extension '.{suffix}'). The file extension must match the byte content; "
-            f"either rename the destination to '.{sniffed}' or supply bytes that match '.{suffix}'."
-        )
-        raise ValueError(msg)
 
 
 class File:
@@ -308,13 +265,17 @@ class File:
         existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
         append: bool = False,
         create_parents: bool = True,
+        coerce_extension_to_match_bytes: bool = True,
     ) -> Path:
         """Write bytes to the file.
 
-        The bytes are sniffed for a known media format. If the sniffed format
-        disagrees with the file's extension, ``ValueError`` is raised before
-        any I/O happens. If the bytes can't be identified, a warning is
-        logged and the write proceeds unchanged.
+        After the write, the bytes are sniffed for a known media format. If
+        the sniffed format disagrees with the file's extension and
+        ``coerce_extension_to_match_bytes`` is True (the default), the
+        on-disk file is renamed so its suffix matches the sniffed format
+        and a single warning is logged. If the flag is False, the write
+        fails with ``FileWriteError(failure_reason=EXTENSION_MISMATCH)`` and
+        no file is left on disk.
 
         Args:
             content: The bytes to write.
@@ -323,20 +284,23 @@ class File:
             append: If True, append to an existing file. Defaults to False.
             create_parents: If True, create parent directories if missing.
                 Defaults to True.
+            coerce_extension_to_match_bytes: If True, rewrite the suffix to
+                match the sniffed bytes; if False, fail on mismatch. Defaults
+                to True.
 
         Returns:
             The actual path where the file was written.
 
         Raises:
-            FileWriteError: If the file cannot be written.
-            ValueError: If the bytes' sniffed format does not match the file
-                extension.
+            FileWriteError: If the file cannot be written, including the
+                ``EXTENSION_MISMATCH`` failure when coercion is disabled.
         """
         return self._write_content(
             content,
             existing_file_policy=existing_file_policy,
             append=append,
             create_parents=create_parents,
+            coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
         )
 
     async def awrite_bytes(
@@ -346,6 +310,7 @@ class File:
         existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
         append: bool = False,
         create_parents: bool = True,
+        coerce_extension_to_match_bytes: bool = True,
     ) -> Path:
         """Async version of write_bytes().
 
@@ -356,20 +321,23 @@ class File:
             append: If True, append to an existing file. Defaults to False.
             create_parents: If True, create parent directories if missing.
                 Defaults to True.
+            coerce_extension_to_match_bytes: If True, rewrite the suffix to
+                match the sniffed bytes; if False, fail on mismatch. Defaults
+                to True.
 
         Returns:
             The actual path where the file was written.
 
         Raises:
-            FileWriteError: If the file cannot be written.
-            ValueError: If the bytes' sniffed format does not match the file
-                extension.
+            FileWriteError: If the file cannot be written, including the
+                ``EXTENSION_MISMATCH`` failure when coercion is disabled.
         """
         return await self._awrite_content(
             content,
             existing_file_policy=existing_file_policy,
             append=append,
             create_parents=create_parents,
+            coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
         )
 
     def write_text(
@@ -617,7 +585,7 @@ class File:
             size=success.file_size,
         )
 
-    def _write_content(
+    def _write_content(  # noqa: PLR0913
         self,
         content: str | bytes,
         encoding: str = "utf-8",
@@ -625,6 +593,7 @@ class File:
         existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
         append: bool = False,
         create_parents: bool = True,
+        coerce_extension_to_match_bytes: bool = True,
     ) -> Path:
         """Perform the sync file write.
 
@@ -634,18 +603,19 @@ class File:
             existing_file_policy: How to handle an existing file.
             append: If True, append to an existing file.
             create_parents: If True, create parent directories if missing.
+            coerce_extension_to_match_bytes: If True, the OSManager rewrites
+                the on-disk suffix to match the sniffed bytes; if False, an
+                ``EXTENSION_MISMATCH`` failure is returned on mismatch.
 
         Returns:
             The actual path where the file was written (may differ from the
-            requested path if CREATE_NEW policy is in effect).
+            requested path if CREATE_NEW policy is in effect, or if the
+            extension was coerced to match the byte content).
 
         Raises:
             FileWriteError: If the file cannot be written.
-            ValueError: If `content` is bytes whose sniffed format does not
-                match the file extension.
         """
         resolved_path = _resolve_file_path(self._file_path)
-        _validate_extension_matches_bytes(resolved_path, content)
         request = WriteFileRequest(
             file_path=resolved_path,
             content=content,
@@ -654,6 +624,7 @@ class File:
             append=append,
             create_parents=create_parents,
             file_metadata=self._build_file_metadata(),
+            coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
         )
         result = GriptapeNodes.handle_request(request)
 
@@ -666,7 +637,7 @@ class File:
 
         return Path(cast("WriteFileResultSuccess", result).final_file_path)
 
-    async def _awrite_content(
+    async def _awrite_content(  # noqa: PLR0913
         self,
         content: str | bytes,
         encoding: str = "utf-8",
@@ -674,6 +645,7 @@ class File:
         existing_file_policy: ExistingFilePolicy = ExistingFilePolicy.OVERWRITE,
         append: bool = False,
         create_parents: bool = True,
+        coerce_extension_to_match_bytes: bool = True,
     ) -> Path:
         """Async version of _write_content.
 
@@ -683,18 +655,19 @@ class File:
             existing_file_policy: How to handle an existing file.
             append: If True, append to an existing file.
             create_parents: If True, create parent directories if missing.
+            coerce_extension_to_match_bytes: If True, the OSManager rewrites
+                the on-disk suffix to match the sniffed bytes; if False, an
+                ``EXTENSION_MISMATCH`` failure is returned on mismatch.
 
         Returns:
             The actual path where the file was written (may differ from the
-            requested path if CREATE_NEW policy is in effect).
+            requested path if CREATE_NEW policy is in effect, or if the
+            extension was coerced to match the byte content).
 
         Raises:
             FileWriteError: If the file cannot be written.
-            ValueError: If `content` is bytes whose sniffed format does not
-                match the file extension.
         """
         resolved_path = await _aresolve_file_path(self._file_path)
-        _validate_extension_matches_bytes(resolved_path, content)
         request = WriteFileRequest(
             file_path=resolved_path,
             content=content,
@@ -703,6 +676,7 @@ class File:
             append=append,
             create_parents=create_parents,
             file_metadata=self._build_file_metadata(),
+            coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
         )
         result = await GriptapeNodes.ahandle_request(request)
 
@@ -744,7 +718,7 @@ class FileDestination:
     For a lean path reference that also supports reading, use ``File`` instead.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         file_path: str | MacroPath,
         *,
@@ -752,6 +726,7 @@ class FileDestination:
         append: bool = False,
         create_parents: bool = True,
         file_metadata: SidecarContent | None = None,
+        coerce_extension_to_match_bytes: bool = True,
     ) -> None:
         """Store file path and write configuration. No I/O is performed.
 
@@ -765,11 +740,16 @@ class FileDestination:
                 Defaults to True.
             file_metadata: Optional caller-provided context to include in the sidecar
                 metadata file alongside auto-collected workflow metadata.
+            coerce_extension_to_match_bytes: If True (default), the OSManager
+                rewrites the on-disk suffix to match the sniffed bytes when
+                they disagree. If False, the write fails with an
+                ``EXTENSION_MISMATCH`` error and no file is left on disk.
         """
         self._file = File(file_path, file_metadata=file_metadata)
         self._existing_file_policy = existing_file_policy
         self._append = append
         self._create_parents = create_parents
+        self._coerce_extension_to_match_bytes = coerce_extension_to_match_bytes
 
     def resolve(self) -> str:
         """Resolve and return the absolute path string for this destination.
@@ -807,6 +787,7 @@ class FileDestination:
             existing_file_policy=self._existing_file_policy,
             append=self._append,
             create_parents=self._create_parents,
+            coerce_extension_to_match_bytes=self._coerce_extension_to_match_bytes,
         )
         return File(str(path))
 
@@ -827,6 +808,7 @@ class FileDestination:
             existing_file_policy=self._existing_file_policy,
             append=self._append,
             create_parents=self._create_parents,
+            coerce_extension_to_match_bytes=self._coerce_extension_to_match_bytes,
         )
         return File(str(path))
 

--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -83,22 +83,19 @@ class ProjectFileDestination(FileDestination):
         cls,
         filename: str,
         situation: str,
-        *,
-        coerce_extension_to_match_bytes: bool = True,
         **extra_vars: str | int,
     ) -> "ProjectFileDestination":
         """Build a ProjectFileDestination from a project situation template.
 
         Looks up the named situation in the current project to obtain the macro
-        template and write policy, then constructs the destination.
+        template and write policy, then constructs the destination. The
+        resulting destination uses the engine default for extension coercion;
+        callers that need to override (e.g. the FileOutputSettings node) build
+        the destination directly via the constructor.
 
         Args:
             filename: Filename to parse into base and extension components.
             situation: Situation name to look up in the current project.
-            coerce_extension_to_match_bytes: If True (default), the OSManager
-                rewrites the on-disk suffix to match the sniffed bytes when
-                they disagree. If False, the write fails with an
-                ``EXTENSION_MISMATCH`` error.
             **extra_vars: Additional macro variables (e.g., node_name="MyNode", _index=1).
         """
         result = GriptapeNodes.handle_request(GetSituationRequest(situation_name=situation))
@@ -167,7 +164,6 @@ class ProjectFileDestination(FileDestination):
                 existing_file_policy=existing_file_policy,
                 create_parents=create_dirs,
                 file_metadata=None,
-                coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
             )
 
         return cls(
@@ -175,5 +171,4 @@ class ProjectFileDestination(FileDestination):
             existing_file_policy=existing_file_policy,
             create_parents=create_dirs,
             file_metadata=file_metadata,
-            coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
         )

--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -83,6 +83,8 @@ class ProjectFileDestination(FileDestination):
         cls,
         filename: str,
         situation: str,
+        *,
+        coerce_extension_to_match_bytes: bool = True,
         **extra_vars: str | int,
     ) -> "ProjectFileDestination":
         """Build a ProjectFileDestination from a project situation template.
@@ -93,6 +95,10 @@ class ProjectFileDestination(FileDestination):
         Args:
             filename: Filename to parse into base and extension components.
             situation: Situation name to look up in the current project.
+            coerce_extension_to_match_bytes: If True (default), the OSManager
+                rewrites the on-disk suffix to match the sniffed bytes when
+                they disagree. If False, the write fails with an
+                ``EXTENSION_MISMATCH`` error.
             **extra_vars: Additional macro variables (e.g., node_name="MyNode", _index=1).
         """
         result = GriptapeNodes.handle_request(GetSituationRequest(situation_name=situation))
@@ -161,6 +167,7 @@ class ProjectFileDestination(FileDestination):
                 existing_file_policy=existing_file_policy,
                 create_parents=create_dirs,
                 file_metadata=None,
+                coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
             )
 
         return cls(
@@ -168,4 +175,5 @@ class ProjectFileDestination(FileDestination):
             existing_file_policy=existing_file_policy,
             create_parents=create_dirs,
             file_metadata=file_metadata,
+            coerce_extension_to_match_bytes=coerce_extension_to_match_bytes,
         )

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -48,6 +48,9 @@ class FileIOFailureReason(StrEnum):
 
     # Content errors
     ENCODING_ERROR = "encoding_error"  # Text encoding/decoding failed
+    EXTENSION_MISMATCH = (
+        "extension_mismatch"  # Sniffed byte format disagrees with destination suffix and coercion is disabled
+    )
 
     # Generic errors
     IO_ERROR = "io_error"  # Generic I/O error
@@ -556,6 +559,10 @@ class WriteFileRequest(RequestPayload):
             (default: False). Use when the content already contains metadata to avoid double-injection.
         file_metadata: Optional caller-provided situation and variable context to include in the sidecar
             metadata file.
+        coerce_extension_to_match_bytes: If True (default), when the sniffed format of the bytes disagrees
+            with the destination suffix, the on-disk file is renamed to match the sniffed extension and a
+            warning is logged. If False, a WriteFileResultFailure with EXTENSION_MISMATCH is returned and
+            no file is left on disk.
 
     Results: WriteFileResultSuccess | WriteFileResultFailure
 
@@ -571,6 +578,7 @@ class WriteFileRequest(RequestPayload):
     create_parents: bool = True
     skip_metadata_injection: bool = False
     file_metadata: SidecarContent | None = None
+    coerce_extension_to_match_bytes: bool = True
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -36,7 +36,7 @@ from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeClou
 from griptape_nodes.files.drivers.http_file_driver import HttpFileDriver
 from griptape_nodes.files.drivers.local_file_driver import LocalFileDriver
 from griptape_nodes.files.drivers.static_server_file_driver import StaticServerFileDriver
-from griptape_nodes.files.file import File, FileLoadError
+from griptape_nodes.files.file import File, FileLoadError, canonical_extension
 from griptape_nodes.files.file_driver import FileDriverNotFoundError, FileDriverRegistry
 from griptape_nodes.files.path_utils import (
     canonicalize_for_identity,
@@ -2105,6 +2105,15 @@ class OSManager:
             msg = "Internal error: success path reached but file path or bytes not set"
             raise RuntimeError(msg)
 
+        # Reconcile the on-disk suffix with the actual byte content. When the
+        # caller passes coerce_extension_to_match_bytes=True (the default) we
+        # rename to match the sniffed format; when False, mismatched bytes are
+        # treated as a hard failure and the just-written file is removed.
+        coercion_result = self._apply_extension_coercion(request, final_file_path)
+        if isinstance(coercion_result, WriteFileResultFailure):
+            return coercion_result
+        final_file_path = coercion_result
+
         # Write sidecar metadata file if caller opted in by providing file_metadata
         if request.file_metadata is not None:
             write_sidecar(final_file_path, request.file_metadata)
@@ -2120,6 +2129,88 @@ class OSManager:
             bytes_written=final_bytes_written,
             result_details=result_details,
         )
+
+    def _apply_extension_coercion(  # noqa: PLR0911
+        self,
+        request: WriteFileRequest,
+        final_file_path: Path,
+    ) -> Path | WriteFileResultFailure:
+        """Reconcile the on-disk suffix with the sniffed byte format.
+
+        Runs only for binary content. Sniffs via the registered artifact
+        providers; when the sniffed canonical extension disagrees with the
+        path's suffix the behavior is controlled by the request flag:
+
+        - ``coerce_extension_to_match_bytes=True`` (default): rename the file
+          to use the sniffed extension and (when present) update the
+          ``file_extension`` variable on the sidecar's situation metadata so
+          provenance reflects the actual on-disk extension.
+        - ``coerce_extension_to_match_bytes=False``: delete the just-written
+          file and return ``WriteFileResultFailure`` with
+          ``EXTENSION_MISMATCH``, preserving the original strict behavior.
+        """
+        content = request.content
+        if not isinstance(content, bytes):
+            return final_file_path
+
+        suffix = final_file_path.suffix.lstrip(".").lower()
+        if not suffix:
+            return final_file_path
+
+        sniffed = GriptapeNodes.ArtifactManager().sniff_extension(content)
+        if sniffed is None:
+            logger.warning(
+                "Could not identify byte content for '%s'; writing through without extension coercion.",
+                final_file_path,
+            )
+            return final_file_path
+
+        if canonical_extension(suffix) == canonical_extension(sniffed):
+            return final_file_path
+
+        if not request.coerce_extension_to_match_bytes:
+            try:
+                final_file_path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.warning(
+                    "Failed to remove '%s' after EXTENSION_MISMATCH: %s",
+                    final_file_path,
+                    e,
+                )
+            msg = (
+                f"Refusing to write {sniffed.upper()} bytes to '{final_file_path}' "
+                f"(extension '.{suffix}'). The file extension must match the byte content; "
+                f"either rename the destination to '.{sniffed}' or supply bytes that match '.{suffix}'."
+            )
+            return WriteFileResultFailure(
+                failure_reason=FileIOFailureReason.EXTENSION_MISMATCH,
+                result_details=msg,
+            )
+
+        coerced_path = final_file_path.with_suffix(f".{sniffed}")
+        try:
+            final_file_path.rename(coerced_path)
+        except OSError as e:
+            logger.warning(
+                "Failed to rename '%s' to '%s' during extension coercion: %s; leaving original suffix.",
+                final_file_path,
+                coerced_path,
+                e,
+            )
+            return final_file_path
+
+        logger.warning(
+            "Coerced file extension to match byte content: '%s' -> '%s'.",
+            final_file_path,
+            coerced_path,
+        )
+
+        if request.file_metadata is not None and request.file_metadata.situation is not None:
+            variables = request.file_metadata.situation.variables
+            if variables is not None and "file_extension" in variables:
+                variables["file_extension"] = sniffed
+
+        return coerced_path
 
     def _ensure_parent_directory_ready(
         self,

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -15,7 +15,6 @@ from griptape_nodes.files.file import (
     FileDestination,
     FileLoadError,
     FileWriteError,
-    _validate_extension_matches_bytes,
 )
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
@@ -1148,10 +1147,6 @@ def _jpeg_bytes() -> bytes:
     return _pil_bytes("JPEG")
 
 
-def _m4v_bytes() -> bytes:
-    return b"\x00\x00\x00\x18ftypM4V " + b"\x00" * 16
-
-
 @pytest.fixture
 def _registered_providers() -> None:
     """Ensure default artifact providers are registered with the ArtifactManager.
@@ -1177,51 +1172,12 @@ def _registered_providers() -> None:
 
 
 @pytest.mark.usefixtures("_registered_providers")
-class TestValidateExtensionMatchesBytes:
-    """Tests for _validate_extension_matches_bytes (the function wired into write_bytes)."""
+class TestFileWriteForwardsCoercionFlag:
+    """File.write_bytes forwards coerce_extension_to_match_bytes to the WriteFileRequest.
 
-    def test_matching_extension_passes(self) -> None:
-        _validate_extension_matches_bytes("/workspace/out.png", _png_bytes())
-
-    def test_jpg_jpeg_alias_passes(self) -> None:
-        _validate_extension_matches_bytes("/workspace/out.jpeg", _jpeg_bytes())
-
-    def test_mismatch_raises_value_error(self) -> None:
-        with pytest.raises(ValueError, match=r"\.png"):
-            _validate_extension_matches_bytes("/workspace/out.png", _jpeg_bytes())
-
-    def test_mismatch_message_names_both_extensions(self) -> None:
-        with pytest.raises(ValueError, match=r"\.png") as exc_info:
-            _validate_extension_matches_bytes("/workspace/out.png", _jpeg_bytes())
-        assert ".png" in str(exc_info.value)
-        assert "JPG" in str(exc_info.value)
-
-    def test_unknown_bytes_logs_warning_and_passes(self, caplog: pytest.LogCaptureFixture) -> None:
-        with caplog.at_level("WARNING", logger="griptape_nodes"):
-            _validate_extension_matches_bytes("/workspace/out.bin", b"some opaque blob nobody knows")
-        assert any("Could not identify byte content" in r.message for r in caplog.records)
-
-    def test_no_extension_skips_validation(self) -> None:
-        _validate_extension_matches_bytes("/workspace/output", _jpeg_bytes())
-
-    def test_text_content_skipped(self) -> None:
-        _validate_extension_matches_bytes("/workspace/out.png", "hello world")
-
-    def test_mp4_to_m4v_alias_passes(self) -> None:
-        _validate_extension_matches_bytes("/workspace/out.mp4", _m4v_bytes())
-
-    def test_uppercase_extension_canonicalizes(self) -> None:
-        _validate_extension_matches_bytes("/workspace/out.PNG", _png_bytes())
-
-
-@pytest.mark.usefixtures("_registered_providers")
-class TestFileWriteValidationIntegration:
-    """End-to-end: File.write_bytes should run validation before issuing the request."""
-
-    def test_write_bytes_raises_on_extension_mismatch(self) -> None:
-        with patch(HANDLE_REQUEST_PATH) as mock_handle, pytest.raises(ValueError, match=r"\.png"):
-            File("/workspace/output.png").write_bytes(_jpeg_bytes())
-        mock_handle.assert_not_called()
+    Extension reconciliation itself lives in OSManager; these tests confirm File correctly
+    propagates the flag and surfaces strict-mode failures as FileWriteError.
+    """
 
     def test_write_bytes_passes_on_match(self) -> None:
         success_result = WriteFileResultSuccess(
@@ -1233,24 +1189,50 @@ class TestFileWriteValidationIntegration:
             path = File("/workspace/output.png").write_bytes(_png_bytes())
         assert path == Path("/workspace/output.png")
 
-    def test_write_bytes_warns_on_unknown_bytes_and_proceeds(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_write_bytes_default_request_coerces(self) -> None:
         success_result = WriteFileResultSuccess(
             result_details="OK",
-            final_file_path="/workspace/output.bin",
-            bytes_written=5,
+            final_file_path="/workspace/output.jpeg",
+            bytes_written=10,
         )
-        with (
-            patch(HANDLE_REQUEST_PATH, return_value=success_result),
-            caplog.at_level("WARNING", logger="griptape_nodes"),
-        ):
-            File("/workspace/output.bin").write_bytes(b"abcde")
-        assert any("Could not identify byte content" in r.message for r in caplog.records)
+        with patch(HANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
+            path = File("/workspace/output.png").write_bytes(_jpeg_bytes())
+        request = mock_handle.call_args.args[0]
+        assert request.coerce_extension_to_match_bytes is True
+        assert path == Path("/workspace/output.jpeg")
+
+    def test_write_bytes_strict_mode_propagates_flag(self) -> None:
+        success_result = WriteFileResultSuccess(
+            result_details="OK",
+            final_file_path="/workspace/output.png",
+            bytes_written=10,
+        )
+        with patch(HANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
+            File("/workspace/output.png").write_bytes(_png_bytes(), coerce_extension_to_match_bytes=False)
+        request = mock_handle.call_args.args[0]
+        assert request.coerce_extension_to_match_bytes is False
+
+    def test_write_bytes_extension_mismatch_failure_raises_file_write_error(self) -> None:
+        failure_result = WriteFileResultFailure(
+            result_details="Refusing to write JPEG bytes to '/workspace/output.png' (extension '.png').",
+            failure_reason=FileIOFailureReason.EXTENSION_MISMATCH,
+        )
+        with patch(HANDLE_REQUEST_PATH, return_value=failure_result), pytest.raises(FileWriteError) as exc_info:
+            File("/workspace/output.png").write_bytes(_jpeg_bytes(), coerce_extension_to_match_bytes=False)
+        assert exc_info.value.failure_reason == FileIOFailureReason.EXTENSION_MISMATCH
 
     @pytest.mark.asyncio
-    async def test_awrite_bytes_raises_on_extension_mismatch(self) -> None:
-        with patch(AHANDLE_REQUEST_PATH) as mock_handle, pytest.raises(ValueError, match=r"\.png"):
-            await File("/workspace/output.png").awrite_bytes(_jpeg_bytes())
-        mock_handle.assert_not_called()
+    async def test_awrite_bytes_default_request_coerces(self) -> None:
+        success_result = WriteFileResultSuccess(
+            result_details="OK",
+            final_file_path="/workspace/output.jpeg",
+            bytes_written=10,
+        )
+        with patch(AHANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
+            path = await File("/workspace/output.png").awrite_bytes(_jpeg_bytes())
+        request = mock_handle.call_args.args[0]
+        assert request.coerce_extension_to_match_bytes is True
+        assert path == Path("/workspace/output.jpeg")
 
     @pytest.mark.asyncio
     async def test_awrite_bytes_passes_on_match(self) -> None:

--- a/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
+++ b/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
@@ -6,15 +6,18 @@ Tests cover:
 - Blanket exception handling for unexpected errors
 - Match/case error message formatting for parent directory failures
 - On-demand candidate generation (doesn't pre-generate all MAX_INDEXED_CANDIDATES)
+- Extension coercion: rename suffix to match sniffed bytes, or fail when strict
 """
 
 import logging
 import tempfile
 from collections.abc import Generator
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from PIL import Image
 
 from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
@@ -632,3 +635,144 @@ class TestSidecarMetadata:
         assert sidecar_path.exists(), "Sidecar should be created at the actual indexed fallback path"
         data = _json.loads(sidecar_path.read_text())
         assert data["schema_version"] == "0.1.0"
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), color="white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _jpeg_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), color="white").save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class TestExtensionCoercion:
+    """Test extension coercion (rename suffix to match sniffed bytes) inside OSManager."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir).resolve()
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        """Set workspace and register the image artifact provider so sniff_extension works."""
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+
+        griptape_nodes.ArtifactManager().on_handle_register_artifact_provider_request(
+            RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
+        )
+
+        yield
+
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    def test_default_coerce_renames_jpeg_when_destination_is_png(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """JPEG bytes saved to a .png path should be renamed to .jpeg by default."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "image.png"
+
+        request = WriteFileRequest(file_path=str(requested_path), content=_jpeg_bytes())
+        with caplog.at_level(logging.WARNING):
+            result = os_manager.on_write_file_request(request)
+
+        assert isinstance(result, WriteFileResultSuccess)
+        coerced_path = temp_dir / "image.jpg"
+        assert Path(result.final_file_path) == coerced_path
+        assert coerced_path.exists()
+        assert not requested_path.exists()
+        assert any("Coerced file extension" in r.message for r in caplog.records)
+
+    def test_strict_mode_returns_extension_mismatch_failure(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """With coerce_extension_to_match_bytes=False, mismatched bytes should fail and leave no file."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "image.png"
+
+        request = WriteFileRequest(
+            file_path=str(requested_path),
+            content=_jpeg_bytes(),
+            coerce_extension_to_match_bytes=False,
+        )
+        result = os_manager.on_write_file_request(request)
+
+        assert isinstance(result, WriteFileResultFailure)
+        assert result.failure_reason == FileIOFailureReason.EXTENSION_MISMATCH
+        assert not requested_path.exists()
+        assert not (temp_dir / "image.jpg").exists()
+
+    def test_coerce_no_op_when_bytes_match_suffix(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """No rename, no warning when bytes already match the destination suffix."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "image.png"
+
+        request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
+        result = os_manager.on_write_file_request(request)
+
+        assert isinstance(result, WriteFileResultSuccess)
+        assert Path(result.final_file_path) == requested_path
+        assert requested_path.exists()
+
+    def test_coerce_no_op_when_sniff_returns_none(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unrecognized bytes log a 'Could not identify' warning and write through unchanged."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "blob.png"
+
+        request = WriteFileRequest(file_path=str(requested_path), content=b"\x00\x01\x02\x03 not a known format")
+        with caplog.at_level(logging.WARNING):
+            result = os_manager.on_write_file_request(request)
+
+        assert isinstance(result, WriteFileResultSuccess)
+        assert Path(result.final_file_path) == requested_path
+        assert any("Could not identify byte content" in r.message for r in caplog.records)
+
+    def test_coerce_updates_sidecar_file_extension_variable(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """When coercion fires, the sidecar's situation.variables.file_extension is rewritten to match."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "image.png"
+
+        file_metadata = SidecarContent(
+            situation=SituationMetadata(
+                name="save_node_output",
+                macro="{outputs}/{file_name_base}.{file_extension}",
+                variables={"file_name_base": "image", "file_extension": "png"},
+            ),
+        )
+
+        request = WriteFileRequest(
+            file_path=str(requested_path),
+            content=_jpeg_bytes(),
+            file_metadata=file_metadata,
+        )
+        result = os_manager.on_write_file_request(request)
+
+        assert isinstance(result, WriteFileResultSuccess)
+        # The mutation happens before write_sidecar runs, so the in-memory metadata
+        # passed in should be updated. Verify by checking the request's metadata.
+        assert request.file_metadata is not None
+        assert request.file_metadata.situation is not None
+        assert request.file_metadata.situation.variables is not None
+        assert request.file_metadata.situation.variables["file_extension"] == "jpg"
+
+    def test_coerce_skipped_for_text_content(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Text writes should never trigger sniffing/rename."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "notes.png"
+
+        request = WriteFileRequest(file_path=str(requested_path), content="just some text")
+        result = os_manager.on_write_file_request(request)
+
+        assert isinstance(result, WriteFileResultSuccess)
+        assert Path(result.final_file_path) == requested_path


### PR DESCRIPTION
Raised by https://github.com/griptape-ai/griptape-nodes-engine/issues/4760

This will turn on by default coercion to the correct file type based on byte content. A toggle to disable will be added in [future](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/297) to File Output Setting node

Coercion on:
```
WARNING  Coerced file extension to match byte content: '/Users/cjkindel/nodes/griptape-nodes/GriptapeNodes/outputs2/Google Nano Banana Image Generation_google_image.png' ->  '/Users/cjkindel/nodes/griptape-nodes/GriptapeNodes/outputs2/Google Nano Banana Image Generation_google_image.jpg'.
```

Coercion off:
<img width="1208" height="514" alt="image" src="https://github.com/user-attachments/assets/a1e8144b-7b2f-45dc-9e0d-9cf3c45108cf" />
