### PR TITLE
feat: add MakeDirectoryRequest

### DIFF
--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -947,3 +947,53 @@ class GetNextVersionIndexResultFailure(WorkflowNotAlteredMixin, ResultPayloadFai
     """
 
     failure_reason: FileIOFailureReason
+
+
+@dataclass
+@PayloadRegistry.register
+class MakeDirectoryRequest(RequestPayload):
+    """Create a directory, optionally including intermediate parent directories.
+
+    Use when: Creating output directories, setting up workspace folder structures,
+    ensuring a directory exists before writing files into it. Prefer this over
+    CreateFileRequest when the goal is purely directory creation.
+
+    Args:
+        path: Absolute path to the directory to create
+        create_parents: If True, create intermediate directories as needed (default: True)
+        exist_ok: If True, succeed silently when the directory already exists (default: True).
+                  Set to False to get a POLICY_NO_OVERWRITE failure if the directory exists.
+
+    Results: MakeDirectoryResultSuccess | MakeDirectoryResultFailure
+    """
+
+    path: str
+    create_parents: bool = True
+    exist_ok: bool = True
+
+
+@dataclass
+@PayloadRegistry.register
+class MakeDirectoryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Directory created (or already existed) successfully.
+
+    Attributes:
+        created_path: Absolute path of the directory
+        already_existed: True when the directory already existed and exist_ok=True
+    """
+
+    created_path: str
+    already_existed: bool = False
+
+
+@dataclass
+@PayloadRegistry.register
+class MakeDirectoryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Directory creation failed.
+
+    Attributes:
+        failure_reason: Classification of why the creation failed
+        result_details: Human-readable error message (inherited from ResultPayloadFailure)
+    """
+
+    failure_reason: FileIOFailureReason

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -83,6 +83,9 @@ from griptape_nodes.retained_mode.events.os_events import (
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
+    MakeDirectoryRequest,
+    MakeDirectoryResultFailure,
+    MakeDirectoryResultSuccess,
     OpenAssociatedFileRequest,
     OpenAssociatedFileResultFailure,
     OpenAssociatedFileResultSuccess,
@@ -356,6 +359,10 @@ class OSManager:
 
             event_manager.assign_manager_to_request_type(
                 request_type=GetNextVersionIndexRequest, callback=self.on_get_next_version_index_request
+            )
+
+            event_manager.assign_manager_to_request_type(
+                request_type=MakeDirectoryRequest, callback=self.on_make_directory_request
             )
 
             # Store event_manager for direct access during resource registration
@@ -2729,6 +2736,56 @@ class OSManager:
             logger.error("Attempted to clean up old files from %s, but no files could be deleted.")
 
         return removed_count > 0
+
+    def on_make_directory_request(self, request: MakeDirectoryRequest) -> ResultPayload:  # noqa: PLR0911
+        """Handle a request to create a directory."""
+        sanitized = sanitize_path_string(request.path)
+        try:
+            dir_path = self._resolve_file_path(sanitized, workspace_only=False)
+        except (ValueError, RuntimeError) as e:
+            msg = f"Attempted to create directory '{sanitized}'. Failed due to invalid path: {e}"
+            return MakeDirectoryResultFailure(failure_reason=FileIOFailureReason.INVALID_PATH, result_details=msg)
+
+        if dir_path.is_file():
+            msg = f"Attempted to create directory '{dir_path}'. Failed because a file already exists at that path."
+            return MakeDirectoryResultFailure(failure_reason=FileIOFailureReason.INVALID_PATH, result_details=msg)
+
+        if dir_path.is_dir() and not request.exist_ok:
+            msg = f"Attempted to create directory '{dir_path}'. Failed because directory already exists."
+            return MakeDirectoryResultFailure(
+                failure_reason=FileIOFailureReason.POLICY_NO_OVERWRITE, result_details=msg
+            )
+
+        if dir_path.is_dir():
+            return MakeDirectoryResultSuccess(
+                created_path=str(dir_path),
+                already_existed=True,
+                result_details=f"Directory already exists at {dir_path}",
+            )
+
+        normalized = normalize_path_for_platform(dir_path)
+        try:
+            Path(normalized).mkdir(parents=request.create_parents, exist_ok=request.exist_ok)
+        except FileNotFoundError as e:
+            msg = f"Attempted to create directory '{dir_path}'. Failed because parent directory does not exist and create_parents is False: {e}"
+            return MakeDirectoryResultFailure(
+                failure_reason=FileIOFailureReason.POLICY_NO_CREATE_PARENT_DIRS, result_details=msg
+            )
+        except PermissionError as e:
+            msg = f"Attempted to create directory '{dir_path}'. Failed due to permission denied: {e}"
+            return MakeDirectoryResultFailure(failure_reason=FileIOFailureReason.PERMISSION_DENIED, result_details=msg)
+        except OSError as e:
+            if "No space left" in str(e) or "Disk full" in str(e):
+                msg = f"Attempted to create directory '{dir_path}'. Failed due to disk full: {e}"
+                return MakeDirectoryResultFailure(failure_reason=FileIOFailureReason.DISK_FULL, result_details=msg)
+            msg = f"Attempted to create directory '{dir_path}'. Failed due to I/O error: {e}"
+            return MakeDirectoryResultFailure(failure_reason=FileIOFailureReason.IO_ERROR, result_details=msg)
+
+        return MakeDirectoryResultSuccess(
+            created_path=str(dir_path),
+            already_existed=False,
+            result_details=f"Directory created successfully at {dir_path}",
+        )
 
     def on_create_file_request(self, request: CreateFileRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, C901
         """Handle a request to create a file or directory."""

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -35,6 +35,9 @@ from griptape_nodes.retained_mode.events.os_events import (
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
+    MakeDirectoryRequest,
+    MakeDirectoryResultFailure,
+    MakeDirectoryResultSuccess,
     ReadFileRequest,
     ReadFileResultFailure,
     ReadFileResultSuccess,
@@ -1576,3 +1579,105 @@ class TestGetNextVersionIndexRequest:
 
         assert isinstance(result, GetNextVersionIndexResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
+
+
+class TestMakeDirectoryRequest:
+    """Test MakeDirectoryRequest handler."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    def test_create_new_directory_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Creating a directory that does not yet exist returns success with already_existed=False."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "new_dir"
+
+        result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path)))
+
+        assert isinstance(result, MakeDirectoryResultSuccess)
+        assert dir_path.is_dir()
+        assert not result.already_existed
+        assert Path(result.created_path).resolve() == dir_path.resolve()
+
+    def test_directory_already_exists_exist_ok_true(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """When the directory already exists and exist_ok=True, returns success with already_existed=True."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "existing_dir"
+        dir_path.mkdir()
+
+        result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path), exist_ok=True))
+
+        assert isinstance(result, MakeDirectoryResultSuccess)
+        assert result.already_existed
+
+    def test_directory_already_exists_exist_ok_false(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """When the directory already exists and exist_ok=False, returns POLICY_NO_OVERWRITE failure."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "existing_dir"
+        dir_path.mkdir()
+
+        result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path), exist_ok=False))
+
+        assert isinstance(result, MakeDirectoryResultFailure)
+        assert result.failure_reason == FileIOFailureReason.POLICY_NO_OVERWRITE
+
+    def test_file_at_path_returns_invalid_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """When a file already exists at the requested path, returns INVALID_PATH failure."""
+        os_manager = griptape_nodes.OSManager()
+        file_path = temp_dir / "not_a_dir.txt"
+        file_path.write_text("content")
+
+        result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(file_path)))
+
+        assert isinstance(result, MakeDirectoryResultFailure)
+        assert result.failure_reason == FileIOFailureReason.INVALID_PATH
+
+    def test_create_parents_true(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """With create_parents=True, missing intermediate directories are created."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "a" / "b" / "c"
+
+        result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path), create_parents=True))
+
+        assert isinstance(result, MakeDirectoryResultSuccess)
+        assert dir_path.is_dir()
+
+    def test_create_parents_false_missing_parent(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """With create_parents=False and a missing parent, returns POLICY_NO_CREATE_PARENT_DIRS failure."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "missing_parent" / "child"
+
+        result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path), create_parents=False))
+
+        assert isinstance(result, MakeDirectoryResultFailure)
+        assert result.failure_reason == FileIOFailureReason.POLICY_NO_CREATE_PARENT_DIRS
+
+    def test_invalid_path_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A path that cannot be resolved returns INVALID_PATH before any filesystem operation."""
+        os_manager = griptape_nodes.OSManager()
+
+        with patch.object(OSManager, "_resolve_file_path", side_effect=ValueError("bad path")):
+            result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(temp_dir / "any")))
+
+        assert isinstance(result, MakeDirectoryResultFailure)
+        assert result.failure_reason == FileIOFailureReason.INVALID_PATH
+
+    def test_permission_denied_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A PermissionError from mkdir is surfaced as a PERMISSION_DENIED failure."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "protected_dir"
+
+        with patch.object(Path, "mkdir", side_effect=PermissionError("Permission denied")):
+            result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path)))
+
+        assert isinstance(result, MakeDirectoryResultFailure)
+        assert result.failure_reason == FileIOFailureReason.PERMISSION_DENIED


### PR DESCRIPTION
## Summary

Required for #4634 

- Adds `MakeDirectoryRequest` to the OS event system, a dedicated request type for creating directories
- Adds `on_make_directory_request` handler in `OSManager` that supports `create_parents` and `exist_ok` options
- Returns structured success/failure results with typed `FileIOFailureReason` codes covering invalid paths, permission errors, missing parents, disk full, and no-overwrite policy

## Motivation

The existing `CreateFileRequest` handles directory creation as a side-effect. `MakeDirectoryRequest` provides a first-class, intent-clear alternative for callers whose only goal is to ensure a directory exists before writing files into it.

## Test plan

- [ ] `MakeDirectoryRequest` with a new path creates the directory and returns `already_existed=False`
- [ ] Re-running with `exist_ok=True` (default) returns `already_existed=True` without error
- [ ] `exist_ok=False` on an existing directory returns `MakeDirectoryResultFailure` with `POLICY_NO_OVERWRITE`
- [ ] `create_parents=False` on a missing parent returns `POLICY_NO_CREATE_PARENT_DIRS`
- [ ] A path where a file already exists returns `INVALID_PATH`
