### PR TITLE
feat(manifest): add GenerateManifestRequest for libraries and projects

### DIFF
--- a/src/griptape_nodes/common/manifests/__init__.py
+++ b/src/griptape_nodes/common/manifests/__init__.py
@@ -1,0 +1,15 @@
+"""Manifest models describing a snapshot of engine-local resources."""
+
+from griptape_nodes.common.manifests.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    LibraryManifestEntry,
+    Manifest,
+    ProjectTemplateManifestEntry,
+)
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "LibraryManifestEntry",
+    "Manifest",
+    "ProjectTemplateManifestEntry",
+]

--- a/src/griptape_nodes/common/manifests/manifest.py
+++ b/src/griptape_nodes/common/manifests/manifest.py
@@ -1,0 +1,84 @@
+"""Manifest data model.
+
+A manifest is a serializable snapshot of the engine-local resources the engine
+currently knows about (libraries and project templates, for now). It is
+generated on request and handed to a UI that builds an interface around those
+resources.
+
+The manifest intentionally carries only descriptive metadata. It references
+resources by the same identifiers the engine already uses (library names,
+project template ids) so consumers can look up live state through the existing
+per-resource events.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# Schema version for the manifest envelope. Bump when the shape changes so
+# consumers can branch on it.
+MANIFEST_SCHEMA_VERSION = "0.1.0"
+
+
+class LibraryManifestEntry(BaseModel):
+    """A single registered library in a manifest.
+
+    Attributes:
+        name: Registered library name (the identifier used by library events).
+        path: Absolute path to the library's ``griptape_nodes_library.json``,
+            when known.
+        version: Library version from its metadata, when available.
+        author: Library author from its metadata, when available.
+        description: Library description from its metadata, when available.
+        tags: Search/classification tags declared in the library metadata.
+    """
+
+    name: str
+    path: str | None = None
+    version: str | None = None
+    author: str | None = None
+    description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+
+
+class ProjectTemplateManifestEntry(BaseModel):
+    """A single loaded project template in a manifest.
+
+    Attributes:
+        project_id: Opaque identifier for the template (the identifier used by
+            project events and referenced by external consumers such as
+            policies). Consumers must not parse or construct it.
+        name: Display name from the project template body, when available.
+        parent_project_path: Canonical absolute path of the parent project
+            template, or None when the template has no parent.
+        path: Filesystem location of the template file on this engine, or None
+            for templates that are not file-backed (e.g. the system defaults).
+            Carried separately from ``project_id`` so consumers never have to
+            assume the id is a path.
+    """
+
+    project_id: str
+    name: str | None = None
+    parent_project_path: str | None = None
+    path: str | None = None
+
+
+class Manifest(BaseModel):
+    """A snapshot of the engine's registered libraries and project templates.
+
+    Attributes:
+        schema_version: Version of the manifest envelope.
+        generated_at: ISO 8601 timestamp (UTC) of when the manifest was built.
+        engine_id: Identifier of the engine that generated this manifest, when
+            known. Lets consumers attribute a manifest to its source engine.
+        engine_version: Engine version string (``major.minor.patch``), when known.
+        libraries: Registered libraries included in this manifest.
+        project_templates: Loaded project templates included in this manifest.
+    """
+
+    schema_version: str = MANIFEST_SCHEMA_VERSION
+    generated_at: str
+    engine_id: str | None = None
+    engine_version: str | None = None
+    libraries: list[LibraryManifestEntry] = Field(default_factory=list)
+    project_templates: list[ProjectTemplateManifestEntry] = Field(default_factory=list)

--- a/src/griptape_nodes/retained_mode/events/manifest_events.py
+++ b/src/griptape_nodes/retained_mode/events/manifest_events.py
@@ -1,0 +1,58 @@
+"""Events for generating manifests of engine-local resources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from griptape_nodes.common.manifests.manifest import Manifest
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+@dataclass
+@PayloadRegistry.register
+class GenerateManifestRequest(RequestPayload):
+    """Generate a manifest of the engine's currently registered resources.
+
+    Use when: A UI needs a single descriptive snapshot of the libraries and
+    project templates the engine knows about so it can build an interface
+    around them.
+
+    The manifest is generated from live engine state and returned in the result.
+    Nothing is written to disk or registered.
+
+    Args:
+        include_libraries: Include registered libraries in the manifest.
+        include_project_templates: Include loaded project templates in the manifest.
+
+    Results: GenerateManifestResultSuccess | GenerateManifestResultFailure
+    """
+
+    include_libraries: bool = True
+    include_project_templates: bool = True
+
+
+@dataclass
+@PayloadRegistry.register
+class GenerateManifestResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Manifest generated successfully.
+
+    Args:
+        manifest: The generated manifest describing registered libraries and project templates.
+    """
+
+    manifest: Manifest
+
+
+@dataclass
+@PayloadRegistry.register
+class GenerateManifestResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Manifest generation failed.
+
+    Common causes: the library registry or project template registry could not be queried.
+    """

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
     from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+    from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
     from griptape_nodes.retained_mode.managers.mcp_manager import MCPManager
     from griptape_nodes.retained_mode.managers.model_manager import ModelManager
     from griptape_nodes.retained_mode.managers.node_manager import NodeManager
@@ -103,6 +104,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
     _user_manager: UserManager
     _project_manager: ProjectManager
     _artifact_manager: ArtifactManager
+    _manifest_manager: ManifestManager
     _worker_manager: WorkerManager
 
     def __init__(self) -> None:  # noqa: PLR0915
@@ -117,6 +119,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
         from griptape_nodes.retained_mode.managers.event_manager import EventManager
         from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+        from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
         from griptape_nodes.retained_mode.managers.mcp_manager import MCPManager
         from griptape_nodes.retained_mode.managers.model_manager import ModelManager
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
@@ -175,6 +178,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._user_manager = UserManager(self._secrets_manager)
             self._project_manager = ProjectManager(self._event_manager, self._config_manager, self._secrets_manager)
             self._artifact_manager = ArtifactManager(self._event_manager)
+            self._manifest_manager = ManifestManager(self._event_manager)
 
             # Assign handlers now that these are created.
             self._event_manager.assign_manager_to_request_type(
@@ -364,6 +368,10 @@ class GriptapeNodes(metaclass=SingletonMeta):
     @classmethod
     def ArtifactManager(cls) -> ArtifactManager:
         return GriptapeNodes.get_instance()._artifact_manager
+
+    @classmethod
+    def ManifestManager(cls) -> ManifestManager:
+        return GriptapeNodes.get_instance()._manifest_manager
 
     @classmethod
     def WorkerManager(cls) -> WorkerManager:

--- a/src/griptape_nodes/retained_mode/managers/manifest_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/manifest_manager.py
@@ -1,0 +1,185 @@
+"""ManifestManager - Generates manifests describing engine-local resources."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from griptape_nodes.common.manifests.manifest import (
+    LibraryManifestEntry,
+    Manifest,
+    ProjectTemplateManifestEntry,
+)
+from griptape_nodes.retained_mode.events.app_events import (
+    GetEngineVersionRequest,
+    GetEngineVersionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    GetLibraryMetadataRequest,
+    GetLibraryMetadataResultSuccess,
+    GetLibrarySourceInfoRequest,
+    GetLibrarySourceInfoResultSuccess,
+    ListRegisteredLibrariesRequest,
+    ListRegisteredLibrariesResultSuccess,
+)
+from griptape_nodes.retained_mode.events.manifest_events import (
+    GenerateManifestRequest,
+    GenerateManifestResultFailure,
+    GenerateManifestResultSuccess,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    ListProjectTemplatesRequest,
+    ListProjectTemplatesResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.project_events import ProjectTemplateInfo
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+logger = logging.getLogger("griptape_nodes")
+
+
+class ManifestManager:
+    """Builds manifests describing the engine's registered libraries and project templates.
+
+    The manager owns no persistent state. It assembles a manifest on demand by
+    querying the existing library and project registries through their events.
+    """
+
+    def __init__(self, event_manager: EventManager) -> None:
+        """Initialize the ManifestManager.
+
+        Args:
+            event_manager: The EventManager instance to use for event handling.
+        """
+        event_manager.assign_manager_to_request_type(GenerateManifestRequest, self.on_generate_manifest_request)
+
+    async def on_generate_manifest_request(
+        self, request: GenerateManifestRequest
+    ) -> GenerateManifestResultSuccess | GenerateManifestResultFailure:
+        """Build a manifest from the engine's currently registered resources."""
+        libraries: list[LibraryManifestEntry] = []
+        if request.include_libraries:
+            list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
+            if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
+                return GenerateManifestResultFailure(
+                    result_details=f"Attempted to generate manifest. Failed to list registered libraries: {list_result.result_details}"
+                )
+            libraries = await self._build_library_entries(list_result.libraries)
+
+        projects: list[ProjectTemplateManifestEntry] = []
+        if request.include_project_templates:
+            # System builtins (the always-loaded default project) are included:
+            # they are real templates an engine can be working in, so consumers
+            # picking from the manifest must be able to reference them.
+            projects_result = await GriptapeNodes.ahandle_request(
+                ListProjectTemplatesRequest(include_system_builtins=True, broadcast_result=False)
+            )
+            if not isinstance(projects_result, ListProjectTemplatesResultSuccess):
+                return GenerateManifestResultFailure(
+                    result_details=f"Attempted to generate manifest. Failed to list project templates: {projects_result.result_details}"
+                )
+            projects = self._build_project_template_entries(projects_result.successfully_loaded)
+
+        manifest = Manifest(
+            generated_at=datetime.now(UTC).isoformat(),
+            engine_id=self._resolve_engine_id(),
+            engine_version=await self._resolve_engine_version(),
+            libraries=libraries,
+            project_templates=projects,
+        )
+
+        return GenerateManifestResultSuccess(
+            manifest=manifest,
+            result_details=f"Successfully generated manifest with {len(libraries)} library/libraries and {len(projects)} project template(s).",
+        )
+
+    async def _build_library_entries(self, library_names: list[str]) -> list[LibraryManifestEntry]:
+        """Build a manifest entry for each registered library.
+
+        A library whose metadata or source path cannot be resolved is still
+        included with whatever could be gathered, so one bad library does not
+        omit it from the manifest.
+        """
+        entries: list[LibraryManifestEntry] = []
+        for name in library_names:
+            metadata_result = await GriptapeNodes.ahandle_request(
+                GetLibraryMetadataRequest(library=name, broadcast_result=False)
+            )
+            metadata = None
+            if isinstance(metadata_result, GetLibraryMetadataResultSuccess):
+                metadata = metadata_result.metadata
+            else:
+                logger.warning(
+                    "Could not load metadata for library '%s' while generating manifest: %s",
+                    name,
+                    metadata_result.result_details,
+                )
+
+            source_result = await GriptapeNodes.ahandle_request(
+                GetLibrarySourceInfoRequest(library=name, broadcast_result=False)
+            )
+            path = None
+            if isinstance(source_result, GetLibrarySourceInfoResultSuccess):
+                path = source_result.library_json_path
+            else:
+                logger.warning(
+                    "Could not resolve source path for library '%s' while generating manifest: %s",
+                    name,
+                    source_result.result_details,
+                )
+
+            entries.append(
+                LibraryManifestEntry(
+                    name=name,
+                    path=path,
+                    version=metadata.library_version if metadata else None,
+                    author=metadata.author if metadata else None,
+                    description=metadata.description if metadata else None,
+                    tags=list(metadata.tags) if metadata else [],
+                )
+            )
+        return entries
+
+    def _build_project_template_entries(
+        self, project_infos: list[ProjectTemplateInfo]
+    ) -> list[ProjectTemplateManifestEntry]:
+        """Build a manifest entry for each successfully loaded project template.
+
+        ``path`` is populated for file-backed templates, where the registry's
+        ``project_id`` is the template file's canonical path. System builtins
+        carry a synthetic id and no file, so their ``path`` stays None.
+        """
+        entries: list[ProjectTemplateManifestEntry] = []
+        for info in project_infos:
+            entries.append(  # noqa: PERF401
+                ProjectTemplateManifestEntry(
+                    project_id=info.project_id,
+                    name=info.name,
+                    parent_project_path=info.parent_project_path,
+                    path=info.project_id if info.project_id != SYSTEM_DEFAULTS_KEY else None,
+                )
+            )
+        return entries
+
+    def _resolve_engine_id(self) -> str | None:
+        """Resolve the engine's identifier, or None when it cannot be determined."""
+        try:
+            return GriptapeNodes.EngineIdentityManager().engine_id
+        except Exception:
+            logger.warning("Could not resolve engine id while generating manifest.", exc_info=True)
+            return None
+
+    async def _resolve_engine_version(self) -> str | None:
+        """Resolve the engine version string, or None when it cannot be determined."""
+        version_result = await GriptapeNodes.ahandle_request(GetEngineVersionRequest(broadcast_result=False))
+        if isinstance(version_result, GetEngineVersionResultSuccess):
+            return f"{version_result.major}.{version_result.minor}.{version_result.patch}"
+        logger.warning(
+            "Could not resolve engine version while generating manifest: %s",
+            version_result.result_details,
+        )
+        return None

--- a/tests/unit/retained_mode/managers/test_manifest_manager.py
+++ b/tests/unit/retained_mode/managers/test_manifest_manager.py
@@ -1,0 +1,211 @@
+"""Tests for ManifestManager.on_generate_manifest_request."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryMetadata
+from griptape_nodes.retained_mode.events.app_events import GetEngineVersionResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    GetLibraryMetadataResultFailure,
+    GetLibraryMetadataResultSuccess,
+    GetLibrarySourceInfoResultSuccess,
+    ListRegisteredLibrariesResultFailure,
+    ListRegisteredLibrariesResultSuccess,
+)
+from griptape_nodes.retained_mode.events.manifest_events import (
+    GenerateManifestRequest,
+    GenerateManifestResultFailure,
+    GenerateManifestResultSuccess,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    ListProjectTemplatesRequest,
+    ListProjectTemplatesResultSuccess,
+    ProjectTemplateInfo,
+)
+from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
+from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+MODULE_PATH = "griptape_nodes.retained_mode.managers.manifest_manager"
+
+
+def _library_metadata() -> LibraryMetadata:
+    return LibraryMetadata(
+        author="Author A",
+        description="Library A description",
+        library_version="1.2.3",
+        engine_version="0.86.0",
+        tags=["image", "demo"],
+    )
+
+
+def _project_info() -> ProjectTemplateInfo:
+    info = MagicMock(spec=ProjectTemplateInfo)
+    info.project_id = "/workspace/projectA/griptape-nodes-project.yml"
+    info.name = "Project A"
+    info.parent_project_path = None
+    return info
+
+
+class TestManifestManager:
+    """Tests for manifest generation."""
+
+    @pytest.fixture
+    def manifest_manager(self) -> ManifestManager:
+        return ManifestManager(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_generate_manifest_includes_libraries_and_project_templates(
+        self, manifest_manager: ManifestManager
+    ) -> None:
+        """A full run includes libraries, project templates, engine id, and engine version."""
+        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
+            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
+            mock_gn.ahandle_request = AsyncMock(
+                side_effect=[
+                    ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
+                    GetLibraryMetadataResultSuccess(metadata=_library_metadata(), result_details="ok"),
+                    GetLibrarySourceInfoResultSuccess(
+                        library_name="Lib A",
+                        library_json_path="/libs/a/griptape_nodes_library.json",
+                        library_directory="/libs/a",
+                        result_details="ok",
+                    ),
+                    ListProjectTemplatesResultSuccess(
+                        successfully_loaded=[_project_info()],
+                        failed_to_load=[],
+                        result_details="ok",
+                    ),
+                    GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+                ]
+            )
+
+            result = await manifest_manager.on_generate_manifest_request(GenerateManifestRequest())
+
+        assert isinstance(result, GenerateManifestResultSuccess)
+        manifest = result.manifest
+        assert manifest.engine_id == "engine-uuid-1"
+        assert manifest.engine_version == "1.2.3"
+        assert manifest.generated_at  # populated with an ISO timestamp
+
+        # Project templates are requested with system builtins included, so the
+        # always-loaded default project is part of the manifest.
+        list_templates_request = mock_gn.ahandle_request.await_args_list[3].args[0]
+        assert isinstance(list_templates_request, ListProjectTemplatesRequest)
+        assert list_templates_request.include_system_builtins is True
+
+        assert len(manifest.libraries) == 1
+        library = manifest.libraries[0]
+        assert library.name == "Lib A"
+        assert library.path == "/libs/a/griptape_nodes_library.json"
+        assert library.version == "1.2.3"
+        assert library.author == "Author A"
+        assert library.description == "Library A description"
+        assert library.tags == ["image", "demo"]
+
+        assert len(manifest.project_templates) == 1
+        project = manifest.project_templates[0]
+        assert project.project_id == "/workspace/projectA/griptape-nodes-project.yml"
+        assert project.name == "Project A"
+        assert project.parent_project_path is None
+        assert project.path == "/workspace/projectA/griptape-nodes-project.yml"
+
+    @pytest.mark.asyncio
+    async def test_generate_manifest_fails_when_library_listing_fails(self, manifest_manager: ManifestManager) -> None:
+        """A failure listing libraries surfaces as a manifest generation failure."""
+        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(
+                side_effect=[ListRegisteredLibrariesResultFailure(result_details="registry down")]
+            )
+
+            result = await manifest_manager.on_generate_manifest_request(GenerateManifestRequest())
+
+        assert isinstance(result, GenerateManifestResultFailure)
+
+    @pytest.mark.asyncio
+    async def test_generate_manifest_includes_library_with_partial_metadata(
+        self, manifest_manager: ManifestManager
+    ) -> None:
+        """A library whose metadata fails is still included with what could be gathered."""
+        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
+            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
+            mock_gn.ahandle_request = AsyncMock(
+                side_effect=[
+                    ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
+                    GetLibraryMetadataResultFailure(result_details="not loaded"),
+                    GetLibrarySourceInfoResultSuccess(
+                        library_name="Lib A",
+                        library_json_path="/libs/a/griptape_nodes_library.json",
+                        library_directory="/libs/a",
+                        result_details="ok",
+                    ),
+                    ListProjectTemplatesResultSuccess(
+                        successfully_loaded=[],
+                        failed_to_load=[],
+                        result_details="ok",
+                    ),
+                    GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+                ]
+            )
+
+            result = await manifest_manager.on_generate_manifest_request(GenerateManifestRequest())
+
+        assert isinstance(result, GenerateManifestResultSuccess)
+        assert len(result.manifest.libraries) == 1
+        library = result.manifest.libraries[0]
+        assert library.name == "Lib A"
+        assert library.path == "/libs/a/griptape_nodes_library.json"
+        assert library.version is None
+        assert library.author is None
+        assert library.tags == []
+
+    @pytest.mark.asyncio
+    async def test_generate_manifest_includes_system_default_template(self, manifest_manager: ManifestManager) -> None:
+        """The system defaults template is included, with no path (it is not file-backed)."""
+        default_info = MagicMock(spec=ProjectTemplateInfo)
+        default_info.project_id = SYSTEM_DEFAULTS_KEY
+        default_info.name = "Default Project"
+        default_info.parent_project_path = None
+
+        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
+            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
+            mock_gn.ahandle_request = AsyncMock(
+                side_effect=[
+                    ListProjectTemplatesResultSuccess(
+                        successfully_loaded=[default_info],
+                        failed_to_load=[],
+                        result_details="ok",
+                    ),
+                    GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+                ]
+            )
+
+            result = await manifest_manager.on_generate_manifest_request(
+                GenerateManifestRequest(include_libraries=False)
+            )
+
+        assert isinstance(result, GenerateManifestResultSuccess)
+        assert len(result.manifest.project_templates) == 1
+        template = result.manifest.project_templates[0]
+        assert template.project_id == SYSTEM_DEFAULTS_KEY
+        assert template.name == "Default Project"
+        assert template.path is None
+
+    @pytest.mark.asyncio
+    async def test_generate_manifest_respects_toggles(self, manifest_manager: ManifestManager) -> None:
+        """Disabling both toggles only resolves the engine version."""
+        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
+            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
+            mock_gn.ahandle_request = AsyncMock(
+                side_effect=[GetEngineVersionResultSuccess(major=2, minor=0, patch=0, result_details="ok")]
+            )
+
+            result = await manifest_manager.on_generate_manifest_request(
+                GenerateManifestRequest(include_libraries=False, include_project_templates=False)
+            )
+
+        assert isinstance(result, GenerateManifestResultSuccess)
+        assert result.manifest.libraries == []
+        assert result.manifest.project_templates == []
+        assert result.manifest.engine_version == "2.0.0"
+        assert mock_gn.ahandle_request.await_count == 1


### PR DESCRIPTION
A UI that builds an interface around an engine's resources needs a single descriptive snapshot of what that engine currently knows about, rather than stitching together several per-resource queries itself. `GenerateManifestRequest` returns a `Manifest` describing the engine's registered libraries and loaded project templates, assembled on demand from live engine state.
```json
   {
     "schema_version": "0.1.0",
     "generated_at": "2026-06-15T17:42:10.512874+00:00",
     "engine_id": "8f3c1d2a-6b9e-4a17-b0d4-2e7c9f5a1b33",
     "engine_version": "0.86.0",
     "libraries": [
       {
         "name": "Griptape Nodes Library",
         "path": "/Users/you/.griptape_nodes/libraries/griptape_nodes_library/griptape_nodes_library.json",
         "version": "1.4.2",
         "author": "Griptape",
         "description": "Core nodes for building Griptape Nodes workflows.",
         "tags": ["core", "agents", "images"]
       },
       {
         "name": "My Sandbox Library",
         "path": "/Users/you/workspace/sandbox/griptape_nodes_library.json",
         "version": "0.1.0",
         "author": "you",
         "description": "Local experiments.",
         "tags": []
       },
       {
         "name": "Partially Loaded Library",
         "path": null,
         "version": null,
         "author": null,
         "description": null,
         "tags": []
       }
     ],
     "project_templates": [
       {
         "project_id": "/Users/you/workspace/projectA/griptape-nodes-project.yml",
         "name": "Project A",
         "parent_project_path": null,
         "path": "/Users/you/workspace/projectA/griptape-nodes-project.yml"
       },
       {
         "project_id": "/Users/you/workspace/projectB/griptape-nodes-project.yml",
         "name": "Project B",
         "parent_project_path": "/Users/you/workspace/projectA/griptape-nodes-project.yml",
         "path": "/Users/you/workspace/projectB/griptape-nodes-project.yml"
       },
       {
         "project_id": "__system_defaults__",
         "name": "Default Project",
         "parent_project_path": null,
         "path": null
       }
     ]
   }
```