### PR TITLE
feat(declarations): add get_declared_models helper to resolve a node's catalog models

### DIFF
--- a/src/griptape_nodes/node_library/library_declarations.py
+++ b/src/griptape_nodes/node_library/library_declarations.py
@@ -19,6 +19,7 @@ schema shape.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple
 
@@ -302,3 +303,58 @@ NodeDeclaration = Annotated[
     LifecycleStageNodeProperty | ModelUsageNodeProperty | ModelProviderUsageNodeProperty,
     Field(discriminator="type"),
 ]
+
+
+def _iter_referenced_models(
+    declaration: NodeDeclaration,
+    models_by_id: dict[str, ResolvedModel],
+    models_by_provider: dict[str, list[ResolvedModel]],
+) -> Iterator[ResolvedModel]:
+    """Yield the catalog models a single node declaration references.
+
+    Unresolved ids/providers yield nothing; the caller relies on library-load
+    validation to surface those as blocking problems.
+    """
+    if isinstance(declaration, ModelUsageNodeProperty):
+        for model_id in declaration.model_ids:
+            resolved = models_by_id.get(model_id)
+            if resolved is not None:
+                yield resolved
+    elif isinstance(declaration, ModelProviderUsageNodeProperty):
+        for provider_id in declaration.provider_ids:
+            yield from models_by_provider.get(provider_id, [])
+
+
+def resolve_node_models(
+    catalog: ModelCatalogLibraryProperty,
+    declarations: Sequence[NodeDeclaration],
+) -> list[ResolvedModel]:
+    """Resolve a node's model declarations against a catalog into concrete models.
+
+    Walks the node's ``model_usage`` (specific model ids) and
+    ``model_provider_usage`` (whole providers) declarations and returns the
+    matching models with their provider context. Results follow declaration
+    order, then catalog order within a ``model_provider_usage`` entry, and are
+    de-duplicated by ``(provider_id, model_id)`` so a model named both directly
+    and via its provider appears once.
+
+    References that do not resolve are skipped rather than raised: library load
+    already blocks unresolved references via ``validate_library_declarations``,
+    so a miss at runtime means the catalog shifted under a stale reference and
+    the node simply offers fewer models.
+    """
+    models_by_id: dict[str, ResolvedModel] = {}
+    models_by_provider: dict[str, list[ResolvedModel]] = defaultdict(list)
+    for resolved in iter_catalog_models(catalog):
+        models_by_id[resolved.model_id] = resolved
+        models_by_provider[resolved.provider_id].append(resolved)
+
+    ordered: list[ResolvedModel] = []
+    seen: set[tuple[str, str]] = set()
+    for declaration in declarations:
+        for resolved in _iter_referenced_models(declaration, models_by_id, models_by_provider):
+            key = (resolved.provider_id, resolved.model_id)
+            if key not in seen:
+                seen.add(key)
+                ordered.append(resolved)
+    return ordered

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -15,6 +15,7 @@ from griptape_nodes.node_library.library_declarations import (
     WorkerCompatibility,
     WorkerMode,
     WorkerModeCompatibility,
+    resolve_node_models,
 )
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries.duplicate_node_registration_problem import (
     DuplicateNodeRegistrationProblem,
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
 
     from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+    from griptape_nodes.node_library.library_declarations import ResolvedModel
     from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
 
 logger = logging.getLogger("griptape_nodes")
@@ -528,6 +530,29 @@ class Library:
     def get_library_data(self) -> LibrarySchema:
         return self._library_data
 
+    def get_models_for_node_type(self, node_type: str) -> list[ResolvedModel]:
+        """Resolve the catalog models a node type is declared to use.
+
+        Returns the models referenced by the node's ``model_usage`` /
+        ``model_provider_usage`` declarations, resolved against this library's
+        ``model_catalog`` declaration. Returns an empty list when the node
+        declares no model usage or the library declares no catalog.
+
+        Raises:
+            KeyError: if ``node_type`` is not registered in this library.
+        """
+        node_metadata = self._node_metadata.get(node_type)
+        if node_metadata is None:
+            msg = f"Node type '{node_type}' not found in library '{self._library_data.name}'"
+            raise KeyError(msg)
+        catalog = next(
+            (d for d in self._library_data.metadata.declarations if isinstance(d, ModelCatalogLibraryProperty)),
+            None,
+        )
+        if catalog is None:
+            return []
+        return resolve_node_models(catalog, node_metadata.declarations)
+
     def create_node(
         self,
         node_type: str,
@@ -613,3 +638,34 @@ class Library:
             if issubclass(node_class, base_type):
                 matching_nodes.append(node_type)
         return matching_nodes
+
+
+def get_declared_models(node: BaseNode) -> list[ResolvedModel]:
+    """Resolve the catalog models a node is declared to use.
+
+    Reads the ``library`` and ``node_type`` that ``Library.create_node`` injects
+    into the node's metadata, looks up that library, and resolves the node's
+    ``model_usage`` / ``model_provider_usage`` declarations against its
+    ``model_catalog``. A node calls this to build its model dropdown from the
+    catalog, passing only ``self`` -- it never restates its own library/type,
+    nothing is stored on the node, and nothing is serialized.
+
+    The catalog is library-local, so this is an in-process lookup that resolves
+    correctly in both the orchestrator and a worker subprocess, including from
+    ``__init__``. Each returned ``ResolvedModel`` carries the model descriptor
+    (``model.display_name``, ``model.provider_model_id``) the node needs to map
+    a dropdown selection back to the provider's model id.
+
+    Returns an empty list when the node declares no model usage, its library
+    declares no catalog, or the library/type cannot be resolved (e.g. a node
+    constructed outside the normal library path).
+    """
+    library_name = node.metadata.get("library")
+    node_type = node.metadata.get("node_type")
+    if not isinstance(library_name, str) or not isinstance(node_type, str):
+        return []
+    try:
+        library = LibraryRegistry.get_library(name=library_name)
+        return library.get_models_for_node_type(node_type)
+    except KeyError:
+        return []

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -24,6 +24,7 @@ from griptape_nodes.node_library.library_declarations import (
     WorkerModeCompatibility,
     iter_catalog_models,
     requires_worker_process,
+    resolve_node_models,
 )
 from griptape_nodes.node_library.library_registry import (
     CategoryDefinition,
@@ -544,3 +545,70 @@ class TestModelProviderUsageRoundTrip:
         decl = rebuilt.declarations[0]
         assert isinstance(decl, ModelProviderUsageNodeProperty)
         assert decl.provider_ids == ["anthropic"]
+
+
+class TestResolveNodeModels:
+    def test_model_usage_resolves_in_declaration_order(self) -> None:
+        catalog = _build_catalog()
+        decls = [ModelUsageNodeProperty(model_ids=["kling_v2", "claude_opus_byok"])]
+
+        resolved = resolve_node_models(catalog, decls)
+
+        assert [r.model_id for r in resolved] == ["kling_v2", "claude_opus_byok"]
+
+    def test_provider_usage_resolves_all_provider_models_in_catalog_order(self) -> None:
+        catalog = _build_catalog()
+        decls = [ModelProviderUsageNodeProperty(provider_ids=["anthropic"])]
+
+        resolved = resolve_node_models(catalog, decls)
+
+        assert [r.model_id for r in resolved] == ["claude_opus_byok", "claude_opus_griptape"]
+        assert {r.provider_id for r in resolved} == {"anthropic"}
+
+    def test_provider_usage_for_model_less_provider_is_empty(self) -> None:
+        # Ollama declares no models; a provider reference resolves to nothing,
+        # leaving the node to enumerate its models dynamically at runtime.
+        catalog = _build_catalog()
+
+        resolved = resolve_node_models(catalog, [ModelProviderUsageNodeProperty(provider_ids=["ollama"])])
+
+        assert resolved == []
+
+    def test_combination_dedups_keeping_first_occurrence(self) -> None:
+        # A model named directly and again via its provider appears once, at the
+        # position of its first mention.
+        catalog = _build_catalog()
+        decls = [
+            ModelUsageNodeProperty(model_ids=["claude_opus_byok"]),
+            ModelProviderUsageNodeProperty(provider_ids=["anthropic"]),
+        ]
+
+        resolved = resolve_node_models(catalog, decls)
+
+        assert [r.model_id for r in resolved] == ["claude_opus_byok", "claude_opus_griptape"]
+
+    def test_unresolved_references_are_skipped(self) -> None:
+        catalog = _build_catalog()
+        decls = [
+            ModelUsageNodeProperty(model_ids=["does_not_exist"]),
+            ModelProviderUsageNodeProperty(provider_ids=["also_missing"]),
+        ]
+
+        assert resolve_node_models(catalog, decls) == []
+
+    def test_non_model_declarations_are_ignored(self) -> None:
+        catalog = _build_catalog()
+        decls = [LifecycleStageNodeProperty(stage=LifecycleStage.BETA)]
+
+        assert resolve_node_models(catalog, decls) == []
+
+    def test_carries_provider_and_model_context(self) -> None:
+        catalog = _build_catalog()
+
+        resolved = resolve_node_models(catalog, [ModelUsageNodeProperty(model_ids=["claude_opus_byok"])])
+
+        (entry,) = resolved
+        assert entry.provider_id == "anthropic"
+        assert entry.model.provider_model_id == "claude-opus-4"
+        assert entry.model.family == "Claude 4"
+        assert entry.provider.display_name == "Anthropic"

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -12,14 +12,21 @@ import pytest
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.node_library.library_declarations import (
+    KeySupport,
     LifecycleStage,
     LifecycleStageNodeProperty,
+    Model,
+    ModelCatalogLibraryProperty,
+    ModelProvider,
+    ModelProviderUsageNodeProperty,
+    ModelUsageNodeProperty,
 )
 from griptape_nodes.node_library.library_registry import (
     LibraryMetadata,
     LibraryRegistry,
     LibrarySchema,
     NodeMetadata,
+    get_declared_models,
 )
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.library_events import (
@@ -2616,3 +2623,151 @@ class TestLibraryManagerInitializationFlag:
             await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
 
         assert library_manager.is_initializing() is False
+
+
+class _ModelProbe(BaseNode):
+    """Concrete BaseNode used to exercise model-catalog resolution end to end."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+
+
+class TestModelCatalogResolution:
+    """Library.get_models_for_node_type and the get_declared_models helper against a registered catalog."""
+
+    _LIBRARY_NAME = "model-catalog-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        LibraryRegistry._libraries.clear()
+        LibraryRegistry._node_aliases.clear()
+        LibraryRegistry._collision_node_names_to_library_names.clear()
+        LibraryRegistry._registered_widgets.clear()
+        yield
+        LibraryRegistry._libraries.clear()
+        LibraryRegistry._node_aliases.clear()
+        LibraryRegistry._collision_node_names_to_library_names.clear()
+        LibraryRegistry._registered_widgets.clear()
+
+    @staticmethod
+    def _catalog() -> ModelCatalogLibraryProperty:
+        return ModelCatalogLibraryProperty(
+            providers={
+                "anthropic": ModelProvider(
+                    display_name="Anthropic",
+                    models={
+                        "claude_opus_byok": Model(
+                            display_name="Claude Opus 4 (BYOK)",
+                            provider_model_id="claude-opus-4",
+                            key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                        ),
+                        "claude_sonnet_byok": Model(
+                            display_name="Claude Sonnet 4 (BYOK)",
+                            provider_model_id="claude-sonnet-4",
+                            key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                        ),
+                    },
+                ),
+                "ollama": ModelProvider(display_name="Ollama", key_support=KeySupport.NO_KEY_REQUIRED),
+            },
+        )
+
+    def _register_library(self, *, node_metadata: NodeMetadata, with_catalog: bool = True) -> None:
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="model catalog probe library",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=[self._catalog()] if with_catalog else [],
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_ModelProbe, node_metadata)
+
+    def _node_metadata(self, **kwargs: Any) -> NodeMetadata:
+        return NodeMetadata(category="test", description="probe", display_name="Probe", **kwargs)
+
+    def test_resolves_model_usage_against_catalog(self) -> None:
+        self._register_library(
+            node_metadata=self._node_metadata(
+                declarations=[ModelUsageNodeProperty(model_ids=["claude_opus_byok"])],
+            ),
+        )
+
+        library = LibraryRegistry.get_library(name=self._LIBRARY_NAME)
+        resolved = library.get_models_for_node_type(_ModelProbe.__name__)
+
+        assert [r.model_id for r in resolved] == ["claude_opus_byok"]
+        assert resolved[0].provider_id == "anthropic"
+
+    def test_resolves_provider_usage_against_catalog(self) -> None:
+        self._register_library(
+            node_metadata=self._node_metadata(
+                declarations=[ModelProviderUsageNodeProperty(provider_ids=["anthropic"])],
+            ),
+        )
+
+        library = LibraryRegistry.get_library(name=self._LIBRARY_NAME)
+        resolved = library.get_models_for_node_type(_ModelProbe.__name__)
+
+        assert [r.model_id for r in resolved] == ["claude_opus_byok", "claude_sonnet_byok"]
+
+    def test_no_catalog_returns_empty(self) -> None:
+        self._register_library(
+            node_metadata=self._node_metadata(
+                declarations=[ModelUsageNodeProperty(model_ids=["claude_opus_byok"])],
+            ),
+            with_catalog=False,
+        )
+
+        library = LibraryRegistry.get_library(name=self._LIBRARY_NAME)
+
+        assert library.get_models_for_node_type(_ModelProbe.__name__) == []
+
+    def test_unknown_node_type_raises_key_error(self) -> None:
+        self._register_library(node_metadata=self._node_metadata())
+
+        library = LibraryRegistry.get_library(name=self._LIBRARY_NAME)
+
+        with pytest.raises(KeyError, match="not found"):
+            library.get_models_for_node_type("NotARegisteredNode")
+
+    def test_get_declared_models_resolves_for_created_node(self) -> None:
+        # The headline path: a node hands itself to the helper and gets back the
+        # resolved models, carrying the display-name -> provider_model_id mapping
+        # it needs to build a dropdown. No request, no self-identification.
+        self._register_library(
+            node_metadata=self._node_metadata(
+                declarations=[ModelProviderUsageNodeProperty(provider_ids=["anthropic"])],
+            ),
+        )
+
+        node = LibraryRegistry.create_node(
+            node_type=_ModelProbe.__name__,
+            name="probe-helper",
+            specific_library_name=self._LIBRARY_NAME,
+        )
+
+        resolved = get_declared_models(node)
+
+        assert [r.model_id for r in resolved] == ["claude_opus_byok", "claude_sonnet_byok"]
+        assert resolved[0].model.display_name == "Claude Opus 4 (BYOK)"
+        assert resolved[0].model.provider_model_id == "claude-opus-4"
+
+    def test_get_declared_models_without_library_context_returns_empty(self) -> None:
+        # A node constructed outside the library path has no injected library/type,
+        # so the helper degrades to an empty list instead of raising.
+        node = _ModelProbe(name="orphan")
+
+        assert get_declared_models(node) == []
+
+    def test_get_declared_models_unknown_library_returns_empty(self) -> None:
+        node = _ModelProbe(name="stale", metadata={"library": "no-such-library", "node_type": _ModelProbe.__name__})
+
+        assert get_declared_models(node) == []


### PR DESCRIPTION
Standard-library nodes hand-copy their model lists into three places that have to agree: the Python `MODEL_CHOICES`/`MODEL_NAME_MAP` that builds the dropdown, the library-level `model_catalog`, and each node's `model_usage`/`model_provider_usage`. They drift, which is the staleness flagged on review of https://github.com/griptape-ai/griptape-nodes-library-standard/pull/338 (a deprecated model still listed, a real one missing).

This adds the engine-side piece that lets the `model_catalog` be the single source of truth. `resolve_node_models` walks a node's declarations against a catalog and returns the referenced `ResolvedModel`s with provider context, de-duplicated and ordered; `Library.get_models_for_node_type` runs it against a registered library. A node reaches it through the free helper `get_declared_models(node)`, which reads the `library`/`node_type` already injected into the node's metadata at creation, so the node passes only `self` and never restates its own identity.

A node uses it where it builds its model dropdown, replacing a hard-coded `MODEL_CHOICES` list:

```python
from griptape_nodes.node_library.library_registry import get_declared_models

class AnthropicPrompt(BasePrompt):
    def __init__(self, **kwargs) -> None:
        super().__init__(**kwargs)
        # Resolve the models this node declares (model_usage / model_provider_usage)
        # against the library's model_catalog. Each entry carries the display name
        # and the provider's model id.
        models = get_declared_models(self)
        self._model_ids = {m.model.display_name: m.model.provider_model_id for m in models}
        choices = list(self._model_ids)
        self._update_option_choices(param="model", choices=choices, default=choices[0])

    def _api_model_id(self) -> str:
        # Map the dropdown selection back to the provider's model id at call time.
        return self._model_ids[self.get_parameter_value("model")]
```

Each element is a `ResolvedModel` pairing the catalog ids with the model descriptor and its parent provider:

```python
ResolvedModel(
    provider_id="anthropic",
    model_id="anthropic_claude_opus_4_7",   # the catalog dict key (stable handle)
    model=Model(
        display_name="Claude Opus 4.7",
        provider_model_id="claude-opus-4-7",  # the id sent to the provider's API
        family="Claude 4.7",
        key_support="REQUIRES_CUSTOMER_KEY",
        terms_url=None,
        notes=None,
    ),
    provider=ModelProvider(display_name="Anthropic", ...),  # the full parent provider
)
```
