### PR TITLE
fix: stop rejecting forwarded storage_backend on LocalWorkflowExecutor run path

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
@@ -100,7 +100,9 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
 
         Parameters:
             flow_input: Input data for the flow, typically a dictionary.
-            storage_backend: The storage backend to use for the workflow execution.
+            storage_backend: Accepted for compatibility with the base-class run path,
+                but ignored here: the storage backend is applied once at construction
+                via `_set_storage_backend`. Passing it to the run path has no effect.
             pickle_control_flow_result: Per-call override for the executor's
                 save-time default. None means "use the instance default".
 
@@ -132,15 +134,18 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
     async def _arun(  # noqa: C901, PLR0915
         self,
         flow_input: Any,
-        storage_backend: StorageBackend | None = None,
+        storage_backend: StorageBackend | None = None,  # noqa: ARG002
         *,
         pickle_control_flow_result: bool | None = None,
         **kwargs: Any,
     ) -> None:
-        """Internal async run method with detailed event handling and websocket integration."""
+        """Internal async run method with detailed event handling and websocket integration.
+
+        `storage_backend` is accepted for signature parity with `arun`/the base run path,
+        but ignored: the backend is applied once at construction via `_set_storage_backend`.
+        """
         flow_name = await self.aprepare_workflow_for_run(
             flow_input=flow_input,
-            storage_backend=storage_backend,
             **kwargs,
         )
 

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -227,7 +227,6 @@ class LocalWorkflowExecutor(WorkflowExecutor):
     async def aprepare_workflow_for_run(
         self,
         flow_input: Any,
-        storage_backend: StorageBackend | None = None,
         **kwargs: Any,
     ) -> str:
         """Prepares a local workflow for execution.
@@ -237,15 +236,10 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         workflow, and preparing the specified workflow for execution.
         Parameters:
             flow_input: Input data for the flow, typically a dictionary.
-            storage_backend: The storage backend to use for the workflow execution.
 
         Returns:
             str: The name of the prepared flow.
         """
-        if storage_backend is not None:
-            msg = "The storage_backend parameter is deprecated. Pass `storage_backend` to the constructor instead."
-            raise ValueError(msg)
-
         GriptapeNodes.EventManager().initialize_queue()
 
         # Load workflow from file if workflow_path is provided
@@ -372,7 +366,7 @@ class LocalWorkflowExecutor(WorkflowExecutor):
     async def arun(
         self,
         flow_input: Any,
-        storage_backend: StorageBackend | None = None,
+        storage_backend: StorageBackend | None = None,  # noqa: ARG002
         *,
         pickle_control_flow_result: bool | None = None,
         **kwargs: Any,
@@ -385,7 +379,9 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         Parameters:
             workflow_name: The name of the workflow to execute.
             flow_input: Input data for the flow, typically a dictionary.
-            storage_backend: The storage backend to use for the workflow execution.
+            storage_backend: Accepted for compatibility with the base-class run path,
+                but ignored here: the storage backend is applied once at construction
+                via `_set_storage_backend`. Passing it to the run path has no effect.
             pickle_control_flow_result: Per-call override for the executor's
                 save-time default. None means "use the instance default".
 
@@ -394,7 +390,6 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         """
         flow_name = await self.aprepare_workflow_for_run(
             flow_input=flow_input,
-            storage_backend=storage_backend,
             **kwargs,
         )
 

--- a/tests/unit/bootstrap/workflow_executors/test_local_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_local_workflow_executor.py
@@ -104,6 +104,69 @@ class TestLoadProject:
         assert mock_gn.ahandle_request.call_count == EXPECTED_REQUEST_COUNT
 
 
+class TestPrepareWorkflowForRunStorageBackend:
+    """Regression tests for issue #4828.
+
+    Generated workflow files splat the same `**kwargs` into both the
+    `LocalWorkflowExecutor(...)` constructor and `executor.arun(...)`, so a
+    `storage_backend` forwarded through `execute_workflow(**kwargs)` reaches the
+    run path. The run path used to hard-raise on any non-None `storage_backend`,
+    turning a valid caller into an error. The backend is applied once at
+    construction; the run path must tolerate a forwarded value.
+    """
+
+    @pytest.mark.asyncio
+    async def test_aprepare_does_not_raise_on_forwarded_storage_backend(self) -> None:
+        """A `storage_backend` forwarded into the run path must no longer raise."""
+        executor = LocalWorkflowExecutor.__new__(LocalWorkflowExecutor)
+
+        with (
+            patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn,
+            patch.object(executor, "_load_flow_for_workflow", return_value="flow-name"),
+            patch.object(executor, "_set_input_for_flow", new=AsyncMock()),
+        ):
+            mock_gn.EventManager.return_value.initialize_queue = MagicMock()
+
+            # storage_backend arrives via **kwargs, exactly like the generated double-splat.
+            flow_name = await executor.aprepare_workflow_for_run(
+                flow_input={},
+                storage_backend=StorageBackend.GTC,
+            )
+
+        assert flow_name == "flow-name"
+
+    @pytest.mark.asyncio
+    async def test_arun_tolerates_forwarded_storage_backend(self) -> None:
+        """`arun` must accept a forwarded storage_backend (base-class run path) and ignore it."""
+        executor = LocalWorkflowExecutor.__new__(LocalWorkflowExecutor)
+        executor._pickle_control_flow_result = False
+
+        mock_start_result = MagicMock()
+        mock_start_result.failed.return_value = True  # short-circuit before the event loop
+        mock_prepare = AsyncMock(return_value="flow-name")
+
+        with (
+            patch.object(executor, "aprepare_workflow_for_run", new=mock_prepare),
+            patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn,
+        ):
+            mock_gn.ahandle_request = AsyncMock(return_value=mock_start_result)
+
+            # Reaching LocalExecutorError (not ValueError about deprecation) proves the
+            # forwarded storage_backend was tolerated and arun proceeded to start the flow.
+            with pytest.raises(LocalExecutorError, match="Failed to start flow"):
+                await executor.arun(flow_input={}, storage_backend=StorageBackend.GTC)
+
+        # arun must NOT forward storage_backend down to aprepare_workflow_for_run, in any
+        # form. Assert it appears in neither the positional args nor the keyword args of the
+        # call (asserting only `not in kwargs` would be tautological, since storage_backend
+        # is a named parameter of arun and can never land in arun's own **kwargs).
+        mock_prepare.assert_awaited_once()
+        await_args = mock_prepare.await_args
+        assert await_args is not None
+        assert StorageBackend.GTC not in await_args.args
+        assert "storage_backend" not in await_args.kwargs
+
+
 class TestLocalWorkflowExecutorCli:
     """Tests for LocalWorkflowExecutor's CLI surface (issue #4599)."""
 


### PR DESCRIPTION
## Summary

Fixes a regression where a `storage_backend` forwarded through the documented `execute_workflow(**kwargs)` surface caused the workflow to hard-error instead of running.

Generated workflow files splat the **same** `**kwargs` into both the `LocalWorkflowExecutor(...)` constructor *and* `executor.arun(...)`:

```py
if workflow_executor is None:
    kwargs.setdefault('pickle_control_flow_result', False)
    workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
async with workflow_executor as executor:
    await executor.arun(flow_input=input, **kwargs)   # SAME kwargs re-splatted
```

The constructor consumed `storage_backend` correctly, but the *same* value was then re-delivered to `arun()`, where `aprepare_workflow_for_run` hard-raised:

```
{"error": "Workflow execution failed: The storage_backend parameter is deprecated. Pass `storage_backend` to the constructor instead."}
```

## Root cause

`LocalWorkflowExecutor.aprepare_workflow_for_run` declared a `storage_backend` parameter it **never used** except to `raise` — a vestigial deprecation tripwire. The backend is applied entirely at construction (`__init__` → `_set_storage_backend`), so forwarding the same value to the run path was redundant, not erroneous, yet it turned a valid caller into a hard error.

## Fix

Fix lives in the executor, not the codegen — the `**kwargs` passthrough into `arun()` is intentional (keeps the generated helper signature stable and lets custom executor subclasses receive caller kwargs), and fixing the executor repairs **both** already-generated workflow files and newly saved ones with no schema bump.

- `aprepare_workflow_for_run`: removed the dead `storage_backend` parameter and the deprecation `raise`. A forwarded `storage_backend` now falls harmlessly into `**kwargs`, exactly like `project_file_path` already does.
- `arun` / `_arun`: keep `storage_backend` in the signature for base-class positional compatibility (`WorkflowExecutor.run` forwards it positionally), but no longer pass it down to `aprepare_workflow_for_run`. Marked `# noqa: ARG002` and documented as accepted-but-ignored, matching the existing `SubprocessWorkflowExecutor` convention.

Intentionally **not** changed: the codegen double-splat, the `WorkflowExecutor` base, and `SubprocessWorkflowExecutor` — where `storage_backend` is genuinely load-bearing.

## Testing

- Added regression tests in `test_local_workflow_executor.py` (forwarded `storage_backend` no longer raises; `arun` does not re-forward it to `aprepare_workflow_for_run`).
- `make check` clean; full bootstrap-executor + codegen suites pass.
- End-to-end: ran a real generated workflow file with `execute_workflow(..., storage_backend=StorageBackend.LOCAL)` — workflow completed and returned output instead of erroring.

Closes #4828