### PR TITLE
Add workspace configuration reference docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,16 @@ test/integration: ## Run integration tests.
 test/e2e: ## Run end-to-end tests (spawns subprocesses; slower than unit/integration).
 	@uv run pytest tests/e2e
 
+.PHONY: docs/settings-reference
+docs/settings-reference: ## Generate the configuration reference doc from the Settings model.
+	@uv run python scripts/generate_settings_reference.py
+
 .PHONY: docs
-docs: ## Build documentation.
-	@uv run python -m mkdocs build --clean --strict 
+docs: docs/settings-reference ## Build documentation.
+	@uv run python -m mkdocs build --clean --strict
 
 .PHONY: docs/serve
-docs/serve: ## Serve documentation.
+docs/serve: docs/settings-reference ## Serve documentation.
 	@uv run python -m mkdocs serve
 	
 .DEFAULT_GOAL := help

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,8 @@ When running Griptape Nodes engine on your own machine, you are provided with ut
 
 > During installation, `gtn init` was run automatically.
 
+> Looking for a specific setting? The [Configuration Reference](configuration_reference.md) lists every setting with its type, default, environment variable, and description, grouped by category.
+
 ## Configuration Loading
 
 Griptape Nodes employs a specific search order to load settings from environment variables and configuration files. Understanding this process is key to managing your setup.
@@ -20,15 +22,15 @@ Griptape Nodes employs a specific search order to load settings from environment
     Configuration files hold information important for Griptape Nodes operation, such as where to locate Node Libraries, as well as user preferences to customize the Griptape Nodes experience.
 
     - If no configuration files are found, Griptape Nodes will run using built-in default values.
-    - Settings are loaded from up to four `griptape_nodes_config.json` files and merged in priority order:
+    - Configuration files are always JSON (`griptape_nodes_config.json`). Settings are loaded from up to three such files plus a runtime override and environment variables, and merged in priority order:
     - **Load Order (lower numbers are loaded first; higher numbers override):**
         1. **Built-in defaults** — values baked into the application.
         1. **User config** — `~/.config/griptape_nodes/griptape_nodes_config.json`. Global settings for this machine.
         1. **Project-adjacent config** — `<project_dir>/griptape_nodes_config.json`. Loaded when a project is set as active. Use this to distribute shared defaults alongside a project file.
         1. **Workspace config** — `<workspace_dir>/griptape_nodes_config.json`. Loaded after the workspace is resolved. Use this for per-user overrides that take precedence over the shared project config. When the workspace directory is the same as the project directory, this file is the same as the project-adjacent config and is not loaded twice.
+        1. **Per-project workspace override** — When the active project's path matches a key in the `project_workspaces` mapping (in your user config), that workspace directory is applied. This sets only `workspace_directory`, overriding any value from the config files above. See [Workspace](projects/workspace.md#per-project-workspace-overrides) for details.
         1. **Environment variables** — `GTN_CONFIG_*` prefix (highest priority). See below.
     - **Override Priority:** Settings in files loaded later override settings from files loaded earlier.
-    - **Per-project workspace overrides** — The `project_workspaces` key in your user config maps project file paths to local workspace directories. See [Workspace](projects/workspace.md#per-project-workspace-overrides) for details.
 
 1. **Defaults and Merging**
     Griptape Nodes comes with built-in default settings for various options, including the default workspace directory. These defaults are used unless overridden by settings loaded from discovered configuration files.
@@ -70,9 +72,9 @@ Here are a few scenarios to illustrate how configuration files are located and l
 
 - **Loading Process:**
 
-    1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
-    1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!).
-    1. **Result:** The application loads settings from `~/.config/griptape_nodes/griptape_nodes_config.json`. The `workspace_directory` is set to `/home/user/my_project/GriptapeNodes`. Subsequent runtime changes managed by `ConfigManager` will be saved to `/home/user/my_project/GriptapeNodes/griptape_nodes_config.json`.
+    1. Loads built-in defaults.
+    1. Loads `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!), merging it over the defaults.
+    1. **Result:** The `workspace_directory` is set to `/home/user/my_project/GriptapeNodes`. Subsequent runtime changes managed by `ConfigManager` will be saved to `/home/user/my_project/GriptapeNodes/griptape_nodes_config.json`.
 
 **Scenario 2: Custom Workspace**
 
@@ -80,7 +82,7 @@ Here are a few scenarios to illustrate how configuration files are located and l
 
 - `gtn init` creates `~/.config/griptape_nodes/griptape_nodes_config.json` (setting `workspace_directory = "/data/gtn_work"`) and `~/.config/griptape_nodes/.env`.
 
-- You might manually create `/data/gtn_work/griptape_nodes_config.yaml` to store project-specific settings.
+- You might manually create `/data/gtn_work/griptape_nodes_config.json` to store workspace-specific settings.
 
 - You run `gtn` from `/home/user/some_dir/`.
 
@@ -95,57 +97,55 @@ Here are a few scenarios to illustrate how configuration files are located and l
                 griptape_nodes_config.json # Contains workspace_directory = /data/gtn_work
     /data/
         gtn_work/            <-- Custom Workspace
-            griptape_nodes_config.yaml # Manually created / runtime saved config
+            griptape_nodes_config.json # Workspace config (also where runtime changes are saved)
             project_flows/
     ```
 
 - **Loading Process:**
 
-    1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
-    1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!).
-    1. **Result:** The application *initially* loads settings from `~/.config/griptape_nodes/griptape_nodes_config.json`. The `workspace_directory` is set to `/data/gtn_work`. Even though `/data/gtn_work/griptape_nodes_config.yaml` exists, it's not checked during initial load because a higher priority file was found. Runtime changes will be saved back to `/data/gtn_work/griptape_nodes_config.json` (overwriting/merging with the YAML potentially, depending on `ConfigManager`'s save logic).
+    1. Loads built-in defaults.
+    1. Loads `~/.config/griptape_nodes/griptape_nodes_config.json` (Found!), merging it over the defaults. This sets `workspace_directory` to `/data/gtn_work`.
+    1. Resolves the workspace and loads `/data/gtn_work/griptape_nodes_config.json` as the workspace config, merging it over the user config.
+    1. **Result:** The `workspace_directory` is `/data/gtn_work`. Settings in the workspace config override the user config for this workspace. Runtime changes are saved back to `/data/gtn_work/griptape_nodes_config.json`.
 
-**Scenario 3: Config in Current Directory (No System Config)**
+**Scenario 3: No User Config (Built-in Defaults)**
 
 - You haven't run `gtn init`, or you deleted `~/.config/griptape_nodes/`.
 
-- You create a project-specific config file directly in your project folder.
-
-- You run `gtn` from `/home/user/my_project/`.
+- You run `gtn` from `/home/user/my_project/` with no project active.
 
 - **File Structure:**
 
     ```
     /home/user/
         my_project/          <-- CWD when running 'gtn'
-            griptape_nodes_config.toml # User-created config
-            GriptapeNodes/   <-- Potential default workspace location
+            GriptapeNodes/   <-- Default workspace location
             my_flow.graph.json
     ```
 
 - **Loading Process:**
 
-    1. Checks `/etc/xdg/griptape_nodes/` (Assume not found).
-    1. Checks `~/.config/griptape_nodes/` (Assume not found).
-    1. Checks `/home/user/my_project/GriptapeNodes/` (Assume not found).
-    1. Checks `/home/user/my_project/griptape_nodes_config.toml` (Found!).
-    1. **Result:** The application loads settings from `/home/user/my_project/griptape_nodes_config.toml`. If this file specifies a `workspace_directory`, that path is used. If not, the default (`<cwd>/GriptapeNodes` = `/home/user/my_project/GriptapeNodes`) is used.
+    1. Loads built-in defaults.
+    1. Checks `~/.config/griptape_nodes/griptape_nodes_config.json` (Assume not found).
+    1. No project is active, so no project-adjacent config is loaded.
+    1. **Result:** The application runs on built-in defaults. `workspace_directory` falls back to its default of `<current_working_directory>/GriptapeNodes` = `/home/user/my_project/GriptapeNodes`, and runtime changes are saved to a `griptape_nodes_config.json` created inside that workspace.
 
 ## Environment Variable Overrides
 
-Any configuration value can be set or overridden using an environment variable with the `GTN_CONFIG_` prefix. The key is the config setting name in uppercase:
+A top-level configuration value can be set or overridden using an environment variable with the `GTN_CONFIG_` prefix. The key is the config setting name in uppercase:
 
 ```
 GTN_CONFIG_<SETTING_NAME>=<value>
 ```
 
-Environment variable overrides have the **highest priority** — they win over user config files, project-adjacent config files, and built-in defaults.
+Environment variable overrides have the **highest priority** — they win over user config files, project-adjacent config files, the per-project workspace override, and built-in defaults.
 
 Examples:
 
 | Setting               | Environment variable             |
 | --------------------- | -------------------------------- |
 | `workspace_directory` | `GTN_CONFIG_WORKSPACE_DIRECTORY` |
+| `libraries_directory` | `GTN_CONFIG_LIBRARIES_DIRECTORY` |
 | `project_file`        | `GTN_CONFIG_PROJECT_FILE`        |
 | `log_level`           | `GTN_CONFIG_LOG_LEVEL`           |
 | `storage_backend`     | `GTN_CONFIG_STORAGE_BACKEND`     |
@@ -155,6 +155,8 @@ This is useful for scripted environments, containers, and CI/CD pipelines where 
 ```bash
 GTN_CONFIG_PROJECT_FILE=/shared/studio-project.yml gtn
 ```
+
+> **Only top-level settings can be set this way.** `GTN_CONFIG_*` variables map to a single top-level config key; they cannot reach nested settings (anything under `app_events`, `worker`, or `agent`, such as `libraries_to_register`). To change a nested setting, edit a `griptape_nodes_config.json` file. The [Configuration Reference](configuration_reference.md) marks which settings have an environment variable.
 
 ### Recursive Discovery Depth (`discovery_max_depth`)
 
@@ -175,6 +177,27 @@ During `gtn init`, you specify a Workspace Directory. This is the root for your 
 While `gtn init` might suggest `<current_working_directory>/GriptapeNodes` as a default, you can choose any location. Griptape Nodes uses the exact path you provide, which is then stored in the system `griptape_nodes_config.json`.
 
 It does **not** automatically search within a hardcoded `GriptapeNodes` subdirectory; it relies solely on the configured path.
+
+### Separating Libraries from the Workspace
+
+By default, downloaded libraries live in a `libraries/` folder **inside** the workspace, because `libraries_directory` is a relative path resolved against `workspace_directory`. If your workspace is on a slow or remote drive (a network share, a mounted volume), keeping libraries there can degrade performance, since the engine reads library code from disk frequently.
+
+You can point `libraries_directory` at an **absolute** path on fast local storage while keeping the workspace (projects, workflows, generated assets) on the remote drive. When `libraries_directory` is absolute, it is used as-is and the workspace location is ignored for libraries:
+
+```json
+{
+    "workspace_directory": "/Volumes/team-share/GriptapeNodes",
+    "libraries_directory": "/Users/me/.griptape-nodes-libraries"
+}
+```
+
+The same equivalently set via an environment variable:
+
+```bash
+GTN_CONFIG_LIBRARIES_DIRECTORY=/Users/me/.griptape-nodes-libraries gtn
+```
+
+The same relative-vs-absolute rule applies to `sandbox_library_directory` and `static_files_directory`, so you can independently relocate any of them onto local storage while the workspace stays remote.
 
 ## Static File Server Configuration
 

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -1,0 +1,99 @@
+<!-- GENERATED FILE - DO NOT EDIT BY HAND.
+     Regenerate with `make docs/settings-reference` after changing the Settings model. -->
+
+# Configuration Reference
+
+Every Griptape Nodes engine setting, grouped by category. Each setting can be placed in any `griptape_nodes_config.json` file (see [Engine Configuration](configuration.md) for the load order). Settings with a `GTN_CONFIG_*` env var can also be overridden from the environment; nested settings must be edited in a config file.
+
+## File System
+
+Directories and file paths for the application
+
+| Setting                          | Type    | Default                                     | Environment variable                        | Description                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------- | ------- | ------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workspace_directory`            | string  | `<current_working_directory>/GriptapeNodes` | `GTN_CONFIG_WORKSPACE_DIRECTORY`            | Root directory for projects, workflows, and generated assets. Defaults to a GriptapeNodes folder under the current working directory. The other File System paths (libraries_directory, static_files_directory, sandbox_library_directory, synced_workflows_directory) are interpreted relative to this directory unless they are set to absolute paths. |
+| `static_files_directory`         | string  | `"staticfiles"`                             | `GTN_CONFIG_STATIC_FILES_DIRECTORY`         | Path to the static files directory, relative to the workspace directory.                                                                                                                                                                                                                                                                                 |
+| `sandbox_library_directory`      | string  | `"sandbox_library"`                         | `GTN_CONFIG_SANDBOX_LIBRARY_DIRECTORY`      | Path to the sandbox library directory (useful while developing nodes). Relative paths are interpreted relative to the workspace directory. Absolute paths are used as-is.                                                                                                                                                                                |
+| `libraries_directory`            | string  | `"libraries"`                               | `GTN_CONFIG_LIBRARIES_DIRECTORY`            | Path to directory for downloaded libraries. All griptape_nodes_library.json files found recursively will be auto-discovered on startup. Relative paths are interpreted relative to the workspace directory. Absolute paths are used as-is.                                                                                                               |
+| `synced_workflows_directory`     | string  | `"synced_workflows"`                        | `GTN_CONFIG_SYNCED_WORKFLOWS_DIRECTORY`     | Path to the synced workflows directory, relative to the workspace directory.                                                                                                                                                                                                                                                                             |
+| `enable_workspace_file_watching` | boolean | `true`                                      | `GTN_CONFIG_ENABLE_WORKSPACE_FILE_WATCHING` | Enable file watching for synced workflows directory                                                                                                                                                                                                                                                                                                      |
+
+## Application Events
+
+Configuration for application lifecycle events
+
+| Setting      | Type   | Default         | Environment variable           | Description                                                   |
+| ------------ | ------ | --------------- | ------------------------------ | ------------------------------------------------------------- |
+| `app_events` | object | (nested object) | n/a (nested; edit config file) | Nested settings; edit the sub-keys directly in a config file. |
+
+## Execution
+
+Workflow execution and processing settings
+
+| Setting                   | Type                                                   | Default         | Environment variable                 | Description                                                                                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------ | --------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log_level`               | one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` | `"INFO"`        | `GTN_CONFIG_LOG_LEVEL`               | Logging verbosity for the engine. One of CRITICAL, ERROR, WARNING, INFO, or DEBUG, from least to most verbose.                                                                                                          |
+| `workflow_execution_mode` | one of `sequential`, `parallel`                        | `"sequential"`  | `GTN_CONFIG_WORKFLOW_EXECUTION_MODE` | Workflow execution mode for node processing. SEQUENTIAL mode uses ParallelResolutionMachine with max_nodes_in_parallel=1 to execute nodes one at a time. PARALLEL mode uses the configured max_nodes_in_parallel value. |
+| `max_nodes_in_parallel`   | integer                                                | `5`             | `GTN_CONFIG_MAX_NODES_IN_PARALLEL`   | Maximum number of nodes executing at a time for parallel execution.                                                                                                                                                     |
+| `worker`                  | object                                                 | (nested object) | n/a (nested; edit config file)       | Nested settings; edit the sub-keys directly in a config file.                                                                                                                                                           |
+
+## Storage
+
+Data storage and persistence configuration
+
+| Setting                         | Type                  | Default   | Environment variable                       | Description                                                                                                                                                      |
+| ------------------------------- | --------------------- | --------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `storage_backend`               | one of `local`, `gtc` | `"local"` | `GTN_CONFIG_STORAGE_BACKEND`               | Backend used to persist workflow data and generated assets. 'local' stores files on the local filesystem under the workspace; 'gtc' uses Griptape Cloud storage. |
+| `auto_inject_workflow_metadata` | boolean               | `true`    | `GTN_CONFIG_AUTO_INJECT_WORKFLOW_METADATA` | Automatically inject workflow metadata into saved files with supported formats                                                                                   |
+| `thread_storage_backend`        | `"local"` (constant)  | `"local"` | `GTN_CONFIG_THREAD_STORAGE_BACKEND`        | Storage backend for conversation threads. Only 'local' (filesystem) is supported; Griptape Cloud support was removed in the Pydantic AI migration.               |
+
+## System Requirements
+
+System resource requirements and limits
+
+| Setting                           | Type    | Default | Environment variable                         | Description                                                                                                                                                                                                                                                                                                       |
+| --------------------------------- | ------- | ------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minimum_disk_space_gb_libraries` | number  | `10.0`  | `GTN_CONFIG_MINIMUM_DISK_SPACE_GB_LIBRARIES` | Minimum disk space in GB required for library installation and virtual environment operations                                                                                                                                                                                                                     |
+| `minimum_disk_space_gb_workflows` | number  | `1.0`   | `GTN_CONFIG_MINIMUM_DISK_SPACE_GB_WORKFLOWS` | Minimum disk space in GB required for saving workflows                                                                                                                                                                                                                                                            |
+| `discovery_max_depth`             | integer | `5`     | `GTN_CONFIG_DISCOVERY_MAX_DEPTH`             | Maximum directory depth the engine walks when a registered entry points at a directory to recursively discover files (e.g. project files under projects_to_register). Bounds boot-time scans against pathologically deep trees and symlink loops. 0 scans only the top-level directory; each nested level adds 1. |
+
+## MCP Servers
+
+Model Context Protocol server configurations
+
+| Setting       | Type  | Default | Environment variable           | Description                                          |
+| ------------- | ----- | ------- | ------------------------------ | ---------------------------------------------------- |
+| `mcp_servers` | array | `[]`    | n/a (nested; edit config file) | List of Model Context Protocol server configurations |
+
+## Static Server
+
+Static file server configuration for serving media assets
+
+| Setting                  | Type   | Default | Environment variable                | Description                                                                                                                                                                                                                                                                                 |
+| ------------------------ | ------ | ------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `static_server_base_url` | string | `null`  | `GTN_CONFIG_STATIC_SERVER_BASE_URL` | Base URL for the static server. Leave unset to derive it from the server's host/port (including the OS-assigned port when the configured port is unavailable). Set this only to override the derived URL, e.g. when fronting the server with a tunnel (ngrok, cloudflare) or reverse proxy. |
+
+## Artifacts
+
+Settings for artifact providers and preview generation
+
+| Setting     | Type   | Default | Environment variable           | Description                                                         |
+| ----------- | ------ | ------- | ------------------------------ | ------------------------------------------------------------------- |
+| `artifacts` | object | `{}`    | n/a (nested; edit config file) | Control how previews are generated for images and other media files |
+
+## Projects
+
+Project template configurations and registrations
+
+| Setting              | Type   | Default | Environment variable           | Description                                                                                                                                                                                                                                                               |
+| -------------------- | ------ | ------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_file`       | string | `null`  | `GTN_CONFIG_PROJECT_FILE`      | Path to the project file (griptape-nodes-project.yml) to load initially when the engine starts. When set, overrides the default location of \<workspace_directory>/griptape-nodes-project.yml. If the specified path does not exist, falls back to the workspace default. |
+| `project_workspaces` | object | `{}`    | n/a (nested; edit config file) | Mapping of project file paths to workspace directory overrides. When a project is loaded, if its resolved path matches a key here, the corresponding value is used as the workspace directory instead of the project-adjacent config or auto-default.                     |
+
+## Agent
+
+Agent behavior and system prompt
+
+| Setting | Type   | Default         | Environment variable           | Description                                                   |
+| ------- | ------ | --------------- | ------------------------------ | ------------------------------------------------------------- |
+| `agent` | object | (nested object) | n/a (nested; edit config file) | Nested settings; edit the sub-keys directly in a config file. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
               - 4. Compare Prompts: ftue/03_compare_prompts/FTUE_03_compare_prompts.md
               - 5. Build a Photography Team: ftue/04_photography_team/FTUE_04_photography_team.md
       - Engine Configuration: configuration.md
+      - Configuration Reference: configuration_reference.md
       - Libraries: libraries.md
       - Command Line Interface: command_line_interface.md
       - Scripting: retained_mode.md

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -1,0 +1,219 @@
+"""Generate the configuration reference doc from the Settings model.
+
+Renders docs/configuration_reference.md from Settings.model_json_schema() so the
+per-setting reference (type, default, env var, description) cannot drift from the
+code. Run via `make docs/settings-reference`; `make docs` runs it before building.
+
+The page is grouped by the category attached to each Field (see the custom Field
+wrapper in settings.py). Only top-level scalar settings get a GTN_CONFIG_* env var
+column, because env-var parsing is a flat key lookup with no nesting support
+(config_manager._load_config_from_env_vars).
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import mdformat
+
+from griptape_nodes.retained_mode.managers.settings import Settings
+
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "docs" / "configuration_reference.md"
+
+BANNER = (
+    "<!-- GENERATED FILE - DO NOT EDIT BY HAND.\n"
+    "     Regenerate with `make docs/settings-reference` after changing the Settings model. -->\n"
+)
+
+# workspace_directory's default is computed from the current working directory at import
+# time, so render a stable placeholder instead of the machine-specific absolute path.
+CWD_DEPENDENT_DEFAULTS = {"workspace_directory": "<current_working_directory>/GriptapeNodes"}
+
+
+@dataclass
+class SettingRow:
+    name: str
+    type_label: str
+    default_label: str
+    env_var_label: str
+    description: str
+    category_name: str
+    category_description: str
+
+
+def generate() -> None:
+    """Render the configuration reference markdown from the Settings schema."""
+    schema = Settings.model_json_schema()
+    properties = schema.get("properties", {})
+    defs = schema.get("$defs", {})
+    dumped_defaults = Settings().model_dump()
+
+    rows = [_build_row(name, prop, defs, dumped_defaults) for name, prop in properties.items()]
+    markdown = _render_markdown(rows)
+    # Match the repo's `make check` formatter (mdformat with the gfm plugin) so the
+    # committed file is byte-identical to what the format check expects.
+    formatted = mdformat.text(markdown, extensions=["gfm"])
+    OUTPUT_PATH.write_text(formatted, encoding="utf-8")
+
+
+def _build_row(name: str, prop: dict, defs: dict, dumped_defaults: dict) -> SettingRow:
+    category = prop.get("category", {})
+    if isinstance(category, str):
+        category_name = category
+        category_description = ""
+    else:
+        category_name = category.get("name", "General")
+        category_description = category.get("description", "")
+
+    is_nested = _is_nested(prop, defs)
+    type_label = _resolve_type_label(prop, defs)
+    default_label = _resolve_default_label(name, dumped_defaults, is_nested=is_nested)
+    env_var_label = _resolve_env_var_label(name, is_nested=is_nested)
+    description = _resolve_description(prop, is_nested=is_nested)
+
+    return SettingRow(
+        name=name,
+        type_label=type_label,
+        default_label=default_label,
+        env_var_label=env_var_label,
+        description=description,
+        category_name=category_name,
+        category_description=category_description,
+    )
+
+
+def _is_nested(prop: dict, defs: dict) -> bool:
+    """True when the setting is a nested model, list, or mapping (not a scalar)."""
+    if prop.get("type") in {"object", "array"}:
+        return True
+    ref = _extract_ref(prop)
+    if ref is not None:
+        target = defs.get(ref, {})
+        return "properties" in target
+    return False
+
+
+def _resolve_type_label(prop: dict, defs: dict) -> str:
+    if "const" in prop:
+        return f"`{json.dumps(prop['const'])}` (constant)"
+
+    if "enum" in prop:
+        return _enum_label(prop["enum"])
+
+    ref = _extract_ref(prop)
+    if ref is not None:
+        return _ref_type_label(ref, defs)
+
+    if "anyOf" in prop:
+        return _any_of_label(prop["anyOf"], defs)
+
+    return prop.get("type", "any")
+
+
+def _ref_type_label(ref: str, defs: dict) -> str:
+    target = defs.get(ref, {})
+    if "enum" in target:
+        return _enum_label(target["enum"])
+    if "properties" in target:
+        return "object"
+    return ref
+
+
+def _enum_label(values: list) -> str:
+    rendered = ", ".join(f"`{value}`" for value in values)
+    return f"one of {rendered}"
+
+
+def _any_of_label(any_of: list, defs: dict) -> str:
+    labels = []
+    for option in any_of:
+        if option.get("type") == "null":
+            continue
+        labels.append(_resolve_type_label(option, defs))
+    if not labels:
+        return "any"
+    return " or ".join(labels)
+
+
+def _resolve_default_label(name: str, dumped_defaults: dict, *, is_nested: bool) -> str:
+    if name in CWD_DEPENDENT_DEFAULTS:
+        return f"`{CWD_DEPENDENT_DEFAULTS[name]}`"
+
+    default_value = dumped_defaults.get(name)
+
+    if is_nested and default_value not in ([], {}):
+        return "(nested object)"
+
+    return f"`{json.dumps(default_value)}`"
+
+
+def _resolve_env_var_label(name: str, *, is_nested: bool) -> str:
+    if is_nested:
+        return "n/a (nested; edit config file)"
+    return f"`GTN_CONFIG_{name.upper()}`"
+
+
+def _resolve_description(prop: dict, *, is_nested: bool) -> str:
+    description = _normalize_cell(prop.get("description", ""))
+    if description:
+        return description
+    if is_nested:
+        return "Nested settings; edit the sub-keys directly in a config file."
+    return ""
+
+
+def _normalize_cell(text: str) -> str:
+    """Flatten a value for a single markdown table cell."""
+    collapsed = " ".join(text.split())
+    return collapsed.replace("|", "\\|")
+
+
+def _render_markdown(rows: list[SettingRow]) -> str:
+    lines = [BANNER, "# Configuration Reference", ""]
+    lines.append(
+        "Every Griptape Nodes engine setting, grouped by category. Each setting can be placed in any "
+        "`griptape_nodes_config.json` file (see [Engine Configuration](configuration.md) for the load "
+        "order). Settings with a `GTN_CONFIG_*` env var can also be overridden from the environment; "
+        "nested settings must be edited in a config file."
+    )
+    lines.append("")
+
+    for category_name in _ordered_categories(rows):
+        category_rows = [row for row in rows if row.category_name == category_name]
+        lines.append(f"## {category_name}")
+        lines.append("")
+        category_description = category_rows[0].category_description
+        if category_description:
+            lines.append(category_description)
+            lines.append("")
+        lines.append("| Setting | Type | Default | Environment variable | Description |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        lines.extend(
+            f"| `{row.name}` | {row.type_label} | {row.default_label} | {row.env_var_label} | {row.description} |"
+            for row in category_rows
+        )
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def _ordered_categories(rows: list[SettingRow]) -> list[str]:
+    """Category names in first-appearance order (declaration order in the model)."""
+    ordered: list[str] = []
+    for row in rows:
+        if row.category_name not in ordered:
+            ordered.append(row.category_name)
+    return ordered
+
+
+def _extract_ref(prop: dict) -> str | None:
+    ref = prop.get("$ref")
+    if ref is None and "allOf" in prop and len(prop["allOf"]) == 1:
+        ref = prop["allOf"][0].get("$ref")
+    if ref is None:
+        return None
+    return ref.split("/")[-1]
+
+
+if __name__ == "__main__":
+    generate()

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -287,6 +287,7 @@ class Settings(BaseModel):
     workspace_directory: str = Field(
         category=FILE_SYSTEM,
         default=str(Path().cwd() / "GriptapeNodes"),
+        description="Root directory for projects, workflows, and generated assets. Defaults to a GriptapeNodes folder under the current working directory. The other File System paths (libraries_directory, static_files_directory, sandbox_library_directory, synced_workflows_directory) are interpreted relative to this directory unless they are set to absolute paths.",
     )
     static_files_directory: str = Field(
         category=FILE_SYSTEM,
@@ -307,7 +308,11 @@ class Settings(BaseModel):
         category=APPLICATION_EVENTS,
         default_factory=AppEvents,
     )
-    log_level: LogLevel = Field(category=EXECUTION, default=LogLevel.INFO)
+    log_level: LogLevel = Field(
+        category=EXECUTION,
+        default=LogLevel.INFO,
+        description="Logging verbosity for the engine. One of CRITICAL, ERROR, WARNING, INFO, or DEBUG, from least to most verbose.",
+    )
     workflow_execution_mode: WorkflowExecutionMode = Field(
         category=EXECUTION,
         default=WorkflowExecutionMode.SEQUENTIAL,
@@ -355,7 +360,11 @@ class Settings(BaseModel):
         category=EXECUTION,
         default_factory=WorkerSettings,
     )
-    storage_backend: Literal["local", "gtc"] = Field(category=STORAGE, default="local")
+    storage_backend: Literal["local", "gtc"] = Field(
+        category=STORAGE,
+        default="local",
+        description="Backend used to persist workflow data and generated assets. 'local' stores files on the local filesystem under the workspace; 'gtc' uses Griptape Cloud storage.",
+    )
     auto_inject_workflow_metadata: bool = Field(
         category=STORAGE,
         default=True,


### PR DESCRIPTION
Identified a docs gap for Workspace configuration while we are deep-diving Project config.

Can be regenerated with isolated 'make docs/settings-reference' or through 'make docs' and 'make docs/server'

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4893.org.readthedocs.build/en/4893/

<!-- readthedocs-preview griptape-nodes end -->