### PR TITLE
feat(libraries): add arbitrary_python_execution node declaration

### DIFF
--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -2511,8 +2511,8 @@ The two usage declarations are independent. A node can carry any combination —
 
 Declares that a node executes arbitrary Python code supplied at runtime (for example, an artist-authored script). Node-level only. This is a security-relevant identity fact: consumers (UI) can warn an artist before the node runs. Absence of this declaration means the node does not execute arbitrary Python.
 
-| Field                       | Meaning                                                |
-| --------------------------- | ------------------------------------------------------ |
+| Field                       | Meaning                                                      |
+| --------------------------- | ------------------------------------------------------------ |
 | `executes_arbitrary_python` | `true` when the node runs unvetted, runtime-supplied Python. |
 
 ```jsonc

--- a/docs/developing_nodes/comprehensive_guide.md
+++ b/docs/developing_nodes/comprehensive_guide.md
@@ -2392,7 +2392,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
     - Category should be `app_events.on_app_initialization_complete`
     - Secrets are accessed via `GriptapeNodes.SecretsManager().get_secret()`
 - **metadata.dependencies**: PIP packages installed on library load
-- **metadata.declarations** / per-node **metadata.declarations**: typed identity properties (lifecycle stage) and a library-level model catalog plus per-node references into it. See [Library and Node Declarations](#library-and-node-declarations) below.
+- **metadata.declarations** / per-node **metadata.declarations**: typed identity properties (lifecycle stage, arbitrary Python execution) and a library-level model catalog plus per-node references into it. See [Library and Node Declarations](#library-and-node-declarations) below.
 - **widgets**: Register custom JS widget components (see [Custom Widget Components](#custom-widget-components))
 - **categories**: Group nodes in UI with colors and icons
 - **nodes**: List node classes, file paths, and metadata
@@ -2404,7 +2404,7 @@ Use flat directory structures. The engine automatically registers and loads libr
 
 ### Library and Node Declarations
 
-Declarations attach typed metadata to a library or to an individual node. Each entry in a `declarations` array is an object with a `type` discriminator that selects a declaration class. Today's vocabulary covers a lifecycle-stage property and a library-level model catalog with per-node references; future engine releases add more declaration types under the same field.
+Declarations attach typed metadata to a library or to an individual node. Each entry in a `declarations` array is an object with a `type` discriminator that selects a declaration class. Today's vocabulary covers a lifecycle-stage property, a library-level model catalog with per-node references, and an arbitrary-Python-execution property; future engine releases add more declaration types under the same field.
 
 Both `metadata.declarations` (library-level) and per-node `metadata.declarations` accept a list. Order in the list does not matter. The field defaults to `[]`, so libraries on older schema versions (`0.6.0`, `0.4.0`, `0.1.0`) load unchanged.
 
@@ -2506,6 +2506,20 @@ A node references one or more entire providers. Use this when a node dynamically
 ```
 
 The two usage declarations are independent. A node can carry any combination — for instance, "every model this provider offers, plus these two specific models from another provider."
+
+#### `arbitrary_python_execution`
+
+Declares that a node executes arbitrary Python code supplied at runtime (for example, an artist-authored script). Node-level only. This is a security-relevant identity fact: consumers (UI) can warn an artist before the node runs. Absence of this declaration means the node does not execute arbitrary Python.
+
+| Field                       | Meaning                                                |
+| --------------------------- | ------------------------------------------------------ |
+| `executes_arbitrary_python` | `true` when the node runs unvetted, runtime-supplied Python. |
+
+```jsonc
+"declarations": [
+  { "type": "arbitrary_python_execution", "executes_arbitrary_python": true }
+]
+```
 
 #### Combining declarations
 

--- a/src/griptape_nodes/node_library/library_declarations.py
+++ b/src/griptape_nodes/node_library/library_declarations.py
@@ -297,8 +297,24 @@ class ModelProviderUsageNodeProperty(BaseModel):
     provider_ids: list[str]
 
 
+class ArbitraryPythonExecutionNodeProperty(BaseModel):
+    """Declares that this node executes arbitrary Python code supplied at runtime.
+
+    A security-relevant identity fact: a node carrying this property runs Python
+    code that is not vetted at authoring time (e.g. an artist-supplied script).
+    Consumers (UI) can surface a warning before such a node runs. Absence of this
+    declaration means the node does not execute arbitrary Python.
+    """
+
+    type: Literal["arbitrary_python_execution"] = "arbitrary_python_execution"
+    executes_arbitrary_python: bool
+
+
 # See the comment above `LibraryDeclaration` for how `Annotated[... discriminator ...]` works.
 NodeDeclaration = Annotated[
-    LifecycleStageNodeProperty | ModelUsageNodeProperty | ModelProviderUsageNodeProperty,
+    LifecycleStageNodeProperty
+    | ModelUsageNodeProperty
+    | ModelProviderUsageNodeProperty
+    | ArbitraryPythonExecutionNodeProperty,
     Field(discriminator="type"),
 ]

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 
 from griptape_nodes.node_library.library_declarations import (
+    ArbitraryPythonExecutionNodeProperty,
     KeySupport,
     LifecycleStage,
     LifecycleStageLibraryProperty,
@@ -88,6 +89,17 @@ class TestDeclarationDiscriminator:
         decl = rebuilt.declarations[0]
         assert isinstance(decl, ModelUsageNodeProperty)
         assert decl.model_ids == ["claude_opus_byok"]
+
+    def test_node_arbitrary_python_execution_round_trips(self) -> None:
+        metadata = _make_node_metadata(
+            declarations=[ArbitraryPythonExecutionNodeProperty(executes_arbitrary_python=True)]
+        )
+
+        rebuilt = NodeMetadata.model_validate(metadata.model_dump())
+
+        decl = rebuilt.declarations[0]
+        assert isinstance(decl, ArbitraryPythonExecutionNodeProperty)
+        assert decl.executes_arbitrary_python is True
 
     def test_library_lifecycle_stage_round_trips(self) -> None:
         metadata = _make_library_metadata(
@@ -181,6 +193,36 @@ class TestRoundTripSerialization:
         assert node_decls[0].stage is LifecycleStage.ALPHA
         assert isinstance(node_decls[1], ModelUsageNodeProperty)
         assert node_decls[1].model_ids == ["claude_opus_byok"]
+
+
+# ---------- ArbitraryPythonExecutionNodeProperty ----------
+
+
+class TestArbitraryPythonExecutionNodeProperty:
+    def test_round_trips_each_value(self) -> None:
+        for executes in (True, False):
+            decl = ArbitraryPythonExecutionNodeProperty(executes_arbitrary_python=executes)
+
+            rebuilt = ArbitraryPythonExecutionNodeProperty.model_validate(json.loads(decl.model_dump_json()))
+
+            assert rebuilt.executes_arbitrary_python is executes
+
+    def test_executes_arbitrary_python_is_required(self) -> None:
+        # Single-value declarations require their value to be set explicitly;
+        # absence of the entire declaration is the only meaningful "default."
+        with pytest.raises(ValidationError):
+            ArbitraryPythonExecutionNodeProperty()  # type: ignore[call-arg]
+
+    def test_node_metadata_round_trips_declaration(self) -> None:
+        metadata = _make_node_metadata(
+            declarations=[ArbitraryPythonExecutionNodeProperty(executes_arbitrary_python=True)],
+        )
+
+        rebuilt = NodeMetadata.model_validate(metadata.model_dump())
+
+        decl = rebuilt.declarations[0]
+        assert isinstance(decl, ArbitraryPythonExecutionNodeProperty)
+        assert decl.executes_arbitrary_python is True
 
 
 # ---------- WorkerModeCompatibility ----------


### PR DESCRIPTION
Nodes like the standard library's `ExecutePython` run Python code supplied by the artist at runtime, which is not vetted at authoring time. Nothing in the library manifest currently surfaces that, so a consumer (the GUI) has no typed way to know a node will execute unvetted code and warn before it runs.

This adds an `arbitrary_python_execution` node-level declaration to the existing `NodeDeclaration` discriminated union, alongside `key_support` and `lifecycle_stage`. It carries a required `executes_arbitrary_python` boolean and follows the established convention where absence of the declaration is the default (node does not execute arbitrary Python). A boolean fits because the fact is genuinely binary, while keeping the same explicit-value-required shape as `WorkerModeCompatibility`.

The standard library's `ExecutePython` node will carry this declaration; that manifest change ships separately in the libraries repo.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4837.org.readthedocs.build/en/4837/

<!-- readthedocs-preview griptape-nodes end -->