### PR TITLE
fix(nodes): construct introspection probes with the node's library context

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1682,8 +1682,16 @@ class LibraryManager:
             # parameter-mutation detector skips this ephemeral probe's
             # declarative ``add_parameter`` calls (this construction
             # bypasses ``LibraryRegistry.create_node``).
+            #
+            # Pass the node's library and type so declarative ``__init__`` logic
+            # that resolves against the library -- e.g. ``get_declared_models``
+            # populating a model dropdown from the ``model_catalog`` -- works
+            # during the probe just as it does under ``create_node``.
             with LibraryRegistry.constructing_node():
-                probe_node = node_class(name=probe_name)
+                probe_node = node_class(
+                    name=probe_name,
+                    metadata={"library": library_name, "node_type": request.node_type},
+                )
         except Exception as err:
             probe_error = f"{type(err).__name__}: {err}"
             return DescribeNodeTypeResultSuccess(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3259,11 +3259,22 @@ class NodeManager:
             # Wrap in ``LibraryRegistry.constructing_node()`` so the parameter-mutation
             # detector skips this ephemeral instance's declarative ``add_parameter``
             # calls (this construction bypasses ``LibraryRegistry.create_node``).
+            #
+            # Carry the node's library and type so the reference resolves the same
+            # library-backed ``__init__`` data the live node did (e.g. a model
+            # dropdown sourced from the ``model_catalog``); otherwise it would look
+            # mutated.
             if isinstance(node, ErrorProxyNode):
                 reference_node = None
             else:
                 with LibraryRegistry.constructing_node():
-                    reference_node = type(node)(name="REFERENCE NODE")
+                    reference_node = type(node)(
+                        name="REFERENCE NODE",
+                        metadata={
+                            "library": node.metadata.get("library"),
+                            "node_type": node.metadata.get("node_type"),
+                        },
+                    )
 
             # Now creation or alteration of all of the elements.
             element_modification_commands = []

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1506,6 +1506,29 @@ class _RaisingProbe(BaseNode):
         raise RuntimeError(msg)
 
 
+class _CatalogProbe(BaseNode):
+    """Probe whose __init__ sources a parameter default from the library model_catalog.
+
+    Exercises the describe/reference probes resolving library-backed __init__ data
+    via get_declared_models -- which only works when the node is constructed with
+    its library/node_type, the way create_node does it.
+    """
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+        resolved = ",".join(r.model.provider_model_id or "" for r in get_declared_models(self))
+        self.add_parameter(
+            Parameter(
+                name="resolved_models",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                default_value=resolved,
+                tooltip="Comma-joined provider model ids resolved from the catalog.",
+            )
+        )
+
+
 class TestDescribeNodeTypeRequest:
     """Exercise LibraryManager.describe_node_type_request."""
 
@@ -1547,6 +1570,60 @@ class TestDescribeNodeTypeRequest:
                 display_name="Probe",
             ),
         )
+
+    def test_probe_resolves_library_model_catalog(self, griptape_nodes: GriptapeNodes) -> None:
+        # The probe must be constructed with the node's library/type so __init__
+        # logic that resolves against the model_catalog (get_declared_models)
+        # works -- otherwise the catalog is invisible and the roster is empty.
+        library_manager = griptape_nodes.LibraryManager()
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="catalog probe library",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=[
+                    ModelCatalogLibraryProperty(
+                        providers={
+                            "acme": ModelProvider(
+                                display_name="Acme",
+                                models={
+                                    "m1": Model(
+                                        display_name="M1",
+                                        provider_model_id="acme-m1",
+                                        key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(
+            _CatalogProbe,
+            NodeMetadata(
+                category="test",
+                description="Catalog-backed probe",
+                display_name="CatalogProbe",
+                declarations=[ModelUsageNodeProperty(model_ids=["m1"])],
+            ),
+        )
+
+        result = library_manager.describe_node_type_request(
+            DescribeNodeTypeRequest(node_type=_CatalogProbe.__name__, library=self._LIBRARY_NAME),
+        )
+
+        assert isinstance(result, DescribeNodeTypeResultSuccess)
+        by_name = {param.name: param for param in result.parameters}
+        # Resolved from the catalog -> non-empty. Without library context it would be "".
+        assert by_name["resolved_models"].default_value == "acme-m1"
 
     def test_returns_parameter_schema_without_touching_object_manager(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()


### PR DESCRIPTION
Nodes are normally created through `LibraryRegistry.create_node`, which injects `library` and `node_type` into the node's metadata. Two paths deliberately bypass `create_node` and construct `node_class(name=...)` directly: the `DescribeNodeType` introspection probe in `LibraryManager`, and the canonical reference node the parameter-mutation detector builds in `NodeManager`. Those instances have no library context.

That was harmless until a node's `__init__` started resolving against its library. With `get_declared_models`, a node sources its model dropdown from the library's `model_catalog`, which only resolves when the node knows its own `library`/`node_type`. Under these two probes it resolved to nothing: the introspection probe reported an empty dropdown (and a node that sets a required default from the catalog would fail to construct there), and the reference node came back without the catalog-backed choices, so the live node looked mutated against it.

Both sites now pass the node's `library`/`node_type` in `metadata`, the same keys `create_node` injects, so library-backed `__init__` logic resolves identically whether a node is created for a flow or constructed for introspection. The describe probe uses the request's library and type; the reference node copies them from the live node it mirrors.

This unblocks sourcing node model dropdowns from the `model_catalog` (the griptape-nodes-library-standard side), so a node can declare its models once in the catalog and resolve them at construction without restating the list.
