### PR TITLE
Add enabled to LibraryMetadata

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -397,12 +397,14 @@ class LoadLibraryMetadataFromFileResultSuccess(WorkflowNotAlteredMixin, ResultPa
                          channels (e.g. sandbox, ad-hoc loads).
         git_remote: The git remote URL if the library is in a git repository, None otherwise.
         git_ref: The current git reference (branch, tag, or commit) if the library is in a git repository, None otherwise.
+        enabled: If the current library is enabled or disabled by the user at the time of the request.
     """
 
     library_schema: LibrarySchema
     file_path: str
     git_remote: str | None
     git_ref: str | None
+    enabled: bool
     registered_path: str | None = None
 
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -365,6 +365,10 @@ class LibraryManager:
         # (registered through workspace discovery, not via `libraries_to_register`).
         registered_path: str | None = None
         problems: list[LibraryProblem] = field(default_factory=list)
+        # Mirrors LibraryRegistration.enabled from the user's libraries_to_register config.
+        # True for sandbox, ad-hoc, and bare-string entries; False only when the user
+        # explicitly set enabled=false on the config object form.
+        enabled: bool = True
         # True when the library's declarations resolve to launching in a worker
         # process (compatible per ``WorkerModeCompatibility`` and suggested per
         # ``SuggestedWorkerMode``). Set whenever metadata is first successfully
@@ -1011,12 +1015,15 @@ class LibraryManager:
             logger.debug("Failed to get git ref for %s: %s", library_dir, e)
             git_ref = None
 
+        existing_info = self._library_file_path_to_info.get(file_path)
+        enabled = existing_info.enabled if existing_info is not None else True
         details = f"Successfully loaded library metadata from JSON file at {json_path}"
         return LoadLibraryMetadataFromFileResultSuccess(
             library_schema=library_data,
             file_path=file_path,
             git_remote=git_remote,
             git_ref=git_ref,
+            enabled=enabled,
             result_details=details,
         )
 
@@ -1068,6 +1075,7 @@ class LibraryManager:
                         file_path=str(sandbox_json_path),
                         git_remote=None,
                         git_ref=None,
+                        enabled=True,
                         result_details=scan_result.result_details,
                     )
                 # else: Keep the load failure result
@@ -1228,6 +1236,7 @@ class LibraryManager:
             file_path=str(sandbox_directory),
             git_remote=git_remote,
             git_ref=git_ref,
+            enabled=True,
             result_details=details,
         )
 
@@ -4204,6 +4213,7 @@ class LibraryManager:
             fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
             library_path=file_path_str,
             is_sandbox=is_sandbox,
+            enabled=enabled,
             library_name=library_name,
             library_version=library_version,
             registered_path=registered_path,

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -654,6 +654,7 @@ class TestLibraryManagerRegisterLibraryFromFile:
                 file_path="/mock.json",
                 git_remote=None,
                 git_ref=None,
+                enabled=True,
                 result_details=ResultDetails(message="Success", level=20),
             )
             mock_venv.return_value.exists.return_value = True
@@ -692,6 +693,7 @@ class TestLibraryManagerRegisterLibraryFromFile:
                     file_path="/f",
                     git_remote=None,
                     git_ref=None,
+                    enabled=True,
                     result_details=ResultDetails(message="OK", level=20),
                 ),
             ),
@@ -719,6 +721,7 @@ class TestLibraryManagerInstallLibraryDependencies:
             file_path="/mock.json",
             git_remote=None,
             git_ref=None,
+            enabled=True,
             result_details=ResultDetails(message="OK", level=20),
         )
 


### PR DESCRIPTION
## Summary

- Adds an `enabled` field to `LoadLibraryMetadataFromFileResultSuccess` so consumers (e.g. the GUI) can see whether a library is enabled or disabled without re-resolving config
- Populates `enabled` from `LibraryRegistration.enabled` at metadata load time; defaults to `True` for sandbox and ad-hoc loads
- Updates tests to include the new required field

Closes #4782
Part of a pair with the GUI PR (coming shortly).

## Test plan

- [ ] `make check` passes (verified locally)
- [ ] Existing unit tests updated and passing
- [ ] GUI PR verifies the field is surfaced correctly in the library panel