### PR TITLE
Use griptape_nodes_app entrypoint for worker spawn

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -448,7 +448,7 @@ class WorkerManager:
         args = [
             sys.executable,
             "-m",
-            "griptape_nodes",
+            "griptape_nodes_app",
             "engine",
             "--session-id",
             session_id,


### PR DESCRIPTION
Artifact of the migration to griptape-nodes-engine/app