### PR TITLE
feat(sequences): macro-path round-trip and explicit NoTokenBehavior dispatch

### DIFF
--- a/docs/projects/sequences.md
+++ b/docs/projects/sequences.md
@@ -1,8 +1,8 @@
 # Sequences
 
-Griptape Nodes can read directories of numbered files as **sequences** — for example, a render output like `render.0001.exr`, `render.0002.exr`, … `render.0100.exr`, but also dialogue takes (`take_##.wav`), text chunks (`chapter_###.md`), or anything else where a numeric key in the filename groups items into an ordered set. You point a sequence-aware node at a *pattern* (the filename with a placeholder for the number), and the engine finds the matching items on disk, handles gaps, and gives you back a list of entries with their integer numbers and zero-padded string forms.
+Griptape Nodes can read directories of numbered files as **sequences** — for example, a render output like `render.0001.exr`, `render.0002.exr`, … `render.0100.exr`, but also dialogue takes (`take_##.wav`), text chunks (`chapter_###.md`), or anything else where a numeric key in the filename groups items into an ordered set. You point a sequence-aware node at a *path or pattern* (a filename with a placeholder for the number, or just a literal file path), and the engine finds the matching items on disk, handles gaps, and gives you back a list of entries with their integer numbers and zero-padded string forms.
 
-This page explains the pattern syntax, the policies for handling missing items, and the conventions you should know before authoring a template.
+This page explains the path/pattern syntax, the policies for handling missing items, and the conventions you should know before authoring one.
 
 ## Pattern syntax
 
@@ -27,15 +27,40 @@ take_##.wav                 item 7 → take_07.wav
 
 The token always sits in the **filename**. Tokens inside directory components (e.g. `render/####/beauty.exr`) are not supported — keep the number in the filename portion only.
 
+## When the path has no sequence token
+
+A path with no sequence token (`/work/photo.png`, `{inputs}/poster.png`, `render.0002.png`) is *ambiguous*. The artist might mean:
+
+1. **the literal name of one specific file** — `render.0002.png` is the file I want;
+1. **one frame of an implicit sequence** — fileseq sees the digits and groups every `render.NNNN.png` it finds into a single sequence;
+1. **an oversight** — the artist forgot to type `####`, and the right answer is to fail loudly so they fix it.
+
+The engine asks the caller which interpretation to use via `NoTokenBehavior` (in `griptape_nodes.common.sequences`):
+
+| Value                     | What you get                                                                                                                                                                                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SINGLE_FILE` *(default)* | Treats the whole filename as a literal. A 1-item sequence (`first=last=1, padding=0`) when the file exists; an empty result when it doesn't. Sibling files in the same directory are ignored — `render.0002.png` returns just `render.0002.png` even if `0001..0005` are next to it. |
+| `EXPLORE_SEQUENCE`        | Lets fileseq read digits in the filename as an implicit sequence token. `render.0002.png` becomes one frame of an inferred `render.####.png` sequence; the scan walks every matching sibling. Useful when a downstream tool gave you one filename but you want the whole take.       |
+| `REJECT`                  | Fails fast with `INVALID_TEMPLATE` and a message asking the artist to add a token. Strict mode for pipelines that should never silently widen the artist's intent.                                                                                                                   |
+
+Defaulting to `SINGLE_FILE` keeps the path → sequence-of-one mapping that "I picked one file" intuitively expects. Workflows that want the implicit-grouping behavior opt in explicitly.
+
 ## Combining with macros
 
-Sequence patterns work alongside the project's [macro language](macros.md). The variables get resolved first, then the resulting filename is interpreted as a sequence pattern:
+Sequence paths work alongside the project's [macro language](macros.md). The macro head is resolved internally so the engine can read the right directory off disk, but the engine emits paths in the shape you supplied:
 
 ```
-{inputs}/shot_a/render.####.exr
+input  : {inputs}/shot_a/render.####.exr
+output : Sequence(directory="{inputs}/shot_a",
+                  entries=[{path: "{inputs}/shot_a/render.0001.exr"},
+                           {path: "{inputs}/shot_a/render.0002.exr"}, ...])
 ```
 
-If `{inputs}` resolves to `/workspace/inputs`, the engine scans `/workspace/inputs/shot_a/` for files matching `render.####.exr`. Macro variables inside `{...}` are completely separate from sequence tokens — they don't share syntax and they're resolved at different stages.
+This is what makes scan results portable. A workflow built on a machine where `{inputs}` resolves to `/Volumes/Renders` produces sequences whose paths still say `{inputs}` — re-opening that workflow on a machine where `{inputs}` resolves to `C:\renders` still works, because every consumer downstream resolves the macro fresh against its own project.
+
+Plain absolute paths (no `{...}` segments) round-trip identically — you put `/work/render.####.png` in, you get `/work/render.0001.png` back.
+
+Macro variables inside `{...}` are completely separate from sequence tokens — they don't share syntax, and they're resolved at different stages.
 
 ## Width matching is strict
 
@@ -78,12 +103,12 @@ Each `Sequence` carries:
 - **`discovered_first`** / **`discovered_last`** — what was actually on disk, ignoring any subset.
 - **`padding`** — the declared zero-padding width (e.g. 4 for `####`).
 - **`pattern`** — the canonical pattern (e.g. `render.####.exr`).
-- **`directory`** — the directory the scan ran in.
+- **`directory`** — the directory portion of the path you supplied, in the same shape (macro-form when you supplied a macro, plain absolute otherwise).
 - **`policy`** — which policy was applied.
 - **`entries`** — one `SequenceEntry` per item in the active range. Each has:
     - `number` — the integer key (e.g. 5).
     - `padded_number` — the zero-padded form (e.g. `0005`).
-    - `path` — the on-disk file path as a plain string. Under `FILL_NEAREST`, gap entries carry the nearest present neighbor's path; cross-check `entry.number in seq.present_numbers` to tell present from filled.
+    - `path` — the file path as a string, in the same shape you supplied. A macro-form input round-trips with the macro head intact (`{inputs}/render.0005.exr`); a plain absolute input round-trips identically (`/work/render.0005.exr`). Under `FILL_NEAREST`, gap entries carry the nearest present neighbor's path; cross-check `entry.number in seq.present_numbers` to tell present from filled.
 - **`present_numbers`** — the set of numbers actually on disk inside `[first, last]`.
 - **`missing_numbers`** — derived from `present_numbers`: the numbers in the active range that aren't on disk (useful for diagnostics under any policy).
 
@@ -102,21 +127,68 @@ Sequence handling is built on [`fileseq`](https://github.com/justinfx/fileseq), 
 
 ## Public entry point: `ScanSequencesRequest`
 
-Scans are dispatched on the engine's event bus, not by importing a function. Send a `ScanSequencesRequest` (defined in `griptape_nodes.retained_mode.events.os_events`) and `await GriptapeNodes.ahandle_request(...)`; the handler runs the directory listing and fileseq parsing in a worker thread, so a long-running scan over a deep directory doesn't block the event loop.
+Scans are dispatched on the engine's event bus, not by importing a function. Send a `ScanSequencesRequest` (defined in `griptape_nodes.retained_mode.events.os_events`) and `await GriptapeNodes.ahandle_request(...)`; the handler resolves any project macros, runs the directory listing, and runs fileseq parsing in a worker thread, so a long-running scan over a deep directory doesn't block the event loop.
+
+The request takes a single `path` field. Examples:
+
+```python
+# Macro-form pattern. The {inputs} head is preserved on every emitted path.
+ScanSequencesRequest(path="{inputs}/shot_a/render.####.exr")
+
+# Plain absolute pattern. Round-trips identically.
+ScanSequencesRequest(path="/work/render.####.png", policy=MissingItemPolicy.SKIP)
+
+# Token-less path. Default `no_token_behavior=SINGLE_FILE` returns a one-item
+# sequence containing exactly that file (or empty if it doesn't exist).
+ScanSequencesRequest(path="/work/photo.png")
+
+# Token-less path, but treat it as one frame of an implicit sequence and
+# walk every matching sibling.
+ScanSequencesRequest(
+    path="/work/render.0002.png",
+    no_token_behavior=NoTokenBehavior.EXPLORE_SEQUENCE,
+)
+
+# Strict mode: fail with INVALID_TEMPLATE if the path has no token.
+ScanSequencesRequest(
+    path="/work/render.0002.png",
+    no_token_behavior=NoTokenBehavior.REJECT,
+)
+
+# Active range subset.
+ScanSequencesRequest(path="{inputs}/render.####.exr", start_number=10, end_number=50)
+```
 
 Success returns `ScanSequencesResultSuccess` carrying:
 
-- **`sequences: list[Sequence]`** — the inferred sequences, post-policy.
+- **`sequences: list[Sequence]`** — the inferred sequences, post-policy. Every `Sequence.directory` and `entry.path` keeps the same path shape you supplied (macro-form in, macro-form out).
 - **`has_entries: bool`** — true iff at least one Sequence has at least one entry. A scan that ran cleanly but found nothing is *success with `has_entries=False`*, not failure — callers that need to fail-fast on empty results check `has_entries` themselves.
 - **`directory_had_matching_files: bool`** — true iff the directory listing produced at least one file whose basename + extension matched the target shape (i.e. the prefilter accepted something). Combined with `has_entries`, it tells you *why* a scan came up empty: false means the path is wrong or the basename/extension doesn't match anything; true with `has_entries=False` means the files are there but the padding doesn't line up *or* the active subset clipped them all out.
 - **`discovered_first: int | None`** / **`discovered_last: int | None`** — the on-disk range of inferred numbers *before* subset clipping is applied. Populated whenever fileseq inferred at least one number from the directory; `None` if the listing yielded no padding-matching numbers. Lets the caller diagnose subset-clip cases without guessing — e.g. "asked for 90..100 but disk has 1..7" comes straight from these fields.
 
 These three diagnostic fields let consumers distinguish wrong-path / wrong-padding / wrong-range cases without inspecting `result_details` strings. Per-Sequence `discovered_first`/`discovered_last` (on each `Sequence` object) are still the right read when you have at least one sequence; the top-level fields are specifically for the empty-result diagnostic.
 
-Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a `SequenceScanFailureReason` (`INVALID_TEMPLATE`, `INVALID_BOUNDS`, `ABORTED_AT_GAP`) or an OS-layer `FileIOFailureReason`. Failures are reserved for cases where the scan couldn't proceed: bad bounds, bad template, the `ABORT` policy hit a gap, or the inner directory listing failed (directory not found, permission denied — these surface via `FileIOFailureReason`, not folded into empty success). Under `ABORTED_AT_GAP`, the failure also populates `missing_item_number` with the offending integer key.
+Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a `SequenceScanFailureReason` (`INVALID_TEMPLATE`, `INVALID_BOUNDS`, `ABORTED_AT_GAP`) or an OS-layer `FileIOFailureReason`. Failures are reserved for cases where the scan couldn't proceed:
+
+- `INVALID_TEMPLATE` — the path string couldn't be parsed (bad macro syntax, multi-token pattern, missing filename component, unresolvable macro variables, etc.). Also surfaces when the path has zero sequence tokens and `no_token_behavior` is `REJECT`.
+- `INVALID_BOUNDS` — `start_number < 0` or `end_number < start_number`.
+- `ABORTED_AT_GAP` — the `ABORT` policy hit a gap. The failure also populates `missing_item_number` with the offending integer key.
+- A `FileIOFailureReason` value — the inner directory listing failed (directory not found, permission denied, etc.). These surface via `FileIOFailureReason`, not folded into empty success.
 
 ### Node-level: `fail_on_empty_result`
 
 The standard library's `ScanSequenceNode` and `ScanSplitSequenceNode` both expose a top-level `fail_on_empty_result: bool = True` parameter. When true (the default), an empty scan result routes the node through its Failure control-flow edge with a diagnostic-aware status message built from the fields above. When false, the node succeeds with empty outputs and a status noting the opt-out — for workflows that legitimately tolerate empty scans (e.g. a sweep that may find nothing).
+
+### Node-level: *When there's no sequence marker*
+
+Both Scan nodes also expose the `NoTokenBehavior` choice as a friendly dropdown labelled **When there's no sequence marker (e.g., ###)**, inside the collapsed *Advanced Sequence Control* group. The three options map onto the engine enum:
+
+| Dropdown label                     | Engine value       |
+| ---------------------------------- | ------------------ |
+| *Treat as a single file* (default) | `SINGLE_FILE`      |
+| *Treat as part of a sequence*      | `EXPLORE_SEQUENCE` |
+| *Fail unless a token is present*   | `REJECT`           |
+
+The same dropdown also drives the relative-bounds discovery probe inside the node (when *Start at* / *End at* is set to *Relative …*), so a literal-file path doesn't get explored just because the node is sniffing for offsets.
 
 Library and node code should never import the underlying scanner directly — the request bus is the only public path.

--- a/docs/projects/sequences.md
+++ b/docs/projects/sequences.md
@@ -60,6 +60,8 @@ This is what makes scan results portable. A workflow built on a machine where `{
 
 Plain absolute paths (no `{...}` segments) round-trip identically — you put `/work/render.####.png` in, you get `/work/render.0001.png` back.
 
+**Relative paths.** A path with no leading `/` and no macro head — e.g. `shot_a/render.####.png` — is interpreted relative to the project's workspace directory. The engine prepends the workspace path before listing, so `shot_a/render.####.png` and `{workspace_dir}/shot_a/render.####.png` resolve identically. Use whichever form reads more naturally for the workflow.
+
 Macro variables inside `{...}` are completely separate from sequence tokens — they don't share syntax, and they're resolved at different stages.
 
 ## Width matching is strict
@@ -172,7 +174,7 @@ Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a 
 
 - `INVALID_TEMPLATE` — the path string couldn't be parsed (bad macro syntax, multi-token pattern, missing filename component, unresolvable macro variables, etc.). Also surfaces when the path has zero sequence tokens and `no_token_behavior` is `REJECT`.
 - `INVALID_BOUNDS` — `start_number < 0` or `end_number < start_number`.
-- `ABORTED_AT_GAP` — the `ABORT` policy hit a gap. The failure also populates `missing_item_number` with the offending integer key.
+- `ABORTED_AT_GAP` — the `ABORT` policy hit at least one gap inside the active range. The failure populates `missing_item_numbers: list[int]` with every offending integer key, sorted ascending — UI consumers can show the artist *all* the missing slots in one pass instead of fixing them one re-run at a time.
 - A `FileIOFailureReason` value — the inner directory listing failed (directory not found, permission denied, etc.). These surface via `FileIOFailureReason`, not folded into empty success.
 
 ### Node-level: `fail_on_empty_result`

--- a/src/griptape_nodes/common/sequences/__init__.py
+++ b/src/griptape_nodes/common/sequences/__init__.py
@@ -30,6 +30,7 @@ from griptape_nodes.common.sequences.models import (
     InvalidTemplateError,
     MissingItemError,
     MissingItemPolicy,
+    NoTokenBehavior,
     Sequence,
     SequenceEntry,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "InvalidTemplateError",
     "MissingItemError",
     "MissingItemPolicy",
+    "NoTokenBehavior",
     "Sequence",
     "SequenceEntry",
 ]

--- a/src/griptape_nodes/common/sequences/models.py
+++ b/src/griptape_nodes/common/sequences/models.py
@@ -1,7 +1,8 @@
 """Data shapes for the sequences module.
 
-Three concepts:
+Four concepts:
     - `MissingItemPolicy`: how to fill gaps inside a sequence's range.
+    - `NoTokenBehavior`: what to do when the input has no sequence token at all.
     - `Sequence`: one contiguous-or-gap-aware sequence with metadata.
     - `SequenceEntry`: one item inside a Sequence (number + path).
 """
@@ -29,6 +30,34 @@ class MissingItemPolicy(StrEnum):
     SPLIT = "split"  # Sparse sequence becomes N contiguous sub-sequences.
     SKIP = "skip"  # Single sequence with only the present items; gaps absent.
     FILL_NEAREST = "fill_nearest"  # Dense sequence; gaps point at the backward-first neighbor.
+
+
+class NoTokenBehavior(StrEnum):
+    """What to do when the caller's path has no sequence token (`####`, `%04d`, etc.).
+
+    A path with zero tokens is ambiguous: the artist may have typed the
+    literal name of one specific file (`render.0002.png`), or they may have
+    meant to scan the surrounding sequence and forgotten the token, or they
+    may have a workflow that should fail loud if the token is missing. This
+    enum picks which interpretation the scanner uses.
+
+    - `SINGLE_FILE` *(default)*: Treat the whole filename as a literal. The
+      result is a 1-item Sequence (`first=last=1, padding=0`) when the file
+      exists, an empty result when it doesn't. Sibling files in the same
+      directory are ignored.
+    - `EXPLORE_SEQUENCE`: Let fileseq parse digits in the filename as an
+      implicit sequence token. `render.0002.png` is treated as one frame of
+      a `render.####.png` sequence; the scan walks every matching sibling
+      and the result reflects the entire on-disk run. Useful when a
+      downstream tool gave you one filename but you want the whole take.
+    - `REJECT`: Fail with `INVALID_TEMPLATE` and tell the artist the path
+      needs an explicit token. Strict mode for workflows that must not
+      silently widen the artist's intent.
+    """
+
+    SINGLE_FILE = "single_file"
+    EXPLORE_SEQUENCE = "explore_sequence"
+    REJECT = "reject"
 
 
 class MissingItemError(Exception):

--- a/src/griptape_nodes/common/sequences/models.py
+++ b/src/griptape_nodes/common/sequences/models.py
@@ -19,14 +19,14 @@ class MissingItemPolicy(StrEnum):
 
     The choice changes the *shape* (or even the success) of `scan_sequences` output:
 
-    - `ABORT`: raise `MissingItemError` on the first missing slot in `[first..last]`.
+    - `ABORT`: raise `MissingItemError` carrying every missing slot in `[first..last]`.
     - `SPLIT`: returns multiple Sequences, each contiguous (no gaps inside any).
     - `SKIP`: one Sequence with only the present items; gaps absent from `entries`.
     - `FILL_NEAREST`: one Sequence whose entries span the full [first, last] range,
       with each missing slot's path pointing at the nearest present neighbor.
     """
 
-    ABORT = "abort"  # Raise MissingItemError on the first gap.
+    ABORT = "abort"  # Raise MissingItemError listing every gap inside the active range.
     SPLIT = "split"  # Sparse sequence becomes N contiguous sub-sequences.
     SKIP = "skip"  # Single sequence with only the present items; gaps absent.
     FILL_NEAREST = "fill_nearest"  # Dense sequence; gaps point at the backward-first neighbor.
@@ -60,16 +60,41 @@ class NoTokenBehavior(StrEnum):
     REJECT = "reject"
 
 
+# Truncate the inline preview of gap numbers in MissingItemError's __str__
+# after this many entries — the full list lives on `numbers` for callers
+# that need it. Matches the threshold used in
+# `OSManager.on_scan_sequences_request`'s `result_details` summary so the
+# exception text and the handler's user-facing string truncate at the same point.
+_GAP_PREVIEW_COUNT = 5
+
+
 class MissingItemError(Exception):
-    """Raised by `MissingItemPolicy.ABORT` on the first missing slot inside the active range.
+    """Raised by `MissingItemPolicy.ABORT` when at least one slot inside the active range is missing.
+
+    Surfaces every gap in one shot so a UI consumer can show the artist all
+    the missing items in a single pass instead of fixing them one-at-a-time
+    across re-runs.
 
     Attributes:
-        number: The slot number that triggered the abort.
+        numbers: All missing slot numbers, sorted ascending. Always non-empty
+            — the scanner only raises when at least one gap was found.
     """
 
-    def __init__(self, number: int) -> None:
-        super().__init__(f"Sequence has a gap at item {number}.")
-        self.number = number
+    def __init__(self, numbers: list[int]) -> None:
+        if not numbers:
+            msg = "Attempted to construct MissingItemError with no missing numbers. Pass at least one."
+            raise ValueError(msg)
+        sorted_numbers = sorted(numbers)
+        if len(sorted_numbers) == 1:
+            super().__init__(f"Sequence has a gap at item {sorted_numbers[0]}.")
+        else:
+            preview = ", ".join(str(n) for n in sorted_numbers[:_GAP_PREVIEW_COUNT])
+            if len(sorted_numbers) <= _GAP_PREVIEW_COUNT:
+                tail = ""
+            else:
+                tail = f", … (+{len(sorted_numbers) - _GAP_PREVIEW_COUNT} more)"
+            super().__init__(f"Sequence has gaps at items {preview}{tail}.")
+        self.numbers = sorted_numbers
 
 
 class InvalidSubsetBoundsError(ValueError):

--- a/src/griptape_nodes/common/sequences/policies.py
+++ b/src/griptape_nodes/common/sequences/policies.py
@@ -3,6 +3,11 @@
 Pure functions that take a `fileseq.FileSequence` plus the present-numbers
 map and produce a list of `Sequence` objects shaped according to the chosen
 policy. No I/O, no fileseq state mutation — just transformation.
+
+Path values flowing through this module are *strings in the caller's shape*
+(macro-form when the caller supplied a macro, plain absolute otherwise). The
+scanner's `PathMapping` does the resolved↔caller conversion before handing
+the present-numbers dict in here, so policies don't touch macros directly.
 """
 
 from __future__ import annotations
@@ -18,22 +23,22 @@ from griptape_nodes.common.sequences.models import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
-    from fileseq.filesequence import FileSequence
+    from griptape_nodes.common.sequences.scan import TargetPattern
 
 
 @dataclass(frozen=True)
 class PolicyContext:
     """Bundle of inputs for `apply_policy`.
 
-    Groups the unchanging context (range, discovered range, fileseq object,
-    drop count) so callers and helpers can pass one object instead of nine
-    keyword arguments.
+    Groups the unchanging context (range, discovered range, fileseq-or-literal
+    target, drop count) so callers and helpers can pass one object instead of
+    nine keyword arguments. `fseq` is the structural protocol satisfied by
+    both `fileseq.FileSequence` and `_LiteralTarget`; only its metadata
+    accessors (basename / padding / extension / zfill) are read here.
     """
 
-    fseq: FileSequence
-    present_numbers: dict[int, Path]
+    fseq: TargetPattern
+    present_numbers: dict[int, str]
     directory: str
     policy: MissingItemPolicy
     first: int
@@ -46,10 +51,11 @@ class PolicyContext:
 def apply_policy(context: PolicyContext) -> list[Sequence]:
     """Build the final list of Sequences according to `context.policy`.
 
-    `context.present_numbers` maps each present integer key to its on-disk
-    Path. Numbers may sit inside or outside [first, last]; only those inside
-    the active range are surfaced. SPLIT returns multiple sequences (one per
-    contiguous run). All other policies return exactly one sequence.
+    `context.present_numbers` maps each present integer key to its
+    caller-shaped path string. Numbers may sit inside or outside [first,
+    last]; only those inside the active range are surfaced. SPLIT returns
+    multiple sequences (one per contiguous run). All other policies return
+    exactly one sequence.
 
     `context.fseq` is used only to read its formatting metadata (basename,
     padding, extension, zfill); it is not mutated.
@@ -117,8 +123,8 @@ def _apply_single(context: PolicyContext) -> Sequence:
 def _gap_entry(
     number: int,
     policy: MissingItemPolicy,
-    fseq: FileSequence,
-    in_range_present: dict[int, Path],
+    fseq: TargetPattern,
+    in_range_present: dict[int, str],
 ) -> SequenceEntry | None:
     """Build the SequenceEntry for a missing item, or None to omit it.
 
@@ -138,7 +144,7 @@ def _gap_entry(
             return SequenceEntry(
                 number=number,
                 padded_number=_format_number(fseq, number),
-                path=str(neighbor_path),
+                path=neighbor_path,
             )
         case _:
             msg = f"Unknown missing-item policy: {policy}"
@@ -158,7 +164,7 @@ def _contiguous_runs(sorted_numbers: list[int]) -> list[list[int]]:
     return runs
 
 
-def _nearest_path(number: int, present: dict[int, Path]) -> Path | None:
+def _nearest_path(number: int, present: dict[int, str]) -> str | None:
     """Find the nearest present number's path. Backward-first, then forward.
 
     Per the spec: when a missing item needs a NEAREST fill, we prefer the
@@ -176,12 +182,12 @@ def _nearest_path(number: int, present: dict[int, Path]) -> Path | None:
     return None
 
 
-def _present_entry(fseq: FileSequence, number: int, path: Path) -> SequenceEntry:
+def _present_entry(fseq: TargetPattern, number: int, path: str) -> SequenceEntry:
     """Build a SequenceEntry for a present-on-disk item."""
-    return SequenceEntry(number=number, padded_number=_format_number(fseq, number), path=str(path))
+    return SequenceEntry(number=number, padded_number=_format_number(fseq, number), path=path)
 
 
-def _format_number(fseq: FileSequence, number: int) -> str:
+def _format_number(fseq: TargetPattern, number: int) -> str:
     """Render an integer key with the sequence's declared zero-padding.
 
     `fseq.frame(N)` returns the full filename (basename + padded number +
@@ -196,6 +202,6 @@ def _format_number(fseq: FileSequence, number: int) -> str:
     return f"{number:0{width}d}"
 
 
-def _canonical_pattern(fseq: FileSequence) -> str:
+def _canonical_pattern(fseq: TargetPattern) -> str:
     """Reconstruct the basename + padding + extension form (no number range)."""
     return f"{fseq.basename()}{fseq.padding()}{fseq.extension()}"

--- a/src/griptape_nodes/common/sequences/policies.py
+++ b/src/griptape_nodes/common/sequences/policies.py
@@ -94,8 +94,17 @@ def _build_split_sequence(run: list[int], context: PolicyContext) -> Sequence:
 
 
 def _apply_single(context: PolicyContext) -> Sequence:
-    """ABORT / SKIP / FILL_NEAREST: emit one Sequence over [first, last] (or raise on ABORT)."""
+    """SKIP / FILL_NEAREST: emit one Sequence over [first, last]; ABORT raises with every gap."""
     in_range_present = {n: p for n, p in context.present_numbers.items() if context.first <= n <= context.last}
+
+    if context.policy is MissingItemPolicy.ABORT:
+        # Collect all gaps in one pass so the failure payload can surface every
+        # missing item at once. Letting `_gap_entry` raise on the first gap (the
+        # old behavior) made artists fix gaps one-re-run-at-a-time.
+        missing = [n for n in range(context.first, context.last + 1) if n not in in_range_present]
+        if missing:
+            raise MissingItemError(missing)
+
     entries: list[SequenceEntry] = []
     for number in range(context.first, context.last + 1):
         if number in in_range_present:
@@ -128,13 +137,13 @@ def _gap_entry(
 ) -> SequenceEntry | None:
     """Build the SequenceEntry for a missing item, or None to omit it.
 
-    None is returned for the ERROR policy (which drops gaps from `entries`)
-    and for NEAREST when there's no neighbor at all (empty in-range present
-    set).
+    None is returned for SKIP (which drops gaps from `entries`) and for
+    FILL_NEAREST when there's no neighbor at all (empty in-range present set).
+
+    ABORT is not handled here — `_apply_single` collects all gaps in a single
+    pass and raises `MissingItemError` itself before this function is called.
     """
     match policy:
-        case MissingItemPolicy.ABORT:
-            raise MissingItemError(number)
         case MissingItemPolicy.SKIP:
             return None
         case MissingItemPolicy.FILL_NEAREST:

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -1,14 +1,19 @@
 """Directory scanning for sequences.
 
-Worker behind `ScanSequencesRequest`. Takes a directory + a fileseq pattern
-(either as a string like `render.####.exr` or a pre-constructed
-`FileSequence`), lists the directory via `ListDirectoryRequest`, hands the
-filenames to `fileseq.findSequencesInList`, applies subset clipping and the
-chosen missing-item policy, and returns a `ScanOutcome` carrying the
-inferred sequences plus diagnostic flags. The intended caller is
+Worker behind `ScanSequencesRequest`. Takes a `PathMapping` (the macro-form
+directory paired with its resolved-on-disk twin) plus a fileseq pattern,
+lists the resolved directory via `ListDirectoryRequest`, hands the filenames
+to `fileseq.findSequencesInList`, applies subset clipping and the chosen
+missing-item policy, and returns a `ScanOutcome` carrying the inferred
+sequences plus diagnostic flags. The intended caller is
 `OSManager.on_scan_sequences_request`; other callers are welcome but should
 prefer dispatching the bus request unless they have a strong reason to
 bypass the worker-thread / async-dispatch path.
+
+The `PathMapping` lets the scanner do all I/O against the resolved absolute
+directory while emitting Sequence objects whose `directory` and entry
+`path` fields stay in the caller's macro form. That preserves portability
+across machines where `{inputs}` resolves to different absolute roots.
 
 All filesystem I/O is routed through the engine's request bus — this module
 never calls `os.scandir`, `os.walk`, or `pathlib.Path.glob` directly.
@@ -21,8 +26,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, Protocol, runtime_checkable
 
 from fileseq.constants import PAD_STYLE_HASH1
 from fileseq.filesequence import FileSequence
@@ -31,6 +35,7 @@ from griptape_nodes.common.sequences.models import (
     InvalidSubsetBoundsError,
     InvalidTemplateError,
     MissingItemPolicy,
+    NoTokenBehavior,
     Sequence,
 )
 from griptape_nodes.common.sequences.policies import PolicyContext, apply_policy
@@ -78,9 +83,15 @@ class DirectoryListingError(Exception):
 
 @dataclass(frozen=True)
 class _PresentNumbers:
-    """Map of item numbers to their on-disk paths, plus the dropped count."""
+    """Map of item numbers to their (caller-shaped) paths, plus the dropped count.
 
-    by_number: dict[int, Path]
+    `by_number[N]` is a string in the *caller's* path shape — macro-form when
+    the caller supplied a macro, plain absolute otherwise. The mapping back
+    to the resolved on-disk path is done up front by `PathMapping` and is
+    not needed past the listing step.
+    """
+
+    by_number: dict[int, str]
     dropped_negatives: int
 
 
@@ -91,15 +102,51 @@ class _ActiveRange(NamedTuple):
     last: int
 
 
-def scan_sequences(
-    directory: str,
+@dataclass(frozen=True)
+class PathMapping:
+    """Pairs a macro-form directory with its resolved-on-disk twin.
+
+    The scanner does all I/O against `resolved_directory` (an absolute path
+    fileseq and `ListDirectoryRequest` can use) but emits paths through
+    `to_caller_path` so the artist's macro shape survives the round trip.
+
+    For plain absolute inputs (no macros), `original_directory` and
+    `resolved_directory` are equal and `to_caller_path` is effectively a
+    pass-through.
+
+    Attributes:
+        original_directory: Directory portion as the caller wrote it. May be
+            macro-form (`{inputs}/xyz`) or plain absolute.
+        resolved_directory: Absolute on-disk directory after macro resolution.
+        filename_pattern: The fileseq filename component (e.g. `render.####.png`).
+            Joined onto `original_directory` to produce the original `path`.
+    """
+
+    original_directory: str
+    resolved_directory: str
+    filename_pattern: str
+
+    def to_caller_path(self, filename: str) -> str:
+        """Return `original_directory + sep + filename`, preserving macro form."""
+        if not self.original_directory:
+            return filename
+        # Use forward slash unconditionally — macros and engine-resolved paths
+        # both speak `/` internally; the OS layer canonicalizes when it does
+        # I/O. This avoids `pathlib.Path` mishandling `{inputs}` segments on
+        # Windows.
+        return f"{self.original_directory}/{filename}"
+
+
+def scan_sequences(  # noqa: PLR0913
+    mapping: PathMapping,
     pattern: str | FileSequence,
     *,
     policy: MissingItemPolicy = MissingItemPolicy.SPLIT,
+    no_token_behavior: NoTokenBehavior = NoTokenBehavior.SINGLE_FILE,
     start: int | None = None,
     end: int | None = None,
 ) -> ScanOutcome:
-    """Find sequences matching `pattern` inside `directory`.
+    """Find sequences matching `pattern` inside `mapping.resolved_directory`.
 
     The intended entry point is `ScanSequencesRequest` on the engine's event
     bus; that request's handler invokes this function via `asyncio.to_thread()`
@@ -108,8 +155,9 @@ def scan_sequences(
     if you've already taken the I/O off the event loop yourself.
 
     Args:
-        directory: Absolute directory path to scan. Listed via
-            `ListDirectoryRequest` (no direct filesystem access).
+        mapping: The directory pair to scan. The scanner reads from
+            `mapping.resolved_directory` and emits paths in the shape of
+            `mapping.original_directory` (so macros stay macros).
         pattern: Either a fileseq pattern string (e.g. "render.####.exr") or
             a pre-constructed `FileSequence` whose basename + padding +
             extension act as the filter. Sequence tokens are interpreted in
@@ -118,6 +166,14 @@ def scan_sequences(
             Sequence per contiguous run; the others yield exactly one
             Sequence with policy-driven gap fills (or omissions for SKIP, or
             a `MissingItemError` for ABORT).
+        no_token_behavior: How to handle a `pattern` with zero sequence
+            tokens. `SINGLE_FILE` (default) treats the whole filename as a
+            literal — one-item sequence if the file exists, empty otherwise.
+            `EXPLORE_SEQUENCE` lets fileseq read digits in the filename as an
+            implicit sequence token (`render.0002.png` → one frame of a
+            `render.####.png` sequence; the scan walks every matching
+            sibling). `REJECT` raises `InvalidTemplateError` when the
+            pattern has no token, useful for strict workflows.
         start: Optional lower bound (inclusive) for the active subset. Items
             below this are dropped from output. Must be >= 0 if supplied.
         end: Optional upper bound (inclusive) for the active subset. Items
@@ -137,7 +193,8 @@ def scan_sequences(
             a failure (directory not found, permission denied, etc.). Carries
             the original `FileIOFailureReason`.
         InvalidSubsetBoundsError: If `start` < 0 or `end` < `start`.
-        InvalidTemplateError: If `pattern` contains more than one sequence token.
+        InvalidTemplateError: If `pattern` contains more than one sequence
+            token, or has zero tokens and `no_token_behavior` is `REJECT`.
         MissingItemError: If `policy` is ABORT and a gap is found inside the
             active range.
 
@@ -145,9 +202,9 @@ def scan_sequences(
     `Sequence.dropped_negative_number_count` records how many were skipped.
     """
     _validate_subset_bounds(start, end)
-    target = _coerce_target_pattern(pattern)
+    target = _coerce_target_pattern(pattern, no_token_behavior=no_token_behavior)
 
-    relevant = _list_pattern_matching_filenames(directory, target)
+    relevant = _list_pattern_matching_filenames(mapping.resolved_directory, target)
     directory_had_matching_files = bool(relevant)
     if not relevant:
         return ScanOutcome(
@@ -157,7 +214,7 @@ def scan_sequences(
             discovered_last=None,
         )
 
-    present = _collect_present_numbers(directory, target, relevant)
+    present = _collect_present_numbers(mapping, target, relevant)
     if not present.by_number:
         # Directory had files matching the basename/extension shape, but
         # fileseq grouped them at a different padding than the target's
@@ -188,7 +245,7 @@ def scan_sequences(
         PolicyContext(
             fseq=target,
             present_numbers=present.by_number,
-            directory=directory,
+            directory=mapping.original_directory,
             policy=policy,
             first=active.first,
             last=active.last,
@@ -218,14 +275,73 @@ def _validate_subset_bounds(start: int | None, end: int | None) -> None:
         raise InvalidSubsetBoundsError(msg)
 
 
-def _coerce_target_pattern(pattern: str | FileSequence) -> FileSequence:
-    """Construct a FileSequence (in HASH1 mode) from the caller's pattern.
+@runtime_checkable
+class TargetPattern(Protocol):
+    """The slice of `fileseq.FileSequence`'s API that the scanner actually uses.
+
+    A real `FileSequence` already satisfies this protocol; `_LiteralTarget`
+    implements it for token-less inputs where fileseq's parse misreads digits
+    in the filename as a sequence (e.g. `render.0002.png` parses with zfill=4
+    even though the user typed it as a literal name).
+    """
+
+    def basename(self) -> str: ...
+    def extension(self) -> str: ...
+    def padding(self) -> str: ...
+    def zfill(self) -> int: ...
+
+
+@dataclass(frozen=True)
+class _LiteralTarget:
+    """Literal-filename target for inputs with zero sequence tokens.
+
+    fileseq parses `render.0002.png` as a sequence with zfill=4 — its view of
+    the basename and extension is wrong for our purposes (we want the entire
+    filename treated as one literal). `_LiteralTarget` keeps the full filename
+    in `_filename` and reports `basename=_filename, extension="", zfill=0`.
+    The downstream literal-file branch in `_collect_present_numbers` matches
+    on `basename + extension` (== `_filename`), so the shim slots in cleanly.
+    """
+
+    _filename: str
+
+    def basename(self) -> str:
+        return self._filename
+
+    def extension(self) -> str:
+        return ""
+
+    def padding(self) -> str:
+        return ""
+
+    def zfill(self) -> int:
+        return 0
+
+
+def _coerce_target_pattern(
+    pattern: str | FileSequence,
+    *,
+    no_token_behavior: NoTokenBehavior = NoTokenBehavior.SINGLE_FILE,
+) -> TargetPattern:
+    """Construct a fileseq-or-literal target from the caller's pattern.
 
     For string inputs, also rejects multi-token templates up-front. fileseq's
     own behavior here is uneven: it raises on some forms (`v##_f####.exr`)
     but silently accepts others (`render.##.##.exr` parses as a single
     `##.##` padding) — neither produces what the user meant. Catching it
     here gives a clear error before any work is done.
+
+    Token-less inputs are dispatched on `no_token_behavior`:
+    - `SINGLE_FILE` returns a `_LiteralTarget`. The whole filename is treated
+      as one literal name; sibling files in the directory are ignored.
+    - `EXPLORE_SEQUENCE` falls through to `FileSequence(pattern)`, letting
+      fileseq read digits in the filename as an implicit sequence (so
+      `render.0002.png` is one frame of an inferred `render.####.png`).
+    - `REJECT` raises `InvalidTemplateError` so the caller learns to add an
+      explicit token.
+
+    A pre-constructed `FileSequence` short-circuits all of this and is
+    returned as-is.
     """
     if isinstance(pattern, FileSequence):
         return pattern
@@ -237,6 +353,20 @@ def _coerce_target_pattern(pattern: str | FileSequence) -> FileSequence:
             f"Multi-token templates like 'v##_f####.exr' are not handled correctly by fileseq."
         )
         raise InvalidTemplateError(msg)
+    if token_count == 0:
+        match no_token_behavior:
+            case NoTokenBehavior.SINGLE_FILE:
+                return _LiteralTarget(_filename=pattern)
+            case NoTokenBehavior.REJECT:
+                msg = (
+                    f"Attempted to parse fileseq template {pattern!r}. "
+                    f"Failed because it has no sequence token (`####`, `%04d`, `@@@`, or `$F4`); "
+                    f"add a token to scan the surrounding sequence, or set `no_token_behavior` "
+                    f"to `SINGLE_FILE` to scan this exact filename."
+                )
+                raise InvalidTemplateError(msg)
+            case NoTokenBehavior.EXPLORE_SEQUENCE:
+                pass  # fall through to FileSequence parse below
     return FileSequence(pattern, pad_style=PAD_STYLE)
 
 
@@ -256,12 +386,14 @@ def _count_sequence_tokens(pattern: str) -> int:
     return len(_TOKEN_PATTERN.findall(pattern))
 
 
-def _list_pattern_matching_filenames(directory: str, target: FileSequence) -> list[str]:
+def _list_pattern_matching_filenames(directory: str, target: TargetPattern) -> list[str]:
     """List `directory` and keep only files whose name matches the target shape.
 
     Filters by basename prefix and extension suffix before fileseq sees the
     list — avoids polluting fileseq's grouping with unrelated files (which
-    would produce noise sequences).
+    would produce noise sequences). For a `_LiteralTarget`, basename is the
+    full filename and extension is empty, so this collapses to an exact-name
+    match — same behavior `_collect_literal_single_file` then applies.
     """
     filenames = _list_directory_filenames(directory)
     if not filenames:
@@ -272,21 +404,29 @@ def _list_pattern_matching_filenames(directory: str, target: FileSequence) -> li
 
 
 def _collect_present_numbers(
-    directory: str,
-    target: FileSequence,
+    mapping: PathMapping,
+    target: TargetPattern,
     relevant_filenames: list[str],
 ) -> _PresentNumbers:
-    """Run fileseq inference on `relevant_filenames` and collect number->path entries.
+    """Run fileseq inference on `relevant_filenames` and collect number->caller-path entries.
 
     Drops negatives, filters to sequences whose padding matches `target`, and
-    reconstructs absolute paths via fileseq's frame-rendering.
+    rebuilds each entry's path through `mapping.to_caller_path` so the macro
+    head (when supplied) survives end-to-end.
+
+    Token-less inputs route through `_collect_literal_single_file` instead.
+    The dispatch keys off `target.zfill() == 0`; a `_LiteralTarget` reports
+    zero deliberately so this branch fires for `render.0002.png`-style names.
     """
+    if target.zfill() == 0:
+        return _collect_literal_single_file(mapping, target, relevant_filenames)
+
     inferred = FileSequence.findSequencesInList(relevant_filenames, pad_style=PAD_STYLE)
     matching = [s for s in inferred if s.zfill() == target.zfill()]
     if not matching:
         return _PresentNumbers(by_number={}, dropped_negatives=0)
 
-    present: dict[int, Path] = {}
+    present: dict[int, str] = {}
     dropped = 0
     for seq in matching:
         frame_set = seq.frameSet()
@@ -301,7 +441,7 @@ def _collect_present_numbers(
             if number < 0:
                 dropped += 1
                 continue
-            present[number] = Path(directory) / seq.frame(number)
+            present[number] = mapping.to_caller_path(seq.frame(number))
 
     if dropped:
         logger.warning(
@@ -310,6 +450,30 @@ def _collect_present_numbers(
             f"{target.basename()}{target.padding()}{target.extension()}",
         )
     return _PresentNumbers(by_number=present, dropped_negatives=dropped)
+
+
+def _collect_literal_single_file(
+    mapping: PathMapping,
+    target: TargetPattern,
+    relevant_filenames: list[str],
+) -> _PresentNumbers:
+    """Treat a token-less target as a one-item sequence.
+
+    When `target` has no sequence token (zfill = 0), the only "match" is the
+    literal `basename + extension`. For `_LiteralTarget` that's the full
+    filename the user typed; for a real `FileSequence` it's the basename and
+    empty extension fileseq inferred. If that filename appears in the listing,
+    return it as item #1 so downstream code emits a 1-item Sequence; otherwise
+    return an empty mapping and let `_scan_sequences` route to its normal
+    empty-result diagnostics.
+    """
+    literal_name = f"{target.basename()}{target.extension()}"
+    if literal_name not in relevant_filenames:
+        return _PresentNumbers(by_number={}, dropped_negatives=0)
+    return _PresentNumbers(
+        by_number={1: mapping.to_caller_path(literal_name)},
+        dropped_negatives=0,
+    )
 
 
 def _compute_active_range(

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from griptape_nodes.common.sequences.models import MissingItemPolicy, Sequence
+from griptape_nodes.common.sequences.models import MissingItemPolicy, NoTokenBehavior, Sequence
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -200,22 +200,37 @@ class ListDirectoryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class ScanSequencesRequest(RequestPayload):
-    """Scan a directory for files matching a fileseq template; produce typed Sequence(s).
+    """Scan a path or pattern; produce typed Sequence(s) with macro-preserving paths.
 
     Use when: A node or workflow needs to discover frame/item sequences on disk
-    (e.g. a render output, a directory of dialogue takes). Mediates fileseq parsing
-    and the underlying directory listing through the engine's request bus so callers
-    don't import the engine's sequence helpers directly.
+    (e.g. a render output, a directory of dialogue takes). The engine handles
+    macro resolution, the directory listing, and fileseq parsing — callers hand
+    in a path or pattern and get back a Sequence whose paths are in the same
+    macro shape they supplied. That makes scan results portable across machines
+    where `{inputs}` may resolve to different absolute roots.
 
     Args:
-        directory: Absolute directory path to scan. Listed via `ListDirectoryRequest`
-            internally (no direct filesystem access). Macro-form paths must be
-            resolved by the caller before dispatching this request.
-        pattern: A fileseq pattern (e.g. `render.####.exr`, `take_%02d.wav`). Sequence
-            tokens are interpreted in HASH1 mode regardless of pattern syntax. Multi-token
-            templates are rejected up-front with `INVALID_TEMPLATE`.
+        path: A path to a numbered file sequence. Can be:
+            - A macro-form pattern: `{inputs}/render.####.png`. The macro head
+              is preserved on every emitted entry path.
+            - A plain absolute pattern: `/work/render.####.png`. Round-trips
+              identically.
+            - A literal single-file path: `/work/photo.png`. Behavior when the
+              filename has no sequence token is controlled by
+              `no_token_behavior` (see below).
+            Sequence tokens (`####`, `%04d`, `@@@`, `$F4`) may appear at most
+            once and only in the filename component. Multi-token paths are
+            rejected with `INVALID_TEMPLATE`.
         policy: How to handle gaps within the matched range. Defaults to `SPLIT`.
-        start_number: Optional lower bound (inclusive) for the active subset. Items
+        no_token_behavior: How to handle a path with zero sequence tokens.
+            `SINGLE_FILE` (default) treats the whole filename as a literal —
+            one-item sequence if the file exists, empty result otherwise.
+            `EXPLORE_SEQUENCE` lets fileseq read digits in the filename as an
+            implicit sequence — `render.0002.png` becomes one frame of an
+            inferred `render.####.png` sequence and the scan walks every
+            matching sibling. `REJECT` fails with `INVALID_TEMPLATE` for
+            workflows that must not silently widen the artist's intent.
+        start_number: Optional lower bound (inclusive) for the active range. Items
             below this are dropped. Must be >= 0 if supplied; rejected with
             `INVALID_BOUNDS` otherwise.
         end_number: Optional upper bound (inclusive). Items above this are dropped.
@@ -226,9 +241,9 @@ class ScanSequencesRequest(RequestPayload):
     (sequence-semantic or OS-layer failure).
     """
 
-    directory: str
-    pattern: str
+    path: str
     policy: MissingItemPolicy = MissingItemPolicy.SPLIT
+    no_token_behavior: NoTokenBehavior = NoTokenBehavior.SINGLE_FILE
     start_number: int | None = None
     end_number: int | None = None
 
@@ -239,17 +254,21 @@ class ScanSequencesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """Sequence scan completed successfully.
 
     A successful scan may legitimately return zero sequences (the directory
-    had no files matching the template, the padding didn't line up, or the
-    active subset clipped them all out). The diagnostic fields let consumers
+    had no files matching the path, the padding didn't line up, or the
+    active range clipped them all out). The diagnostic fields let consumers
     distinguish those cases without inspecting `result_details` strings:
 
-    - `directory_had_matching_files=False` → wrong path / wrong template /
+    - `directory_had_matching_files=False` → wrong path / wrong pattern /
       empty directory: nothing on disk matched the basename + extension.
     - `directory_had_matching_files=True`, `has_entries=False` → right path,
-      but either the padding didn't line up with the template's zfill, or
-      the active subset (`start_number`/`end_number`) clipped everything out.
+      but either the padding didn't line up with the pattern's token, or
+      the active range (`start_number`/`end_number`) clipped everything out.
       `discovered_first`/`discovered_last` give the on-disk range so callers
       can show "asked for 90..100 but disk has 1..7."
+
+    All emitted paths (`Sequence.directory` and `entry.path`) are in the
+    same shape the caller supplied: a macro-form input round-trips with the
+    macro head intact; a plain absolute input round-trips identically.
 
     Attributes:
         sequences: Zero or more `Sequence` objects produced by the scan.
@@ -262,10 +281,10 @@ class ScanSequencesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
             produced ≥1 file matching the target's basename + extension
             (before fileseq parsing or subset clipping).
         discovered_first: Lowest item number actually found on disk that
-            matched the target's full shape (basename + extension + zfill),
+            matched the pattern's full shape (basename + extension + zfill),
             ignoring any subset bounds. None when no sequences were inferred.
         discovered_last: Highest item number actually found on disk that
-            matched the target's full shape, ignoring any subset bounds.
+            matched the pattern's full shape, ignoring any subset bounds.
             None when no sequences were inferred.
     """
 

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 
 from griptape_nodes.common.sequences.models import MissingItemPolicy, NoTokenBehavior, Sequence
@@ -71,7 +71,9 @@ class SequenceScanFailureReason(StrEnum):
 
     INVALID_TEMPLATE = "invalid_template"  # Multi-token templates or fileseq parse errors.
     INVALID_BOUNDS = "invalid_bounds"  # `start_number` < 0, or `end_number` < `start_number`.
-    ABORTED_AT_GAP = "aborted_at_gap"  # `MissingItemPolicy.ABORT` hit a gap; payload carries the offending number.
+    ABORTED_AT_GAP = (
+        "aborted_at_gap"  # `MissingItemPolicy.ABORT` hit at least one gap; payload lists every offending number.
+    )
 
 
 class DeletionBehavior(StrEnum):
@@ -304,14 +306,16 @@ class ScanSequencesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
         failure_reason: Either a sequence-semantic reason (`SequenceScanFailureReason`)
             or an OS-layer reason (`FileIOFailureReason`) when the underlying
             directory listing failed.
-        missing_item_number: Populated only when `failure_reason` is
-            `SequenceScanFailureReason.ABORTED_AT_GAP`. Carries the integer key
-            of the first slot the scan aborted on.
+        missing_item_numbers: Populated only when `failure_reason` is
+            `SequenceScanFailureReason.ABORTED_AT_GAP`. Lists every missing
+            slot inside the active range, sorted ascending — UI consumers
+            can show the artist all the gaps in one pass instead of fixing
+            them one re-run at a time. Empty list for every other failure.
         result_details: Human-readable error message (inherited from ResultPayloadFailure).
     """
 
     failure_reason: SequenceScanFailureReason | FileIOFailureReason
-    missing_item_number: int | None = None
+    missing_item_numbers: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -129,6 +129,11 @@ console = Console()
 # Maximum number of indexed candidates to try when CREATE_NEW policy is used
 MAX_INDEXED_CANDIDATES = 1000
 
+# How many gap numbers to show inline in the ABORTED_AT_GAP `result_details`
+# string before truncating the rest with "(+N more)". Larger lists overwhelm
+# the artist's status panel; the full list lives on `missing_item_numbers`.
+ABORTED_AT_GAP_PREVIEW_COUNT = 5
+
 
 @dataclass
 class DiskSpaceInfo:
@@ -1486,7 +1491,7 @@ class OSManager:
         - Macro syntax / resolution / shape problems → `INVALID_TEMPLATE`
           (sequence-semantic).
         - Subset bound problems → `INVALID_BOUNDS`.
-        - ABORT-policy gaps → `ABORTED_AT_GAP` with the offending item number.
+        - ABORT-policy gaps → `ABORTED_AT_GAP` listing every offending item number.
         - OS-layer listing failures (directory not found, permission denied)
           propagate via `DirectoryListingError` and surface their original
           `FileIOFailureReason` so the underlying diagnostic isn't lost.
@@ -1530,12 +1535,21 @@ class OSManager:
                 ),
             )
         except MissingItemError as e:
+            gap_count = len(e.numbers)
+            if gap_count == 1:
+                summary = f"the sequence has a gap at item {e.numbers[0]}"
+            else:
+                sample = ", ".join(str(n) for n in e.numbers[:ABORTED_AT_GAP_PREVIEW_COUNT])
+                if gap_count <= ABORTED_AT_GAP_PREVIEW_COUNT:
+                    suffix = ""
+                else:
+                    suffix = f" (+ {gap_count - ABORTED_AT_GAP_PREVIEW_COUNT} more)"
+                summary = f"the sequence has {gap_count} gaps: items {sample}{suffix}"
             return ScanSequencesResultFailure(
                 failure_reason=SequenceScanFailureReason.ABORTED_AT_GAP,
-                missing_item_number=e.number,
+                missing_item_numbers=e.numbers,
                 result_details=(
-                    f"Attempted to scan sequences with path={request.path!r}, policy=ABORT. "
-                    f"Failed because the sequence has a gap at item {e.number}."
+                    f"Attempted to scan sequences with path={request.path!r}, policy=ABORT. Failed because {summary}."
                 ),
             )
 

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -19,7 +19,13 @@ import send2trash
 from fileseq.exceptions import FileSeqException
 from rich.console import Console
 
-from griptape_nodes.common.macro_parser import MacroResolutionError, MacroResolutionFailure, MacroVariables, ParsedMacro
+from griptape_nodes.common.macro_parser import (
+    MacroResolutionError,
+    MacroResolutionFailure,
+    MacroSyntaxError,
+    MacroVariables,
+    ParsedMacro,
+)
 from griptape_nodes.common.macro_parser.exceptions import MacroResolutionFailureReason
 from griptape_nodes.common.macro_parser.formats import NumericPaddingFormat
 from griptape_nodes.common.macro_parser.resolution import partial_resolve
@@ -29,7 +35,7 @@ from griptape_nodes.common.sequences import (
     InvalidTemplateError,
     MissingItemError,
 )
-from griptape_nodes.common.sequences.scan import DirectoryListingError, scan_sequences
+from griptape_nodes.common.sequences.scan import DirectoryListingError, PathMapping, scan_sequences
 from griptape_nodes.files.drivers.base64_file_driver import Base64FileDriver
 from griptape_nodes.files.drivers.data_uri_file_driver import DataUriFileDriver
 from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeCloudFileDriver
@@ -97,7 +103,11 @@ from griptape_nodes.retained_mode.events.os_events import (
     WriteFileResultFailure,
     WriteFileResultSuccess,
 )
-from griptape_nodes.retained_mode.events.project_events import MacroPath
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroRequest,
+    GetPathForMacroResultSuccess,
+    MacroPath,
+)
 from griptape_nodes.retained_mode.events.resource_events import (
     CreateResourceInstanceRequest,
     CreateResourceInstanceResultSuccess,
@@ -1464,25 +1474,35 @@ class OSManager:
             logger.error(msg)
             return ListDirectoryResultFailure(failure_reason=FileIOFailureReason.UNKNOWN, result_details=msg)
 
-    async def on_scan_sequences_request(self, request: ScanSequencesRequest) -> ResultPayload:
-        """Handle a request to scan a directory for sequences matching a fileseq template.
+    async def on_scan_sequences_request(self, request: ScanSequencesRequest) -> ResultPayload:  # noqa: PLR0911
+        """Handle a request to scan a path or pattern for file sequences.
 
-        The handler runs `scan_sequences` in a worker thread (`asyncio.to_thread`)
-        so neither the directory listing (via `ListDirectoryRequest`, performed
+        The handler does macro resolution itself, builds a `PathMapping`, and
+        runs `scan_sequences` in a worker thread (`asyncio.to_thread`) so
+        neither the directory listing (via `ListDirectoryRequest`, performed
         inside `scan_sequences`) nor fileseq parsing blocks the event loop.
 
-        Routes failures to the appropriate taxonomy: typed exceptions raised by
-        the scanner map to `SequenceScanFailureReason`; OS-layer listing
-        failures (directory not found, permission denied) propagate via
-        `DirectoryListingError` and map to `FileIOFailureReason` so the
-        underlying OS diagnostic isn't lost.
+        Routes failures to the appropriate taxonomy:
+        - Macro syntax / resolution / shape problems → `INVALID_TEMPLATE`
+          (sequence-semantic).
+        - Subset bound problems → `INVALID_BOUNDS`.
+        - ABORT-policy gaps → `ABORTED_AT_GAP` with the offending item number.
+        - OS-layer listing failures (directory not found, permission denied)
+          propagate via `DirectoryListingError` and surface their original
+          `FileIOFailureReason` so the underlying diagnostic isn't lost.
         """
+        mapping_or_failure = self._build_scan_path_mapping(request.path)
+        if isinstance(mapping_or_failure, ScanSequencesResultFailure):
+            return mapping_or_failure
+        mapping = mapping_or_failure
+
         try:
             outcome = await asyncio.to_thread(
                 scan_sequences,
-                request.directory,
-                request.pattern,
+                mapping,
+                mapping.filename_pattern,
                 policy=request.policy,
+                no_token_behavior=request.no_token_behavior,
                 start=request.start_number,
                 end=request.end_number,
             )
@@ -1505,8 +1525,8 @@ class OSManager:
             return ScanSequencesResultFailure(
                 failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
                 result_details=(
-                    f"Attempted to scan sequences with pattern={request.pattern!r}. "
-                    f"Failed because fileseq could not parse the template: {e}"
+                    f"Attempted to scan sequences with path={request.path!r}. "
+                    f"Failed because fileseq could not parse the path: {e}"
                 ),
             )
         except MissingItemError as e:
@@ -1514,7 +1534,7 @@ class OSManager:
                 failure_reason=SequenceScanFailureReason.ABORTED_AT_GAP,
                 missing_item_number=e.number,
                 result_details=(
-                    f"Attempted to scan sequences with pattern={request.pattern!r}, policy=ABORT. "
+                    f"Attempted to scan sequences with path={request.path!r}, policy=ABORT. "
                     f"Failed because the sequence has a gap at item {e.number}."
                 ),
             )
@@ -1525,10 +1545,7 @@ class OSManager:
         if has_entries:
             details = f"Found {len(outcome.sequences)} sequence(s)."
         else:
-            details = (
-                f"Scanned directory={request.directory!r} with pattern={request.pattern!r}; "
-                f"no matching sequence entries found."
-            )
+            details = f"Scanned path={request.path!r}; no matching sequence entries found."
         return ScanSequencesResultSuccess(
             sequences=outcome.sequences,
             has_entries=has_entries,
@@ -1536,6 +1553,72 @@ class OSManager:
             discovered_first=outcome.discovered_first,
             discovered_last=outcome.discovered_last,
             result_details=details,
+        )
+
+    def _build_scan_path_mapping(self, path: str) -> PathMapping | ScanSequencesResultFailure:  # noqa: PLR0911
+        """Parse `path`, resolve any macro head, and build a `PathMapping`.
+
+        The path is split into a directory portion and a filename portion at
+        the last separator. The directory portion is resolved through
+        `GetPathForMacroRequest` if it carries macros; the filename portion
+        (which holds any sequence token) is preserved verbatim so the macro
+        head survives the round trip.
+
+        Returns either the assembled `PathMapping` or a `ScanSequencesResultFailure`
+        ready to return up the stack.
+        """
+        if not path:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details="No path or pattern provided.",
+            )
+
+        sep_index = max(path.rfind("/"), path.rfind("\\"))
+        if sep_index < 0:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details=(
+                    f"`{path}` has no directory portion — point at a file or pattern "
+                    "(e.g. `/work/render.####.png` or `{inputs}/render.####.png`)."
+                ),
+            )
+        original_directory = path[:sep_index]
+        filename_pattern = path[sep_index + 1 :]
+        if not filename_pattern:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details=(f"`{path}` has no filename to scan — point at a file or pattern, not a directory."),
+            )
+
+        try:
+            parsed_directory = ParsedMacro(original_directory)
+        except MacroSyntaxError as e:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details=f"Invalid path or pattern `{path}`: {e}",
+            )
+
+        if not parsed_directory.get_variables():
+            # No macros in the directory portion — treat it as a plain
+            # absolute (or relative) path. Round-trip is a no-op.
+            return PathMapping(
+                original_directory=original_directory,
+                resolved_directory=original_directory,
+                filename_pattern=filename_pattern,
+            )
+
+        resolve_result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(parsed_macro=parsed_directory, variables={})
+        )
+        if not isinstance(resolve_result, GetPathForMacroResultSuccess):
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details=(f"Couldn't resolve project variables in `{path}`: {resolve_result.result_details}"),
+            )
+        return PathMapping(
+            original_directory=original_directory,
+            resolved_directory=str(resolve_result.absolute_path),
+            filename_pattern=filename_pattern,
         )
 
     def _detect_mime_type_from_location(self, location: str) -> str:

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -94,7 +94,11 @@ def _stub_listing_with_macro(
                 result_details="ok",
             )
         if isinstance(request, ListDirectoryRequest):
-            if request.directory_path == resolved_directory:
+            # Path()-normalize both sides: on Windows the handler emits backslashes
+            # via str(WindowsPath(...)), but the test fixture is POSIX-style.
+            # `directory_path` is `str | None`; the macro tests always supply a
+            # string but we narrow defensively so pyright is happy.
+            if request.directory_path is not None and Path(request.directory_path) == Path(resolved_directory):
                 entries = [
                     FileSystemEntry(name=name, path=str(Path(resolved_directory) / name), is_dir=False)
                     for name in filenames
@@ -292,19 +296,50 @@ class TestFillNearestPolicy:
 
 class TestAbortPolicy:
     @pytest.mark.asyncio
-    async def test_abort_surfaces_failure_at_first_gap(self) -> None:
-        """ABORT surfaces a ScanSequencesResultFailure with the offending number."""
+    async def test_abort_surfaces_all_gaps(self) -> None:
+        """ABORT surfaces a ScanSequencesResultFailure listing every gap.
+
+        With items 1, 2, 4, 5 on disk, the active range 1..5 has exactly one
+        gap (item 3). The failure payload should expose it as a one-element
+        list — no longer the bare integer the previous shape carried.
+        """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 5]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
             result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.ABORTED_AT_GAP
-        assert result.missing_item_number == 3
+        assert result.missing_item_numbers == [3]
+
+    @pytest.mark.asyncio
+    async def test_abort_surfaces_multiple_gaps(self) -> None:
+        """ABORT collects every gap in one pass, sorted ascending.
+
+        Items 1, 2, 5, 7 on disk; active range 1..7. The expected gaps are 3,
+        4, 6 — one continuous range and one singleton, surfaced together so a
+        UI consumer can show the artist all the missing slots in one go
+        instead of fixing them one re-run at a time.
+        """
+        directory = "/work/in"
+        filenames = [f"render.{n:04d}.png" for n in [1, 2, 5, 7]]
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.ABORTED_AT_GAP
+        assert result.missing_item_numbers == [3, 4, 6]
+        # Sanity: result_details summarises the count and shows the list.
+        details = str(result.result_details or "")
+        assert "3 gaps" in details
+        assert "3, 4, 6" in details
 
     @pytest.mark.asyncio
     async def test_abort_succeeds_when_dense(self) -> None:
-        """ABORT returns one Sequence with all entries when there are no gaps."""
+        """ABORT returns one Sequence with all entries when there are no gaps.
+
+        The all-gaps pre-pass runs but finds nothing, so the scanner falls
+        through to the normal entries-build loop and emits a contiguous
+        sequence the same way SKIP would.
+        """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-from griptape_nodes.common.sequences import MissingItemPolicy
+from griptape_nodes.common.sequences import MissingItemPolicy, NoTokenBehavior
 from griptape_nodes.retained_mode.events.os_events import (
     FileIOFailureReason,
     FileSystemEntry,
@@ -31,6 +31,10 @@ from griptape_nodes.retained_mode.events.os_events import (
     ScanSequencesResultFailure,
     ScanSequencesResultSuccess,
     SequenceScanFailureReason,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroRequest,
+    GetPathForMacroResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -65,20 +69,73 @@ def _stub_listing(directory: str, filenames: list[str]) -> Any:
     return handle_request
 
 
-async def _scan(
+def _stub_listing_with_macro(
+    *,
+    macro_directory: str,
+    resolved_directory: str,
+    filenames: list[str],
+) -> Any:
+    """Stub both `GetPathForMacroRequest` and `ListDirectoryRequest`.
+
+    Used by the macro-round-trip tests: the handler resolves the macro
+    head via the project's macro resolver, then lists the resolved-on-disk
+    directory. Both dispatches need to be intercepted since the test
+    doesn't bring up a real ProjectManager.
+    """
+
+    def handle_request(request: object) -> object:
+        if isinstance(request, GetPathForMacroRequest):
+            assert request.parsed_macro.template == macro_directory, (
+                f"unexpected macro: {request.parsed_macro.template!r} (expected {macro_directory!r})"
+            )
+            return GetPathForMacroResultSuccess(
+                resolved_path=Path(resolved_directory),
+                absolute_path=Path(resolved_directory),
+                result_details="ok",
+            )
+        if isinstance(request, ListDirectoryRequest):
+            if request.directory_path == resolved_directory:
+                entries = [
+                    FileSystemEntry(name=name, path=str(Path(resolved_directory) / name), is_dir=False)
+                    for name in filenames
+                ]
+                return ListDirectoryResultSuccess(
+                    entries=entries,
+                    current_path=resolved_directory,
+                    is_workspace_path=False,
+                    result_details="ok",
+                )
+            return ListDirectoryResultFailure(
+                failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
+                result_details=f"{request.directory_path} not stubbed",
+            )
+        msg = f"Unexpected request: {type(request).__name__}"
+        raise AssertionError(msg)
+
+    return handle_request
+
+
+async def _scan(  # noqa: PLR0913
     directory: str,
     pattern: str,
     *,
     policy: MissingItemPolicy = MissingItemPolicy.SPLIT,
+    no_token_behavior: NoTokenBehavior = NoTokenBehavior.SINGLE_FILE,
     start_number: int | None = None,
     end_number: int | None = None,
 ) -> ScanSequencesResultSuccess | ScanSequencesResultFailure:
-    """Dispatch a ScanSequencesRequest and narrow the result type for assertions."""
+    """Dispatch a ScanSequencesRequest and narrow the result type for assertions.
+
+    Test helper signature is unchanged for ergonomics — `directory` + `pattern`
+    are concatenated into the new single `path=` field the request actually
+    takes.
+    """
+    path = f"{directory}/{pattern}" if directory else pattern
     result = await GriptapeNodes.ahandle_request(
         ScanSequencesRequest(
-            directory=directory,
-            pattern=pattern,
+            path=path,
             policy=policy,
+            no_token_behavior=no_token_behavior,
             start_number=start_number,
             end_number=end_number,
         )
@@ -468,18 +525,47 @@ class TestPatternValidation:
         assert "2 sequence tokens" in str(result.result_details or "")
 
     @pytest.mark.asyncio
-    async def test_zero_token_pattern_left_to_fileseq(self) -> None:
-        """A pattern with no token returns empty success.
+    async def test_zero_token_path_one_item_when_present(self) -> None:
+        """A token-less path becomes a one-item sequence when the file exists.
 
-        fileseq itself accepts non-sequence patterns silently; either way, no
-        result-set means a successful scan with `has_entries=False`.
+        The artist pasted in `photo.png` and the file is on disk → produce a
+        Sequence with `entries=[#1]`, `padding=0`, `first=last=1`. This is the
+        path the artist actually traveled most of the time when typing in a
+        single-file path.
         """
         directory = "/work/in"
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, [])):
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, ["photo.png"])):
+            result = await _scan(directory, "photo.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.has_entries is True
+        seqs = result.sequences
+        assert len(seqs) == 1
+        assert seqs[0].first == 1
+        assert seqs[0].last == 1
+        assert seqs[0].padding == 0
+        assert [e.number for e in seqs[0].entries] == [1]
+        # Path round-trips through the scanner — for a plain absolute input
+        # the entry path matches the directory + filename verbatim.
+        assert seqs[0].entries[0].path == "/work/in/photo.png"
+
+    @pytest.mark.asyncio
+    async def test_zero_token_path_empty_when_absent(self) -> None:
+        """A token-less path returns empty success when the file isn't on disk.
+
+        The literal filename is the only way a zero-token target can match;
+        if it's absent, fall back to the same empty-result diagnostic any
+        other miss produces.
+        """
+        directory = "/work/in"
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, ["other.png"])):
             result = await _scan(directory, "photo.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
+        # `directory_had_matching_files` is False here because the prefilter
+        # checks startswith(basename) + endswith(extension), and `other.png`
+        # doesn't share `photo` as a basename prefix.
+        assert result.directory_had_matching_files is False
 
     @pytest.mark.asyncio
     async def test_single_token_passes(self) -> None:
@@ -490,3 +576,197 @@ class TestPatternValidation:
             result = await _scan(directory, "render.####.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert len(result.sequences) == 1
+
+
+# --- Path round-trip ---------------------------------------------------
+
+
+class TestPathRoundTrip:
+    """Verify the engine emits paths in the same shape it received them.
+
+    Macros stay macros, plain absolutes stay plain absolutes. This is what
+    makes scan results portable between machines whose `{inputs}` resolve to
+    different absolute roots.
+    """
+
+    @pytest.mark.asyncio
+    async def test_macro_path_preserves_macro_head(self) -> None:
+        """A macro-form input round-trips with the `{inputs}` head intact.
+
+        The handler resolves the macro internally for I/O but rebuilds each
+        emitted entry path off the original (macro) directory, so downstream
+        consumers see the macro shape they supplied.
+        """
+        macro_directory = "{inputs}/xyz"
+        resolved_directory = "/Users/me/project/inputs/xyz"
+        filenames = [f"abc{n:03d}.png" for n in [1, 2, 3]]
+        path = f"{macro_directory}/abc###.png"
+        with patch.object(
+            GriptapeNodes,
+            "handle_request",
+            side_effect=_stub_listing_with_macro(
+                macro_directory=macro_directory,
+                resolved_directory=resolved_directory,
+                filenames=filenames,
+            ),
+        ):
+            result = await GriptapeNodes.ahandle_request(
+                ScanSequencesRequest(path=path, policy=MissingItemPolicy.SPLIT)
+            )
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        # `directory` and every `entry.path` retain the macro head.
+        assert seq.directory == macro_directory
+        assert [e.path for e in seq.entries] == [
+            "{inputs}/xyz/abc001.png",
+            "{inputs}/xyz/abc002.png",
+            "{inputs}/xyz/abc003.png",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_round_trips_unchanged(self) -> None:
+        """A plain absolute path (no macros) round-trips identically.
+
+        The macro-resolver dispatch is skipped entirely — `_build_scan_path_mapping`
+        sees no macro variables in the directory portion and treats `original`
+        and `resolved` as equal. The combined stub here would raise on a
+        macro-resolve dispatch; getting through the test confirms the skip.
+        """
+        directory = "/work/in"
+        filenames = [f"render.{n:04d}.png" for n in [1, 2]]
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(directory, "render.####.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seq = result.sequences[0]
+        assert seq.directory == directory
+        assert [e.path for e in seq.entries] == [
+            "/work/in/render.0001.png",
+            "/work/in/render.0002.png",
+        ]
+
+
+# --- NoTokenBehavior dispatch ------------------------------------------
+
+
+class TestNoTokenBehavior:
+    """Verify the three-way dispatch on `no_token_behavior`.
+
+    A path with zero sequence tokens (e.g. `render.0002.png`) is ambiguous —
+    the user might mean a literal single file, or might be naming one frame of
+    an implicit sequence, or might be expected to add an explicit token. The
+    `no_token_behavior` field on `ScanSequencesRequest` picks which.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_file_default_ignores_siblings(self) -> None:
+        """SINGLE_FILE: `render.0002.png` returns just that one file.
+
+        This is the regression pin for the bug where fileseq's parse of
+        `render.0002.png` saw zfill=4 and grouped every sibling into a
+        5-item sequence. Default behavior must produce a 1-item sequence
+        containing only the named file.
+        """
+        directory = "/work/in"
+        # Five renders on disk; only the named one should come back.
+        filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(directory, "render.0002.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.has_entries is True
+        seqs = result.sequences
+        assert len(seqs) == 1
+        assert seqs[0].first == 1
+        assert seqs[0].last == 1
+        assert seqs[0].padding == 0
+        assert [e.number for e in seqs[0].entries] == [1]
+        # Crucially, only render.0002.png — not the other four siblings.
+        assert [e.path for e in seqs[0].entries] == ["/work/in/render.0002.png"]
+        assert seqs[0].discovered_first == 1
+        assert seqs[0].discovered_last == 1
+
+    @pytest.mark.asyncio
+    async def test_explore_sequence_recovers_implicit_grouping(self) -> None:
+        """EXPLORE_SEQUENCE: `render.0002.png` walks the full sibling sequence.
+
+        Useful when a downstream tool gave the artist one filename but they
+        want the whole take. fileseq parses the digits as a frame token and
+        the scan returns every match (here, all five sibling renders).
+        """
+        directory = "/work/in"
+        filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(
+                directory,
+                "render.0002.png",
+                policy=MissingItemPolicy.SPLIT,
+                no_token_behavior=NoTokenBehavior.EXPLORE_SEQUENCE,
+            )
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.has_entries is True
+        seqs = result.sequences
+        assert len(seqs) == 1
+        assert [e.number for e in seqs[0].entries] == [1, 2, 3, 4, 5]
+        assert seqs[0].padding == 4
+        assert seqs[0].discovered_first == 1
+        assert seqs[0].discovered_last == 5
+
+    @pytest.mark.asyncio
+    async def test_reject_fails_with_invalid_template(self) -> None:
+        """REJECT: a token-less path fails fast with INVALID_TEMPLATE.
+
+        For workflows that should never silently widen the artist's intent
+        (e.g. an automated pipeline that requires an explicit token).
+        """
+        result = await _scan(
+            "/work/in",
+            "render.0002.png",
+            no_token_behavior=NoTokenBehavior.REJECT,
+        )
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
+        # Surface useful guidance, not just "rejected".
+        assert "no sequence token" in str(result.result_details or "")
+
+    @pytest.mark.asyncio
+    async def test_single_file_with_no_digits_still_works(self) -> None:
+        """SINGLE_FILE on `photo.png` (no digits at all) — sanity check."""
+        directory = "/work/in"
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, ["photo.png"])):
+            result = await _scan(directory, "photo.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.has_entries is True
+        seqs = result.sequences
+        assert len(seqs) == 1
+        assert seqs[0].entries[0].path == "/work/in/photo.png"
+
+    @pytest.mark.asyncio
+    async def test_single_file_macro_path_round_trip(self) -> None:
+        """SINGLE_FILE keeps macro paths macro-shaped on the way back out.
+
+        Mirrors `test_macro_path_preserves_macro_head` for the literal-file
+        branch: an `{inputs}` head supplied on a token-less path should
+        survive into the entry's `path`.
+        """
+        macro_directory = "{inputs}/sequences/01_contiguous"
+        resolved_directory = "/Users/me/project/inputs/sequences/01_contiguous"
+        # Five siblings on disk; SINGLE_FILE should ignore all but the named one.
+        filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
+        path = f"{macro_directory}/render.0002.png"
+        with patch.object(
+            GriptapeNodes,
+            "handle_request",
+            side_effect=_stub_listing_with_macro(
+                macro_directory=macro_directory,
+                resolved_directory=resolved_directory,
+                filenames=filenames,
+            ),
+        ):
+            result = await GriptapeNodes.ahandle_request(
+                ScanSequencesRequest(path=path, policy=MissingItemPolicy.SPLIT)
+            )
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert [e.path for e in seq.entries] == [f"{macro_directory}/render.0002.png"]
+        assert seq.directory == macro_directory


### PR DESCRIPTION
Closes #4712.

Successor to #4711 (already merged). Sequences now speak macros end-to-end — you put `{inputs}/render.####.png` in, you get `{inputs}/render.0001.png`, `{inputs}/render.0002.png`, … back, so workflows stay portable across machines whose macros resolve to different absolute roots. Also adds explicit dispatch for the case where a path has no sequence token at all (`render.0002.png`, `photo.png`) — the caller picks single-file vs implicit-sequence vs strict-rejection via the new `NoTokenBehavior` enum.

## Macro-path round-trip (closes #4712)

`ScanSequencesRequest` now takes a single `path: str` (replacing the previous `directory: str` + `pattern: str` pair). Macro resolution from `{inputs}` to the absolute on-disk directory happens *inside* the handler, not at the call site.

`Sequence.directory` and every `entry.path` come back in the **caller's** shape:

```python
ScanSequencesRequest(path="{inputs}/shot/render.####.exr")
# → Sequence(
#     directory="{inputs}/shot",
#     entries=[
#         SequenceEntry(path="{inputs}/shot/render.0001.exr", …),
#         SequenceEntry(path="{inputs}/shot/render.0002.exr", …),
#         …
#     ],
#   )
```

Plain absolute paths round-trip identically — input shape == output shape regardless of whether macros are involved. This is what makes scan results portable across machines: a workflow built where `{inputs}` resolves to `/Volumes/Renders` produces sequences whose paths still say `{inputs}`, so a collaborator whose `{inputs}` resolves to `C:\Renders` can re-open and re-execute it without touching anything.

The plumbing carrying this:
- New `PathMapping` dataclass in `scan.py` pairs the macro-form directory with its resolved-on-disk twin and exposes a `to_caller_path(filename)` accessor that emits caller-shaped paths.
- `present_numbers` switched from `dict[int, Path]` to `dict[int, str]` so macro-shaped strings flow through `policies.py` without ever passing through `pathlib.Path` (which mangles `{…}` segments on Windows).

## `NoTokenBehavior` enum

New `StrEnum` in `common/sequences/models.py`, exported from the package. The motivating ambiguity: a path like `render.0002.png` could mean *"this one literal file I picked"* or *"frame 2 of an implicit `render.####.png` sequence the artist forgot to type the token for."* The request now lets the caller pick:

| Value                     | Behavior on `render.0002.png` against a directory holding `render.0001.png`–`render.0005.png` |
| ------------------------- | --------------------------------------------------------------------------------------------- |
| `SINGLE_FILE` *(default)* | 1-item sequence containing exactly `render.0002.png`. Siblings ignored. Empty-success when the file doesn't exist. |
| `EXPLORE_SEQUENCE`        | fileseq reads the digits as an implicit token and walks every matching sibling — 5-item sequence. |
| `REJECT`                  | Raises `InvalidTemplateError`; handler maps to `INVALID_TEMPLATE` with a message asking the artist to add a token. |

Defaulting to `SINGLE_FILE` matches the artist's typical mental model: "I picked one file" → one file in, one item out.

## Internals worth flagging

- `_LiteralTarget` is a small private shim that satisfies the new `TargetPattern` Protocol (`basename` / `extension` / `padding` / `zfill`). Required because `FileSequence("render.0002.png")` parses the digits as a sequence with `zfill=4` — fileseq has no way to express "this is one literal name, leave the digits alone." Without the shim, `SINGLE_FILE` would silently group siblings the way `EXPLORE_SEQUENCE` now does on purpose.
- The `TargetPattern` Protocol replaces the `FileSequence` type annotation throughout `policies.py`, so real `FileSequence` objects and the literal shim flow through the same code paths. Pure structural typing — no isinstance checks downstream.

## Tests

34 unit tests in `tests/unit/common/test_sequences.py`, all dispatching via the bus (`GriptapeNodes.ahandle_request(ScanSequencesRequest(...))`). New coverage:

- **`TestPathRoundTrip`** — `test_macro_path_preserves_macro_head` and `test_absolute_path_round_trips_unchanged` pin the new behavior. Both stub `GetPathForMacroRequest` + `ListDirectoryRequest` so the handler exercises its full async path.
- **`TestNoTokenBehavior`** — five tests: regression pin (`render.0002.png` returns 1 item under `SINGLE_FILE`), `EXPLORE_SEQUENCE` walks siblings, `REJECT` fails with `INVALID_TEMPLATE` and the marker-required message, `photo.png` literal sanity, and macro-literal round-trip.

The pre-existing zero-token tests were updated to pass under the new `SINGLE_FILE` default. None of the bus-semantics or policy tests needed behavioral changes.

## Docs

`docs/projects/sequences.md` updated with:
- New section *When the path has no sequence token* explaining the trichotomy with worked examples.
- Request-shape examples extended to show all four kwargs (`path`, `policy`, `no_token_behavior`, range bounds).
- Failure-reason list extended for the `REJECT`-as-`INVALID_TEMPLATE` case.
- The success payload's macro round-trip contract documented in the *Combining with macros* section.

## Breaking changes

Two breaking changes to the bus payloads — both surface area we'd rather take once now while the request shape is already moving than ship as a second breaking change later.

1. **`ScanSequencesRequest` field rename**: `directory: str` + `pattern: str` → `path: str`. Macro resolution moves into the handler; saved workflows that hand-built the old two-field shape won't deserialize cleanly.

2. **`ScanSequencesResultFailure` field rename**: `missing_item_number: int | None` → `missing_item_numbers: list[int]` (default empty list). Under `MissingItemPolicy.ABORT` the engine now collects every gap inside the active range and reports them all in one pass, so a UI consumer can show the artist all the missing slots at once instead of fixing them one re-run at a time. Driven by reviewer feedback on this PR — see Alex's review thread on `sequences.md:175`.

The standard library's sequence nodes ([library PR #288](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/288)) are the only known consumer of either field and are updated in lockstep — neither the engine nor the library should be released or pinned until both PRs land.

`MissingItemPolicy.SPLIT` default unchanged. All other request kwargs (`policy`, `no_token_behavior`, `start_number`, `end_number`) keep their current shape.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4771.org.readthedocs.build/en/4771/

<!-- readthedocs-preview griptape-nodes end -->
