### PR TITLE
fix(serialization): dump NodeMetadata at boundary to fix BETA workflow reload (#4770)

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -514,8 +514,17 @@ class Library:
         # into the node's metadata blob.
         if metadata is None:
             metadata = {}
-        library_node_metadata = self._node_metadata.get(node_type, {})
-        metadata["library_node_metadata"] = library_node_metadata
+        # Dump to a JSON-safe dict so downstream consumers (and the workflow
+        # serializer in particular) only ever see plain literals — no Pydantic
+        # models, no StrEnum members. Without this, a NodeMetadata carrying a
+        # LifecycleStageNodeProperty would leak through to the generated workflow
+        # as a Python repr (e.g. `<LifecycleStage.BETA: 'BETA'>`), which is not
+        # valid Python.
+        library_node_metadata_model = self._node_metadata.get(node_type)
+        if library_node_metadata_model is None:
+            metadata["library_node_metadata"] = {}
+        else:
+            metadata["library_node_metadata"] = library_node_metadata_model.model_dump(mode="json")
         metadata["library"] = self._library_data.name
         metadata["node_type"] = node_type
         node = node_class(name=name, metadata=metadata)

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -46,7 +46,7 @@ class WorkflowShape(BaseModel):
 
 
 class WorkflowMetadata(BaseModel):
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.19.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.19.1"
 
     name: str
     schema_version: str

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -10,6 +10,10 @@ import pytest
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.node_library.library_declarations import (
+    LifecycleStage,
+    LifecycleStageNodeProperty,
+)
 from griptape_nodes.node_library.library_registry import (
     LibraryMetadata,
     LibraryRegistry,
@@ -1604,3 +1608,113 @@ class TestDescribeNodeTypeRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert any(detail.level == logging.WARNING for detail in result.result_details.result_details)
         assert "simulated I/O failure" in str(result.result_details)
+
+
+class _LifecycleProbe(BaseNode):
+    """Concrete BaseNode used to exercise Library.create_node's metadata injection."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+
+
+class TestLibraryNodeMetadataInjection:
+    """Regression coverage for #4770.
+
+    Before the fix, Library.create_node injected the live Pydantic NodeMetadata
+    instance under metadata["library_node_metadata"]. The workflow serializer
+    then emitted that model's repr (e.g. ``<LifecycleStage.BETA: 'BETA'>``)
+    via ast.Constant -> ast.unparse, producing invalid Python that couldn't
+    reload. Library.create_node now dumps to a JSON-safe dict at the boundary.
+    """
+
+    _LIBRARY_NAME = "lifecycle-probe-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        LibraryRegistry._libraries.clear()
+        LibraryRegistry._node_aliases.clear()
+        LibraryRegistry._collision_node_names_to_library_names.clear()
+        LibraryRegistry._registered_widgets.clear()
+        yield
+        LibraryRegistry._libraries.clear()
+        LibraryRegistry._node_aliases.clear()
+        LibraryRegistry._collision_node_names_to_library_names.clear()
+        LibraryRegistry._registered_widgets.clear()
+
+    def _register_probe_library(self, node_metadata: NodeMetadata) -> None:
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="lifecycle probe library",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_LifecycleProbe, node_metadata)
+
+    def test_library_node_metadata_is_dict_not_pydantic_model(self) -> None:
+        """The injected value must be a plain dict so the workflow serializer never sees a Pydantic instance."""
+        self._register_probe_library(
+            NodeMetadata(category="test", description="probe", display_name="Probe"),
+        )
+
+        node = LibraryRegistry.create_node(
+            node_type=_LifecycleProbe.__name__,
+            name="probe-1",
+            specific_library_name=self._LIBRARY_NAME,
+        )
+
+        injected = node.metadata["library_node_metadata"]
+        assert isinstance(injected, dict)
+        assert not isinstance(injected, NodeMetadata)
+
+    def test_lifecycle_stage_strenum_dumps_to_plain_string(self) -> None:
+        """The headline #4770 case: a BETA declaration must not survive as a StrEnum member."""
+        self._register_probe_library(
+            NodeMetadata(
+                category="test",
+                description="probe",
+                display_name="Probe",
+                declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.BETA)],
+            ),
+        )
+
+        node = LibraryRegistry.create_node(
+            node_type=_LifecycleProbe.__name__,
+            name="probe-2",
+            specific_library_name=self._LIBRARY_NAME,
+        )
+
+        declarations = node.metadata["library_node_metadata"]["declarations"]
+        assert declarations == [{"type": "lifecycle_stage", "stage": "BETA"}]
+        # Specifically: the stage value is a plain string, not a LifecycleStage member.
+        assert declarations[0]["stage"].__class__ is str
+
+    def test_caller_provided_library_node_metadata_is_overwritten(self) -> None:
+        """Loading an old workflow that emits ``library_node_metadata=NodeMetadata(...)`` still works.
+
+        Library.create_node has always overwritten the caller-supplied value with the
+        registry's authoritative copy; this test pins that behavior so old generated
+        workflows continue to load after the boundary fix.
+        """
+        self._register_probe_library(
+            NodeMetadata(category="test", description="probe", display_name="Probe"),
+        )
+
+        stale_model = NodeMetadata(category="STALE", description="STALE", display_name="STALE")
+        node = LibraryRegistry.create_node(
+            node_type=_LifecycleProbe.__name__,
+            name="probe-3",
+            specific_library_name=self._LIBRARY_NAME,
+            metadata={"library_node_metadata": stale_model},
+        )
+
+        injected = node.metadata["library_node_metadata"]
+        assert injected["category"] == "test"
+        assert injected["description"] == "probe"


### PR DESCRIPTION
Closes #4770.

## Summary
- `Library.create_node` now stores `library_node_metadata` as a JSON-safe dict (`model_dump(mode="json")`) instead of injecting the live Pydantic `NodeMetadata` instance. The workflow serializer downstream uses `ast.Constant`, which falls back to `repr()` for non-literal values — so a `NodeMetadata` carrying a `LifecycleStageNodeProperty(stage=LifecycleStage.BETA)` would get emitted as `stage=<LifecycleStage.BETA: 'BETA'>`, which is invalid Python and broke workflow reload.
- Bumps `WorkflowMetadata.LATEST_SCHEMA_VERSION` `0.19.0` → `0.19.1` so a saved workflow's schema version is a triage signal for whether it came from a fixed generator.
- Adds three regression tests covering (a) injected value is a dict, not a Pydantic model; (b) the headline `LifecycleStage.BETA` case dumps to a plain string; (c) old workflows that emit `library_node_metadata=NodeMetadata(...)` still load — `Library.create_node` overwrites the caller-supplied value with the registry's authoritative copy, as it always has.

This is intentionally a single-source boundary fix. An earlier draft also added a generic literal-safe AST helper in `WorkflowManager`, but a second-opinion review showed it was incomplete (no `datetime`/`Path`/`UUID`/dataclass coverage), inconsistently applied across the four `ast.Constant(value=field_value)` sites, and would silently absorb future "non-literal got into metadata" bugs that we'd rather see crash loudly.

## Test plan
- [x] `make check` clean
- [x] `tests/unit/retained_mode/managers/test_library_manager.py::TestLibraryNodeMetadataInjection` (3 new tests)
- [x] No regressions across `test_workflow_manager.py`, `test_node_manager.py`, `test_library_manager.py`, `test_library_declarations.py` (144 tests)
- [x] Manual repro of the issue's `BetaNode` (ParameterDict + Widget + BETA): build → save → reload succeeds; generated `.py` contains `'declarations': [{'type': 'lifecycle_stage', 'stage': 'BETA'}]` (no `<LifecycleStage.BETA: 'BETA'>` repr)
- [x] Cross-trigger sanity: ParameterString+Widget+BETA, ParameterDict+no-Widget+BETA, no-Widget+no-Dict+BETA still save/reload cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)