### PR TITLE
fix(library): restore inter-library dependency feature lost in bad merge

### DIFF
--- a/src/griptape_nodes/node_library/library_declarations.py
+++ b/src/griptape_nodes/node_library/library_declarations.py
@@ -190,6 +190,18 @@ class ModelCatalogLibraryProperty(BaseModel):
     providers: dict[str, ModelProvider] = Field(default_factory=dict)
 
 
+class LibraryDependencyDeclaration(BaseModel):
+    """Declares another Griptape Node Library that this library depends on.
+
+    Placed in ``metadata.declarations`` so consumers can inspect inter-library
+    dependencies before committing to install anything.
+    """
+
+    type: Literal["library_dependency"] = "library_dependency"
+    url: str
+    required: bool = True
+
+
 # `Annotated[X | Y, Field(discriminator="type")]` is Pydantic v2's discriminated-union
 # idiom. Breakdown:
 #   - `X | Y` is the union of valid member classes.
@@ -201,7 +213,11 @@ class ModelCatalogLibraryProperty(BaseModel):
 #     ValidationError (strict validation).
 # This is the canonical Pydantic v2 way to round-trip "one of several shapes" through JSON.
 LibraryDeclaration = Annotated[
-    LifecycleStageLibraryProperty | WorkerModeCompatibility | SuggestedWorkerMode | ModelCatalogLibraryProperty,
+    LifecycleStageLibraryProperty
+    | WorkerModeCompatibility
+    | SuggestedWorkerMode
+    | ModelCatalogLibraryProperty
+    | LibraryDependencyDeclaration,
     Field(discriminator="type"),
 ]
 

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -47,11 +47,7 @@ class LibraryNameAndVersion(NamedTuple):
 
 
 class Dependencies(BaseModel):
-    """Dependencies for the library.
-
-    This can include other libraries, as well as external packages that need to
-    be installed with pip.
-    """
+    """Pip packages that need to be installed for this library."""
 
     pip_dependencies: list[str] | None = None
     pip_install_flags: list[str] | None = None

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -15,6 +15,7 @@ from .engine_version_error_problem import EngineVersionErrorProblem
 from .incompatible_requirements_problem import IncompatibleRequirementsProblem
 from .insufficient_disk_space_problem import InsufficientDiskSpaceProblem
 from .invalid_version_string_problem import InvalidVersionStringProblem
+from .library_dependency_problem import LibraryDependencyProblem
 from .library_json_decode_problem import LibraryJsonDecodeProblem
 from .library_load_exception_problem import LibraryLoadExceptionProblem
 from .library_not_found_problem import LibraryNotFoundProblem
@@ -55,6 +56,7 @@ __all__ = [
     "IncompatibleRequirementsProblem",
     "InsufficientDiskSpaceProblem",
     "InvalidVersionStringProblem",
+    "LibraryDependencyProblem",
     "LibraryJsonDecodeProblem",
     "LibraryLoadExceptionProblem",
     "LibraryNotFoundProblem",

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/library_dependency_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/library_dependency_problem.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+
+@dataclass
+class LibraryDependencyProblem(LibraryProblem):
+    """Problem indicating a required library dependency failed to load."""
+
+    dependency_name: str
+    error_message: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[LibraryDependencyProblem]) -> str:
+        if len(instances) == 1:
+            return f"Required library dependency '{instances[0].dependency_name}' failed to load: {instances[0].error_message}"
+        lines = ["Required library dependencies failed to load:"]
+        lines.extend(f"  '{i.dependency_name}': {i.error_message}" for i in instances)
+        return "\n".join(lines)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -43,6 +43,7 @@ from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.path_utils import canonicalize_for_identity, canonicalize_for_io, resolve_workspace_path
 from griptape_nodes.node_library.library_declarations import (
     LibraryDeclaration,
+    LibraryDependencyDeclaration,
     WorkerCompatibility,
     WorkerMode,
     WorkerModeCompatibility,
@@ -52,6 +53,7 @@ from griptape_nodes.node_library.library_registry import (
     CategoryDefinition,
     Library,
     LibraryMetadata,
+    LibraryNameAndVersion,
     LibraryRegistry,
     LibrarySchema,
     NodeDefinition,
@@ -201,6 +203,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     EngineVersionErrorProblem,
     IncompatibleRequirementsProblem,
     InvalidVersionStringProblem,
+    LibraryDependencyProblem,
     LibraryJsonDecodeProblem,
     LibraryLoadExceptionProblem,
     LibraryNotFoundProblem,
@@ -221,8 +224,10 @@ from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULT
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
+    LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
     REQUIRES_ENGINE_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
+    LibraryDependencyInstallBehavior,
     LibraryDownload,
     LibraryRegistration,
 )
@@ -781,6 +786,61 @@ class LibraryManager:
             if library_info.library_name == library_name:
                 return library_info
         return None
+
+    def resolve_transitive_library_deps(
+        self,
+        initial: list[LibraryNameAndVersion],
+    ) -> list[LibraryNameAndVersion]:
+        """Expand an initial library set by following each library's library_dependencies.
+
+        BFS walks declared library_dependencies until no new libraries are found.
+        Unregistered deps are logged and skipped. Cycle-safe via a visited set.
+        """
+        resolved: dict[str, LibraryNameAndVersion] = {ref.library_name: ref for ref in initial}
+        queue = list(initial)
+
+        while queue:
+            library_ref = queue.pop(0)
+            try:
+                library_data = LibraryRegistry.get_library(library_ref.library_name).get_library_data()
+            except KeyError:
+                logger.warning(
+                    "Library '%s' not found in registry during transitive dep resolution, skipping",
+                    library_ref.library_name,
+                )
+                continue
+
+            if not library_data.metadata:
+                continue
+            lib_deps = [
+                d for d in (library_data.metadata.declarations or []) if isinstance(d, LibraryDependencyDeclaration)
+            ]
+            if not lib_deps:
+                continue
+
+            for dep in lib_deps:
+                repo_name = extract_repo_name_from_url(dep.url)
+                dep_info = self.get_library_info_by_library_name(repo_name)
+                if dep_info is None:
+                    logger.warning(
+                        "Library dependency '%s' (resolved as '%s') is not registered; skipping",
+                        dep.url,
+                        repo_name,
+                    )
+                    continue
+                dep_library_name = dep_info.library_name
+                if dep_library_name is None:
+                    logger.warning("Library dependency '%s' has no library_name; skipping", dep.url)
+                    continue
+                if dep_library_name not in resolved:
+                    lib_nav = LibraryNameAndVersion(
+                        library_name=dep_library_name,
+                        library_version=dep_info.library_version or "unknown",
+                    )
+                    resolved[dep_library_name] = lib_nav
+                    queue.append(lib_nav)
+
+        return list(resolved.values())
 
     def collate_problems_for_lib_info(self, lib_info: LibraryInfo) -> str | None:
         """Return a collated display string for a LibraryInfo's problems, or None if there are none."""
@@ -2071,7 +2131,92 @@ class LibraryManager:
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.EVALUATED
 
                 case LibraryManager.LibraryLifecycleState.EVALUATED:
-                    # EVALUATED → DEPENDENCIES_INSTALLED or WORKER_DELEGATED
+                    # EVALUATED -> DEPENDENCIES_INSTALLED or WORKER_DELEGATED
+                    # Resolve library_dependencies before node imports: each dependency library must be
+                    # fully loaded (including its venv added to sys.path via _add_library_paths_to_sys_path)
+                    # before this library's nodes are imported in the LOADED phase. Venvs are completely
+                    # isolated - dependency packages are not accessible to this library's pip install
+                    # subprocess.
+                    dep_metadata_result = self.load_library_metadata_from_file_request(
+                        LoadLibraryMetadataFromFileRequest(file_path=library_info.library_path)
+                    )
+                    if not isinstance(dep_metadata_result, LoadLibraryMetadataFromFileResultFailure):
+                        dep_schema = dep_metadata_result.library_schema
+                        griptape_library_deps = [
+                            d
+                            for d in (dep_schema.metadata.declarations or [])
+                            if isinstance(d, LibraryDependencyDeclaration)
+                        ] or None
+
+                        # Download and install any griptape libraries this library depends on.
+                        if griptape_library_deps:
+                            config_mgr = GriptapeNodes.ConfigManager()
+                            install_behavior = config_mgr.get_config_value(
+                                LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
+                                default=LibraryDependencyInstallBehavior.ALWAYS,
+                                cast_type=str,
+                            )
+                            for dep in griptape_library_deps:
+                                parsed = parse_git_url_with_ref(dep.url)
+                                normalized_url = normalize_github_url(parsed.url)
+                                repo_name = extract_repo_name_from_url(normalized_url)
+                                already_registered = any(
+                                    (info.library_name == repo_name or repo_name in Path(info.library_path).parts)
+                                    and info.lifecycle_state != LibraryManager.LibraryLifecycleState.FAILURE
+                                    and info.fitness
+                                    not in (
+                                        LibraryManager.LibraryFitness.UNUSABLE,
+                                        LibraryManager.LibraryFitness.MISSING,
+                                    )
+                                    for info in self._library_file_path_to_info.values()
+                                )
+                                if already_registered:
+                                    logger.debug(
+                                        "Library dependency '%s' is already registered, skipping download",
+                                        dep.url,
+                                    )
+                                    continue
+                                if install_behavior == LibraryDependencyInstallBehavior.NEVER:
+                                    if dep.required:
+                                        library_info.problems.append(
+                                            LibraryDependencyProblem(
+                                                dependency_name=dep.url,
+                                                error_message="Automatic dependency installation is disabled (library_dependency_install_behavior=never).",
+                                            )
+                                        )
+                                        library_info.fitness = LibraryManager.LibraryFitness.FLAWED
+                                    logger.debug(
+                                        "Skipping download of library dependency '%s' (library_dependency_install_behavior=never)",
+                                        dep.url,
+                                    )
+                                    continue
+                                dep_result = await self.download_library_request(
+                                    DownloadLibraryRequest(
+                                        git_url=normalized_url,
+                                        branch_tag_commit=parsed.ref,
+                                        fail_on_exists=False,
+                                        auto_register=True,
+                                    )
+                                )
+                                if isinstance(dep_result, DownloadLibraryResultFailure):
+                                    if dep.required:
+                                        library_info.problems.append(
+                                            LibraryDependencyProblem(
+                                                dependency_name=dep.url,
+                                                error_message=str(dep_result.result_details),
+                                            )
+                                        )
+                                        library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
+                                        library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
+                                        self._library_file_path_to_info[library_info.library_path] = library_info
+                                        details = f"Attempted to load Library '{library_info.library_name}'. Failed to load required library dependency '{dep.url}': {dep_result.result_details}"
+                                        return RegisterLibraryFromFileResultFailure(result_details=details)
+                                    logger.warning(
+                                        "Optional library dependency '%s' failed to load: %s",
+                                        dep.url,
+                                        dep_result.result_details,
+                                    )
+
                     # On the orchestrator (_is_worker is False), skip venv creation and pip
                     # install for libraries that require a dedicated worker. The lifecycle still
                     # completes through LOADED so the library is registered in LibraryRegistry
@@ -5678,13 +5823,10 @@ class LibraryManager:
             register_request = RegisterLibraryFromFileRequest(file_path=str(library_json_path))
             register_result = await GriptapeNodes.ahandle_request(register_request)
             if not register_result.succeeded():
-                logger.warning(
-                    "Library '%s' was downloaded but registration failed: %s",
-                    library_name,
-                    register_result.result_details,
+                return DownloadLibraryResultFailure(
+                    result_details=f"Library '{library_name}' downloaded but failed to register: {register_result.result_details}"
                 )
-            else:
-                logger.info("Library '%s' registered successfully", library_name)
+            logger.info("Library '%s' registered successfully", library_name)
 
         # Persist the path to libraries_to_register only when registering now. The
         # write lands in the GLOBAL user config (set_config_value -> user config),

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -21,6 +21,7 @@ WORKER_HEARTBEAT_INTERVAL_KEY = "worker.heartbeat_interval_s"
 WORKER_HEARTBEAT_TIMEOUT_KEY = "worker.heartbeat_timeout_s"
 WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
+LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 
 
 class Category(BaseModel):
@@ -45,6 +46,7 @@ PROJECTS = Category(name="Projects", description="Project template configuration
 STATIC_SERVER = Category(name="Static Server", description="Static file server configuration for serving media assets")
 ARTIFACTS = Category(name="Artifacts", description="Settings for artifact providers and preview generation")
 AGENT = Category(name="Agent", description="Agent behavior and system prompt")
+LIBRARIES = Category(name="Libraries", description="Settings for library management and dependency installation")
 
 
 def Field(category: str | Category = "General", **kwargs) -> Any:
@@ -281,6 +283,34 @@ class AgentSettings(BaseModel):
     )
 
 
+class LibraryDependencyInstallBehavior(StrEnum):
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+class LibrarySettings(BaseModel):
+    dependency_install_behavior: LibraryDependencyInstallBehavior = Field(
+        default=LibraryDependencyInstallBehavior.ALWAYS,
+        description=(
+            "Controls automatic installation of library dependencies declared in library manifests. "
+            "'always' downloads and installs them on registration. "
+            "'never' skips installation and marks the library as degraded if required dependencies are missing."
+        ),
+    )
+
+    @field_validator("dependency_install_behavior", mode="before")
+    @classmethod
+    def validate_dependency_install_behavior(cls, v: Any) -> LibraryDependencyInstallBehavior:
+        if isinstance(v, str):
+            try:
+                return LibraryDependencyInstallBehavior(v.lower())
+            except ValueError:
+                return LibraryDependencyInstallBehavior.ALWAYS
+        elif isinstance(v, LibraryDependencyInstallBehavior):
+            return v
+        return LibraryDependencyInstallBehavior.ALWAYS
+
+
 class Settings(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -439,4 +469,8 @@ class Settings(BaseModel):
     agent: AgentSettings = Field(
         category=AGENT,
         default_factory=AgentSettings,
+    )
+    library: LibrarySettings = Field(
+        category=LIBRARIES,
+        default_factory=LibrarySettings,
     )

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -204,6 +204,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands, SetLockNodeStateRequest
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -2536,11 +2537,14 @@ class WorkflowManager:
         # display_name is the human-readable label (metadata.name); falls back to file_name if not provided.
         metadata_name = display_name if display_name is not None else str(file_name)
 
+        direct_libs: list[LibraryNameAndVersion] = list(serialized_flow_commands.node_dependencies.libraries)
+        all_libs = GriptapeNodes.LibraryManager().resolve_transitive_library_deps(direct_libs)
+
         return WorkflowMetadata(
             name=metadata_name,
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
             engine_version_created_with=engine_version,
-            node_libraries_referenced=list(serialized_flow_commands.node_dependencies.libraries),
+            node_libraries_referenced=all_libs,
             node_types_used=serialized_flow_commands.node_types_used,
             workflows_referenced=workflows_referenced,
             creation_date=creation_date,

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -132,6 +132,13 @@ class WorkflowPackager:
 
     # -- Library bundling --
 
+    def _resolve_all_library_deps(
+        self,
+        initial: list[LibraryNameAndVersion],
+    ) -> list[LibraryNameAndVersion]:
+        """Expand the initial library set to include all transitive library_dependencies."""
+        return GriptapeNodes.LibraryManager().resolve_transitive_library_deps(initial)
+
     def copy_libraries(
         self,
         node_libraries: list[LibraryNameAndVersion],
@@ -340,7 +347,7 @@ class WorkflowPackager:
             f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{engine_version}",
         ]
 
-        for library_ref in workflow.metadata.node_libraries_referenced:
+        for library_ref in self._resolve_all_library_deps(workflow.metadata.node_libraries_referenced):
             library_data = LibraryRegistry.get_library(library_ref.library_name).get_library_data()
             if library_data.metadata and library_data.metadata.dependencies:
                 pip_deps = library_data.metadata.dependencies.pip_dependencies
@@ -354,7 +361,7 @@ class WorkflowPackager:
     def collect_pip_install_flags(self, workflow: Workflow) -> list[str]:
         """Collect all unique pip install flags from the workflow's referenced libraries."""
         flags: list[str] = []
-        for library_ref in workflow.metadata.node_libraries_referenced:
+        for library_ref in self._resolve_all_library_deps(workflow.metadata.node_libraries_referenced):
             library_data = LibraryRegistry.get_library(library_ref.library_name).get_library_data()
             if library_data.metadata and library_data.metadata.dependencies:
                 install_flags = library_data.metadata.dependencies.pip_install_flags
@@ -623,10 +630,11 @@ dependencies = [
         full_path = WorkflowRegistry.get_complete_file_path(workflow_file_path)
         self.copy_file(full_path, destination / Path(full_path).name)
 
-        # Copy libraries
+        # Copy libraries (including transitive library dependencies)
         self.emit_progress(15.0, "Copying libraries...")
+        all_libraries = self._resolve_all_library_deps(workflow.metadata.node_libraries_referenced)
         library_paths = self.copy_libraries(
-            node_libraries=workflow.metadata.node_libraries_referenced,
+            node_libraries=all_libraries,
             destination_path=destination / "libraries",
             workflow=workflow,
         )

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -2852,14 +2852,29 @@ class TestDownloadLibraryRegisterPersistence:
         from griptape_nodes.retained_mode.events.library_events import (
             DownloadLibraryRequest,
             DownloadLibraryResultSuccess,
+            RegisterLibraryFromFileResultSuccess,
         )
 
         library_manager = griptape_nodes.LibraryManager()
         config_mgr = griptape_nodes.ConfigManager()
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.clone_repository",
-            side_effect=self._make_clone("explicit_lib"),
+        # download_library_request routes registration through GriptapeNodes.ahandle_request;
+        # the minimal fake manifest can't pass full LibrarySchema validation, so mock the
+        # registration step to return success so the test stays focused on config persistence.
+        mock_register_result = RegisterLibraryFromFileResultSuccess(
+            library_name="explicit_lib",
+            result_details=ResultDetails(message="OK", level=20),
+        )
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.clone_repository",
+                side_effect=self._make_clone("explicit_lib"),
+            ),
+            patch.object(
+                GriptapeNodes,
+                "ahandle_request",
+                new=AsyncMock(return_value=mock_register_result),
+            ),
         ):
             result = await library_manager.download_library_request(
                 DownloadLibraryRequest(

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -1,0 +1,715 @@
+"""Tests for inter-library dependency resolution (GH#4740)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.node_library.library_declarations import LibraryDependencyDeclaration
+from griptape_nodes.node_library.library_registry import (
+    Dependencies,
+    LibraryNameAndVersion,
+    LibrarySchema,
+)
+from griptape_nodes.retained_mode.events.base_events import ResultDetails
+from griptape_nodes.retained_mode.events.library_events import (
+    DownloadLibraryRequest,
+    DownloadLibraryResultFailure,
+    DownloadLibraryResultSuccess,
+    InstallLibraryDependenciesResultFailure,
+    LoadLibraryMetadataFromFileResultSuccess,
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultFailure,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import LibraryDependencyProblem
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.retained_mode.managers.settings import LibraryDependencyInstallBehavior
+
+
+class TestLibraryDependencyDeclaration:
+    """Tests for the LibraryDependencyDeclaration declaration type."""
+
+    def test_required_dep(self) -> None:
+        decl = LibraryDependencyDeclaration(url="griptape-ai/griptape-nodes-library-opencolorio@v1.2.0")
+        assert decl.url == "griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"
+        assert decl.required is True
+
+    def test_optional_dep(self) -> None:
+        decl = LibraryDependencyDeclaration(url="griptape-ai/griptape-nodes-library-opencolorio@v1.2.0", required=False)
+        assert decl.required is False
+
+    def test_round_trips_as_library_declaration(self) -> None:
+        """LibraryDependencyDeclaration serializes/deserializes correctly via the discriminated union."""
+        from griptape_nodes.node_library.library_registry import LibraryMetadata
+
+        meta = LibraryMetadata.model_validate(
+            {
+                "author": "test",
+                "description": "test",
+                "library_version": "1.0.0",
+                "engine_version": "0.10.0",
+                "tags": [],
+                "declarations": [
+                    {"type": "library_dependency", "url": "griptape-ai/lib-a@v1.0.0", "required": True},
+                    {"type": "library_dependency", "url": "griptape-ai/lib-b@v2.0.0", "required": False},
+                ],
+            }
+        )
+        lib_deps = [d for d in meta.declarations if isinstance(d, LibraryDependencyDeclaration)]
+        assert lib_deps[0].url == "griptape-ai/lib-a@v1.0.0"
+        assert lib_deps[0].required is True
+        assert lib_deps[1].required is False
+
+    def test_dependencies_has_no_library_dependencies_field(self) -> None:
+        deps = Dependencies()
+        assert not hasattr(deps, "library_dependencies")
+
+    def test_schema_version_bumped(self) -> None:
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.10.0"
+
+
+class TestLibraryDependencyProblem:
+    """Tests for the LibraryDependencyProblem fitness problem."""
+
+    def test_single_problem_message(self) -> None:
+        problem = LibraryDependencyProblem(
+            dependency_name="griptape-ai/griptape-nodes-library-opencolorio@v1.2.0",
+            error_message="Clone failed",
+        )
+        msg = LibraryDependencyProblem.collate_problems_for_display([problem])
+        assert "griptape-ai/griptape-nodes-library-opencolorio@v1.2.0" in msg
+        assert "Clone failed" in msg
+
+    def test_multiple_problems_message_includes_errors(self) -> None:
+        problems = [
+            LibraryDependencyProblem(dependency_name="dep-a@v1", error_message="err1"),
+            LibraryDependencyProblem(dependency_name="dep-b@v2", error_message="err2"),
+        ]
+        msg = LibraryDependencyProblem.collate_problems_for_display(problems)
+        assert "dep-a@v1" in msg
+        assert "dep-b@v2" in msg
+        assert "err1" in msg
+        assert "err2" in msg
+
+
+def _make_lib_info() -> LibraryManager.LibraryInfo:
+    """Create a LibraryInfo in EVALUATED state ready for the dep-resolution step."""
+    return LibraryManager.LibraryInfo(
+        lifecycle_state=LibraryManager.LibraryLifecycleState.EVALUATED,
+        library_path="/mock.json",
+        is_sandbox=False,
+        library_name="test_lib",
+        library_version="1.0.0",
+        fitness=LibraryManager.LibraryFitness.GOOD,
+        problems=[],
+    )
+
+
+def _make_schema_mock(library_dependencies: list[str] | None, *, optional: bool = False) -> MagicMock:
+    schema = MagicMock()
+    schema.name = "test_lib"
+    schema.metadata.library_version = "1.0.0"
+    schema.metadata.declarations = (
+        [LibraryDependencyDeclaration(url=url, required=not optional) for url in library_dependencies]
+        if library_dependencies is not None
+        else []
+    )
+    return schema
+
+
+def _metadata_success(schema: MagicMock) -> LoadLibraryMetadataFromFileResultSuccess:
+    return LoadLibraryMetadataFromFileResultSuccess(
+        library_schema=schema,
+        file_path="/mock.json",
+        git_remote=None,
+        git_ref=None,
+        enabled=True,
+        result_details=ResultDetails(message="OK", level=20),
+    )
+
+
+# Sentinel failure used to stop the lifecycle after EVALUATED without entering the LOADED step.
+_INSTALL_STOP = InstallLibraryDependenciesResultFailure(result_details="stop-sentinel")
+
+
+class TestLibraryDependencyResolution:
+    """Tests for library dependency resolution in the EVALUATED lifecycle step.
+
+    Each test drives _progress_library_through_lifecycle with a LibraryInfo pre-set
+    to EVALUATED and mocks install_library_dependencies_request to return failure so
+    the lifecycle stops cleanly after the dependency-resolution block, without needing
+    to mock the full LOADED phase (node imports, LibraryRegistry, sys.path, etc.).
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_library_dependencies_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library with no library_dependencies does not call download_library_request."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+
+        with (
+            patch.object(
+                mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(_make_schema_mock(None))
+            ),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "download_library_request") as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_library_dependencies_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library with library_dependencies=[] does not call download_library_request."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+
+        with (
+            patch.object(
+                mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(_make_schema_mock([]))
+            ),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "download_library_request") as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_already_tracked_dependency_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+        """If the dep repo name appears in an existing tracked path with healthy state, download is skipped."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"])
+
+        existing_dep_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            library_path="/workspace/libraries/griptape-nodes-library-opencolorio/griptape_nodes_library.json",
+            is_sandbox=False,
+            library_name="griptape-nodes-library-opencolorio",
+            library_version="1.2.0",
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            problems=[],
+        )
+        existing_paths = {
+            "/workspace/libraries/griptape-nodes-library-opencolorio/griptape_nodes_library.json": existing_dep_info,
+            "/mock.json": lib_info,
+        }
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "download_library_request") as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", existing_paths),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_dependency_triggers_download(self, griptape_nodes: GriptapeNodes) -> None:
+        """A dep not yet tracked causes download_library_request to be called with correct args."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(
+                mgr,
+                "download_library_request",
+                new_callable=AsyncMock,
+                return_value=DownloadLibraryResultSuccess(
+                    library_name="nodes-dep",
+                    library_path="/workspace/libraries/nodes-dep/griptape_nodes_library.json",
+                    result_details="Downloaded",
+                ),
+            ) as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_called_once()
+        req = mock_download.call_args[0][0]
+        assert req.git_url == "https://github.com/griptape-ai/nodes-dep.git"
+        assert req.branch_tag_commit == "v1.0.0"
+        assert req.fail_on_exists is False
+        assert req.auto_register is True
+
+    @pytest.mark.asyncio
+    async def test_dependency_failure_marks_library_unusable(self, griptape_nodes: GriptapeNodes) -> None:
+        """When a dependency download fails, the library gets LibraryDependencyProblem and UNUSABLE fitness."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-bad@v1.0.0"])
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request") as mock_install,
+            patch.object(
+                mgr,
+                "download_library_request",
+                new_callable=AsyncMock,
+                return_value=DownloadLibraryResultFailure(result_details="Clone failed"),
+            ),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            result = await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        assert isinstance(result, RegisterLibraryFromFileResultFailure)
+        mock_install.assert_not_called()
+        assert lib_info.fitness == LibraryManager.LibraryFitness.UNUSABLE
+        dep_problems = [p for p in lib_info.problems if isinstance(p, LibraryDependencyProblem)]
+        assert len(dep_problems) == 1
+        assert "griptape-ai/nodes-bad@v1.0.0" in dep_problems[0].dependency_name
+
+    @pytest.mark.asyncio
+    async def test_dependency_resolved_before_pip_install(self, griptape_nodes: GriptapeNodes) -> None:
+        """Library dependency download happens before pip package installation."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
+
+        call_order: list[str] = []
+
+        async def mock_download(_request: object) -> DownloadLibraryResultSuccess:
+            call_order.append("download")
+            return DownloadLibraryResultSuccess(
+                library_name="nodes-dep",
+                library_path="/workspace/libraries/nodes-dep/griptape_nodes_library.json",
+                result_details="Downloaded",
+            )
+
+        async def mock_install(_request: object) -> InstallLibraryDependenciesResultFailure:
+            call_order.append("install")
+            return _INSTALL_STOP
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", side_effect=mock_install),
+            patch.object(mgr, "download_library_request", side_effect=mock_download),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        assert "download" in call_order
+        assert "install" in call_order
+        assert call_order.index("download") < call_order.index("install")
+
+    @pytest.mark.asyncio
+    async def test_never_behavior_skips_required_dep_and_marks_flawed(self, griptape_nodes: GriptapeNodes) -> None:
+        """When install behavior is 'never', required deps are skipped and library is FLAWED."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
+
+        config_mock = MagicMock()
+        config_mock.get_config_value.return_value = LibraryDependencyInstallBehavior.NEVER
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "download_library_request") as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn,
+        ):
+            mock_gtn.ConfigManager.return_value = config_mock
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_not_called()
+        assert lib_info.fitness == LibraryManager.LibraryFitness.FLAWED
+        dep_problems = [p for p in lib_info.problems if isinstance(p, LibraryDependencyProblem)]
+        assert len(dep_problems) == 1
+        assert "nodes-dep" in dep_problems[0].dependency_name
+
+    @pytest.mark.asyncio
+    async def test_never_behavior_skips_optional_dep_without_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        """When install behavior is 'never', optional deps are silently skipped."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"], optional=True)
+
+        config_mock = MagicMock()
+        config_mock.get_config_value.return_value = LibraryDependencyInstallBehavior.NEVER
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "download_library_request") as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn,
+        ):
+            mock_gtn.ConfigManager.return_value = config_mock
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_not_called()
+        assert lib_info.fitness == LibraryManager.LibraryFitness.GOOD
+        dep_problems = [p for p in lib_info.problems if isinstance(p, LibraryDependencyProblem)]
+        assert len(dep_problems) == 0
+
+    @pytest.mark.asyncio
+    async def test_optional_dep_failure_does_not_fail_registration(self, griptape_nodes: GriptapeNodes) -> None:
+        """When an optional dep download fails, the lifecycle continues past the dep block.
+
+        Unlike a required dep failure (which returns early before pip install), an optional
+        dep failure only logs a warning. The lifecycle proceeds to install_library_dependencies,
+        so mock_install must be called and no LibraryDependencyProblem must be recorded.
+        """
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-optional@v1.0.0"], optional=True)
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP) as mock_install,
+            patch.object(
+                mgr,
+                "download_library_request",
+                new_callable=AsyncMock,
+                return_value=DownloadLibraryResultFailure(result_details="Clone failed"),
+            ),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        # install was reached (we did NOT return early like required deps do)
+        mock_install.assert_called()
+        # no dependency problem recorded for an optional dep
+        dep_problems = [p for p in lib_info.problems if isinstance(p, LibraryDependencyProblem)]
+        assert len(dep_problems) == 0
+
+    @pytest.mark.asyncio
+    async def test_registration_failure_after_download_marks_library_unusable(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """When download_library_request returns failure, the dependent library is marked UNUSABLE and install is not reached."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request") as mock_install,
+            patch.object(
+                mgr,
+                "download_library_request",
+                new_callable=AsyncMock,
+                return_value=DownloadLibraryResultFailure(
+                    result_details="downloaded but failed to register: schema error"
+                ),
+            ),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            result = await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        assert isinstance(result, RegisterLibraryFromFileResultFailure)
+        mock_install.assert_not_called()
+        assert lib_info.fitness == LibraryManager.LibraryFitness.UNUSABLE
+        dep_problems = [p for p in lib_info.problems if isinstance(p, LibraryDependencyProblem)]
+        assert len(dep_problems) == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_dep_already_in_tracker_triggers_download(self, griptape_nodes: GriptapeNodes) -> None:
+        """A dep in _library_file_path_to_info but in FAILURE state is not treated as satisfied — download must still be attempted."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"])
+
+        failed_dep_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.FAILURE,
+            library_path="/workspace/libraries/griptape-nodes-library-opencolorio/griptape_nodes_library.json",
+            is_sandbox=False,
+            library_name="griptape-nodes-library-opencolorio",
+            library_version="1.2.0",
+            fitness=LibraryManager.LibraryFitness.UNUSABLE,
+            problems=[],
+        )
+        existing_paths = {
+            "/workspace/libraries/griptape-nodes-library-opencolorio/griptape_nodes_library.json": failed_dep_info,
+            "/mock.json": lib_info,
+        }
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(
+                mgr,
+                "download_library_request",
+                new_callable=AsyncMock,
+                return_value=DownloadLibraryResultSuccess(
+                    library_name="griptape-nodes-library-opencolorio",
+                    library_path="/workspace/libraries/griptape-nodes-library-opencolorio/griptape_nodes_library.json",
+                    result_details="Downloaded",
+                ),
+            ) as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", existing_paths),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dep_recognized_by_library_name_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+        """A dep whose library_name matches repo name skips download even when its path has no matching component."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock(["griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"])
+
+        # Path parts do not contain 'griptape-nodes-library-opencolorio' — only library_name does.
+        custom_path_dep_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            library_path="/custom/monorepo/subdir/griptape_nodes_library.json",
+            is_sandbox=False,
+            library_name="griptape-nodes-library-opencolorio",
+            library_version="1.2.0",
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            problems=[],
+        )
+        existing_paths = {
+            "/custom/monorepo/subdir/griptape_nodes_library.json": custom_path_dep_info,
+            "/mock.json": lib_info,
+        }
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "download_library_request") as mock_download,
+            patch.object(mgr, "_library_file_path_to_info", existing_paths),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        mock_download.assert_not_called()
+
+
+def _make_lib_info_for_resolve(name: str, version: str = "1.0.0") -> LibraryManager.LibraryInfo:
+    return LibraryManager.LibraryInfo(
+        lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+        library_path=f"/workspace/libraries/{name}/griptape_nodes_library.json",
+        is_sandbox=False,
+        library_name=name,
+        library_version=version,
+        fitness=LibraryManager.LibraryFitness.GOOD,
+        problems=[],
+    )
+
+
+def _make_lib_registry_mock(
+    library_dependencies: list[LibraryDependencyDeclaration] | None,
+) -> MagicMock:
+    """Return a mock object as returned by LibraryRegistry.get_library(name)."""
+    lib_mock = MagicMock()
+    lib_mock.get_library_data.return_value.metadata.declarations = library_dependencies or []
+    return lib_mock
+
+
+class TestResolveTransitiveLibraryDeps:
+    """Tests for LibraryManager.resolve_transitive_library_deps()."""
+
+    def test_no_deps_returns_initial(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library with no library_dependencies returns just the initial set."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_a = _make_lib_registry_mock(library_dependencies=None)
+
+        with patch(
+            "griptape_nodes.node_library.library_registry.LibraryRegistry.get_library",
+            side_effect=lambda name: lib_a if name == "lib-a" else (_ for _ in ()).throw(KeyError(name)),
+        ):
+            result = mgr.resolve_transitive_library_deps([LibraryNameAndVersion("lib-a", "1.0.0")])
+
+        assert [r.library_name for r in result] == ["lib-a"]
+
+    def test_direct_dep_added(self, griptape_nodes: GriptapeNodes) -> None:
+        """Library A declaring a library_dependency on Library B includes B in the result."""
+        mgr = griptape_nodes.LibraryManager()
+        dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
+        lib_a = _make_lib_registry_mock(library_dependencies=[dep_b])
+        lib_b = _make_lib_registry_mock(library_dependencies=None)
+        info_b = _make_lib_info_for_resolve("lib-b")
+
+        with (
+            patch(
+                "griptape_nodes.node_library.library_registry.LibraryRegistry.get_library",
+                side_effect=lambda name: {"lib-a": lib_a, "lib-b": lib_b}[name],
+            ),
+            patch.object(
+                mgr, "get_library_info_by_library_name", side_effect=lambda n: info_b if n == "lib-b" else None
+            ),
+        ):
+            result = mgr.resolve_transitive_library_deps([LibraryNameAndVersion("lib-a", "1.0.0")])
+
+        names = {r.library_name for r in result}
+        assert "lib-a" in names
+        assert "lib-b" in names
+
+    def test_transitive_dep_added(self, griptape_nodes: GriptapeNodes) -> None:
+        """A→B→C chain results in all three libraries being included."""
+        mgr = griptape_nodes.LibraryManager()
+        dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
+        dep_c = LibraryDependencyDeclaration(url="griptape-ai/lib-c@v1.0.0", required=True)
+        lib_a = _make_lib_registry_mock(library_dependencies=[dep_b])
+        lib_b = _make_lib_registry_mock(library_dependencies=[dep_c])
+        lib_c = _make_lib_registry_mock(library_dependencies=None)
+        info_b = _make_lib_info_for_resolve("lib-b")
+        info_c = _make_lib_info_for_resolve("lib-c")
+
+        with (
+            patch(
+                "griptape_nodes.node_library.library_registry.LibraryRegistry.get_library",
+                side_effect=lambda name: {"lib-a": lib_a, "lib-b": lib_b, "lib-c": lib_c}[name],
+            ),
+            patch.object(mgr, "get_library_info_by_library_name", side_effect={"lib-b": info_b, "lib-c": info_c}.get),
+        ):
+            result = mgr.resolve_transitive_library_deps([LibraryNameAndVersion("lib-a", "1.0.0")])
+
+        assert {r.library_name for r in result} == {"lib-a", "lib-b", "lib-c"}
+
+    def test_cycle_does_not_loop(self, griptape_nodes: GriptapeNodes) -> None:
+        """A→B→A cycle terminates and includes both libraries exactly once."""
+        mgr = griptape_nodes.LibraryManager()
+        dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
+        dep_a = LibraryDependencyDeclaration(url="griptape-ai/lib-a@v1.0.0", required=True)
+        lib_a = _make_lib_registry_mock(library_dependencies=[dep_b])
+        lib_b = _make_lib_registry_mock(library_dependencies=[dep_a])
+        info_a = _make_lib_info_for_resolve("lib-a")
+        info_b = _make_lib_info_for_resolve("lib-b")
+
+        with (
+            patch(
+                "griptape_nodes.node_library.library_registry.LibraryRegistry.get_library",
+                side_effect=lambda name: {"lib-a": lib_a, "lib-b": lib_b}[name],
+            ),
+            patch.object(mgr, "get_library_info_by_library_name", side_effect={"lib-a": info_a, "lib-b": info_b}.get),
+        ):
+            result = mgr.resolve_transitive_library_deps([LibraryNameAndVersion("lib-a", "1.0.0")])
+
+        assert {r.library_name for r in result} == {"lib-a", "lib-b"}
+
+    def test_unregistered_dep_skipped(self, griptape_nodes: GriptapeNodes) -> None:
+        """A dep that has no LibraryInfo is skipped without raising."""
+        mgr = griptape_nodes.LibraryManager()
+        dep_missing = LibraryDependencyDeclaration(url="griptape-ai/lib-missing@v1.0.0", required=True)
+        lib_a = _make_lib_registry_mock(library_dependencies=[dep_missing])
+
+        with (
+            patch(
+                "griptape_nodes.node_library.library_registry.LibraryRegistry.get_library",
+                return_value=lib_a,
+            ),
+            patch.object(mgr, "get_library_info_by_library_name", return_value=None),
+        ):
+            result = mgr.resolve_transitive_library_deps([LibraryNameAndVersion("lib-a", "1.0.0")])
+
+        assert [r.library_name for r in result] == ["lib-a"]
+
+
+class TestDownloadLibraryRequestAutoRegister:
+    """Regression guard for silent-registration-failure bug (collindutter, PR #4752).
+
+    Old code only logged a warning when auto-registration failed and returned
+    DownloadLibraryResultSuccess anyway. The fix at lines 5139-5143 of library_manager.py
+    propagates registration failure as DownloadLibraryResultFailure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_register_failure_returns_download_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """When RegisterLibraryFromFileRequest fails, download_library_request must return DownloadLibraryResultFailure.
+
+        Regression guard: old code only logged a warning on registration failure and fell through to
+        DownloadLibraryResultSuccess.
+        """
+        import json as _json
+        import tempfile
+
+        mgr = griptape_nodes.LibraryManager()
+        tracked: dict = {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_json_path = f"{tmpdir}/fake-library/griptape_nodes_library.json"
+            fake_json_content = _json.dumps({"name": "fake-library"})
+
+            mock_path_instance = AsyncMock()
+            mock_path_instance.mkdir = AsyncMock(return_value=None)
+            # exists() → True forces skip_clone path, avoiding actual git clone
+            mock_path_instance.exists = AsyncMock(return_value=True)
+            mock_path_instance.read_text = AsyncMock(return_value=fake_json_content)
+
+            with (
+                patch(
+                    "griptape_nodes.retained_mode.managers.library_manager.anyio.Path",
+                    return_value=mock_path_instance,
+                ),
+                patch(
+                    "griptape_nodes.retained_mode.managers.library_manager.find_file_in_directory",
+                    return_value=fake_json_path,
+                ),
+                patch.object(
+                    GriptapeNodes,
+                    "ahandle_request",
+                    new_callable=AsyncMock,
+                    return_value=RegisterLibraryFromFileResultFailure(result_details="schema validation error"),
+                ),
+                patch.object(mgr, "_library_file_path_to_info", tracked),
+            ):
+                result = await mgr.download_library_request(
+                    DownloadLibraryRequest(
+                        git_url="https://github.com/griptape-ai/fake-library.git",
+                        download_directory=tmpdir,
+                        auto_register=True,
+                        fail_on_exists=False,
+                    )
+                )
+
+        assert isinstance(result, DownloadLibraryResultFailure)
+        assert "downloaded but failed to register" in str(result.result_details)
+        assert "fake-library" in str(result.result_details)

--- a/tests/unit/retained_mode/managers/test_settings.py
+++ b/tests/unit/retained_mode/managers/test_settings.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from griptape_nodes.retained_mode.managers.settings import (
     AppInitializationComplete,
+    LibraryDependencyInstallBehavior,
     LibraryDownload,
     LibraryRegistration,
     Settings,
@@ -98,3 +99,24 @@ class TestThreadStorageBackend:
 
     def test_default_is_local(self) -> None:
         assert Settings().thread_storage_backend == "local"
+
+
+class TestLibraryDependencyInstallBehavior:
+    """The library.dependency_install_behavior field coerces bad persisted values to ALWAYS.
+
+    A typo or stale value in a persisted config must not fail whole-config
+    validation and reset every other user setting to defaults.
+    """
+
+    @pytest.mark.parametrize("value", ["typo", "", None, 123, "ALWAYS"])
+    def test_unknown_values_coerce_to_always(self, value: object) -> None:
+        result = Settings.model_validate({"library": {"dependency_install_behavior": value}})
+        assert result.library.dependency_install_behavior == LibraryDependencyInstallBehavior.ALWAYS
+
+    @pytest.mark.parametrize("value", ["always", "never"])
+    def test_valid_string_values_are_preserved(self, value: str) -> None:
+        result = Settings.model_validate({"library": {"dependency_install_behavior": value}})
+        assert result.library.dependency_install_behavior == LibraryDependencyInstallBehavior(value)
+
+    def test_default_is_always(self) -> None:
+        assert Settings().library.dependency_install_behavior == LibraryDependencyInstallBehavior.ALWAYS

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2445,3 +2445,65 @@ class TestWorkflowsLoadingGate:
         result = asyncio.run(gated())
 
         assert isinstance(result, ListAllWorkflowsResultSuccess)
+
+
+class TestWorkflowMetadataTransitiveDeps:
+    """node_libraries_referenced in saved workflow metadata includes transitive library_dependencies."""
+
+    def test_transitive_library_dep_included_in_metadata(self, griptape_nodes: GriptapeNodes) -> None:
+        """When lib-a has library_dependency on lib-b, generated metadata lists both in node_libraries_referenced."""
+        from datetime import UTC, datetime
+
+        from griptape_nodes.node_library.library_declarations import LibraryDependencyDeclaration
+        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+        from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        lib_mgr = griptape_nodes.LibraryManager()
+
+        commands = SerializedFlowCommands(
+            flow_initialization_command=None,
+            serialized_node_commands=[],
+            serialized_connections=[],
+            unique_parameter_uuid_to_values={},
+            set_parameter_value_commands={},
+            set_lock_commands_per_node={},
+            sub_flows_commands=[],
+            node_dependencies=NodeDependencies(),
+            node_types_used=set(),
+        )
+        commands.node_dependencies.libraries.add(LibraryNameAndVersion("lib-a", "1.0.0"))
+
+        dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
+        lib_a_mock = MagicMock()
+        lib_a_mock.get_library_data.return_value.metadata.declarations = [dep_b]
+        lib_b_mock = MagicMock()
+        lib_b_mock.get_library_data.return_value.metadata.declarations = []
+        info_b = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            library_path="/workspace/libraries/lib-b/griptape_nodes_library.json",
+            is_sandbox=False,
+            library_name="lib-b",
+            library_version="1.0.0",
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            problems=[],
+        )
+
+        with (
+            patch(
+                "griptape_nodes.node_library.library_registry.LibraryRegistry.get_library",
+                side_effect=lambda name: {"lib-a": lib_a_mock, "lib-b": lib_b_mock}[name],
+            ),
+            patch.object(
+                lib_mgr, "get_library_info_by_library_name", side_effect=lambda n: info_b if n == "lib-b" else None
+            ),
+        ):
+            metadata = workflow_manager._generate_workflow_metadata_from_commands(
+                serialized_flow_commands=commands,
+                file_name="test_workflow.py",
+                creation_date=datetime.now(UTC),
+            )
+
+        names = {lib.library_name for lib in metadata.node_libraries_referenced}
+        assert "lib-a" in names
+        assert "lib-b" in names, "Transitive library dependency must appear in node_libraries_referenced"

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -1,0 +1,134 @@
+"""Tests for WorkflowPackager transitive library dependency resolution."""
+
+from unittest.mock import MagicMock, patch
+
+from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+from griptape_nodes.retained_mode.publishing.workflow_packager import WorkflowPackager
+
+
+def _make_library_data_mock(
+    pip_dependencies: list[str] | None = None,
+    pip_install_flags: list[str] | None = None,
+) -> MagicMock:
+    """Return a mock library.get_library_data() with the given pip dependency fields."""
+    deps_mock = MagicMock()
+    deps_mock.pip_dependencies = pip_dependencies
+    deps_mock.pip_install_flags = pip_install_flags
+
+    metadata_mock = MagicMock()
+    metadata_mock.dependencies = deps_mock
+
+    schema_mock = MagicMock()
+    schema_mock.metadata = metadata_mock
+
+    library_mock = MagicMock()
+    library_mock.get_library_data.return_value = schema_mock
+
+    return library_mock
+
+
+def _make_workflow_mock(library_names: list[str]) -> MagicMock:
+    workflow = MagicMock()
+    workflow.metadata.node_libraries_referenced = [
+        LibraryNameAndVersion(library_name=name, library_version="1.0.0") for name in library_names
+    ]
+    return workflow
+
+
+def _make_lib_manager_mock(resolved: list[LibraryNameAndVersion]) -> MagicMock:
+    """Return a LibraryManager mock whose resolve_transitive_library_deps returns `resolved`."""
+    return MagicMock(resolve_transitive_library_deps=lambda _initial: resolved)
+
+
+class TestResolveAllLibraryDeps:
+    """_resolve_all_library_deps delegates to LibraryManager.resolve_transitive_library_deps."""
+
+    def test_delegates_to_library_manager(self) -> None:
+        """_resolve_all_library_deps returns whatever resolve_transitive_library_deps returns."""
+        packager = WorkflowPackager("test_workflow")
+        initial = [LibraryNameAndVersion("lib-a", "1.0.0")]
+        expected = [LibraryNameAndVersion("lib-a", "1.0.0"), LibraryNameAndVersion("lib-b", "1.0.0")]
+
+        with patch(
+            "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.LibraryManager",
+            return_value=_make_lib_manager_mock(expected),
+        ):
+            result = packager._resolve_all_library_deps(initial)
+
+        assert result == expected
+
+    def test_passes_initial_list_through(self) -> None:
+        """The initial library list is forwarded unchanged to resolve_transitive_library_deps."""
+        packager = WorkflowPackager("test_workflow")
+        initial = [LibraryNameAndVersion("lib-a", "1.0.0")]
+        captured: list[list[LibraryNameAndVersion]] = []
+
+        def capture_and_return(libs: list[LibraryNameAndVersion]) -> list[LibraryNameAndVersion]:
+            captured.append(libs)
+            return libs
+
+        with patch(
+            "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.LibraryManager",
+            return_value=MagicMock(resolve_transitive_library_deps=capture_and_return),
+        ):
+            packager._resolve_all_library_deps(initial)
+
+        assert captured[0] == initial
+
+
+class TestCollectDependenciesTransitive:
+    """collect_dependencies includes pip deps from transitive library dependencies."""
+
+    def test_includes_pip_deps_from_transitive_library(self) -> None:
+        """Workflow uses Library A; A depends on Library B; B's pip deps appear in result."""
+        packager = WorkflowPackager("test_workflow")
+        workflow = _make_workflow_mock(["lib-a"])
+
+        lib_a = _make_library_data_mock(pip_dependencies=["requests>=2.0"])
+        lib_b = _make_library_data_mock(pip_dependencies=["numpy>=1.0"])
+        resolved = [LibraryNameAndVersion("lib-a", "1.0.0"), LibraryNameAndVersion("lib-b", "1.0.0")]
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.LibraryManager",
+                return_value=_make_lib_manager_mock(resolved),
+            ),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.LibraryRegistry.get_library",
+                side_effect=lambda name: {"lib-a": lib_a, "lib-b": lib_b}[name],
+            ),
+            patch.object(packager, "get_engine_version", return_value="0.0.0"),
+            patch.object(packager, "get_install_source", return_value=("pypi", None)),
+        ):
+            result = packager.collect_dependencies(workflow)
+
+        assert "numpy>=1.0" in result
+        assert "requests>=2.0" in result
+
+
+class TestCollectPipInstallFlagsTransitive:
+    """collect_pip_install_flags includes flags from transitive library dependencies."""
+
+    def test_includes_flags_from_transitive_library(self) -> None:
+        """Workflow uses Library A; A depends on Library B; B's pip flags appear in result."""
+        packager = WorkflowPackager("test_workflow")
+        workflow = _make_workflow_mock(["lib-a"])
+
+        lib_a = _make_library_data_mock(pip_install_flags=["--extra-index-url=https://a.example.com"])
+        lib_b = _make_library_data_mock(pip_install_flags=["--extra-index-url=https://b.example.com"])
+        resolved = [LibraryNameAndVersion("lib-a", "1.0.0"), LibraryNameAndVersion("lib-b", "1.0.0")]
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.LibraryManager",
+                return_value=_make_lib_manager_mock(resolved),
+            ),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.LibraryRegistry.get_library",
+                side_effect=lambda name: {"lib-a": lib_a, "lib-b": lib_b}[name],
+            ),
+        ):
+            result = packager.collect_pip_install_flags(workflow)
+
+        assert "--extra-index-url=https://a.example.com" in result
+        assert "--extra-index-url=https://b.example.com" in result


### PR DESCRIPTION
## Root Cause

PR #4752 (library deps, `127ea20a`) and PR #4762 (AdvancedNodeLibrary handlers, `97c37026`) both branched from the same ancestor commit (`90956ac0`). #4752 landed first. #4762 was **never rebased** onto updated main before merging.

When GitHub squash-merged #4762, it applied the full delta from the old shared base to the branch tip. That delta implicitly reset every shared file back to the pre-#4752 state — silently clobbering the entire inter-library dependency feature 53 minutes after it landed.

## What Was Lost

11 of 14 files from `127ea20a` were overwritten by `97c37026`:

| File | Loss |
|------|------|
| `library_declarations.py` | `LibraryDependencyDeclaration` class + union entry |
| `fitness_problems/libraries/library_dependency_problem.py` | Entire file deleted |
| `fitness_problems/libraries/__init__.py` | `LibraryDependencyProblem` export |
| `library_manager.py` | `resolve_transitive_library_deps()` BFS method + EVALUATED-state dep-resolution block (~170 lines) |
| `settings.py` | `LibraryDependencyInstallBehavior` enum, `LibrarySettings` model, `Settings.library` field |
| `workflow_manager.py` | Transitive dep resolution in `_generate_workflow_metadata_from_commands` |
| `workflow_packager.py` | `_resolve_all_library_deps()` helper + 3 call-sites |
| `test_library_manager_deps.py` | Entire 715-line test file deleted |
| `test_settings.py` | `TestLibraryDependencyInstallBehavior` class |
| `test_workflow_manager.py` | `TestWorkflowMetadataTransitiveDeps` class |
| `test_workflow_packager.py` | Entire 134-line test file deleted |

## Fix

Cherry-picked `127ea20a` onto the current HEAD. Git auto-merged all files cleanly (no manual conflict resolution required) — `97c37026`'s AdvancedNodeLibrary additions are fully preserved alongside the restored dependency feature.

## Verification

- `make check` — 0 errors
- 190 tests pass across all affected modules