### PR TITLE
feature: implement Engine requests for sequence detection and grouping in directory listing

### DIFF
--- a/src/griptape_nodes/common/sequences/__init__.py
+++ b/src/griptape_nodes/common/sequences/__init__.py
@@ -33,6 +33,7 @@ from griptape_nodes.common.sequences.models import (
     NoTokenBehavior,
     Sequence,
     SequenceEntry,
+    SequenceScanOptions,
 )
 
 __all__ = [
@@ -43,4 +44,5 @@ __all__ = [
     "NoTokenBehavior",
     "Sequence",
     "SequenceEntry",
+    "SequenceScanOptions",
 ]

--- a/src/griptape_nodes/common/sequences/models.py
+++ b/src/griptape_nodes/common/sequences/models.py
@@ -1,14 +1,16 @@
 """Data shapes for the sequences module.
 
-Four concepts:
+Five concepts:
     - `MissingItemPolicy`: how to fill gaps inside a sequence's range.
     - `NoTokenBehavior`: what to do when the input has no sequence token at all.
+    - `SequenceScanOptions`: bundled options for sequence detection and filtering.
     - `Sequence`: one contiguous-or-gap-aware sequence with metadata.
     - `SequenceEntry`: one item inside a Sequence (number + path).
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
 
 from pydantic import BaseModel, Field, computed_field
@@ -58,6 +60,29 @@ class NoTokenBehavior(StrEnum):
     SINGLE_FILE = "single_file"
     EXPLORE_SEQUENCE = "explore_sequence"
     REJECT = "reject"
+
+
+@dataclass
+class SequenceScanOptions:
+    """Options controlling how sequences are detected and filtered.
+
+    Attributes:
+        policy: How to handle gaps in the detected range.
+        no_token_behavior: Whether to include or reject sequences with no
+            explicit sequence token (e.g. plain ``readme.txt``).
+        start_number: Lower bound (inclusive) for the active frame subset.
+            Must be >= 0 if supplied.
+        end_number: Upper bound (inclusive) for the active frame subset.
+            Must be >= ``start_number`` if both supplied.
+        padding: If set, only include sequences whose zero-fill width equals
+            this value (e.g. ``padding=4`` matches ``####`` sequences only).
+    """
+
+    policy: MissingItemPolicy = MissingItemPolicy.SKIP
+    no_token_behavior: NoTokenBehavior = NoTokenBehavior.REJECT
+    start_number: int | None = None
+    end_number: int | None = None
+    padding: int | None = None
 
 
 # Truncate the inline preview of gap numbers in MissingItemError's __str__

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -546,7 +546,7 @@ def scan_sequences_from_filenames(
         if options.padding is not None and fseq.zfill() != options.padding:
             continue
 
-        present_numbers, dropped, bare_names = _collect_present_numbers_from_fseq(fseq, directory)
+        present_numbers, dropped = _collect_present_numbers_from_fseq(fseq, directory)
         if not present_numbers:
             continue
 
@@ -556,7 +556,7 @@ def scan_sequences_from_filenames(
         if active.first > active.last:
             continue
 
-        consumed_filenames.update(bare_names)
+        consumed_filenames.update(fseq.frame(n) for n in present_numbers if active.first <= n <= active.last)
         result_sequences.extend(
             apply_policy(
                 PolicyContext(
@@ -579,20 +579,18 @@ def scan_sequences_from_filenames(
 def _collect_present_numbers_from_fseq(
     fseq: FileSequence,
     directory: str,
-) -> tuple[dict[int, str], int, set[str]]:
+) -> tuple[dict[int, str], int]:
     """Build a present-numbers map from a ``FileSequence``'s frame set.
 
-    Returns ``(present_numbers, dropped_negative_count, bare_filenames)``
+    Returns ``(present_numbers, dropped_negative_count)``
     where ``present_numbers`` maps frame number to the full path string
-    (using ``directory`` as the prefix) and ``bare_filenames`` is the set
-    of bare names that were consumed.
+    (using ``directory`` as the prefix).
     """
     present_numbers: dict[int, str] = {}
-    bare_filenames: set[str] = set()
     dropped = 0
     frame_set = fseq.frameSet()
     if frame_set is None:
-        return present_numbers, dropped, bare_filenames
+        return present_numbers, dropped
     for n in frame_set:
         if not isinstance(n, int):
             continue
@@ -602,8 +600,7 @@ def _collect_present_numbers_from_fseq(
         bare = fseq.frame(n)
         full = str(Path(directory) / bare) if directory else bare
         present_numbers[n] = full
-        bare_filenames.add(bare)
-    return present_numbers, dropped, bare_filenames
+    return present_numbers, dropped
 
 
 def _list_directory_filenames(directory: str) -> list[str]:

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -556,22 +556,25 @@ def scan_sequences_from_filenames(
         if active.first > active.last:
             continue
 
-        consumed_filenames.update(fseq.frame(n) for n in present_numbers if active.first <= n <= active.last)
-        result_sequences.extend(
-            apply_policy(
-                PolicyContext(
-                    fseq=fseq,
-                    present_numbers=present_numbers,
-                    directory=directory,
-                    policy=options.policy,
-                    first=active.first,
-                    last=active.last,
-                    discovered_first=discovered_first,
-                    discovered_last=discovered_last,
-                    dropped_negative_number_count=dropped,
-                )
+        new_sequences = apply_policy(
+            PolicyContext(
+                fseq=fseq,
+                present_numbers=present_numbers,
+                directory=directory,
+                policy=options.policy,
+                first=active.first,
+                last=active.last,
+                discovered_first=discovered_first,
+                discovered_last=discovered_last,
+                dropped_negative_number_count=dropped,
             )
         )
+        # A single matching file is not a sequence — leave it as a flat entry.
+        kept = [s for s in new_sequences if len(s.present_numbers) > 1]
+        if kept:
+            kept_numbers = set().union(*(s.present_numbers for s in kept))
+            consumed_filenames.update(fseq.frame(n) for n in kept_numbers)
+            result_sequences.extend(kept)
 
     return result_sequences, consumed_filenames
 

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -37,6 +37,7 @@ from griptape_nodes.common.sequences.models import (
     MissingItemPolicy,
     NoTokenBehavior,
     Sequence,
+    SequenceScanOptions,
 )
 from griptape_nodes.common.sequences.policies import PolicyContext, apply_policy
 from griptape_nodes.retained_mode.events.os_events import (
@@ -494,6 +495,117 @@ def _compute_active_range(
     return _ActiveRange(first=active_first, last=active_last)
 
 
+def scan_sequences_from_filenames(
+    filenames: list[str],
+    directory: str,
+    options: SequenceScanOptions | None = None,
+) -> tuple[list[Sequence], set[str]]:
+    """Detect all sequences within a pre-existing list of bare filenames.
+
+    No filesystem I/O is performed — callers are responsible for supplying
+    the filenames themselves (e.g. from a prior directory listing). The
+    second return value is the set of bare filenames that were grouped into
+    at least one ``Sequence``; callers can use it to filter those entries
+    out of a directory listing.
+
+    Args:
+        filenames: Bare filenames (no directory prefix) to inspect.
+        directory: The directory string stored in emitted ``Sequence.directory``
+            and ``SequenceEntry.path`` fields. May be macro-form or absolute.
+        options: Detection and policy options. Defaults to
+            ``SequenceScanOptions()`` (SKIP policy, REJECT token-less files).
+
+    Returns:
+        ``(sequences, consumed_filenames)`` where ``consumed_filenames`` is
+        the set of bare filenames that belong to at least one returned
+        ``Sequence``.
+
+    Raises:
+        InvalidSubsetBoundsError: If ``options.start_number`` < 0 or
+            ``options.end_number`` < ``options.start_number``.
+        MissingItemError: If ``options.policy`` is ABORT and a gap is found
+            inside the active range.
+    """
+    if options is None:
+        options = SequenceScanOptions()
+
+    _validate_subset_bounds(options.start_number, options.end_number)
+
+    all_detected = FileSequence.findSequencesInList(filenames, pad_style=PAD_STYLE)
+
+    result_sequences: list[Sequence] = []
+    consumed_filenames: set[str] = set()
+
+    for fseq in all_detected:
+        frame_set = fseq.frameSet()
+        if frame_set is None or not list(frame_set):
+            continue
+        if options.no_token_behavior == NoTokenBehavior.REJECT and fseq.zfill() == 0:
+            continue
+        if options.padding is not None and fseq.zfill() != options.padding:
+            continue
+
+        present_numbers, dropped, bare_names = _collect_present_numbers_from_fseq(fseq, directory)
+        if not present_numbers:
+            continue
+
+        consumed_filenames.update(bare_names)
+
+        discovered_first = min(present_numbers)
+        discovered_last = max(present_numbers)
+        active = _compute_active_range(options.start_number, options.end_number, discovered_first, discovered_last)
+        if active.first > active.last:
+            continue
+
+        result_sequences.extend(
+            apply_policy(
+                PolicyContext(
+                    fseq=fseq,
+                    present_numbers=present_numbers,
+                    directory=directory,
+                    policy=options.policy,
+                    first=active.first,
+                    last=active.last,
+                    discovered_first=discovered_first,
+                    discovered_last=discovered_last,
+                    dropped_negative_number_count=dropped,
+                )
+            )
+        )
+
+    return result_sequences, consumed_filenames
+
+
+def _collect_present_numbers_from_fseq(
+    fseq: FileSequence,
+    directory: str,
+) -> tuple[dict[int, str], int, set[str]]:
+    """Build a present-numbers map from a ``FileSequence``'s frame set.
+
+    Returns ``(present_numbers, dropped_negative_count, bare_filenames)``
+    where ``present_numbers`` maps frame number to the full path string
+    (using ``directory`` as the prefix) and ``bare_filenames`` is the set
+    of bare names that were consumed.
+    """
+    present_numbers: dict[int, str] = {}
+    bare_filenames: set[str] = set()
+    dropped = 0
+    frame_set = fseq.frameSet()
+    if frame_set is None:
+        return present_numbers, dropped, bare_filenames
+    for n in frame_set:
+        if not isinstance(n, int):
+            continue
+        if n < 0:
+            dropped += 1
+            continue
+        bare = fseq.frame(n)
+        full = f"{directory}/{bare}" if directory else bare
+        present_numbers[n] = full
+        bare_filenames.add(bare)
+    return present_numbers, dropped, bare_filenames
+
+
 def _list_directory_filenames(directory: str) -> list[str]:
     """List `directory` via ListDirectoryRequest, returning bare filenames.
 
@@ -515,6 +627,7 @@ def _list_directory_filenames(directory: str) -> list[str]:
             include_mime_type=False,
             include_absolute_path=False,
             broadcast_result=False,
+            group_sequences=False,
         )
     )
     if not isinstance(result, ListDirectoryResultSuccess):

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -546,12 +546,12 @@ def scan_sequences_from_filenames(
         if options.padding is not None and fseq.zfill() != options.padding:
             continue
 
-        present_numbers, dropped = _collect_present_numbers_from_fseq(fseq, directory)
-        if not present_numbers:
+        collected = _collect_present_numbers_from_fseq(fseq, directory)
+        if not collected.by_number:
             continue
 
-        discovered_first = min(present_numbers)
-        discovered_last = max(present_numbers)
+        discovered_first = min(collected.by_number)
+        discovered_last = max(collected.by_number)
         active = _compute_active_range(options.start_number, options.end_number, discovered_first, discovered_last)
         if active.first > active.last:
             continue
@@ -559,14 +559,14 @@ def scan_sequences_from_filenames(
         new_sequences = apply_policy(
             PolicyContext(
                 fseq=fseq,
-                present_numbers=present_numbers,
+                present_numbers=collected.by_number,
                 directory=directory,
                 policy=options.policy,
                 first=active.first,
                 last=active.last,
                 discovered_first=discovered_first,
                 discovered_last=discovered_last,
-                dropped_negative_number_count=dropped,
+                dropped_negative_number_count=collected.dropped_negatives,
             )
         )
         # A single matching file is not a sequence — leave it as a flat entry.
@@ -582,28 +582,28 @@ def scan_sequences_from_filenames(
 def _collect_present_numbers_from_fseq(
     fseq: FileSequence,
     directory: str,
-) -> tuple[dict[int, str], int]:
+) -> _PresentNumbers:
     """Build a present-numbers map from a ``FileSequence``'s frame set.
 
-    Returns ``(present_numbers, dropped_negative_count)``
-    where ``present_numbers`` maps frame number to the full path string
-    (using ``directory`` as the prefix).
+    Returns a ``_PresentNumbers`` where ``by_number`` maps frame number to the
+    full path string (using ``directory`` as the prefix) and
+    ``dropped_negatives`` is the count of negative frame numbers skipped.
     """
-    present_numbers: dict[int, str] = {}
-    dropped = 0
+    by_number: dict[int, str] = {}
+    dropped_negatives = 0
     frame_set = fseq.frameSet()
     if frame_set is None:
-        return present_numbers, dropped
+        return _PresentNumbers(by_number=by_number, dropped_negatives=dropped_negatives)
     for n in frame_set:
         if not isinstance(n, int):
             continue
         if n < 0:
-            dropped += 1
+            dropped_negatives += 1
             continue
         bare = fseq.frame(n)
         full = str(Path(directory) / bare) if directory else bare
-        present_numbers[n] = full
-    return present_numbers, dropped
+        by_number[n] = full
+    return _PresentNumbers(by_number=by_number, dropped_negatives=dropped_negatives)
 
 
 def _list_directory_filenames(directory: str) -> list[str]:

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import NamedTuple, Protocol, runtime_checkable
 
 from fileseq.constants import PAD_STYLE_HASH1
@@ -549,14 +550,13 @@ def scan_sequences_from_filenames(
         if not present_numbers:
             continue
 
-        consumed_filenames.update(bare_names)
-
         discovered_first = min(present_numbers)
         discovered_last = max(present_numbers)
         active = _compute_active_range(options.start_number, options.end_number, discovered_first, discovered_last)
         if active.first > active.last:
             continue
 
+        consumed_filenames.update(bare_names)
         result_sequences.extend(
             apply_policy(
                 PolicyContext(
@@ -600,7 +600,7 @@ def _collect_present_numbers_from_fseq(
             dropped += 1
             continue
         bare = fseq.frame(n)
-        full = f"{directory}/{bare}" if directory else bare
+        full = str(Path(directory) / bare) if directory else bare
         present_numbers[n] = full
         bare_filenames.add(bare)
     return present_numbers, dropped, bare_filenames

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
-from griptape_nodes.common.sequences.models import MissingItemPolicy, NoTokenBehavior, Sequence
+from griptape_nodes.common.sequences.models import MissingItemPolicy, NoTokenBehavior, Sequence, SequenceScanOptions
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -165,6 +165,12 @@ class ListDirectoryRequest(RequestPayload):
         include_modified_time: If True, include modified time in results (default: True). Set to False for faster listing.
         include_mime_type: If True, include MIME type in results (default: True). Set to False for faster listing.
         include_absolute_path: If True, include absolute resolved path in results (default: True). Set to False for faster listing.
+        group_sequences: If True (default), files that form a numbered sequence are returned as
+            ``Sequence`` objects in the ``sequences`` field instead of individual ``FileSystemEntry``
+            objects in ``entries``. Set to False to suppress sequence detection and always return flat
+            ``FileSystemEntry`` objects.
+        sequence_options: Controls sequence detection behaviour (policy, padding filter, frame bounds).
+            Defaults to ``SequenceScanOptions()`` when ``group_sequences=True`` and this is None.
 
     Results: ListDirectoryResultSuccess (with entries) | ListDirectoryResultFailure (access denied, not found)
     """
@@ -177,16 +183,29 @@ class ListDirectoryRequest(RequestPayload):
     include_modified_time: bool = True
     include_mime_type: bool = True
     include_absolute_path: bool = True
+    group_sequences: bool = True
+    sequence_options: SequenceScanOptions | None = None
 
 
 @dataclass
 @PayloadRegistry.register
 class ListDirectoryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    """Directory listing retrieved successfully."""
+    """Directory listing retrieved successfully.
+
+    Attributes:
+        entries: Files and directories that are not part of a detected sequence.
+            When ``group_sequences=False`` this contains all entries; when
+            ``group_sequences=True`` sequence-member files are moved to ``sequences``.
+        sequences: ``Sequence`` objects detected when ``group_sequences=True``.
+            Empty list when ``group_sequences=False``.
+        current_path: The directory path used for the listing.
+        is_workspace_path: True when the listed directory is inside the workspace.
+    """
 
     entries: list[FileSystemEntry]
     current_path: str
     is_workspace_path: bool
+    sequences: list[Sequence] = field(default_factory=list)
 
 
 @dataclass
@@ -197,6 +216,106 @@ class ListDirectoryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     Attributes:
         failure_reason: Classification of why the listing failed
         result_details: Human-readable error message (inherited from ResultPayloadFailure)
+    """
+
+    failure_reason: FileIOFailureReason
+
+
+@dataclass
+@PayloadRegistry.register
+class ListDirectorySequencesRequest(ListDirectoryRequest):
+    """List only file sequences in a directory.
+
+    Returns sequence objects only — non-sequence files and directories are
+    omitted from the result. Equivalent to issuing ``ListDirectoryRequest``
+    with ``group_sequences=True`` but with a dedicated result type and
+    without the flat-entry payload.
+
+    Inherits all filtering arguments from ``ListDirectoryRequest``
+    (``show_hidden``, ``pattern``, ``workspace_only``, etc.).
+
+    Results: ListDirectorySequencesResultSuccess | ListDirectorySequencesResultFailure
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class ListDirectorySequencesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Directory sequence listing retrieved successfully.
+
+    Attributes:
+        sequences: All ``Sequence`` objects detected in the directory.
+            Empty list when the directory contains no sequences.
+        current_path: The directory path used for the listing.
+        is_workspace_path: True when the listed directory is inside the workspace.
+    """
+
+    sequences: list[Sequence]
+    current_path: str
+    is_workspace_path: bool
+
+
+@dataclass
+@PayloadRegistry.register
+class ListDirectorySequencesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Directory sequence listing failed.
+
+    Attributes:
+        failure_reason: Classification of why the listing failed.
+        result_details: Human-readable error message (inherited from ResultPayloadFailure).
+    """
+
+    failure_reason: FileIOFailureReason
+
+
+@dataclass
+@PayloadRegistry.register
+class DeduceSequencesFromFileListRequest(RequestPayload):
+    """Detect file sequences within a caller-supplied list of file paths.
+
+    No additional filesystem I/O is performed — pass paths already obtained
+    from a directory listing or any other source. Directories in the list are
+    silently ignored. Files from different parent directories are grouped
+    independently by their shared parent.
+
+    Use when: Sequence grouping is needed for a file list that has already
+    been collected, avoiding a redundant directory scan.
+
+    Args:
+        file_paths: Absolute (or workspace-relative) paths to inspect.
+            Bare filenames without a directory component are allowed but
+            result in ``Sequence.directory`` being an empty string.
+        sequence_options: Policy, padding filter, and frame-range bounds.
+            Defaults to ``SequenceScanOptions()`` when None.
+
+    Results: DeduceSequencesFromFileListResultSuccess | DeduceSequencesFromFileListResultFailure
+    """
+
+    file_paths: list[str] = field(default_factory=list)
+    sequence_options: SequenceScanOptions | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class DeduceSequencesFromFileListResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Sequence deduction from file list completed successfully.
+
+    Attributes:
+        sequences: All ``Sequence`` objects detected. Empty list when no
+            sequences were found in the provided file paths.
+    """
+
+    sequences: list[Sequence] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class DeduceSequencesFromFileListResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Sequence deduction from file list failed.
+
+    Attributes:
+        failure_reason: Classification of why the deduction failed.
+        result_details: Human-readable error message (inherited from ResultPayloadFailure).
     """
 
     failure_reason: FileIOFailureReason

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -165,12 +165,11 @@ class ListDirectoryRequest(RequestPayload):
         include_modified_time: If True, include modified time in results (default: True). Set to False for faster listing.
         include_mime_type: If True, include MIME type in results (default: True). Set to False for faster listing.
         include_absolute_path: If True, include absolute resolved path in results (default: True). Set to False for faster listing.
-        group_sequences: If True (default), files that form a numbered sequence are returned as
+        group_sequences: If True, files that form a numbered sequence are returned as
             ``Sequence`` objects in the ``sequences`` field instead of individual ``FileSystemEntry``
-            objects in ``entries``. Set to False to suppress sequence detection and always return flat
-            ``FileSystemEntry`` objects.
+            objects in ``entries``. Defaults to False — sequence detection is opt-in.
         sequence_options: Controls sequence detection behaviour (policy, padding filter, frame bounds).
-            Defaults to ``SequenceScanOptions()`` when ``group_sequences=True`` and this is None.
+            Only used when ``group_sequences=True``. Defaults to ``SequenceScanOptions()`` when None.
 
     Results: ListDirectoryResultSuccess (with entries) | ListDirectoryResultFailure (access denied, not found)
     """
@@ -183,7 +182,7 @@ class ListDirectoryRequest(RequestPayload):
     include_modified_time: bool = True
     include_mime_type: bool = True
     include_absolute_path: bool = True
-    group_sequences: bool = True
+    group_sequences: bool = False
     sequence_options: SequenceScanOptions | None = None
 
 
@@ -193,11 +192,11 @@ class ListDirectoryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """Directory listing retrieved successfully.
 
     Attributes:
-        entries: Files and directories that are not part of a detected sequence.
-            When ``group_sequences=False`` this contains all entries; when
-            ``group_sequences=True`` sequence-member files are moved to ``sequences``.
+        entries: Files and directories. When ``group_sequences=True`` (opt-in),
+            sequence-member files are removed and appear in ``sequences`` instead;
+            when ``group_sequences=False`` (default) all entries are returned here.
         sequences: ``Sequence`` objects detected when ``group_sequences=True``.
-            Empty list when ``group_sequences=False``.
+            Always an empty list when ``group_sequences=False``.
         current_path: The directory path used for the listing.
         is_workspace_path: True when the listed directory is inside the workspace.
     """
@@ -274,9 +273,10 @@ class DeduceSequencesFromFileListRequest(RequestPayload):
     """Detect file sequences within a caller-supplied list of file paths.
 
     No additional filesystem I/O is performed — pass paths already obtained
-    from a directory listing or any other source. Directories in the list are
-    silently ignored. Files from different parent directories are grouped
-    independently by their shared parent.
+    from a directory listing or any other source. Callers are responsible for
+    supplying only file paths; directory paths in the list will not be
+    filtered out and may produce unexpected results. Files from different
+    parent directories are grouped independently by their shared parent.
 
     Use when: Sequence grouping is needed for a file list that has already
     been collected, avoiding a redundant directory scan.

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -213,11 +213,17 @@ class ListDirectoryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Directory listing failed.
 
     Attributes:
-        failure_reason: Classification of why the listing failed
+        failure_reason: Classification of why the listing failed. Sequence-semantic
+            failures (bad bounds, ABORT-policy gaps) use ``SequenceScanFailureReason``;
+            OS-layer failures use ``FileIOFailureReason``.
+        missing_item_numbers: Populated only when ``failure_reason`` is
+            ``SequenceScanFailureReason.ABORTED_AT_GAP``. Lists every missing frame
+            number inside the active range, sorted ascending.
         result_details: Human-readable error message (inherited from ResultPayloadFailure)
     """
 
-    failure_reason: FileIOFailureReason
+    failure_reason: SequenceScanFailureReason | FileIOFailureReason
+    missing_item_numbers: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -260,11 +266,17 @@ class ListDirectorySequencesResultFailure(WorkflowNotAlteredMixin, ResultPayload
     """Directory sequence listing failed.
 
     Attributes:
-        failure_reason: Classification of why the listing failed.
+        failure_reason: Classification of why the listing failed. Sequence-semantic
+            failures (bad bounds, ABORT-policy gaps) use ``SequenceScanFailureReason``;
+            OS-layer failures use ``FileIOFailureReason``.
+        missing_item_numbers: Populated only when ``failure_reason`` is
+            ``SequenceScanFailureReason.ABORTED_AT_GAP``. Lists every missing frame
+            number inside the active range, sorted ascending.
         result_details: Human-readable error message (inherited from ResultPayloadFailure).
     """
 
-    failure_reason: FileIOFailureReason
+    failure_reason: SequenceScanFailureReason | FileIOFailureReason
+    missing_item_numbers: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -314,11 +326,17 @@ class DeduceSequencesFromFileListResultFailure(WorkflowNotAlteredMixin, ResultPa
     """Sequence deduction from file list failed.
 
     Attributes:
-        failure_reason: Classification of why the deduction failed.
+        failure_reason: Classification of why the deduction failed. Sequence-semantic
+            failures (bad bounds, ABORT-policy gaps) use ``SequenceScanFailureReason``;
+            OS-layer failures use ``FileIOFailureReason``.
+        missing_item_numbers: Populated only when ``failure_reason`` is
+            ``SequenceScanFailureReason.ABORTED_AT_GAP``. Lists every missing frame
+            number inside the active range, sorted ascending.
         result_details: Human-readable error message (inherited from ResultPayloadFailure).
     """
 
-    failure_reason: FileIOFailureReason
+    failure_reason: SequenceScanFailureReason | FileIOFailureReason
+    missing_item_numbers: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1562,9 +1562,8 @@ class OSManager:
             dir_groups: dict[str, list[str]] = {}
             for fp in request.file_paths:
                 p = Path(fp)
-                if p.is_dir():
-                    continue
-                parent = str(p.parent)
+                raw_parent = str(p.parent)
+                parent = "" if raw_parent == "." else raw_parent
                 if parent not in dir_groups:
                     dir_groups[parent] = []
                 dir_groups[parent].append(p.name)

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1605,11 +1605,6 @@ class OSManager:
             for parent_dir, bare_names in dir_groups.items():
                 seqs, _ = scan_sequences_from_filenames(bare_names, parent_dir, options)
                 all_sequences.extend(seqs)
-
-            return DeduceSequencesFromFileListResultSuccess(
-                sequences=all_sequences,
-                result_details=(f"Deduced {len(all_sequences)} sequence(s) from {len(request.file_paths)} path(s)."),
-            )
         except InvalidSubsetBoundsError as e:
             return DeduceSequencesFromFileListResultFailure(
                 failure_reason=SequenceScanFailureReason.INVALID_BOUNDS,
@@ -1641,6 +1636,11 @@ class OSManager:
                 failure_reason=FileIOFailureReason.UNKNOWN,
                 result_details=msg,
             )
+
+        return DeduceSequencesFromFileListResultSuccess(
+            sequences=all_sequences,
+            result_details=(f"Deduced {len(all_sequences)} sequence(s) from {len(request.file_paths)} path(s)."),
+        )
 
     async def on_scan_sequences_request(self, request: ScanSequencesRequest) -> ResultPayload:  # noqa: PLR0911
         """Handle a request to scan a path or pattern for file sequences.

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -34,8 +34,15 @@ from griptape_nodes.common.sequences import (
     InvalidSubsetBoundsError,
     InvalidTemplateError,
     MissingItemError,
+    Sequence,
+    SequenceScanOptions,
 )
-from griptape_nodes.common.sequences.scan import DirectoryListingError, PathMapping, scan_sequences
+from griptape_nodes.common.sequences.scan import (
+    DirectoryListingError,
+    PathMapping,
+    scan_sequences,
+    scan_sequences_from_filenames,
+)
 from griptape_nodes.files.drivers.base64_file_driver import Base64FileDriver
 from griptape_nodes.files.drivers.data_uri_file_driver import DataUriFileDriver
 from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeCloudFileDriver
@@ -63,6 +70,9 @@ from griptape_nodes.retained_mode.events.os_events import (
     CreateFileRequest,
     CreateFileResultFailure,
     CreateFileResultSuccess,
+    DeduceSequencesFromFileListRequest,
+    DeduceSequencesFromFileListResultFailure,
+    DeduceSequencesFromFileListResultSuccess,
     DeleteFileRequest,
     DeleteFileResultFailure,
     DeleteFileResultSuccess,
@@ -83,6 +93,9 @@ from griptape_nodes.retained_mode.events.os_events import (
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
+    ListDirectorySequencesRequest,
+    ListDirectorySequencesResultFailure,
+    ListDirectorySequencesResultSuccess,
     MakeDirectoryRequest,
     MakeDirectoryResultFailure,
     MakeDirectoryResultSuccess,
@@ -311,6 +324,16 @@ class OSManager:
             )
             event_manager.assign_manager_to_request_type(
                 request_type=ListDirectoryRequest, callback=self.on_list_directory_request
+            )
+
+            event_manager.assign_manager_to_request_type(
+                request_type=ListDirectorySequencesRequest,
+                callback=self.on_list_directory_sequences_request,
+            )
+
+            event_manager.assign_manager_to_request_type(
+                request_type=DeduceSequencesFromFileListRequest,
+                callback=self.on_deduce_sequences_from_file_list_request,
             )
 
             event_manager.assign_manager_to_request_type(
@@ -1464,6 +1487,14 @@ class OSManager:
                 logger.error(msg)
                 return ListDirectoryResultFailure(failure_reason=FileIOFailureReason.IO_ERROR, result_details=msg)
 
+            # Group sequence files into Sequence objects when requested.
+            sequences: list[Sequence] = []
+            if request.group_sequences:
+                options = request.sequence_options or SequenceScanOptions()
+                bare_names = [e.name for e in entries if not e.is_dir]
+                sequences, consumed = scan_sequences_from_filenames(bare_names, str(directory), options)
+                entries = [e for e in entries if e.name not in consumed]
+
             # Return appropriate path format based on mode
             if request.workspace_only:
                 # In workspace mode, return relative path if within workspace, absolute if outside
@@ -1471,6 +1502,7 @@ class OSManager:
                     entries=entries,
                     current_path=str(relative_or_abs_path),
                     is_workspace_path=is_workspace_path,
+                    sequences=sequences,
                     result_details="Directory listing retrieved successfully.",
                 )
             # In system-wide mode, always return the full absolute path
@@ -1478,6 +1510,7 @@ class OSManager:
                 entries=entries,
                 current_path=str(directory),
                 is_workspace_path=is_workspace_path,
+                sequences=sequences,
                 result_details="Directory listing retrieved successfully.",
             )
 
@@ -1485,6 +1518,73 @@ class OSManager:
             msg = f"Unexpected error in list_directory: {type(e).__name__}: {e}"
             logger.error(msg)
             return ListDirectoryResultFailure(failure_reason=FileIOFailureReason.UNKNOWN, result_details=msg)
+
+    def on_list_directory_sequences_request(self, request: ListDirectorySequencesRequest) -> ResultPayload:
+        """Handle a request to list only file sequences in a directory.
+
+        Delegates to `on_list_directory_request` with `group_sequences=True` and
+        re-wraps the result to expose only the detected sequences.
+        """
+        inner = ListDirectoryRequest(
+            directory_path=request.directory_path,
+            show_hidden=request.show_hidden,
+            workspace_only=request.workspace_only,
+            pattern=request.pattern,
+            include_size=request.include_size,
+            include_modified_time=request.include_modified_time,
+            include_mime_type=request.include_mime_type,
+            include_absolute_path=request.include_absolute_path,
+            group_sequences=True,
+            sequence_options=request.sequence_options,
+        )
+        result = self.on_list_directory_request(inner)
+        if isinstance(result, ListDirectoryResultSuccess):
+            return ListDirectorySequencesResultSuccess(
+                sequences=result.sequences,
+                current_path=result.current_path,
+                is_workspace_path=result.is_workspace_path,
+                result_details=result.result_details,
+            )
+        return ListDirectorySequencesResultFailure(
+            failure_reason=result.failure_reason,  # pyright: ignore[reportAttributeAccessIssue]
+            result_details=str(result.result_details),
+        )
+
+    def on_deduce_sequences_from_file_list_request(self, request: DeduceSequencesFromFileListRequest) -> ResultPayload:
+        """Handle a request to detect sequences from a caller-supplied file list.
+
+        Groups input paths by parent directory, then calls
+        `scan_sequences_from_filenames` per group. No directory I/O is
+        performed.
+        """
+        try:
+            options = request.sequence_options or SequenceScanOptions()
+            dir_groups: dict[str, list[str]] = {}
+            for fp in request.file_paths:
+                p = Path(fp)
+                if p.is_dir():
+                    continue
+                parent = str(p.parent)
+                if parent not in dir_groups:
+                    dir_groups[parent] = []
+                dir_groups[parent].append(p.name)
+
+            all_sequences: list[Sequence] = []
+            for parent_dir, bare_names in dir_groups.items():
+                seqs, _ = scan_sequences_from_filenames(bare_names, parent_dir, options)
+                all_sequences.extend(seqs)
+
+            return DeduceSequencesFromFileListResultSuccess(
+                sequences=all_sequences,
+                result_details=(f"Deduced {len(all_sequences)} sequence(s) from {len(request.file_paths)} path(s)."),
+            )
+        except Exception as e:
+            msg = f"Attempted to deduce sequences from file list. Failed with {type(e).__name__}: {e}"
+            logger.error(msg)
+            return DeduceSequencesFromFileListResultFailure(
+                failure_reason=FileIOFailureReason.UNKNOWN,
+                result_details=msg,
+            )
 
     async def on_scan_sequences_request(self, request: ScanSequencesRequest) -> ResultPayload:  # noqa: PLR0911
         """Handle a request to scan a path or pattern for file sequences.

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1493,7 +1493,33 @@ class OSManager:
                 options = request.sequence_options or SequenceScanOptions()
                 bare_names = [e.name for e in entries if not e.is_dir]
                 seq_directory = str(relative_or_abs_path) if request.workspace_only else str(directory)
-                sequences, consumed = scan_sequences_from_filenames(bare_names, seq_directory, options)
+                try:
+                    sequences, consumed = scan_sequences_from_filenames(bare_names, seq_directory, options)
+                except InvalidSubsetBoundsError as e:
+                    return ListDirectoryResultFailure(
+                        failure_reason=SequenceScanFailureReason.INVALID_BOUNDS,
+                        result_details=str(e),
+                    )
+                except MissingItemError as e:
+                    gap_count = len(e.numbers)
+                    if gap_count == 1:
+                        summary = f"the sequence has a gap at item {e.numbers[0]}"
+                    else:
+                        sample = ", ".join(str(n) for n in e.numbers[:ABORTED_AT_GAP_PREVIEW_COUNT])
+                        suffix = (
+                            ""
+                            if gap_count <= ABORTED_AT_GAP_PREVIEW_COUNT
+                            else f" (+ {gap_count - ABORTED_AT_GAP_PREVIEW_COUNT} more)"
+                        )
+                        summary = f"the sequence has {gap_count} gaps: items {sample}{suffix}"
+                    return ListDirectoryResultFailure(
+                        failure_reason=SequenceScanFailureReason.ABORTED_AT_GAP,
+                        missing_item_numbers=e.numbers,
+                        result_details=(
+                            f"Attempted to list directory {str(directory)!r} with group_sequences=True, "
+                            f"policy=ABORT. Failed because {summary}."
+                        ),
+                    )
                 entries = [e for e in entries if e.name not in consumed]
 
             # Return appropriate path format based on mode
@@ -1546,9 +1572,15 @@ class OSManager:
                 is_workspace_path=result.is_workspace_path,
                 result_details=result.result_details,
             )
+        if isinstance(result, ListDirectoryResultFailure):
+            return ListDirectorySequencesResultFailure(
+                failure_reason=result.failure_reason,
+                missing_item_numbers=result.missing_item_numbers,
+                result_details=str(result.result_details),
+            )
         return ListDirectorySequencesResultFailure(
-            failure_reason=result.failure_reason,  # pyright: ignore[reportAttributeAccessIssue]
-            result_details=str(result.result_details),
+            failure_reason=FileIOFailureReason.UNKNOWN,
+            result_details="Unexpected result type from on_list_directory_request.",
         )
 
     def on_deduce_sequences_from_file_list_request(self, request: DeduceSequencesFromFileListRequest) -> ResultPayload:
@@ -1577,6 +1609,30 @@ class OSManager:
             return DeduceSequencesFromFileListResultSuccess(
                 sequences=all_sequences,
                 result_details=(f"Deduced {len(all_sequences)} sequence(s) from {len(request.file_paths)} path(s)."),
+            )
+        except InvalidSubsetBoundsError as e:
+            return DeduceSequencesFromFileListResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_BOUNDS,
+                result_details=str(e),
+            )
+        except MissingItemError as e:
+            gap_count = len(e.numbers)
+            if gap_count == 1:
+                summary = f"the sequence has a gap at item {e.numbers[0]}"
+            else:
+                sample = ", ".join(str(n) for n in e.numbers[:ABORTED_AT_GAP_PREVIEW_COUNT])
+                suffix = (
+                    ""
+                    if gap_count <= ABORTED_AT_GAP_PREVIEW_COUNT
+                    else f" (+ {gap_count - ABORTED_AT_GAP_PREVIEW_COUNT} more)"
+                )
+                summary = f"the sequence has {gap_count} gaps: items {sample}{suffix}"
+            return DeduceSequencesFromFileListResultFailure(
+                failure_reason=SequenceScanFailureReason.ABORTED_AT_GAP,
+                missing_item_numbers=e.numbers,
+                result_details=(
+                    f"Attempted to deduce sequences from file list with policy=ABORT. Failed because {summary}."
+                ),
             )
         except Exception as e:
             msg = f"Attempted to deduce sequences from file list. Failed with {type(e).__name__}: {e}"

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1492,7 +1492,8 @@ class OSManager:
             if request.group_sequences:
                 options = request.sequence_options or SequenceScanOptions()
                 bare_names = [e.name for e in entries if not e.is_dir]
-                sequences, consumed = scan_sequences_from_filenames(bare_names, str(directory), options)
+                seq_directory = str(relative_or_abs_path) if request.workspace_only else str(directory)
+                sequences, consumed = scan_sequences_from_filenames(bare_names, seq_directory, options)
                 entries = [e for e in entries if e.name not in consumed]
 
             # Return appropriate path format based on mode

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -10,7 +10,7 @@ import pytest
 import send2trash
 
 from griptape_nodes.common.macro_parser import ParsedMacro
-from griptape_nodes.common.sequences import MissingItemPolicy, SequenceScanOptions
+from griptape_nodes.common.sequences import MissingItemPolicy, NoTokenBehavior, SequenceScanOptions
 from griptape_nodes.files.path_utils import normalize_path_for_platform, resolve_path_safely
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.os_events import (
@@ -18,6 +18,7 @@ from griptape_nodes.retained_mode.events.os_events import (
     CreateFileResultFailure,
     CreateFileResultSuccess,
     DeduceSequencesFromFileListRequest,
+    DeduceSequencesFromFileListResultFailure,
     DeduceSequencesFromFileListResultSuccess,
     DeleteFileRequest,
     DeleteFileResultFailure,
@@ -49,6 +50,7 @@ from griptape_nodes.retained_mode.events.os_events import (
     RenameFileRequest,
     RenameFileResultFailure,
     RenameFileResultSuccess,
+    SequenceScanFailureReason,
     WriteFileRequest,
     WriteFileResultFailure,
     WriteFileResultSuccess,
@@ -922,6 +924,116 @@ class TestDeduceSequencesFromFileListRequest:
 
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert result.sequences == []
+
+    def test_invalid_bounds_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A negative start_number surfaces as INVALID_BOUNDS failure."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3])
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(start_number=-1),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultFailure)
+        assert result.failure_reason == SequenceScanFailureReason.INVALID_BOUNDS
+
+    def test_abort_policy_with_single_gap_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """ABORT policy with exactly one gap returns ABORTED_AT_GAP with a single-gap message."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 3])  # gap at 2
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(policy=MissingItemPolicy.ABORT),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultFailure)
+        assert result.failure_reason == SequenceScanFailureReason.ABORTED_AT_GAP
+        assert isinstance(result.result_details, ResultDetails)
+        assert "gap at item 2" in result.result_details.result_details[0].message
+
+    def test_abort_policy_with_multiple_gaps_returns_failure(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """ABORT policy with multiple gaps lists all gap positions in the message."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 3, 5])  # gaps at 2, 4
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(policy=MissingItemPolicy.ABORT),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultFailure)
+        assert result.failure_reason == SequenceScanFailureReason.ABORTED_AT_GAP
+        assert isinstance(result.result_details, ResultDetails)
+        assert "2 gaps" in result.result_details.result_details[0].message
+
+    def test_abort_policy_with_many_gaps_truncates_preview(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """ABORT with more gaps than ABORTED_AT_GAP_PREVIEW_COUNT appends a '+ N more' suffix."""
+        os_manager = griptape_nodes.OSManager()
+        # 6 gaps: missing 2, 4, 6, 8, 10, 12 — exceeds the preview count of 5
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 3, 5, 7, 9, 11, 13])
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(policy=MissingItemPolicy.ABORT),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultFailure)
+        assert result.failure_reason == SequenceScanFailureReason.ABORTED_AT_GAP
+        assert isinstance(result.result_details, ResultDetails)
+        assert "more" in result.result_details.result_details[0].message
+
+    def test_unexpected_exception_returns_unknown_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """An unexpected exception from the scan is caught and returned as UNKNOWN failure."""
+        os_manager = griptape_nodes.OSManager()
+
+        request = DeduceSequencesFromFileListRequest(file_paths=["render.0001.exr"])
+        with patch(
+            "griptape_nodes.retained_mode.managers.os_manager.scan_sequences_from_filenames",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultFailure)
+        assert result.failure_reason == FileIOFailureReason.UNKNOWN
+        assert isinstance(result.result_details, ResultDetails)
+        assert "boom" in result.result_details.result_details[0].message
+
+    def test_single_frame_sequence_not_returned(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A sequence with only one present frame is not included in the result."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1])
+
+        request = DeduceSequencesFromFileListRequest(file_paths=paths)
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert result.sequences == []
+
+    def test_reject_no_token_behavior_skips_token_less_sequences(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """NoTokenBehavior.REJECT causes token-less files to be silently skipped."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 2])
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(
+                no_token_behavior=NoTokenBehavior.REJECT,
+                padding=0,  # only match zero-padded (token-less) sequences
+            ),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
 
 
 class TestNormalizePathPartsForSpecialFolder:

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -10,12 +10,15 @@ import pytest
 import send2trash
 
 from griptape_nodes.common.macro_parser import ParsedMacro
+from griptape_nodes.common.sequences import MissingItemPolicy, SequenceScanOptions
 from griptape_nodes.files.path_utils import normalize_path_for_platform, resolve_path_safely
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.os_events import (
     CreateFileRequest,
     CreateFileResultFailure,
     CreateFileResultSuccess,
+    DeduceSequencesFromFileListRequest,
+    DeduceSequencesFromFileListResultSuccess,
     DeleteFileRequest,
     DeleteFileResultFailure,
     DeleteFileResultSuccess,
@@ -35,6 +38,8 @@ from griptape_nodes.retained_mode.events.os_events import (
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
+    ListDirectorySequencesRequest,
+    ListDirectorySequencesResultSuccess,
     MakeDirectoryRequest,
     MakeDirectoryResultFailure,
     MakeDirectoryResultSuccess,
@@ -454,7 +459,7 @@ class TestListDirectoryRequest:
         (temp_dir / "file2.txt").write_text("Content 2")
         (temp_dir / "subdir").mkdir()
 
-        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False, group_sequences=False)
+        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False)
         result = os_manager.on_list_directory_request(request)
 
         assert isinstance(result, ListDirectoryResultSuccess)
@@ -462,6 +467,33 @@ class TestListDirectoryRequest:
         names = {entry.name for entry in result.entries}
         assert names == {"file1.txt", "file2.txt", "subdir"}
         assert result.sequences == []
+
+    def test_bounds_clip_entire_sequence_files_stay_in_entries(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Files fully clipped by start_number/end_number remain in entries.
+
+        Regression: consumed_filenames must not be updated before the active-range
+        check — otherwise listing removes sequence-member files from entries even
+        though no Sequence is returned for them.
+        """
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "render.0001.exr").write_text("f1")
+        (temp_dir / "render.0002.exr").write_text("f2")
+
+        request = ListDirectoryRequest(
+            directory_path=str(temp_dir),
+            workspace_only=False,
+            group_sequences=True,
+            sequence_options=SequenceScanOptions(start_number=100),
+        )
+        result = os_manager.on_list_directory_request(request)
+
+        assert isinstance(result, ListDirectoryResultSuccess)
+        assert result.sequences == []
+        entry_names = {e.name for e in result.entries}
+        assert "render.0001.exr" in entry_names
+        assert "render.0002.exr" in entry_names
 
     def test_list_directory_groups_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Test that numbered files are grouped into Sequence objects by default."""
@@ -472,7 +504,7 @@ class TestListDirectoryRequest:
         (temp_dir / "readme.txt").write_text("notes")
         (temp_dir / "subdir").mkdir()
 
-        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False)
+        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False, group_sequences=True)
         result = os_manager.on_list_directory_request(request)
 
         assert isinstance(result, ListDirectoryResultSuccess)
@@ -600,6 +632,251 @@ class TestListDirectoryRequest:
         assert symlink_path.is_symlink()
         assert symlink_path.resolve() == target_dir.resolve()
         assert str(symlink_path) == str(symlink_dir.absolute())
+
+
+class TestListDirectorySequencesRequest:
+    """Test ListDirectorySequencesRequest — sequences-only result."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    def test_returns_only_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Non-sequence files are absent from the result; sequences are present."""
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "render.0001.exr").write_text("f1")
+        (temp_dir / "render.0002.exr").write_text("f2")
+        (temp_dir / "readme.txt").write_text("notes")
+        (temp_dir / "subdir").mkdir()
+
+        request = ListDirectorySequencesRequest(directory_path=str(temp_dir), workspace_only=False)
+        result = os_manager.on_list_directory_sequences_request(request)
+
+        assert isinstance(result, ListDirectorySequencesResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert seq.first == 1
+        assert seq.last == 2  # noqa: PLR2004
+
+    def test_empty_directory_returns_success_with_no_sequences(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """A directory with no sequences returns an empty success, not a failure."""
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "readme.txt").write_text("notes")
+
+        request = ListDirectorySequencesRequest(directory_path=str(temp_dir), workspace_only=False)
+        result = os_manager.on_list_directory_sequences_request(request)
+
+        assert isinstance(result, ListDirectorySequencesResultSuccess)
+        assert result.sequences == []
+
+    def test_padding_filter_excludes_mismatched_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """sequence_options.padding=4 keeps only #### sequences; ### sequences are excluded."""
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "hi.0001.exr").write_text("f1")  # 4-digit
+        (temp_dir / "hi.0002.exr").write_text("f2")
+        (temp_dir / "lo.001.exr").write_text("f1")  # 3-digit
+        (temp_dir / "lo.002.exr").write_text("f2")
+
+        request = ListDirectorySequencesRequest(
+            directory_path=str(temp_dir),
+            workspace_only=False,
+            sequence_options=SequenceScanOptions(padding=4),
+        )
+        result = os_manager.on_list_directory_sequences_request(request)
+
+        assert isinstance(result, ListDirectorySequencesResultSuccess)
+        assert len(result.sequences) == 1
+        assert result.sequences[0].padding == 4  # noqa: PLR2004
+
+    def test_delegates_failure_from_inner_request(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A bad directory path surfaces as a failure result."""
+        os_manager = griptape_nodes.OSManager()
+        request = ListDirectorySequencesRequest(directory_path=str(temp_dir / "nonexistent"), workspace_only=False)
+        from griptape_nodes.retained_mode.events.os_events import ListDirectorySequencesResultFailure
+
+        result = os_manager.on_list_directory_sequences_request(request)
+
+        assert isinstance(result, ListDirectorySequencesResultFailure)
+        assert result.failure_reason == FileIOFailureReason.FILE_NOT_FOUND
+
+
+class TestDeduceSequencesFromFileListRequest:
+    """Test DeduceSequencesFromFileListRequest — no-I/O sequence detection."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    def _write_frames(self, directory: Path, basename: str, ext: str, frames: list[int]) -> list[str]:
+        paths = []
+        for n in frames:
+            p = directory / f"{basename}.{n:04d}.{ext}"
+            p.write_text(f"frame {n}")
+            paths.append(str(p))
+        return paths
+
+    def test_detects_sequence_from_absolute_paths(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A list of absolute file paths is grouped into a Sequence."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3])
+
+        request = DeduceSequencesFromFileListRequest(file_paths=paths)
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert seq.first == 1
+        assert seq.last == 3  # noqa: PLR2004
+        assert len(seq.entries) == 3  # noqa: PLR2004
+
+    def test_empty_file_list_returns_empty_success(self, griptape_nodes: GriptapeNodes) -> None:
+        """An empty file list returns success with no sequences."""
+        os_manager = griptape_nodes.OSManager()
+        request = DeduceSequencesFromFileListRequest(file_paths=[])
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert result.sequences == []
+
+    def test_bare_filenames_yield_empty_directory(self, griptape_nodes: GriptapeNodes) -> None:
+        """Bare filenames (no directory component) produce Sequence.directory == ''.
+
+        Path('render.0001.exr').parent is '.', which must be normalised to ''
+        so that Sequence.directory and entry paths match the documented contract
+        rather than emitting './render.0001.exr'.
+        """
+        os_manager = griptape_nodes.OSManager()
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=["render.0001.exr", "render.0002.exr"],
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert seq.directory == ""
+        assert not any(e.path.startswith("./") for e in seq.entries)
+
+    def test_non_sequence_names_do_not_produce_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Plain names without numeric tokens produce no sequences (callers filter directories)."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "frame", "exr", [1, 2])
+        paths.append(str(temp_dir / "subdir"))  # bare name with no sequence token
+
+        request = DeduceSequencesFromFileListRequest(file_paths=paths)
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert len(result.sequences) == 1  # subdir produces no sequence
+
+    def test_files_from_multiple_directories(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Files from different parent directories are grouped independently."""
+        os_manager = griptape_nodes.OSManager()
+        dir_a = temp_dir / "a"
+        dir_b = temp_dir / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        paths_a = self._write_frames(dir_a, "render", "exr", [1, 2])
+        paths_b = self._write_frames(dir_b, "comp", "exr", [10, 11])
+
+        request = DeduceSequencesFromFileListRequest(file_paths=paths_a + paths_b)
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert len(result.sequences) == 2  # noqa: PLR2004
+
+    def test_no_sequence_files_returns_empty_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Files with no sequence tokens return success with an empty sequences list."""
+        os_manager = griptape_nodes.OSManager()
+        p = temp_dir / "readme.txt"
+        p.write_text("notes")
+
+        request = DeduceSequencesFromFileListRequest(file_paths=[str(p)])
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert result.sequences == []
+
+    def test_padding_filter(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """sequence_options.padding filters to only matching zero-fill width."""
+        os_manager = griptape_nodes.OSManager()
+        paths_4 = self._write_frames(temp_dir, "hi", "exr", [1, 2])  # 4-digit
+        paths_3 = [str(temp_dir / f"lo.{n:03d}.exr") for n in [1, 2]]
+        for p in paths_3:
+            Path(p).write_text("f")
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths_4 + paths_3,
+            sequence_options=SequenceScanOptions(padding=4),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert len(result.sequences) == 1
+        assert result.sequences[0].padding == 4  # noqa: PLR2004
+
+    def test_frame_bounds(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """start_number / end_number clip the active range."""
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3, 4, 5])
+
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(
+                policy=MissingItemPolicy.SKIP,
+                start_number=2,
+                end_number=4,
+            ),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert seq.first == 2  # noqa: PLR2004
+        assert seq.last == 4  # noqa: PLR2004
+        assert [e.number for e in seq.entries] == [2, 3, 4]
+
+    def test_bounds_clip_entire_sequence_files_stay_in_entries(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Files whose sequence is fully clipped by bounds are NOT removed from the result.
+
+        Regression: consumed_filenames must not be updated before the active-range
+        check, otherwise files that produce no Sequence (because start_number >
+        discovered_last) are silently consumed and callers lose them.
+        """
+        os_manager = griptape_nodes.OSManager()
+        paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3])
+
+        # Ask for frames 100+, which clips the entire on-disk range out.
+        request = DeduceSequencesFromFileListRequest(
+            file_paths=paths,
+            sequence_options=SequenceScanOptions(start_number=100),
+        )
+        result = os_manager.on_deduce_sequences_from_file_list_request(request)
+
+        assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
+        assert result.sequences == []
 
 
 class TestNormalizePathPartsForSpecialFolder:

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -549,6 +549,21 @@ class TestListDirectoryRequest:
         assert seq.first == 1
         assert seq.last == 3  # noqa: PLR2004
 
+    def test_single_sequence_file_stays_in_entries(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """A lone file that looks like a sequence pattern must not be grouped into a Sequence."""
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "render.0001.exr").write_text("frame 1")
+        (temp_dir / "readme.txt").write_text("notes")
+
+        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False, group_sequences=True)
+        result = os_manager.on_list_directory_request(request)
+
+        assert isinstance(result, ListDirectoryResultSuccess)
+        assert result.sequences == []
+        entry_names = {e.name for e in result.entries}
+        assert "render.0001.exr" in entry_names
+        assert "readme.txt" in entry_names
+
     def test_list_directory_hidden_files(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Test listing directory with hidden files."""
         os_manager = griptape_nodes.OSManager()

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -495,6 +495,36 @@ class TestListDirectoryRequest:
         assert "render.0001.exr" in entry_names
         assert "render.0002.exr" in entry_names
 
+    def test_bounds_partial_clip_out_of_range_files_stay_in_entries(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Files outside the active range remain in entries even when a Sequence is returned.
+
+        Regression: consumed_filenames was populated from the full bare_names set
+        (all frames in the FileSequence) rather than only the frames within
+        [active.first, active.last]. Files clipped by start_number/end_number were
+        silently dropped from entries despite never appearing in any Sequence.
+        """
+        os_manager = griptape_nodes.OSManager()
+        for i in range(1, 6):
+            (temp_dir / f"render.{i:04d}.exr").write_text(f"f{i}")
+
+        request = ListDirectoryRequest(
+            directory_path=str(temp_dir),
+            workspace_only=False,
+            group_sequences=True,
+            sequence_options=SequenceScanOptions(start_number=2),
+        )
+        result = os_manager.on_list_directory_request(request)
+
+        assert isinstance(result, ListDirectoryResultSuccess)
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert seq.first == 2  # noqa: PLR2004
+        entry_names = {e.name for e in result.entries}
+        # Frame 1 is outside the active range — it must not be consumed
+        assert "render.0001.exr" in entry_names
+
     def test_list_directory_groups_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Test that numbered files are grouped into Sequence objects by default."""
         os_manager = griptape_nodes.OSManager()

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -447,20 +447,45 @@ class TestListDirectoryRequest:
         griptape_nodes.ConfigManager().workspace_path = original_workspace
 
     def test_list_directory_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
-        """Test successfully listing a directory."""
+        """Test successfully listing a directory with sequence grouping disabled."""
         os_manager = griptape_nodes.OSManager()
         # Create some test files
         (temp_dir / "file1.txt").write_text("Content 1")
         (temp_dir / "file2.txt").write_text("Content 2")
         (temp_dir / "subdir").mkdir()
 
-        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False)
+        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False, group_sequences=False)
         result = os_manager.on_list_directory_request(request)
 
         assert isinstance(result, ListDirectoryResultSuccess)
         assert len(result.entries) == 3  # noqa: PLR2004
         names = {entry.name for entry in result.entries}
         assert names == {"file1.txt", "file2.txt", "subdir"}
+        assert result.sequences == []
+
+    def test_list_directory_groups_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Test that numbered files are grouped into Sequence objects by default."""
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "render.0001.exr").write_text("frame 1")
+        (temp_dir / "render.0002.exr").write_text("frame 2")
+        (temp_dir / "render.0003.exr").write_text("frame 3")
+        (temp_dir / "readme.txt").write_text("notes")
+        (temp_dir / "subdir").mkdir()
+
+        request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False)
+        result = os_manager.on_list_directory_request(request)
+
+        assert isinstance(result, ListDirectoryResultSuccess)
+        # Non-sequence entries only
+        entry_names = {e.name for e in result.entries}
+        assert "readme.txt" in entry_names
+        assert "subdir" in entry_names
+        assert "render.0001.exr" not in entry_names
+        # Sequence detected
+        assert len(result.sequences) == 1
+        seq = result.sequences[0]
+        assert seq.first == 1
+        assert seq.last == 3  # noqa: PLR2004
 
     def test_list_directory_hidden_files(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Test listing directory with hidden files."""


### PR DESCRIPTION
## Summary

Adds sequence-aware directory listing to the engine's file I/O layer. Three new request types let callers discover numbered file sequences (`render.####.exr`, `comp.%04d.png`, etc.) either from a live directory scan or from a pre-collected file list, without duplicating the detection logic scattered across each call site.

Closes #4827, #4792

---

## New requests

### `ListDirectoryRequest` — extended

Two new optional fields:

- `group_sequences: bool = False` — opt-in; when `True`, files that form a numbered sequence are moved out of `entries` and grouped into `Sequence` objects returned in a new `sequences: list[Sequence]` field on `ListDirectoryResultSuccess`. Non-sequence files and all directories remain in `entries` unchanged.
- `sequence_options: SequenceScanOptions | None = None` — controls how detection and filtering is performed (see below).

### `ListDirectorySequencesRequest` (inherits `ListDirectoryRequest`)

Returns only sequences — `entries` is omitted from the result type (`ListDirectorySequencesResultSuccess`). Delegates internally to `on_list_directory_request` with `group_sequences=True`, then re-wraps the result. Useful for nodes that only care about sequences and don't need the full flat listing.

### `DeduceSequencesFromFileListRequest`

Detects sequences from a caller-supplied `file_paths: list[str]` with **no filesystem I/O**. Paths are grouped by their parent directory; each group is run through `scan_sequences_from_filenames`. Callers are responsible for supplying file paths only — the handler does not stat entries to filter directories, as that would violate the no-I/O contract. Bare filenames (no directory component) produce `Sequence.directory == ""` via explicit `"." → ""` normalisation.

---

## New shared model: `SequenceScanOptions`

Defined in `common/sequences/models.py` alongside the existing sequence types:

```python
@dataclass
class SequenceScanOptions:
    policy: MissingItemPolicy = MissingItemPolicy.SKIP
    no_token_behavior: NoTokenBehavior = NoTokenBehavior.REJECT
    start_number: int | None = None
    end_number: int | None = None
    padding: int | None = None   # filter: only sequences whose zfill == this value
```

Exported from `common/sequences/__init__.py` and imported by both `os_events.py` (request fields) and `scan.py` (new function parameter).

---

## New internal function: `scan_sequences_from_filenames`

Added to `common/sequences/scan.py` alongside the existing `scan_sequences` worker:

```python
def scan_sequences_from_filenames(
    filenames: list[str],   # bare names, no directory prefix
    directory: str,         # stored in Sequence.directory and entry paths
    options: SequenceScanOptions | None = None,
) -> tuple[list[Sequence], set[str]]:   # (sequences, consumed_bare_filenames)
```

Uses `FileSequence.findSequencesInList(filenames, pad_style=PAD_STYLE)` — the same primitive `scan_sequences` already uses — so no additional I/O is introduced. The second return value is the set of bare filenames that were grouped; `on_list_directory_request` uses it to filter those files out of `entries`.

**Ordering bug fixed during implementation**: `consumed_filenames` is updated only *after* the `active.first > active.last` subset-bound check. Updating before that check would silently remove files from the listing even when the entire sequence range was clipped out and no `Sequence` was returned.

A private helper `_collect_present_numbers_from_fseq` is extracted to keep McCabe complexity within the project limit.

`_list_directory_filenames` (the existing internal function that routes through `ListDirectoryRequest`) gains an explicit `group_sequences=False` to avoid unnecessary sequence-grouping overhead on every inner listing.

---

## Design decisions

- **`group_sequences` defaults to `False`** — conservative opt-in; existing callers are unaffected.
- **Separate `sequences` field on `ListDirectoryResultSuccess`** — keeps the result type strongly-typed and backward-compatible: callers that don't opt in see an empty list and can ignore it entirely.
- **`'.'` normalised to `''` in `DeduceSequencesFromFileListRequest`** — `Path('render.0001.exr').parent` is `Path('.')`, which stringifies to `'.'` and would produce `./render.0001.exr` in entry paths. The handler normalises it before passing to `scan_sequences_from_filenames`.
- **New sequence listing rule**: a file entry is considered a `Sequence` if it has >=2 elements in it. Otherwise it's a plain `FileSystemEntry`.

---

## Future suggestion: fold `Sequence` into `FileSystemEntry`

The current shape returns two parallel lists — `entries: list[FileSystemEntry]` and `sequences: list[Sequence]` — and callers must iterate both. An alternative worth considering for a follow-up is to extend `FileSystemEntry` with an optional `sequence: Sequence | None = None` field:

```python
@dataclass
class FileSystemEntry:
    name: str
    path: str
    is_dir: bool
    ...
    sequence: Sequence | None = None   # populated when this entry represents a detected sequence
```

A detected sequence would then appear as a single `FileSystemEntry` (with `is_dir=False`, `name=<pattern>`, `sequence=<Sequence>`) inside the existing `entries` list rather than in a separate field. Callers iterate one list; sequence-aware callers branch on `entry.sequence is not None`. This simplifies the result type and removes the parallel-list problem, at the cost of making `FileSystemEntry` aware of `Sequence` (the import is already in `os_events.py`).

---

## Test plan

- [x] `make check` — 0 errors, 0 warnings
- [x] 144 unit tests pass (`test_sequences.py`, `test_os_manager.py`)
- [x] `test_list_directory_groups_sequences` — frame files move to `sequences`; non-sequence files and dirs stay in `entries`
- [x] `test_bounds_clip_entire_sequence_files_stay_in_entries` — files whose sequence is fully clipped by `start_number`/`end_number` remain in `entries` (regression for the `consumed_filenames` ordering fix)
- [x] `TestListDirectorySequencesRequest` — 4 tests covering the happy path, empty directory, padding filter, and failure delegation
- [x] `TestDeduceSequencesFromFileListRequest` — 9 tests covering basic detection, empty list, multiple directories, padding filter, frame bounds, bounds-clip regression, and bare-filename `'.'` normalisation
