### PR TITLE
feat(agent): user-configurable agent instructions

### DIFF
--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -151,6 +151,7 @@ class PydanticAgentRunner:
     workspace_root: Path
     storage: BaseThreadStorageDriver
     instructions: str | None = None
+    system_prompt: str | None = None
     base_url: str | None = None
     mcp_servers: list[AbstractToolset[Any]] = field(default_factory=list)
     image_config: ImageGenerationToolsetConfig | None = None
@@ -166,11 +167,16 @@ class PydanticAgentRunner:
         toolsets: list[Any] = list(self.mcp_servers)
         instructions = self._build_instructions()
         capabilities = self._build_skills_capabilities()
+        agent_kwargs: dict[str, Any] = {
+            "instructions": instructions,
+            "toolsets": toolsets or None,
+            "capabilities": capabilities or None,
+        }
+        if self.system_prompt:
+            agent_kwargs["system_prompt"] = self.system_prompt
         self._agent = Agent(
             build_griptape_cloud_model(self.model_name, api_key=self.api_key, base_url=self.base_url),
-            instructions=instructions,
-            toolsets=toolsets or None,
-            capabilities=capabilities or None,
+            **agent_kwargs,
         )
         if self.image_config is not None:
             if self.static_files_manager is None:

--- a/src/griptape_nodes/retained_mode/events/agent_events.py
+++ b/src/griptape_nodes/retained_mode/events/agent_events.py
@@ -176,15 +176,12 @@ class ConfigureAgentRequest(RequestPayload):
     Args:
         prompt_driver: Dictionary of prompt driver configuration options
         image_generation_driver: Dictionary of image generation driver configuration options
-        instructions: Additional instructions appended to the agent's built-in system prompt.
-            Pass an empty string to clear user instructions. Pass None to leave unchanged.
 
     Results: ConfigureAgentResultSuccess | ConfigureAgentResultFailure (configuration error)
     """
 
     prompt_driver: dict = field(default_factory=dict)
     image_generation_driver: dict = field(default_factory=dict)
-    instructions: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/agent_events.py
+++ b/src/griptape_nodes/retained_mode/events/agent_events.py
@@ -176,12 +176,15 @@ class ConfigureAgentRequest(RequestPayload):
     Args:
         prompt_driver: Dictionary of prompt driver configuration options
         image_generation_driver: Dictionary of image generation driver configuration options
+        instructions: Additional instructions appended to the agent's built-in system prompt.
+            Pass an empty string to clear user instructions. Pass None to leave unchanged.
 
     Results: ConfigureAgentResultSuccess | ConfigureAgentResultFailure (configuration error)
     """
 
     prompt_driver: dict = field(default_factory=dict)
     image_generation_driver: dict = field(default_factory=dict)
+    instructions: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -179,7 +179,7 @@ class AgentManager:
         self._model_name: str = MODEL_CHOICES[0] if MODEL_CHOICES else "gpt-4o"
         self._image_model_name: str = IMAGE_MODEL_CHOICES[0] if IMAGE_MODEL_CHOICES else "gpt-image-1-mini"
         self._instructions: str = DEFAULT_AGENT_INSTRUCTIONS
-        self._user_instructions: str = config_manager.get_config_value("agent.instructions", default="")
+        self._system_prompt_extra: str = config_manager.get_config_value("agent.system_prompt", default="")
 
         self._threads_dir: Path = xdg_data_home() / "griptape_nodes" / "threads"
         self._thread_storage: LocalThreadStorageDriver = LocalThreadStorageDriver(
@@ -229,11 +229,11 @@ class AgentManager:
         threading.Thread(target=start_mcp_server, args=(sock,), daemon=True, name="mcp-server").start()
 
     def _on_config_changed(self, event: ConfigChanged) -> None:
-        if event.key not in ("agent.instructions", "agent", ""):
+        if event.key not in ("agent.system_prompt", "agent", ""):
             return
-        new_value = config_manager.get_config_value("agent.instructions", default="")
-        if new_value != self._user_instructions:
-            self._user_instructions = new_value
+        new_value = config_manager.get_config_value("agent.system_prompt", default="")
+        if new_value != self._system_prompt_extra:
+            self._system_prompt_extra = new_value
             self._runner_cache.clear()
 
     async def on_handle_run_agent_request(self, request: RunAgentRequest) -> ResultPayload:
@@ -540,8 +540,8 @@ class AgentManager:
         first so their non-negotiable behavioral rules cannot be overridden.
         """
         parts = [self._instructions]
-        if self._user_instructions.strip():
-            parts.append(self._user_instructions.strip())
+        if self._system_prompt_extra.strip():
+            parts.append(self._system_prompt_extra.strip())
         parts.extend(server_rules)
         return "\n\n".join(parts)
 

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -179,6 +179,7 @@ class AgentManager:
         self._model_name: str = MODEL_CHOICES[0] if MODEL_CHOICES else "gpt-4o"
         self._image_model_name: str = IMAGE_MODEL_CHOICES[0] if IMAGE_MODEL_CHOICES else "gpt-image-1-mini"
         self._instructions: str = DEFAULT_AGENT_INSTRUCTIONS
+        self._user_instructions: str = config_manager.get_config_value("agent_instructions", default="")
 
         self._threads_dir: Path = xdg_data_home() / "griptape_nodes" / "threads"
         self._thread_storage: LocalThreadStorageDriver = LocalThreadStorageDriver(
@@ -444,6 +445,12 @@ class AgentManager:
                 if new_image_model != self._image_model_name:
                     self._image_model_name = new_image_model
                     self._runner_cache.clear()
+            if request.instructions is not None:
+                new_instructions = request.instructions
+                if new_instructions != self._user_instructions:
+                    self._user_instructions = new_instructions
+                    config_manager.set_config_value("agent_instructions", new_instructions)
+                    self._runner_cache.clear()
         except Exception as e:
             details = f"Error configuring agent: {e}"
             logger.exception(details)
@@ -520,15 +527,17 @@ class AgentManager:
         return runner
 
     def _compose_instructions(self, server_rules: list[str]) -> str:
-        """Append any per-MCP-server `rules` to the base instructions.
+        """Compose the full system prompt from base, user, and per-server rules.
 
-        The previous harness injected each enabled MCP server's configured
-        ``rules`` as agent rulesets; this folds them into the system prompt so
-        that user-configured per-server guidance is not silently dropped.
+        Composition order: built-in base instructions → user instructions (if
+        set) → per-MCP-server rules (if any). The base instructions are always
+        first so their non-negotiable behavioral rules cannot be overridden.
         """
-        if not server_rules:
-            return self._instructions
-        return self._instructions + "\n\n" + "\n\n".join(server_rules)
+        parts = [self._instructions]
+        if self._user_instructions.strip():
+            parts.append(self._user_instructions.strip())
+        parts.extend(server_rules)
+        return "\n\n".join(parts)
 
     @staticmethod
     def _lookup_mcp_configs(server_names: list[str]) -> list[dict[str, Any]]:

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -522,6 +522,7 @@ class AgentManager:
             workspace_root=workspace_root,
             storage=self._thread_storage,
             instructions=self._compose_instructions(server_rules),
+            system_prompt=self._system_prompt_extra or None,
             mcp_servers=mcp_servers,
             image_config=ImageGenerationToolsetConfig(
                 api_key=api_key, model=self._image_model_name, base_url=cloud_base_url
@@ -533,15 +534,14 @@ class AgentManager:
         return runner
 
     def _compose_instructions(self, server_rules: list[str]) -> str:
-        """Compose the full system prompt from base, user, and per-server rules.
+        """Compose the instructions string from base rules and per-MCP-server rules.
 
-        Composition order: built-in base instructions → user instructions (if
-        set) → per-MCP-server rules (if any). The base instructions are always
-        first so their non-negotiable behavioral rules cannot be overridden.
+        Composition order: built-in base instructions → per-MCP-server rules (if
+        any). The base instructions are always first so their non-negotiable
+        behavioral rules cannot be overridden. User system prompt text is passed
+        separately via PydanticAgentRunner.system_prompt.
         """
         parts = [self._instructions]
-        if self._system_prompt_extra.strip():
-            parts.append(self._system_prompt_extra.strip())
         parts.extend(server_rules)
         return "\n\n".join(parts)
 

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -91,7 +91,7 @@ from griptape_nodes.retained_mode.events.agent_events import (
     UnarchiveThreadResultFailure,
     UnarchiveThreadResultSuccess,
 )
-from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete, ConfigChanged
 from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent, ResultPayload
 from griptape_nodes.retained_mode.events.mcp_events import (
     GetEnabledMCPServersRequest,
@@ -179,7 +179,7 @@ class AgentManager:
         self._model_name: str = MODEL_CHOICES[0] if MODEL_CHOICES else "gpt-4o"
         self._image_model_name: str = IMAGE_MODEL_CHOICES[0] if IMAGE_MODEL_CHOICES else "gpt-image-1-mini"
         self._instructions: str = DEFAULT_AGENT_INSTRUCTIONS
-        self._user_instructions: str = config_manager.get_config_value("agent_instructions", default="")
+        self._user_instructions: str = config_manager.get_config_value("agent.instructions", default="")
 
         self._threads_dir: Path = xdg_data_home() / "griptape_nodes" / "threads"
         self._thread_storage: LocalThreadStorageDriver = LocalThreadStorageDriver(
@@ -218,11 +218,23 @@ class AgentManager:
                 AppInitializationComplete,
                 self.on_app_initialization_complete,
             )
+            event_manager.add_listener_to_app_event(
+                ConfigChanged,
+                self._on_config_changed,
+            )
 
     def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         sock = bind_free_socket(GTN_MCP_SERVER_HOST, GTN_MCP_SERVER_PORT)
         self._mcp_server_port = sock.getsockname()[1]
         threading.Thread(target=start_mcp_server, args=(sock,), daemon=True, name="mcp-server").start()
+
+    def _on_config_changed(self, event: ConfigChanged) -> None:
+        if event.key not in ("agent.instructions", "agent", ""):
+            return
+        new_value = config_manager.get_config_value("agent.instructions", default="")
+        if new_value != self._user_instructions:
+            self._user_instructions = new_value
+            self._runner_cache.clear()
 
     async def on_handle_run_agent_request(self, request: RunAgentRequest) -> ResultPayload:
         try:
@@ -444,12 +456,6 @@ class AgentManager:
                 new_image_model = str(request.image_generation_driver["model"])
                 if new_image_model != self._image_model_name:
                     self._image_model_name = new_image_model
-                    self._runner_cache.clear()
-            if request.instructions is not None:
-                new_instructions = request.instructions
-                if new_instructions != self._user_instructions:
-                    self._user_instructions = new_instructions
-                    config_manager.set_config_value("agent_instructions", new_instructions)
                     self._runner_cache.clear()
         except Exception as e:
             details = f"Error configuring agent: {e}"

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -274,6 +274,13 @@ class WorkerSettings(BaseModel):
     )
 
 
+class AgentSettings(BaseModel):
+    instructions: str = Field(
+        default="",
+        description="Additional instructions appended to the agent's built-in system prompt. Use to customize tone, preferred patterns, or domain context.",
+    )
+
+
 class Settings(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -429,8 +436,7 @@ class Settings(BaseModel):
         default_factory=dict,
         description="Mapping of project file paths to workspace directory overrides. When a project is loaded, if its resolved path matches a key here, the corresponding value is used as the workspace directory instead of the project-adjacent config or auto-default.",
     )
-    agent_instructions: str = Field(
+    agent: AgentSettings = Field(
         category=AGENT,
-        default="",
-        description="Additional instructions appended to the agent's built-in system prompt. Use to customize tone, preferred patterns, or domain context.",
+        default_factory=AgentSettings,
     )

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -44,6 +44,7 @@ MCP_SERVERS = Category(name="MCP Servers", description="Model Context Protocol s
 PROJECTS = Category(name="Projects", description="Project template configurations and registrations")
 STATIC_SERVER = Category(name="Static Server", description="Static file server configuration for serving media assets")
 ARTIFACTS = Category(name="Artifacts", description="Settings for artifact providers and preview generation")
+AGENT = Category(name="Agent", description="Agent behavior and instructions")
 
 
 def Field(category: str | Category = "General", **kwargs) -> Any:
@@ -427,4 +428,9 @@ class Settings(BaseModel):
         category=PROJECTS,
         default_factory=dict,
         description="Mapping of project file paths to workspace directory overrides. When a project is loaded, if its resolved path matches a key here, the corresponding value is used as the workspace directory instead of the project-adjacent config or auto-default.",
+    )
+    agent_instructions: str = Field(
+        category=AGENT,
+        default="",
+        description="Additional instructions appended to the agent's built-in system prompt. Use to customize tone, preferred patterns, or domain context.",
     )

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -44,7 +44,7 @@ MCP_SERVERS = Category(name="MCP Servers", description="Model Context Protocol s
 PROJECTS = Category(name="Projects", description="Project template configurations and registrations")
 STATIC_SERVER = Category(name="Static Server", description="Static file server configuration for serving media assets")
 ARTIFACTS = Category(name="Artifacts", description="Settings for artifact providers and preview generation")
-AGENT = Category(name="Agent", description="Agent behavior and instructions")
+AGENT = Category(name="Agent", description="Agent behavior and system prompt")
 
 
 def Field(category: str | Category = "General", **kwargs) -> Any:
@@ -275,9 +275,9 @@ class WorkerSettings(BaseModel):
 
 
 class AgentSettings(BaseModel):
-    instructions: str = Field(
+    system_prompt: str = Field(
         default="",
-        description="Additional instructions appended to the agent's built-in system prompt. Use to customize tone, preferred patterns, or domain context.",
+        description="Additional text appended to the agent's built-in system prompt. Use to customize tone, preferred patterns, or domain context.",
     )
 
 

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -43,12 +43,12 @@ class TestComposeInstructions:
 
     def test_no_rules_returns_base_instructions(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._user_instructions = ""
+        agent_manager._system_prompt_extra = ""
         assert agent_manager._compose_instructions([]) == "BASE"
 
     def test_rules_are_appended_to_base_instructions(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._user_instructions = ""
+        agent_manager._system_prompt_extra = ""
         composed = agent_manager._compose_instructions(
             ["Rules for MCP server 'a':\nbe terse", "Rules for MCP server 'b':\nbe kind"]
         )
@@ -56,20 +56,20 @@ class TestComposeInstructions:
         assert "be terse" in composed
         assert "be kind" in composed
 
-    def test_user_instructions_are_included_between_base_and_server_rules(self, agent_manager: AgentManager) -> None:
+    def test_system_prompt_extra_are_included_between_base_and_server_rules(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._user_instructions = "USER"
+        agent_manager._system_prompt_extra = "USER"
         composed = agent_manager._compose_instructions(["SERVER"])
         assert composed.index("BASE") < composed.index("USER") < composed.index("SERVER")
 
-    def test_empty_user_instructions_are_not_included(self, agent_manager: AgentManager) -> None:
+    def test_empty_system_prompt_extra_are_not_included(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._user_instructions = ""
+        agent_manager._system_prompt_extra = ""
         assert agent_manager._compose_instructions([]) == "BASE"
 
-    def test_whitespace_only_user_instructions_are_not_included(self, agent_manager: AgentManager) -> None:
+    def test_whitespace_only_system_prompt_extra_are_not_included(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._user_instructions = "   "
+        agent_manager._system_prompt_extra = "   "
         assert agent_manager._compose_instructions([]) == "BASE"
 
 

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -39,38 +39,20 @@ def agent_manager() -> AgentManager:
 
 
 class TestComposeInstructions:
-    """Per-MCP-server `rules` are folded into the system prompt, not dropped."""
+    """Per-MCP-server `rules` are folded into the instructions string, not dropped."""
 
     def test_no_rules_returns_base_instructions(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._system_prompt_extra = ""
         assert agent_manager._compose_instructions([]) == "BASE"
 
     def test_rules_are_appended_to_base_instructions(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
-        agent_manager._system_prompt_extra = ""
         composed = agent_manager._compose_instructions(
             ["Rules for MCP server 'a':\nbe terse", "Rules for MCP server 'b':\nbe kind"]
         )
         assert composed.startswith("BASE")
         assert "be terse" in composed
         assert "be kind" in composed
-
-    def test_system_prompt_extra_are_included_between_base_and_server_rules(self, agent_manager: AgentManager) -> None:
-        agent_manager._instructions = "BASE"
-        agent_manager._system_prompt_extra = "USER"
-        composed = agent_manager._compose_instructions(["SERVER"])
-        assert composed.index("BASE") < composed.index("USER") < composed.index("SERVER")
-
-    def test_empty_system_prompt_extra_are_not_included(self, agent_manager: AgentManager) -> None:
-        agent_manager._instructions = "BASE"
-        agent_manager._system_prompt_extra = ""
-        assert agent_manager._compose_instructions([]) == "BASE"
-
-    def test_whitespace_only_system_prompt_extra_are_not_included(self, agent_manager: AgentManager) -> None:
-        agent_manager._instructions = "BASE"
-        agent_manager._system_prompt_extra = "   "
-        assert agent_manager._compose_instructions([]) == "BASE"
 
 
 class TestOnHandleListAgentModelsRequest:

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -43,16 +43,34 @@ class TestComposeInstructions:
 
     def test_no_rules_returns_base_instructions(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
+        agent_manager._user_instructions = ""
         assert agent_manager._compose_instructions([]) == "BASE"
 
     def test_rules_are_appended_to_base_instructions(self, agent_manager: AgentManager) -> None:
         agent_manager._instructions = "BASE"
+        agent_manager._user_instructions = ""
         composed = agent_manager._compose_instructions(
             ["Rules for MCP server 'a':\nbe terse", "Rules for MCP server 'b':\nbe kind"]
         )
         assert composed.startswith("BASE")
         assert "be terse" in composed
         assert "be kind" in composed
+
+    def test_user_instructions_are_included_between_base_and_server_rules(self, agent_manager: AgentManager) -> None:
+        agent_manager._instructions = "BASE"
+        agent_manager._user_instructions = "USER"
+        composed = agent_manager._compose_instructions(["SERVER"])
+        assert composed.index("BASE") < composed.index("USER") < composed.index("SERVER")
+
+    def test_empty_user_instructions_are_not_included(self, agent_manager: AgentManager) -> None:
+        agent_manager._instructions = "BASE"
+        agent_manager._user_instructions = ""
+        assert agent_manager._compose_instructions([]) == "BASE"
+
+    def test_whitespace_only_user_instructions_are_not_included(self, agent_manager: AgentManager) -> None:
+        agent_manager._instructions = "BASE"
+        agent_manager._user_instructions = "   "
+        assert agent_manager._compose_instructions([]) == "BASE"
 
 
 class TestOnHandleListAgentModelsRequest:


### PR DESCRIPTION
## Summary

Closes #4852

- Adds a new `AGENT` category to `Settings` with a nested `AgentSettings` model containing a `system_prompt` field (type `str`, default `""`) — persisted to the user's config JSON under `agent.system_prompt`
- `AgentManager` loads the saved value on init, listens for `ConfigChanged` to pick up frontend writes, clears the runner cache when the value changes, and passes it to `PydanticAgentRunner` as `system_prompt` (static, per Pydantic AI's distinction from dynamic `instructions`)
- `PydanticAgentRunner` gains a `system_prompt` field and conditionally passes it to `Agent()` at construction time
- MCP server rules remain in `instructions` (dynamic/per-run); user system prompt text is separate

## Frontend API

**Read current system prompt:**
```json
{ "type": "GetConfigValueRequest", "category_and_key": "agent.system_prompt" }
// → { "ok": true, "value": "..." }  (empty string if never set)
```

**Set system prompt:**
```json
{ "type": "SetConfigValueRequest", "category_and_key": "agent.system_prompt", "value": "Always respond concisely." }
```

**Clear system prompt:**
```json
{ "type": "SetConfigValueRequest", "category_and_key": "agent.system_prompt", "value": "" }
```

No restart required — `AgentManager` reacts to the `ConfigChanged` event fired after the write and clears the runner cache automatically.

## Test plan

- [ ] Set `agent.system_prompt` via `SetConfigValueRequest` — confirm value appears in `~/.config/griptape_nodes/griptape_nodes_config.json` as `{"agent": {"system_prompt": "..."}}`
- [ ] Restart engine — confirm `_system_prompt_extra` is restored from config (not reset to `""`)
- [ ] Run the sidebar agent — confirm the custom system prompt influences the response
- [ ] Set `agent.system_prompt` to `""` — confirm runner cache is cleared and blank value doesn't add an empty section to the prompt
- [ ] Set an unrelated config value — confirm the runner cache is NOT cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)