### PR TITLE
remove project_macro_path

### DIFF
--- a/src/griptape_nodes/common/project_templates/project.py
+++ b/src/griptape_nodes/common/project_templates/project.py
@@ -32,10 +32,12 @@ class ProjectTemplate(BaseModel):
         default=None,
         description=(
             "Optional path to a parent project YAML. When set, the parent's merged template is the "
-            "base for this template (instead of system defaults alone). The value may be: "
-            "(1) absolute, (2) relative to the directory of this project's YAML, or "
-            "(3) the macro `{workspace_dir}/...` which expands to the active workspace at load time. "
-            "Macro form is preferred for cross-machine portability."
+            "base for this template (instead of system defaults alone). The value must be: "
+            "(1) absolute, or "
+            "(2) relative to the directory of this project's YAML (e.g. `../base/griptape-nodes-project.yml`). "
+            "Relative paths are preferred for cross-machine portability. "
+            "Macro tokens are not allowed: they would resolve against runtime state (e.g. the active "
+            "workspace) that can change while the project is loaded, which would corrupt parent/child links."
         ),
     )
     situations: dict[str, SituationTemplate] = Field(description="Situation templates (situation_name -> template)")

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -6,6 +6,7 @@ import types
 from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Union, get_args, get_origin
 
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
@@ -80,6 +81,11 @@ converter.register_unstructure_hook(type, lambda t: f"{t.__module__}.{t.__qualna
 # The JSON preset strict mode rejects ints for float fields, but JSON has
 # no distinction between int and float, so coerce int -> float on input.
 converter.register_structure_hook(float, lambda v, _: float(v))
+
+# Request payloads declare path-bearing fields as `Path` (e.g. project_path),
+# but the wire form is always a string. Coerce so handlers can call .parent /
+# Path arithmetic without first re-wrapping.
+converter.register_structure_hook(Path, lambda v, _: Path(v))
 
 # Union types composed entirely of JSON-primitive types (str, int, float, bool,
 # dict, list, None). The JSON parser already produces the correct Python type,

--- a/src/griptape_nodes/retained_mode/events/project_events.py
+++ b/src/griptape_nodes/retained_mode/events/project_events.py
@@ -133,23 +133,16 @@ class ProjectTemplateInfo:
         project_id: Canonical absolute path identifying this template in the registry.
         validation: Outcome of loading + parsing this template.
         name: Display name from the template body, when available.
-        parent_project_path: The parent's path expressed in the same form a user
-            would write into a YAML overlay (e.g. `{workspace_dir}/base.yml`,
-            an absolute path, or None). Use this when persisting a child's link
-            back to a parent.
-        project_macro_path: This template's own path expressed as a portable
-            macro string. If the template lives under the active workspace,
-            this is `{workspace_dir}/<rel>`; otherwise it is the canonical
-            absolute path. The GUI parent-picker stores this value into a
-            child's `parent_project_path` so the link round-trips across
-            machines without baking in absolute home directories.
+        parent_project_path: The parent's canonical absolute path, suitable for
+            direct equality matching against another entry's project_id when
+            reconstructing the parent/child hierarchy. None means no parent
+            (system defaults are the only base).
     """
 
     project_id: ProjectID
     validation: ProjectValidationInfo
     name: str | None = None
     parent_project_path: str | None = None
-    project_macro_path: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -524,10 +524,9 @@ class ProjectManager:
 
         Relative `parent_project_path` paths resolve against the directory of
         `project_file_path` so a child project can name its parent with a relative
-        path (e.g. `parent_project_path: ../base/griptape-nodes-project.yml`). The
-        macro `{workspace_dir}` is also expanded against the active workspace so
-        a parent shared between collaborators on different machines remains
-        portable.
+        path (e.g. `parent_project_path: ../base/griptape-nodes-project.yml`).
+        Macro tokens are rejected by the loader; only absolute or relative
+        paths reach this resolver.
 
         Errors during parent resolution (missing file, unparsable YAML, cycle)
         are recorded on the child's `validation` and surfaced to the caller as
@@ -536,8 +535,7 @@ class ProjectManager:
         if overlay.parent_project_path is None:
             return DEFAULT_PROJECT_TEMPLATE
 
-        parent_path_str = self._expand_workspace_dir_macro(overlay.parent_project_path)
-        parent_path_raw = Path(parent_path_str)
+        parent_path_raw = Path(overlay.parent_project_path)
         if not parent_path_raw.is_absolute():
             parent_path_raw = project_file_path.parent / parent_path_raw
         parent_file_path = canonicalize_for_identity(parent_path_raw)
@@ -634,28 +632,19 @@ class ProjectManager:
             if not request.include_system_builtins and project_id == SYSTEM_DEFAULTS_KEY:
                 continue
 
-            # Surface the parent_project_path in its stored form (after expanding
-            # the {workspace_dir} macro and resolving relative paths against the
-            # child YAML's directory). The result is a canonical absolute path
-            # that consumers can match against other entries' project_id for
-            # hierarchy reconstruction. The original macro form (if any) lives
-            # on the child template itself; this field is for cross-referencing.
+            # Resolve parent_project_path to a canonical absolute string that
+            # matches another entry's project_id, so consumers can reconstruct
+            # the parent/child hierarchy with a string-equality lookup. Parent
+            # links are either absolute or relative to the child YAML's
+            # directory (the loader rejects macro tokens); both forms canonicalize
+            # to the same result here regardless of which workspace is active.
             raw_parent = project_info.template.parent_project_path
             resolved_parent: str | None = None
             if raw_parent is not None:
-                expanded = self._expand_workspace_dir_macro(raw_parent)
-                parent_path = Path(expanded)
+                parent_path = Path(raw_parent)
                 if not parent_path.is_absolute() and project_info.project_file_path is not None:
                     parent_path = project_info.project_file_path.parent / parent_path
                 resolved_parent = str(canonicalize_for_identity(parent_path))
-
-            # Each project's own path expressed in portable macro form. The GUI
-            # parent-picker stores this directly into a child's parent_project_path
-            # so links remain valid across machines and OSes when both projects
-            # live under the workspace.
-            project_macro_path: str | None = None
-            if project_info.project_file_path is not None and project_id != SYSTEM_DEFAULTS_KEY:
-                project_macro_path = self._workspace_relative_macro_path(project_info.project_file_path)
 
             successfully_loaded.append(
                 ProjectTemplateInfo(
@@ -663,7 +652,6 @@ class ProjectManager:
                     validation=project_info.validation,
                     name=project_info.template.name,
                     parent_project_path=resolved_parent,
-                    project_macro_path=project_macro_path,
                 )
             )
 
@@ -1272,48 +1260,18 @@ class ProjectManager:
     def _resolve_parent_path_for_lookup(self, raw_parent: str, anchor: Path | None) -> str | None:
         """Resolve a stored parent_project_path to a canonical registry key.
 
-        Expands `{workspace_dir}`, then resolves relative paths against `anchor`
-        (the containing template's file path). Returns None if the path is
-        relative and no anchor was provided, since we can't form an absolute
-        path without one.
+        Resolves relative paths against `anchor` (the containing template's
+        file path). Returns None if the path is relative and no anchor was
+        provided, since we can't form an absolute path without one. Macro
+        tokens are rejected by the loader; this resolver only sees absolute
+        or anchor-relative paths.
         """
-        expanded = self._expand_workspace_dir_macro(raw_parent)
-        parent_path = Path(expanded)
+        parent_path = Path(raw_parent)
         if not parent_path.is_absolute():
             if anchor is None:
                 return None
             parent_path = anchor.parent / parent_path
         return str(canonicalize_for_identity(parent_path))
-
-    def _expand_workspace_dir_macro(self, value: str) -> str:
-        """Substitute the `{workspace_dir}` token with the active workspace path.
-
-        Other macro tokens are intentionally left untouched here. Path-bearing
-        fields that need full macro resolution (situations, directories) go
-        through the macro parser; `parent_project_path` only honors
-        `{workspace_dir}` to keep the resolution surface narrow.
-        """
-        if "{workspace_dir}" not in value:
-            return value
-        return value.replace("{workspace_dir}", str(self._config_manager.workspace_path))
-
-    def _workspace_relative_macro_path(self, absolute_path: Path) -> str:
-        """Express an absolute path in portable form for cross-machine sharing.
-
-        If the path lives under the active workspace, returns
-        `{workspace_dir}/<rel>` (POSIX-style). Otherwise returns the
-        canonicalized absolute path as a string. Callers persist this value
-        into a child's `parent_project_path` so the link survives moves
-        between machines that share the same workspace layout.
-        """
-        workspace = canonicalize_for_identity(self._config_manager.workspace_path)
-        abs_canon = canonicalize_for_identity(absolute_path)
-        if abs_canon.is_relative_to(workspace):
-            rel = abs_canon.relative_to(workspace).as_posix()
-            if rel == ".":
-                return "{workspace_dir}"
-            return f"{{workspace_dir}}/{rel}"
-        return str(abs_canon)
 
     def on_unregister_project_template_request(
         self, request: UnregisterProjectTemplateRequest

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1257,7 +1257,7 @@ class ProjectManager:
             current_parent_raw = parent_info.template.parent_project_path
             current_anchor = parent_info.project_file_path
 
-    def _resolve_parent_path_for_lookup(self, raw_parent: str, anchor: Path | None) -> str | None:
+    def _resolve_parent_path_for_lookup(self, raw_parent: str, anchor: Path | str | None) -> str | None:
         """Resolve a stored parent_project_path to a canonical registry key.
 
         Resolves relative paths against `anchor` (the containing template's
@@ -1265,12 +1265,15 @@ class ProjectManager:
         provided, since we can't form an absolute path without one. Macro
         tokens are rejected by the loader; this resolver only sees absolute
         or anchor-relative paths.
+
+        `anchor` is coerced to `Path` defensively because request payloads
+        deserialized over the wire arrive with `project_path` as a `str`.
         """
         parent_path = Path(raw_parent)
         if not parent_path.is_absolute():
             if anchor is None:
                 return None
-            parent_path = anchor.parent / parent_path
+            parent_path = Path(anchor).parent / parent_path
         return str(canonicalize_for_identity(parent_path))
 
     def on_unregister_project_template_request(

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -3947,35 +3947,6 @@ directories:
         assert "directories" not in parsed or "outputs" not in (parsed.get("directories") or {})
 
     @pytest.mark.asyncio
-    async def test_save_with_relative_parent_path(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """`parent_project_path` written as a relative path resolves against the child YAML's directory."""
-        from griptape_nodes.retained_mode.events.project_events import (
-            SaveProjectTemplateRequest,
-            SaveProjectTemplateResultSuccess,
-        )
-
-        # Sibling layout: child.yml lives next to parent.yml, links via "./parent.yml".
-        parent_path = (tmp_path / "parent.yml").resolve()
-        await self._load_parent(pm, parent_path, self.BASE_PARENT_YAML)
-
-        child_path = tmp_path / "child.yml"
-        template_data = {
-            "project_template_schema_version": "0.3.2",
-            "name": "child",
-            "parent_project_path": "./parent.yml",
-            "situations": {},
-            "directories": {
-                "outputs": {"name": "outputs", "path_macro": "outputs2"},  # inherited
-            },
-        }
-        result = pm.on_save_project_template_request(
-            SaveProjectTemplateRequest(project_path=child_path, template_data=template_data)
-        )
-        assert isinstance(result, SaveProjectTemplateResultSuccess)
-        parsed = self._parse_yaml(child_path.read_text())
-        assert "directories" not in parsed or "outputs" not in (parsed.get("directories") or {})
-
-    @pytest.mark.asyncio
     async def test_save_grandchild_diffs_against_parent_merged_chain(self, pm: ProjectManager, tmp_path: Path) -> None:
         """Grandchild's diff base is the parent's *fully-merged* template (which carries grandparent values)."""
         from griptape_nodes.retained_mode.events.project_events import (

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -3339,24 +3339,25 @@ directories:
         assert child_info.parent_project_path == str(base_path)
 
     @pytest.mark.asyncio
-    async def test_parent_project_path_workspace_macro_resolves(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """`parent_project_path` written as `{workspace_dir}/p.yml` resolves to the workspace-anchored parent.
+    async def test_parent_project_path_relative_resolves_against_child_yaml(
+        self, pm: ProjectManager, tmp_path: Path
+    ) -> None:
+        """`parent_project_path` written as `./base.yml` resolves against the child YAML's directory.
 
-        Pins the portability contract: a child stored with the macro form must
-        successfully merge its parent in when the engine loads on a different
-        machine where the workspace lives at a different absolute path.
+        Relative encoding is the supported portable form: it doesn't depend on
+        runtime workspace state, so the same string resolves to the same
+        sibling file regardless of which project is currently active.
         """
         from griptape_nodes.retained_mode.events.project_events import (
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
 
-        # pm fixture sets workspace_path = tmp_path, so {workspace_dir} expands to tmp_path.
         base_path = (tmp_path / "base.yml").resolve()
         child_path = (tmp_path / "child.yml").resolve()
         files = {
             base_path: self.BASE_PROJECT_YAML,
-            child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent="{workspace_dir}/base.yml"),
+            child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent="./base.yml"),
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
@@ -3368,83 +3369,6 @@ directories:
         # Merged template carries the parent's contribution, so the child sees both directories.
         assert "shared_outputs" in child_load.template.directories
         assert "child_outputs" in child_load.template.directories
-
-    @pytest.mark.asyncio
-    async def test_parent_project_path_macro_canonical_in_list_response(
-        self, pm: ProjectManager, tmp_path: Path
-    ) -> None:
-        """`project_macro_path` is `{workspace_dir}/<rel>` for templates living under the workspace.
-
-        The GUI parent-picker reads this and stores it into a child's
-        `parent_project_path`, so the value must round-trip cleanly with
-        `_expand_workspace_dir_macro`.
-        """
-        from griptape_nodes.retained_mode.events.project_events import (
-            ListProjectTemplatesRequest,
-            LoadProjectTemplateRequest,
-        )
-
-        base_path = (tmp_path / "base.yml").resolve()
-        files = {base_path: self.BASE_PROJECT_YAML}
-
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ahandle_request = self._file_router(files)
-            await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=base_path))
-
-        list_result = pm.on_list_project_templates_request(ListProjectTemplatesRequest(include_system_builtins=False))
-        by_id = {info.project_id: info for info in list_result.successfully_loaded}
-        info = by_id[str(base_path)]
-
-        assert info.project_macro_path == "{workspace_dir}/base.yml"
-
-    @pytest.mark.asyncio
-    async def test_parent_project_path_outside_workspace_falls_back_to_absolute(
-        self, pm: ProjectManager, tmp_path: Path
-    ) -> None:
-        """Templates outside the workspace get an absolute `project_macro_path`.
-
-        Decision captured in the plan: silently fall back to the canonicalized
-        absolute path (no warning, no filtering) so the picker still surfaces
-        out-of-workspace projects.
-        """
-        from griptape_nodes.retained_mode.events.project_events import (
-            ListProjectTemplatesRequest,
-            LoadProjectTemplateRequest,
-        )
-
-        # Move the workspace away from tmp_path so the project lives outside it.
-        outside_workspace = tmp_path / "elsewhere"
-        outside_workspace.mkdir()
-        pm._config_manager.workspace_path = outside_workspace
-
-        base_path = (tmp_path / "base.yml").resolve()
-        files = {base_path: self.BASE_PROJECT_YAML}
-
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ahandle_request = self._file_router(files)
-            await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=base_path))
-
-        list_result = pm.on_list_project_templates_request(ListProjectTemplatesRequest(include_system_builtins=False))
-        info = list_result.successfully_loaded[0]
-
-        assert info.project_macro_path is not None
-        assert info.project_macro_path == str(base_path)
-        assert "{workspace_dir}" not in info.project_macro_path
-
-    def test_expand_workspace_dir_macro_substitutes_token(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """`_expand_workspace_dir_macro` replaces `{workspace_dir}` with the active workspace path string.
-
-        Tested at the helper level (rather than through a YAML round-trip) so
-        the assertion stays cross-platform: the resulting path string is
-        constructed by `str.replace`, separator handling is delegated to
-        `Path()` downstream.
-        """
-        # pm fixture sets workspace_path = tmp_path.
-        expanded = pm._expand_workspace_dir_macro("{workspace_dir}/sub/file.yml")
-        assert expanded == f"{tmp_path}/sub/file.yml"
-
-        # No-op when the token is absent.
-        assert pm._expand_workspace_dir_macro("/literal/path.yml") == "/literal/path.yml"
 
     @pytest.mark.asyncio
     async def test_overlay_round_trip_preserves_parent_project_path(self, pm: ProjectManager, tmp_path: Path) -> None:
@@ -4023,14 +3947,14 @@ directories:
         assert "directories" not in parsed or "outputs" not in (parsed.get("directories") or {})
 
     @pytest.mark.asyncio
-    async def test_save_with_workspace_dir_parent_path(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """`parent_project_path` of `{workspace_dir}/parent.yml` must expand against the active workspace."""
+    async def test_save_with_relative_parent_path(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """`parent_project_path` written as a relative path resolves against the child YAML's directory."""
         from griptape_nodes.retained_mode.events.project_events import (
             SaveProjectTemplateRequest,
             SaveProjectTemplateResultSuccess,
         )
 
-        # pm fixture sets workspace_path = tmp_path.
+        # Sibling layout: child.yml lives next to parent.yml, links via "./parent.yml".
         parent_path = (tmp_path / "parent.yml").resolve()
         await self._load_parent(pm, parent_path, self.BASE_PARENT_YAML)
 
@@ -4038,7 +3962,7 @@ directories:
         template_data = {
             "project_template_schema_version": "0.3.2",
             "name": "child",
-            "parent_project_path": "{workspace_dir}/parent.yml",
+            "parent_project_path": "./parent.yml",
             "situations": {},
             "directories": {
                 "outputs": {"name": "outputs", "path_macro": "outputs2"},  # inherited


### PR DESCRIPTION
This removes macros from project paths. It was a bad idea, because the value of a macro changes depending on which project is loaded. So workspace_dir could be change (based on active project), which would change the parent of a project with workspace_dir in their parent_path

Unblocks https://github.com/griptape-ai/griptape-vsl-gui/pull/2335/

