### PR TITLE
Download library to project workspace when required

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2112,58 +2112,7 @@ class LibraryManager:
 
                         # Check the library's custom config settings
                         if library_data.settings is not None:
-                            for library_data_setting in library_data.settings:
-                                # Does the category exist?
-                                get_category_request = GetConfigCategoryRequest(
-                                    category=library_data_setting.category,
-                                    failure_log_level=logging.DEBUG,
-                                )
-                                get_category_result = GriptapeNodes.handle_request(get_category_request)
-                                if not isinstance(get_category_result, GetConfigCategoryResultSuccess):
-                                    # Create new category
-                                    create_new_category_request = SetConfigCategoryRequest(
-                                        category=library_data_setting.category, contents=library_data_setting.contents
-                                    )
-                                    create_new_category_result = GriptapeNodes.handle_request(
-                                        create_new_category_request
-                                    )
-                                    if not isinstance(create_new_category_result, SetConfigCategoryResultSuccess):
-                                        library_info.problems.append(
-                                            CreateConfigCategoryProblem(category_name=library_data_setting.category)
-                                        )
-                                        details = f"Failed attempting to create new config category '{library_data_setting.category}' for library '{library_data.name}'."
-                                        logger.error(details)
-                                        continue
-                                else:
-                                    # Normalize secrets_to_register before merge (handles list/dict format mismatch)
-                                    library_contents = dict(library_data_setting.contents)
-                                    existing_contents = dict(get_category_result.contents)
-                                    if "secrets_to_register" in library_contents:
-                                        library_contents["secrets_to_register"] = normalize_secrets_to_register(
-                                            library_contents["secrets_to_register"]
-                                        )
-                                    if "secrets_to_register" in existing_contents:
-                                        existing_contents["secrets_to_register"] = normalize_secrets_to_register(
-                                            existing_contents["secrets_to_register"]
-                                        )
-                                    # Merge with existing category
-                                    existing_category_contents = merge_dicts(
-                                        library_contents,
-                                        existing_contents,
-                                        add_keys=True,
-                                        merge_lists=True,
-                                    )
-                                    set_category_request = SetConfigCategoryRequest(
-                                        category=library_data_setting.category, contents=existing_category_contents
-                                    )
-                                    set_category_result = GriptapeNodes.handle_request(set_category_request)
-                                    if not isinstance(set_category_result, SetConfigCategoryResultSuccess):
-                                        library_info.problems.append(
-                                            UpdateConfigCategoryProblem(category_name=library_data_setting.category)
-                                        )
-                                        details = f"Failed attempting to update config category '{library_data_setting.category}' for library '{library_data.name}'."
-                                        logger.error(details)
-                                        continue
+                            library_info.problems.extend(self._persist_library_settings(library_data))
 
                         # For worker-delegated libraries on the orchestrator, skip node module
                         # imports entirely -- importing them would pull heavy deps (torch, triton,
@@ -2241,6 +2190,79 @@ class LibraryManager:
 
         # Success - progressed to LOADED state
         return None
+
+    def _persist_library_settings(self, library_data: LibrarySchema) -> list[LibraryProblem]:
+        """Inject a library's declared settings into the user config, returning any problems.
+
+        For each declared setting category: when the category does not yet exist,
+        write the library's contents as-is. When it does, persist only what THIS
+        library declares merged onto the GLOBAL user-config layer for the category.
+
+        The existing category is read from the `user_config` layer, NOT the merged
+        config. The merged config folds in the active project's
+        project/workspace/env layers (e.g. libraries_to_download, requires_engine);
+        writing that back through SetConfigCategory (which lands in the global user
+        config) would leak those per-project values into every other project's
+        startup. Reading user_config keeps the write scoped to what is genuinely
+        global plus the library's own declared settings.
+        """
+        if library_data.settings is None:
+            return []
+
+        problems: list[LibraryProblem] = []
+        config_mgr = GriptapeNodes.ConfigManager()
+        for library_data_setting in library_data.settings:
+            get_category_request = GetConfigCategoryRequest(
+                category=library_data_setting.category,
+                failure_log_level=logging.DEBUG,
+            )
+            get_category_result = GriptapeNodes.handle_request(get_category_request)
+            if not isinstance(get_category_result, GetConfigCategoryResultSuccess):
+                # Create new category
+                create_new_category_request = SetConfigCategoryRequest(
+                    category=library_data_setting.category, contents=library_data_setting.contents
+                )
+                create_new_category_result = GriptapeNodes.handle_request(create_new_category_request)
+                if not isinstance(create_new_category_result, SetConfigCategoryResultSuccess):
+                    problems.append(CreateConfigCategoryProblem(category_name=library_data_setting.category))
+                    details = f"Failed attempting to create new config category '{library_data_setting.category}' for library '{library_data.name}'."
+                    logger.error(details)
+                continue
+
+            # Normalize secrets_to_register before merge (handles list/dict format mismatch)
+            library_contents = dict(library_data_setting.contents)
+            existing_contents = dict(
+                config_mgr.get_config_value(
+                    library_data_setting.category,
+                    config_source="user_config",
+                    default={},
+                )
+            )
+            if "secrets_to_register" in library_contents:
+                library_contents["secrets_to_register"] = normalize_secrets_to_register(
+                    library_contents["secrets_to_register"]
+                )
+            if "secrets_to_register" in existing_contents:
+                existing_contents["secrets_to_register"] = normalize_secrets_to_register(
+                    existing_contents["secrets_to_register"]
+                )
+            # Merge with existing category
+            existing_category_contents = merge_dicts(
+                library_contents,
+                existing_contents,
+                add_keys=True,
+                merge_lists=True,
+            )
+            set_category_request = SetConfigCategoryRequest(
+                category=library_data_setting.category, contents=existing_category_contents
+            )
+            set_category_result = GriptapeNodes.handle_request(set_category_request)
+            if not isinstance(set_category_result, SetConfigCategoryResultSuccess):
+                problems.append(UpdateConfigCategoryProblem(category_name=library_data_setting.category))
+                details = f"Failed attempting to update config category '{library_data_setting.category}' for library '{library_data.name}'."
+                logger.error(details)
+
+        return problems
 
     async def register_library_from_requirement_specifier_request(
         self, request: RegisterLibraryFromRequirementSpecifierRequest
@@ -5030,6 +5052,17 @@ class LibraryManager:
             if resolved is not None:
                 process_path(resolved.path, enabled=entry.enabled, registered_path=resolved.registered_path)
 
+        # Add provisioned git-sourced libraries. Each libraries_to_download entry is
+        # cloned into the workspace libraries_directory by reconcile; discovery
+        # resolves it to its installed manifest there so it loads scoped to the
+        # workspace that declares it, without ever being written into the global
+        # libraries_to_register config (which would leak it into every project).
+        download_libraries = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
+        for download in normalize_library_downloads(download_libraries):
+            manifest_path = self._installed_manifest_path_for_download(download)
+            if manifest_path is not None:
+                process_path(manifest_path, enabled=True, registered_path=str(manifest_path))
+
         return discovered_entries
 
     @staticmethod
@@ -5038,10 +5071,10 @@ class LibraryManager:
 
         A register entry names an already-present local library by `path`, which
         resolves against the workspace. Libraries pinned to a git source live in
-        `libraries_to_download`; the download handler appends each provisioned
-        manifest path back into `libraries_to_register`, so they reach discovery
-        as ordinary path-backed entries. Returns None when the path does not exist
-        on disk.
+        `libraries_to_download` and are resolved separately in
+        `_discover_library_files` by locating their provisioned manifest under the
+        workspace libraries directory, so they never need a `libraries_to_register`
+        entry. Returns None when the path does not exist on disk.
         """
         # TODO: Update to check on project manager for workspace path. https://github.com/griptape-ai/griptape-nodes/issues/4396
         library_path = resolve_workspace_path(Path(entry.path), workspace_path)
@@ -5551,14 +5584,23 @@ class LibraryManager:
             else:
                 logger.info("Library '%s' registered successfully", library_name)
 
-        # Add library JSON file path to config so it's registered on future startups
-        libraries_to_register = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
-        library_json_str = str(library_json_path)
-        existing_paths = {extract_library_path(entry) for entry in libraries_to_register}
-        if library_json_str not in existing_paths:
-            libraries_to_register.append(library_json_str)
-            config_mgr.set_config_value(LIBRARIES_TO_REGISTER_KEY, libraries_to_register)
-            logger.info("Added library '%s' to config for auto-registration on startup", library_name)
+        # Persist the path to libraries_to_register only when registering now. The
+        # write lands in the GLOBAL user config (set_config_value -> user config),
+        # so a project-reconcile download (auto_register=False) must NOT touch it:
+        # the project's own libraries_to_download is the per-activation source of
+        # truth, and persisting its clone path here would leak that library into
+        # every other project's startup registration. Reconcile-downloaded
+        # libraries instead reach discovery directly from libraries_to_download
+        # (see _discover_library_files), so they load scoped to the workspace that
+        # declares them without any global config write.
+        if request.auto_register:
+            libraries_to_register = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
+            library_json_str = str(library_json_path)
+            existing_paths = {extract_library_path(entry) for entry in libraries_to_register}
+            if library_json_str not in existing_paths:
+                libraries_to_register.append(library_json_str)
+                config_mgr.set_config_value(LIBRARIES_TO_REGISTER_KEY, libraries_to_register)
+                logger.info("Added library '%s' to config for auto-registration on startup", library_name)
 
         if skip_clone:
             details = f"Library '{library_name}' already exists at {target_path} and has been registered"

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -49,21 +49,55 @@ from griptape_nodes.retained_mode.managers.settings import (
     LibraryDownload,
     LibraryRegistration,
 )
+from griptape_nodes.utils.library_utils import extract_library_path
 
 
-def _config_value_dispatcher(libraries_dir: Path, libraries: object) -> Callable[..., object]:
+def _config_value_dispatcher(
+    libraries_dir: Path, libraries: object, downloads: object | None = None
+) -> Callable[..., object]:
     """A `get_config_value` side_effect that dispatches by key.
 
-    `_discover_library_files` reads `libraries_to_register`; `libraries_directory`
-    is also served so callers that touch both keys share one mock.
+    `_discover_library_files` reads `libraries_to_register` and
+    `libraries_to_download`; `libraries_directory` is also served so callers that
+    touch all three keys share one mock. `downloads` defaults to an empty list so
+    discovery's download-sourcing pass finds nothing unless a test opts in.
     """
-    from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
+    from griptape_nodes.retained_mode.managers.settings import (
+        LIBRARIES_TO_DOWNLOAD_KEY,
+        LIBRARIES_TO_REGISTER_KEY,
+    )
+
+    download_entries = downloads if downloads is not None else []
 
     def get_config_value(key: str, **_: object) -> object:
         if key == LIBRARIES_TO_REGISTER_KEY:
             return libraries
+        if key == LIBRARIES_TO_DOWNLOAD_KEY:
+            return download_entries
         if key == "libraries_directory":
             return str(libraries_dir)
+        return None
+
+    return get_config_value
+
+
+def _register_only_config(libraries: object) -> Callable[..., object]:
+    """A `get_config_value` side_effect serving only `libraries_to_register`.
+
+    Discovery also reads `libraries_to_download`; this returns an empty list for it
+    so tests exercising register-only behavior do not have their register entries
+    misread as malformed download entries. Other keys return None.
+    """
+    from griptape_nodes.retained_mode.managers.settings import (
+        LIBRARIES_TO_DOWNLOAD_KEY,
+        LIBRARIES_TO_REGISTER_KEY,
+    )
+
+    def get_config_value(key: str, **_: object) -> object:
+        if key == LIBRARIES_TO_REGISTER_KEY:
+            return libraries
+        if key == LIBRARIES_TO_DOWNLOAD_KEY:
+            return []
         return None
 
     return get_config_value
@@ -199,7 +233,9 @@ class TestLibraryManagerDisabledEntries:
             {"path": str(disabled_lib), "enabled": False},
         ]
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config)
+        ):
             result = library_manager._discover_library_files()
 
         by_path = {
@@ -217,7 +253,9 @@ class TestLibraryManagerDisabledEntries:
         library_manager = griptape_nodes.LibraryManager()
         enabled_lib, _ = lib_files
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=[str(enabled_lib)]):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config([str(enabled_lib)])
+        ):
             result = library_manager._discover_library_files()
 
         assert len(result) == 1
@@ -237,7 +275,9 @@ class TestLibraryManagerDisabledEntries:
         # Reset tracking so this test does not depend on prior state.
         library_manager._library_file_path_to_info = {}
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config)
+        ):
             result = library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
 
         from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesResultSuccess
@@ -292,7 +332,9 @@ class TestLibraryManagerDisabledEntries:
 
         # Initial discovery: first_lib enabled, second_lib disabled.
         initial_config = [str(first_lib), {"path": str(second_lib), "enabled": False}]
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=initial_config):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(initial_config)
+        ):
             library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
 
         first_state = library_manager._library_file_path_to_info[str(first_lib)].lifecycle_state
@@ -302,7 +344,9 @@ class TestLibraryManagerDisabledEntries:
 
         # User flips the config: first_lib disabled, second_lib enabled, then triggers refresh.
         toggled_config = [{"path": str(first_lib), "enabled": False}, str(second_lib)]
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=toggled_config):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(toggled_config)
+        ):
             library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
 
         first_state_after = library_manager._library_file_path_to_info[str(first_lib)].lifecycle_state
@@ -2616,3 +2660,223 @@ class TestLibraryManagerInitializationFlag:
             await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
 
         assert library_manager.is_initializing() is False
+
+
+class TestDownloadLibraryRegisterPersistence:
+    """download_library_request must only persist to the GLOBAL config when registering now.
+
+    A project-reconcile download passes auto_register=False: the project's own
+    libraries_to_download is the per-activation source of truth, so the clone path
+    must NOT be appended to the global libraries_to_register (doing so leaks the
+    library into every other project's startup registration). The explicit CLI
+    download (auto_register=True) keeps persisting so it loads on future startups.
+    """
+
+    @staticmethod
+    def _make_clone(library_name: str) -> Callable[[str, Path, str | None], None]:
+        """Return a clone_repository stand-in that writes a minimal manifest into target_path."""
+
+        def fake_clone(_git_url: str, target_path: Path, _ref: str | None = None) -> None:
+            target_path.mkdir(parents=True, exist_ok=True)
+            (target_path / "griptape_nodes_library.json").write_text(
+                json.dumps({"name": library_name}), encoding="utf-8"
+            )
+
+        return fake_clone
+
+    @pytest.mark.asyncio
+    async def test_reconcile_download_does_not_persist_to_global_config(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """auto_register=False (the reconcile/provisioning path) leaves global libraries_to_register untouched."""
+        from griptape_nodes.retained_mode.events.library_events import (
+            DownloadLibraryRequest,
+            DownloadLibraryResultSuccess,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        before = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.library_manager.clone_repository",
+            side_effect=self._make_clone("provisioned_lib"),
+        ):
+            result = await library_manager.download_library_request(
+                DownloadLibraryRequest(
+                    git_url="owner/provisioned_lib",
+                    download_directory=str(tmp_path / "libs"),
+                    auto_register=False,
+                )
+            )
+
+        assert isinstance(result, DownloadLibraryResultSuccess)
+        after = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
+        assert {extract_library_path(entry) for entry in after} == {extract_library_path(entry) for entry in before}
+        assert result.library_path not in {extract_library_path(entry) for entry in after}
+
+    @pytest.mark.asyncio
+    async def test_explicit_download_persists_to_global_config(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """auto_register=True (the explicit CLI download) appends the clone path to global libraries_to_register."""
+        from griptape_nodes.retained_mode.events.library_events import (
+            DownloadLibraryRequest,
+            DownloadLibraryResultSuccess,
+        )
+
+        library_manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.library_manager.clone_repository",
+            side_effect=self._make_clone("explicit_lib"),
+        ):
+            result = await library_manager.download_library_request(
+                DownloadLibraryRequest(
+                    git_url="owner/explicit_lib",
+                    download_directory=str(tmp_path / "libs"),
+                    auto_register=True,
+                )
+            )
+
+        assert isinstance(result, DownloadLibraryResultSuccess)
+        after = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
+        assert result.library_path in {extract_library_path(entry) for entry in after}
+
+
+class TestDiscoverDownloadedLibraries:
+    """A provisioned libraries_to_download entry must be discoverable from the workspace.
+
+    Reconcile clones each libraries_to_download entry into the workspace
+    libraries_directory; discovery resolves it there so the library loads scoped
+    to the workspace that declares it, WITHOUT any libraries_to_register entry.
+    This is the mechanism that replaces the global-config append, so projects that
+    pin a library only via libraries_to_download (e.g. the lib-swap fixtures) still
+    load it.
+    """
+
+    @staticmethod
+    def _install_manifest(libraries_dir: Path, repo_name: str, library_name: str) -> Path:
+        """Materialize a provisioned library manifest under <libraries_dir>/<repo_name>/."""
+        manifest_dir = libraries_dir / repo_name
+        manifest_dir.mkdir(parents=True)
+        manifest_path = manifest_dir / "griptape_nodes_library.json"
+        manifest_path.write_text(json.dumps({"name": library_name}), encoding="utf-8")
+        return manifest_path
+
+    def test_download_only_library_is_discovered_from_workspace(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """A libraries_to_download entry with no libraries_to_register row is still discovered."""
+        from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_DOWNLOAD_KEY
+
+        library_manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+
+        libraries_dir = tmp_path / "libraries"
+        manifest_path = self._install_manifest(libraries_dir, "remote_lib", "remote_lib")
+
+        def get_config_value(key: str, **_: object) -> object:
+            if key == LIBRARIES_TO_REGISTER_KEY:
+                return []
+            if key == LIBRARIES_TO_DOWNLOAD_KEY:
+                return ["owner/remote_lib"]
+            if key == "libraries_directory":
+                return str(libraries_dir)
+            return None
+
+        with patch.object(config_mgr, "get_config_value", side_effect=get_config_value):
+            entries = library_manager._discover_library_files()
+
+        discovered_paths = {Path(entry.registration.path) for entry in entries}
+        assert manifest_path in discovered_paths
+
+
+class TestPersistLibrarySettings:
+    """A library's declared settings must persist to global WITHOUT leaking project-layer values.
+
+    Library load injects each declared setting category into the user config. The
+    existing category must be read from the user_config layer, not the merged
+    config: the merged config folds in the active project's project/workspace/env
+    layers (e.g. libraries_to_download, requires_engine), and round-tripping that
+    through SetConfigCategory (which writes the GLOBAL user config) would leak the
+    active project's per-activation pins into every other project's startup. This
+    is the canonical repro for the duplicate-standard-library symptom seen when
+    switching from a download-pinned project to one that declares no download.
+    """
+
+    @staticmethod
+    def _library_with_settings(category: str, contents: dict[str, object]) -> LibrarySchema:
+        """Build a minimal LibrarySchema declaring a single settings category."""
+        from griptape_nodes.node_library.library_registry import Setting
+
+        return LibrarySchema(
+            name="settings_lib",
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t",
+                description="d",
+                library_version="0.1.0",
+                engine_version="0.1.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+            settings=[Setting(category=category, contents=contents)],
+        )
+
+    def test_persist_does_not_leak_project_download_pin_to_global(
+        self, griptape_nodes: GriptapeNodes, isolate_user_config: Path, tmp_path: Path
+    ) -> None:
+        """A project-layer libraries_to_download pin must NOT be written into the global user config."""
+        library_manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+
+        # Prime a project-adjacent config carrying a download pin, then load it as
+        # the project layer so the MERGED config sees the pin but the global user
+        # config file does not.
+        project_dir = tmp_path / "pinned_project"
+        project_dir.mkdir()
+        (project_dir / "griptape_nodes_config.json").write_text(
+            json.dumps(
+                {
+                    "app_events": {
+                        "on_app_initialization_complete": {
+                            "libraries_to_download": [{"git_url": "owner/standard@v0.79.0", "version": "==0.79.0"}]
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        config_mgr.load_project_config(project_dir)
+        assert config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[]) != []
+
+        library = self._library_with_settings(
+            "app_events.on_app_initialization_complete",
+            {"secrets_to_register": {"MY_LIB_KEY": ""}},
+        )
+        problems = library_manager._persist_library_settings(library)
+
+        assert problems == []
+        # The library's own declared setting persisted globally...
+        global_config = json.loads(isolate_user_config.read_text(encoding="utf-8"))
+        init = global_config.get("app_events", {}).get("on_app_initialization_complete", {})
+        assert "MY_LIB_KEY" in init.get("secrets_to_register", {})
+        # ...but the project-layer download pin did NOT leak into the global config.
+        assert "libraries_to_download" not in init
+
+    def test_persist_creates_missing_category(self, griptape_nodes: GriptapeNodes, isolate_user_config: Path) -> None:
+        """A library declaring a brand-new category writes its contents verbatim to global."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        library = self._library_with_settings(
+            "my_library_category",
+            {"some_setting": "value"},
+        )
+        problems = library_manager._persist_library_settings(library)
+
+        assert problems == []
+        global_config = json.loads(isolate_user_config.read_text(encoding="utf-8"))
+        assert global_config.get("my_library_category", {}).get("some_setting") == "value"

--- a/tests/unit/retained_mode/managers/test_library_manager_ordering.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_ordering.py
@@ -15,9 +15,31 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+def _register_only_config(libraries: object) -> Callable[..., object]:
+    """A `get_config_value` side_effect serving only `libraries_to_register`.
+
+    Discovery also reads `libraries_to_download`; this returns an empty list for it
+    so these ordering tests, which only seed register entries, do not have their
+    register list misread as the download list. Other keys return None.
+    """
+    from griptape_nodes.retained_mode.managers.settings import (
+        LIBRARIES_TO_DOWNLOAD_KEY,
+        LIBRARIES_TO_REGISTER_KEY,
+    )
+
+    def get_config_value(key: str, **_: object) -> object:
+        if key == LIBRARIES_TO_REGISTER_KEY:
+            return libraries
+        if key == LIBRARIES_TO_DOWNLOAD_KEY:
+            return []
+        return None
+
+    return get_config_value
 
 
 class TestLibraryManagerDeterministicOrdering:
@@ -47,7 +69,9 @@ class TestLibraryManagerDeterministicOrdering:
         # Mock config to return libraries in specific order (z, a, m)
         config_order = [str(lib_z), str(lib_a), str(lib_m)]
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config_order):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
+        ):
             result = library_manager._discover_library_files()
 
             # Should preserve config order, not alphabetical
@@ -81,7 +105,9 @@ class TestLibraryManagerDeterministicOrdering:
         lib_b.write_text("{}")
 
         # Mock config to point to the parent directory
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=[str(lib_dir)]):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config([str(lib_dir)])
+        ):
             result = library_manager._discover_library_files()
 
             # Files from directory should be sorted alphabetically by path
@@ -123,7 +149,9 @@ class TestLibraryManagerDeterministicOrdering:
         # Config order: direct file, directory, another direct file
         config_order = [str(direct_lib), str(lib_dir), str(another_direct)]
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config_order):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
+        ):
             result = library_manager._discover_library_files()
 
             # Should be: direct_lib, dir_lib_a, dir_lib_b, another_direct
@@ -150,7 +178,9 @@ class TestLibraryManagerDeterministicOrdering:
         # Config lists same library twice
         config_order = [str(lib), str(lib)]
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config_order):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
+        ):
             result = library_manager._discover_library_files()
 
             # Should only appear once
@@ -176,7 +206,9 @@ class TestLibraryManagerDeterministicOrdering:
         # Mock config to return libraries in specific order
         config_order = [str(lib1), str(lib2)]
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config_order):
+        with patch.object(
+            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
+        ):
             request = DiscoverLibrariesRequest(include_sandbox=False)
             result = library_manager.discover_libraries_request(request)
 
@@ -202,7 +234,7 @@ class TestLibraryManagerDeterministicOrdering:
             lib.write_text("{}")
             libs.append(str(lib))
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=libs):
+        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(libs)):
             request = DiscoverLibrariesRequest(include_sandbox=False)
 
             result1 = library_manager.discover_libraries_request(request)


### PR DESCRIPTION
Project's libraries to download were being downloaded to the global workspace, influencing other projects