### PR TITLE
fix(agent): inherit parent env for stdio MCP servers

### DIFF
--- a/src/griptape_nodes/agents/pydantic_ai/mcp_servers.py
+++ b/src/griptape_nodes/agents/pydantic_ai/mcp_servers.py
@@ -22,6 +22,7 @@ run fails. Graceful per-server degradation can be layered on later.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from fastmcp.client.transports import SSETransport, StdioTransport, StreamableHttpTransport
@@ -76,7 +77,7 @@ def mcp_server_from_config(name: str, config: Mapping[str, Any]) -> AbstractTool
         client = StdioTransport(
             command=command,
             args=list(config.get("args") or []),
-            env=config.get("env"),
+            env=_stdio_env(config.get("env")),
             cwd=config.get("cwd"),
         )
         return _compose(name, MCPToolset(client, max_retries=DEFAULT_TOOL_MAX_RETRIES))
@@ -119,6 +120,21 @@ def streamable_http_local(url: str, *, name: str | None = None) -> AbstractTools
 
 def _connect_timeout(config: Mapping[str, Any]) -> float:
     return float(config.get("timeout") or DEFAULT_CONNECT_TIMEOUT)
+
+
+def _stdio_env(config_env: Mapping[str, str] | None) -> dict[str, str]:
+    """Build the environment for an stdio MCP subprocess.
+
+    The subprocess inherits the engine's full environment, with the server's
+    configured ``env`` layered on top. Without this the MCP SDK forwards only a
+    tiny allowlist (``HOME``/``LOGNAME``/``PATH``/``SHELL``/``TERM``/``USER``),
+    which strips the toolchain variables a launcher like ``uv`` needs to resolve
+    its target command. A launcher that survives but can't find its entry point
+    then fails with ``Failed to spawn: <command>`` and the agent sees the MCP
+    connection close. Inheriting the parent environment matches both the engine's
+    other subprocess spawns and how desktop MCP clients launch stdio servers.
+    """
+    return {**os.environ, **(config_env or {})}
 
 
 def _compose(

--- a/tests/unit/agents/pydantic_ai/test_mcp_servers.py
+++ b/tests/unit/agents/pydantic_ai/test_mcp_servers.py
@@ -9,6 +9,7 @@ These cover two concerns without spinning up a real MCP server:
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 from typing import Any
 
@@ -59,7 +60,12 @@ def test_websocket_transport_returns_none() -> None:
 
 
 def test_stdio_maps_command_args_env_cwd() -> None:
-    """Stdio config fields land on the FastMCP StdioTransport."""
+    """Stdio config fields land on the FastMCP StdioTransport.
+
+    The subprocess inherits the engine's environment with the configured ``env``
+    layered on top, so the launcher (e.g. ``uv``) keeps the toolchain variables
+    it needs to resolve its target command.
+    """
     composed = mcp_server_from_config(
         "svc",
         {"transport": "stdio", "command": "uvx", "args": ["server"], "env": {"K": "V"}, "cwd": "/srv/app"},
@@ -68,8 +74,22 @@ def test_stdio_maps_command_args_env_cwd() -> None:
     assert isinstance(transport, StdioTransport)
     assert transport.command == "uvx"
     assert transport.args == ["server"]
-    assert transport.env == {"K": "V"}
+    assert transport.env is not None
+    assert transport.env == {**os.environ, "K": "V"}
     assert transport.cwd == "/srv/app"
+
+
+def test_stdio_inherits_parent_env_when_config_env_empty() -> None:
+    """An empty config ``env`` still inherits the parent environment.
+
+    Regression guard: forwarding only the MCP SDK allowlist stripped the PATH and
+    toolchain variables a launcher like ``uv`` needs, so stdio servers failed to
+    spawn while HTTP servers (no subprocess) worked.
+    """
+    composed = mcp_server_from_config("svc", {"transport": "stdio", "command": "uv", "env": {}})
+    transport = _mcp_toolset(composed).client.transport
+    assert isinstance(transport, StdioTransport)
+    assert transport.env == dict(os.environ)
 
 
 def test_sse_maps_url_and_headers() -> None:


### PR DESCRIPTION
Custom MCP servers using the `stdio` transport stopped working in the chat sidebar agent after the pydantic-ai migration, while `streamable_http`/`sse` servers and the MCP task node kept working. The agent failed with `uv` reporting `Failed to spawn: <command>` / `No such file or directory`, surfaced as `Connection closed`.

The cause is the environment handed to the stdio subprocess. The agent passed the server's configured `env` straight to fastmcp's `StdioTransport`, and the MCP SDK only augments that with a 6-variable allowlist (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`), stripping everything else. A launcher like `uv` survives that but loses the toolchain context it needs to resolve its target command, so it dies before the server ever starts. HTTP transports never spawn a child process, which is why only `stdio` was affected. The engine's other subprocess spawns already inherit the full environment, so this path was the outlier.

The stdio child now inherits the engine's environment with the configured `env` layered on top, matching both the engine's other spawns and how desktop MCP clients launch stdio servers.

Inheriting the full parent environment exposes engine secrets present in `os.environ` to user-configured MCP subprocesses. That matches the pre-migration behavior and the standard expectation for stdio MCP, but it is the contested default here, so calling it out: an allowlist-plus-`PATH` approach would be the stricter alternative if we decide leaking the engine env is unacceptable.
