### PR TITLE
Worker Project Inheritance

### DIFF
--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from griptape_nodes.common.strict_mode import STRICT_MODE
@@ -74,6 +75,11 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.project_events import (
+    LoadProjectTemplateRequest,
+    LoadProjectTemplateResultSuccess,
+    SetCurrentProjectRequest,
+)
 from griptape_nodes.retained_mode.events.secrets_events import (
     DeleteSecretValueRequest,
     SetSecretValueRequest,
@@ -86,6 +92,7 @@ logger = logging.getLogger("griptape_nodes")
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
 
@@ -185,6 +192,42 @@ class RefreshSecretsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure)
 
 
 @dataclass
+@PayloadRegistry.register
+class ActivateProjectRequest(RequestPayload, SkipTheLineMixin):
+    """Sent by the orchestrator to each registered worker after it switches projects.
+
+    The orchestrator is the single source of truth for the current project, but a
+    worker re-derives its project independently at boot and is only restarted on a
+    switch that changes library config. A switch that keeps the same workspace and
+    library config (only environment / directories / situations differ) leaves the
+    worker on a stale project. This tells the worker to adopt the orchestrator's new
+    project so env vars, directory macros, and situation/path macros resolve against
+    the right project.
+
+    project_file_path is the absolute path of the new project's file, or None when
+    the orchestrator switched to system defaults. Both processes share the same
+    machine, so the path the orchestrator sends is readable by the worker.
+
+    Uses SkipTheLineMixin so the worker activates the new project immediately, ahead
+    of any queued ExecuteNodeRequest that would otherwise run against the stale one.
+    """
+
+    project_file_path: str | None
+
+
+@dataclass
+@PayloadRegistry.register
+class ActivateProjectResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Worker adopted the orchestrator's current project."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ActivateProjectResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Worker failed to adopt the orchestrator's current project."""
+
+
+@dataclass
 class RemoteHandler:
     """Worker-side dispatch shim.
 
@@ -265,13 +308,15 @@ def register_broadcast_handlers(
     *,
     config_manager: ConfigManager,
     secrets_manager: SecretsManager,
+    project_manager: ProjectManager,
 ) -> None:
     """Install worker-side handlers for orchestrator-originated broadcasts.
 
-    Workers receive ``ReloadConfigRequest`` / ``RefreshSecretsRequest`` from
-    the orchestrator and respond by re-reading the shared on-disk state. The
-    actual reload is delegated to the corresponding manager so domain logic
-    stays in the manager and routing decisions stay here.
+    Workers receive ``ReloadConfigRequest`` / ``RefreshSecretsRequest`` /
+    ``ActivateProjectRequest`` from the orchestrator and respond by re-reading
+    the shared on-disk state or adopting the orchestrator's current project. The
+    actual work is delegated to the corresponding manager so domain logic stays
+    in the manager and routing decisions stay here.
     """
 
     def handle_reload_config(request: ReloadConfigRequest) -> ResultPayload:  # noqa: ARG001
@@ -292,5 +337,43 @@ def register_broadcast_handlers(
             return RefreshSecretsResultFailure(result_details=details)
         return RefreshSecretsResultSuccess(result_details="Refreshed secrets from shared .env file.")
 
+    async def handle_activate_project(request: ActivateProjectRequest) -> ResultPayload:
+        # No path means the orchestrator is on system defaults. SetCurrentProjectRequest
+        # treats project_id=None as the wire signal to land on system defaults, so the
+        # worker mirrors the orchestrator without a load step.
+        if request.project_file_path is None:
+            set_result = await project_manager.on_set_current_project_request(SetCurrentProjectRequest(project_id=None))
+            if set_result.failed():
+                details = f"Attempted to activate system defaults. Failed with result: {set_result.result_details}"
+                logger.error(details)
+                return ActivateProjectResultFailure(result_details=details)
+            return ActivateProjectResultSuccess(result_details="Adopted system defaults from orchestrator.")
+
+        load_result = await project_manager.on_load_project_template_request(
+            LoadProjectTemplateRequest(project_path=Path(request.project_file_path))
+        )
+        if not isinstance(load_result, LoadProjectTemplateResultSuccess):
+            details = (
+                f"Attempted to load project template from {request.project_file_path}. "
+                f"Failed with result: {load_result.result_details}"
+            )
+            logger.error(details)
+            return ActivateProjectResultFailure(result_details=details)
+
+        set_result = await project_manager.on_set_current_project_request(
+            SetCurrentProjectRequest(project_id=load_result.project_id)
+        )
+        if set_result.failed():
+            details = (
+                f"Attempted to set project {load_result.project_id} as current. "
+                f"Failed with result: {set_result.result_details}"
+            )
+            logger.error(details)
+            return ActivateProjectResultFailure(result_details=details)
+        return ActivateProjectResultSuccess(
+            result_details=f"Adopted project from orchestrator: {request.project_file_path}."
+        )
+
     event_manager.assign_manager_to_request_type(ReloadConfigRequest, handle_reload_config)
     event_manager.assign_manager_to_request_type(RefreshSecretsRequest, handle_refresh_secrets)
+    event_manager.assign_manager_to_request_type(ActivateProjectRequest, handle_activate_project)

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from griptape_nodes.common.strict_mode import STRICT_MODE
@@ -76,8 +75,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
-    LoadProjectTemplateRequest,
-    LoadProjectTemplateResultSuccess,
     SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.secrets_events import (
@@ -197,22 +194,21 @@ class ActivateProjectRequest(RequestPayload, SkipTheLineMixin):
     """Sent by the orchestrator to each registered worker after it switches projects.
 
     The orchestrator is the single source of truth for the current project, but a
-    worker re-derives its project independently at boot and is only restarted on a
-    switch that changes library config. A switch that keeps the same workspace and
-    library config (only environment / directories / situations differ) leaves the
-    worker on a stale project. This tells the worker to adopt the orchestrator's new
-    project so env vars, directory macros, and situation/path macros resolve against
-    the right project.
+    worker is only restarted on a switch that changes library config. A switch that
+    keeps the same workspace and library config (only environment / directories /
+    situations differ) leaves the worker on a stale project. This tells the worker
+    to adopt the orchestrator's new project so env vars, directory macros, and
+    situation/path macros resolve against the right project.
 
-    project_file_path is the absolute path of the new project's file, or None when
-    the orchestrator switched to system defaults. Both processes share the same
-    machine, so the path the orchestrator sends is readable by the worker.
+    project_id is the opaque id of the new current project (SYSTEM_DEFAULTS_KEY for
+    system defaults). A worker boots like an engine off the same shared on-disk
+    config, so the orchestrator's registry id is already loaded in the worker.
 
     Uses SkipTheLineMixin so the worker activates the new project immediately, ahead
     of any queued ExecuteNodeRequest that would otherwise run against the stale one.
     """
 
-    project_file_path: str | None
+    project_id: str
 
 
 @dataclass
@@ -338,40 +334,21 @@ def register_broadcast_handlers(
         return RefreshSecretsResultSuccess(result_details="Refreshed secrets from shared .env file.")
 
     async def handle_activate_project(request: ActivateProjectRequest) -> ResultPayload:
-        # No path means the orchestrator is on system defaults. SetCurrentProjectRequest
-        # treats project_id=None as the wire signal to land on system defaults, so the
-        # worker mirrors the orchestrator without a load step.
-        if request.project_file_path is None:
-            set_result = await project_manager.on_set_current_project_request(SetCurrentProjectRequest(project_id=None))
-            if set_result.failed():
-                details = f"Attempted to activate system defaults. Failed with result: {set_result.result_details}"
-                logger.error(details)
-                return ActivateProjectResultFailure(result_details=details)
-            return ActivateProjectResultSuccess(result_details="Adopted system defaults from orchestrator.")
-
-        load_result = await project_manager.on_load_project_template_request(
-            LoadProjectTemplateRequest(project_path=Path(request.project_file_path))
-        )
-        if not isinstance(load_result, LoadProjectTemplateResultSuccess):
-            details = (
-                f"Attempted to load project template from {request.project_file_path}. "
-                f"Failed with result: {load_result.result_details}"
-            )
-            logger.error(details)
-            return ActivateProjectResultFailure(result_details=details)
-
+        # A worker boots like an engine off the same shared on-disk config, so the
+        # orchestrator's project id is already loaded in the worker's registry. Adopt
+        # it by id; no load-by-path step is needed. SYSTEM_DEFAULTS_KEY is a normal id.
         set_result = await project_manager.on_set_current_project_request(
-            SetCurrentProjectRequest(project_id=load_result.project_id)
+            SetCurrentProjectRequest(project_id=request.project_id)
         )
         if set_result.failed():
             details = (
-                f"Attempted to set project {load_result.project_id} as current. "
+                f"Attempted to adopt orchestrator project '{request.project_id}'. "
                 f"Failed with result: {set_result.result_details}"
             )
             logger.error(details)
             return ActivateProjectResultFailure(result_details=details)
         return ActivateProjectResultSuccess(
-            result_details=f"Adopted project from orchestrator: {request.project_file_path}."
+            result_details=f"Adopted project from orchestrator: {request.project_id}."
         )
 
     event_manager.assign_manager_to_request_type(ReloadConfigRequest, handle_reload_config)

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -347,9 +347,7 @@ def register_broadcast_handlers(
             )
             logger.error(details)
             return ActivateProjectResultFailure(result_details=details)
-        return ActivateProjectResultSuccess(
-            result_details=f"Adopted project from orchestrator: {request.project_id}."
-        )
+        return ActivateProjectResultSuccess(result_details=f"Adopted project from orchestrator: {request.project_id}.")
 
     event_manager.assign_manager_to_request_type(ReloadConfigRequest, handle_reload_config)
     event_manager.assign_manager_to_request_type(RefreshSecretsRequest, handle_refresh_secrets)

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -335,8 +335,21 @@ def register_broadcast_handlers(
 
     async def handle_activate_project(request: ActivateProjectRequest) -> ResultPayload:
         # A worker boots like an engine off the same shared on-disk config, so the
-        # orchestrator's project id is already loaded in the worker's registry. Adopt
-        # it by id; no load-by-path step is needed. SYSTEM_DEFAULTS_KEY is a normal id.
+        # orchestrator's project id is usually already loaded in the worker's registry.
+        # But a worker's registry is frozen at boot: if the orchestrator switched to a
+        # project it registered AFTER this worker spawned, the id is absent here. Re-read
+        # the shared config and re-run registered-project discovery (engine-style) so the
+        # worker learns it. Fail loud if the id is still unknown -- silently landing on a
+        # stale project while reporting success is exactly the divergence we must avoid.
+        if not await project_manager.ensure_project_loaded(request.project_id):
+            details = (
+                f"Attempted to adopt orchestrator project '{request.project_id}'. "
+                f"Failed because the id is absent from the worker's registry even after "
+                f"reloading config and re-running registered-project discovery."
+            )
+            logger.error(details)
+            return ActivateProjectResultFailure(result_details=details)
+
         set_result = await project_manager.on_set_current_project_request(
             SetCurrentProjectRequest(project_id=request.project_id)
         )

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -334,6 +334,13 @@ def register_broadcast_handlers(
         return RefreshSecretsResultSuccess(result_details="Refreshed secrets from shared .env file.")
 
     async def handle_activate_project(request: ActivateProjectRequest) -> ResultPayload:
+        # A ReloadConfigRequest may land concurrently: a post-init orchestrator switch
+        # persists project_file, which emits ConfigChanged -> ReloadConfigRequest to every
+        # worker, right alongside this activation. Both are SkipTheLine and run as separate
+        # tasks, so they interleave. It is safe because _activate_project below does
+        # clear_project_layers() + a full re-merge, so a concurrent load_configs() only
+        # refreshes the user layer idempotently and cannot leave layers half-applied.
+        #
         # A worker boots like an engine off the same shared on-disk config, so the
         # orchestrator's project id is usually already loaded in the worker's registry.
         # But a worker's registry is frozen at boot: if the orchestrator switched to a

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -257,6 +257,29 @@ class SecretChanged(AppPayload):
 
 @dataclass
 @PayloadRegistry.register
+class CurrentProjectChanged(AppPayload):
+    """Current project switched notification.
+
+    Emitted by the orchestrator's ProjectManager after a post-init project
+    activation succeeds. WorkerManager listens for this and fans out an
+    ActivateProjectRequest to every registered worker so they adopt the
+    orchestrator's project even on a "shallow" switch (same workspace and
+    library config) that would not otherwise restart them.
+
+    Boot-time activation is handled separately via the worker spawn arg, so
+    ProjectManager only emits this after _initialization_complete.
+
+    Args:
+        project_file_path: Absolute path of the new project's file, or None when
+            the orchestrator switched to system defaults. Both processes share
+            the same machine, so the path is readable by every worker.
+    """
+
+    project_file_path: str | None
+
+
+@dataclass
+@PayloadRegistry.register
 class GetEngineVersionRequest(RequestPayload):
     """Get the engine version information.
 

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -266,16 +266,17 @@ class CurrentProjectChanged(AppPayload):
     orchestrator's project even on a "shallow" switch (same workspace and
     library config) that would not otherwise restart them.
 
-    Boot-time activation is handled separately via the worker spawn arg, so
+    Boot-time activation is handled separately: a worker boots like any engine
+    and re-derives the orchestrator's project from shared on-disk config, so
     ProjectManager only emits this after _initialization_complete.
 
     Args:
-        project_file_path: Absolute path of the new project's file, or None when
-            the orchestrator switched to system defaults. Both processes share
-            the same machine, so the path is readable by every worker.
+        project_id: The opaque id of the new current project (SYSTEM_DEFAULTS_KEY
+            for system defaults). A worker boots like the orchestrator, so the
+            same registry id resolves in both processes.
     """
 
-    project_file_path: str | None
+    project_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1546,6 +1546,25 @@ class ProjectManager:
 
         return _ProjectActivationOutcome(failure=None, workspace_changed=workspace_changed)
 
+    async def ensure_project_loaded(self, project_id: ProjectID) -> bool:
+        """Ensure a project id is present in the in-memory registry, re-deriving if absent.
+
+        A worker boots like an engine and freezes its project registry at boot
+        (`_load_registered_projects` / `_load_workspace_project` run only from
+        `on_app_initialization_complete`). When the orchestrator switches to a project it
+        registered AFTER this worker spawned, the worker's registry lacks that id. This
+        re-reads the shared on-disk config and re-runs registered-project discovery (the
+        same derivation boot uses) so the worker learns projects registered after spawn.
+
+        Returns True if the id is present (already, or after re-derivation), False
+        otherwise. SYSTEM_DEFAULTS_KEY is loaded at boot and so is always present.
+        """
+        if project_id in self._successfully_loaded_project_templates:
+            return True
+        self._config_manager.load_configs()
+        await self._load_registered_projects()
+        return project_id in self._successfully_loaded_project_templates
+
     def on_get_current_project_request(
         self, _request: GetCurrentProjectRequest
     ) -> GetCurrentProjectResultSuccess | GetCurrentProjectResultFailure:

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1180,6 +1180,24 @@ class ProjectManager:
     # project.yml, but we emit a warning so overrides are visible in logs.
     _DANGEROUS_ENV_KEYS: frozenset[str] = frozenset({"PATH", "HOME", "PYTHONPATH", "LD_LIBRARY_PATH"})
 
+    def get_pre_project_environ(self) -> dict[str, str]:
+        """Return a copy of os.environ with the active project's env mutations reverted.
+
+        A worker is spawned by the orchestrator, which has already applied its current
+        project's environment to os.environ. Inheriting that polluted environ would make
+        the worker snapshot a baseline that already contains project A's values, so on a
+        later switch to project B the worker could not unset the keys project A added.
+        Spawning with this reconstructed pre-project environ gives the worker the same
+        clean baseline a freshly launched engine would have. Does not mutate os.environ.
+        """
+        base = dict(os.environ)
+        for key, original in self._applied_env_snapshot.items():
+            if original is None:
+                base.pop(key, None)
+            else:
+                base[key] = original
+        return base
+
     def _restore_project_env(self) -> None:
         """Revert any os.environ entries mutated by the currently-active project."""
         for key, original in self._applied_env_snapshot.items():
@@ -1542,19 +1560,6 @@ class ProjectManager:
             project_info=project_info,
             result_details=f"Successfully retrieved current project. ID: {self._current_project_id}",
         )
-
-    def get_current_project_file_path(self) -> Path | None:
-        """Return the current project's file path, or None for system defaults.
-
-        Used to thread the orchestrator's active project into a worker at spawn time
-        so the worker boots adopting the same project. Returns None when the current
-        project has no backing file (system defaults) or its id is not loaded, which
-        the caller treats as "spawn the worker without a project (system defaults)".
-        """
-        project_info = self._successfully_loaded_project_templates.get(self._current_project_id)
-        if project_info is None:
-            return None
-        return project_info.project_file_path
 
     def on_save_project_template_request(  # noqa: C901, PLR0911
         self, request: SaveProjectTemplateRequest
@@ -2044,7 +2049,7 @@ class ProjectManager:
             result_details=f"Activated workspace project: {self._current_project_id}",
         )
 
-    async def on_app_initialization_complete(self, payload: AppInitializationComplete) -> None:
+    async def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         """Load system default project template when app initializes.
 
         Called by EventManager after all libraries are loaded.
@@ -2053,18 +2058,13 @@ class ProjectManager:
         already been explicitly selected before this event (e.g., by a CLI executor
         via --project-file-path), preserves that choice and skips workspace discovery.
 
-        A worker process NEVER runs workspace discovery: its project is dictated by the
-        orchestrator (pre-activated from the --project-file-path spawn arg, or system
-        defaults when that arg is absent). Discovering a workspace griptape-nodes-project.yml
-        here would let the worker diverge from the orchestrator, so it is skipped for workers.
+        A worker boots exactly like an orchestrator: it re-derives the current project
+        from the same shared on-disk config (project_file / workspace default), so it
+        lands on the orchestrator's project for free. The orchestrator persists the
+        SYSTEM_DEFAULTS_KEY sentinel when it deliberately stays on system defaults, so a
+        worker honoring project_file does not "discover" a workspace griptape-nodes-project.yml
+        the orchestrator chose to ignore.
         """
-        # A worker's project is owned by the orchestrator. Whatever was pre-activated at
-        # boot (a real project, or system defaults) stays as-is; skip workspace discovery.
-        if payload.is_worker:
-            await self._load_registered_projects()
-            self._initialization_complete = True
-            return
-
         # If an explicit project was selected before init completed (e.g., by
         # LocalWorkflowExecutor loading --project-file-path), keep it. Still load
         # registered projects for visibility and mark init complete.

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -41,7 +41,7 @@ from griptape_nodes.files.path_utils import (
     resolve_workspace_path,
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
-from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete, CurrentProjectChanged
 from griptape_nodes.retained_mode.events.library_events import (
     ReloadAllLibrariesRequest,
     ReloadAllLibrariesResultFailure,
@@ -406,6 +406,7 @@ class ProjectManager:
             config_manager: ConfigManager instance for accessing configuration
             secrets_manager: SecretsManager instance for macro resolution
         """
+        self._event_manager = event_manager
         self._config_manager = config_manager
         self._secrets_manager = secrets_manager
 
@@ -1404,6 +1405,19 @@ class ProjectManager:
         )
         if outcome.workspace_changed and self._initialization_complete:
             result.altered_workflow_state = True
+
+        # Push the switch to running workers so they adopt the orchestrator's project
+        # even on a shallow switch (same workspace + library config) that would not
+        # restart them. Boot is handled separately by the worker spawn arg, so emit
+        # only post-init and only when the project actually changed. The worker's
+        # ActivateProjectRequest handler re-derives the path from the new project.
+        if self._initialization_complete and previous_project_id != resolved_project_id:
+            new_project_file_path = self.get_current_project_file_path()
+            self._event_manager.broadcast_app_event(
+                CurrentProjectChanged(
+                    project_file_path=str(new_project_file_path) if new_project_file_path is not None else None
+                )
+            )
         return result
 
     async def _activate_project(self, resolved_project_id: ProjectID) -> _ProjectActivationOutcome:
@@ -1486,18 +1500,23 @@ class ProjectManager:
         library_config_changed = old_library_config != new_library_config
 
         if self._initialization_complete:
-            # Persist the active project's file path so the next engine restart
-            # restores it via _resolve_project_file_path(). System defaults has
-            # no file path, so persist None for that case and let startup fall
-            # back to the workspace default.
-            persisted_project_file: str | None = None
-            persisted_info = self._successfully_loaded_project_templates.get(resolved_project_id)
-            if persisted_info is not None and persisted_info.project_file_path is not None:
-                persisted_project_file = str(persisted_info.project_file_path)
-            try:
-                self._config_manager.set_config_value("project_file", persisted_project_file)
-            except Exception:
-                logger.warning("Failed to persist project_file '%s' to config", persisted_project_file)
+            # The orchestrator owns project_file in the shared config. A worker adopting
+            # the orchestrator's project must not write it back: both processes share the
+            # on-disk config, so a worker write races the orchestrator's. The worker still
+            # re-establishes its in-memory layers above; it just skips the persist.
+            if not GriptapeNodes.LibraryManager().is_worker:
+                # Persist the active project's file path so the next engine restart
+                # restores it via _resolve_project_file_path(). System defaults has
+                # no file path, so persist None for that case and let startup fall
+                # back to the workspace default.
+                persisted_project_file: str | None = None
+                persisted_info = self._successfully_loaded_project_templates.get(resolved_project_id)
+                if persisted_info is not None and persisted_info.project_file_path is not None:
+                    persisted_project_file = str(persisted_info.project_file_path)
+                try:
+                    self._config_manager.set_config_value("project_file", persisted_project_file)
+                except Exception:
+                    logger.warning("Failed to persist project_file '%s' to config", persisted_project_file)
 
             failure = await self._reload_after_project_switch(
                 resolved_project_id,
@@ -1523,6 +1542,19 @@ class ProjectManager:
             project_info=project_info,
             result_details=f"Successfully retrieved current project. ID: {self._current_project_id}",
         )
+
+    def get_current_project_file_path(self) -> Path | None:
+        """Return the current project's file path, or None for system defaults.
+
+        Used to thread the orchestrator's active project into a worker at spawn time
+        so the worker boots adopting the same project. Returns None when the current
+        project has no backing file (system defaults) or its id is not loaded, which
+        the caller treats as "spawn the worker without a project (system defaults)".
+        """
+        project_info = self._successfully_loaded_project_templates.get(self._current_project_id)
+        if project_info is None:
+            return None
+        return project_info.project_file_path
 
     def on_save_project_template_request(  # noqa: C901, PLR0911
         self, request: SaveProjectTemplateRequest
@@ -2012,7 +2044,7 @@ class ProjectManager:
             result_details=f"Activated workspace project: {self._current_project_id}",
         )
 
-    async def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
+    async def on_app_initialization_complete(self, payload: AppInitializationComplete) -> None:
         """Load system default project template when app initializes.
 
         Called by EventManager after all libraries are loaded.
@@ -2020,7 +2052,19 @@ class ProjectManager:
         overlay file and sets it as the current project if found. If a project has
         already been explicitly selected before this event (e.g., by a CLI executor
         via --project-file-path), preserves that choice and skips workspace discovery.
+
+        A worker process NEVER runs workspace discovery: its project is dictated by the
+        orchestrator (pre-activated from the --project-file-path spawn arg, or system
+        defaults when that arg is absent). Discovering a workspace griptape-nodes-project.yml
+        here would let the worker diverge from the orchestrator, so it is skipped for workers.
         """
+        # A worker's project is owned by the orchestrator. Whatever was pre-activated at
+        # boot (a real project, or system defaults) stays as-is; skip workspace discovery.
+        if payload.is_worker:
+            await self._load_registered_projects()
+            self._initialization_complete = True
+            return
+
         # If an explicit project was selected before init completed (e.g., by
         # LocalWorkflowExecutor loading --project-file-path), keep it. Still load
         # registered projects for visibility and mark init complete.
@@ -2672,7 +2716,14 @@ class ProjectManager:
         reloads each file by path and re-derives its id. Appends the canonical
         path to the list if not already present. Errors are logged as warnings
         and do not affect the load result.
+
+        No-op on a worker: the orchestrator owns projects_to_register in the
+        shared on-disk config. A worker that loads a project to adopt the
+        orchestrator's switch must not write the shared file back, since both
+        processes share it and a worker write races the orchestrator's.
         """
+        if GriptapeNodes.LibraryManager().is_worker:
+            return
         try:
             registered: list[str | dict | PerPlatformProjectPath] = (
                 self._config_manager.get_config_value(PROJECTS_TO_REGISTER_KEY, default=[]) or []

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1408,16 +1408,12 @@ class ProjectManager:
 
         # Push the switch to running workers so they adopt the orchestrator's project
         # even on a shallow switch (same workspace + library config) that would not
-        # restart them. Boot is handled separately by the worker spawn arg, so emit
-        # only post-init and only when the project actually changed. The worker's
-        # ActivateProjectRequest handler re-derives the path from the new project.
+        # restart them. Boot is handled separately (a worker boots like an engine and
+        # re-derives the same project), so emit only post-init and only when the
+        # project actually changed. A worker that boots like the orchestrator has the
+        # same registry, so the id resolves there too.
         if self._initialization_complete and previous_project_id != resolved_project_id:
-            new_project_file_path = self.get_current_project_file_path()
-            self._event_manager.broadcast_app_event(
-                CurrentProjectChanged(
-                    project_file_path=str(new_project_file_path) if new_project_file_path is not None else None
-                )
-            )
+            self._event_manager.broadcast_app_event(CurrentProjectChanged(project_id=resolved_project_id))
         return result
 
     async def _activate_project(self, resolved_project_id: ProjectID) -> _ProjectActivationOutcome:
@@ -1505,14 +1501,18 @@ class ProjectManager:
             # on-disk config, so a worker write races the orchestrator's. The worker still
             # re-establishes its in-memory layers above; it just skips the persist.
             if not GriptapeNodes.LibraryManager().is_worker:
-                # Persist the active project's file path so the next engine restart
-                # restores it via _resolve_project_file_path(). System defaults has
-                # no file path, so persist None for that case and let startup fall
-                # back to the workspace default.
-                persisted_project_file: str | None = None
+                # Persist the active project so the next engine restart restores it via
+                # _resolve_project_file_path(). A file-backed project persists its path.
+                # System defaults persists the SYSTEM_DEFAULTS_KEY sentinel so that a
+                # deliberate "stay on system defaults" choice is honored on the next
+                # restart (and by a freshly spawned worker, which boots like an engine):
+                # the sentinel suppresses workspace discovery instead of re-adopting a
+                # workspace griptape-nodes-project.yml.
                 persisted_info = self._successfully_loaded_project_templates.get(resolved_project_id)
                 if persisted_info is not None and persisted_info.project_file_path is not None:
                     persisted_project_file = str(persisted_info.project_file_path)
+                else:
+                    persisted_project_file = SYSTEM_DEFAULTS_KEY
                 try:
                     self._config_manager.set_config_value("project_file", persisted_project_file)
                 except Exception:
@@ -2435,12 +2435,18 @@ class ProjectManager:
         """Resolve the path to the project file to load, or None if no file should be loaded.
 
         Checks config in the following order:
-        1. The path specified by the `project_file` config setting (if set)
+        1. The `project_file` config setting (if set). The SYSTEM_DEFAULTS_KEY sentinel
+           means "deliberately on system defaults": return None WITHOUT falling through
+           to workspace discovery, so a restart (or a freshly spawned worker booting like
+           an engine) stays on defaults instead of re-adopting a workspace file.
         2. griptape-nodes-project.yml in the workspace directory (default)
 
-        Returns None if no project file should be loaded (missing config, file not found).
+        Returns None if no project file should be loaded (explicit system defaults,
+        missing config, file not found).
         """
         project_file_value = self._config_manager.get_config_value("project_file")
+        if project_file_value == SYSTEM_DEFAULTS_KEY:
+            return None
         if project_file_value is not None:
             project_path = Path(project_file_value)
             if project_path.exists():

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -429,7 +429,7 @@ class Settings(BaseModel):
     project_file: str | None = Field(
         category=PROJECTS,
         default=None,
-        description="Path to the project file (griptape-nodes-project.yml) to load initially when the engine starts. When set, overrides the default location of <workspace_directory>/griptape-nodes-project.yml. If the specified path does not exist, falls back to the workspace default.",
+        description="Path to the project file (griptape-nodes-project.yml) to load initially when the engine starts. When set, overrides the default location of <workspace_directory>/griptape-nodes-project.yml. If the specified path does not exist, falls back to the workspace default. The sentinel value '<system-defaults>' means the engine deliberately stays on system defaults and suppresses the workspace-default fallback (so a workspace griptape-nodes-project.yml is not auto-discovered); this is what the engine persists when it is intentionally on system defaults.",
     )
     project_workspaces: dict[str, str] = Field(
         category=PROJECTS,

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -701,8 +701,8 @@ class WorkerManager:
 
         ProjectManager only emits ``CurrentProjectChanged`` from a successful
         post-init activation, so receiving it means workers should adopt the new
-        project. Carries the project's file path (None for system defaults); the
-        worker re-derives the project from it. Awaited inline for the same
+        project. Carries the new project's id; a worker boots like an engine, so
+        the same id is already loaded in its registry. Awaited inline for the same
         side-loop reason documented on ``_on_config_changed``; lazy import for
         the same circular-dependency reason.
         """
@@ -710,9 +710,7 @@ class WorkerManager:
 
         if self._transport is None or not self._workers:
             return
-        await self.broadcast_to_workers(
-            EventRequest(request=ActivateProjectRequest(project_file_path=event.project_file_path))
-        )
+        await self.broadcast_to_workers(EventRequest(request=ActivateProjectRequest(project_id=event.project_id)))
 
     def schedule_broadcast(self, request_type: type[RequestPayload]) -> None:
         """Tell every registered worker to handle ``request_type`` locally.

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from griptape_nodes.bootstrap.utils.subprocess_websocket_base import WebSocketMessage
 from griptape_nodes.retained_mode.events import worker_events
-from griptape_nodes.retained_mode.events.app_events import ConfigChanged, SecretChanged
+from griptape_nodes.retained_mode.events.app_events import ConfigChanged, CurrentProjectChanged, SecretChanged
 from griptape_nodes.retained_mode.events.base_events import EventRequest
 from griptape_nodes.retained_mode.managers.settings import (
     WORKER_HEARTBEAT_INTERVAL_KEY,
@@ -163,6 +163,7 @@ class WorkerManager:
         # a worker fan-out.
         event_manager.add_listener_to_app_event(ConfigChanged, self._on_config_changed)
         event_manager.add_listener_to_app_event(SecretChanged, self._on_secret_changed)
+        event_manager.add_listener_to_app_event(CurrentProjectChanged, self._on_current_project_changed)
 
     @property
     def _tx(self) -> _WorkerTransport:
@@ -591,6 +592,12 @@ class WorkerManager:
             "--library-name",
             library_name,
         ]
+        # Thread the orchestrator's current project into the worker so it boots adopting
+        # the same project instead of independently re-deriving one from shared on-disk
+        # config. Absent arg means system defaults (the worker skips workspace discovery).
+        project_file_path = self._griptape_nodes.ProjectManager().get_current_project_file_path()
+        if project_file_path is not None:
+            args.extend(["--project-file-path", str(project_file_path)])
         await self.spawn_worker(args, library_name)
 
     @staticmethod
@@ -688,6 +695,24 @@ class WorkerManager:
         if self._transport is None or not self._workers:
             return
         await self.broadcast_to_workers(EventRequest(request=RefreshSecretsRequest()))
+
+    async def _on_current_project_changed(self, event: CurrentProjectChanged) -> None:
+        """Fan out an ActivateProjectRequest after the orchestrator switched projects.
+
+        ProjectManager only emits ``CurrentProjectChanged`` from a successful
+        post-init activation, so receiving it means workers should adopt the new
+        project. Carries the project's file path (None for system defaults); the
+        worker re-derives the project from it. Awaited inline for the same
+        side-loop reason documented on ``_on_config_changed``; lazy import for
+        the same circular-dependency reason.
+        """
+        from griptape_nodes.app.worker_routing import ActivateProjectRequest
+
+        if self._transport is None or not self._workers:
+            return
+        await self.broadcast_to_workers(
+            EventRequest(request=ActivateProjectRequest(project_file_path=event.project_file_path))
+        )
 
     def schedule_broadcast(self, request_type: type[RequestPayload]) -> None:
         """Tell every registered worker to handle ``request_type`` locally.

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -4,7 +4,6 @@ import asyncio
 import functools
 import json
 import logging
-import os
 import re
 import sys
 import time
@@ -323,7 +322,12 @@ class WorkerManager:
         if worker_key in self._managed_worker_processes:
             logger.error("Worker for key '%s' already spawned; refusing duplicate spawn.", worker_key)
             return
-        proc = await asyncio.create_subprocess_exec(*args, env={**os.environ, "GTN_ENGINE_ID": str(uuid.uuid4())})
+        # Spawn with the orchestrator's PRE-project environ so the worker boots with the
+        # same clean env baseline a fresh engine would have. Inheriting the live os.environ
+        # would bake the orchestrator's current-project env vars into the worker's restore
+        # baseline, leaving the worker unable to unset them on a later project switch.
+        base_environ = self._griptape_nodes.ProjectManager().get_pre_project_environ()
+        proc = await asyncio.create_subprocess_exec(*args, env={**base_environ, "GTN_ENGINE_ID": str(uuid.uuid4())})
         # Record the loop that owns this subprocess so termination can hop back to it.
         # All spawns run on the engine event-queue loop, so this is idempotent.
         self._spawn_loop = asyncio.get_running_loop()
@@ -592,12 +596,6 @@ class WorkerManager:
             "--library-name",
             library_name,
         ]
-        # Thread the orchestrator's current project into the worker so it boots adopting
-        # the same project instead of independently re-deriving one from shared on-disk
-        # config. Absent arg means system defaults (the worker skips workspace discovery).
-        project_file_path = self._griptape_nodes.ProjectManager().get_current_project_file_path()
-        if project_file_path is not None:
-            args.extend(["--project-file-path", str(project_file_path)])
         await self.spawn_worker(args, library_name)
 
     @staticmethod

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -67,6 +67,9 @@ def worker_manager() -> WorkerManager:
     # WorkerManager reads several float config values at construction; hand back
     # the declared default so asyncio.wait_for / time arithmetic gets a real number.
     gtn._config_manager.get_config_value.side_effect = lambda _key, default, cast_type=float: cast_type(default)
+    # spawn_worker builds the child env from the orchestrator's pre-project environ;
+    # hand back a real dict so {**base_environ, ...} doesn't choke on a MagicMock.
+    gtn.ProjectManager().get_pre_project_environ.return_value = {}
     wm = WorkerManager(griptape_nodes=gtn, event_manager=MagicMock())
     wm.attach_transport(
         ws_outgoing_queue=asyncio.Queue(),

--- a/tests/unit/worker/test_secret_and_config_propagation.py
+++ b/tests/unit/worker/test_secret_and_config_propagation.py
@@ -48,6 +48,7 @@ from griptape_nodes.app.worker_routing import (
 from griptape_nodes.retained_mode.events.base_events import EventRequest
 from griptape_nodes.retained_mode.events.config_events import SetConfigValueRequest
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from tests.unit.worker.harness import InProcessWorkerHarness
 
@@ -110,10 +111,12 @@ class TestSecretPropagation:
             worker_config = ConfigManager()
             worker_config.workspace_path = shared_workspace
             worker_secrets = SecretsManager(worker_config, event_manager=harness.worker)
+            worker_project = ProjectManager(harness.worker, worker_config, worker_secrets)
             register_broadcast_handlers(
                 harness.worker,
                 config_manager=worker_config,
                 secrets_manager=worker_secrets,
+                project_manager=worker_project,
             )
 
             assert worker_secrets.get_secret(secret_key) == "boot_value"
@@ -162,10 +165,12 @@ class TestConfigPropagation:
             worker_config = ConfigManager(event_manager=harness.worker)
             worker_config.workspace_path = shared_workspace
             worker_secrets = SecretsManager(worker_config, event_manager=harness.worker)
+            worker_project = ProjectManager(harness.worker, worker_config, worker_secrets)
             register_broadcast_handlers(
                 harness.worker,
                 config_manager=worker_config,
                 secrets_manager=worker_secrets,
+                project_manager=worker_project,
             )
 
             # Both see boot value.


### PR DESCRIPTION
Closes https://github.com/griptape-ai/internal/issues/124

## Problem

Workers had no project awareness. A spawned worker loaded only system defaults,
the user config layer, and whatever environment it inherited at spawn; it never
established the orchestrator's project / workspace / env layers. As a result, env
vars, directory macros, and situation/path macros resolved against the wrong (or
no) project, and a runtime project switch on the orchestrator left every running
worker on a stale project.

Inheritance has to hold in two cases: when a worker is first spawned, and when the
orchestrator switches projects at runtime.

## Approach

Two paths, one per case.

**Boot (spawn).** A worker now boots exactly like an engine and re-derives the
current project from the same shared on-disk config (`project_file` / workspace
default). Two pieces make that derivation land on the orchestrator's project:
- `get_pre_project_environ()` reconstructs the orchestrator's pre-project
  `os.environ`, and workers are spawned with it, so a worker starts from the same
  clean env baseline a fresh engine would have. Inheriting the live (project-
  polluted) environ would bake project A's vars into the worker's restore baseline,
  leaving it unable to unset them on a later switch to project B.
- A `<system-defaults>` sentinel (`SYSTEM_DEFAULTS_KEY`) is persisted to
  `project_file` when the orchestrator deliberately stays on system defaults.
  `_resolve_project_file_path()` honors it by returning None WITHOUT falling
  through to workspace discovery, so a restart or a freshly spawned worker stays on
  defaults instead of auto-adopting a workspace `griptape-nodes-project.yml`.

**Runtime switch.** `ProjectManager` emits a new `CurrentProjectChanged` app event
after a successful post-init activation when the project actually changed.
`WorkerManager` listens and fans out a new `ActivateProjectRequest` to every
registered worker. This covers the "shallow" switch (same workspace + library
config) that would not otherwise restart the worker; switches that change library
config still restart the worker as before. `ActivateProjectRequest` is
`SkipTheLine`, so a worker adopts the new project ahead of any queued
`ExecuteNodeRequest` that would otherwise run against the stale one.

The worker-side handler (`ensure_project_loaded()` + `on_set_current_project_request`)
re-reads shared config and re-runs registered-project discovery if the id is absent
(orchestrator registered the project after this worker spawned), and fails loud if
the id is still unknown rather than silently running against a stale project.

Workers never write the shared on-disk config: `project_file` persistence and
`_register_project_path()` are no-ops on a worker, since both processes share the
file and a worker write would race the orchestrator's.

## Changes

- `worker_routing.py`: `ActivateProjectRequest` / `ActivateProjectResultSuccess` /
  `ActivateProjectResultFailure` and the worker-side handler.
- `app_events.py`: `CurrentProjectChanged` app event.
- `project_manager.py`: `get_pre_project_environ()`, `ensure_project_loaded()`,
  `CurrentProjectChanged` emission, `<system-defaults>` sentinel handling, and
  worker write guards.
- `worker_manager.py`: spawn workers with the pre-project environ; listen for
  `CurrentProjectChanged` and fan out `ActivateProjectRequest`.
- `settings.py`: document the `<system-defaults>` sentinel on `project_file`.
- Tests updated for the new `project_manager` arg and pre-project-environ spawn.

## Pairing

Requires griptape-ai/griptape-nodes-app#141.