### PR TITLE
Projects now inherit parent's workspace is not provided

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -316,8 +316,8 @@ class ConfigManager:
 
         `workspace_dir` and `apply_override` come from ProjectManager.decide_workspace,
         the same decision the live activation applies. The override is applied here only
-        when `apply_override` is True (the project_workspaces mapping, configured-root
-        inheritance, and auto-default branches), exactly as _activate_project calls
+        when `apply_override` is True (the project_workspaces mapping, parent-chain
+        inheritance, and global-default branches), exactly as _activate_project calls
         set_workspace_override; for an env/project-adjacent workspace_directory it is False
         so the workspace config layer can re-point workspace_directory, matching the live
         path. When applied, the value is resolved the same way set_workspace_override
@@ -345,9 +345,9 @@ class ConfigManager:
             merged = merge_dicts(merged, self._load_config_from_file(workspace_config_path, "workspace"))
 
         # Apply the runtime workspace override conditionally, mirroring _activate_project:
-        # only the project_workspaces and auto-default branches pin it (apply_override),
-        # and the value is resolved exactly as set_workspace_override would so preview and
-        # live agree. It sits above config files but below env vars.
+        # only the project_workspaces, parent-chain inheritance, and global-default branches
+        # pin it (apply_override), and the value is resolved exactly as set_workspace_override
+        # would so preview and live agree. It sits above config files but below env vars.
         if apply_override:
             merged["workspace_directory"] = str(Path(workspace_dir).expanduser().resolve())
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -316,12 +316,13 @@ class ConfigManager:
 
         `workspace_dir` and `apply_override` come from ProjectManager.decide_workspace,
         the same decision the live activation applies. The override is applied here only
-        when `apply_override` is True (the project_workspaces mapping and auto-default
-        branches), exactly as _activate_project calls set_workspace_override; for an
-        env/project-adjacent workspace_directory it is False so the workspace config layer
-        can re-point workspace_directory, matching the live path. When applied, the value
-        is resolved the same way set_workspace_override resolves it (expanduser + resolve),
-        so the merged workspace_directory matches the live merged config byte-for-byte.
+        when `apply_override` is True (the project_workspaces mapping, configured-root
+        inheritance, and auto-default branches), exactly as _activate_project calls
+        set_workspace_override; for an env/project-adjacent workspace_directory it is False
+        so the workspace config layer can re-point workspace_directory, matching the live
+        path. When applied, the value is resolved the same way set_workspace_override
+        resolves it (expanduser + resolve), so the merged workspace_directory matches the
+        live merged config byte-for-byte.
 
         Args:
             project_dir: Directory holding the project YAML and its adjacent config.

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -348,10 +348,10 @@ class WorkspaceDecision(NamedTuple):
 
     `workspace_dir` is the directory whose griptape_nodes_config.json supplies the
     workspace config layer. `apply_override` is True only when activation calls
-    set_workspace_override(workspace_dir): the project_workspaces mapping and the
-    auto-default-to-project-dir branches. It is False when env vars or the
-    project-adjacent config supply workspace_directory, because activation then
-    leaves the override unset so the workspace config layer can re-point it.
+    set_workspace_override(workspace_dir): the project_workspaces mapping, the
+    parent-chain inheritance, and the global-default branches. It is False when env
+    vars or the project-adjacent config supply workspace_directory, because activation
+    then leaves the override unset so the workspace config layer can re-point it.
     """
 
     workspace_dir: Path
@@ -1268,19 +1268,29 @@ class ProjectManager:
         1. project_workspaces user-config override -> (override dir, apply_override=True)
         2. workspace_directory from env vars -> (env dir, apply_override=False)
         3. workspace_directory from the project-adjacent config -> (project dir, apply_override=False)
-        4. configured workspace root, when the project file lives inside it ->
-           (configured root, apply_override=True)
-        5. the project's own directory (auto-default) -> (project dir, apply_override=True)
+        4. the nearest ancestor's resolved workspace, walking the explicit parent-project chain ->
+           (ancestor workspace, apply_override=True)
+        5. the global configured workspace_directory, else the project's own directory (auto-default)
+           -> (configured root or project dir, apply_override=True)
 
-        Branch 4 makes a project nested inside the configured workspace inherit that enclosing
-        workspace instead of treating its own subdir as a fresh workspace (which would resolve
-        libraries_directory to an empty libraries/ tree and wrongly prompt to reinstall already
-        downloaded libraries). It only fires when no explicit workspace was named above, so a
-        project-adjacent workspace_directory (branch 3) still wins and a sidecar config remains a
-        full opt-out. A project outside the configured root falls through to branch 5, preserving
-        the portability of imported standalone projects.
+        Branch 4 walks the project's explicit parent chain (parent_project_id / legacy
+        parent_project_path, resolved through the registry) and inherits the first ancestor that
+        resolves a workspace via its own override mapping or project-adjacent config. This makes a
+        derived project with no workspace of its own inherit its parent's workspace instead of
+        treating its own subdir as a fresh workspace (which would resolve libraries_directory to an
+        empty libraries/ tree and wrongly prompt to reinstall already downloaded libraries). It only
+        fires when no explicit workspace was named above, so a project-adjacent workspace_directory
+        (branch 3) still wins and a sidecar config remains a full opt-out at every level of the
+        chain. See _inherit_workspace_from_parents.
 
-        `apply_override` is True only for the override-mapping, configured-root, and auto-default
+        Branch 5's global default is unconditional: when the chain is exhausted with no ancestor
+        workspace, the configured workspace_directory is used regardless of where the project file
+        sits on disk, so an imported standalone project with no ancestor workspace adopts the global
+        workspace. The final own-directory fallback only fires when workspace_directory is unset in
+        both config layers; in a real engine the Settings default always populates default_config, so
+        this is a defensive path exercised only by tests that mock both layers to None.
+
+        `apply_override` is True only for the override-mapping, parent-inheritance, and global-default
         branches, because those are the cases where activation calls set_workspace_override. For env
         or project-adjacent workspace_directory, activation leaves the override unset so the
         workspace config layer can re-point the final workspace_path; a forced override
@@ -1305,6 +1315,10 @@ class ProjectManager:
         if project_workspace is not None:
             return WorkspaceDecision(Path(project_workspace), apply_override=False)
 
+        inherited = self._inherit_workspace_from_parents(project_file_path)
+        if inherited is not None:
+            return WorkspaceDecision(Path(inherited), apply_override=True)
+
         configured_root = self._config_manager.get_config_value(
             "workspace_directory",
             config_source="user_config",
@@ -1317,10 +1331,7 @@ class ProjectManager:
                 default=None,
             )
         if configured_root is not None:
-            project_dir = canonicalize_for_identity(project_file_path.parent)
-            root_dir = canonicalize_for_identity(Path(configured_root))
-            if project_dir.is_relative_to(root_dir):
-                return WorkspaceDecision(Path(configured_root), apply_override=True)
+            return WorkspaceDecision(Path(configured_root), apply_override=True)
 
         return WorkspaceDecision(project_file_path.parent, apply_override=True)
 
@@ -1331,6 +1342,70 @@ class ProjectManager:
             (v for k, v in project_workspaces.items() if str(canonicalize_for_identity(k)) == resolved_project_path),
             None,
         )
+
+    def _inherit_workspace_from_parents(self, project_file_path: Path) -> str | None:  # noqa: PLR0911
+        """Walk the explicit parent-project chain for the nearest ancestor's workspace.
+
+        Returns the workspace_directory the nearest ancestor would resolve to (its
+        project_workspaces override, else its adjacent griptape_nodes_config.json),
+        or None when no ancestor in the chain defines one. The walk is conducted in
+        id-space through the registry (no disk template loads); each ancestor's
+        adjacent config is read read-only. A visited id-set guards against a cyclic
+        parent chain. The starting project's OWN explicit sources are handled by the
+        earlier branches of decide_workspace, so the walk begins at the parent.
+        """
+        project_workspaces = self._config_manager.get_config_value(
+            "project_workspaces",
+            config_source="user_config",
+            default={},
+        )
+        file_path_to_id: dict[Path, ProjectID] = {
+            info.project_file_path: pid
+            for pid, info in self._successfully_loaded_project_templates.items()
+            if info.project_file_path is not None
+        }
+
+        resolved_start_path = canonicalize_for_identity(project_file_path)
+        start_id = next(
+            (
+                pid
+                for pid, info in self._successfully_loaded_project_templates.items()
+                if info.project_file_path is not None
+                and canonicalize_for_identity(info.project_file_path) == resolved_start_path
+            ),
+            None,
+        )
+        if start_id is None:
+            return None
+
+        visited: set[ProjectID] = {start_id}
+        current_info = self._successfully_loaded_project_templates.get(start_id)
+        while current_info is not None:
+            parent_id = self._reduce_parent_link_to_id(
+                current_info.template,
+                current_info.project_file_path,
+                file_path_to_id,
+            )
+            if parent_id is None:
+                return None
+            if parent_id in visited:
+                return None
+            visited.add(parent_id)
+            parent_info = self._successfully_loaded_project_templates.get(parent_id)
+            if parent_info is None:
+                return None
+            if parent_info.project_file_path is not None:
+                override = self._find_workspace_override(parent_info.project_file_path, project_workspaces)
+                if override is not None:
+                    return override
+                parent_config = self._config_manager.read_config_file(
+                    parent_info.project_file_path.parent / "griptape_nodes_config.json"
+                )
+                parent_workspace = parent_config.get("workspace_directory")
+                if parent_workspace is not None:
+                    return parent_workspace
+            current_info = parent_info
+        return None
 
     def _snapshot_library_config(self) -> str:
         """Return a stable string of the merged library-affecting config for change detection.
@@ -1475,9 +1550,10 @@ class ProjectManager:
 
             # Decide the workspace dir + override bit once (shared with the provisioning
             # preview via decide_workspace, so the two cannot drift). apply_override is
-            # True only for the project_workspaces mapping and the auto-default-to-project
-            # branches; for an env/project-adjacent workspace_directory it is False, so the
-            # override stays unset and the workspace config layer can re-point workspace_path.
+            # True for the project_workspaces mapping, parent-chain inheritance, and
+            # global-default branches; for an env/project-adjacent workspace_directory it is
+            # False, so the override stays unset and the workspace config layer can re-point
+            # workspace_path.
             decision = self.decide_workspace(
                 project_file_path,
                 self._config_manager.project_config,

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1268,10 +1268,20 @@ class ProjectManager:
         1. project_workspaces user-config override -> (override dir, apply_override=True)
         2. workspace_directory from env vars -> (env dir, apply_override=False)
         3. workspace_directory from the project-adjacent config -> (project dir, apply_override=False)
-        4. the project's own directory (auto-default) -> (project dir, apply_override=True)
+        4. configured workspace root, when the project file lives inside it ->
+           (configured root, apply_override=True)
+        5. the project's own directory (auto-default) -> (project dir, apply_override=True)
 
-        `apply_override` is True only for the override-mapping and auto-default branches,
-        because those are the cases where activation calls set_workspace_override. For env
+        Branch 4 makes a project nested inside the configured workspace inherit that enclosing
+        workspace instead of treating its own subdir as a fresh workspace (which would resolve
+        libraries_directory to an empty libraries/ tree and wrongly prompt to reinstall already
+        downloaded libraries). It only fires when no explicit workspace was named above, so a
+        project-adjacent workspace_directory (branch 3) still wins and a sidecar config remains a
+        full opt-out. A project outside the configured root falls through to branch 5, preserving
+        the portability of imported standalone projects.
+
+        `apply_override` is True only for the override-mapping, configured-root, and auto-default
+        branches, because those are the cases where activation calls set_workspace_override. For env
         or project-adjacent workspace_directory, activation leaves the override unset so the
         workspace config layer can re-point the final workspace_path; a forced override
         would mask that. Both _activate_project (live) and the provisioning preview drive
@@ -1294,6 +1304,23 @@ class ProjectManager:
         project_workspace = project_config.get("workspace_directory")
         if project_workspace is not None:
             return WorkspaceDecision(Path(project_workspace), apply_override=False)
+
+        configured_root = self._config_manager.get_config_value(
+            "workspace_directory",
+            config_source="user_config",
+            default=None,
+        )
+        if configured_root is None:
+            configured_root = self._config_manager.get_config_value(
+                "workspace_directory",
+                config_source="default_config",
+                default=None,
+            )
+        if configured_root is not None:
+            project_dir = canonicalize_for_identity(project_file_path.parent)
+            root_dir = canonicalize_for_identity(Path(configured_root))
+            if project_dir.is_relative_to(root_dir):
+                return WorkspaceDecision(Path(configured_root), apply_override=True)
 
         return WorkspaceDecision(project_file_path.parent, apply_override=True)
 

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -3,7 +3,6 @@ import os
 import platform
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,9 +10,7 @@ import pytest
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
+from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
 
 
 @pytest.mark.skipif(
@@ -878,7 +875,7 @@ class TestProvisioningPreviewMatchesActivation:
         *,
         expected_libraries: list,
         expected_engine_version: str,
-        pm: "ProjectManager | None" = None,
+        pm: ProjectManager | None = None,
     ) -> None:
         """Compute the preview and live-activation merged configs and assert they agree.
 
@@ -891,7 +888,6 @@ class TestProvisioningPreviewMatchesActivation:
         `pm` lets a caller pass a ProjectManager whose registry already models a parent chain (the
         branch-4 walk needs registered ancestors); when None a fresh, registry-less manager is built.
         """
-        from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
         from griptape_nodes.utils.dict_utils import get_dot_value
 
@@ -1032,7 +1028,7 @@ class TestProvisioningPreviewMatchesActivation:
         """
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
-        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo, ProjectManager
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
 
         workspace_root = tmp_path / "workspace"

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -3,6 +3,7 @@ import os
 import platform
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,6 +11,9 @@ import pytest
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
 
 
 @pytest.mark.skipif(
@@ -867,13 +871,14 @@ class TestProvisioningPreviewMatchesActivation:
         path.write_text(json.dumps(config), encoding="utf-8")
 
     @staticmethod
-    def _assert_preview_matches_live(
+    def _assert_preview_matches_live(  # noqa: PLR0913
         cm: ConfigManager,
         project_dir: Path,
         project_file: Path,
         *,
         expected_libraries: list,
         expected_engine_version: str,
+        pm: "ProjectManager | None" = None,
     ) -> None:
         """Compute the preview and live-activation merged configs and assert they agree.
 
@@ -882,12 +887,16 @@ class TestProvisioningPreviewMatchesActivation:
         block for the live path, then cross-checks the consumed keys + workspace_directory. The
         expected-winner assertions prove the workspace layer was actually consumed, so a bug that
         made BOTH paths ignore it (preview == live but both wrong) still fails.
+
+        `pm` lets a caller pass a ProjectManager whose registry already models a parent chain (the
+        branch-4 walk needs registered ancestors); when None a fresh, registry-less manager is built.
         """
         from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
         from griptape_nodes.utils.dict_utils import get_dot_value
 
-        pm = ProjectManager(Mock(), cm, Mock())
+        if pm is None:
+            pm = ProjectManager(Mock(), cm, Mock())
 
         # Preview path, read-only and before any live mutation.
         preview_project_config = cm.read_config_file(project_dir / "griptape_nodes_config.json")
@@ -1014,18 +1023,81 @@ class TestProvisioningPreviewMatchesActivation:
                 expected_engine_version=">=4.0",
             )
 
-    def test_configured_root_inheritance_branch(self, tmp_path: Path, isolate_user_config: Path) -> None:
-        """A project nested inside the configured workspace root inherits it (apply_override=True).
+    def test_parent_chain_inheritance_branch(self, tmp_path: Path) -> None:
+        """A child with no workspace inherits its registered parent's resolved workspace (apply_override=True).
 
-        The user config sets workspace_directory to an enclosing root and the project lives in a
-        subdir of it with no workspace driver of its own, so decide_workspace's inheritance branch
-        fires and both paths must resolve the workspace layer to that root.
+        The child declares parent_project_id pointing at a registered parent whose project-adjacent
+        config sets workspace_directory; decide_workspace's parent-chain walk inherits that workspace,
+        and both paths must resolve the workspace layer to it.
         """
+        from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo, ProjectManager
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
 
         workspace_root = tmp_path / "workspace"
         workspace_root.mkdir()
-        project_dir = workspace_root / "nested"
+        parent_dir = tmp_path / "parent"
+        parent_dir.mkdir()
+        parent_file = parent_dir / "griptape-nodes-project.yml"
+        parent_file.touch()
+        project_dir = tmp_path / "child"
+        project_dir.mkdir()
+        project_file = project_dir / "griptape-nodes-project.yml"
+        project_file.touch()
+
+        self._write_config_file(
+            project_dir / "griptape_nodes_config.json",
+            {LIBRARIES_TO_REGISTER_KEY: ["project-lib"], REQUIRES_ENGINE_KEY: ">=1.0"},
+        )
+        # The parent's adjacent config points its workspace at workspace_root.
+        self._write_config_file(
+            parent_dir / "griptape_nodes_config.json",
+            {"workspace_directory": str(workspace_root)},
+        )
+        self._write_config_file(
+            workspace_root / "griptape_nodes_config.json",
+            {LIBRARIES_TO_REGISTER_KEY: ["root-workspace-lib"], REQUIRES_ENGINE_KEY: ">=5.0"},
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            cm = ConfigManager()
+            pm = ProjectManager(Mock(), cm, Mock())
+            validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+            for project_id, file_path, parent_id in (
+                ("parent", parent_file, None),
+                ("child", project_file, "parent"),
+            ):
+                pm._successfully_loaded_project_templates[project_id] = ProjectInfo(
+                    project_id=project_id,
+                    project_file_path=file_path,
+                    project_base_dir=file_path.parent,
+                    template=DEFAULT_PROJECT_TEMPLATE.model_copy(update={"parent_project_id": parent_id}),
+                    validation=validation,
+                    parsed_situation_schemas={},
+                    parsed_directory_schemas={},
+                )
+            self._assert_preview_matches_live(
+                cm,
+                project_dir,
+                project_file,
+                expected_libraries=["root-workspace-lib"],
+                expected_engine_version=">=5.0",
+                pm=pm,
+            )
+
+    def test_global_default_branch(self, tmp_path: Path, isolate_user_config: Path) -> None:
+        """Chain exhausted: the global configured workspace_directory is used unconditionally (apply_override=True).
+
+        The user config sets workspace_directory to a root the parentless project does NOT live under,
+        so decide_workspace's global-default branch (no containment guard) fires and both paths must
+        resolve the workspace layer to that root rather than the project's own dir.
+        """
+        from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
+
+        workspace_root = tmp_path / "global_ws"
+        workspace_root.mkdir()
+        project_dir = tmp_path / "project"
         project_dir.mkdir()
         project_file = project_dir / "project.yml"
         project_file.touch()
@@ -1036,7 +1108,7 @@ class TestProvisioningPreviewMatchesActivation:
         )
         self._write_config_file(
             workspace_root / "griptape_nodes_config.json",
-            {LIBRARIES_TO_REGISTER_KEY: ["root-workspace-lib"], REQUIRES_ENGINE_KEY: ">=5.0"},
+            {LIBRARIES_TO_REGISTER_KEY: ["global-workspace-lib"], REQUIRES_ENGINE_KEY: ">=5.0"},
         )
         isolate_user_config.write_text(json.dumps({"workspace_directory": str(workspace_root)}), encoding="utf-8")
 
@@ -1046,37 +1118,8 @@ class TestProvisioningPreviewMatchesActivation:
                 cm,
                 project_dir,
                 project_file,
-                expected_libraries=["root-workspace-lib"],
+                expected_libraries=["global-workspace-lib"],
                 expected_engine_version=">=5.0",
-            )
-
-    def test_auto_default_branch(self, tmp_path: Path) -> None:
-        """Project outside the configured root: the project's own dir is the workspace (apply_override=True).
-
-        The real ConfigManager's default workspace_directory is CWD/GriptapeNodes; the tmp_path
-        project is not under it, so decide_workspace's inheritance branch is skipped and it falls
-        through to the auto-default branch.
-        """
-        from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
-
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        project_file = project_dir / "project.yml"
-        project_file.touch()
-
-        self._write_config_file(
-            project_dir / "griptape_nodes_config.json",
-            {LIBRARIES_TO_REGISTER_KEY: ["project-lib"], REQUIRES_ENGINE_KEY: ">=1.0"},
-        )
-
-        with patch.dict(os.environ, {}, clear=True):
-            cm = ConfigManager()
-            self._assert_preview_matches_live(
-                cm,
-                project_dir,
-                project_file,
-                expected_libraries=["project-lib"],
-                expected_engine_version=">=1.0",
             )
 
     def test_system_defaults_branch(self, isolate_user_config: Path) -> None:

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -853,7 +853,7 @@ class TestProvisioningPreviewMatchesActivation:
     Equality is asserted per-key, not as a blanket ==: the live merged config also carries
     unrelated layers (e.g. project_workspaces from the user config) that the preview legitimately
     includes too, so a blanket == would be hostage to that noise and to scalar normalization.
-    All four decide_workspace branches are covered, since each resolves the workspace layer
+    All five decide_workspace branches are covered, since each resolves the workspace layer
     differently and is the surface where preview and live could drift.
     """
 
@@ -1014,8 +1014,49 @@ class TestProvisioningPreviewMatchesActivation:
                 expected_engine_version=">=4.0",
             )
 
+    def test_configured_root_inheritance_branch(self, tmp_path: Path, isolate_user_config: Path) -> None:
+        """A project nested inside the configured workspace root inherits it (apply_override=True).
+
+        The user config sets workspace_directory to an enclosing root and the project lives in a
+        subdir of it with no workspace driver of its own, so decide_workspace's inheritance branch
+        fires and both paths must resolve the workspace layer to that root.
+        """
+        from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
+
+        workspace_root = tmp_path / "workspace"
+        workspace_root.mkdir()
+        project_dir = workspace_root / "nested"
+        project_dir.mkdir()
+        project_file = project_dir / "project.yml"
+        project_file.touch()
+
+        self._write_config_file(
+            project_dir / "griptape_nodes_config.json",
+            {LIBRARIES_TO_REGISTER_KEY: ["project-lib"], REQUIRES_ENGINE_KEY: ">=1.0"},
+        )
+        self._write_config_file(
+            workspace_root / "griptape_nodes_config.json",
+            {LIBRARIES_TO_REGISTER_KEY: ["root-workspace-lib"], REQUIRES_ENGINE_KEY: ">=5.0"},
+        )
+        isolate_user_config.write_text(json.dumps({"workspace_directory": str(workspace_root)}), encoding="utf-8")
+
+        with patch.dict(os.environ, {}, clear=True):
+            cm = ConfigManager()
+            self._assert_preview_matches_live(
+                cm,
+                project_dir,
+                project_file,
+                expected_libraries=["root-workspace-lib"],
+                expected_engine_version=">=5.0",
+            )
+
     def test_auto_default_branch(self, tmp_path: Path) -> None:
-        """No workspace driver: the project's own dir is the workspace (apply_override=True)."""
+        """Project outside the configured root: the project's own dir is the workspace (apply_override=True).
+
+        The real ConfigManager's default workspace_directory is CWD/GriptapeNodes; the tmp_path
+        project is not under it, so decide_workspace's inheritance branch is skipped and it falls
+        through to the auto-default branch.
+        """
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY, REQUIRES_ENGINE_KEY
 
         project_dir = tmp_path / "project"

--- a/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
+++ b/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
@@ -538,8 +538,14 @@ class TestSidecarMetadata:
     @pytest.fixture(autouse=True)
     def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
         """Set workspace to temp_dir and load a project template for sidecar path resolution."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        config_manager = griptape_nodes.ConfigManager()
+        original_workspace = config_manager.workspace_path
+        # Set the *configured* workspace_directory, not just the workspace_path property.
+        # The project loaded below is parentless, so activation resolves its workspace via
+        # decide_workspace's global-default branch (the configured workspace_directory) and
+        # pins it with set_workspace_override. A bare workspace_path assignment would be
+        # clobbered by that pin; setting the configured value makes the pin land on temp_dir.
+        config_manager.set_config_value("workspace_directory", str(temp_dir))
 
         # Create a project template file so sidecar path resolution has a project to use
         project_yml = temp_dir / "project_template.yml"
@@ -551,7 +557,7 @@ class TestSidecarMetadata:
         yield
 
         GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        config_manager.set_config_value("workspace_directory", str(original_workspace))
 
     def test_sidecar_not_written_without_file_metadata(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Test that no sidecar is written when file_metadata is not provided."""

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1780,13 +1780,19 @@ class TestDecideWorkspace:
         return ProjectManager(Mock(), mock_config, Mock())
 
     @staticmethod
-    def _pm_with_config(project_workspaces: dict[str, str], configured_root: str | None) -> ProjectManager:
+    def _pm_with_config(
+        project_workspaces: dict[str, str],
+        configured_root: str | None,
+        default_root: str | None = None,
+    ) -> ProjectManager:
         """Build a ProjectManager whose config distinguishes the branch-4 reads.
 
         The single-return _pm_with_project_workspaces helper can't tell apart the
         project_workspaces lookup from the configured-root workspace_directory reads (user_config
         then default_config), which the inheritance branch needs. This keys the mock on
-        (key, config_source) instead.
+        (key, config_source) instead. `configured_root` is the user_config layer value;
+        `default_root` is the default_config fallback the branch reads when user_config is None
+        (in production this is always populated by the Settings default).
         """
         mock_config = Mock()
 
@@ -1796,7 +1802,7 @@ class TestDecideWorkspace:
             if key == "workspace_directory" and config_source == "user_config":
                 return configured_root
             if key == "workspace_directory" and config_source == "default_config":
-                return default
+                return default_root
             return default
 
         mock_config.get_config_value.side_effect = fake_get
@@ -1918,10 +1924,29 @@ class TestDecideWorkspace:
         project_file = nested_dir / "project.yml"
         project_file.touch()
 
-        pm = self._pm_with_config(project_workspaces={}, configured_root=None)
+        pm = self._pm_with_config(project_workspaces={}, configured_root=None, default_root=None)
         decision = pm.decide_workspace(project_file, project_config={}, env_config={})
 
         assert decision.workspace_dir == project_file.parent
+        assert decision.apply_override is True
+
+    def test_nested_inherits_default_config_root_when_user_config_unset(self, tmp_path: Path) -> None:
+        """When user_config has no workspace_directory, the branch falls back to default_config.
+
+        In production default_config always supplies the Settings default, so this fallback
+        (not the configured_root=None fallthrough) is the realistic path for a project under the
+        engine's default workspace.
+        """
+        workspace_root = tmp_path / "ws"
+        nested_dir = workspace_root / "test"
+        nested_dir.mkdir(parents=True)
+        project_file = nested_dir / "project.yml"
+        project_file.touch()
+
+        pm = self._pm_with_config(project_workspaces={}, configured_root=None, default_root=str(workspace_root))
+        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == Path(str(workspace_root))
         assert decision.apply_override is True
 
 
@@ -1953,6 +1978,8 @@ class TestProjectManagerProjectWorkspaces:
             if key == LIBRARIES_TO_DOWNLOAD_KEY:
                 return []
             if key == REQUIRES_ENGINE_KEY:
+                return None
+            if key == "workspace_directory":
                 return None
             return default if default is not None else {}
 
@@ -2211,6 +2238,8 @@ class TestProjectManagerProjectWorkspaces:
             if key == LIBRARIES_TO_DOWNLOAD_KEY:
                 return []
             if key == REQUIRES_ENGINE_KEY:
+                return None
+            if key == "workspace_directory":
                 return None
             return default if default is not None else {}
 

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1808,6 +1808,71 @@ class TestDecideWorkspace:
         mock_config.get_config_value.side_effect = fake_get
         return ProjectManager(Mock(), mock_config, Mock())
 
+    @staticmethod
+    def _pm_with_chain(
+        specs: list[dict[str, Any]],
+        *,
+        project_workspaces: dict[str, str] | None = None,
+        configured_root: str | None = None,
+        default_root: str | None = None,
+    ) -> ProjectManager:
+        """Build a ProjectManager whose registry models an explicit parent chain.
+
+        Each spec is a dict with keys `id` (registry key / parent link target),
+        `file` (Path to the project YAML, or None for a file-less project like system
+        defaults), `parent_id` (the spec's parent_project_id, or None), and an optional
+        `config` dict standing in for that project's adjacent griptape_nodes_config.json.
+        The mock `read_config_file` returns a spec's `config` keyed on the directory of
+        its file; `get_config_value` resolves project_workspaces and the global
+        workspace_directory (user_config then default_config) so the branch-4 walk and
+        branch-5 fallback both have realistic inputs.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+        project_workspaces = project_workspaces or {}
+        mock_config = Mock()
+
+        def fake_get(key: str, *, config_source: str = "merged_config", default: Any = None, **_: Any) -> Any:
+            if key == "project_workspaces":
+                return project_workspaces
+            if key == "workspace_directory" and config_source == "user_config":
+                return configured_root
+            if key == "workspace_directory" and config_source == "default_config":
+                return default_root
+            return default
+
+        mock_config.get_config_value.side_effect = fake_get
+
+        dir_to_config: dict[Path, dict] = {
+            Path(spec["file"]).parent: spec["config"]
+            for spec in specs
+            if spec.get("file") is not None and "config" in spec
+        }
+
+        def fake_read_config_file(path: Path) -> dict:
+            return dir_to_config.get(Path(path).parent, {})
+
+        mock_config.read_config_file.side_effect = fake_read_config_file
+
+        pm = ProjectManager(Mock(), mock_config, Mock())
+        validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+        for spec in specs:
+            file_path = spec.get("file")
+            base_dir = Path(file_path).parent if file_path is not None else Path("/")
+            template = DEFAULT_PROJECT_TEMPLATE.model_copy(update={"parent_project_id": spec.get("parent_id")})
+            pm._successfully_loaded_project_templates[spec["id"]] = ProjectInfo(
+                project_id=spec["id"],
+                project_file_path=Path(file_path) if file_path is not None else None,
+                project_base_dir=base_dir,
+                template=template,
+                validation=validation,
+                parsed_situation_schemas={},
+                parsed_directory_schemas={},
+            )
+        return pm
+
     def test_project_workspaces_override_wins(self, tmp_path: Path) -> None:
         project_file = tmp_path / "project.yml"
         project_file.touch()
@@ -1861,29 +1926,106 @@ class TestDecideWorkspace:
         assert decision.workspace_dir == project_file.parent
         assert decision.apply_override is True
 
-    def test_nested_project_inherits_configured_root(self, tmp_path: Path) -> None:
-        workspace_root = tmp_path / "ws"
-        nested_dir = workspace_root / "test"
-        nested_dir.mkdir(parents=True)
-        project_file = nested_dir / "project.yml"
-        project_file.touch()
+    def test_three_level_inherits_nearest_ancestor_workspace(self, tmp_path: Path) -> None:
+        """C inherits B's workspace when B (the nearest ancestor) defines one, not A's."""
+        a_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        b_file = tmp_path / "b" / "griptape-nodes-project.yml"
+        c_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        for f in (a_file, b_file, c_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
 
-        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
-        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+        pm = self._pm_with_chain(
+            [
+                {"id": "A", "file": a_file, "parent_id": None, "config": {"workspace_directory": "/ws/a"}},
+                {"id": "B", "file": b_file, "parent_id": "A", "config": {"workspace_directory": "/ws/b"}},
+                {"id": "C", "file": c_file, "parent_id": "B", "config": {}},
+            ],
+            configured_root="/global/ws",
+        )
+        decision = pm.decide_workspace(c_file, project_config={}, env_config={})
 
-        assert decision.workspace_dir == Path(str(workspace_root))
+        assert decision.workspace_dir == Path("/ws/b")
         assert decision.apply_override is True
 
-    def test_nested_with_sidecar_keeps_own(self, tmp_path: Path) -> None:
-        workspace_root = tmp_path / "ws"
-        nested_dir = workspace_root / "test"
-        nested_dir.mkdir(parents=True)
-        project_file = nested_dir / "project.yml"
-        project_file.touch()
+    def test_three_level_skips_to_grandparent_when_parent_has_none(self, tmp_path: Path) -> None:
+        """C inherits A's workspace when B (its parent) defines none but A does."""
+        a_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        b_file = tmp_path / "b" / "griptape-nodes-project.yml"
+        c_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        for f in (a_file, b_file, c_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
 
-        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
+        pm = self._pm_with_chain(
+            [
+                {"id": "A", "file": a_file, "parent_id": None, "config": {"workspace_directory": "/ws/a"}},
+                {"id": "B", "file": b_file, "parent_id": "A", "config": {}},
+                {"id": "C", "file": c_file, "parent_id": "B", "config": {}},
+            ],
+            configured_root="/global/ws",
+        )
+        decision = pm.decide_workspace(c_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == Path("/ws/a")
+        assert decision.apply_override is True
+
+    def test_chain_exhausted_uses_global_default(self, tmp_path: Path) -> None:
+        """A project derived from the file-less default inherits the global workspace (Jason's case)."""
+        c_file = tmp_path / "test" / "griptape-nodes-project.yml"
+        c_file.parent.mkdir(parents=True)
+        c_file.touch()
+
+        pm = self._pm_with_chain(
+            [
+                {"id": "<system-defaults>", "file": None, "parent_id": None},
+                {"id": "C", "file": c_file, "parent_id": "<system-defaults>", "config": {}},
+            ],
+            configured_root="/global/ws",
+        )
+        decision = pm.decide_workspace(c_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == Path("/global/ws")
+        assert decision.apply_override is True
+
+    def test_ancestor_override_mapping_wins(self, tmp_path: Path) -> None:
+        """An ancestor keyed in project_workspaces is inherited over its adjacent config."""
+        a_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        c_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        for f in (a_file, c_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
+
+        pm = self._pm_with_chain(
+            [
+                {"id": "A", "file": a_file, "parent_id": None, "config": {"workspace_directory": "/ws/a"}},
+                {"id": "C", "file": c_file, "parent_id": "A", "config": {}},
+            ],
+            project_workspaces={str(a_file): "/mapped/a"},
+            configured_root="/global/ws",
+        )
+        decision = pm.decide_workspace(c_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == Path("/mapped/a")
+        assert decision.apply_override is True
+
+    def test_start_project_sidecar_still_wins(self, tmp_path: Path) -> None:
+        """C's own project-adjacent workspace_directory (branch 3) wins and the walk never runs."""
+        a_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        c_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        for f in (a_file, c_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
+
+        pm = self._pm_with_chain(
+            [
+                {"id": "A", "file": a_file, "parent_id": None, "config": {"workspace_directory": "/ws/a"}},
+                {"id": "C", "file": c_file, "parent_id": "A", "config": {}},
+            ],
+            configured_root="/global/ws",
+        )
         decision = pm.decide_workspace(
-            project_file,
+            c_file,
             project_config={"workspace_directory": "/explicit/ws"},
             env_config={},
         )
@@ -1891,62 +2033,56 @@ class TestDecideWorkspace:
         assert decision.workspace_dir == Path("/explicit/ws")
         assert decision.apply_override is False
 
-    def test_outside_root_auto_defaults(self, tmp_path: Path) -> None:
-        workspace_root = tmp_path / "ws"
-        workspace_root.mkdir()
+    def test_imported_standalone_uses_global_default(self, tmp_path: Path) -> None:
+        """A parentless project outside the configured root adopts the global workspace, not its own dir."""
         other_dir = tmp_path / "other"
         other_dir.mkdir()
-        project_file = other_dir / "project.yml"
+        project_file = other_dir / "griptape-nodes-project.yml"
         project_file.touch()
 
-        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
+        pm = self._pm_with_chain(
+            [{"id": "C", "file": project_file, "parent_id": None, "config": {}}],
+            configured_root="/global/ws",
+        )
         decision = pm.decide_workspace(project_file, project_config={}, env_config={})
 
-        assert decision.workspace_dir == project_file.parent
+        assert decision.workspace_dir == Path("/global/ws")
         assert decision.apply_override is True
 
-    def test_base_dir_equals_root(self, tmp_path: Path) -> None:
-        workspace_root = tmp_path / "ws"
-        workspace_root.mkdir()
-        project_file = workspace_root / "project.yml"
-        project_file.touch()
+    def test_cyclic_chain_falls_back_to_global_default(self, tmp_path: Path) -> None:
+        """A cyclic parent chain terminates via the visited set and falls back to the global default."""
+        a_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        b_file = tmp_path / "b" / "griptape-nodes-project.yml"
+        for f in (a_file, b_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
 
-        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
-        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+        pm = self._pm_with_chain(
+            [
+                {"id": "A", "file": a_file, "parent_id": "B", "config": {}},
+                {"id": "B", "file": b_file, "parent_id": "A", "config": {}},
+            ],
+            configured_root="/global/ws",
+        )
+        decision = pm.decide_workspace(a_file, project_config={}, env_config={})
 
-        assert decision.workspace_dir == Path(str(workspace_root))
+        assert decision.workspace_dir == Path("/global/ws")
         assert decision.apply_override is True
 
-    def test_configured_root_unset_auto_defaults(self, tmp_path: Path) -> None:
-        workspace_root = tmp_path / "ws"
-        nested_dir = workspace_root / "test"
-        nested_dir.mkdir(parents=True)
-        project_file = nested_dir / "project.yml"
-        project_file.touch()
+    def test_global_default_unset_falls_back_to_own_dir(self, tmp_path: Path) -> None:
+        """Chain exhausted AND workspace_directory unset in both layers falls back to the project's own dir."""
+        c_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        c_file.parent.mkdir(parents=True)
+        c_file.touch()
 
-        pm = self._pm_with_config(project_workspaces={}, configured_root=None, default_root=None)
-        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+        pm = self._pm_with_chain(
+            [{"id": "C", "file": c_file, "parent_id": None, "config": {}}],
+            configured_root=None,
+            default_root=None,
+        )
+        decision = pm.decide_workspace(c_file, project_config={}, env_config={})
 
-        assert decision.workspace_dir == project_file.parent
-        assert decision.apply_override is True
-
-    def test_nested_inherits_default_config_root_when_user_config_unset(self, tmp_path: Path) -> None:
-        """When user_config has no workspace_directory, the branch falls back to default_config.
-
-        In production default_config always supplies the Settings default, so this fallback
-        (not the configured_root=None fallthrough) is the realistic path for a project under the
-        engine's default workspace.
-        """
-        workspace_root = tmp_path / "ws"
-        nested_dir = workspace_root / "test"
-        nested_dir.mkdir(parents=True)
-        project_file = nested_dir / "project.yml"
-        project_file.touch()
-
-        pm = self._pm_with_config(project_workspaces={}, configured_root=None, default_root=str(workspace_root))
-        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
-
-        assert decision.workspace_dir == Path(str(workspace_root))
+        assert decision.workspace_dir == c_file.parent
         assert decision.apply_override is True
 
 

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -1779,6 +1779,29 @@ class TestDecideWorkspace:
         mock_config.get_config_value.return_value = project_workspaces
         return ProjectManager(Mock(), mock_config, Mock())
 
+    @staticmethod
+    def _pm_with_config(project_workspaces: dict[str, str], configured_root: str | None) -> ProjectManager:
+        """Build a ProjectManager whose config distinguishes the branch-4 reads.
+
+        The single-return _pm_with_project_workspaces helper can't tell apart the
+        project_workspaces lookup from the configured-root workspace_directory reads (user_config
+        then default_config), which the inheritance branch needs. This keys the mock on
+        (key, config_source) instead.
+        """
+        mock_config = Mock()
+
+        def fake_get(key: str, *, config_source: str = "merged_config", default: Any = None, **_: Any) -> Any:
+            if key == "project_workspaces":
+                return project_workspaces
+            if key == "workspace_directory" and config_source == "user_config":
+                return configured_root
+            if key == "workspace_directory" and config_source == "default_config":
+                return default
+            return default
+
+        mock_config.get_config_value.side_effect = fake_get
+        return ProjectManager(Mock(), mock_config, Mock())
+
     def test_project_workspaces_override_wins(self, tmp_path: Path) -> None:
         project_file = tmp_path / "project.yml"
         project_file.touch()
@@ -1826,7 +1849,76 @@ class TestDecideWorkspace:
         project_file = tmp_path / "project.yml"
         project_file.touch()
 
-        pm = self._pm_with_project_workspaces({})
+        pm = self._pm_with_config(project_workspaces={}, configured_root=None)
+        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == project_file.parent
+        assert decision.apply_override is True
+
+    def test_nested_project_inherits_configured_root(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "ws"
+        nested_dir = workspace_root / "test"
+        nested_dir.mkdir(parents=True)
+        project_file = nested_dir / "project.yml"
+        project_file.touch()
+
+        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
+        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == Path(str(workspace_root))
+        assert decision.apply_override is True
+
+    def test_nested_with_sidecar_keeps_own(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "ws"
+        nested_dir = workspace_root / "test"
+        nested_dir.mkdir(parents=True)
+        project_file = nested_dir / "project.yml"
+        project_file.touch()
+
+        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
+        decision = pm.decide_workspace(
+            project_file,
+            project_config={"workspace_directory": "/explicit/ws"},
+            env_config={},
+        )
+
+        assert decision.workspace_dir == Path("/explicit/ws")
+        assert decision.apply_override is False
+
+    def test_outside_root_auto_defaults(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "ws"
+        workspace_root.mkdir()
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        project_file = other_dir / "project.yml"
+        project_file.touch()
+
+        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
+        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == project_file.parent
+        assert decision.apply_override is True
+
+    def test_base_dir_equals_root(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "ws"
+        workspace_root.mkdir()
+        project_file = workspace_root / "project.yml"
+        project_file.touch()
+
+        pm = self._pm_with_config(project_workspaces={}, configured_root=str(workspace_root))
+        decision = pm.decide_workspace(project_file, project_config={}, env_config={})
+
+        assert decision.workspace_dir == Path(str(workspace_root))
+        assert decision.apply_override is True
+
+    def test_configured_root_unset_auto_defaults(self, tmp_path: Path) -> None:
+        workspace_root = tmp_path / "ws"
+        nested_dir = workspace_root / "test"
+        nested_dir.mkdir(parents=True)
+        project_file = nested_dir / "project.yml"
+        project_file.touch()
+
+        pm = self._pm_with_config(project_workspaces={}, configured_root=None)
         decision = pm.decide_workspace(project_file, project_config={}, env_config={})
 
         assert decision.workspace_dir == project_file.parent


### PR DESCRIPTION
### Problem
A new project saved in a *subdirectory* of the workspace (e.g.
`~/GriptapeNodes/test/griptape-nodes-project.yml`) wrongly prompted to reinstall the
standard library on activation. The subdir project had no adjacent config, so the
workspace auto-defaulted to the subdir itself, `libraries_directory` resolved to an empty
`<subdir>/libraries/`, and the provisioning preview saw no installed libraries.

### Changes (engine, working tree only — no git actions)

**`project_manager.py` — `decide_workspace`**
- Added a new branch (priority 4): when no explicit workspace was named (override / env /
  project-adjacent config) and the project file lives *inside* the configured workspace
  root, return the **configured root** instead of auto-defaulting to the project's own subdir.
- Reads `workspace_directory` from `user_config`, falling back to `default_config`.
  Containment uses `canonicalize_for_identity` + `is_relative_to`. Returns the raw root so
  preview and live activation re-resolve identically (no drift).
- Updated the docstring to document the new branch and the preserved opt-out.

**`test_project_manager.py` — `TestDecideWorkspace`**
- Added a `_pm_with_config` helper keying the config mock on `(key, config_source)`.
- Migrated `test_auto_defaults_to_project_dir` onto it.
- Added 5 cases: nested-inherits-root, sidecar-wins, outside-root-auto-defaults,
  base==root, root-unset.

### Impact
- A project saved inside the workspace now inherits the enclosing workspace, so
  already-downloaded libraries (standard + custom) resolve correctly and the spurious
  install prompt no longer fires.
- **Opt-out preserved:** a sidecar `griptape_nodes_config.json` with an explicit
  `workspace_directory` (branch 3) still wins.
- **Portability preserved:** a project *outside* the configured root still auto-defaults to
  its own dir (branch 5), so imported standalone projects are unaffected.
- **Default-project behavior unchanged:** project dir == root → inherits root, same as before.