### PR TITLE
add worker cleanup escalation via _terminate_managed_process

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -325,8 +325,12 @@ class WorkerManager:
             len(self._managed_worker_processes),
             list(self._managed_worker_processes.keys()),
         )
-        for library_name, proc in list(self._managed_worker_processes.items()):
-            await self._terminate_managed_process(library_name, proc)
+        await asyncio.gather(
+            *(
+                self._terminate_managed_process(library_name, proc)
+                for library_name, proc in list(self._managed_worker_processes.items())
+            )
+        )
         session_id = self._griptape_nodes.get_session_id()
         if session_id and self._transport is not None:
             for wid in list(self._workers):

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -80,6 +80,10 @@ class WorkerManager:
     # this matches the _await_pending_workers() ceiling so a worker never kills
     # itself before the orchestrator gives up waiting for it.
     DEFAULT_HEARTBEAT_STARTUP_GRACE_S: float = 600.0
+    # How long to wait for a worker to exit after SIGTERM before escalating to
+    # SIGKILL. Workers convert SIGTERM into a cooperative shutdown on their event
+    # loop; a wedged loop never services it, so SIGTERM alone can leak the process.
+    DEFAULT_TERMINATE_GRACE_S: float = 10.0
 
     _WORKER_RESPONSE_TOPIC_RE: re.Pattern = re.compile(r"sessions/[^/]+/workers/(?P<worker_engine_id>[^/]+)/response$")
 
@@ -322,11 +326,7 @@ class WorkerManager:
             list(self._managed_worker_processes.keys()),
         )
         for library_name, proc in list(self._managed_worker_processes.items()):
-            try:
-                proc.terminate()
-                logger.info("Terminated worker for key '%s' (pid %s)", library_name, proc.pid)
-            except ProcessLookupError:
-                logger.debug("Worker for key '%s' already exited before termination", library_name)
+            await self._terminate_managed_process(library_name, proc)
         session_id = self._griptape_nodes.get_session_id()
         if session_id and self._transport is not None:
             for wid in list(self._workers):
@@ -389,8 +389,7 @@ class WorkerManager:
         if lib_name:
             proc = self._managed_worker_processes.pop(lib_name, None)
             if proc is not None:
-                proc.terminate()
-                logger.info("Eviction: terminated managed process for key '%s' (pid %s)", lib_name, proc.pid)
+                await self._terminate_managed_process(lib_name, proc)
         # Cancel any requests that were awaiting a result from this worker.
         await self._tx.request_client.cancel_requests_by_tag(worker_engine_id)
 
@@ -400,6 +399,35 @@ class WorkerManager:
                 cb(worker_engine_id, lib_name)
             except Exception:
                 logger.warning("Worker-evicted callback raised an exception for worker '%s'", worker_engine_id)
+
+    async def _terminate_managed_process(self, library_name: str, proc: asyncio.subprocess.Process) -> None:
+        """Terminate a managed worker, escalating to SIGKILL if it does not exit.
+
+        SIGTERM is converted by the worker into a cooperative shutdown on its
+        event loop; a wedged loop never services it. After DEFAULT_TERMINATE_GRACE_S
+        we send SIGKILL, which the kernel delivers regardless of loop state, so a
+        hung worker can never leak.
+        """
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            logger.debug("Worker for key '%s' already exited before termination", library_name)
+            return
+        logger.info("Terminated worker for key '%s' (pid %s)", library_name, proc.pid)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=WorkerManager.DEFAULT_TERMINATE_GRACE_S)
+        except TimeoutError:
+            logger.warning(
+                "Worker for key '%s' (pid %s) did not exit within %.0fs of SIGTERM; sending SIGKILL",
+                library_name,
+                proc.pid,
+                WorkerManager.DEFAULT_TERMINATE_GRACE_S,
+            )
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
+            await proc.wait()
 
     def register_worker_evicted_callback(self, callback: Callable[[str, str | None], None]) -> None:
         """Register a callback invoked when a worker is evicted.

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -77,6 +77,17 @@ def worker_manager() -> WorkerManager:
     return wm
 
 
+def _managed_proc_mock() -> MagicMock:
+    """Build a mock worker process whose ``wait()`` is awaitable.
+
+    ``_terminate_managed_process`` awaits ``proc.wait()`` after SIGTERM; a bare
+    MagicMock returns a non-awaitable, so stand in an AsyncMock for ``wait``.
+    """
+    proc = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
 class TestHandleRegisterWorkerRequest:
     @pytest.mark.asyncio
     async def test_adds_worker_to_registered_workers(self, worker_manager: WorkerManager) -> None:
@@ -331,7 +342,7 @@ class TestEvictWorker:
 
     @pytest.mark.asyncio
     async def test_terminates_managed_subprocess_for_library(self, worker_manager: WorkerManager) -> None:
-        proc = MagicMock()
+        proc = _managed_proc_mock()
         worker_manager._workers[_ENGINE] = WorkerRegistration(
             request_topic=_WORKER_REQUEST_TOPIC, worker_key="My Library"
         )
@@ -451,7 +462,7 @@ class TestSpawnWorker:
 class TestResetWorkers:
     @pytest.mark.asyncio
     async def test_terminates_all_processes(self, worker_manager: WorkerManager) -> None:
-        proc_a, proc_b = MagicMock(), MagicMock()
+        proc_a, proc_b = _managed_proc_mock(), _managed_proc_mock()
         worker_manager._managed_worker_processes["Lib A"] = proc_a
         worker_manager._managed_worker_processes["Lib B"] = proc_b
 
@@ -462,7 +473,7 @@ class TestResetWorkers:
 
     @pytest.mark.asyncio
     async def test_clears_all_tracking_state(self, worker_manager: WorkerManager) -> None:
-        worker_manager._managed_worker_processes["Lib A"] = MagicMock()
+        worker_manager._managed_worker_processes["Lib A"] = _managed_proc_mock()
         worker_manager._workers[_ENGINE] = WorkerRegistration(request_topic=_WORKER_REQUEST_TOPIC, worker_key="Lib A")
         worker_manager._worker_last_seen[_ENGINE] = 999.0
 
@@ -489,6 +500,24 @@ class TestResetWorkers:
         await worker_manager.reset_workers()
 
         assert worker_manager._managed_worker_processes == {}
+
+    @pytest.mark.asyncio
+    async def test_escalates_to_sigkill_when_terminate_times_out(self, worker_manager: WorkerManager) -> None:
+        """A worker that ignores SIGTERM must be SIGKILLed after the grace period."""
+        proc = _managed_proc_mock()
+        worker_manager._managed_worker_processes["Lib A"] = proc
+
+        def _close_and_timeout(awaitable: object, *_args: object, **_kwargs: object) -> None:
+            # Close the proc.wait() coroutine we are bypassing so it is not
+            # reported as never-awaited, then simulate the SIGTERM grace expiring.
+            awaitable.close()  # type: ignore[attr-defined]
+            raise TimeoutError
+
+        with patch("asyncio.wait_for", side_effect=_close_and_timeout):
+            await worker_manager.reset_workers()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_unsubscribes_response_topic_for_each_registered_worker(self, worker_manager: WorkerManager) -> None:


### PR DESCRIPTION
Ran into orphaned workers and wanted to add a second layer of defense for termination.