### PR TITLE
fix(vscode): repair launch.json after engine/app split

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,13 +16,17 @@
             }
         },
         {
-            "name": "Python Debugger: Run Griptape Nodes App",
+            // Requires a one-time persistent install of the published app
+            // with this checkout layered as the editable engine. See
+            // CONTRIBUTING.md → "Debugging in VS Code" for setup steps.
+            "name": "Python Debugger: Run Griptape Nodes Engine (persistent gtn tool)",
             "type": "debugpy",
             "request": "launch",
-            "python": "${command:python.interpreterPath}",
-            "module": "src.griptape_nodes.__main__",
+            "python": "${userHome}/.local/share/uv/tools/griptape-nodes/bin/python",
+            "module": "griptape_nodes_app",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "cwd": "${workspaceFolder}",
             "args": []
         }
     ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,24 @@ make run
 
 This pulls the published app into a cached ephemeral environment and imports the engine from this checkout's `src` directory, so engine edits are reflected immediately with no reinstall. Pass arguments through `ARGS`, e.g. `make run ARGS=init` to trigger the initial setup prompts. Use `make run/refresh` to pull the latest published app first.
 
+### Debugging in VS Code
+
+VS Code's debugger needs a stable Python interpreter path on disk to inject `debugpy` into. The `make run` / `uvx` flow above creates an ephemeral environment per invocation and is not suitable; use the **persistent** `uv tool install` flow described below instead.
+
+1. From the repo root, install the published app with this checkout layered as the editable engine (one time):
+
+    ```shell
+    uv tool install griptape-nodes --python 3.12 --with-editable . --force
+    ```
+
+    This populates `~/.local/share/uv/tools/griptape-nodes/` with the app and a `.pth` file pointing back at this checkout's `src/`. Both the `gtn` command and the VS Code debug configuration reuse that interpreter, so breakpoints in `src/griptape_nodes/...` bind against your local source.
+
+1. Open the **Run and Debug** panel in VS Code, select **Python Debugger: Run Griptape Nodes Engine (persistent gtn tool)**, and press F5. The configuration in `.vscode/launch.json` invokes `python -m griptape_nodes` against the tool venv's interpreter and sets `cwd` to the workspace root so the local `griptape_nodes_config.json` (see [Configuration for Development](#configuration-for-development)) is picked up — without it, local libraries will not register under the debugger.
+
+The configuration assumes the default `uv` tools location. If you've set `UV_TOOL_DIR` to a non-default path, edit the `python` field in `.vscode/launch.json` to match.
+
+### Persistent `gtn` on your `PATH`
+
 For a persistent `gtn` (or `griptape-nodes`) command on your `PATH`, install the app as a `uv` tool with the editable engine layer instead:
 
 ```shell


### PR DESCRIPTION
Closes #4789.

## Summary

- Replaces the broken `module: src.griptape_nodes.__main__` debug configuration in [.vscode/launch.json](.vscode/launch.json) with one that targets the persistent `uv tool install` venv and runs `python -m griptape_nodes_app`. The published app's editable overlay (`.pth` → `src/`) means breakpoints set in this checkout's engine source bind correctly.
- Adds a **Debugging in VS Code** subsection to [CONTRIBUTING.md](CONTRIBUTING.md) documenting the one-time `uv tool install griptape-nodes --python 3.12 --with-editable . --force` prerequisite, the F5 flow, and the `UV_TOOL_DIR` caveat. Splits the existing persistent-install guidance under a new **Persistent `gtn` on your `PATH`** heading so the section ordering reads ephemeral → persistent → debugging.

## Why this approach

Three flows are available to launch the engine; only one supports the debugger:

| Flow | Stable Python path? | Debugger-compatible? |
|---|---|---|
| `make run` (`uvx --with-editable .`) | No — ephemeral env per invocation | No |
| `uv tool install ... --with-editable .` | Yes — `~/.local/share/uv/tools/griptape-nodes/` | **Yes** |
| Engine repo's `.venv` | Yes, but no published app installed | No |

`debugpy` needs a stable interpreter on disk to inject into. The persistent uv-tool venv is the only flow that has both the published app *and* this checkout's editable engine on the same `sys.path`.

The launch config keeps a one-line pointer to CONTRIBUTING.md rather than duplicating the install command, so the docs remain the single source of truth.

## Notes

- The package name changed: the published app is `griptape_nodes_app` (with console scripts `gtn` and `griptape-nodes`), not `griptape_nodes`. An earlier draft of this PR used `griptape_nodes` based on a stale tool venv from May 2025; corrected after verifying against a fresh install of `griptape-nodes==0.85.3`.
- The existing **Python Debugger: Current File** configuration is unrelated to this breakage and is preserved unchanged.
- No new dependencies. The VS Code Python Debugger extension ships its own `debugpy` and injects it into the target interpreter at launch — the tool venv does not need `debugpy` installed.

## Test plan

- [ ] Fresh checkout: run `uv tool install griptape-nodes --python 3.12 --with-editable . --force` from repo root.
- [ ] In VS Code, Run & Debug panel → select **Python Debugger: Run Griptape Nodes Engine (persistent gtn tool)** → press F5. Engine boots without `ModuleNotFoundError`.
- [ ] Set a breakpoint in `src/griptape_nodes/retained_mode/managers/flow_manager.py` (or any hot engine path); confirm it binds (solid red dot) and trips.
- [ ] Confirm local libraries register: with a `griptape_nodes_config.json` at repo root listing the local libraries, they should appear in the engine's startup output (proves `cwd: ${workspaceFolder}` is taking effect).
- [ ] Re-run the existing **Python Debugger: Current File** config to confirm no regression.
- [ ] Read the new CONTRIBUTING.md subsection cold and confirm a contributor unfamiliar with the tool-install flow could follow it without asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)