### PR TITLE
chore: bump v0.87.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-engine"
-version = "0.87.0"
+version = "0.87.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.87.0"
+version = "0.87.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR cherry-picks the version bump commit from `release/v0.87`.

Cherry-picked commit: 19cde73458b6f7d48087d9a87ad2073ae460f125