### PR TITLE
feat(models): add DeclareModelInvocationRequest declaration

### DIFF
--- a/src/griptape_nodes/retained_mode/events/model_events.py
+++ b/src/griptape_nodes/retained_mode/events/model_events.py
@@ -345,3 +345,66 @@ class GetModelInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
 @PayloadRegistry.register
 class GetModelInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Model info retrieval failed. Common causes: invalid model ID, network error, authentication required."""
+
+
+@dataclass
+@PayloadRegistry.register
+class DeclareModelInvocationRequest(RequestPayload):
+    """Declare that a node is about to invoke a model, so the call is subject to entitlements.
+
+    This is how a well-intentioned node opts into the permission system: before
+    invoking a model it declares the invocation, and the pre-dispatch hook chain
+    decides whether it is permitted. The node performs the actual inference
+    itself, in its own code; this request runs no backend. A success result
+    means "cleared to proceed"; a failure means the invocation is not permitted
+    and the node should not run it.
+
+    Enforcement is advisory in the sense that it relies on the node to declare.
+    It is the engine-side point that sees every model invocation a node
+    performs, whatever the routing: a call routed through the Griptape cloud
+    proxy, a locally-run model, or a third-party API called directly. The proxy
+    independently enforces the calls that flow through it; this declaration is
+    the engine's own gate, seeing and recording every invocation uniformly
+    regardless of how it is routed, and the natural place to meter or audit.
+
+    The declaration carries the two facts the node owns at call time: the
+    concrete `model` being invoked and the `provider_id` it routes to. Coarser
+    catalog structure (family, offering, key support) is not declared here — the
+    permission evaluator owns the model catalog and resolves those from
+    `(provider_id, model)` itself. `provider_id` is included because it is not
+    derivable from `model`: the same model is served by multiple providers
+    (e.g. Groq, NVIDIA NIM, and Ollama all serve Llama 3.3), and only the node
+    knows which one it actually called.
+
+    Use when: A node is about to invoke a model and wants the call gated by
+    (and visible to) the permission system.
+
+    Args:
+        model: Concrete model being invoked (e.g., "claude-opus-4-7")
+        provider_id: Catalog provider handle the call routes to (e.g., "anthropic", "ollama")
+        node_name: Name of the node instance declaring the invocation, when invoked from a node
+
+    Results: DeclareModelInvocationResultSuccess (cleared to proceed) | DeclareModelInvocationResultFailure (not permitted)
+    """
+
+    model: str
+    provider_id: str | None = None
+    node_name: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class DeclareModelInvocationResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """The declared model invocation is permitted; the node may proceed.
+
+    Args:
+        model: The concrete upstream model cleared for invocation
+    """
+
+    model: str
+
+
+@dataclass
+@PayloadRegistry.register
+class DeclareModelInvocationResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """The declared model invocation is not permitted. The node should not invoke the model."""

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -20,6 +20,8 @@ from xdg_base_dirs import xdg_data_home
 from griptape_nodes.files.file import File, FileWriteError
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.model_events import (
+    DeclareModelInvocationRequest,
+    DeclareModelInvocationResultSuccess,
     DeleteModelDownloadRequest,
     DeleteModelDownloadResultFailure,
     DeleteModelDownloadResultSuccess,
@@ -239,6 +241,9 @@ class ModelManager:
             event_manager.assign_manager_to_request_type(DeleteModelRequest, self.on_handle_delete_model_request)
             event_manager.assign_manager_to_request_type(SearchModelsRequest, self.on_handle_search_models_request)
             event_manager.assign_manager_to_request_type(GetModelInfoRequest, self.on_handle_get_model_info_request)
+            event_manager.assign_manager_to_request_type(
+                DeclareModelInvocationRequest, self.on_handle_declare_model_invocation_request
+            )
             event_manager.assign_manager_to_request_type(
                 ListModelDownloadsRequest, self.on_handle_list_model_downloads_request
             )
@@ -716,6 +721,27 @@ class ModelManager:
             downloads=getattr(info, "downloads", None),
             likes=getattr(info, "likes", None),
             result_details=f"Retrieved info for '{request.model_id}'",
+        )
+
+    def on_handle_declare_model_invocation_request(self, request: DeclareModelInvocationRequest) -> ResultPayload:
+        """Acknowledge a node's declaration that it is about to invoke a model.
+
+        This request is how a well-intentioned node opts into the permission
+        system: it declares the invocation and the engine decides whether it is
+        permitted. Enforcement runs entirely in the event manager's
+        pre-dispatch hook chain before this handler is reached, so arriving here
+        means the invocation is sanctioned. The node performs the actual
+        inference itself; this handler does not run any backend.
+
+        Args:
+            request: The declared invocation, identifying the model and task
+
+        Returns:
+            ResultPayload: Success, meaning the node is cleared to proceed
+        """
+        return DeclareModelInvocationResultSuccess(
+            model=request.model,
+            result_details=f"Model invocation permitted for '{request.model}'.",
         )
 
     def _search_models(self, request: SearchModelsRequest) -> SearchResultsData:

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -3,6 +3,7 @@
 Covers:
 - `on_handle_get_model_info_request` — token guard and HF API delegation
 - `on_handle_search_models_request` — search result handling
+- `on_handle_declare_model_invocation_request` — clears a declared invocation past the pre-dispatch chain
 - `_download_model_task` — the spawned subprocess targets a runnable module
 """
 
@@ -13,7 +14,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.model_events import (
+    DeclareModelInvocationRequest,
+    DeclareModelInvocationResultFailure,
+    DeclareModelInvocationResultSuccess,
     GetModelInfoRequest,
     GetModelInfoResultFailure,
     GetModelInfoResultSuccess,
@@ -21,6 +26,7 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultFailure,
     SearchModelsResultSuccess,
 )
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, ModelManager
 
 
@@ -178,6 +184,54 @@ class TestOnHandleSearchModelsRequest:
             result = await model_manager.on_handle_search_models_request(SearchModelsRequest(query="model"))
 
         assert isinstance(result, SearchModelsResultFailure)
+
+
+# ---------------------------------------------------------------------------
+# on_handle_declare_model_invocation_request
+# ---------------------------------------------------------------------------
+
+
+class TestOnHandleDeclareModelInvocationRequest:
+    def test_clears_the_node_to_proceed(self, model_manager: ModelManager) -> None:
+        # Reaching the handler means the pre-dispatch chain did not deny the
+        # declaration, so the node is cleared to invoke the model itself.
+        result = model_manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(
+                model="claude-opus-4-7",
+                provider_id="anthropic",
+                node_name="Agent_1",
+            )
+        )
+
+        assert isinstance(result, DeclareModelInvocationResultSuccess)
+        assert result.model == "claude-opus-4-7"
+
+    def test_a_denying_pre_dispatch_hook_short_circuits_before_the_handler(self) -> None:
+        # End to end: enforcement lives in the pre-dispatch chain, not the
+        # handler. A hook that denies the declaration short-circuits with its
+        # own failure; an allowed declaration reaches the handler and comes
+        # back as a clear-to-proceed success. Policies gate the shared catalog
+        # handles (here, the provider), not the concrete model string.
+        event_manager = EventManager()
+        ModelManager(event_manager)
+
+        def deny(request: RequestPayload, _context: object) -> DeclareModelInvocationResultFailure | None:
+            if isinstance(request, DeclareModelInvocationRequest) and request.provider_id == "blocked_provider":
+                return DeclareModelInvocationResultFailure(result_details="This provider is blocked by your license.")
+            return None
+
+        event_manager.add_pre_dispatch_hook(deny)
+
+        denied = event_manager.handle_request(
+            DeclareModelInvocationRequest(model="blocked-model", provider_id="blocked_provider")
+        )
+        allowed = event_manager.handle_request(DeclareModelInvocationRequest(model="gpt-ok", provider_id="openai"))
+
+        assert isinstance(denied.result, DeclareModelInvocationResultFailure)
+        assert "blocked by your license" in str(denied.result.result_details)
+        # The allowed declaration reached the handler, which cleared it.
+        assert isinstance(allowed.result, DeclareModelInvocationResultSuccess)
+        assert allowed.result.model == "gpt-ok"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Model invocations happen across several routings: through the Griptape cloud proxy, against a locally-run model, or via a third-party API a node calls directly. The proxy enforces the calls that flow through it server-side, but the engine has no single point where its own permission layer sees a model invocation, so entitlements can't be applied uniformly and a call can't be gated before it leaves the engine. This adds the request a node dispatches to put every invocation in front of that layer.

`DeclareModelInvocationRequest` is a *declaration*, not a chokepoint. Before invoking a model a node declares the invocation, and the pre-dispatch hook chain decides whether it is permitted. The node still performs the actual inference itself; the request runs no backend. A success result means cleared to proceed; a failure means the node should not invoke. It is the engine-side gate that sees and records every invocation regardless of routing (the proxy remains an additional downstream tier for proxy-routed calls), and the natural place to meter or audit.

The shape is designed to drop into the standard library's proxy nodes, which share one `GriptapeProxyNode` base: a single dispatch before submission gates every proxy node at once, with `model` taken from `_get_api_model_id()` and `node_name` from `self.name`. Wiring that in (and sourcing a stable `provider_id` for each provider) is a follow-up that lands with the model-catalog work.
