### PR TITLE
feat(models): add InvokeModelRequest as the model invocation chokepoint

### DIFF
--- a/src/griptape_nodes/retained_mode/events/model_events.py
+++ b/src/griptape_nodes/retained_mode/events/model_events.py
@@ -345,3 +345,56 @@ class GetModelInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
 @PayloadRegistry.register
 class GetModelInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Model info retrieval failed. Common causes: invalid model ID, network error, authentication required."""
+
+
+@dataclass
+@PayloadRegistry.register
+class InvokeModelRequest(RequestPayload):
+    """Invoke a model through the engine's model invocation chokepoint.
+
+    Routing inference through a single request gives enforcement one place to
+    bind: pre-dispatch hooks see this request's attributes (model_id, task)
+    before any backend runs. The actual inference is performed by a library
+    that registered an event handler for this request type (see
+    LibraryManager.on_register_event_handler), mirroring how workflow
+    publishing delegates to library-registered publishers.
+
+    Use when: Invoking a model from a node or service so the call is subject
+    to model entitlements, rather than calling an inference backend directly.
+
+    Args:
+        model_id: Model identifier to invoke (e.g., "black-forest-labs/FLUX.1-dev")
+        task: What the invocation does (e.g., "text-generation", "image-to-image")
+        invoker_name: Library whose registered invocation handler should service the
+            call. Optional when exactly one library has registered a handler.
+        node_name: Name of the node instance making the call, when invoked from a node
+        parameters: Backend-specific invocation payload
+
+    Results: InvokeModelResultSuccess (with output) | InvokeModelResultFailure (no invoker registered, ambiguous invoker, invocation error)
+    """
+
+    model_id: str
+    task: str | None = None
+    invoker_name: str | None = None
+    node_name: str | None = None
+    parameters: dict | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class InvokeModelResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Model invocation completed successfully.
+
+    Args:
+        model_id: The model that was invoked
+        output: Backend-specific invocation output
+    """
+
+    model_id: str
+    output: dict | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class InvokeModelResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Model invocation failed. Common causes: no invoker registered, ambiguous invoker, denied by policy, backend error."""

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -32,6 +32,8 @@ from griptape_nodes.retained_mode.events.model_events import (
     GetModelInfoRequest,
     GetModelInfoResultFailure,
     GetModelInfoResultSuccess,
+    InvokeModelRequest,
+    InvokeModelResultFailure,
     ListModelDownloadsRequest,
     ListModelDownloadsResultFailure,
     ListModelDownloadsResultSuccess,
@@ -239,6 +241,7 @@ class ModelManager:
             event_manager.assign_manager_to_request_type(DeleteModelRequest, self.on_handle_delete_model_request)
             event_manager.assign_manager_to_request_type(SearchModelsRequest, self.on_handle_search_models_request)
             event_manager.assign_manager_to_request_type(GetModelInfoRequest, self.on_handle_get_model_info_request)
+            event_manager.assign_manager_to_request_type(InvokeModelRequest, self.on_handle_invoke_model_request)
             event_manager.assign_manager_to_request_type(
                 ListModelDownloadsRequest, self.on_handle_list_model_downloads_request
             )
@@ -717,6 +720,62 @@ class ModelManager:
             likes=getattr(info, "likes", None),
             result_details=f"Retrieved info for '{request.model_id}'",
         )
+
+    async def on_handle_invoke_model_request(self, request: InvokeModelRequest) -> ResultPayload:
+        """Handle model invocation requests.
+
+        The handler is deliberately thin: enforcement runs in the event
+        manager's pre-dispatch hook chain before this point, so by the time it
+        executes the invocation is sanctioned. The actual inference is
+        delegated to a library-registered event handler for InvokeModelRequest
+        (the same mechanism workflow publishing uses for publishers).
+
+        Args:
+            request: The invocation request identifying the model and invoker
+
+        Returns:
+            ResultPayload: The invoker's result, or failure when no invoker can service the call
+        """
+        handler_mappings = GriptapeNodes.LibraryManager().get_registered_event_handlers(InvokeModelRequest)
+        if not handler_mappings:
+            error_msg = (
+                f"Attempted to invoke model '{request.model_id}'. Failed because no library has registered "
+                "an event handler for InvokeModelRequest."
+            )
+            return InvokeModelResultFailure(result_details=error_msg)
+
+        if request.invoker_name is None and len(handler_mappings) > 1:
+            error_msg = (
+                f"Attempted to invoke model '{request.model_id}'. Failed because multiple libraries have "
+                f"registered invocation handlers ({sorted(handler_mappings)}) and the request did not set "
+                "invoker_name to choose one."
+            )
+            return InvokeModelResultFailure(result_details=error_msg)
+
+        if request.invoker_name is None:
+            invocation_handler = next(iter(handler_mappings.values()))
+        else:
+            named_handler = handler_mappings.get(request.invoker_name)
+            if named_handler is None:
+                error_msg = (
+                    f"Attempted to invoke model '{request.model_id}' with invoker '{request.invoker_name}'. "
+                    f"Failed because no library by that name has registered an invocation handler. "
+                    f"Registered invokers: {sorted(handler_mappings)}."
+                )
+                return InvokeModelResultFailure(result_details=error_msg)
+            invocation_handler = named_handler
+
+        try:
+            return await asyncio.to_thread(invocation_handler.handler, request)
+        except Exception as e:
+            # The invoker is library code; this is the dispatch boundary, so an
+            # escaping exception becomes a failure result rather than a crash.
+            error_msg = (
+                f"Attempted to invoke model '{request.model_id}'. Failed because the invocation handler "
+                f"raised {type(e).__name__}: {e}"
+            )
+            logger.exception(error_msg)
+            return InvokeModelResultFailure(exception=e, result_details=error_msg)
 
     def _search_models(self, request: SearchModelsRequest) -> SearchResultsData:
         """Synchronous model search implementation.

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -3,6 +3,7 @@
 Covers:
 - `on_handle_get_model_info_request` — token guard and HF API delegation
 - `on_handle_search_models_request` — search result handling
+- `on_handle_invoke_model_request` — invoker lookup, selection, and dispatch-boundary failures
 - `_download_model_task` — the spawned subprocess targets a runnable module
 """
 
@@ -17,6 +18,9 @@ from griptape_nodes.retained_mode.events.model_events import (
     GetModelInfoRequest,
     GetModelInfoResultFailure,
     GetModelInfoResultSuccess,
+    InvokeModelRequest,
+    InvokeModelResultFailure,
+    InvokeModelResultSuccess,
     SearchModelsRequest,
     SearchModelsResultFailure,
     SearchModelsResultSuccess,
@@ -182,6 +186,97 @@ class TestOnHandleSearchModelsRequest:
 
 # ---------------------------------------------------------------------------
 # _download_model_task — subprocess entry point
+# ---------------------------------------------------------------------------
+
+
+class TestOnHandleInvokeModelRequest:
+    def _patch_registered_handlers(self, handler_mappings: dict[str, SimpleNamespace]):  # noqa: ANN202
+        """Patch the library-registered InvokeModelRequest handlers the manager looks up."""
+        library_manager = SimpleNamespace(get_registered_event_handlers=lambda _request_type: handler_mappings)
+        return patch(
+            "griptape_nodes.retained_mode.managers.model_manager.GriptapeNodes.LibraryManager",
+            return_value=library_manager,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_no_invoker_registered(self, model_manager: ModelManager) -> None:
+        with self._patch_registered_handlers({}):
+            result = await model_manager.on_handle_invoke_model_request(InvokeModelRequest(model_id="microsoft/phi-2"))
+
+        assert isinstance(result, InvokeModelResultFailure)
+        assert "no library has registered" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_sole_invoker_when_unnamed(self, model_manager: ModelManager) -> None:
+        received: list[InvokeModelRequest] = []
+        success = InvokeModelResultSuccess(model_id="microsoft/phi-2", result_details="ok")
+
+        def invoker(request: InvokeModelRequest) -> InvokeModelResultSuccess:
+            received.append(request)
+            return success
+
+        handlers = {"Some Library": SimpleNamespace(handler=invoker)}
+        with self._patch_registered_handlers(handlers):
+            result = await model_manager.on_handle_invoke_model_request(InvokeModelRequest(model_id="microsoft/phi-2"))
+
+        assert result is success
+        assert len(received) == 1
+        assert received[0].model_id == "microsoft/phi-2"
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_unnamed_and_ambiguous(self, model_manager: ModelManager) -> None:
+        handlers = {
+            "Library A": SimpleNamespace(handler=lambda _request: None),
+            "Library B": SimpleNamespace(handler=lambda _request: None),
+        }
+        with self._patch_registered_handlers(handlers):
+            result = await model_manager.on_handle_invoke_model_request(InvokeModelRequest(model_id="microsoft/phi-2"))
+
+        assert isinstance(result, InvokeModelResultFailure)
+        assert "multiple libraries" in str(result.result_details)
+        assert "Library A" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_selects_invoker_by_name(self, model_manager: ModelManager) -> None:
+        success = InvokeModelResultSuccess(model_id="microsoft/phi-2", result_details="ok")
+        handlers = {
+            "Library A": SimpleNamespace(handler=lambda _request: None),
+            "Library B": SimpleNamespace(handler=lambda _request: success),
+        }
+        with self._patch_registered_handlers(handlers):
+            result = await model_manager.on_handle_invoke_model_request(
+                InvokeModelRequest(model_id="microsoft/phi-2", invoker_name="Library B")
+            )
+
+        assert result is success
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_named_invoker_missing(self, model_manager: ModelManager) -> None:
+        handlers = {"Library A": SimpleNamespace(handler=lambda _request: None)}
+        with self._patch_registered_handlers(handlers):
+            result = await model_manager.on_handle_invoke_model_request(
+                InvokeModelRequest(model_id="microsoft/phi-2", invoker_name="Library B")
+            )
+
+        assert isinstance(result, InvokeModelResultFailure)
+        assert "no library by that name" in str(result.result_details)
+        assert "Library A" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_invoker_exception_becomes_failure_result(self, model_manager: ModelManager) -> None:
+        def invoker(_request: InvokeModelRequest) -> InvokeModelResultSuccess:
+            msg = "backend exploded"
+            raise RuntimeError(msg)
+
+        handlers = {"Some Library": SimpleNamespace(handler=invoker)}
+        with self._patch_registered_handlers(handlers):
+            result = await model_manager.on_handle_invoke_model_request(InvokeModelRequest(model_id="microsoft/phi-2"))
+
+        assert isinstance(result, InvokeModelResultFailure)
+        assert "backend exploded" in str(result.result_details)
+        assert isinstance(result.exception, RuntimeError)
+
+
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Model entitlements currently have no enforcement point for local inference: nodes call their backends directly, so the permission layer's pre-dispatch hooks never see the invocation (the cloud proxy only covers remote calls). `InvokeModelRequest` gives inference a single request to route through, so policies can match on `model_id` and `task` before any backend runs.

The handler stays thin on purpose. Enforcement happens in the pre-dispatch hook chain before the handler executes, and the actual inference is delegated to a library-registered event handler for `InvokeModelRequest`, the same mechanism workflow publishing uses for publishers. `invoker_name` mirrors `publisher_name`: it is only required when more than one library has registered an invocation handler.

Nothing registers an invocation handler yet. Node libraries that own inference backends adopt this by registering a handler at load time; until then the request fails with a clear message. A follow-up PR adds `CheckModelAccessRequest`, which preflights hypothetical invocations of this request type so model selectors can grey out denied models.