### PR TITLE
Fix: update the index key on connections on rename

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4312,19 +4312,25 @@ class NodeManager:
         # Update connections that reference this parameter
         if node_name in connections.incoming_index:
             incoming_connections = connections.incoming_index[node_name]
-            for connection_ids in incoming_connections.values():
+            if request.parameter_name in incoming_connections:
+                connection_ids = incoming_connections[request.parameter_name]
                 for connection_id in connection_ids:
                     connection = connections.connections[connection_id]
                     if connection.target_parameter.name == request.parameter_name:
                         connection.target_parameter.name = request.new_parameter_name
+                # Update the index key from old name to new name
+                incoming_connections[request.new_parameter_name] = incoming_connections.pop(request.parameter_name)
 
         if node_name in connections.outgoing_index:
             outgoing_connections = connections.outgoing_index[node_name]
-            for connection_ids in outgoing_connections.values():
+            if request.parameter_name in outgoing_connections:
+                connection_ids = outgoing_connections[request.parameter_name]
                 for connection_id in connection_ids:
                     connection = connections.connections[connection_id]
                     if connection.source_parameter.name == request.parameter_name:
                         connection.source_parameter.name = request.new_parameter_name
+                # Update the index key from old name to new name
+                outgoing_connections[request.new_parameter_name] = outgoing_connections.pop(request.parameter_name)
 
         # Update parameter name
         old_name = parameter.name


### PR DESCRIPTION
### Bug 
When renaming a parameter with connections we were updating the connection obj's parameter names but not the index dictionary keys. This caused temporarily borked connections until save and re-open. 

Reported here and here

### Repro
Create a Start Flow Node and another Node
Connect the add param row of the start flow node to a param in the other node
Rename the start flow node's param 
Try deleting the connection, and replacing, or connecting somewhere else


Helps close leftover issues with these two previously closed tickets:
[#2354 ](https://github.com/griptape-ai/griptape-vsl-gui/issues/2354), #4552 