### PR TITLE
Fix non-async worker termination code

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -85,6 +85,14 @@ class WorkerManager:
     # loop; a wedged loop never services it, so SIGTERM alone can leak the process.
     DEFAULT_TERMINATE_GRACE_S: float = 10.0
 
+    # Ceiling on awaiting a cross-loop termination hopped onto the spawning loop.
+    # The hopped coroutine itself can take up to DEFAULT_TERMINATE_GRACE_S, so this
+    # must exceed it; the extra margin covers the SIGKILL escalation and reap. It
+    # bounds the case where the spawning loop closes after the hop is scheduled but
+    # before it completes, so the evicting loop never blocks forever on a future
+    # that will never resolve.
+    DEFAULT_TERMINATE_HOP_TIMEOUT_S: float = 15.0
+
     _WORKER_RESPONSE_TOPIC_RE: re.Pattern = re.compile(r"sessions/[^/]+/workers/(?P<worker_engine_id>[^/]+)/response$")
 
     def __init__(
@@ -102,6 +110,12 @@ class WorkerManager:
 
         # Subprocesses spawned by this orchestrator (library_name → process)
         self._managed_worker_processes: dict[str, asyncio.subprocess.Process] = {}
+
+        # The event loop that spawned the worker subprocesses. asyncio.subprocess.Process
+        # binds its exit Future to its creating loop, so proc.wait() is only legal on this
+        # loop. Eviction can run on a different loop (the websocket-tasks loop), which is
+        # why termination is hopped back here. Captured in spawn_worker.
+        self._spawn_loop: asyncio.AbstractEventLoop | None = None
 
         # Orchestrator-side: worker_engine_id → monotonic timestamp of last heartbeat response
         self._worker_last_seen: dict[str, float] = {}
@@ -309,6 +323,9 @@ class WorkerManager:
             logger.error("Worker for key '%s' already spawned; refusing duplicate spawn.", worker_key)
             return
         proc = await asyncio.create_subprocess_exec(*args, env={**os.environ, "GTN_ENGINE_ID": str(uuid.uuid4())})
+        # Record the loop that owns this subprocess so termination can hop back to it.
+        # All spawns run on the engine event-queue loop, so this is idempotent.
+        self._spawn_loop = asyncio.get_running_loop()
         self._managed_worker_processes[worker_key] = proc
         logger.info("Spawned worker for key '%s' (pid %s)", worker_key, proc.pid)
 
@@ -327,7 +344,7 @@ class WorkerManager:
         )
         await asyncio.gather(
             *(
-                self._terminate_managed_process(library_name, proc)
+                self._terminate_via_spawn_loop(library_name, proc)
                 for library_name, proc in list(self._managed_worker_processes.items())
             )
         )
@@ -393,7 +410,7 @@ class WorkerManager:
         if lib_name:
             proc = self._managed_worker_processes.pop(lib_name, None)
             if proc is not None:
-                await self._terminate_managed_process(lib_name, proc)
+                await self._terminate_via_spawn_loop(lib_name, proc)
         # Cancel any requests that were awaiting a result from this worker.
         await self._tx.request_client.cancel_requests_by_tag(worker_engine_id)
 
@@ -404,6 +421,67 @@ class WorkerManager:
             except Exception:
                 logger.warning("Worker-evicted callback raised an exception for worker '%s'", worker_engine_id)
 
+    async def _terminate_via_spawn_loop(self, library_name: str, proc: asyncio.subprocess.Process) -> None:
+        """Terminate a managed worker on the loop that owns its subprocess.
+
+        asyncio.subprocess.Process binds its exit Future to the loop that created
+        it (the engine event-queue loop), so proc.wait() is only legal there.
+        Eviction can run on a different loop (the websocket-tasks loop); awaiting
+        proc.wait() from there raises "got Future attached to a different loop".
+        Hop the termination coroutine back onto the spawning loop via
+        run_coroutine_threadsafe so proc.wait() always touches its own loop.
+
+        During shutdown the spawning loop may be cancelling or closed. If the hop
+        cannot complete, fall back to a loop-agnostic signal (terminate/kill are
+        plain os.kill, safe from any loop) without awaiting the exit Future.
+        """
+        spawn_loop = self._spawn_loop
+        running_loop = asyncio.get_running_loop()
+        # No separate spawn loop (tests / single-loop deploys) or already on it:
+        # proc.wait() is legal here, so run termination inline.
+        if spawn_loop is None or spawn_loop is running_loop:
+            await self._terminate_managed_process(library_name, proc)
+            return
+        coro = self._terminate_managed_process(library_name, proc)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, spawn_loop)
+        except RuntimeError as e:
+            # The spawning loop is closed (shutdown). The coroutine was never
+            # scheduled, so close it to avoid a never-awaited warning, then signal
+            # the worker directly without awaiting its exit Future.
+            coro.close()
+            logger.warning(
+                "Spawning loop unavailable to terminate worker for key '%s' (%s); "
+                "sending a synchronous signal without awaiting exit confirmation",
+                library_name,
+                e,
+            )
+            self._terminate_without_wait(library_name, proc)
+            return
+        try:
+            await asyncio.wait_for(asyncio.wrap_future(future), timeout=WorkerManager.DEFAULT_TERMINATE_HOP_TIMEOUT_S)
+        except asyncio.CancelledError:
+            # Termination was cancelled during shutdown; ensure the worker still
+            # gets a kill signal that needs no await on the spawning loop.
+            logger.warning(
+                "Termination of worker for key '%s' was cancelled; sending a "
+                "synchronous signal without awaiting exit confirmation",
+                library_name,
+            )
+            self._terminate_without_wait(library_name, proc)
+        except TimeoutError:
+            # The hop was scheduled but never completed: the spawning loop most
+            # likely closed mid-shutdown before draining it. Stop waiting on a
+            # future that will never resolve and signal the worker directly.
+            future.cancel()
+            logger.warning(
+                "Termination of worker for key '%s' did not complete on the spawning loop "
+                "within %.0fs; sending a synchronous signal without awaiting exit confirmation",
+                library_name,
+                WorkerManager.DEFAULT_TERMINATE_HOP_TIMEOUT_S,
+            )
+            self._terminate_without_wait(library_name, proc)
+
     async def _terminate_managed_process(self, library_name: str, proc: asyncio.subprocess.Process) -> None:
         """Terminate a managed worker, escalating to SIGKILL if it does not exit.
 
@@ -412,11 +490,8 @@ class WorkerManager:
         we send SIGKILL, which the kernel delivers regardless of loop state, so a
         hung worker can never leak.
 
-        The subprocess transport is bound to the loop that spawned it (the engine
-        event-queue loop), which may differ from the loop running eviction (the
-        websocket-tasks loop). Awaiting proc.wait() across loops raises "attached
-        to a different loop", so we poll the loop-agnostic returncode attribute,
-        and terminate()/kill() are synchronous os.kill calls usable from any loop.
+        Must run on the loop that spawned proc, since it awaits proc.wait(). Callers
+        on another loop route through _terminate_via_spawn_loop.
         """
         try:
             proc.terminate()
@@ -424,22 +499,34 @@ class WorkerManager:
             logger.debug("Worker for key '%s' already exited before termination", library_name)
             return
         logger.info("Terminated worker for key '%s' (pid %s)", library_name, proc.pid)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=WorkerManager.DEFAULT_TERMINATE_GRACE_S)
+        except TimeoutError:
+            logger.warning(
+                "Worker for key '%s' (pid %s) did not exit within %.0fs of SIGTERM; sending SIGKILL",
+                library_name,
+                proc.pid,
+                WorkerManager.DEFAULT_TERMINATE_GRACE_S,
+            )
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
+            await proc.wait()
 
-        deadline = time.monotonic() + WorkerManager.DEFAULT_TERMINATE_GRACE_S
-        # ASYNC110: an asyncio.Event cannot replace the poll here. returncode is
-        # set by the spawning loop's child watcher, and an Event would bind to
-        # whichever loop created it, reintroducing the cross-loop await we avoid.
-        while proc.returncode is None and time.monotonic() < deadline:  # noqa: ASYNC110
-            await asyncio.sleep(0.1)
-        if proc.returncode is not None:
+    def _terminate_without_wait(self, library_name: str, proc: asyncio.subprocess.Process) -> None:
+        """Signal a worker to die without awaiting its exit Future.
+
+        Shutdown-only fallback for when the spawning loop is unavailable to run
+        proc.wait(). terminate() then kill() are synchronous os.kill calls, safe
+        from any loop; we forgo the graceful grace period and exit confirmation
+        because the orchestrator is tearing down and only needs the worker gone.
+        """
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            logger.debug("Worker for key '%s' already exited before termination", library_name)
             return
-
-        logger.warning(
-            "Worker for key '%s' (pid %s) did not exit within %.0fs of SIGTERM; sending SIGKILL",
-            library_name,
-            proc.pid,
-            WorkerManager.DEFAULT_TERMINATE_GRACE_S,
-        )
         try:
             proc.kill()
         except ProcessLookupError:

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -462,13 +462,18 @@ class WorkerManager:
             await asyncio.wait_for(asyncio.wrap_future(future), timeout=WorkerManager.DEFAULT_TERMINATE_HOP_TIMEOUT_S)
         except asyncio.CancelledError:
             # Termination was cancelled during shutdown; ensure the worker still
-            # gets a kill signal that needs no await on the spawning loop.
+            # gets a kill signal that needs no await on the spawning loop, then
+            # re-raise so cooperative cancellation propagates. Both hop callers run
+            # under TaskGroup-driven teardown (orchestrator_heartbeat_loop and the
+            # reset_workers gather); swallowing the cancel would let cleanup resume
+            # in a context that was supposed to stop and wedge TaskGroup convergence.
             logger.warning(
                 "Termination of worker for key '%s' was cancelled; sending a "
                 "synchronous signal without awaiting exit confirmation",
                 library_name,
             )
             self._terminate_without_wait(library_name, proc)
+            raise
         except TimeoutError:
             # The hop was scheduled but never completed: the spawning loop most
             # likely closed mid-shutdown before draining it. Stop waiting on a

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -411,6 +411,12 @@ class WorkerManager:
         event loop; a wedged loop never services it. After DEFAULT_TERMINATE_GRACE_S
         we send SIGKILL, which the kernel delivers regardless of loop state, so a
         hung worker can never leak.
+
+        The subprocess transport is bound to the loop that spawned it (the engine
+        event-queue loop), which may differ from the loop running eviction (the
+        websocket-tasks loop). Awaiting proc.wait() across loops raises "attached
+        to a different loop", so we poll the loop-agnostic returncode attribute,
+        and terminate()/kill() are synchronous os.kill calls usable from any loop.
         """
         try:
             proc.terminate()
@@ -418,20 +424,26 @@ class WorkerManager:
             logger.debug("Worker for key '%s' already exited before termination", library_name)
             return
         logger.info("Terminated worker for key '%s' (pid %s)", library_name, proc.pid)
+
+        deadline = time.monotonic() + WorkerManager.DEFAULT_TERMINATE_GRACE_S
+        # ASYNC110: an asyncio.Event cannot replace the poll here. returncode is
+        # set by the spawning loop's child watcher, and an Event would bind to
+        # whichever loop created it, reintroducing the cross-loop await we avoid.
+        while proc.returncode is None and time.monotonic() < deadline:  # noqa: ASYNC110
+            await asyncio.sleep(0.1)
+        if proc.returncode is not None:
+            return
+
+        logger.warning(
+            "Worker for key '%s' (pid %s) did not exit within %.0fs of SIGTERM; sending SIGKILL",
+            library_name,
+            proc.pid,
+            WorkerManager.DEFAULT_TERMINATE_GRACE_S,
+        )
         try:
-            await asyncio.wait_for(proc.wait(), timeout=WorkerManager.DEFAULT_TERMINATE_GRACE_S)
-        except TimeoutError:
-            logger.warning(
-                "Worker for key '%s' (pid %s) did not exit within %.0fs of SIGTERM; sending SIGKILL",
-                library_name,
-                proc.pid,
-                WorkerManager.DEFAULT_TERMINATE_GRACE_S,
-            )
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                return
-            await proc.wait()
+            proc.kill()
+        except ProcessLookupError:
+            return
 
     def register_worker_evicted_callback(self, callback: Callable[[str, str | None], None]) -> None:
         """Register a callback invoked when a worker is evicted.

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -636,6 +636,48 @@ class TestTerminateViaSpawnLoop:
             thread.join(timeout=5)
             spawn_loop.close()
 
+    @pytest.mark.asyncio
+    async def test_cancellation_signals_worker_then_propagates(self, worker_manager: WorkerManager) -> None:
+        """A cancelled hop must signal the worker AND re-raise the cancellation.
+
+        Both hop callers run under TaskGroup-driven teardown; swallowing the
+        CancelledError would let cleanup resume in a context that was meant to
+        stop. The fallback kill still fires, but the cancel must propagate.
+        """
+        spawn_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run_spawn_loop() -> None:
+            asyncio.set_event_loop(spawn_loop)
+            ready.set()
+            spawn_loop.run_forever()
+
+        thread = threading.Thread(target=_run_spawn_loop, daemon=True)
+        thread.start()
+        ready.wait()
+        try:
+            worker_manager._spawn_loop = spawn_loop
+            proc = _managed_proc_mock()
+
+            async def _never_exits() -> None:
+                await asyncio.Event().wait()
+
+            proc.wait = _never_exits  # keep the hop pending so we can cancel it
+            worker_manager._managed_worker_processes["Lib A"] = proc
+
+            task = asyncio.ensure_future(worker_manager._terminate_via_spawn_loop("Lib A", proc))
+            # Let the hop reach the await before cancelling.
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            proc.kill.assert_called_once()
+        finally:
+            spawn_loop.call_soon_threadsafe(spawn_loop.stop)
+            thread.join(timeout=5)
+            spawn_loop.close()
+
 
 class TestSetSessionReady:
     def test_sets_session_ready_event(self, worker_manager: WorkerManager) -> None:

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 import time
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -78,14 +79,13 @@ def worker_manager() -> WorkerManager:
 
 
 def _managed_proc_mock() -> MagicMock:
-    """Build a mock worker process that reports as exited after SIGTERM.
+    """Build a mock worker process whose ``wait()`` is awaitable.
 
-    ``_terminate_managed_process`` polls ``proc.returncode`` to decide whether to
-    escalate to SIGKILL; a non-None value means the process already exited, so the
-    happy path returns without killing.
+    ``_terminate_managed_process`` awaits ``proc.wait()`` after SIGTERM; a bare
+    MagicMock returns a non-awaitable, so stand in an AsyncMock for ``wait``.
     """
     proc = MagicMock()
-    proc.returncode = 0
+    proc.wait = AsyncMock()
     return proc
 
 
@@ -505,11 +505,16 @@ class TestResetWorkers:
     @pytest.mark.asyncio
     async def test_escalates_to_sigkill_when_terminate_times_out(self, worker_manager: WorkerManager) -> None:
         """A worker that ignores SIGTERM must be SIGKILLed after the grace period."""
-        proc = MagicMock()
-        proc.returncode = None  # never exits, so the grace-period poll always times out
+        proc = _managed_proc_mock()
         worker_manager._managed_worker_processes["Lib A"] = proc
 
-        with patch.object(WorkerManager, "DEFAULT_TERMINATE_GRACE_S", 0.0):
+        def _close_and_timeout(awaitable: object, *_args: object, **_kwargs: object) -> None:
+            # Close the proc.wait() coroutine we are bypassing so it is not
+            # reported as never-awaited, then simulate the SIGTERM grace expiring.
+            awaitable.close()  # type: ignore[attr-defined]
+            raise TimeoutError
+
+        with patch("asyncio.wait_for", side_effect=_close_and_timeout):
             await worker_manager.reset_workers()
 
         proc.terminate.assert_called_once()
@@ -529,6 +534,107 @@ class TestResetWorkers:
         unsubscribed = {call.args[0] for call in worker_manager._tx.unsubscribe_from_topic.call_args_list}  # type: ignore[union-attr]
         assert f"sessions/{_SESSION}/workers/eng-1/response" in unsubscribed
         assert f"sessions/{_SESSION}/workers/eng-2/response" in unsubscribed
+
+
+class TestTerminateViaSpawnLoop:
+    """Cross-loop worker termination.
+
+    The subprocess binds to its spawning loop, but eviction can run on another
+    loop. _terminate_via_spawn_loop must hop termination back to the spawning loop
+    so proc.wait() never crosses loops, and fall back to a synchronous signal when
+    the spawning loop is gone (shutdown).
+    """
+
+    @pytest.mark.asyncio
+    async def test_hops_termination_to_spawn_loop(self, worker_manager: WorkerManager) -> None:
+        """Termination is hopped onto the spawn loop when it differs from the running loop.
+
+        Avoids awaiting proc.wait() across loops, which would raise.
+        """
+        spawn_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run_spawn_loop() -> None:
+            asyncio.set_event_loop(spawn_loop)
+            ready.set()
+            spawn_loop.run_forever()
+
+        thread = threading.Thread(target=_run_spawn_loop, daemon=True)
+        thread.start()
+        ready.wait()
+        try:
+            worker_manager._spawn_loop = spawn_loop
+            proc = _managed_proc_mock()
+            worker_manager._managed_worker_processes["Lib A"] = proc
+
+            # Runs on the test's loop, which is NOT spawn_loop: the hop must engage.
+            await worker_manager.reset_workers()
+
+            proc.terminate.assert_called_once()
+            assert worker_manager._managed_worker_processes == {}
+        finally:
+            spawn_loop.call_soon_threadsafe(spawn_loop.stop)
+            thread.join(timeout=5)
+            spawn_loop.close()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sync_signal_when_spawn_loop_closed(self, worker_manager: WorkerManager) -> None:
+        """A closed spawn loop forces the synchronous-signal fallback.
+
+        run_coroutine_threadsafe raises on a closed loop; the dispatcher must
+        swallow it and signal the worker synchronously.
+        """
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+        worker_manager._spawn_loop = closed_loop
+        proc = _managed_proc_mock()
+        worker_manager._managed_worker_processes["Lib A"] = proc
+
+        await worker_manager.reset_workers()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert worker_manager._managed_worker_processes == {}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_sync_signal_when_hop_times_out(self, worker_manager: WorkerManager) -> None:
+        """A hop that is scheduled but never completes triggers the sync fallback.
+
+        Simulates the spawning loop closing after the hop is scheduled but before
+        it drains: the hopped termination never finishes, so the evicting loop must
+        stop waiting at DEFAULT_TERMINATE_HOP_TIMEOUT_S and signal the worker.
+        """
+        spawn_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run_spawn_loop() -> None:
+            asyncio.set_event_loop(spawn_loop)
+            ready.set()
+            spawn_loop.run_forever()
+
+        thread = threading.Thread(target=_run_spawn_loop, daemon=True)
+        thread.start()
+        ready.wait()
+        try:
+            worker_manager._spawn_loop = spawn_loop
+            proc = _managed_proc_mock()
+
+            async def _never_exits() -> None:
+                await asyncio.Event().wait()
+
+            proc.wait = _never_exits  # the hopped termination hangs forever
+            worker_manager._managed_worker_processes["Lib A"] = proc
+
+            with patch.object(WorkerManager, "DEFAULT_TERMINATE_HOP_TIMEOUT_S", 0.1):
+                await worker_manager.reset_workers()
+
+            # Fallback signalled the worker without awaiting the stuck exit Future.
+            proc.kill.assert_called_once()
+            assert worker_manager._managed_worker_processes == {}
+        finally:
+            spawn_loop.call_soon_threadsafe(spawn_loop.stop)
+            thread.join(timeout=5)
+            spawn_loop.close()
 
 
 class TestSetSessionReady:

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -78,13 +78,14 @@ def worker_manager() -> WorkerManager:
 
 
 def _managed_proc_mock() -> MagicMock:
-    """Build a mock worker process whose ``wait()`` is awaitable.
+    """Build a mock worker process that reports as exited after SIGTERM.
 
-    ``_terminate_managed_process`` awaits ``proc.wait()`` after SIGTERM; a bare
-    MagicMock returns a non-awaitable, so stand in an AsyncMock for ``wait``.
+    ``_terminate_managed_process`` polls ``proc.returncode`` to decide whether to
+    escalate to SIGKILL; a non-None value means the process already exited, so the
+    happy path returns without killing.
     """
     proc = MagicMock()
-    proc.wait = AsyncMock()
+    proc.returncode = 0
     return proc
 
 
@@ -504,16 +505,11 @@ class TestResetWorkers:
     @pytest.mark.asyncio
     async def test_escalates_to_sigkill_when_terminate_times_out(self, worker_manager: WorkerManager) -> None:
         """A worker that ignores SIGTERM must be SIGKILLed after the grace period."""
-        proc = _managed_proc_mock()
+        proc = MagicMock()
+        proc.returncode = None  # never exits, so the grace-period poll always times out
         worker_manager._managed_worker_processes["Lib A"] = proc
 
-        def _close_and_timeout(awaitable: object, *_args: object, **_kwargs: object) -> None:
-            # Close the proc.wait() coroutine we are bypassing so it is not
-            # reported as never-awaited, then simulate the SIGTERM grace expiring.
-            awaitable.close()  # type: ignore[attr-defined]
-            raise TimeoutError
-
-        with patch("asyncio.wait_for", side_effect=_close_and_timeout):
+        with patch.object(WorkerManager, "DEFAULT_TERMINATE_GRACE_S", 0.0):
             await worker_manager.reset_workers()
 
         proc.terminate.assert_called_once()


### PR DESCRIPTION
https://github.com/griptape-ai/griptape-nodes-engine/commit/dd4af0762ad56d322b42530824a54bde3585d028 was too aggressive, came back from the weekend to a timeout failure that exposed a cross-loop assumption from that PR