### PR TITLE
feat: let request handlers screen through the pre-dispatch hook chain

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -123,6 +123,12 @@ class EventManager:
         # chain is skipped so the hook can't keep re-triggering itself into
         # unbounded recursion.
         self._hook_evaluation = threading.local()
+        # Request types whose handler runs the pre-dispatch hook chain itself
+        # (via run_pre_dispatch_hooks) instead of being screened automatically by
+        # the dispatcher. Lets a handler shape a short-circuit outcome -- e.g.
+        # turn a denial into an error-proxy node -- and keeps a request gated
+        # identically whether it arrived through dispatch or a direct call.
+        self._self_screened_request_types: set[type[RequestPayload]] = set()
 
     @property
     def event_queue(self) -> asyncio.Queue:
@@ -316,6 +322,30 @@ class EventManager:
             return None
         finally:
             self._hook_evaluation.active = False
+
+    def mark_request_type_self_screened(self, request_type: type[RequestPayload]) -> None:
+        """Declare that `request_type`'s handler runs the pre-dispatch hook chain itself.
+
+        The dispatcher then skips its automatic pre-dispatch screen for this type
+        (in both `handle_request` and `ahandle_request`). The handler is expected
+        to call `run_pre_dispatch_hooks` and act on any short-circuit result. Use
+        this when a handler needs to shape the short-circuit outcome rather than
+        return it verbatim, or when the operation is also reached by direct calls
+        that never pass through the dispatcher.
+        """
+        self._self_screened_request_types.add(request_type)
+
+    def run_pre_dispatch_hooks(self, request: RequestPayload) -> ResultPayload | None:
+        """Run the registered pre-dispatch hook chain against `request`.
+
+        Public counterpart to the automatic screen the dispatcher performs.
+        Returns the first hook's short-circuit `ResultPayload`, or None when every
+        hook falls through. Intended for handlers of self-screened request types
+        (see `mark_request_type_self_screened`) and for operations invoked by
+        direct method call rather than through `handle_request`, which would
+        otherwise never see the chain.
+        """
+        return self._run_pre_dispatch_hooks(request, ResultContext())
 
     def assign_manager_to_request_type(
         self,
@@ -609,14 +639,18 @@ class EventManager:
             raise TypeError(msg)
 
         # Pre-dispatch hooks (e.g. PermissionManager) may short-circuit before
-        # the manager callback runs.
-        short_circuit = self._run_pre_dispatch_hooks(request, result_context)
-        if short_circuit is not None:
-            return self._handle_request_core(
-                request,
-                short_circuit,
-                context=result_context,
-            )
+        # the manager callback runs. A self-screened request type runs the hook
+        # chain from inside its own handler so it can shape the outcome (e.g.
+        # substitute an error proxy), so skip the automatic screen here to avoid
+        # running the chain twice.
+        if request_type not in self._self_screened_request_types:
+            short_circuit = self._run_pre_dispatch_hooks(request, result_context)
+            if short_circuit is not None:
+                return self._handle_request_core(
+                    request,
+                    short_circuit,
+                    context=result_context,
+                )
 
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
@@ -637,7 +671,7 @@ class EventManager:
         finally:
             _active_request_type.reset(token)
 
-    def handle_request(  # noqa: PLR0912
+    def handle_request(  # noqa: PLR0912, C901
         self,
         request: RP,
         *,
@@ -665,14 +699,18 @@ class EventManager:
             raise TypeError(msg)
 
         # Pre-dispatch hooks (e.g. PermissionManager) may short-circuit before
-        # the manager callback runs.
-        short_circuit = self._run_pre_dispatch_hooks(request, result_context)
-        if short_circuit is not None:
-            return self._handle_request_core(
-                request,
-                short_circuit,
-                context=result_context,
-            )
+        # the manager callback runs. A self-screened request type runs the hook
+        # chain from inside its own handler so it can shape the outcome (e.g.
+        # substitute an error proxy), so skip the automatic screen here to avoid
+        # running the chain twice.
+        if request_type not in self._self_screened_request_types:
+            short_circuit = self._run_pre_dispatch_hooks(request, result_context)
+            if short_circuit is not None:
+                return self._handle_request_core(
+                    request,
+                    short_circuit,
+                    context=result_context,
+                )
 
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -26,6 +26,7 @@ from .node_class_not_base_node_problem import NodeClassNotBaseNodeProblem
 from .node_class_not_found_problem import NodeClassNotFoundProblem
 from .node_module_import_problem import NodeModuleImportProblem
 from .old_xdg_location_warning_problem import OldXdgLocationWarningProblem
+from .permission_denied_library_problem import PermissionDeniedLibraryProblem
 from .retired_node_declaration_problem import RetiredNodeDeclarationProblem
 from .sandbox_directory_missing_problem import SandboxDirectoryMissingProblem
 from .ui_options_field_modified_incompatible_problem import UiOptionsFieldModifiedIncompatibleProblem
@@ -62,6 +63,7 @@ __all__ = [
     "NodeClassNotFoundProblem",
     "NodeModuleImportProblem",
     "OldXdgLocationWarningProblem",
+    "PermissionDeniedLibraryProblem",
     "RetiredNodeDeclarationProblem",
     "SandboxDirectoryMissingProblem",
     "UiOptionsFieldModifiedIncompatibleProblem",

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/permission_denied_library_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/permission_denied_library_problem.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+
+@dataclass
+class PermissionDeniedLibraryProblem(LibraryProblem):
+    """Problem indicating a pre-dispatch hook forbids loading this library.
+
+    Raised when the engine screens the library's fitness request through the
+    registered hook chain and a hook short-circuits it (in practice the host
+    application's license policy). The library is treated as unusable and is not
+    registered. `detail` carries the hook's own explanation -- the missing
+    capability and what to ask an administrator for -- so the GUI can surface it
+    on the library's failure icon.
+
+    Stackable: a library screened more than once (e.g. re-evaluated on reload)
+    can accumulate several detail lines.
+    """
+
+    detail: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[PermissionDeniedLibraryProblem]) -> str:
+        """Display the explanation(s) for why loading the library was denied."""
+        details = [instance.detail for instance in instances if instance.detail]
+        if not details:
+            return "Loading this library is not permitted by the active policy."
+        if len(details) == 1:
+            return details[0]
+        return "Loading this library is not permitted by the active policy:\n" + "\n".join(
+            f"  - {detail}" for detail in details
+        )

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -4840,9 +4840,10 @@ class LibraryManager:
         # A short-circuit means a hook forbids the library; treat it as unusable
         # and surface the hook's explanation on the library's failure icon.
         policy_denial = GriptapeNodes.EventManager().run_pre_dispatch_hooks(request)
-        # Only a failure short-circuit forbids the library; a success short-circuit
-        # would be returned verbatim by the dispatcher rather than blocking, so it
-        # must not mark the library unusable.
+        # Only a failure short-circuit forbids the library (a genuine policy denial,
+        # or a fail-closed result when a hook itself errors). A success short-circuit
+        # is ignored and fitness evaluation continues; enforcement hooks only ever
+        # deny, so that case is not expected here.
         if policy_denial is not None and policy_denial.failed():
             detail = getattr(policy_denial, "result_details", None)
             problems.append(PermissionDeniedLibraryProblem(detail=str(detail) if detail else ""))

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -211,6 +211,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     NodeClassNotFoundProblem,
     NodeModuleImportProblem,
     OldXdgLocationWarningProblem,
+    PermissionDeniedLibraryProblem,
     SandboxDirectoryMissingProblem,
     UpdateConfigCategoryProblem,
 )
@@ -4832,6 +4833,21 @@ class LibraryManager:
         """
         schema = request.schema
         problems: list[LibraryProblem] = []
+
+        # Screen the load through the registered pre-dispatch hook chain (the host
+        # application installs license-policy enforcement there). This handler is
+        # reached by direct call, not dispatch, so it runs the chain explicitly.
+        # A short-circuit means a hook forbids the library; treat it as unusable
+        # and surface the hook's explanation on the library's failure icon.
+        policy_denial = GriptapeNodes.EventManager().run_pre_dispatch_hooks(request)
+        if policy_denial is not None:
+            detail = getattr(policy_denial, "result_details", None)
+            problems.append(PermissionDeniedLibraryProblem(detail=str(detail) if detail else ""))
+            return EvaluateLibraryFitnessResultFailure(
+                result_details=f"Library '{schema.name}' is not permitted by the active policy.",
+                fitness=LibraryManager.LibraryFitness.UNUSABLE,
+                problems=problems,
+            )
 
         # Check for version-based compatibility issues
         version_issues = GriptapeNodes.VersionCompatibilityManager().check_library_version_compatibility(schema)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -4840,7 +4840,10 @@ class LibraryManager:
         # A short-circuit means a hook forbids the library; treat it as unusable
         # and surface the hook's explanation on the library's failure icon.
         policy_denial = GriptapeNodes.EventManager().run_pre_dispatch_hooks(request)
-        if policy_denial is not None:
+        # Only a failure short-circuit forbids the library; a success short-circuit
+        # would be returned verbatim by the dispatcher rather than blocking, so it
+        # must not mark the library unusable.
+        if policy_denial is not None and policy_denial.failed():
             detail = getattr(policy_denial, "result_details", None)
             problems.append(PermissionDeniedLibraryProblem(detail=str(detail) if detail else ""))
             return EvaluateLibraryFitnessResultFailure(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -291,6 +291,11 @@ class NodeManager:
         self._worker_inflight_aprocesses: dict[str, tuple[asyncio.Task, BaseNode]] = {}
 
         event_manager.assign_manager_to_request_type(CreateNodeRequest, self.on_create_node_request)
+        # CreateNodeRequest screens itself through the pre-dispatch hook chain from
+        # inside its handler so a denial can be turned into an Error Proxy node
+        # (rather than a bare short-circuit) and so node creation reached by direct
+        # call is gated the same as dispatched creation.
+        event_manager.mark_request_type_self_screened(CreateNodeRequest)
         event_manager.assign_manager_to_request_type(
             AddNodesToNodeGroupRequest, self.on_add_nodes_to_node_group_request
         )
@@ -495,6 +500,21 @@ class NodeManager:
         # OK, let's try and create the Node.
         node = None
         try:
+            # Screen creation through the registered pre-dispatch hook chain (the
+            # host application installs license-policy enforcement there).
+            # CreateNodeRequest is marked self-screened, so the dispatcher does not
+            # screen it automatically; running the chain here gates dispatched and
+            # direct-call creation alike. A short-circuit means a hook forbids this
+            # node type: raise so the error-proxy path below substitutes a
+            # placeholder carrying the explanation.
+            policy_denial = GriptapeNodes.EventManager().run_pre_dispatch_hooks(request)
+            if policy_denial is not None:
+                denial_detail = getattr(policy_denial, "result_details", None)
+                raise PermissionError(  # noqa: TRY301
+                    str(denial_detail)
+                    if denial_detail
+                    else f"Creating a node of type '{request.node_type}' is not permitted by the active policy."
+                )
             node = LibraryRegistry.create_node(
                 name=final_node_name,
                 node_type=request.node_type,

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -508,7 +508,10 @@ class NodeManager:
             # node type: raise so the error-proxy path below substitutes a
             # placeholder carrying the explanation.
             policy_denial = GriptapeNodes.EventManager().run_pre_dispatch_hooks(request)
-            if policy_denial is not None:
+            # A hook may short-circuit with a success result; only a failure
+            # result denies creation. This matches the dispatcher, which returns a
+            # success short-circuit verbatim rather than blocking the operation.
+            if policy_denial is not None and policy_denial.failed():
                 denial_detail = getattr(policy_denial, "result_details", None)
                 raise PermissionError(  # noqa: TRY301
                     str(denial_detail)
@@ -523,7 +526,13 @@ class NodeManager:
             )
         # modifying to exception to try to catch all possible issues with node creation.
         except Exception as err:
-            logger.error(err)
+            # A policy denial (PermissionError) is an expected, by-design outcome
+            # that the error-proxy path below substitutes with a placeholder node,
+            # so log it as info rather than as a node-creation error.
+            if isinstance(err, PermissionError):
+                logger.info("Creation of node type '%s' denied by active policy: %s", request.node_type, err)
+            else:
+                logger.error(err)
             details = f"Could not create Node '{final_node_name}' of type '{request.node_type}': {err}"
 
             # Check if we should create an Error Proxy node instead of failing

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -549,17 +549,22 @@ class NodeManager:
             # Check if we should create an Error Proxy node instead of failing
             if request.create_error_proxy_on_failure:
                 try:
-                    # Use fitness problem details if available for a more actionable error message
-                    library_metadata_result = GriptapeNodes.handle_request(
-                        GetLibraryMetadataRequest(library=request.specific_library_name or "")
-                    )
-                    if (
-                        isinstance(library_metadata_result, GetLibraryMetadataResultFailure)
-                        and library_metadata_result.problems is not None
-                    ):
-                        failure_reason = library_metadata_result.problems
-                    else:
+                    if isinstance(err, _NodeCreationPolicyDeniedError):
+                        # A policy denial carries its own explanation; surface it
+                        # verbatim rather than the library's fitness problems.
                         failure_reason = str(err)
+                    else:
+                        # Use fitness problem details if available for a more actionable error message
+                        library_metadata_result = GriptapeNodes.handle_request(
+                            GetLibraryMetadataRequest(library=request.specific_library_name or "")
+                        )
+                        if (
+                            isinstance(library_metadata_result, GetLibraryMetadataResultFailure)
+                            and library_metadata_result.problems is not None
+                        ):
+                            failure_reason = library_metadata_result.problems
+                        else:
+                            failure_reason = str(err)
 
                     # Create ErrorProxyNode directly since it needs special initialization
                     node = ErrorProxyNode(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -221,6 +221,15 @@ logger = logging.getLogger("griptape_nodes")
 _PARAM_MISSING = object()
 
 
+class _NodeCreationPolicyDeniedError(Exception):
+    """Internal signal that a pre-dispatch hook denied this node creation.
+
+    A distinct type so the creation handler can tell a denial it raised itself
+    apart from an organic exception (including a real PermissionError) bubbling
+    out of node construction, which must still be logged as an error.
+    """
+
+
 class SerializedParameterValues(NamedTuple):
     """Result of serializing parameter output values.
 
@@ -515,7 +524,7 @@ class NodeManager:
             # ever deny, so that case is not expected here.
             if policy_denial is not None and policy_denial.failed():
                 denial_detail = getattr(policy_denial, "result_details", None)
-                raise PermissionError(  # noqa: TRY301
+                raise _NodeCreationPolicyDeniedError(  # noqa: TRY301
                     str(denial_detail)
                     if denial_detail
                     else f"Creating a node of type '{request.node_type}' is not permitted by the active policy."
@@ -528,10 +537,10 @@ class NodeManager:
             )
         # modifying to exception to try to catch all possible issues with node creation.
         except Exception as err:
-            # A policy denial (PermissionError) is an expected, by-design outcome
-            # that the error-proxy path below substitutes with a placeholder node,
-            # so log it as info rather than as a node-creation error.
-            if isinstance(err, PermissionError):
+            # A policy denial (_NodeCreationPolicyDeniedError) is an expected, by-design
+            # outcome that the error-proxy path below substitutes with a placeholder
+            # node, so log it as info rather than as a node-creation error.
+            if isinstance(err, _NodeCreationPolicyDeniedError):
                 logger.info("Creation of node type '%s' denied by active policy: %s", request.node_type, err)
             else:
                 logger.error(err)

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -508,9 +508,11 @@ class NodeManager:
             # node type: raise so the error-proxy path below substitutes a
             # placeholder carrying the explanation.
             policy_denial = GriptapeNodes.EventManager().run_pre_dispatch_hooks(request)
-            # A hook may short-circuit with a success result; only a failure
-            # result denies creation. This matches the dispatcher, which returns a
-            # success short-circuit verbatim rather than blocking the operation.
+            # Only a failure short-circuit denies creation (a genuine policy
+            # denial, or a fail-closed result when a hook itself errors). A
+            # success short-circuit is ignored and creation proceeds; unlike the
+            # dispatcher it is not returned verbatim, but enforcement hooks only
+            # ever deny, so that case is not expected here.
             if policy_denial is not None and policy_denial.failed():
                 denial_detail = getattr(policy_denial, "result_details", None)
                 raise PermissionError(  # noqa: TRY301

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -647,3 +647,63 @@ class TestPreDispatchHooks:
 
         assert event.result.failed()
         assert handler_calls == []
+
+    def test_run_pre_dispatch_hooks_runs_chain_explicitly(self) -> None:
+        event_manager = EventManager()
+
+        # No hooks registered: nothing to short-circuit.
+        assert event_manager.run_pre_dispatch_hooks(_ProbeRequest()) is None
+
+        def denier(_request: RequestPayload, _context: object) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager.add_pre_dispatch_hook(denier)
+
+        result = event_manager.run_pre_dispatch_hooks(_ProbeRequest())
+        assert isinstance(result, _DeniedResult)
+        assert "denied" in str(result.result_details)
+
+    def test_self_screened_type_is_not_auto_screened_by_dispatcher(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+        event_manager.mark_request_type_self_screened(_ProbeRequest)
+
+        def denier(_request: RequestPayload, _context: object) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager.add_pre_dispatch_hook(denier)
+
+        # The dispatcher skips the automatic screen for a self-screened type, so a
+        # denying hook does not short-circuit; the handler runs and decides.
+        event = event_manager.handle_request(_ProbeRequest())
+        assert event.result.succeeded()
+        assert len(handler_calls) == 1
+        # The handler can still run the chain itself and observe the denial.
+        assert isinstance(event_manager.run_pre_dispatch_hooks(_ProbeRequest()), _DeniedResult)
+
+    @pytest.mark.asyncio
+    async def test_self_screened_type_is_not_auto_screened_async(self) -> None:
+        event_manager = EventManager()
+        handler_calls: list[RequestPayload] = []
+
+        async def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+        event_manager.mark_request_type_self_screened(_ProbeRequest)
+
+        def denier(_request: RequestPayload, _context: object) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager.add_pre_dispatch_hook(denier)
+
+        event = await event_manager.ahandle_request(_ProbeRequest())
+        assert event.result.succeeded()
+        assert len(handler_calls) == 1


### PR DESCRIPTION
The pre-dispatch hook chain, only ran for requests that travel through the dispatcher. Library loading reaches fitness evaluation and node creation through direct method calls, and startup library loading is entirely direct calls, so those operations were never screened. A node type or library that policy forbids could still be loaded as long as it entered through one of those direct paths.

This exposes `run_pre_dispatch_hooks` so a handler can run the registered chain against a request it received directly, and `mark_request_type_self_screened` so a dispatchable type can move that screen into its own handler. When a type is self-screened the dispatcher skips its automatic pre-dispatch screen, so the chain runs exactly once whether the request arrived by dispatch or direct call. Running the screen inside the handler also lets it shape a short-circuit into something richer than a verbatim denial.

`evaluate_library_fitness_request` now screens its own request and turns a denial into a `PermissionDeniedLibraryProblem`, marking the library unusable so it is not registered, with the hook's explanation surfaced on the library's failure icon. `CreateNodeRequest` is self-screened and turns a denial into an `ErrorProxyNode` carrying the explanation instead of failing silently.
