### PR TITLE
Adds a save_temp_file Project Situation

### DIFF
--- a/docs/projects/situations.md
+++ b/docs/projects/situations.md
@@ -103,6 +103,16 @@ fallback: save_file
 
 Used by the static files manager to save static assets. Files go into the `static_files_dir` subdirectory of the current workflow's directory. These files are overwritten when regenerated.
 
+### `save_temp_file`
+
+```
+macro:    {temp}/{node_name?:_}{file_name_base}{_index?:03}.{file_extension}
+policy:   overwrite, create_dirs: true
+fallback: save_file
+```
+
+Used when a node needs to write an intermediate or scratch file during processing (for example, a temporary EXR written between color-space conversion steps). Files go into the `temp` directory and are overwritten on re-run rather than versioned.
+
 ## How nodes use situations
 
 Nodes that save files use a `ProjectFileParameter` to declare which situation they operate in. The node provides its situation-specific variables (like `file_name_base` and `file_extension`), and the project system supplies everything else (directory paths, builtin variables).

--- a/docs/projects/situations.md
+++ b/docs/projects/situations.md
@@ -111,7 +111,7 @@ policy:   overwrite, create_dirs: true
 fallback: save_file
 ```
 
-Used when a node needs to write an intermediate or scratch file during processing (for example, a temporary EXR written between color-space conversion steps). Files go into the `temp` directory and are overwritten on re-run rather than versioned.
+Used when a node needs to write an intermediate or scratch file during processing (for example, a temporary EXR written between color-space conversion steps). Files go into the `temp` directory and should be deleted by the node after use.
 
 ## How nodes use situations
 

--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -174,5 +174,15 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             ),
             fallback="save_workflow",
         ),
+        "save_temp_file": SituationTemplate(
+            name="save_temp_file",
+            description="Save a temporary scratch file (e.g. intermediate processing artifacts)",
+            macro="{temp}/{node_name?:_}{file_name_base}{_index?:03}.{file_extension}",
+            policy=SituationPolicy(
+                on_collision=SituationFilePolicy.OVERWRITE,
+                create_dirs=True,
+            ),
+            fallback="save_file",
+        ),
     },
 )

--- a/tests/unit/common/test_project_templates_merge.py
+++ b/tests/unit/common/test_project_templates_merge.py
@@ -815,6 +815,31 @@ class TestProjectTemplateToYaml:
         assert merged.situations["save_file"].policy.on_collision == base_sit.policy.on_collision
 
 
+class TestDefaultProjectTemplate:
+    """Tests for the content of the default project template."""
+
+    def test_save_temp_file_situation_exists(self) -> None:
+        assert "save_temp_file" in DEFAULT_PROJECT_TEMPLATE.situations
+
+    def test_save_temp_file_situation_uses_overwrite_policy(self) -> None:
+        from griptape_nodes.common.project_templates.situation import SituationFilePolicy
+
+        situation = DEFAULT_PROJECT_TEMPLATE.situations["save_temp_file"]
+        assert situation.policy.on_collision == SituationFilePolicy.OVERWRITE
+
+    def test_save_temp_file_situation_creates_dirs(self) -> None:
+        situation = DEFAULT_PROJECT_TEMPLATE.situations["save_temp_file"]
+        assert situation.policy.create_dirs is True
+
+    def test_save_temp_file_situation_falls_back_to_save_file(self) -> None:
+        situation = DEFAULT_PROJECT_TEMPLATE.situations["save_temp_file"]
+        assert situation.fallback == "save_file"
+
+    def test_save_temp_file_macro_uses_temp_directory(self) -> None:
+        situation = DEFAULT_PROJECT_TEMPLATE.situations["save_temp_file"]
+        assert situation.macro.startswith("{temp}/")
+
+
 class TestOverlayDeletions:
     """Overlay/merge symmetry for deletions: removed base items must stay removed on reload."""
 


### PR DESCRIPTION
# Motivation
A few libraries have required writing temporary files. This small commit adds a `save_temp_file` Project Situation to allow library authors to better signal intent that a temporary file is being written.

# Use Cases
OpenEXR: https://github.com/griptape-ai/griptape-nodes-library-openexr/issues/17
Nuke: A number of temp files are currently written that are better served by the existing Project infrastructure.

Resolves: https://github.com/griptape-ai/griptape-nodes-library-opencolorio/issues/10

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4798.org.readthedocs.build/en/4798/

<!-- readthedocs-preview griptape-nodes end -->