### PR TITLE
feat(workflows): add RefreshWorkflowRegistryRequest

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -990,6 +990,30 @@ class SetWorkflowMetadataResultFailure(ResultPayloadFailure):
 
 @dataclass
 @PayloadRegistry.register
+class RefreshWorkflowRegistryRequest(RequestPayload):
+    """Rescan the workspace and config for workflow files and refresh the in-memory registry.
+
+    Use when: Workflows have been added or removed on disk outside of the engine,
+    forcing a re-discovery without changing the workspace.
+
+    Results: RefreshWorkflowRegistryResultSuccess | RefreshWorkflowRegistryResultFailure
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class RefreshWorkflowRegistryResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Workflow registry refreshed successfully."""
+
+
+@dataclass
+@PayloadRegistry.register
+class RefreshWorkflowRegistryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Workflow registry refresh failed."""
+
+
+@dataclass
+@PayloadRegistry.register
 class RegisterWorkflowsFromConfigRequest(RequestPayload):
     """Register workflows from configuration section.
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -133,6 +133,9 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     PublishWorkflowRequest,
     PublishWorkflowResultFailure,
     PublishWorkflowResultSuccess,
+    RefreshWorkflowRegistryRequest,
+    RefreshWorkflowRegistryResultFailure,
+    RefreshWorkflowRegistryResultSuccess,
     RegisterWorkflowRequest,
     RegisterWorkflowResultFailure,
     RegisterWorkflowResultSuccess,
@@ -430,6 +433,10 @@ class WorkflowManager:
         event_manager.assign_manager_to_request_type(
             CompareWorkflowsRequest,
             self.on_compare_workflows_request,
+        )
+        event_manager.assign_manager_to_request_type(
+            RefreshWorkflowRegistryRequest,
+            self.on_refresh_workflow_registry_request,
         )
         event_manager.assign_manager_to_request_type(
             RegisterWorkflowsFromConfigRequest,
@@ -5667,6 +5674,13 @@ class WorkflowManager:
                     import_recorder.add_from_import(module.__name__, class_type.__name__)
 
         self._walk_object_tree(obj, collect_class_import)
+
+    async def on_refresh_workflow_registry_request(self, _request: RefreshWorkflowRegistryRequest) -> ResultPayload:
+        try:
+            await self.refresh_workflow_registry()
+        except Exception as e:
+            return RefreshWorkflowRegistryResultFailure(result_details=f"Failed to refresh workflow registry: {e!s}")
+        return RefreshWorkflowRegistryResultSuccess(result_details="Workflow registry refreshed successfully.")
 
     async def on_register_workflows_from_config_request(
         self, request: RegisterWorkflowsFromConfigRequest


### PR DESCRIPTION
## Summary

Closes #4876

Unblocks griptape-ai/griptape-vsl-gui#2477

Adds `RefreshWorkflowRegistryRequest` (+ `ResultSuccess` / `ResultFailure`) so the frontend can trigger a full workspace rescan on demand without restarting or switching workspaces. The UI can now call this endpoint and then re-issue `ListAllWorkflows` to get a fresh list.

## Test plan

- [ ] Call `RefreshWorkflowRegistryRequest` after adding a `.gtn` file to the workspace directory — verify the new workflow appears in a subsequent `ListAllWorkflowsRequest`
- [ ] Call `RefreshWorkflowRegistryRequest` after removing a workflow file — verify it no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)