### PR TITLE
Library and node model declarations: provider/family/offering catalog + node references

### DIFF
--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -2306,7 +2306,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
 ```json
 {
   "name": "Library Name",
-  "library_schema_version": "0.9.0",
+  "library_schema_version": "0.10.0",
   "settings": [
     {
       "description": "API keys required by nodes in this library",
@@ -2431,7 +2431,18 @@ Semantics:
 
 #### `model_catalog`
 
-A library-level declaration of the third-party models nodes in the library can use, organized as a `provider → family → offering` hierarchy. Identifiers at every level are dict keys (the key *is* the stable handle used by node references and admin policies); each entry carries a `display_name` for UI plus optional `terms_url`. Leaf `ModelOffering`s additionally declare `key_support` (required) and an optional upstream `model` identifier.
+A library-level declaration of the third-party models nodes in the library can use, organized as a `provider → family → offering` hierarchy. Identifiers at every level are dict keys (the key *is* the stable handle used by node references and admin policies); each entry carries a `display_name` for UI plus optional `terms_url` and `notes`. Leaf `ModelOffering`s additionally declare `key_support` (required) and an optional upstream `model` identifier.
+
+The `key_support` value tells admins what kind of API key authorizes the call:
+
+| Value                                   | Meaning                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| `REQUIRES_CUSTOMER_KEY`                 | Customer-supplied API key only.                                                     |
+| `SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY` | Customer key or Griptape-provided key both work.                                    |
+| `REQUIRES_GRIPTAPE_KEY`                 | Griptape-provided key only.                                                         |
+| `NO_KEY_REQUIRED`                       | The model runs locally or otherwise needs no API key (e.g. an Ollama-hosted model). |
+
+`notes` (available at every level — provider, family, and offering) is free-form author guidance rendered alongside the entry. Use it for caveats that don't fit other fields, like "BYOK requires injecting a provider-specific prompt driver."
 
 ```jsonc
 {
@@ -2477,16 +2488,40 @@ A few rules worth knowing:
 
 - **Family is optional.** Providers without meaningful families (Kling above) put offerings directly under `provider.offerings`. Providers with meaningful families (Anthropic above) put offerings under `provider.families.<family_id>.offerings`.
 - **`terms_url` cascades most-specific-wins.** If a `ModelOffering` sets `terms_url`, that wins. Otherwise the parent family's `terms_url` is used; otherwise the parent provider's. Absence at every level is reported as "no TOS declared" rather than silently defaulting.
-- **`key_support` does NOT cascade.** Every `ModelOffering` declares its own value. The same upstream model with two different key requirements becomes two offerings under two distinct dict keys (see `claude_opus_byok` and `claude_opus_griptape` above).
+- **`key_support` lives on the offering by default.** Every `ModelOffering` declares its own value. The same upstream model with two different key requirements becomes two offerings under two distinct dict keys (see `claude_opus_byok` and `claude_opus_griptape` above). `ModelProvider` and `ModelFamily` also accept an optional `key_support` for cases where a provider has no offerings at all (e.g. a local-runtime provider like Ollama where `key_support=NO_KEY_REQUIRED` is the only meaningful signal).
 - **Offering IDs must be unique across the entire library.** Pydantic enforces sibling-uniqueness within each `offerings` dict for free; cross-parent collisions are caught at library-load time as `DuplicateModelOfferingIdProblem`.
 
 ##### `model_usage`
 
-A node references one or more catalog offerings by their dict keys. Each entry must resolve to an offering somewhere in the catalog at library-load time; unresolved references surface as `UnresolvedModelUsageReferenceProblem`.
+A node references one or more catalog offerings by their dict keys. Use this when the node binds to a specific, named set of offerings. Each entry must resolve to an offering somewhere in the catalog at library-load time; unresolved references surface as `UnresolvedModelUsageReferenceProblem`.
 
 ```jsonc
 { "type": "model_usage", "offering_ids": ["claude_opus_byok", "kling_v2"] }
 ```
+
+##### `model_family_usage`
+
+A node references one or more entire model families. Use this when a node dynamically enumerates every offering in a family at runtime. Family ids are scoped within their provider, so each entry carries both the `provider_id` and the `family_id`. Unresolved references surface as `UnresolvedModelFamilyUsageReferenceProblem`.
+
+```jsonc
+{
+  "type": "model_family_usage",
+  "families": [
+    { "provider_id": "openai",    "family_id": "gpt_5" },
+    { "provider_id": "anthropic", "family_id": "claude_4_6" }
+  ]
+}
+```
+
+##### `model_provider_usage`
+
+A node references one or more entire providers. Use this when a node dynamically enumerates every offering across a whole provider at runtime. Each entry must resolve to a provider declared in the catalog; unresolved references surface as `UnresolvedModelProviderUsageReferenceProblem`.
+
+```jsonc
+{ "type": "model_provider_usage", "provider_ids": ["anthropic", "openai"] }
+```
+
+The three usage declarations are independent. A node can carry any combination — for instance, "every offering in this family, plus these two specific offerings from another provider."
 
 #### Combining declarations
 

--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -2306,7 +2306,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
 ```json
 {
   "name": "Library Name",
-  "library_schema_version": "0.8.0",
+  "library_schema_version": "0.9.0",
   "settings": [
     {
       "description": "API keys required by nodes in this library",
@@ -2327,7 +2327,28 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
       "pip_install_flags": ["--upgrade"]
     },
     "declarations": [
-      { "type": "lifecycle_stage", "stage": "STABLE" }
+      { "type": "lifecycle_stage", "stage": "STABLE" },
+      {
+        "type": "model_catalog",
+        "providers": {
+          "anthropic": {
+            "display_name": "Anthropic",
+            "terms_url": "https://www.anthropic.com/legal/commercial-terms",
+            "families": {
+              "claude_4": {
+                "display_name": "Claude 4",
+                "offerings": {
+                  "claude_opus_byok": {
+                    "display_name": "Claude Opus 4 (BYOK)",
+                    "model": "claude-opus-4",
+                    "key_support": "REQUIRES_CUSTOMER_KEY"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     ]
   },
   "widgets": [
@@ -2358,7 +2379,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
         "icon": "image",
         "group": "processing",
         "declarations": [
-          { "type": "key_support", "support": "REQUIRES_CUSTOMER_KEY" }
+          { "type": "model_usage", "offering_ids": ["claude_opus_byok"] }
         ]
       }
     }
@@ -2375,7 +2396,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
     - Category should be `app_events.on_app_initialization_complete`
     - Secrets are accessed via `GriptapeNodes.SecretsManager().get_secret()`
 - **metadata.dependencies**: PIP packages installed on library load
-- **metadata.declarations** / per-node **metadata.declarations**: typed identity properties (lifecycle stage, key support). See [Library and Node Declarations](#library-and-node-declarations) below.
+- **metadata.declarations** / per-node **metadata.declarations**: typed identity properties (lifecycle stage) and a library-level model catalog plus per-node references into it. See [Library and Node Declarations](#library-and-node-declarations) below.
 - **widgets**: Register custom JS widget components (see [Custom Widget Components](#custom-widget-components))
 - **categories**: Group nodes in UI with colors and icons
 - **nodes**: List node classes, file paths, and metadata
@@ -2387,7 +2408,7 @@ Use flat directory structures. The engine automatically registers and loads libr
 
 ### Library and Node Declarations
 
-Declarations attach typed metadata to a library or to an individual node. Each entry in a `declarations` array is an object with a `type` discriminator that selects a declaration class. Today's vocabulary covers identity properties (lifecycle stage and key support); future engine releases add more declaration types under the same field.
+Declarations attach typed metadata to a library or to an individual node. Each entry in a `declarations` array is an object with a `type` discriminator that selects a declaration class. Today's vocabulary covers a lifecycle-stage property and a library-level model catalog with per-node references; future engine releases add more declaration types under the same field.
 
 Both `metadata.declarations` (library-level) and per-node `metadata.declarations` accept a list. Order in the list does not matter. The field defaults to `[]`, so libraries on older schema versions (`0.6.0`, `0.4.0`, `0.1.0`) load unchanged.
 
@@ -2408,19 +2429,68 @@ Semantics:
 - **Library-level absence is intentionally distinct from `STABLE`.** A library with no `lifecycle_stage` declaration is "unstated" — consumers should surface that explicitly (`<No lifecycle stage provided by library author>`) rather than silently assume `STABLE`.
 - **Node-level absence means "inherit the library's stage."** A node-level `lifecycle_stage` overrides the library's value.
 
-#### `key_support`
+#### `model_catalog`
 
-How a node consumes API keys. Node-level only. Values:
+A library-level declaration of the third-party models nodes in the library can use, organized as a `provider → family → offering` hierarchy. Identifiers at every level are dict keys (the key *is* the stable handle used by node references and admin policies); each entry carries a `display_name` for UI plus optional `terms_url`. Leaf `ModelOffering`s additionally declare `key_support` (required) and an optional upstream `model` identifier.
 
-| Value                                   | Meaning                                                        |
-| --------------------------------------- | -------------------------------------------------------------- |
-| `REQUIRES_CUSTOMER_KEY`                 | Node needs a customer-supplied API key.                        |
-| `SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY` | Node accepts either a customer key or a Griptape-provided key. |
-| `REQUIRES_GRIPTAPE_KEY`                 | Node only operates with a Griptape-provided key.               |
+```jsonc
+{
+  "type": "model_catalog",
+  "providers": {
+    "anthropic": {
+      "display_name": "Anthropic",
+      "terms_url": "https://www.anthropic.com/legal/commercial-terms",
+      "families": {
+        "claude_4": {
+          "display_name": "Claude 4",
+          "offerings": {
+            "claude_opus_byok": {
+              "display_name": "Claude Opus 4 (BYOK)",
+              "model": "claude-opus-4",
+              "key_support": "REQUIRES_CUSTOMER_KEY"
+            },
+            "claude_opus_griptape": {
+              "display_name": "Claude Opus 4 (Griptape Key)",
+              "model": "claude-opus-4",
+              "key_support": "REQUIRES_GRIPTAPE_KEY"
+            }
+          }
+        }
+      }
+    },
+    "kling": {
+      "display_name": "Kling",
+      "terms_url": "https://app.klingai.com/global/about/terms",
+      "offerings": {
+        "kling_v2": {
+          "display_name": "Kling v2",
+          "model": "kling-v2-master",
+          "key_support": "REQUIRES_GRIPTAPE_KEY"
+        }
+      }
+    }
+  }
+}
+```
+
+A few rules worth knowing:
+
+- **Family is optional.** Providers without meaningful families (Kling above) put offerings directly under `provider.offerings`. Providers with meaningful families (Anthropic above) put offerings under `provider.families.<family_id>.offerings`.
+- **`terms_url` cascades most-specific-wins.** If a `ModelOffering` sets `terms_url`, that wins. Otherwise the parent family's `terms_url` is used; otherwise the parent provider's. Absence at every level is reported as "no TOS declared" rather than silently defaulting.
+- **`key_support` does NOT cascade.** Every `ModelOffering` declares its own value. The same upstream model with two different key requirements becomes two offerings under two distinct dict keys (see `claude_opus_byok` and `claude_opus_griptape` above).
+- **Offering IDs must be unique across the entire library.** Pydantic enforces sibling-uniqueness within each `offerings` dict for free; cross-parent collisions are caught at library-load time as `DuplicateModelOfferingIdProblem`.
+
+##### `model_usage`
+
+A node references one or more catalog offerings by their dict keys. Each entry must resolve to an offering somewhere in the catalog at library-load time; unresolved references surface as `UnresolvedModelUsageReferenceProblem`.
+
+```jsonc
+{ "type": "model_usage", "offering_ids": ["claude_opus_byok", "kling_v2"] }
+```
 
 #### Combining declarations
 
-A node can carry any combination of declarations. For example, a Labs node that requires a Griptape key:
+A node can carry any combination of declarations. For example, a Labs node that supports two model offerings:
 
 ```jsonc
 "metadata": {
@@ -2429,7 +2499,7 @@ A node can carry any combination of declarations. For example, a Labs node that 
   "display_name": "Labs Node",
   "declarations": [
     { "type": "lifecycle_stage", "stage": "LABS" },
-    { "type": "key_support", "support": "REQUIRES_GRIPTAPE_KEY" }
+    { "type": "model_usage", "offering_ids": ["claude_opus_byok", "kling_v2"] }
   ]
 }
 ```

--- a/docs/developing_nodes/node_isolation_with_workers.md
+++ b/docs/developing_nodes/node_isolation_with_workers.md
@@ -85,7 +85,7 @@ combination.
 ```json
 {
     "name": "My Library",
-    "library_schema_version": "0.9.0",
+    "library_schema_version": "0.10.0",
     "metadata": {
         "author": "<Your Name>",
         "description": "<Description>",

--- a/src/griptape_nodes/node_library/library_declarations.py
+++ b/src/griptape_nodes/node_library/library_declarations.py
@@ -18,12 +18,12 @@ schema shape.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple
 
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
 # ---------- Shared enums ----------
 
@@ -122,6 +122,52 @@ class SuggestedWorkerMode(BaseModel):
     mode: WorkerMode
 
 
+# ---------- Model catalog (provider -> family -> model) ----------
+
+
+class ModelOffering(BaseModel):
+    """A single model the library offers. Leaf of the catalog.
+
+    Identified by its parent dict key, not by a field on this class -- the
+    key is the stable handle that admin policies and node references use.
+    Multiple offerings can describe the same upstream `model` value with
+    different `key_support`; they appear as two dict entries with two keys.
+    """
+
+    display_name: str
+    model: str | None = None
+    key_support: KeySupport
+    terms_url: str | None = None
+
+
+class ModelFamily(BaseModel):
+    """A family within a provider (e.g. 'Claude 4', 'GPT-4'). Optional layer.
+
+    Providers without meaningful families put their offerings directly under
+    the provider's `offerings` dict.
+    """
+
+    display_name: str
+    terms_url: str | None = None
+    offerings: dict[str, ModelOffering] = Field(default_factory=dict)
+
+
+class ModelProvider(BaseModel):
+    """A model provider (e.g. 'Anthropic', 'OpenAI', 'Kling')."""
+
+    display_name: str
+    terms_url: str | None = None
+    families: dict[str, ModelFamily] = Field(default_factory=dict)
+    offerings: dict[str, ModelOffering] = Field(default_factory=dict)
+
+
+class ModelCatalogLibraryProperty(BaseModel):
+    """Library-level declaration of available models, organized by provider/family/model."""
+
+    type: Literal["model_catalog"] = "model_catalog"
+    providers: dict[str, ModelProvider] = Field(default_factory=dict)
+
+
 # `Annotated[X | Y, Field(discriminator="type")]` is Pydantic v2's discriminated-union
 # idiom. Breakdown:
 #   - `X | Y` is the union of valid member classes.
@@ -133,7 +179,7 @@ class SuggestedWorkerMode(BaseModel):
 #     ValidationError (strict validation).
 # This is the canonical Pydantic v2 way to round-trip "one of several shapes" through JSON.
 LibraryDeclaration = Annotated[
-    LifecycleStageLibraryProperty | WorkerModeCompatibility | SuggestedWorkerMode,
+    LifecycleStageLibraryProperty | WorkerModeCompatibility | SuggestedWorkerMode | ModelCatalogLibraryProperty,
     Field(discriminator="type"),
 ]
 
@@ -163,6 +209,76 @@ def requires_worker_process(declarations: Sequence[LibraryDeclaration]) -> bool:
     return suggested.mode is WorkerMode.WORKER
 
 
+class ResolvedOffering(NamedTuple):
+    """An offering paired with its parent provider/family identifiers.
+
+    `family_id` is None when the offering hangs directly off a provider's
+    top-level `offerings` dict.
+    """
+
+    provider_id: str
+    family_id: str | None
+    offering_id: str
+    offering: ModelOffering
+    provider: ModelProvider
+    family: ModelFamily | None
+
+
+def iter_catalog_offerings(catalog: ModelCatalogLibraryProperty) -> Iterator[ResolvedOffering]:
+    """Yield every offering in the catalog with its parent context.
+
+    Walks both the family-nested offerings and the provider-direct offerings.
+    Order: provider insertion order, then family insertion order, then
+    offering insertion order within each container.
+    """
+    for provider_id, provider in catalog.providers.items():
+        for family_id, family in provider.families.items():
+            for offering_id, offering in family.offerings.items():
+                yield ResolvedOffering(
+                    provider_id=provider_id,
+                    family_id=family_id,
+                    offering_id=offering_id,
+                    offering=offering,
+                    provider=provider,
+                    family=family,
+                )
+        for offering_id, offering in provider.offerings.items():
+            yield ResolvedOffering(
+                provider_id=provider_id,
+                family_id=None,
+                offering_id=offering_id,
+                offering=offering,
+                provider=provider,
+                family=None,
+            )
+
+
+def resolve_terms_url(catalog: ModelCatalogLibraryProperty, offering_id: str) -> str | None:
+    """Resolve an offering's effective TOS URL, cascading most-specific-wins.
+
+    Resolution order:
+      1. The offering's own `terms_url`, if set.
+      2. The parent family's `terms_url`, if set.
+      3. The parent provider's `terms_url`, if set.
+      4. None -- consumers should surface "no TOS declared" rather than
+         silently defaulting.
+
+    Returns None if the offering id does not resolve to any offering in the
+    catalog. Use validation (`validate_library_declarations`) to detect that
+    case at library load; `resolve_terms_url` is meant for runtime queries
+    where the catalog is already trusted.
+    """
+    for resolved in iter_catalog_offerings(catalog):
+        if resolved.offering_id != offering_id:
+            continue
+        if resolved.offering.terms_url is not None:
+            return resolved.offering.terms_url
+        if resolved.family is not None and resolved.family.terms_url is not None:
+            return resolved.family.terms_url
+        return resolved.provider.terms_url
+    return None
+
+
 # ---------- Node-level declarations ----------
 
 
@@ -178,15 +294,19 @@ class LifecycleStageNodeProperty(BaseModel):
     stage: LifecycleStage
 
 
-class KeySupportNodeProperty(BaseModel):
-    """Declares how this node consumes API keys."""
+class ModelUsageNodeProperty(BaseModel):
+    """References model offerings the node uses, by their catalog dict keys.
 
-    type: Literal["key_support"] = "key_support"
-    support: KeySupport
+    Each entry must resolve to an offering somewhere in the library's
+    `ModelCatalogLibraryProperty` (validated at library load).
+    """
+
+    type: Literal["model_usage"] = "model_usage"
+    offering_ids: list[str]
 
 
 # See the comment above `LibraryDeclaration` for how `Annotated[... discriminator ...]` works.
 NodeDeclaration = Annotated[
-    LifecycleStageNodeProperty | KeySupportNodeProperty,
+    LifecycleStageNodeProperty | ModelUsageNodeProperty,
     Field(discriminator="type"),
 ]

--- a/src/griptape_nodes/node_library/library_declarations.py
+++ b/src/griptape_nodes/node_library/library_declarations.py
@@ -54,6 +54,7 @@ class KeySupport(StrEnum):
     REQUIRES_CUSTOMER_KEY = "REQUIRES_CUSTOMER_KEY"
     SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY = "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
     REQUIRES_GRIPTAPE_KEY = "REQUIRES_GRIPTAPE_KEY"
+    NO_KEY_REQUIRED = "NO_KEY_REQUIRED"
 
 
 class WorkerCompatibility(StrEnum):
@@ -132,12 +133,17 @@ class ModelOffering(BaseModel):
     key is the stable handle that admin policies and node references use.
     Multiple offerings can describe the same upstream `model` value with
     different `key_support`; they appear as two dict entries with two keys.
+
+    `notes` is free-form author guidance surfaced alongside the offering in
+    UIs and admin tooling (e.g. "BYOK requires injecting a provider-specific
+    prompt driver"). Use it for caveats that don't fit other fields.
     """
 
     display_name: str
     model: str | None = None
     key_support: KeySupport
     terms_url: str | None = None
+    notes: str | None = None
 
 
 class ModelFamily(BaseModel):
@@ -145,18 +151,41 @@ class ModelFamily(BaseModel):
 
     Providers without meaningful families put their offerings directly under
     the provider's `offerings` dict.
+
+    `notes` is free-form author guidance applying to every offering in the
+    family (e.g. an explanation of how the family is positioned vs. the
+    provider's other families). Per-offering `notes` are additive.
+
+    `key_support` declared here describes a default for the family. Per-offering
+    `key_support` is required and overrides the family value; the family value is
+    informational (admin-policy hint, default for future offerings).
     """
 
     display_name: str
     terms_url: str | None = None
+    notes: str | None = None
+    key_support: KeySupport | None = None
     offerings: dict[str, ModelOffering] = Field(default_factory=dict)
 
 
 class ModelProvider(BaseModel):
-    """A model provider (e.g. 'Anthropic', 'OpenAI', 'Kling')."""
+    """A model provider (e.g. 'Anthropic', 'OpenAI', 'Kling').
+
+    `notes` is free-form author guidance applying to every family/offering
+    under the provider (e.g. "BYOK requires injecting a provider-specific
+    prompt driver"). Lower-level `notes` are additive.
+
+    `key_support` declared here describes a default for everything under the
+    provider. It is most useful when the provider has no offerings at all
+    (e.g. a dynamic-runtime provider like Ollama where `key_support=NO_KEY_REQUIRED`
+    is the only meaningful signal); it also carries through as a default for
+    any family or offering that doesn't override.
+    """
 
     display_name: str
     terms_url: str | None = None
+    notes: str | None = None
+    key_support: KeySupport | None = None
     families: dict[str, ModelFamily] = Field(default_factory=dict)
     offerings: dict[str, ModelOffering] = Field(default_factory=dict)
 
@@ -279,6 +308,28 @@ def resolve_terms_url(catalog: ModelCatalogLibraryProperty, offering_id: str) ->
     return None
 
 
+def resolve_key_support(catalog: ModelCatalogLibraryProperty, offering_id: str) -> KeySupport | None:
+    """Resolve an offering's effective key_support, cascading most-specific-wins.
+
+    Resolution order:
+      1. The offering's own `key_support` (always set on offerings).
+      2. The parent family's `key_support`, if set.
+      3. The parent provider's `key_support`, if set.
+      4. None -- only reachable for an unknown offering id.
+
+    Returns None if the offering id does not resolve to any offering in the
+    catalog. Use validation (`validate_library_declarations`) to detect that
+    case at library load.
+    """
+    for resolved in iter_catalog_offerings(catalog):
+        if resolved.offering_id != offering_id:
+            continue
+        # Offerings always declare key_support; the cascade exists for
+        # provider-only declarations (e.g. Ollama with no offerings).
+        return resolved.offering.key_support
+    return None
+
+
 # ---------- Node-level declarations ----------
 
 
@@ -295,18 +346,58 @@ class LifecycleStageNodeProperty(BaseModel):
 
 
 class ModelUsageNodeProperty(BaseModel):
-    """References model offerings the node uses, by their catalog dict keys.
+    """References specific model offerings the node uses, by their catalog dict keys.
 
     Each entry must resolve to an offering somewhere in the library's
     `ModelCatalogLibraryProperty` (validated at library load).
+
+    Use this when the node binds to a specific, named set of offerings. For
+    nodes that dynamically enumerate everything in a family or provider at
+    runtime, see `ModelFamilyUsageNodeProperty` and `ModelProviderUsageNodeProperty`.
     """
 
     type: Literal["model_usage"] = "model_usage"
     offering_ids: list[str]
 
 
+class FamilyReference(BaseModel):
+    """A reference to a single family within a provider.
+
+    Family ids are scoped within a provider (the same family id can appear under
+    different providers), so a reference must carry both pieces.
+    """
+
+    provider_id: str
+    family_id: str
+
+
+class ModelFamilyUsageNodeProperty(BaseModel):
+    """References whole model families the node uses.
+
+    Use this when a node dynamically enumerates every offering in one or more
+    families at runtime. Each entry must resolve to a family that exists under
+    its named provider in the library's `ModelCatalogLibraryProperty`
+    (validated at library load).
+    """
+
+    type: Literal["model_family_usage"] = "model_family_usage"
+    families: list[FamilyReference]
+
+
+class ModelProviderUsageNodeProperty(BaseModel):
+    """References whole providers the node uses.
+
+    Use this when a node dynamically enumerates every offering across an
+    entire provider at runtime. Each entry must resolve to a provider declared
+    in the library's `ModelCatalogLibraryProperty` (validated at library load).
+    """
+
+    type: Literal["model_provider_usage"] = "model_provider_usage"
+    provider_ids: list[str]
+
+
 # See the comment above `LibraryDeclaration` for how `Annotated[... discriminator ...]` works.
 NodeDeclaration = Annotated[
-    LifecycleStageNodeProperty | ModelUsageNodeProperty,
+    LifecycleStageNodeProperty | ModelUsageNodeProperty | ModelFamilyUsageNodeProperty | ModelProviderUsageNodeProperty,
     Field(discriminator="type"),
 ]

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -209,7 +209,7 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.9.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.10.0"
 
     name: str
     library_schema_version: str

--- a/src/griptape_nodes/node_library/library_validation.py
+++ b/src/griptape_nodes/node_library/library_validation.py
@@ -21,12 +21,16 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from griptape_nodes.node_library.library_declarations import (
     ModelCatalogLibraryProperty,
+    ModelFamilyUsageNodeProperty,
+    ModelProviderUsageNodeProperty,
     ModelUsageNodeProperty,
     iter_catalog_offerings,
 )
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     DuplicateModelOfferingIdProblem,
     LibraryProblem,
+    UnresolvedModelFamilyUsageReferenceProblem,
+    UnresolvedModelProviderUsageReferenceProblem,
     UnresolvedModelUsageReferenceProblem,
 )
 
@@ -38,8 +42,8 @@ class LibraryDeclarationValidationResult(NamedTuple):
     """Outcome of `validate_library_declarations`.
 
     - `fatal`: problems that must block library load. Cross-parent duplicate
-      offering ids and unresolved `ModelUsageNodeProperty.offering_ids`
-      references go here.
+      offering ids and any unresolved node-side reference (`ModelUsageNodeProperty`,
+      `ModelFamilyUsageNodeProperty`, `ModelProviderUsageNodeProperty`) go here.
     - `warnings`: problems that should be surfaced but do not block load.
       Currently empty by construction; the slot stays in case future
       validation surfaces hygiene-only issues.
@@ -60,10 +64,23 @@ def validate_library_declarations(library_data: LibrarySchema) -> LibraryDeclara
 
     catalog = _find_model_catalog(library_data)
     declared_offering_ids: set[str] = set()
+    declared_provider_ids: set[str] = set()
+    declared_families: set[tuple[str, str]] = set()
     if catalog is not None:
         declared_offering_ids = _check_duplicate_offering_ids(library_name, catalog, fatal)
+        declared_provider_ids = set(catalog.providers.keys())
+        for provider_id, provider in catalog.providers.items():
+            for family_id in provider.families:
+                declared_families.add((provider_id, family_id))
 
-    _check_unresolved_model_usage(library_name, library_data, declared_offering_ids, fatal)
+    _check_unresolved_node_references(
+        library_name=library_name,
+        library_data=library_data,
+        declared_offering_ids=declared_offering_ids,
+        declared_provider_ids=declared_provider_ids,
+        declared_families=declared_families,
+        fatal=fatal,
+    )
 
     return LibraryDeclarationValidationResult(fatal=fatal, warnings=warnings)
 
@@ -105,23 +122,49 @@ def _check_duplicate_offering_ids(
     return set(parents_by_id.keys())
 
 
-def _check_unresolved_model_usage(
+def _check_unresolved_node_references(  # noqa: C901, PLR0913  -- one branch per declaration kind; explicit kwargs are clearer than packing
+    *,
     library_name: str,
     library_data: LibrarySchema,
     declared_offering_ids: set[str],
+    declared_provider_ids: set[str],
+    declared_families: set[tuple[str, str]],
     fatal: list[LibraryProblem],
 ) -> None:
+    """Walk every node and validate each model_usage / family / provider reference."""
     for node_def in library_data.nodes:
         for node_decl in node_def.metadata.declarations:
-            if not isinstance(node_decl, ModelUsageNodeProperty):
-                continue
-            for offering_id in node_decl.offering_ids:
-                if offering_id in declared_offering_ids:
-                    continue
-                fatal.append(
-                    UnresolvedModelUsageReferenceProblem(
-                        library_name=library_name,
-                        node_name=node_def.class_name,
-                        offering_id=offering_id,
+            if isinstance(node_decl, ModelUsageNodeProperty):
+                for offering_id in node_decl.offering_ids:
+                    if offering_id in declared_offering_ids:
+                        continue
+                    fatal.append(
+                        UnresolvedModelUsageReferenceProblem(
+                            library_name=library_name,
+                            node_name=node_def.class_name,
+                            offering_id=offering_id,
+                        )
                     )
-                )
+            elif isinstance(node_decl, ModelFamilyUsageNodeProperty):
+                for ref in node_decl.families:
+                    if (ref.provider_id, ref.family_id) in declared_families:
+                        continue
+                    fatal.append(
+                        UnresolvedModelFamilyUsageReferenceProblem(
+                            library_name=library_name,
+                            node_name=node_def.class_name,
+                            provider_id=ref.provider_id,
+                            family_id=ref.family_id,
+                        )
+                    )
+            elif isinstance(node_decl, ModelProviderUsageNodeProperty):
+                for provider_id in node_decl.provider_ids:
+                    if provider_id in declared_provider_ids:
+                        continue
+                    fatal.append(
+                        UnresolvedModelProviderUsageReferenceProblem(
+                            library_name=library_name,
+                            node_name=node_def.class_name,
+                            provider_id=provider_id,
+                        )
+                    )

--- a/src/griptape_nodes/node_library/library_validation.py
+++ b/src/griptape_nodes/node_library/library_validation.py
@@ -1,0 +1,127 @@
+"""Cross-reference validation for declarative library declarations.
+
+After Pydantic shape validation via `LibrarySchema.model_validate()`, references
+between declarations (a `ModelUsageNodeProperty.offering_ids` entry pointing to
+an offering id in `ModelCatalogLibraryProperty`) need to be resolved against
+the library's own declarations.
+
+This module's single public entry point is `validate_library_declarations`,
+which walks a validated `LibrarySchema` and returns a
+`LibraryDeclarationValidationResult` with two lists: `fatal` problems that
+should block library load, and `warnings` that should be surfaced alongside a
+successful load.
+
+The caller folds these into the existing library-loading problem-reporting flow.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, NamedTuple
+
+from griptape_nodes.node_library.library_declarations import (
+    ModelCatalogLibraryProperty,
+    ModelUsageNodeProperty,
+    iter_catalog_offerings,
+)
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
+    DuplicateModelOfferingIdProblem,
+    LibraryProblem,
+    UnresolvedModelUsageReferenceProblem,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.node_library.library_registry import LibrarySchema
+
+
+class LibraryDeclarationValidationResult(NamedTuple):
+    """Outcome of `validate_library_declarations`.
+
+    - `fatal`: problems that must block library load. Cross-parent duplicate
+      offering ids and unresolved `ModelUsageNodeProperty.offering_ids`
+      references go here.
+    - `warnings`: problems that should be surfaced but do not block load.
+      Currently empty by construction; the slot stays in case future
+      validation surfaces hygiene-only issues.
+    """
+
+    fatal: list[LibraryProblem]
+    warnings: list[LibraryProblem]
+
+
+def validate_library_declarations(library_data: LibrarySchema) -> LibraryDeclarationValidationResult:
+    """Resolve cross-references within a library.
+
+    All failures are collected; validation does not short-circuit on the first problem.
+    """
+    fatal: list[LibraryProblem] = []
+    warnings: list[LibraryProblem] = []
+    library_name = library_data.name
+
+    catalog = _find_model_catalog(library_data)
+    declared_offering_ids: set[str] = set()
+    if catalog is not None:
+        declared_offering_ids = _check_duplicate_offering_ids(library_name, catalog, fatal)
+
+    _check_unresolved_model_usage(library_name, library_data, declared_offering_ids, fatal)
+
+    return LibraryDeclarationValidationResult(fatal=fatal, warnings=warnings)
+
+
+def _find_model_catalog(library_data: LibrarySchema) -> ModelCatalogLibraryProperty | None:
+    for decl in library_data.metadata.declarations:
+        if isinstance(decl, ModelCatalogLibraryProperty):
+            return decl
+    return None
+
+
+def _check_duplicate_offering_ids(
+    library_name: str,
+    catalog: ModelCatalogLibraryProperty,
+    fatal: list[LibraryProblem],
+) -> set[str]:
+    """Walk the catalog and report cross-parent duplicate offering ids.
+
+    Returns the set of declared offering ids (ignoring duplicates) so the caller
+    can validate node references against it.
+    """
+    parents_by_id: dict[str, list[str]] = defaultdict(list)
+    for resolved in iter_catalog_offerings(catalog):
+        parent_path = resolved.provider_id
+        if resolved.family_id is not None:
+            parent_path = f"{resolved.provider_id}/{resolved.family_id}"
+        parents_by_id[resolved.offering_id].append(parent_path)
+
+    for offering_id, parent_paths in parents_by_id.items():
+        if len(parent_paths) > 1:
+            fatal.append(
+                DuplicateModelOfferingIdProblem(
+                    library_name=library_name,
+                    offering_id=offering_id,
+                    parent_paths=tuple(parent_paths),
+                )
+            )
+
+    return set(parents_by_id.keys())
+
+
+def _check_unresolved_model_usage(
+    library_name: str,
+    library_data: LibrarySchema,
+    declared_offering_ids: set[str],
+    fatal: list[LibraryProblem],
+) -> None:
+    for node_def in library_data.nodes:
+        for node_decl in node_def.metadata.declarations:
+            if not isinstance(node_decl, ModelUsageNodeProperty):
+                continue
+            for offering_id in node_decl.offering_ids:
+                if offering_id in declared_offering_ids:
+                    continue
+                fatal.append(
+                    UnresolvedModelUsageReferenceProblem(
+                        library_name=library_name,
+                        node_name=node_def.class_name,
+                        offering_id=offering_id,
+                    )
+                )

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -29,6 +29,8 @@ from .old_xdg_location_warning_problem import OldXdgLocationWarningProblem
 from .sandbox_directory_missing_problem import SandboxDirectoryMissingProblem
 from .ui_options_field_modified_incompatible_problem import UiOptionsFieldModifiedIncompatibleProblem
 from .ui_options_field_modified_warning_problem import UiOptionsFieldModifiedWarningProblem
+from .unresolved_model_family_usage_reference_problem import UnresolvedModelFamilyUsageReferenceProblem
+from .unresolved_model_provider_usage_reference_problem import UnresolvedModelProviderUsageReferenceProblem
 from .unresolved_model_usage_reference_problem import UnresolvedModelUsageReferenceProblem
 from .update_config_category_problem import UpdateConfigCategoryProblem
 from .venv_creation_failed_problem import VenvCreationFailedProblem
@@ -63,6 +65,8 @@ __all__ = [
     "SandboxDirectoryMissingProblem",
     "UiOptionsFieldModifiedIncompatibleProblem",
     "UiOptionsFieldModifiedWarningProblem",
+    "UnresolvedModelFamilyUsageReferenceProblem",
+    "UnresolvedModelProviderUsageReferenceProblem",
     "UnresolvedModelUsageReferenceProblem",
     "UpdateConfigCategoryProblem",
     "VenvCreationFailedProblem",

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -7,6 +7,7 @@ from .create_config_category_problem import CreateConfigCategoryProblem
 from .dependency_installation_failed_problem import DependencyInstallationFailedProblem
 from .deprecated_node_warning_problem import DeprecatedNodeWarningProblem
 from .duplicate_library_problem import DuplicateLibraryProblem
+from .duplicate_model_offering_id_problem import DuplicateModelOfferingIdProblem
 from .duplicate_node_registration_problem import DuplicateNodeRegistrationProblem
 from .duplicate_widget_registration_problem import DuplicateWidgetRegistrationProblem
 from .engine_version_error_problem import EngineVersionErrorProblem
@@ -28,6 +29,7 @@ from .old_xdg_location_warning_problem import OldXdgLocationWarningProblem
 from .sandbox_directory_missing_problem import SandboxDirectoryMissingProblem
 from .ui_options_field_modified_incompatible_problem import UiOptionsFieldModifiedIncompatibleProblem
 from .ui_options_field_modified_warning_problem import UiOptionsFieldModifiedWarningProblem
+from .unresolved_model_usage_reference_problem import UnresolvedModelUsageReferenceProblem
 from .update_config_category_problem import UpdateConfigCategoryProblem
 from .venv_creation_failed_problem import VenvCreationFailedProblem
 
@@ -39,6 +41,7 @@ __all__ = [
     "DependencyInstallationFailedProblem",
     "DeprecatedNodeWarningProblem",
     "DuplicateLibraryProblem",
+    "DuplicateModelOfferingIdProblem",
     "DuplicateNodeRegistrationProblem",
     "DuplicateWidgetRegistrationProblem",
     "EngineVersionErrorProblem",
@@ -60,6 +63,7 @@ __all__ = [
     "SandboxDirectoryMissingProblem",
     "UiOptionsFieldModifiedIncompatibleProblem",
     "UiOptionsFieldModifiedWarningProblem",
+    "UnresolvedModelUsageReferenceProblem",
     "UpdateConfigCategoryProblem",
     "VenvCreationFailedProblem",
 ]

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/duplicate_model_offering_id_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/duplicate_model_offering_id_problem.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DuplicateModelOfferingIdProblem(LibraryProblem):
+    """The same offering id appears in two different parents within a library's catalog.
+
+    Pydantic enforces sibling-uniqueness within a single ``offerings`` dict, so
+    this only fires when the *same* id is used under different providers or
+    families (e.g. once under ``anthropic.claude_4.offerings`` and again under
+    ``kling.offerings``). Cross-parent duplicates break admin policies and
+    runtime resolution: a node referencing the id can't pick which of the
+    two parents it meant.
+
+    Stackable.
+    """
+
+    library_name: str
+    offering_id: str
+    # Parent paths where this id appeared (e.g. "anthropic/claude_4", "kling").
+    parent_paths: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[DuplicateModelOfferingIdProblem]) -> str:
+        if len(instances) == 1:
+            problem = instances[0]
+            paths = ", ".join(f"'{p}'" for p in problem.parent_paths)
+            return (
+                f"Library '{problem.library_name}' declares offering id "
+                f"'{problem.offering_id}' under multiple parents: {paths}. "
+                f"Offering ids must be unique across the library."
+            )
+
+        by_library: dict[str, list[DuplicateModelOfferingIdProblem]] = defaultdict(list)
+        for problem in instances:
+            by_library[problem.library_name].append(problem)
+
+        output_lines = [f"Encountered {len(instances)} duplicate model offering ids:"]
+        for library_name in sorted(by_library.keys()):
+            output_lines.append(f"  Library '{library_name}':")
+            for problem in sorted(by_library[library_name], key=lambda p: p.offering_id):
+                paths = ", ".join(f"'{p}'" for p in problem.parent_paths)
+                output_lines.append(f"    - id '{problem.offering_id}' appears under: {paths}")
+        return "\n".join(output_lines)

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/unresolved_model_family_usage_reference_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/unresolved_model_family_usage_reference_problem.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UnresolvedModelFamilyUsageReferenceProblem(LibraryProblem):
+    """A node's `ModelFamilyUsageNodeProperty.families` entry doesn't resolve to a catalog family.
+
+    Either the catalog doesn't declare the named provider, or it does but the
+    named family doesn't exist under that provider. Either way the engine can't
+    enumerate the offerings the node intended.
+
+    Stackable.
+    """
+
+    library_name: str
+    node_name: str
+    provider_id: str
+    family_id: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[UnresolvedModelFamilyUsageReferenceProblem]) -> str:
+        if len(instances) == 1:
+            problem = instances[0]
+            return (
+                f"Node '{problem.node_name}' in library '{problem.library_name}' references model family "
+                f"'{problem.provider_id}/{problem.family_id}', which is not declared in the library's "
+                f"ModelCatalogLibraryProperty."
+            )
+
+        by_library: dict[str, list[UnresolvedModelFamilyUsageReferenceProblem]] = defaultdict(list)
+        for problem in instances:
+            by_library[problem.library_name].append(problem)
+
+        output_lines = [f"Encountered {len(instances)} unresolved model family references:"]
+        for library_name in sorted(by_library.keys()):
+            output_lines.append(f"  Library '{library_name}':")
+            for problem in sorted(by_library[library_name], key=lambda p: (p.node_name, p.provider_id, p.family_id)):
+                output_lines.append(  # noqa: PERF401  -- explicit loop is clearer than list.extend
+                    f"    - node '{problem.node_name}' references missing family "
+                    f"'{problem.provider_id}/{problem.family_id}'"
+                )
+        return "\n".join(output_lines)

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/unresolved_model_provider_usage_reference_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/unresolved_model_provider_usage_reference_problem.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UnresolvedModelProviderUsageReferenceProblem(LibraryProblem):
+    """A node's `ModelProviderUsageNodeProperty.provider_ids` entry doesn't resolve.
+
+    The catalog doesn't declare a provider with that id. The engine can't
+    enumerate the offerings the node intended.
+
+    Stackable.
+    """
+
+    library_name: str
+    node_name: str
+    provider_id: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[UnresolvedModelProviderUsageReferenceProblem]) -> str:
+        if len(instances) == 1:
+            problem = instances[0]
+            return (
+                f"Node '{problem.node_name}' in library '{problem.library_name}' references model provider "
+                f"'{problem.provider_id}', which is not declared in the library's "
+                f"ModelCatalogLibraryProperty."
+            )
+
+        by_library: dict[str, list[UnresolvedModelProviderUsageReferenceProblem]] = defaultdict(list)
+        for problem in instances:
+            by_library[problem.library_name].append(problem)
+
+        output_lines = [f"Encountered {len(instances)} unresolved model provider references:"]
+        for library_name in sorted(by_library.keys()):
+            output_lines.append(f"  Library '{library_name}':")
+            for problem in sorted(by_library[library_name], key=lambda p: (p.node_name, p.provider_id)):
+                output_lines.append(  # noqa: PERF401  -- explicit loop is clearer than list.extend
+                    f"    - node '{problem.node_name}' references missing provider '{problem.provider_id}'"
+                )
+        return "\n".join(output_lines)

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/unresolved_model_usage_reference_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/unresolved_model_usage_reference_problem.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UnresolvedModelUsageReferenceProblem(LibraryProblem):
+    """A node's ModelUsageNodeProperty.offering_ids entry doesn't resolve to any catalog offering.
+
+    Either the catalog doesn't declare the id, or the node was authored against
+    an older version of the catalog. Either way the engine can't tell what the
+    node intended.
+
+    Stackable.
+    """
+
+    library_name: str
+    node_name: str
+    offering_id: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[UnresolvedModelUsageReferenceProblem]) -> str:
+        if len(instances) == 1:
+            problem = instances[0]
+            return (
+                f"Node '{problem.node_name}' in library '{problem.library_name}' "
+                f"references model offering id '{problem.offering_id}', which is not "
+                f"declared in the library's ModelCatalogLibraryProperty."
+            )
+
+        by_library: dict[str, list[UnresolvedModelUsageReferenceProblem]] = defaultdict(list)
+        for problem in instances:
+            by_library[problem.library_name].append(problem)
+
+        output_lines = [f"Encountered {len(instances)} unresolved model offering references:"]
+        for library_name in sorted(by_library.keys()):
+            output_lines.append(f"  Library '{library_name}':")
+            for problem in sorted(by_library[library_name], key=lambda p: (p.node_name, p.offering_id)):
+                output_lines.append(  # noqa: PERF401  -- explicit loop is clearer than list.extend
+                    f"    - node '{problem.node_name}' references missing offering '{problem.offering_id}'"
+                )
+        return "\n".join(output_lines)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -54,6 +54,7 @@ from griptape_nodes.node_library.library_registry import (
     NodeDefinition,
     NodeMetadata,
 )
+from griptape_nodes.node_library.library_validation import validate_library_declarations
 from griptape_nodes.retained_mode.events.app_events import (
     AppInitializationComplete,
     AppSessionStartedEvent,
@@ -909,7 +910,7 @@ class LibraryManager:
         result = GetLibraryMetadataResultSuccess(metadata=metadata, result_details=details)
         return result
 
-    def load_library_metadata_from_file_request(  # noqa: PLR0911
+    def load_library_metadata_from_file_request(  # noqa: PLR0911, C901
         self, request: LoadLibraryMetadataFromFileRequest
     ) -> LoadLibraryMetadataFromFileResultSuccess | LoadLibraryMetadataFromFileResultFailure:
         """Load library metadata from a JSON file without loading the actual node modules.
@@ -998,6 +999,23 @@ class LibraryManager:
                 library_name=library_data.name,
                 status=LibraryManager.LibraryFitness.UNUSABLE,
                 problems=[InvalidVersionStringProblem(version_string=str(library_data.metadata.library_version))],
+                result_details=details,
+            )
+
+        # Resolve cross-references between declarations (catalog offering ids,
+        # node-level model_usage references, etc.). Fatal problems block the load.
+        declaration_validation = validate_library_declarations(library_data)
+        if declaration_validation.fatal:
+            details = (
+                f"Attempted to load Library '{library_data.name}' JSON file from '{json_path}'. "
+                f"Failed because declarative references did not resolve. "
+                f"Count: {len(declaration_validation.fatal)}."
+            )
+            return LoadLibraryMetadataFromFileResultFailure(
+                library_path=file_path,
+                library_name=library_data.name,
+                status=LibraryManager.LibraryFitness.UNUSABLE,
+                problems=list(declaration_validation.fatal),
                 result_details=details,
             )
 

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -9,14 +9,17 @@ import pytest
 from pydantic import ValidationError
 
 from griptape_nodes.node_library.library_declarations import (
+    FamilyReference,
     KeySupport,
     LifecycleStage,
     LifecycleStageLibraryProperty,
     LifecycleStageNodeProperty,
     ModelCatalogLibraryProperty,
     ModelFamily,
+    ModelFamilyUsageNodeProperty,
     ModelOffering,
     ModelProvider,
+    ModelProviderUsageNodeProperty,
     ModelUsageNodeProperty,
     SuggestedWorkerMode,
     WorkerCompatibility,
@@ -24,6 +27,7 @@ from griptape_nodes.node_library.library_declarations import (
     WorkerModeCompatibility,
     iter_catalog_offerings,
     requires_worker_process,
+    resolve_key_support,
     resolve_terms_url,
 )
 from griptape_nodes.node_library.library_registry import (
@@ -360,8 +364,8 @@ class TestRequiresWorkerProcess:
 
 
 class TestSchemaVersion:
-    def test_latest_schema_version_is_090(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.9.0"
+    def test_latest_schema_version_is_0_10_0(self) -> None:
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.10.0"
 
 
 # ---------- Model catalog ----------
@@ -485,3 +489,161 @@ class TestResolveTermsUrl:
         )
 
         assert resolve_terms_url(catalog, "o") is None
+
+
+class TestKeySupportEnum:
+    def test_no_key_required_is_a_legal_value(self) -> None:
+        # Models that run locally (e.g. Ollama-hosted) declare NO_KEY_REQUIRED
+        # so admin tooling can distinguish them from Griptape-key / BYOK models.
+        offering = ModelOffering(
+            display_name="Local Llama",
+            key_support=KeySupport.NO_KEY_REQUIRED,
+        )
+
+        rebuilt = ModelOffering.model_validate(json.loads(offering.model_dump_json()))
+
+        assert rebuilt.key_support is KeySupport.NO_KEY_REQUIRED
+
+
+class TestCatalogNotesField:
+    def test_provider_family_offering_each_carry_notes(self) -> None:
+        catalog = ModelCatalogLibraryProperty(
+            providers={
+                "p": ModelProvider(
+                    display_name="Provider",
+                    notes="provider-level note",
+                    families={
+                        "f": ModelFamily(
+                            display_name="Family",
+                            notes="family-level note",
+                            offerings={
+                                "o": ModelOffering(
+                                    display_name="Offering",
+                                    key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                                    notes="offering-level note",
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        )
+
+        rebuilt = ModelCatalogLibraryProperty.model_validate(json.loads(catalog.model_dump_json()))
+
+        provider = rebuilt.providers["p"]
+        family = provider.families["f"]
+        offering = family.offerings["o"]
+        assert provider.notes == "provider-level note"
+        assert family.notes == "family-level note"
+        assert offering.notes == "offering-level note"
+
+    def test_notes_default_to_none(self) -> None:
+        offering = ModelOffering(display_name="X", key_support=KeySupport.REQUIRES_GRIPTAPE_KEY)
+
+        assert offering.notes is None
+
+
+class TestProviderLevelKeySupport:
+    def test_provider_key_support_is_optional(self) -> None:
+        # Most providers omit key_support at the provider level (offerings carry it).
+        provider = ModelProvider(display_name="P")
+
+        assert provider.key_support is None
+
+    def test_provider_can_declare_no_key_required(self) -> None:
+        # The Ollama-style case: provider declares NO_KEY_REQUIRED with no offerings.
+        provider = ModelProvider(
+            display_name="Ollama (local)",
+            key_support=KeySupport.NO_KEY_REQUIRED,
+        )
+
+        rebuilt = ModelProvider.model_validate(json.loads(provider.model_dump_json()))
+
+        assert rebuilt.key_support is KeySupport.NO_KEY_REQUIRED
+
+    def test_family_key_support_is_optional(self) -> None:
+        family = ModelFamily(display_name="F")
+
+        assert family.key_support is None
+
+    def test_family_can_declare_key_support(self) -> None:
+        family = ModelFamily(display_name="F", key_support=KeySupport.REQUIRES_GRIPTAPE_KEY)
+
+        rebuilt = ModelFamily.model_validate(json.loads(family.model_dump_json()))
+
+        assert rebuilt.key_support is KeySupport.REQUIRES_GRIPTAPE_KEY
+
+
+class TestResolveKeySupport:
+    def test_returns_offering_key_support(self) -> None:
+        catalog = ModelCatalogLibraryProperty(
+            providers={
+                "p": ModelProvider(
+                    display_name="P",
+                    offerings={
+                        "o": ModelOffering(
+                            display_name="O",
+                            key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                        ),
+                    },
+                ),
+            },
+        )
+
+        assert resolve_key_support(catalog, "o") is KeySupport.REQUIRES_CUSTOMER_KEY
+
+    def test_unknown_offering_returns_none(self) -> None:
+        catalog = ModelCatalogLibraryProperty(providers={})
+
+        assert resolve_key_support(catalog, "nonexistent") is None
+
+
+class TestModelFamilyUsageRoundTrip:
+    def test_round_trip(self) -> None:
+        decl = ModelFamilyUsageNodeProperty(
+            families=[
+                FamilyReference(provider_id="openai", family_id="gpt_5"),
+                FamilyReference(provider_id="anthropic", family_id="claude_4_6"),
+            ],
+        )
+
+        rebuilt = ModelFamilyUsageNodeProperty.model_validate(json.loads(decl.model_dump_json()))
+
+        assert rebuilt == decl
+
+    def test_inside_node_metadata(self) -> None:
+        metadata = _make_node_metadata(
+            declarations=[
+                ModelFamilyUsageNodeProperty(
+                    families=[FamilyReference(provider_id="openai", family_id="gpt_5")],
+                ),
+            ],
+        )
+
+        rebuilt = NodeMetadata.model_validate(metadata.model_dump())
+
+        decl = rebuilt.declarations[0]
+        assert isinstance(decl, ModelFamilyUsageNodeProperty)
+        assert decl.families[0].provider_id == "openai"
+        assert decl.families[0].family_id == "gpt_5"
+
+
+class TestModelProviderUsageRoundTrip:
+    def test_round_trip(self) -> None:
+        decl = ModelProviderUsageNodeProperty(provider_ids=["anthropic", "openai"])
+
+        rebuilt = ModelProviderUsageNodeProperty.model_validate(json.loads(decl.model_dump_json()))
+
+        assert rebuilt == decl
+
+    def test_inside_node_metadata(self) -> None:
+        metadata = _make_node_metadata(
+            declarations=[ModelProviderUsageNodeProperty(provider_ids=["anthropic"])],
+        )
+
+        rebuilt = NodeMetadata.model_validate(metadata.model_dump())
+
+        decl = rebuilt.declarations[0]
+        assert isinstance(decl, ModelProviderUsageNodeProperty)
+        assert decl.provider_ids == ["anthropic"]

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -10,15 +10,21 @@ from pydantic import ValidationError
 
 from griptape_nodes.node_library.library_declarations import (
     KeySupport,
-    KeySupportNodeProperty,
     LifecycleStage,
     LifecycleStageLibraryProperty,
     LifecycleStageNodeProperty,
+    ModelCatalogLibraryProperty,
+    ModelFamily,
+    ModelOffering,
+    ModelProvider,
+    ModelUsageNodeProperty,
     SuggestedWorkerMode,
     WorkerCompatibility,
     WorkerMode,
     WorkerModeCompatibility,
+    iter_catalog_offerings,
     requires_worker_process,
+    resolve_terms_url,
 )
 from griptape_nodes.node_library.library_registry import (
     CategoryDefinition,
@@ -75,14 +81,14 @@ class TestDeclarationDiscriminator:
         assert isinstance(rebuilt.declarations[0], LifecycleStageNodeProperty)
         assert rebuilt.declarations[0].stage is LifecycleStage.BETA
 
-    def test_node_key_support_round_trips(self) -> None:
-        metadata = _make_node_metadata(declarations=[KeySupportNodeProperty(support=KeySupport.REQUIRES_CUSTOMER_KEY)])
+    def test_node_model_usage_round_trips(self) -> None:
+        metadata = _make_node_metadata(declarations=[ModelUsageNodeProperty(offering_ids=["claude_opus_byok"])])
 
         rebuilt = NodeMetadata.model_validate(metadata.model_dump())
 
         decl = rebuilt.declarations[0]
-        assert isinstance(decl, KeySupportNodeProperty)
-        assert decl.support is KeySupport.REQUIRES_CUSTOMER_KEY
+        assert isinstance(decl, ModelUsageNodeProperty)
+        assert decl.offering_ids == ["claude_opus_byok"]
 
     def test_library_lifecycle_stage_round_trips(self) -> None:
         metadata = _make_library_metadata(
@@ -161,7 +167,7 @@ class TestRoundTripSerialization:
                     metadata=_make_node_metadata(
                         declarations=[
                             LifecycleStageNodeProperty(stage=LifecycleStage.ALPHA),
-                            KeySupportNodeProperty(support=KeySupport.REQUIRES_CUSTOMER_KEY),
+                            ModelUsageNodeProperty(offering_ids=["claude_opus_byok"]),
                         ],
                     ),
                 ),
@@ -174,7 +180,8 @@ class TestRoundTripSerialization:
         node_decls = rebuilt.nodes[0].metadata.declarations
         assert isinstance(node_decls[0], LifecycleStageNodeProperty)
         assert node_decls[0].stage is LifecycleStage.ALPHA
-        assert isinstance(node_decls[1], KeySupportNodeProperty)
+        assert isinstance(node_decls[1], ModelUsageNodeProperty)
+        assert node_decls[1].offering_ids == ["claude_opus_byok"]
 
 
 # ---------- WorkerModeCompatibility ----------
@@ -355,3 +362,126 @@ class TestRequiresWorkerProcess:
 class TestSchemaVersion:
     def test_latest_schema_version_is_090(self) -> None:
         assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.9.0"
+
+
+# ---------- Model catalog ----------
+
+
+def _build_catalog() -> ModelCatalogLibraryProperty:
+    """Build a catalog that exercises both family-nested and provider-direct paths.
+
+    Different `terms_url` placements at each level let the cascade tests verify
+    most-specific-wins resolution.
+    """
+    return ModelCatalogLibraryProperty(
+        providers={
+            "anthropic": ModelProvider(
+                display_name="Anthropic",
+                terms_url="https://example.com/anthropic/terms",
+                families={
+                    "claude_4": ModelFamily(
+                        display_name="Claude 4",
+                        terms_url="https://example.com/anthropic/claude_4/terms",
+                        offerings={
+                            "claude_opus_byok": ModelOffering(
+                                display_name="Claude Opus 4 (BYOK)",
+                                model="claude-opus-4",
+                                key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                                terms_url="https://example.com/anthropic/claude_4/opus/terms",
+                            ),
+                            "claude_opus_griptape": ModelOffering(
+                                display_name="Claude Opus 4 (Griptape Key)",
+                                model="claude-opus-4",
+                                key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
+                                # No terms_url -- should cascade up to family.
+                            ),
+                        },
+                    ),
+                },
+            ),
+            "kling": ModelProvider(
+                display_name="Kling",
+                terms_url="https://example.com/kling/terms",
+                offerings={
+                    "kling_v2": ModelOffering(
+                        display_name="Kling v2",
+                        model="kling-v2-master",
+                        key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
+                        # No family, no offering terms_url -- should cascade up to provider.
+                    ),
+                },
+            ),
+        },
+    )
+
+
+class TestModelCatalogRoundTrip:
+    def test_full_catalog_round_trips(self) -> None:
+        catalog = _build_catalog()
+
+        rebuilt = ModelCatalogLibraryProperty.model_validate(json.loads(catalog.model_dump_json()))
+
+        assert rebuilt == catalog
+
+    def test_catalog_inside_library_metadata(self) -> None:
+        metadata = _make_library_metadata(declarations=[_build_catalog()])
+
+        rebuilt = LibraryMetadata.model_validate(metadata.model_dump())
+
+        catalogs = [d for d in rebuilt.declarations if isinstance(d, ModelCatalogLibraryProperty)]
+        assert len(catalogs) == 1
+        assert "anthropic" in catalogs[0].providers
+        assert "claude_opus_byok" in catalogs[0].providers["anthropic"].families["claude_4"].offerings
+
+
+class TestIterCatalogOfferings:
+    def test_iterates_family_nested_and_provider_direct(self) -> None:
+        catalog = _build_catalog()
+
+        offerings = list(iter_catalog_offerings(catalog))
+
+        ids = [r.offering_id for r in offerings]
+        assert sorted(ids) == ["claude_opus_byok", "claude_opus_griptape", "kling_v2"]
+        kling = next(r for r in offerings if r.offering_id == "kling_v2")
+        assert kling.family_id is None
+        anthropic = next(r for r in offerings if r.offering_id == "claude_opus_byok")
+        assert anthropic.family_id == "claude_4"
+
+
+class TestResolveTermsUrl:
+    def test_offering_level_url_wins(self) -> None:
+        catalog = _build_catalog()
+
+        assert resolve_terms_url(catalog, "claude_opus_byok") == "https://example.com/anthropic/claude_4/opus/terms"
+
+    def test_falls_back_to_family_url(self) -> None:
+        catalog = _build_catalog()
+
+        assert resolve_terms_url(catalog, "claude_opus_griptape") == "https://example.com/anthropic/claude_4/terms"
+
+    def test_falls_back_to_provider_url(self) -> None:
+        catalog = _build_catalog()
+
+        assert resolve_terms_url(catalog, "kling_v2") == "https://example.com/kling/terms"
+
+    def test_unknown_offering_returns_none(self) -> None:
+        catalog = _build_catalog()
+
+        assert resolve_terms_url(catalog, "nonexistent") is None
+
+    def test_returns_none_when_nothing_set_anywhere(self) -> None:
+        catalog = ModelCatalogLibraryProperty(
+            providers={
+                "p": ModelProvider(
+                    display_name="P",
+                    offerings={
+                        "o": ModelOffering(
+                            display_name="O",
+                            key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                        ),
+                    },
+                ),
+            },
+        )
+
+        assert resolve_terms_url(catalog, "o") is None

--- a/tests/unit/node_library/test_library_validation.py
+++ b/tests/unit/node_library/test_library_validation.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from griptape_nodes.node_library.library_declarations import (
+    FamilyReference,
     KeySupport,
     ModelCatalogLibraryProperty,
     ModelFamily,
+    ModelFamilyUsageNodeProperty,
     ModelOffering,
     ModelProvider,
+    ModelProviderUsageNodeProperty,
     ModelUsageNodeProperty,
 )
 from griptape_nodes.node_library.library_registry import (
@@ -22,6 +25,8 @@ from griptape_nodes.node_library.library_registry import (
 from griptape_nodes.node_library.library_validation import validate_library_declarations
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     DuplicateModelOfferingIdProblem,
+    UnresolvedModelFamilyUsageReferenceProblem,
+    UnresolvedModelProviderUsageReferenceProblem,
     UnresolvedModelUsageReferenceProblem,
 )
 
@@ -267,3 +272,157 @@ class TestUnresolvedModelUsageReferences:
 
         ids = [p.offering_id for p in result.fatal if isinstance(p, UnresolvedModelUsageReferenceProblem)]
         assert sorted(ids) == ["a", "b"]
+
+
+# ---------- Unresolved family-usage references ----------
+
+
+def _catalog_with_one_family() -> ModelCatalogLibraryProperty:
+    return ModelCatalogLibraryProperty(
+        providers={
+            "openai": ModelProvider(
+                display_name="OpenAI",
+                families={
+                    "gpt_5": ModelFamily(
+                        display_name="GPT-5",
+                        offerings={"openai_gpt_5": _offering()},
+                    ),
+                },
+            ),
+        },
+    )
+
+
+class TestUnresolvedFamilyUsageReferences:
+    def test_node_referencing_existing_family_passes(self) -> None:
+        schema = _make_schema(
+            library_declarations=[_catalog_with_one_family()],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesGpt5",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(
+                        declarations=[
+                            ModelFamilyUsageNodeProperty(
+                                families=[FamilyReference(provider_id="openai", family_id="gpt_5")],
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        assert result.fatal == []
+
+    def test_node_referencing_missing_family_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[_catalog_with_one_family()],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesNonexistent",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(
+                        declarations=[
+                            ModelFamilyUsageNodeProperty(
+                                families=[FamilyReference(provider_id="openai", family_id="gpt_99")],
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        unresolved = [p for p in result.fatal if isinstance(p, UnresolvedModelFamilyUsageReferenceProblem)]
+        assert len(unresolved) == 1
+        assert unresolved[0].provider_id == "openai"
+        assert unresolved[0].family_id == "gpt_99"
+
+    def test_family_under_unknown_provider_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[_catalog_with_one_family()],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesUnknownProvider",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(
+                        declarations=[
+                            ModelFamilyUsageNodeProperty(
+                                families=[FamilyReference(provider_id="acme", family_id="gpt_5")],
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        unresolved = [p for p in result.fatal if isinstance(p, UnresolvedModelFamilyUsageReferenceProblem)]
+        assert len(unresolved) == 1
+        assert unresolved[0].provider_id == "acme"
+
+
+# ---------- Unresolved provider-usage references ----------
+
+
+class TestUnresolvedProviderUsageReferences:
+    def test_node_referencing_existing_provider_passes(self) -> None:
+        schema = _make_schema(
+            library_declarations=[_catalog_with_one_family()],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesOpenai",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(
+                        declarations=[ModelProviderUsageNodeProperty(provider_ids=["openai"])],
+                    ),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        assert result.fatal == []
+
+    def test_node_referencing_missing_provider_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[_catalog_with_one_family()],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesAcme",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(
+                        declarations=[ModelProviderUsageNodeProperty(provider_ids=["acme"])],
+                    ),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        unresolved = [p for p in result.fatal if isinstance(p, UnresolvedModelProviderUsageReferenceProblem)]
+        assert len(unresolved) == 1
+        assert unresolved[0].provider_id == "acme"
+
+    def test_multiple_unresolved_providers_all_reported(self) -> None:
+        schema = _make_schema(
+            library_declarations=[_catalog_with_one_family()],
+            nodes=[
+                NodeDefinition(
+                    class_name="N",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(
+                        declarations=[ModelProviderUsageNodeProperty(provider_ids=["acme", "wile_e"])],
+                    ),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        ids = [p.provider_id for p in result.fatal if isinstance(p, UnresolvedModelProviderUsageReferenceProblem)]
+        assert sorted(ids) == ["acme", "wile_e"]

--- a/tests/unit/node_library/test_library_validation.py
+++ b/tests/unit/node_library/test_library_validation.py
@@ -1,0 +1,269 @@
+"""Tests for `validate_library_declarations`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.node_library.library_declarations import (
+    KeySupport,
+    ModelCatalogLibraryProperty,
+    ModelFamily,
+    ModelOffering,
+    ModelProvider,
+    ModelUsageNodeProperty,
+)
+from griptape_nodes.node_library.library_registry import (
+    CategoryDefinition,
+    LibraryMetadata,
+    LibrarySchema,
+    NodeDefinition,
+    NodeMetadata,
+)
+from griptape_nodes.node_library.library_validation import validate_library_declarations
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
+    DuplicateModelOfferingIdProblem,
+    UnresolvedModelUsageReferenceProblem,
+)
+
+
+def _make_library_metadata(**kwargs: Any) -> LibraryMetadata:
+    return LibraryMetadata(
+        author="test",
+        description="test library",
+        library_version="1.0.0",
+        engine_version="1.0.0",
+        tags=[],
+        **kwargs,
+    )
+
+
+def _make_node_metadata(**kwargs: Any) -> NodeMetadata:
+    return NodeMetadata(
+        category="Test",
+        description="test node",
+        display_name="TestNode",
+        **kwargs,
+    )
+
+
+def _make_schema(
+    *,
+    library_declarations: list[Any] | None = None,
+    nodes: list[NodeDefinition] | None = None,
+) -> LibrarySchema:
+    lib_kwargs: dict[str, Any] = {}
+    if library_declarations is not None:
+        lib_kwargs["declarations"] = library_declarations
+    return LibrarySchema(
+        name="Test Library",
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=_make_library_metadata(**lib_kwargs),
+        categories=[{"Test": CategoryDefinition(title="Test", description="test", color="#000", icon="Folder")}],
+        nodes=nodes or [],
+    )
+
+
+def _offering(display_name: str = "X") -> ModelOffering:
+    return ModelOffering(display_name=display_name, key_support=KeySupport.REQUIRES_CUSTOMER_KEY)
+
+
+# ---------- No declarations / clean library ----------
+
+
+class TestCleanLibrary:
+    def test_library_with_no_declarations_has_no_problems(self) -> None:
+        schema = _make_schema()
+
+        result = validate_library_declarations(schema)
+
+        assert result.fatal == []
+        assert result.warnings == []
+
+    def test_library_with_only_a_clean_catalog_has_no_problems(self) -> None:
+        schema = _make_schema(
+            library_declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "p": ModelProvider(
+                            display_name="P",
+                            offerings={"o": _offering()},
+                        ),
+                    },
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        assert result.fatal == []
+        assert result.warnings == []
+
+
+# ---------- Duplicate offering ids ----------
+
+
+class TestDuplicateOfferingIds:
+    def test_same_id_under_two_providers_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "anthropic": ModelProvider(
+                            display_name="Anthropic",
+                            offerings={"shared": _offering()},
+                        ),
+                        "kling": ModelProvider(
+                            display_name="Kling",
+                            offerings={"shared": _offering()},
+                        ),
+                    },
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        duplicates = [p for p in result.fatal if isinstance(p, DuplicateModelOfferingIdProblem)]
+        assert len(duplicates) == 1
+        assert duplicates[0].offering_id == "shared"
+        assert sorted(duplicates[0].parent_paths) == ["anthropic", "kling"]
+
+    def test_same_id_under_provider_and_family_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "anthropic": ModelProvider(
+                            display_name="Anthropic",
+                            families={
+                                "claude_4": ModelFamily(
+                                    display_name="Claude 4",
+                                    offerings={"shared": _offering()},
+                                ),
+                            },
+                            offerings={"shared": _offering()},
+                        ),
+                    },
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        duplicates = [p for p in result.fatal if isinstance(p, DuplicateModelOfferingIdProblem)]
+        assert len(duplicates) == 1
+        assert sorted(duplicates[0].parent_paths) == ["anthropic", "anthropic/claude_4"]
+
+    def test_unique_ids_pass(self) -> None:
+        schema = _make_schema(
+            library_declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "anthropic": ModelProvider(
+                            display_name="Anthropic",
+                            offerings={"a": _offering()},
+                        ),
+                        "kling": ModelProvider(
+                            display_name="Kling",
+                            offerings={"b": _offering()},
+                        ),
+                    },
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        assert [p for p in result.fatal if isinstance(p, DuplicateModelOfferingIdProblem)] == []
+
+
+# ---------- Unresolved model usage references ----------
+
+
+class TestUnresolvedModelUsageReferences:
+    def test_node_referencing_missing_offering_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "p": ModelProvider(
+                            display_name="P",
+                            offerings={"o": _offering()},
+                        ),
+                    },
+                ),
+            ],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesMissing",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(declarations=[ModelUsageNodeProperty(offering_ids=["nonexistent"])]),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        unresolved = [p for p in result.fatal if isinstance(p, UnresolvedModelUsageReferenceProblem)]
+        assert len(unresolved) == 1
+        assert unresolved[0].node_name == "UsesMissing"
+        assert unresolved[0].offering_id == "nonexistent"
+
+    def test_node_referencing_existing_offering_passes(self) -> None:
+        schema = _make_schema(
+            library_declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "p": ModelProvider(
+                            display_name="P",
+                            offerings={"o": _offering()},
+                        ),
+                    },
+                ),
+            ],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesExisting",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(declarations=[ModelUsageNodeProperty(offering_ids=["o"])]),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        assert result.fatal == []
+
+    def test_node_with_no_catalog_and_a_reference_is_fatal(self) -> None:
+        schema = _make_schema(
+            library_declarations=[],
+            nodes=[
+                NodeDefinition(
+                    class_name="UsesMissing",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(declarations=[ModelUsageNodeProperty(offering_ids=["o"])]),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        unresolved = [p for p in result.fatal if isinstance(p, UnresolvedModelUsageReferenceProblem)]
+        assert len(unresolved) == 1
+
+    def test_multiple_unresolved_references_all_reported(self) -> None:
+        schema = _make_schema(
+            library_declarations=[],
+            nodes=[
+                NodeDefinition(
+                    class_name="N",
+                    file_path="x.py",
+                    metadata=_make_node_metadata(declarations=[ModelUsageNodeProperty(offering_ids=["a", "b"])]),
+                ),
+            ],
+        )
+
+        result = validate_library_declarations(schema)
+
+        ids = [p.offering_id for p in result.fatal if isinstance(p, UnresolvedModelUsageReferenceProblem)]
+        assert sorted(ids) == ["a", "b"]


### PR DESCRIPTION
## Summary

Closes #4805.

Adds typed model declarations to library and node metadata so studios and admins can see, gate, and reason about which third-party models a library makes available, where they're routed, and what kind of API key authorizes the call. Library authors declare a hierarchical `provider → family → offering` model catalog once at the library level; individual nodes reference what they use via three new declaration types.

The schema is opt-in (older library JSONs continue to load unchanged) and additive (capabilities/requirements/permissions remain deferred to follow-up PRs).

## What ships in this PR

### Schema (engine-defined)

- `LibraryMetadata.declarations` and `NodeMetadata.declarations` — discriminated-union lists where every declaration carries a `type` field.
- **Library-level declarations**: `LifecycleStageLibraryProperty`, `WorkerModeCompatibility`, `SuggestedWorkerMode`, `ModelCatalogLibraryProperty` (the catalog).
- **Node-level declarations**: `LifecycleStageNodeProperty`, `ModelUsageNodeProperty`, `ModelFamilyUsageNodeProperty`, `ModelProviderUsageNodeProperty`.
- **Catalog hierarchy**: `ModelCatalogLibraryProperty.providers: dict[str, ModelProvider]`, each with `families: dict[str, ModelFamily]` and/or direct `offerings: dict[str, ModelOffering]`. Dict keys at every level are the stable identifiers admin policies and node references use; Pydantic enforces sibling-uniqueness for free.
- **`KeySupport` enum** values: `REQUIRES_CUSTOMER_KEY`, `SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY`, `REQUIRES_GRIPTAPE_KEY`, `NO_KEY_REQUIRED` (for local-runtime providers like Ollama).
- **Cascading fields**: `terms_url` and `notes` cascade most-specific-wins (offering → family → provider). `key_support` lives on offerings by default; `ModelProvider`/`ModelFamily` accept an optional `key_support` for the case where a provider has no offerings (Ollama-style).

### Node-side reference declarations

| Discriminator | Reference field | When to use |
| --- | --- | --- |
| `model_usage` | `offering_ids: list[str]` | Node binds to specific named offerings |
| `model_family_usage` | `families: list[FamilyReference]` (each has `provider_id` + `family_id`) | Node dynamically enumerates a whole family |
| `model_provider_usage` | `provider_ids: list[str]` | Node dynamically enumerates a whole provider |

Family references carry both `provider_id` and `family_id` because family ids are scoped per provider (the same family id can intentionally appear under multiple providers — e.g. `groq.meta_llama_3_3` and `nvidia_nim.meta_llama_3_3`).

### Validation

`validate_library_declarations` runs at library load and surfaces fatal problems:

- `DuplicateModelOfferingIdProblem` — same offering id under two different parents.
- `UnresolvedModelUsageReferenceProblem` — node references an offering id not in the catalog.
- `UnresolvedModelFamilyUsageReferenceProblem` — node references a family that doesn't exist under the named provider.
- `UnresolvedModelProviderUsageReferenceProblem` — node references a provider not in the catalog.

Schema bumps to **`0.10.0`**. Older library JSONs (`0.6.0`, `0.4.0`, `0.1.0`) continue to load because `declarations` defaults to `[]` at both the library and node level.

## Concrete example

```jsonc
{
  "library_schema_version": "0.10.0",
  "metadata": {
    "declarations": [
      { "type": "lifecycle_stage", "stage": "STABLE" },
      {
        "type": "model_catalog",
        "providers": {
          "anthropic": {
            "display_name": "Anthropic",
            "terms_url": "https://www.anthropic.com/legal/commercial-terms",
            "notes": "Direct API access. Requires ANTHROPIC_API_KEY (BYOK).",
            "families": {
              "claude_4_7": {
                "display_name": "Claude 4.7",
                "offerings": {
                  "anthropic_claude_opus_4_7": {
                    "display_name": "Claude Opus 4.7",
                    "model": "claude-opus-4-7",
                    "key_support": "REQUIRES_CUSTOMER_KEY"
                  }
                }
              }
            }
          },
          "ollama": {
            "display_name": "Ollama (local)",
            "key_support": "NO_KEY_REQUIRED",
            "notes": "Models are dynamically discovered from the user's local Ollama installation."
          }
        }
      }
    ]
  },
  "nodes": [
    {
      "class_name": "AnthropicPrompt",
      "metadata": {
        "declarations": [
          { "type": "model_usage", "offering_ids": ["anthropic_claude_opus_4_7"] }
        ]
      }
    }
  ]
}
```

## Out of scope (deferred to follow-ups)

- **Capabilities** ("if you ran me, here's what I'd do" — executes_arbitrary_code, network egress, etc.).
- **Requirements** ("what I need to run" — CUDA, VRAM, etc.).
- **Permissions enforcement** (Cedar-policy evaluator that gates Properties/Capabilities/Requirements).

The `declarations` field is a Pydantic discriminated union; each of the above lands additively without another schema-version bump.

## Companion PR

The `griptape-nodes-library-standard` repo has a companion PR that exercises this schema by declaring a full model catalog (86 offerings across 9 providers) and annotating every prompt-driver node and the Agent node with `model_usage` declarations. **That PR depends on this one** — the engine schema must merge first or the standard library JSON will fail to load.

## Test plan

- [x] `make check` passes (lint, format, type-check)
- [x] `uv run pytest tests/unit/` passes (2372 passed, 9 skipped)
- [x] `uv run python -m mkdocs build --clean --strict` succeeds
- [x] Loading the companion standard-library JSON (`library_schema_version: 0.10.0`) produces 0 fatal / 0 warning declaration-validation problems
- [ ] Reviewer spot-checks docs at `developing_nodes/comprehensive_guide.md` "Library and Node Declarations" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4811.org.readthedocs.build/en/4811/

<!-- readthedocs-preview griptape-nodes end -->