### PR TITLE
feat(permissions): authorization checkpoint hooks for resolved-resource gating

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -69,3 +69,13 @@ class CheckpointDenial:
     def messages(self) -> list[str]:
         """The per-failure detail sentences, for plain-text rendering."""
         return [failure.detail for failure in self.failures]
+
+    def reason(self, *, separator: str = "; ", default: str = "Denied by the license policy.") -> str:
+        """The denial as one display string: every failure detail joined, or `default`.
+
+        A hook returns `None` (not an empty denial) to allow, so empty `failures` is
+        a contract violation; `default` keeps the surfaced message coherent if one
+        slips through. Callers pass `separator` to match their surrounding format
+        (inline `"; "` in a failure result, a newline in a multi-line node error).
+        """
+        return separator.join(self.messages()) or default

--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -19,23 +19,69 @@ model it likes.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
+
+
+class CheckpointAction(StrEnum):
+    """The semantic operations the engine gates at a checkpoint.
+
+    Carried by `AuthorizationCheckpoint.action` so a hook branches on a named
+    member rather than a bare string literal. Each value is the wire string the
+    app's policy matches on.
+    """
+
+    LOAD_LIBRARY = "LoadLibrary"
+    INSTANTIATE_NODE = "InstantiateNode"
+    INVOKE_MODEL = "InvokeModel"
+    LOAD_PROJECT = "LoadProject"
+    ACTIVATE_PROJECT = "ActivateProject"
+
+
+class CheckpointSubjectType(StrEnum):
+    """The kinds of subject a checkpoint acts on, paired with `subject_id`."""
+
+    LIBRARY = "Library"
+    NODE_TYPE = "NodeType"
+    MODEL = "Model"
+    PROJECT = "Project"
+
+
+class CheckpointAttribute(StrEnum):
+    """The attribute keys the engine fills on a checkpoint's `attributes`.
+
+    Centralizing the keys keeps the engine's producer side and the app's policy
+    hook reading the same names, so a typo cannot silently drop a fact. The engine
+    fills only the keys it has resolved for a given checkpoint; a hook reads
+    whichever it cares about. Members are `str` values, so they serve as dict keys
+    that compare equal to their literal spelling on the reading side.
+    """
+
+    ID = "id"
+    LIFECYCLE_STAGE = "lifecycle_stage"
+    PROVIDER_ID = "provider_id"
+    EXECUTES_ARBITRARY_CODE = "executes_arbitrary_code"
+    NAME = "name"
+    MODEL_IDS = "model_ids"
+    PROVIDER_IDS = "provider_ids"
+    MODEL_FAMILIES = "model_families"
 
 
 @dataclass(frozen=True)
 class AuthorizationCheckpoint:
     """One point where the engine asks whether a resolved operation is permitted.
 
-    `action` is the semantic operation (e.g. ``"LoadLibrary"``, ``"InstantiateNode"``).
+    `action` is the semantic operation (e.g. ``CheckpointAction.LOAD_LIBRARY``).
     `subject_type` / `subject_id` identify the thing being acted on (e.g.
-    ``"Library"`` and the library name). `attributes` are the facts the engine
-    owns about that subject (e.g. ``{"lifecycle_stage": "EXPERIMENTAL"}``); a hook
-    decides which it cares about. The engine fills only what it has resolved; it
-    does not know which attributes a policy will read.
+    ``CheckpointSubjectType.LIBRARY`` and the library name). `attributes` are the
+    facts the engine owns about that subject (e.g.
+    ``{CheckpointAttribute.LIFECYCLE_STAGE: "EXPERIMENTAL"}``); a hook decides
+    which it cares about. The engine fills only what it has resolved; it does not
+    know which attributes a policy will read.
     """
 
-    action: str
-    subject_type: str
+    action: CheckpointAction
+    subject_type: CheckpointSubjectType
     subject_id: str
     attributes: dict[str, Any] = field(default_factory=dict)
 

--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -1,0 +1,71 @@
+"""Authorization checkpoints: extension points the engine offers for gating.
+
+The engine cannot evaluate permissions itself -- it knows nothing about the
+license, Cedar, or the app that wraps it. Instead, at the points where a
+privileged operation is about to happen (loading a library past its metadata
+stage, instantiating a node, activating a project, invoking a model) it
+constructs an `AuthorizationCheckpoint` describing the resolved subject and asks
+any registered hook whether to proceed. The app registers such a hook (alongside
+the pre-dispatch hook it already installs on `EventManager`) and answers with a
+`CheckpointDenial` or `None`.
+
+This keeps the dependency arrow pointing one way: the engine defines the hook
+shape and calls it; the app supplies the policy. The types here are deliberately
+Cedar-agnostic -- the engine fills domain facts it owns (a library's lifecycle
+stage, a node's arbitrary-code flag) and a hook maps them onto whatever policy
+model it likes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AuthorizationCheckpoint:
+    """One point where the engine asks whether a resolved operation is permitted.
+
+    `action` is the semantic operation (e.g. ``"LoadLibrary"``, ``"InstantiateNode"``).
+    `subject_type` / `subject_id` identify the thing being acted on (e.g.
+    ``"Library"`` and the library name). `attributes` are the facts the engine
+    owns about that subject (e.g. ``{"lifecycle_stage": "EXPERIMENTAL"}``); a hook
+    decides which it cares about. The engine fills only what it has resolved; it
+    does not know which attributes a policy will read.
+    """
+
+    action: str
+    subject_type: str
+    subject_id: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CheckpointFailure:
+    """One reason a checkpoint was denied, in a form the engine can render.
+
+    `detail` is a human-readable sentence the engine surfaces directly (in a
+    fitness problem, an error-proxy node, or a failure result). `capability` and
+    `advice` are optional structured fields a richer UI can render separately
+    (the entitlement the user lacks and what to ask their admin for).
+    """
+
+    detail: str
+    capability: str | None = None
+    advice: str | None = None
+
+
+@dataclass(frozen=True)
+class CheckpointDenial:
+    """The verdict when a checkpoint is denied: one or more failures to surface.
+
+    A denial carries *every* failure so the engine can show all missing
+    permissions at once rather than the first. A hook returns `None` (not an
+    empty denial) to allow.
+    """
+
+    failures: tuple[CheckpointFailure, ...]
+
+    def messages(self) -> list[str]:
+        """The per-failure detail sentences, for plain-text rendering."""
+        return [failure.detail for failure in self.failures]

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -372,8 +372,10 @@ class EventManager:
         # Bypass the chain when a hook is already evaluating on this thread. A
         # hook that re-enters an engine operation guarded by a checkpoint would
         # otherwise re-trigger itself and recurse without bound. Mirrors the
-        # pre-dispatch chain's recursion guard; returning None allows the nested
-        # operation, which is already running inside an authorized outer one.
+        # pre-dispatch chain's recursion guard. Returning None allows the nested
+        # operation unconditionally -- the bypass is coarse and permits a nested
+        # checkpoint with a different subject too -- which is acceptable because
+        # the policy code itself triggered it; the alternative is the recursion.
         if getattr(self._hook_evaluation, "authorizing", False):
             return None
 

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -124,9 +124,10 @@ class EventManager:
         # handle_request runs on arbitrary threads, so guard the list and snapshot
         # it before iteration.
         self._pre_dispatch_hooks_lock = threading.Lock()
-        # Thread-local flag: if a hook re-enters handle_request on this thread, the
-        # chain is skipped so the hook can't keep re-triggering itself into
-        # unbounded recursion.
+        # Thread-local flags: if a hook re-enters an engine operation on this
+        # thread, the corresponding chain is skipped so the hook can't keep
+        # re-triggering itself into unbounded recursion. `active` guards the
+        # pre-dispatch chain; `authorizing` guards the authorization chain.
         self._hook_evaluation = threading.local()
         # Authorization checkpoint hooks. The engine calls
         # evaluate_authorization_checkpoint at privileged operations (library
@@ -364,27 +365,47 @@ class EventManager:
         allows (including when none are registered, so an engine with no policy
         installed runs unrestricted). Fails closed: a hook that raises is treated
         as a denial rather than letting the exception escape into the calling
-        operation, mirroring the pre-dispatch chain.
+        operation, mirroring the pre-dispatch chain. A re-entrant call on the same
+        thread (a hook that triggers another guarded operation) bypasses the chain
+        and allows, so the chain cannot recurse without bound.
         """
+        # Bypass the chain when a hook is already evaluating on this thread. A
+        # hook that re-enters an engine operation guarded by a checkpoint would
+        # otherwise re-trigger itself and recurse without bound. Mirrors the
+        # pre-dispatch chain's recursion guard; returning None allows the nested
+        # operation, which is already running inside an authorized outer one.
+        if getattr(self._hook_evaluation, "authorizing", False):
+            return None
+
         with self._authorization_hooks_lock:
             hooks = list(self._authorization_hooks)
-        for hook in hooks:
-            try:
-                denial = hook(checkpoint)
-            except Exception as exc:
-                logging.getLogger("griptape_nodes").exception(
-                    "Authorization hook '%s' raised on checkpoint '%s'; denying.",
-                    getattr(hook, "__name__", hook),
-                    checkpoint.action,
-                )
-                return CheckpointDenial(
-                    failures=(
-                        CheckpointFailure(detail=f"Authorization could not be evaluated: {type(exc).__name__}: {exc}"),
+
+        if not hooks:
+            return None
+
+        self._hook_evaluation.authorizing = True
+        try:
+            for hook in hooks:
+                try:
+                    denial = hook(checkpoint)
+                except Exception as exc:
+                    logging.getLogger("griptape_nodes").exception(
+                        "Authorization hook '%s' raised on checkpoint '%s'; denying.",
+                        getattr(hook, "__name__", hook),
+                        checkpoint.action,
                     )
-                )
-            if denial is not None:
-                return denial
-        return None
+                    return CheckpointDenial(
+                        failures=(
+                            CheckpointFailure(
+                                detail=f"Authorization could not be evaluated: {type(exc).__name__}: {exc}"
+                            ),
+                        )
+                    )
+                if denial is not None:
+                    return denial
+            return None
+        finally:
+            self._hook_evaluation.authorizing = False
 
     def assign_manager_to_request_type(
         self,

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -32,6 +32,11 @@ from griptape_nodes.retained_mode.events.base_events import (
 from griptape_nodes.retained_mode.events.event_converter import converter
 from griptape_nodes.retained_mode.events.generic_events import GenericResultFailure
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointDenial,
+    CheckpointFailure,
+)
 from griptape_nodes.utils.async_utils import call_function
 
 if TYPE_CHECKING:
@@ -123,6 +128,14 @@ class EventManager:
         # chain is skipped so the hook can't keep re-triggering itself into
         # unbounded recursion.
         self._hook_evaluation = threading.local()
+        # Authorization checkpoint hooks. The engine calls
+        # evaluate_authorization_checkpoint at privileged operations (library
+        # load, node instantiation, ...); a hook returns a CheckpointDenial to
+        # block or None to allow. Separate from pre-dispatch hooks because a
+        # checkpoint carries a resolved domain subject rather than a raw request.
+        # The engine itself registers nothing here; the app installs the policy.
+        self._authorization_hooks: list[Callable[[AuthorizationCheckpoint], CheckpointDenial | None]] = []
+        self._authorization_hooks_lock = threading.Lock()
 
     @property
     def event_queue(self) -> asyncio.Queue:
@@ -316,6 +329,62 @@ class EventManager:
             return None
         finally:
             self._hook_evaluation.active = False
+
+    def add_authorization_hook(
+        self,
+        hook: Callable[[AuthorizationCheckpoint], CheckpointDenial | None],
+    ) -> None:
+        """Register an authorization-checkpoint hook.
+
+        The engine calls `evaluate_authorization_checkpoint` at privileged
+        operations; each registered hook returns a `CheckpointDenial` to block the
+        operation or `None` to allow it. Hooks run in registration order and the
+        first denial wins. The engine registers nothing itself -- this is how the
+        app installs license policy without the engine depending on it.
+        Registering the same hook twice is a no-op.
+        """
+        with self._authorization_hooks_lock:
+            if hook not in self._authorization_hooks:
+                self._authorization_hooks.append(hook)
+
+    def remove_authorization_hook(
+        self,
+        hook: Callable[[AuthorizationCheckpoint], CheckpointDenial | None],
+    ) -> None:
+        with self._authorization_hooks_lock:
+            try:
+                self._authorization_hooks.remove(hook)
+            except ValueError:
+                return
+
+    def evaluate_authorization_checkpoint(self, checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+        """Ask registered hooks whether a resolved operation is permitted.
+
+        Returns the first hook's `CheckpointDenial`, or `None` when every hook
+        allows (including when none are registered, so an engine with no policy
+        installed runs unrestricted). Fails closed: a hook that raises is treated
+        as a denial rather than letting the exception escape into the calling
+        operation, mirroring the pre-dispatch chain.
+        """
+        with self._authorization_hooks_lock:
+            hooks = list(self._authorization_hooks)
+        for hook in hooks:
+            try:
+                denial = hook(checkpoint)
+            except Exception as exc:
+                logging.getLogger("griptape_nodes").exception(
+                    "Authorization hook '%s' raised on checkpoint '%s'; denying.",
+                    getattr(hook, "__name__", hook),
+                    checkpoint.action,
+                )
+                return CheckpointDenial(
+                    failures=(
+                        CheckpointFailure(detail=f"Authorization could not be evaluated: {type(exc).__name__}: {exc}"),
+                    )
+                )
+            if denial is not None:
+                return denial
+        return None
 
     def assign_manager_to_request_type(
         self,

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -27,6 +27,7 @@ from .modified_parameters_set_removed_problem import ModifiedParametersSetRemove
 from .node_class_not_base_node_problem import NodeClassNotBaseNodeProblem
 from .node_class_not_found_problem import NodeClassNotFoundProblem
 from .node_module_import_problem import NodeModuleImportProblem
+from .node_permission_denied_problem import NodePermissionDeniedProblem
 from .old_xdg_location_warning_problem import OldXdgLocationWarningProblem
 from .permission_denied_problem import PermissionDeniedProblem
 from .pre_dispatch_hook_registration_problem import PreDispatchHookRegistrationProblem
@@ -69,6 +70,7 @@ __all__ = [
     "NodeClassNotBaseNodeProblem",
     "NodeClassNotFoundProblem",
     "NodeModuleImportProblem",
+    "NodePermissionDeniedProblem",
     "OldXdgLocationWarningProblem",
     "PermissionDeniedProblem",
     "PreDispatchHookRegistrationProblem",

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -28,6 +28,7 @@ from .node_class_not_base_node_problem import NodeClassNotBaseNodeProblem
 from .node_class_not_found_problem import NodeClassNotFoundProblem
 from .node_module_import_problem import NodeModuleImportProblem
 from .old_xdg_location_warning_problem import OldXdgLocationWarningProblem
+from .permission_denied_problem import PermissionDeniedProblem
 from .pre_dispatch_hook_registration_problem import PreDispatchHookRegistrationProblem
 from .request_handler_registration_problem import RequestHandlerRegistrationProblem
 from .request_handlers_worker_incompatible_problem import RequestHandlersWorkerIncompatibleProblem
@@ -69,6 +70,7 @@ __all__ = [
     "NodeClassNotFoundProblem",
     "NodeModuleImportProblem",
     "OldXdgLocationWarningProblem",
+    "PermissionDeniedProblem",
     "PreDispatchHookRegistrationProblem",
     "RequestHandlerRegistrationProblem",
     "RequestHandlersWorkerIncompatibleProblem",

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/node_permission_denied_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/node_permission_denied_problem.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+
+@dataclass
+class NodePermissionDeniedProblem(LibraryProblem):
+    """Problem indicating the license policy does not permit a node type in this library.
+
+    Surfaced while a library loads: the library itself still loads (its permitted
+    nodes work), but each denied node type is listed so the GUI failure icon
+    explains why it is blocked and what to ask an admin for. Instantiating a denied
+    node later substitutes an Error Proxy carrying the same reasons. Stackable: one
+    instance per denied node type.
+    """
+
+    node_type: str
+    messages: list[str] = field(default_factory=list)
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[NodePermissionDeniedProblem]) -> str:
+        """List every denied node type with the reasons it is blocked, de-duplicated in order."""
+        lines: list[str] = []
+        for problem in instances:
+            reasons = "; ".join(problem.messages) or "Denied by the license policy."
+            entry = f"- {problem.node_type}: {reasons}"
+            if entry not in lines:
+                lines.append(entry)
+        if not lines:
+            return "Some nodes are not permitted by your license."
+        body = "\n".join(lines)
+        return f"Some nodes are not permitted by your license:\n{body}"

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/permission_denied_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/permission_denied_problem.py
@@ -11,8 +11,7 @@ class PermissionDeniedProblem(LibraryProblem):
 
     `messages` is one human-readable sentence per missing permission, so the
     failure icon can list every reason the library is blocked rather than the
-    first. Capabilities/advice are carried verbatim from the authorization
-    denial.
+    first.
     """
 
     library_name: str

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/permission_denied_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/permission_denied_problem.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+
+@dataclass
+class PermissionDeniedProblem(LibraryProblem):
+    """Problem indicating the license policy does not permit loading this library.
+
+    `messages` is one human-readable sentence per missing permission, so the
+    failure icon can list every reason the library is blocked rather than the
+    first. Capabilities/advice are carried verbatim from the authorization
+    denial.
+    """
+
+    library_name: str
+    messages: list[str] = field(default_factory=list)
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[PermissionDeniedProblem]) -> str:
+        """List every missing permission across all instances, de-duplicated in order."""
+        lines: list[str] = []
+        for problem in instances:
+            for message in problem.messages:
+                if message not in lines:
+                    lines.append(message)
+        if not lines:
+            return "This library is not permitted by your license."
+        bullets = "\n".join(f"- {line}" for line in lines)
+        return f"This library is not permitted by your license:\n{bullets}"

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -44,6 +44,7 @@ from griptape_nodes.files.path_utils import canonicalize_for_identity, canonical
 from griptape_nodes.node_library.library_declarations import (
     LibraryDeclaration,
     LibraryDependencyDeclaration,
+    LifecycleStageLibraryProperty,
     WorkerCompatibility,
     WorkerMode,
     WorkerModeCompatibility,
@@ -194,6 +195,7 @@ from griptape_nodes.retained_mode.events.resource_events import (
 )
 from griptape_nodes.retained_mode.events.worker_events import StartWorkerRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     AdvancedLibraryLoadFailureProblem,
     AfterLibraryCallbackProblem,
@@ -214,6 +216,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     NodeClassNotFoundProblem,
     NodeModuleImportProblem,
     OldXdgLocationWarningProblem,
+    PermissionDeniedProblem,
     RequestHandlerRegistrationProblem,
     RequestHandlersWorkerIncompatibleProblem,
     SandboxDirectoryMissingProblem,
@@ -5108,6 +5111,27 @@ class LibraryManager:
                 problems=problems,
             )
 
+        # License-policy checkpoint: ask any registered authorization hook (the
+        # app installs one) whether this library may load past its metadata
+        # stage. A denial is rendered as a fitness problem and marks the library
+        # UNUSABLE, so it is not registered and the GUI shows every missing
+        # permission on the failure icon. With no hook installed this allows.
+        denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+            AuthorizationCheckpoint(
+                action="LoadLibrary",
+                subject_type="Library",
+                subject_id=schema.name,
+                attributes=self._library_checkpoint_attributes(schema),
+            )
+        )
+        if denial is not None:
+            problems.append(PermissionDeniedProblem(library_name=schema.name, messages=denial.messages()))
+            return EvaluateLibraryFitnessResultFailure(
+                result_details=f"Library '{schema.name}' is not permitted by the license policy",
+                fitness=LibraryManager.LibraryFitness.UNUSABLE,
+                problems=problems,
+            )
+
         # Determine fitness based on whether we have any non-disqualifying issues
         fitness = LibraryManager.LibraryFitness.FLAWED if problems else LibraryManager.LibraryFitness.GOOD
 
@@ -5116,6 +5140,28 @@ class LibraryManager:
             fitness=fitness,
             problems=problems,
         )
+
+    @staticmethod
+    def _library_checkpoint_attributes(schema: LibrarySchema) -> dict[str, Any]:
+        """Resolve the facts an authorization hook may gate a library load on.
+
+        `id` is the library name (so a policy can match a specific library);
+        `lifecycle_stage` is the library's declared stage when one is present.
+        The engine supplies what it has resolved and does not know which a policy
+        will read.
+        """
+        attributes: dict[str, Any] = {"id": schema.name}
+        stage = next(
+            (
+                declaration.stage
+                for declaration in schema.metadata.declarations
+                if isinstance(declaration, LifecycleStageLibraryProperty)
+            ),
+            None,
+        )
+        if stage is not None:
+            attributes["lifecycle_stage"] = stage.value
+        return attributes
 
     async def load_libraries_request(self, request: LoadLibrariesRequest) -> ResultPayload:  # noqa: ARG002, C901, PLR0912
         """Load all libraries from configuration (backward compatibility wrapper).

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -195,7 +195,12 @@ from griptape_nodes.retained_mode.events.resource_events import (
 )
 from griptape_nodes.retained_mode.events.worker_events import StartWorkerRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointSubjectType,
+)
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     AdvancedLibraryLoadFailureProblem,
     AfterLibraryCallbackProblem,
@@ -5119,8 +5124,8 @@ class LibraryManager:
         # permission on the failure icon. With no hook installed this allows.
         denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
-                action="LoadLibrary",
-                subject_type="Library",
+                action=CheckpointAction.LOAD_LIBRARY,
+                subject_type=CheckpointSubjectType.LIBRARY,
                 subject_id=schema.name,
                 attributes=self._library_checkpoint_attributes(schema),
             )
@@ -5162,7 +5167,7 @@ class LibraryManager:
         The engine supplies what it has resolved and does not know which a policy
         will read.
         """
-        attributes: dict[str, Any] = {"id": schema.name}
+        attributes: dict[str, Any] = {CheckpointAttribute.ID: schema.name}
         stage = next(
             (
                 declaration.stage
@@ -5172,7 +5177,7 @@ class LibraryManager:
             None,
         )
         if stage is not None:
-            attributes["lifecycle_stage"] = stage.value
+            attributes[CheckpointAttribute.LIFECYCLE_STAGE] = stage.value
         return attributes
 
     async def load_libraries_request(self, request: LoadLibrariesRequest) -> ResultPayload:  # noqa: ARG002, C901, PLR0912

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -215,6 +215,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     NodeClassNotBaseNodeProblem,
     NodeClassNotFoundProblem,
     NodeModuleImportProblem,
+    NodePermissionDeniedProblem,
     OldXdgLocationWarningProblem,
     PermissionDeniedProblem,
     RequestHandlerRegistrationProblem,
@@ -5131,6 +5132,17 @@ class LibraryManager:
                 fitness=LibraryManager.LibraryFitness.UNUSABLE,
                 problems=problems,
             )
+
+        # Per-node license-policy preview. A library may be permitted to load while
+        # still declaring node types the policy forbids (by lifecycle stage or the
+        # arbitrary-code flag). Surface each denied node type as a library problem
+        # now -- so the GUI failure icon lists them and what to ask an admin for --
+        # without blocking the library, which stays usable for its permitted nodes.
+        # Instantiating a denied node later substitutes an Error Proxy via the same
+        # checkpoint. Runs on the schema, so no library module is imported here.
+        node_denials = GriptapeNodes.NodeManager().evaluate_schema_node_instantiation_denials(schema)
+        for node_type, node_denial in node_denials.items():
+            problems.append(NodePermissionDeniedProblem(node_type=node_type, messages=node_denial.messages()))
 
         # Determine fitness based on whether we have any non-disqualifying issues
         fitness = LibraryManager.LibraryFitness.FLAWED if problems else LibraryManager.LibraryFitness.GOOD

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -767,7 +767,7 @@ class ModelManager:
             )
         )
         if denial is not None:
-            reason = "; ".join(denial.messages())
+            reason = "; ".join(denial.messages()) or "Denied by the license policy."
             return DeclareModelInvocationResultFailure(
                 result_details=f"Model invocation denied for '{request.model}'. {reason}"
             )

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -9,7 +9,7 @@ import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from huggingface_hub import get_token, list_models, scan_cache_dir, snapshot_download
@@ -21,6 +21,7 @@ from griptape_nodes.files.file import File, FileWriteError
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
+    DeclareModelInvocationResultFailure,
     DeclareModelInvocationResultSuccess,
     DeleteModelDownloadRequest,
     DeleteModelDownloadResultFailure,
@@ -48,6 +49,7 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint
 from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD_KEY
 from griptape_nodes.utils.async_utils import cancel_subprocess
 
@@ -723,6 +725,19 @@ class ModelManager:
             result_details=f"Retrieved info for '{request.model_id}'",
         )
 
+    @staticmethod
+    def _model_checkpoint_attributes(request: DeclareModelInvocationRequest) -> dict[str, Any]:
+        """Resolve the facts a hook may gate a model invocation on.
+
+        `id` is the concrete model; `provider_id` is the catalog provider the call
+        routes to (when the node declared one). The app maps `provider_id` onto
+        the `Model in ModelProvider` hierarchy a policy walks via `in`.
+        """
+        attributes: dict[str, Any] = {"id": request.model}
+        if request.provider_id:
+            attributes["provider_id"] = request.provider_id
+        return attributes
+
     def on_handle_declare_model_invocation_request(self, request: DeclareModelInvocationRequest) -> ResultPayload:
         """Acknowledge a node's declaration that it is about to invoke a model.
 
@@ -739,6 +754,23 @@ class ModelManager:
         Returns:
             ResultPayload: Success, meaning the node is cleared to proceed
         """
+        # License-policy checkpoint: gate the declared invocation on the model and
+        # its provider. The node already opted in by declaring; a denial returns a
+        # failure so the node does not invoke the model. Provider/family hierarchy
+        # is resolved app-side from the declared provider_id.
+        denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+            AuthorizationCheckpoint(
+                action="InvokeModel",
+                subject_type="Model",
+                subject_id=request.model,
+                attributes=self._model_checkpoint_attributes(request),
+            )
+        )
+        if denial is not None:
+            reason = "; ".join(denial.messages())
+            return DeclareModelInvocationResultFailure(
+                result_details=f"Model invocation denied for '{request.model}'. {reason}"
+            )
         return DeclareModelInvocationResultSuccess(
             model=request.model,
             result_details=f"Model invocation permitted for '{request.model}'.",

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -767,7 +767,7 @@ class ModelManager:
             )
         )
         if denial is not None:
-            reason = "; ".join(denial.messages()) or "Denied by the license policy."
+            reason = denial.reason()
             return DeclareModelInvocationResultFailure(
                 result_details=f"Model invocation denied for '{request.model}'. {reason}"
             )

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -49,7 +49,12 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointSubjectType,
+)
 from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD_KEY
 from griptape_nodes.utils.async_utils import cancel_subprocess
 
@@ -733,9 +738,9 @@ class ModelManager:
         routes to (when the node declared one). The app maps `provider_id` onto
         the `Model in ModelProvider` hierarchy a policy walks via `in`.
         """
-        attributes: dict[str, Any] = {"id": request.model}
+        attributes: dict[str, Any] = {CheckpointAttribute.ID: request.model}
         if request.provider_id:
-            attributes["provider_id"] = request.provider_id
+            attributes[CheckpointAttribute.PROVIDER_ID] = request.provider_id
         return attributes
 
     def on_handle_declare_model_invocation_request(self, request: DeclareModelInvocationRequest) -> ResultPayload:
@@ -760,8 +765,8 @@ class ModelManager:
         # is resolved app-side from the declared provider_id.
         denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
-                action="InvokeModel",
-                subject_type="Model",
+                action=CheckpointAction.INVOKE_MODEL,
+                subject_type=CheckpointSubjectType.MODEL,
                 subject_id=request.model,
                 attributes=self._model_checkpoint_attributes(request),
             )

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -225,7 +225,13 @@ from griptape_nodes.retained_mode.events.validation_events import (
     ValidateNodeDependenciesResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint, CheckpointDenial
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointDenial,
+    CheckpointSubjectType,
+)
 from griptape_nodes.retained_mode.retained_mode import RetainedMode
 
 logger = logging.getLogger("griptape_nodes")
@@ -491,7 +497,7 @@ class NodeManager:
         gate runs from a loaded library (node instantiation) and from a library
         schema (library-load fitness preview), before any module is imported.
         """
-        attributes: dict[str, Any] = {"id": node_type}
+        attributes: dict[str, Any] = {CheckpointAttribute.ID: node_type}
         node_stage = next(
             (
                 declaration.stage
@@ -501,7 +507,7 @@ class NodeManager:
             None,
         )
         if node_stage is not None:
-            attributes["lifecycle_stage"] = node_stage.value
+            attributes[CheckpointAttribute.LIFECYCLE_STAGE] = node_stage.value
         else:
             library_stage = next(
                 (
@@ -512,7 +518,7 @@ class NodeManager:
                 None,
             )
             if library_stage is not None:
-                attributes["lifecycle_stage"] = library_stage.value
+                attributes[CheckpointAttribute.LIFECYCLE_STAGE] = library_stage.value
         arbitrary = next(
             (
                 declaration
@@ -521,7 +527,9 @@ class NodeManager:
             ),
             None,
         )
-        attributes["executes_arbitrary_code"] = bool(arbitrary.executes_arbitrary_python) if arbitrary else False
+        attributes[CheckpointAttribute.EXECUTES_ARBITRARY_CODE] = (
+            bool(arbitrary.executes_arbitrary_python) if arbitrary else False
+        )
         attributes.update(
             NodeManager._node_model_checkpoint_facts(
                 node_declarations=node_declarations, library_declarations=library_declarations
@@ -584,11 +592,11 @@ class NodeManager:
 
         facts: dict[str, Any] = {}
         if model_ids:
-            facts["model_ids"] = list(dict.fromkeys(model_ids))
+            facts[CheckpointAttribute.MODEL_IDS] = list(dict.fromkeys(model_ids))
         if provider_ids:
-            facts["provider_ids"] = list(dict.fromkeys(provider_ids))
+            facts[CheckpointAttribute.PROVIDER_IDS] = list(dict.fromkeys(provider_ids))
         if families:
-            facts["model_families"] = list(dict.fromkeys(families))
+            facts[CheckpointAttribute.MODEL_FAMILIES] = list(dict.fromkeys(families))
         return facts
 
     @staticmethod
@@ -606,8 +614,8 @@ class NodeManager:
         """
         return GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
-                action="InstantiateNode",
-                subject_type="NodeType",
+                action=CheckpointAction.INSTANTIATE_NODE,
+                subject_type=CheckpointSubjectType.NODE_TYPE,
                 subject_id=node_type,
                 attributes=NodeManager._node_checkpoint_attributes(
                     node_type=node_type,

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3062,6 +3062,24 @@ class NodeManager:
             return ExecuteNodeResultFailure(
                 result_details=f"Node '{node_name}' node_metadata is missing 'node_type'.",
             )
+        # Gate worker-side construction on the same InstantiateNode checkpoint
+        # CreateNode enforces. node_metadata is caller-supplied, so without this
+        # a node the policy denies could be instantiated and executed by sending
+        # ExecuteNodeRequest straight to a worker, never passing through the
+        # gated CreateNode path.
+        try:
+            denial = self._evaluate_instantiation_checkpoint(node_type=node_type, specific_library_name=library_name)
+        except KeyError:
+            # Node type/library not registered here; let create_node below
+            # surface the clearer "node type not found" failure rather than
+            # masking it with a checkpoint-resolution error.
+            denial = None
+        if denial is not None:
+            return ExecuteNodeResultFailure(
+                result_details=(
+                    f"Node '{node_name}' of type '{node_type}' denied by license policy: {denial.reason()}"
+                ),
+            )
         try:
             return LibraryRegistry.create_node(
                 node_type=node_type,

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -56,6 +56,10 @@ from griptape_nodes.node_library.library_declarations import (
     ArbitraryPythonExecutionNodeProperty,
     LifecycleStageLibraryProperty,
     LifecycleStageNodeProperty,
+    ModelCatalogLibraryProperty,
+    ModelProviderUsageNodeProperty,
+    ModelUsageNodeProperty,
+    resolve_node_models,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
@@ -478,7 +482,10 @@ class NodeManager:
         `lifecycle_stage` is the node's effective stage: its own override when
         declared, else the library stage it inherits, omitted when neither states
         one. `executes_arbitrary_code` is the node's declared flag (absent means
-        False). The engine supplies what it resolved; a policy reads what it wants.
+        False). `model_ids` / `provider_ids` / `model_families` are the catalog
+        handles a node binds to (see `_node_model_checkpoint_facts`), present only
+        when the node declares model usage. The engine supplies what it resolved; a
+        policy reads what it wants.
 
         Takes declaration lists rather than a registered `Library` so the identical
         gate runs from a loaded library (node instantiation) and from a library
@@ -515,7 +522,74 @@ class NodeManager:
             None,
         )
         attributes["executes_arbitrary_code"] = bool(arbitrary.executes_arbitrary_python) if arbitrary else False
+        attributes.update(
+            NodeManager._node_model_checkpoint_facts(
+                node_declarations=node_declarations, library_declarations=library_declarations
+            )
+        )
         return attributes
+
+    @staticmethod
+    def _node_model_checkpoint_facts(
+        *,
+        node_declarations: Sequence[NodeDeclaration],
+        library_declarations: Sequence[LibraryDeclaration],
+    ) -> dict[str, Any]:
+        """The model facts a node binds to, resolved against the library's model catalog.
+
+        A node declares its models via `model_usage` (specific catalog ids) or
+        `model_provider_usage` (whole providers). Resolving those against the
+        library's `model_catalog` yields the concrete provider/model/family handles
+        a policy gates on, so a provider/family/model-specific node is denied by the
+        same `InstantiateNode` checkpoint that gates lifecycle and arbitrary code
+        (and its reasons join the same denial). Returns `model_ids`, `provider_ids`,
+        and `model_families`, each omitted when empty. A node that declares no model
+        usage contributes nothing, so non-model nodes skip catalog resolution.
+        """
+        declared_provider_ids = [
+            provider_id
+            for declaration in node_declarations
+            if isinstance(declaration, ModelProviderUsageNodeProperty)
+            for provider_id in declaration.provider_ids
+        ]
+        declared_model_ids = [
+            model_id
+            for declaration in node_declarations
+            if isinstance(declaration, ModelUsageNodeProperty)
+            for model_id in declaration.model_ids
+        ]
+        if not declared_provider_ids and not declared_model_ids:
+            return {}
+
+        # Directly declared handles match a policy even when the catalog is absent
+        # or a provider declares no concrete models. The catalog enriches them with
+        # the provider a `model_usage` id belongs to and each model's family.
+        model_ids = list(declared_model_ids)
+        provider_ids = list(declared_provider_ids)
+        families: list[str] = []
+        catalog = next(
+            (
+                declaration
+                for declaration in library_declarations
+                if isinstance(declaration, ModelCatalogLibraryProperty)
+            ),
+            None,
+        )
+        if catalog is not None:
+            for resolved in resolve_node_models(catalog, node_declarations):
+                model_ids.append(resolved.model_id)
+                provider_ids.append(resolved.provider_id)
+                if resolved.model.family:
+                    families.append(resolved.model.family)
+
+        facts: dict[str, Any] = {}
+        if model_ids:
+            facts["model_ids"] = list(dict.fromkeys(model_ids))
+        if provider_ids:
+            facts["provider_ids"] = list(dict.fromkeys(provider_ids))
+        if families:
+            facts["model_families"] = list(dict.fromkeys(families))
+        return facts
 
     @staticmethod
     def _evaluate_node_instantiation_checkpoint(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -465,13 +465,14 @@ class NodeManager:
     def _node_checkpoint_attributes(library: Library, node_type: str) -> dict[str, Any]:
         """Resolve the facts a hook may gate node instantiation on.
 
+        `id` is the node type (so a policy can match a specific node type).
         `lifecycle_stage` is the node's effective stage: its own override when
         declared, else the library stage it inherits, omitted when neither states
         one. `executes_arbitrary_code` is the node's declared flag (absent means
         False). The engine supplies what it resolved; a policy reads what it wants.
         """
         node_declarations = library.get_node_metadata(node_type).declarations
-        attributes: dict[str, Any] = {}
+        attributes: dict[str, Any] = {"id": node_type}
         node_stage = next(
             (
                 declaration.stage

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -532,7 +532,7 @@ class NodeManager:
             node_type=node_type, specific_library_name=specific_library_name
         )
         if denial is not None:
-            message = "\n".join(denial.messages()) or "Denied by the license policy."
+            message = denial.reason(separator="\n")
             raise _NodeInstantiationDeniedError(message)
 
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -48,7 +48,12 @@ from griptape_nodes.exe_types.node_types import (
     aprocess_scope,
     sanctioned_parameter_mutation,
 )
-from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
+from griptape_nodes.node_library.library_declarations import (
+    ArbitraryPythonExecutionNodeProperty,
+    LifecycleStageLibraryProperty,
+    LifecycleStageNodeProperty,
+)
+from griptape_nodes.node_library.library_registry import Library, LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
     EventRequest,
     ResultDetails,
@@ -212,6 +217,7 @@ from griptape_nodes.retained_mode.events.validation_events import (
     ValidateNodeDependenciesResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint, CheckpointDenial
 from griptape_nodes.retained_mode.retained_mode import RetainedMode
 
 logger = logging.getLogger("griptape_nodes")
@@ -268,6 +274,16 @@ class SerializedGroupResult:
         SerializedNodeCommands.NodeUUID, list[SerializedNodeCommands.IndirectSetParameterValueCommand]
     ]
     child_uuids: list[SerializedNodeCommands.NodeUUID]
+
+
+class _NodeInstantiationDeniedError(Exception):
+    """Raised inside node creation when the license policy denies the node type.
+
+    Caught by the same handler path that substitutes an Error Proxy for a node
+    whose library failed to load, so a denied node surfaces identically: a proxy
+    carrying the missing-permission detail, or a failure result when the caller
+    opted out of proxy substitution.
+    """
 
 
 class NodeManager:
@@ -445,6 +461,79 @@ class NodeManager:
         for node_name in node_names:
             self._cleanup_node_on_failed_deserialization(node_name)
 
+    @staticmethod
+    def _node_checkpoint_attributes(library: Library, node_type: str) -> dict[str, Any]:
+        """Resolve the facts a hook may gate node instantiation on.
+
+        `lifecycle_stage` is the node's effective stage: its own override when
+        declared, else the library stage it inherits, omitted when neither states
+        one. `executes_arbitrary_code` is the node's declared flag (absent means
+        False). The engine supplies what it resolved; a policy reads what it wants.
+        """
+        node_declarations = library.get_node_metadata(node_type).declarations
+        attributes: dict[str, Any] = {}
+        node_stage = next(
+            (
+                declaration.stage
+                for declaration in node_declarations
+                if isinstance(declaration, LifecycleStageNodeProperty)
+            ),
+            None,
+        )
+        if node_stage is not None:
+            attributes["lifecycle_stage"] = node_stage.value
+        else:
+            library_stage = next(
+                (
+                    declaration.stage
+                    for declaration in library.get_metadata().declarations
+                    if isinstance(declaration, LifecycleStageLibraryProperty)
+                ),
+                None,
+            )
+            if library_stage is not None:
+                attributes["lifecycle_stage"] = library_stage.value
+        arbitrary = next(
+            (
+                declaration
+                for declaration in node_declarations
+                if isinstance(declaration, ArbitraryPythonExecutionNodeProperty)
+            ),
+            None,
+        )
+        attributes["executes_arbitrary_code"] = bool(arbitrary.executes_arbitrary_python) if arbitrary else False
+        return attributes
+
+    @staticmethod
+    def _evaluate_instantiation_checkpoint(
+        *, node_type: str, specific_library_name: str | None
+    ) -> CheckpointDenial | None:
+        """Ask any registered authorization hook whether this node type may be instantiated."""
+        library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
+        return GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+            AuthorizationCheckpoint(
+                action="InstantiateNode",
+                subject_type="NodeType",
+                subject_id=node_type,
+                attributes=NodeManager._node_checkpoint_attributes(library, node_type),
+            )
+        )
+
+    @staticmethod
+    def _enforce_instantiation_checkpoint(*, node_type: str, specific_library_name: str | None) -> None:
+        """Raise `_NodeInstantiationDeniedError` when the policy denies this node type.
+
+        Raised rather than returned so a denial joins the Error Proxy substitution
+        path in `on_create_node_request`, identical to a node whose library failed
+        to load. The message lists every missing permission.
+        """
+        denial = NodeManager._evaluate_instantiation_checkpoint(
+            node_type=node_type, specific_library_name=specific_library_name
+        )
+        if denial is not None:
+            message = "\n".join(denial.messages()) or "Denied by the license policy."
+            raise _NodeInstantiationDeniedError(message)
+
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         # Validate as much as possible before we actually create one.
         parent_flow_name = request.override_parent_flow_name
@@ -495,6 +584,15 @@ class NodeManager:
         # OK, let's try and create the Node.
         node = None
         try:
+            # License-policy checkpoint: gate instantiating this node type on its
+            # effective lifecycle stage and arbitrary-code flag. A denial raises
+            # (from inside the helper) so it flows into the Error Proxy
+            # substitution below -- the same surface a node whose library failed
+            # to load uses -- and the proxy carries every missing permission.
+            self._enforce_instantiation_checkpoint(
+                node_type=request.node_type,
+                specific_library_name=request.specific_library_name,
+            )
             node = LibraryRegistry.create_node(
                 name=final_node_name,
                 node_type=request.node_type,

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -17,6 +17,10 @@ from griptape_nodes.common.strict_mode import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from griptape_nodes.node_library.library_declarations import LibraryDeclaration, NodeDeclaration
+    from griptape_nodes.node_library.library_registry import LibrarySchema
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
 from griptape_nodes.exe_types.base_iterative_nodes import (
@@ -53,7 +57,7 @@ from griptape_nodes.node_library.library_declarations import (
     LifecycleStageLibraryProperty,
     LifecycleStageNodeProperty,
 )
-from griptape_nodes.node_library.library_registry import Library, LibraryNameAndVersion, LibraryRegistry
+from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.retained_mode.events.base_events import (
     EventRequest,
     ResultDetails,
@@ -462,7 +466,12 @@ class NodeManager:
             self._cleanup_node_on_failed_deserialization(node_name)
 
     @staticmethod
-    def _node_checkpoint_attributes(library: Library, node_type: str) -> dict[str, Any]:
+    def _node_checkpoint_attributes(
+        *,
+        node_type: str,
+        node_declarations: Sequence[NodeDeclaration],
+        library_declarations: Sequence[LibraryDeclaration],
+    ) -> dict[str, Any]:
         """Resolve the facts a hook may gate node instantiation on.
 
         `id` is the node type (so a policy can match a specific node type).
@@ -470,8 +479,11 @@ class NodeManager:
         declared, else the library stage it inherits, omitted when neither states
         one. `executes_arbitrary_code` is the node's declared flag (absent means
         False). The engine supplies what it resolved; a policy reads what it wants.
+
+        Takes declaration lists rather than a registered `Library` so the identical
+        gate runs from a loaded library (node instantiation) and from a library
+        schema (library-load fitness preview), before any module is imported.
         """
-        node_declarations = library.get_node_metadata(node_type).declarations
         attributes: dict[str, Any] = {"id": node_type}
         node_stage = next(
             (
@@ -487,7 +499,7 @@ class NodeManager:
             library_stage = next(
                 (
                     declaration.stage
-                    for declaration in library.get_metadata().declarations
+                    for declaration in library_declarations
                     if isinstance(declaration, LifecycleStageLibraryProperty)
                 ),
                 None,
@@ -506,18 +518,41 @@ class NodeManager:
         return attributes
 
     @staticmethod
-    def _evaluate_instantiation_checkpoint(
-        *, node_type: str, specific_library_name: str | None
+    def _evaluate_node_instantiation_checkpoint(
+        *,
+        node_type: str,
+        node_declarations: Sequence[NodeDeclaration],
+        library_declarations: Sequence[LibraryDeclaration],
     ) -> CheckpointDenial | None:
-        """Ask any registered authorization hook whether this node type may be instantiated."""
-        library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
+        """Ask any registered authorization hook whether this node type may be instantiated.
+
+        Single source for the `InstantiateNode` checkpoint, shared by the
+        instantiation path (CreateNode) and the library-load fitness preview so both
+        resolve the same action and facts from whatever declarations they hold.
+        """
         return GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action="InstantiateNode",
                 subject_type="NodeType",
                 subject_id=node_type,
-                attributes=NodeManager._node_checkpoint_attributes(library, node_type),
+                attributes=NodeManager._node_checkpoint_attributes(
+                    node_type=node_type,
+                    node_declarations=node_declarations,
+                    library_declarations=library_declarations,
+                ),
             )
+        )
+
+    @staticmethod
+    def _evaluate_instantiation_checkpoint(
+        *, node_type: str, specific_library_name: str | None
+    ) -> CheckpointDenial | None:
+        """Ask any registered authorization hook whether this node type may be instantiated."""
+        library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
+        return NodeManager._evaluate_node_instantiation_checkpoint(
+            node_type=node_type,
+            node_declarations=library.get_node_metadata(node_type).declarations,
+            library_declarations=library.get_metadata().declarations,
         )
 
     @staticmethod
@@ -534,6 +569,28 @@ class NodeManager:
         if denial is not None:
             message = denial.reason(separator="\n")
             raise _NodeInstantiationDeniedError(message)
+
+    @staticmethod
+    def evaluate_schema_node_instantiation_denials(schema: LibrarySchema) -> dict[str, CheckpointDenial]:
+        """Denials that would block instantiating each node type a library schema declares.
+
+        Lets library-load fitness preview the node-instantiation gate without
+        importing the library's modules: a denied node type becomes a library
+        problem now and, when later instantiated, an Error Proxy. Returns one entry
+        per denied node type (class name -> denial); permitted node types are
+        omitted. With no authorization hook installed every node is permitted, so
+        the result is empty.
+        """
+        denials: dict[str, CheckpointDenial] = {}
+        for node in schema.nodes:
+            denial = NodeManager._evaluate_node_instantiation_checkpoint(
+                node_type=node.class_name,
+                node_declarations=node.metadata.declarations,
+                library_declarations=schema.metadata.declarations,
+            )
+            if denial is not None:
+                denials[node.class_name] = denial
+        return denials
 
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         # Validate as much as possible before we actually create one.

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1425,7 +1425,7 @@ class ProjectManager:
                 )
             )
             if denial is not None:
-                reason = "; ".join(denial.messages())
+                reason = "; ".join(denial.messages()) or "Denied by the license policy."
                 return SetCurrentProjectResultFailure(
                     result_details=f"Attempted to set current project '{resolved_project_id}'. Failed because: {reason}"
                 )

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -7,7 +7,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pydantic import ValidationError
 
@@ -96,6 +96,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     ValidateProjectTemplateResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
@@ -1374,6 +1375,15 @@ class ProjectManager:
             await GriptapeNodes.WorkflowManager().refresh_workflow_registry()
         return None
 
+    def _project_checkpoint_attributes(self, project_id: ProjectID) -> dict[str, Any]:
+        """Resolve the facts a hook may gate project activation on: id and (best-effort) name."""
+        attributes: dict[str, Any] = {"id": project_id}
+        info = self._successfully_loaded_project_templates.get(project_id)
+        name = getattr(getattr(info, "template", None), "name", None)
+        if name:
+            attributes["name"] = str(name)
+        return attributes
+
     async def on_set_current_project_request(
         self, request: SetCurrentProjectRequest
     ) -> SetCurrentProjectResultSuccess | SetCurrentProjectResultFailure:
@@ -1399,6 +1409,26 @@ class ProjectManager:
         # string were already canonicalized at load time, so a verbatim lookup
         # still hits. SYSTEM_DEFAULTS_KEY is a synthetic id and is preserved as-is.
         resolved_project_id: ProjectID = request.project_id if request.project_id is not None else SYSTEM_DEFAULTS_KEY
+
+        # License-policy checkpoint: gate activating a user project on its id. The
+        # system-defaults rest state is always allowed -- it is the fallback a
+        # failed activation rolls back to. A denial rejects the switch with the
+        # missing permissions and leaves the current project untouched (the
+        # activation below never runs).
+        if resolved_project_id != SYSTEM_DEFAULTS_KEY:
+            denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+                AuthorizationCheckpoint(
+                    action="ActivateProject",
+                    subject_type="Project",
+                    subject_id=resolved_project_id,
+                    attributes=self._project_checkpoint_attributes(resolved_project_id),
+                )
+            )
+            if denial is not None:
+                reason = "; ".join(denial.messages())
+                return SetCurrentProjectResultFailure(
+                    result_details=f"Attempted to set current project '{resolved_project_id}'. Failed because: {reason}"
+                )
 
         outcome = await self._activate_project(resolved_project_id)
         if outcome.failure is not None:

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1425,7 +1425,7 @@ class ProjectManager:
                 )
             )
             if denial is not None:
-                reason = "; ".join(denial.messages()) or "Denied by the license policy."
+                reason = denial.reason()
                 return SetCurrentProjectResultFailure(
                     result_details=f"Attempted to set current project '{resolved_project_id}'. Failed because: {reason}"
                 )

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -591,6 +591,31 @@ class ProjectManager:
                 result_details=f"Attempted to load project template from '{project_file_path}'. Failed because template is not usable (status: {validation.status})",
             )
 
+        # License-policy checkpoint: gate loading this project on its resolved
+        # identity. A denial blocks the load -- the project is not cached as usable
+        # and the failure carries the missing permissions -- so a project the policy
+        # forbids never enters the engine, whether reached by explicit load or
+        # directory discovery. Mirrors the activation gate, which resolves the same
+        # facts; the name is passed in because the project is not cached yet.
+        load_denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+            AuthorizationCheckpoint(
+                action="LoadProject",
+                subject_type="Project",
+                subject_id=project_id,
+                attributes=self._project_checkpoint_attributes(project_id, name=template.name),
+            )
+        )
+        if load_denial is not None:
+            reason = load_denial.reason()
+            validation.add_error(field_path="permission", message=reason)
+            self._registered_template_status[project_file_path] = validation
+            return LoadProjectTemplateResultFailure(
+                validation=validation,
+                result_details=(
+                    f"Attempted to load project template from '{project_file_path}'. Failed because: {reason}"
+                ),
+            )
+
         # Create consolidated ProjectInfo with fully populated macro caches
         project_info = ProjectInfo(
             project_id=project_id,
@@ -1375,14 +1400,22 @@ class ProjectManager:
             await GriptapeNodes.WorkflowManager().refresh_workflow_registry()
         return None
 
-    def _project_checkpoint_attributes(self, project_id: ProjectID) -> dict[str, Any]:
-        """Resolve the facts a hook may gate project activation on: id and (best-effort) name."""
+    def _project_checkpoint_attributes(self, project_id: ProjectID, *, name: str | None = None) -> dict[str, Any]:
+        """The facts a hook may gate project load/activation on: id and (best-effort) name.
+
+        `name` is the resolved template name when the caller already holds it (load
+        time, before the project is cached); at activation it falls back to the
+        cached template so the load and activation gates resolve the same facts.
+        """
         attributes: dict[str, Any] = {"id": project_id}
-        info = self._successfully_loaded_project_templates.get(project_id)
-        name = getattr(getattr(info, "template", None), "name", None)
-        if name:
-            attributes["name"] = str(name)
+        resolved_name = name if name is not None else self._cached_project_name(project_id)
+        if resolved_name:
+            attributes["name"] = str(resolved_name)
         return attributes
+
+    def _cached_project_name(self, project_id: ProjectID) -> str | None:
+        info = self._successfully_loaded_project_templates.get(project_id)
+        return getattr(getattr(info, "template", None), "name", None)
 
     async def on_set_current_project_request(
         self, request: SetCurrentProjectRequest

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -96,7 +96,12 @@ from griptape_nodes.retained_mode.events.project_events import (
     ValidateProjectTemplateResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.authorization_checkpoint import AuthorizationCheckpoint
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointSubjectType,
+)
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
@@ -599,8 +604,8 @@ class ProjectManager:
         # facts; the name is passed in because the project is not cached yet.
         load_denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
-                action="LoadProject",
-                subject_type="Project",
+                action=CheckpointAction.LOAD_PROJECT,
+                subject_type=CheckpointSubjectType.PROJECT,
                 subject_id=project_id,
                 attributes=self._project_checkpoint_attributes(project_id, name=template.name),
             )
@@ -1407,10 +1412,10 @@ class ProjectManager:
         time, before the project is cached); at activation it falls back to the
         cached template so the load and activation gates resolve the same facts.
         """
-        attributes: dict[str, Any] = {"id": project_id}
+        attributes: dict[str, Any] = {CheckpointAttribute.ID: project_id}
         resolved_name = name if name is not None else self._cached_project_name(project_id)
         if resolved_name:
-            attributes["name"] = str(resolved_name)
+            attributes[CheckpointAttribute.NAME] = str(resolved_name)
         return attributes
 
     def _cached_project_name(self, project_id: ProjectID) -> str | None:
@@ -1451,8 +1456,8 @@ class ProjectManager:
         if resolved_project_id != SYSTEM_DEFAULTS_KEY:
             denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
                 AuthorizationCheckpoint(
-                    action="ActivateProject",
-                    subject_type="Project",
+                    action=CheckpointAction.ACTIVATE_PROJECT,
+                    subject_type=CheckpointSubjectType.PROJECT,
                     subject_id=resolved_project_id,
                     attributes=self._project_checkpoint_attributes(resolved_project_id),
                 )

--- a/tests/unit/retained_mode/managers/test_authorization_checkpoint.py
+++ b/tests/unit/retained_mode/managers/test_authorization_checkpoint.py
@@ -1,0 +1,36 @@
+"""Tests for the authorization checkpoint value types."""
+
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    CheckpointDenial,
+    CheckpointFailure,
+)
+
+
+class TestCheckpointDenialReason:
+    """`reason` renders the denial as one display string with a safe fallback."""
+
+    def test_joins_failure_details_with_default_separator(self) -> None:
+        denial = CheckpointDenial(
+            failures=(
+                CheckpointFailure(detail="Labs libraries are disabled."),
+                CheckpointFailure(detail="Ask your admin to enable them."),
+            )
+        )
+        assert denial.reason() == "Labs libraries are disabled.; Ask your admin to enable them."
+
+    def test_honors_custom_separator(self) -> None:
+        denial = CheckpointDenial(
+            failures=(
+                CheckpointFailure(detail="first"),
+                CheckpointFailure(detail="second"),
+            )
+        )
+        assert denial.reason(separator="\n") == "first\nsecond"
+
+    def test_empty_failures_falls_back_to_default(self) -> None:
+        # A hook returns None to allow, so empty failures is a contract violation;
+        # reason must still yield a coherent sentence rather than an empty string.
+        assert CheckpointDenial(failures=()).reason() == "Denied by the license policy."
+
+    def test_empty_failures_honors_custom_default(self) -> None:
+        assert CheckpointDenial(failures=()).reason(default="nope") == "nope"

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -23,8 +23,11 @@ from griptape_nodes.retained_mode.events.generic_events import GenericResultFail
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
     CheckpointDenial,
     CheckpointFailure,
+    CheckpointSubjectType,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -660,10 +663,10 @@ class TestAuthorizationCheckpointHooks:
     @staticmethod
     def _checkpoint() -> AuthorizationCheckpoint:
         return AuthorizationCheckpoint(
-            action="LoadLibrary",
-            subject_type="Library",
+            action=CheckpointAction.LOAD_LIBRARY,
+            subject_type=CheckpointSubjectType.LIBRARY,
             subject_id="lib",
-            attributes={"lifecycle_stage": "LABS"},
+            attributes={CheckpointAttribute.LIFECYCLE_STAGE: "LABS"},
         )
 
     def test_no_hooks_allows(self) -> None:

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -21,6 +21,11 @@ from griptape_nodes.retained_mode.events.base_events import (
 )
 from griptape_nodes.retained_mode.events.generic_events import GenericResultFailure
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointDenial,
+    CheckpointFailure,
+)
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 
@@ -647,3 +652,55 @@ class TestPreDispatchHooks:
 
         assert event.result.failed()
         assert handler_calls == []
+
+
+class TestAuthorizationCheckpointHooks:
+    """The engine-side hook mechanism the app registers a policy into."""
+
+    @staticmethod
+    def _checkpoint() -> AuthorizationCheckpoint:
+        return AuthorizationCheckpoint(
+            action="LoadLibrary",
+            subject_type="Library",
+            subject_id="lib",
+            attributes={"lifecycle_stage": "LABS"},
+        )
+
+    def test_no_hooks_allows(self) -> None:
+        assert EventManager().evaluate_authorization_checkpoint(self._checkpoint()) is None
+
+    def test_hook_denial_is_returned(self) -> None:
+        denial = CheckpointDenial(failures=(CheckpointFailure(detail="blocked", capability="cap"),))
+        manager = EventManager()
+        manager.add_authorization_hook(lambda _checkpoint: denial)
+        assert manager.evaluate_authorization_checkpoint(self._checkpoint()) is denial
+
+    def test_first_denial_wins_and_allowing_hooks_fall_through(self) -> None:
+        denial = CheckpointDenial(failures=(CheckpointFailure(detail="second"),))
+        manager = EventManager()
+        manager.add_authorization_hook(lambda _checkpoint: None)
+        manager.add_authorization_hook(lambda _checkpoint: denial)
+        assert manager.evaluate_authorization_checkpoint(self._checkpoint()) is denial
+
+    def test_hook_exception_fails_closed(self) -> None:
+        def boom(_checkpoint: AuthorizationCheckpoint) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        manager = EventManager()
+        manager.add_authorization_hook(boom)
+        denial = manager.evaluate_authorization_checkpoint(self._checkpoint())
+        assert denial is not None
+        assert "boom" in denial.failures[0].detail
+
+    def test_remove_hook(self) -> None:
+        manager = EventManager()
+
+        def hook(_checkpoint: AuthorizationCheckpoint) -> None:
+            return None
+
+        manager.add_authorization_hook(hook)
+        manager.remove_authorization_hook(hook)
+        # Removing again is a no-op, not an error.
+        manager.remove_authorization_hook(hook)
+        assert manager.evaluate_authorization_checkpoint(self._checkpoint()) is None

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -704,3 +704,42 @@ class TestAuthorizationCheckpointHooks:
         # Removing again is a no-op, not an error.
         manager.remove_authorization_hook(hook)
         assert manager.evaluate_authorization_checkpoint(self._checkpoint()) is None
+
+    def test_reentrant_hook_is_bypassed_not_recursive(self) -> None:
+        manager = EventManager()
+        hook_calls: list[AuthorizationCheckpoint] = []
+
+        def hook(checkpoint: AuthorizationCheckpoint) -> None:
+            hook_calls.append(checkpoint)
+            # Re-enter the checkpoint from inside the hook. The nested call must
+            # bypass the chain rather than re-trigger this hook and recurse.
+            if len(hook_calls) == 1:
+                assert manager.evaluate_authorization_checkpoint(self._checkpoint()) is None
+
+        manager.add_authorization_hook(hook)
+
+        assert manager.evaluate_authorization_checkpoint(self._checkpoint()) is None
+        # Hook ran only for the outer checkpoint; the re-entrant call skipped it.
+        assert len(hook_calls) == 1
+
+    def test_hook_error_does_not_wedge_later_evaluation(self) -> None:
+        manager = EventManager()
+        calls: list[int] = []
+
+        def hook(_checkpoint: AuthorizationCheckpoint) -> None:
+            calls.append(1)
+            if len(calls) == 1:
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        manager.add_authorization_hook(hook)
+
+        # First evaluation is denied by the erroring hook...
+        first = manager.evaluate_authorization_checkpoint(self._checkpoint())
+        assert first is not None
+
+        # ...and the thread-local guard is cleared, so the next evaluation still
+        # runs the chain and allows.
+        second = manager.evaluate_authorization_checkpoint(self._checkpoint())
+        assert second is None
+        assert len(calls) == 2  # noqa: PLR2004

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -3259,9 +3259,14 @@ class TestLibraryFitnessAuthorizationCheckpoint:
 
     @staticmethod
     def _schema(name: str, stage: "LifecycleStage | None" = None) -> "LibrarySchema":
-        from griptape_nodes.node_library.library_declarations import LifecycleStageLibraryProperty
+        from griptape_nodes.node_library.library_declarations import (
+            LibraryDeclaration,
+            LifecycleStageLibraryProperty,
+        )
 
-        declarations = [LifecycleStageLibraryProperty(stage=stage)] if stage is not None else []
+        declarations: list[LibraryDeclaration] = (
+            [LifecycleStageLibraryProperty(stage=stage)] if stage is not None else []
+        )
         return LibrarySchema(
             name=name,
             library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -3252,3 +3252,80 @@ class TestLibraryManagerMetadataLoadFailureSurfacing:
         assert stored.lifecycle_state == LibraryManager.LibraryLifecycleState.FAILURE
         assert stored.fitness == LibraryManager.LibraryFitness.MISSING
         assert stored.problems
+
+
+class TestLibraryFitnessAuthorizationCheckpoint:
+    """The license-policy checkpoint wired into library fitness evaluation."""
+
+    @staticmethod
+    def _schema(name: str, stage: "LifecycleStage | None" = None) -> "LibrarySchema":
+        from griptape_nodes.node_library.library_declarations import LifecycleStageLibraryProperty
+
+        declarations = [LifecycleStageLibraryProperty(stage=stage)] if stage is not None else []
+        return LibrarySchema(
+            name=name,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="d",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=declarations,
+            ),
+            categories=[],
+            nodes=[],
+        )
+
+    def test_denied_library_is_unusable_with_permission_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            EvaluateLibraryFitnessRequest,
+            EvaluateLibraryFitnessResultFailure,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            CheckpointDenial,
+            CheckpointFailure,
+        )
+        from griptape_nodes.retained_mode.managers.fitness_problems.libraries import PermissionDeniedProblem
+
+        seen: dict[str, object] = {}
+
+        def deny(checkpoint: object) -> CheckpointDenial:
+            seen["action"] = checkpoint.action  # type: ignore[attr-defined]
+            seen["subject_id"] = checkpoint.subject_id  # type: ignore[attr-defined]
+            seen["stage"] = checkpoint.attributes.get("lifecycle_stage")  # type: ignore[attr-defined]
+            return CheckpointDenial(
+                failures=(CheckpointFailure(detail="Ask your admin to enable Labs libraries.", capability="lib:labs"),)
+            )
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        with patch(
+            "griptape_nodes.retained_mode.managers.version_compatibility_manager.VersionCompatibilityManager.check_library_version_compatibility",
+            return_value=[],
+        ):
+            result = griptape_nodes.LibraryManager().evaluate_library_fitness_request(
+                EvaluateLibraryFitnessRequest(schema=self._schema("blocked-lib", LifecycleStage.LABS))
+            )
+
+        assert seen == {"action": "LoadLibrary", "subject_id": "blocked-lib", "stage": "LABS"}
+        assert isinstance(result, EvaluateLibraryFitnessResultFailure)
+        assert result.fitness == _LibraryManager.LibraryFitness.UNUSABLE
+        problems = [p for p in result.problems if isinstance(p, PermissionDeniedProblem)]
+        assert len(problems) == 1
+        assert "Ask your admin to enable Labs libraries." in problems[0].collate_problems_for_display(problems)
+
+    def test_allowed_library_passes(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.library_events import (
+            EvaluateLibraryFitnessRequest,
+            EvaluateLibraryFitnessResultSuccess,
+        )
+
+        # No authorization hook registered -> the checkpoint allows.
+        with patch(
+            "griptape_nodes.retained_mode.managers.version_compatibility_manager.VersionCompatibilityManager.check_library_version_compatibility",
+            return_value=[],
+        ):
+            result = griptape_nodes.LibraryManager().evaluate_library_fitness_request(
+                EvaluateLibraryFitnessRequest(schema=self._schema("ok-lib"))
+            )
+        assert isinstance(result, EvaluateLibraryFitnessResultSuccess)

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -3334,3 +3334,51 @@ class TestLibraryFitnessAuthorizationCheckpoint:
                 EvaluateLibraryFitnessRequest(schema=self._schema("ok-lib"))
             )
         assert isinstance(result, EvaluateLibraryFitnessResultSuccess)
+
+    def test_denied_node_is_a_library_problem_but_library_stays_usable(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
+        from griptape_nodes.node_library.library_registry import NodeDefinition, NodeMetadata
+        from griptape_nodes.retained_mode.events.library_events import (
+            EvaluateLibraryFitnessRequest,
+            EvaluateLibraryFitnessResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+        from griptape_nodes.retained_mode.managers.fitness_problems.libraries import NodePermissionDeniedProblem
+
+        # Deny only the node (by lifecycle stage); the library itself is allowed.
+        def deny(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.action == "InstantiateNode":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Ask your admin to enable Labs nodes."),))
+            return None
+
+        schema = self._schema("mixed-lib")
+        schema.nodes.append(
+            NodeDefinition(
+                class_name="LabsNode",
+                file_path="labs.py",
+                metadata=NodeMetadata(
+                    category="t",
+                    description="d",
+                    display_name="Labs",
+                    declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.LABS)],
+                ),
+            )
+        )
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        with patch(
+            "griptape_nodes.retained_mode.managers.version_compatibility_manager.VersionCompatibilityManager.check_library_version_compatibility",
+            return_value=[],
+        ):
+            result = griptape_nodes.LibraryManager().evaluate_library_fitness_request(
+                EvaluateLibraryFitnessRequest(schema=schema)
+            )
+
+        # The library is permitted, so it stays usable (registered), but the denied
+        # node is surfaced as a library problem rather than silently dropped.
+        assert isinstance(result, EvaluateLibraryFitnessResultSuccess)
+        assert result.fitness == _LibraryManager.LibraryFitness.FLAWED
+        problems = [p for p in result.problems if isinstance(p, NodePermissionDeniedProblem)]
+        assert len(problems) == 1
+        assert problems[0].node_type == "LabsNode"
+        assert "Ask your admin to enable Labs nodes." in problems[0].collate_problems_for_display(problems)

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -269,6 +269,27 @@ class TestOnHandleDeclareModelInvocationRequest:
         )
         assert isinstance(allowed, DeclareModelInvocationResultSuccess)
 
+    def test_empty_failure_denial_still_yields_a_reason(self) -> None:
+        # A hook that misuses the contract by returning a denial with no failures
+        # (it should return None to allow) must not produce a reason-less message.
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+        )
+
+        def deny(_checkpoint: AuthorizationCheckpoint) -> CheckpointDenial:
+            return CheckpointDenial(failures=())
+
+        GriptapeNodes.EventManager().add_authorization_hook(deny)
+        manager = ModelManager.__new__(ModelManager)
+
+        denied = manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model="claude-opus-4", provider_id="anthropic")
+        )
+        assert isinstance(denied, DeclareModelInvocationResultFailure)
+        assert "Denied by the license policy." in str(denied.result_details)
+
 
 # ---------------------------------------------------------------------------
 # _download_model_task — subprocess entry point

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -233,6 +233,42 @@ class TestOnHandleDeclareModelInvocationRequest:
         assert isinstance(allowed.result, DeclareModelInvocationResultSuccess)
         assert allowed.result.model == "gpt-ok"
 
+    def test_authorization_checkpoint_denial_blocks_invocation(self) -> None:
+        # The InvokeModel checkpoint gates the declared invocation: a denial from
+        # a registered authorization hook turns into a failure so the node does
+        # not invoke the model. The handler resolves the model + provider facts.
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+            CheckpointFailure,
+        )
+
+        seen: dict[str, object] = {}
+
+        def deny(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            seen["action"] = checkpoint.action
+            seen["subject_id"] = checkpoint.subject_id
+            seen["provider_id"] = checkpoint.attributes.get("provider_id")
+            if checkpoint.attributes.get("provider_id") == "anthropic":
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Anthropic models are not enabled."),))
+            return None
+
+        GriptapeNodes.EventManager().add_authorization_hook(deny)
+        manager = ModelManager.__new__(ModelManager)
+
+        denied = manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model="claude-opus-4", provider_id="anthropic")
+        )
+        assert isinstance(denied, DeclareModelInvocationResultFailure)
+        assert "Anthropic models are not enabled." in str(denied.result_details)
+        assert seen == {"action": "InvokeModel", "subject_id": "claude-opus-4", "provider_id": "anthropic"}
+
+        allowed = manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model="gpt-4o", provider_id="openai")
+        )
+        assert isinstance(allowed, DeclareModelInvocationResultSuccess)
+
 
 # ---------------------------------------------------------------------------
 # _download_model_task — subprocess entry point

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -460,19 +460,28 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         )
         return LibraryRegistry.get_library_for_node_type(_GateProbe.__name__, self._LIBRARY_NAME)
 
+    @staticmethod
+    def _attrs(library):  # noqa: ANN001, ANN205
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        return NodeManager._node_checkpoint_attributes(
+            node_type=_GateProbe.__name__,
+            node_declarations=library.get_node_metadata(_GateProbe.__name__).declarations,
+            library_declarations=library.get_metadata().declarations,
+        )
+
     def test_node_override_stage_wins(self) -> None:
         from griptape_nodes.node_library.library_declarations import (
             LifecycleStage,
             LifecycleStageLibraryProperty,
             LifecycleStageNodeProperty,
         )
-        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         library = self._register(
             node_declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.LABS)],
             library_declarations=[LifecycleStageLibraryProperty(stage=LifecycleStage.STABLE)],
         )
-        attrs = NodeManager._node_checkpoint_attributes(library, _GateProbe.__name__)
+        attrs = self._attrs(library)
         assert attrs["id"] == _GateProbe.__name__
         assert attrs["lifecycle_stage"] == "LABS"
         assert attrs["executes_arbitrary_code"] is False
@@ -482,10 +491,9 @@ class TestNodeInstantiationAuthorizationCheckpoint:
             LifecycleStage,
             LifecycleStageLibraryProperty,
         )
-        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         inherit = self._register(library_declarations=[LifecycleStageLibraryProperty(stage=LifecycleStage.BETA)])
-        assert NodeManager._node_checkpoint_attributes(inherit, _GateProbe.__name__)["lifecycle_stage"] == "BETA"
+        assert self._attrs(inherit)["lifecycle_stage"] == "BETA"
 
         # Re-register with neither stated -> lifecycle_stage omitted entirely.
         for store in ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets"):
@@ -493,16 +501,15 @@ class TestNodeInstantiationAuthorizationCheckpoint:
 
             getattr(LibraryRegistry, store).clear()
         unstated = self._register()
-        assert "lifecycle_stage" not in NodeManager._node_checkpoint_attributes(unstated, _GateProbe.__name__)
+        assert "lifecycle_stage" not in self._attrs(unstated)
 
     def test_arbitrary_code_flag(self) -> None:
         from griptape_nodes.node_library.library_declarations import ArbitraryPythonExecutionNodeProperty
-        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         library = self._register(
             node_declarations=[ArbitraryPythonExecutionNodeProperty(executes_arbitrary_python=True)]
         )
-        assert NodeManager._node_checkpoint_attributes(library, _GateProbe.__name__)["executes_arbitrary_code"] is True
+        assert self._attrs(library)["executes_arbitrary_code"] is True
 
     def test_enforce_raises_on_denial(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
@@ -532,4 +539,59 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         # No hook registered -> no denial, no raise.
         NodeManager._enforce_instantiation_checkpoint(
             node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME
+        )
+
+    def test_schema_preview_returns_denied_node_types(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        schema = self._schema_with_node(node_declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.LABS)])
+
+        def deny(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("lifecycle_stage") == "LABS":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Labs nodes are disabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        denials = NodeManager.evaluate_schema_node_instantiation_denials(schema)
+        assert set(denials) == {_GateProbe.__name__}
+        assert denials[_GateProbe.__name__].messages() == ["Labs nodes are disabled."]
+
+    def test_schema_preview_empty_without_hook(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        # No hook -> nothing denied.
+        assert NodeManager.evaluate_schema_node_instantiation_denials(self._schema_with_node()) == {}
+
+    @staticmethod
+    def _schema_with_node(node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN205
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibrarySchema,
+            NodeDefinition,
+            NodeMetadata,
+        )
+
+        return LibrarySchema(
+            name="preview-lib",
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t",
+                description="d",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=list(library_declarations),
+            ),
+            categories=[],
+            nodes=[
+                NodeDefinition(
+                    class_name=_GateProbe.__name__,
+                    file_path="probe.py",
+                    metadata=NodeMetadata(
+                        category="t", description="d", display_name="Probe", declarations=list(node_declarations)
+                    ),
+                )
+            ],
         )

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -473,6 +473,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
             library_declarations=[LifecycleStageLibraryProperty(stage=LifecycleStage.STABLE)],
         )
         attrs = NodeManager._node_checkpoint_attributes(library, _GateProbe.__name__)
+        assert attrs["id"] == _GateProbe.__name__
         assert attrs["lifecycle_stage"] == "LABS"
         assert attrs["executes_arbitrary_code"] is False
 

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -541,6 +541,45 @@ class TestNodeInstantiationAuthorizationCheckpoint:
             node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME
         )
 
+    def test_worker_materialize_denied_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """Worker-side construction from caller-supplied metadata is gated by the same checkpoint."""
+        from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultFailure,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        self._register(node_declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.LABS)])
+
+        def deny(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.action == "InstantiateNode":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Labs nodes are disabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        request = ExecuteNodeRequest(
+            node_name="probe-1",
+            node_metadata={"node_type": _GateProbe.__name__, "library": self._LIBRARY_NAME},
+        )
+        result = griptape_nodes.NodeManager()._materialize_transient_node_from_metadata(request)
+        assert isinstance(result, ExecuteNodeResultFailure)
+        assert "Labs nodes are disabled." in str(result.result_details)
+
+    def test_worker_materialize_allows_without_hook(self, griptape_nodes: GriptapeNodes) -> None:
+        """With no policy hook the worker path builds the node, matching the no-denial contract."""
+        from griptape_nodes.exe_types.node_types import BaseNode
+        from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeRequest
+
+        self._register()
+        request = ExecuteNodeRequest(
+            node_name="probe-1",
+            node_metadata={"node_type": _GateProbe.__name__, "library": self._LIBRARY_NAME},
+        )
+        result = griptape_nodes.NodeManager()._materialize_transient_node_from_metadata(request)
+        assert isinstance(result, BaseNode)
+        assert result.name == "probe-1"
+
     def test_schema_preview_returns_denied_node_types(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 
 from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeMetadataRequest,
     BatchSetNodeMetadataResultFailure,
@@ -405,3 +406,129 @@ class TestDeserializeNodeFromCommandsRetargetsElementCommands:
         # Every element command must have been retargeted at the new copy, not the original node.
         for command in element_commands:
             assert command.node_name == copy_name
+
+
+class _GateProbe(BaseNode):
+    """Concrete BaseNode used to exercise node-instantiation checkpoint resolution."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+
+
+class TestNodeInstantiationAuthorizationCheckpoint:
+    """The license-policy checkpoint wired into node instantiation."""
+
+    _LIBRARY_NAME = "node-checkpoint-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):  # noqa: ANN202
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        stores = ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets")
+        for store in stores:
+            getattr(LibraryRegistry, store).clear()
+        yield
+        for store in stores:
+            getattr(LibraryRegistry, store).clear()
+
+    def _register(self, node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN202
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t",
+                description="d",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=list(library_declarations),
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(
+            _GateProbe,
+            NodeMetadata(category="t", description="d", display_name="Probe", declarations=list(node_declarations)),
+        )
+        return LibraryRegistry.get_library_for_node_type(_GateProbe.__name__, self._LIBRARY_NAME)
+
+    def test_node_override_stage_wins(self) -> None:
+        from griptape_nodes.node_library.library_declarations import (
+            LifecycleStage,
+            LifecycleStageLibraryProperty,
+            LifecycleStageNodeProperty,
+        )
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        library = self._register(
+            node_declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.LABS)],
+            library_declarations=[LifecycleStageLibraryProperty(stage=LifecycleStage.STABLE)],
+        )
+        attrs = NodeManager._node_checkpoint_attributes(library, _GateProbe.__name__)
+        assert attrs["lifecycle_stage"] == "LABS"
+        assert attrs["executes_arbitrary_code"] is False
+
+    def test_inherits_library_stage_then_unstated(self) -> None:
+        from griptape_nodes.node_library.library_declarations import (
+            LifecycleStage,
+            LifecycleStageLibraryProperty,
+        )
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        inherit = self._register(library_declarations=[LifecycleStageLibraryProperty(stage=LifecycleStage.BETA)])
+        assert NodeManager._node_checkpoint_attributes(inherit, _GateProbe.__name__)["lifecycle_stage"] == "BETA"
+
+        # Re-register with neither stated -> lifecycle_stage omitted entirely.
+        for store in ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets"):
+            from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+            getattr(LibraryRegistry, store).clear()
+        unstated = self._register()
+        assert "lifecycle_stage" not in NodeManager._node_checkpoint_attributes(unstated, _GateProbe.__name__)
+
+    def test_arbitrary_code_flag(self) -> None:
+        from griptape_nodes.node_library.library_declarations import ArbitraryPythonExecutionNodeProperty
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        library = self._register(
+            node_declarations=[ArbitraryPythonExecutionNodeProperty(executes_arbitrary_python=True)]
+        )
+        assert NodeManager._node_checkpoint_attributes(library, _GateProbe.__name__)["executes_arbitrary_code"] is True
+
+    def test_enforce_raises_on_denial(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager, _NodeInstantiationDeniedError
+
+        self._register(node_declarations=[LifecycleStageNodeProperty(stage=LifecycleStage.LABS)])
+
+        seen: dict[str, object] = {}
+
+        def deny(checkpoint: object) -> CheckpointDenial:
+            seen["action"] = checkpoint.action  # type: ignore[attr-defined]
+            seen["stage"] = checkpoint.attributes.get("lifecycle_stage")  # type: ignore[attr-defined]
+            return CheckpointDenial(failures=(CheckpointFailure(detail="Ask your admin to enable Labs nodes."),))
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        with pytest.raises(_NodeInstantiationDeniedError, match="Ask your admin to enable Labs nodes"):
+            NodeManager._enforce_instantiation_checkpoint(
+                node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME
+            )
+        assert seen == {"action": "InstantiateNode", "stage": "LABS"}
+
+    def test_enforce_allows_without_hook(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        self._register()
+        # No hook registered -> no denial, no raise.
+        NodeManager._enforce_instantiation_checkpoint(
+            node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME
+        )

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -564,6 +564,108 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         # No hook -> nothing denied.
         assert NodeManager.evaluate_schema_node_instantiation_denials(self._schema_with_node()) == {}
 
+    def test_model_usage_resolves_catalog_facts(self) -> None:
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        attrs = NodeManager._node_checkpoint_attributes(
+            node_type="ModelNode",
+            node_declarations=[ModelUsageNodeProperty(model_ids=["claude-opus-4"])],
+            library_declarations=[self._catalog()],
+        )
+        assert attrs["model_ids"] == ["claude-opus-4"]
+        assert attrs["provider_ids"] == ["anthropic"]
+        assert attrs["model_families"] == ["Claude 4"]
+
+    def test_provider_usage_resolves_provider_and_its_models(self) -> None:
+        from griptape_nodes.node_library.library_declarations import ModelProviderUsageNodeProperty
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        attrs = NodeManager._node_checkpoint_attributes(
+            node_type="ProviderNode",
+            node_declarations=[ModelProviderUsageNodeProperty(provider_ids=["anthropic"])],
+            library_declarations=[self._catalog()],
+        )
+        assert attrs["provider_ids"] == ["anthropic"]
+        # The whole provider expands to its catalog models.
+        assert attrs["model_ids"] == ["claude-opus-4", "claude-sonnet-4"]
+        assert attrs["model_families"] == ["Claude 4"]
+
+    def test_provider_usage_without_catalog_models_still_gates_provider(self) -> None:
+        from griptape_nodes.node_library.library_declarations import ModelProviderUsageNodeProperty
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        # No catalog declared: the directly declared provider id is still surfaced
+        # so a provider-level policy can match, but no model ids or families exist.
+        attrs = NodeManager._node_checkpoint_attributes(
+            node_type="ProviderNode",
+            node_declarations=[ModelProviderUsageNodeProperty(provider_ids=["ollama"])],
+            library_declarations=[],
+        )
+        assert attrs["provider_ids"] == ["ollama"]
+        assert "model_ids" not in attrs
+        assert "model_families" not in attrs
+
+    def test_non_model_node_has_no_model_facts(self) -> None:
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        attrs = NodeManager._node_checkpoint_attributes(
+            node_type="Plain", node_declarations=[], library_declarations=[self._catalog()]
+        )
+        assert "model_ids" not in attrs
+        assert "provider_ids" not in attrs
+        assert "model_families" not in attrs
+
+    def test_model_facts_reach_the_checkpoint_and_can_be_denied(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+
+        schema = self._schema_with_node(
+            node_declarations=[ModelUsageNodeProperty(model_ids=["claude-opus-4"])],
+            library_declarations=[self._catalog()],
+        )
+
+        seen: dict[str, object] = {}
+
+        def deny(checkpoint: object) -> CheckpointDenial | None:
+            seen["provider_ids"] = checkpoint.attributes.get("provider_ids")  # type: ignore[attr-defined]
+            seen["model_families"] = checkpoint.attributes.get("model_families")  # type: ignore[attr-defined]
+            if "anthropic" in (checkpoint.attributes.get("provider_ids") or []):  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Anthropic is not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        denials = NodeManager.evaluate_schema_node_instantiation_denials(schema)
+        assert seen == {"provider_ids": ["anthropic"], "model_families": ["Claude 4"]}
+        assert set(denials) == {_GateProbe.__name__}
+        assert denials[_GateProbe.__name__].messages() == ["Anthropic is not enabled."]
+
+    @staticmethod
+    def _catalog():  # noqa: ANN205
+        from griptape_nodes.node_library.library_declarations import (
+            KeySupport,
+            Model,
+            ModelCatalogLibraryProperty,
+            ModelProvider,
+        )
+
+        return ModelCatalogLibraryProperty(
+            providers={
+                "anthropic": ModelProvider(
+                    display_name="Anthropic",
+                    models={
+                        "claude-opus-4": Model(
+                            display_name="Opus", family="Claude 4", key_support=KeySupport.REQUIRES_CUSTOMER_KEY
+                        ),
+                        "claude-sonnet-4": Model(
+                            display_name="Sonnet", family="Claude 4", key_support=KeySupport.REQUIRES_CUSTOMER_KEY
+                        ),
+                    },
+                )
+            }
+        )
+
     @staticmethod
     def _schema_with_node(node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN205
         from griptape_nodes.node_library.library_registry import (

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1034,6 +1034,7 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         # Mock GriptapeNodes.ContextManager()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
@@ -1086,6 +1087,7 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
@@ -1154,6 +1156,7 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
@@ -1206,6 +1209,7 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
             mock_gn.ContextManager.return_value = mock_context
@@ -1256,6 +1260,7 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
             mock_gn.ContextManager.return_value = mock_context
@@ -1318,6 +1323,7 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
 
         # Mock GriptapeNodes - workflow_name will fail because no workflow
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = str(project_base)
             mock_config.workspace_path = project_base
@@ -1435,6 +1441,51 @@ situations:
 
         assert pm._current_project_id == str(workspace_project_path)
         assert str(workspace_project_path) in pm._successfully_loaded_project_templates
+
+    @pytest.mark.asyncio
+    async def test_load_project_denied_by_policy_is_not_cached(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A LoadProject denial blocks the load: the project is not cached as usable."""
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+            CheckpointFailure,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import WORKSPACE_PROJECT_FILE
+
+        self._setup_system_defaults(pm, str(tmp_path))
+        project_path = tmp_path / WORKSPACE_PROJECT_FILE
+        project_path.write_text(self.VALID_PROJECT_YAML)
+
+        seen: dict[str, object] = {}
+
+        def deny(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            # Gate only the load; resolved facts (id + name) must be present even
+            # though the project is not cached yet.
+            if checkpoint.action == "LoadProject":
+                seen["subject_id"] = checkpoint.subject_id
+                seen["name"] = checkpoint.attributes.get("name")
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Ask your admin to grant this project."),))
+            return None
+
+        event_manager = GriptapeNodes.EventManager()
+        event_manager.add_authorization_hook(deny)
+        try:
+            with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
+                mock_file_instance = Mock()
+                mock_file_instance.aread_text = AsyncMock(return_value=self.VALID_PROJECT_YAML)
+                mock_file_cls.return_value = mock_file_instance
+                result = await pm._load_and_cache_project_template(project_path, persist_path=False)
+        finally:
+            event_manager.remove_authorization_hook(deny)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert "Ask your admin to grant this project." in str(result.result_details)
+        # The denied project is never cached as usable.
+        assert str(project_path) not in pm._successfully_loaded_project_templates
+        # The gate resolved the project's name from the in-hand template, not the cache.
+        assert seen["name"] == "Workspace Project"
 
     @pytest.mark.asyncio
     async def test_load_workspace_project_merges_with_defaults(self, pm: ProjectManager, tmp_path: Path) -> None:
@@ -2477,6 +2528,7 @@ class TestRegisterProjectPath:
         project_id = "/path/to/project.yml"
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = [project_id]
             mock_gn.ConfigManager.return_value = mock_config
@@ -2488,6 +2540,7 @@ class TestRegisterProjectPath:
     def test_register_exception_is_swallowed(self, pm: ProjectManager) -> None:
         """A config manager exception does not propagate out of _register_project_path."""
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.side_effect = RuntimeError("config failure")
             mock_gn.ConfigManager.return_value = mock_config
@@ -2524,6 +2577,7 @@ situations:
     async def test_empty_list_does_nothing(self, pm: ProjectManager) -> None:
         """An empty projects_to_register list results in no load attempts."""
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = []
             mock_gn.ConfigManager.return_value = mock_config
@@ -2536,6 +2590,7 @@ situations:
     async def test_none_config_return_does_nothing(self, pm: ProjectManager) -> None:
         """None from config (treated as empty via 'or []') results in no load attempts."""
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = None
             mock_gn.ConfigManager.return_value = mock_config
@@ -2567,6 +2622,7 @@ situations:
         pm._successfully_loaded_project_templates[existing_path] = project_info
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = [existing_path]
             mock_gn.ConfigManager.return_value = mock_config
@@ -2592,6 +2648,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=yaml_content,
@@ -2633,6 +2690,7 @@ situations:
             patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn,
             patch.object(pm, "_register_project_path") as mock_register,
         ):
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=yaml_content,
@@ -2726,6 +2784,7 @@ situations:
         cast("Mock", pm._config_manager).workspace_path = tmp_path
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=yaml_content,
@@ -2906,6 +2965,7 @@ situations:
         absolute_path = (tmp_path / "project.yml").resolve()
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
@@ -2970,6 +3030,7 @@ situations:
         tilde_path = Path("~/project.yml")
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
@@ -3231,6 +3292,7 @@ class TestProjectEnvironmentVariableRecursion:
 
         pm = self._make_pm_with_template(environment={"WF": "{workflow_name}_suffix"})
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
             mock_gn.ContextManager.return_value = mock_context
@@ -3250,6 +3312,7 @@ class TestProjectEnvironmentVariableRecursion:
             directories={"inputs": "{workflow_dir?:/}inputs"},
         )
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
             mock_gn.ContextManager.return_value = mock_context
@@ -3269,6 +3332,7 @@ class TestProjectEnvironmentVariableRecursion:
             directories={"inputs": "{workflow_dir}/inputs"},
         )
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
             mock_gn.ContextManager.return_value = mock_context
@@ -3291,6 +3355,7 @@ class TestProjectEnvironmentVariableRecursion:
             patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn,
             patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry") as mock_registry,
         ):
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = True
             mock_context.get_current_workflow_name.return_value = "my_workflow"
@@ -3313,6 +3378,7 @@ class TestProjectEnvironmentVariableRecursion:
 
         pm = self._make_pm_with_template(environment={"WF": "{workflow_dir?:/}sub"})
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
             mock_gn.ContextManager.return_value = mock_context
@@ -3718,6 +3784,7 @@ directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.replace('parent_project_path: "{parent}"\n', "").format(),
         }
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -3743,6 +3810,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -3774,6 +3842,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=grandchild_path))
 
@@ -3802,6 +3871,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -3820,6 +3890,7 @@ directories:
         files = {self_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=self_path.as_posix())}
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=self_path))
 
@@ -3842,6 +3913,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=a_path))
 
@@ -3861,6 +3933,7 @@ directories:
         files = {child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=missing_parent.as_posix())}
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -3897,6 +3970,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -3933,6 +4007,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             base_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=base_path))
             child_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
@@ -3971,6 +4046,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=base_path))
             child_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
@@ -4000,6 +4076,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -4050,6 +4127,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=grandchild_path))
 
@@ -4100,6 +4178,7 @@ file_extension_directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -4129,6 +4208,7 @@ file_extension_directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             a_result = await pm.on_load_project_template_request(
                 LoadProjectTemplateRequest(project_path=sibling_a_path)
@@ -4161,6 +4241,7 @@ file_extension_directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=a_path))
 
@@ -4183,6 +4264,7 @@ file_extension_directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=a_path))
 
@@ -4268,6 +4350,7 @@ directories:
 
         files = {parent_path: parent_yaml}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=parent_path))
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -4582,6 +4665,7 @@ parent_project_path: "{grandparent_path.as_posix()}"
             parent_path: parent_yaml,
         }
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             gp_load = await pm.on_load_project_template_request(
                 LoadProjectTemplateRequest(project_path=grandparent_path)
@@ -4803,6 +4887,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
@@ -4841,6 +4926,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
@@ -4938,6 +5024,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
@@ -5032,6 +5119,7 @@ directories:
         }
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -5064,6 +5152,7 @@ directories:
         files = {child_path: child_yaml}
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -5097,6 +5186,7 @@ directories:
         files = {base_path: self.BASE_PROJECT_YAML, child_path: child_yaml}
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -5128,6 +5218,7 @@ directories:
         files = {base_path: self.BASE_PROJECT_YAML, child_path: child_yaml}
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -5489,6 +5580,7 @@ parent_project_id: "ghost-parent-id"
         project_path = (tmp_path / "explicit.yml").resolve()
         files = {project_path: self.EXPLICIT_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
 
@@ -5514,6 +5606,7 @@ parent_project_id: "ghost-parent-id"
         project_path = (tmp_path / "legacy.yml").resolve()
         files = {project_path: self.LEGACY_NO_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
 
@@ -5534,6 +5627,7 @@ parent_project_id: "ghost-parent-id"
         path_b = (tmp_path / "b.yml").resolve()
         files = {path_a: self.EXPLICIT_ID_YAML, path_b: self.EXPLICIT_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             first = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=path_a))
             second = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=path_b))
@@ -5558,6 +5652,7 @@ parent_project_id: "ghost-parent-id"
         project_path = (tmp_path / "explicit.yml").resolve()
         files = {project_path: self.EXPLICIT_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             first = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
             second = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
@@ -5732,6 +5827,7 @@ parent_project_id: "ghost-parent-id"
         project_path = (tmp_path / "explicit.yml").resolve()
         files = {project_path: self.EXPLICIT_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
         assert isinstance(load, LoadProjectTemplateResultSuccess)
@@ -5768,6 +5864,7 @@ parent_project_id: "ghost-parent-id"
         child_path = (tmp_path / "child.yml").resolve()
         files = {parent_path: self.PARENT_WITH_ID_YAML, child_path: self.CHILD_BY_PARENT_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             parent = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=parent_path))
             child = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
@@ -5793,6 +5890,7 @@ parent_project_id: "ghost-parent-id"
         child_path = (tmp_path / "orphan.yml").resolve()
         files = {child_path: self.CHILD_MISSING_PARENT_ID_YAML}
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -5818,6 +5916,7 @@ parent_project_id: "ghost-parent-id"
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = self._file_router(files)
             await pm._load_registered_projects()
 

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -2147,6 +2147,7 @@ class TestProjectManagerProjectWorkspaces:
         )
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
             mock_gn.WorkflowManager.return_value = Mock()
 
@@ -2192,6 +2193,7 @@ class TestProjectManagerProjectWorkspaces:
         pm._initialization_complete = True
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock()
             await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(unknown_file)))
 
@@ -2219,6 +2221,7 @@ class TestProjectManagerProjectWorkspaces:
         from griptape_nodes.retained_mode.events.project_events import SetCurrentProjectRequest
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock()
             await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(project_file)))
             mock_gn.ahandle_request.assert_not_called()
@@ -2251,6 +2254,7 @@ class TestProjectManagerProjectWorkspaces:
 
         mock_workflow_manager = Mock()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
             mock_gn.WorkflowManager.return_value = mock_workflow_manager
 
@@ -2292,6 +2296,7 @@ class TestProjectManagerProjectWorkspaces:
 
         mock_workflow_manager = Mock()
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
             mock_gn.WorkflowManager.return_value = mock_workflow_manager
 
@@ -2336,6 +2341,7 @@ class TestProjectManagerProjectWorkspaces:
         )
 
         with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
+            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
             mock_gn.ahandle_request = AsyncMock(
                 return_value=ReloadAllLibrariesResultFailure(result_details="reload failed")
             )
@@ -5822,3 +5828,58 @@ parent_project_id: "ghost-parent-id"
         assert "shared_outputs" in child_info.template.directories
         # The transient boot index is cleared once loading finishes.
         assert pm._boot_id_to_file_path == {}
+
+
+class TestProjectActivationAuthorizationCheckpoint:
+    """The license-policy checkpoint wired into project activation."""
+
+    @pytest.fixture
+    def project_manager(self) -> ProjectManager:
+        return ProjectManager(Mock(), Mock(), Mock())
+
+    @pytest.mark.asyncio
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    async def test_denied_activation_is_rejected_and_leaves_current_project(
+        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
+    ) -> None:
+        from griptape_nodes.retained_mode.events.project_events import (
+            SetCurrentProjectRequest,
+            SetCurrentProjectResultFailure,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint.return_value = CheckpointDenial(
+            failures=(CheckpointFailure(detail="Ask your admin to grant access to acme-prod."),)
+        )
+        # A denying activation must roll nowhere: _activate_project never runs.
+        activate = AsyncMock()
+        with patch.object(project_manager, "_activate_project", new=activate):
+            result = await project_manager.on_set_current_project_request(
+                SetCurrentProjectRequest(project_id="acme-prod")
+            )
+
+        assert isinstance(result, SetCurrentProjectResultFailure)
+        assert "acme-prod" in str(result.result_details)
+        assert "Ask your admin to grant access to acme-prod." in str(result.result_details)
+        assert project_manager._current_project_id == SYSTEM_DEFAULTS_KEY
+        activate.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    async def test_system_defaults_bypasses_checkpoint(
+        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
+    ) -> None:
+        from griptape_nodes.retained_mode.events.project_events import (
+            SetCurrentProjectRequest,
+            SetCurrentProjectResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import _ProjectActivationOutcome
+
+        outcome = _ProjectActivationOutcome(failure=None, workspace_changed=False)
+        with patch.object(project_manager, "_activate_project", new=AsyncMock(return_value=outcome)):
+            result = await project_manager.on_set_current_project_request(SetCurrentProjectRequest(project_id=None))
+
+        assert isinstance(result, SetCurrentProjectResultSuccess)
+        # The rest state is always allowed; the checkpoint is never consulted.
+        mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint.assert_not_called()

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -5867,6 +5867,33 @@ class TestProjectActivationAuthorizationCheckpoint:
 
     @pytest.mark.asyncio
     @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
+    async def test_empty_failure_denial_still_yields_a_reason(
+        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
+    ) -> None:
+        # A hook that misuses the contract by returning a denial with no failures
+        # (it should return None to allow) must still produce a reason, not an
+        # empty "Failed because: " tail.
+        from griptape_nodes.retained_mode.events.project_events import (
+            SetCurrentProjectRequest,
+            SetCurrentProjectResultFailure,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+
+        mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint.return_value = CheckpointDenial(
+            failures=()
+        )
+        activate = AsyncMock()
+        with patch.object(project_manager, "_activate_project", new=activate):
+            result = await project_manager.on_set_current_project_request(
+                SetCurrentProjectRequest(project_id="acme-prod")
+            )
+
+        assert isinstance(result, SetCurrentProjectResultFailure)
+        assert "Denied by the license policy." in str(result.result_details)
+        activate.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     async def test_system_defaults_bypasses_checkpoint(
         self, mock_griptape_nodes: Mock, project_manager: ProjectManager
     ) -> None:


### PR DESCRIPTION
The engine cannot evaluate license permissions: it has no knowledge of the license, Cedar, or the app that wraps it, and the dependency only points from app to engine. So gating a privileged operation cannot mean calling into the app. This adds the inverse: synchronous hook points the engine calls at the operations worth gating, which the app registers a handler for, the same inversion already used for the pre-dispatch request hook.

The facts these entitlements turn on (a library or node's lifecycle stage, a node's arbitrary-code flag, the provider/family/model a node binds to, the provider a model invocation routes to) live on the resolved domain object at those points, not in any request payload, so request-level screening could never express them. `EventManager.evaluate_authorization_checkpoint` takes a Cedar-agnostic `AuthorizationCheckpoint` (the resolved subject plus the facts the engine owns) and returns a `CheckpointDenial` carrying every reason it was blocked, so a caller can surface all missing permissions at once. With no handler installed every checkpoint allows, so the engine still runs unrestricted on its own. The hook chain fails closed (a handler that raises becomes a denial) and is guarded against unbounded re-entry.

Five checkpoints are wired in. `LoadLibrary` gates loading a library past its metadata stage; a denial becomes a fitness problem and marks the library unusable. `InstantiateNode` gates node instantiation and is evaluated twice: once as a preview while a library loads, so a denied node type surfaces as a library problem up front while the library stays usable for its permitted nodes, and again when the node is actually created, where a denial flows into the existing Error Proxy substitution. That checkpoint carries the node's effective lifecycle stage, its arbitrary-code flag, and the provider/family/model handles it binds to, resolved from the library's model catalog, so a model-specific node is gated by the same hook. `LoadProject` gates project load/discovery (a denied project is never cached as usable) and `ActivateProject` gates activation (a denial leaves the current project untouched). `InvokeModel` gates a declared model invocation; a denial returns a failure so the node does not invoke.

This is the engine half of a cross-repo change; a companion app layer evaluates the Cedar policy and the manage UI authors it. The app maps each checkpoint onto a Cedar request: `action` becomes `Action::"<action>"`, `subject_type` and `subject_id` become the resource (so `resource.id` equals `subject_id`), and the checkpoint attributes become resource attributes. Optional attributes are guarded with `has`, and under Cedar's default-deny a `forbid` overrides any `permit`. The principal, entity types, and the model provider/family hierarchy walked by `in` are app-side. Each denial's user-facing reason is the determining `forbid`'s `@advice`, and the entitlement it lacks is its `@capability`; the engine carries both on `CheckpointFailure` (rendering `@advice` as the message today, with `@capability` reserved for a richer UI).

## End-to-end verification

Exercised against the local app permission layer (which installs `authorize_checkpoint` as the engine hook) and the standard library, which declares a library `lifecycle_stage`, a LABS node (`BoolInput`), an arbitrary-code node (`ExecutePython`), and the existing `model_catalog` / `model_usage` bindings (`Agent`, `GriptapeCloudPrompt`, `gtc_*`), so every checkpoint has a concrete target. Each block is the entitlement's applied policy plus its result; each is applied alongside a catch-all `permit(principal, action, resource);` because Cedar is default-deny. Every `forbid` carries `@capability` (the entitlement lacked) and `@advice` (the message surfaced on denial). Paste evidence under each Result.

### 1. Can use library X (`LoadLibrary`)

```cedar
@capability("library:griptape-nodes")
@advice("Ask your admin to enable the Griptape Nodes library.")
forbid(principal, action == Action::"LoadLibrary", resource == Library::"Griptape Nodes Library");
```

Expected: library marked unusable, a permission fitness problem carrying the advice, nodes unavailable.

Result:
```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ X - Griptape Nodes Library v0.79.0 (UNUSABLE)                                                              │ This library is not permitted by your license:                                                             ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - Ask your admin to enable the Griptape Nodes library.                                                     ┃ │
│ ┃ des_library.json                                                                                           │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - RunwayML Library v0.1.2 (GOOD)                                                                        │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │                                                                                                            ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### 2. Library at lifecycle X (`LoadLibrary`)

```cedar
@capability("library-lifecycle:stable")
@advice("Ask your admin to enable libraries at this lifecycle stage.")
forbid(principal, action == Action::"LoadLibrary", resource)
  when { resource has lifecycle_stage && resource.lifecycle_stage == "STABLE" };
```

Expected: same as #1, keyed on the library's declared stage.

Result:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ X - Griptape Nodes Library v0.79.0 (UNUSABLE)                                                              │ This library is not permitted by your license:                                                             ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - Ask your admin to enable libraries at this lifecycle stage.                                              ┃ │
│ ┃ des_library.json                                                                                           │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - RunwayML Library v0.1.2 (GOOD)                                                                        │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │                                                                                                            ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### 3. Node at lifecycle X (`InstantiateNode`)

```cedar
@capability("node-lifecycle:labs")
@advice("Ask your admin to enable Labs nodes.")
forbid(principal, action == Action::"InstantiateNode", resource)
  when { resource has lifecycle_stage && resource.lifecycle_stage == "LABS" };
```

Target `BoolInput`. Expected: surfaced as a library problem at load; Error Proxy carrying the advice on instantiate.

Result:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ ! - Griptape Nodes Library v0.79.0 (FLAWED)                                                                │ Some nodes are not permitted by your license:                                                              ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - BoolInput: Ask your admin to enable Labs nodes.                                                          ┃ │
│ ┃ des_library.json                                                                                           │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ ! - RunwayML Library v0.1.2 (FLAWED)                                                                       │ Some nodes are not permitted by your license:                                                              ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │ - RunwayML_ActTwo: Ask your admin to enable Labs nodes.                                                    ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │ - RunwayML_ImageToVideo: Ask your admin to enable Labs nodes.                                              ┃ │
│ ┃                                                                                                            │ - RunwayML_VideoToVideo: Ask your admin to enable Labs nodes.                                              ┃ │
│ ┃                                                                                                            │ - RunwayML_CreateReferenceImage: Ask your admin to enable Labs nodes.                                      ┃ │
│ ┃                                                                                                            │ - RunwayML_TextToImage: Ask your admin to enable Labs nodes.                                               ┃ │
│ ┃                                                                                                            │ - RunwayML_VideoUpscale: Ask your admin to enable Labs nodes.                                              ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

<img width="723" height="629" alt="image" src="https://github.com/user-attachments/assets/8dcba708-941a-43f1-8d15-5e5809f059fa" />


### 4. Nodes that run arbitrary Python (`InstantiateNode`)

```cedar
@capability("arbitrary-code-execution")
@advice("Ask your admin to enable nodes that run arbitrary code.")
forbid(principal, action == Action::"InstantiateNode", resource)
  when { resource.executes_arbitrary_code };
```

Target `ExecutePython`. Expected: library problem at load; Error Proxy carrying the advice on instantiate.

Result:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ ! - Griptape Nodes Library v0.79.0 (FLAWED)                                                                │ Some nodes are not permitted by your license:                                                              ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - ExecutePython: Ask your admin to enable nodes that run arbitrary code.                                   ┃ │
│ ┃ des_library.json                                                                                           │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - RunwayML Library v0.1.2 (GOOD)                                                                        │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │                                                                                                            ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
<img width="672" height="517" alt="image" src="https://github.com/user-attachments/assets/f8135966-6b06-4aa8-8549-b49457160b83" />


### 5. Model provider on a node (`InstantiateNode`)

```cedar
@capability("model-provider:griptape_cloud")
@advice("Ask your admin to enable Griptape Cloud models.")
forbid(principal, action == Action::"InstantiateNode", resource)
  when { resource has provider_ids && resource.provider_ids.contains("griptape_cloud") };
```

Targets `Agent`, `GriptapeCloudPrompt`, `gtc_*`. Expected: library problem at load; Error Proxy carrying the advice on instantiate.

Result:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ ! - Griptape Nodes Library v0.79.0 (FLAWED)                                                                │ Some nodes are not permitted by your license:                                                              ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - Agent: Ask your admin to enable Griptape Cloud models.                                                   ┃ │
│ ┃ des_library.json                                                                                           │ - TranscribeAudio: Ask your admin to enable Griptape Cloud models.                                         ┃ │
│ ┃                                                                                                            │ - ElevenLabsTextToSpeechGeneration: Ask your admin to enable Griptape Cloud models.                        ┃ │
│ ┃                                                                                                            │ - ElevenLabsSoundEffectGeneration: Ask your admin to enable Griptape Cloud models.                         ┃ │
│ ┃                                                                                                            │ - ElevenLabsMusicGeneration: Ask your admin to enable Griptape Cloud models.                               ┃ │
│ ┃                                                                                                            │ - SeedanceVideoGeneration: Ask your admin to enable Griptape Cloud models.                                 ┃ │
│ ┃                                                                                                            │ - Seedance20VideoGeneration: Ask your admin to enable Griptape Cloud models.                               ┃ │
│ ┃                                                                                                            │ - GrokVideoGeneration: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - GrokVideoEdit: Ask your admin to enable Griptape Cloud models.                                           ┃ │
│ ┃                                                                                                            │ - OmnihumanSubjectRecognition: Ask your admin to enable Griptape Cloud models.                             ┃ │
│ ┃                                                                                                            │ - OmnihumanSubjectDetection: Ask your admin to enable Griptape Cloud models.                               ┃ │
│ ┃                                                                                                            │ - OmnihumanVideoGeneration: Ask your admin to enable Griptape Cloud models.                                ┃ │
│ ┃                                                                                                            │ - MinimaxHailuoVideoGeneration: Ask your admin to enable Griptape Cloud models.                            ┃ │
│ ┃                                                                                                            │ - KlingTextToVideoGeneration: Ask your admin to enable Griptape Cloud models.                              ┃ │
│ ┃                                                                                                            │ - KlingImageToVideoGeneration: Ask your admin to enable Griptape Cloud models.                             ┃ │
│ ┃                                                                                                            │ - LTXTextToVideoGeneration: Ask your admin to enable Griptape Cloud models.                                ┃ │
│ ┃                                                                                                            │ - LTXImageToVideoGeneration: Ask your admin to enable Griptape Cloud models.                               ┃ │
│ ┃                                                                                                            │ - LTXAudioToVideoGeneration: Ask your admin to enable Griptape Cloud models.                               ┃ │
│ ┃                                                                                                            │ - LTXVideoRetake: Ask your admin to enable Griptape Cloud models.                                          ┃ │
│ ┃                                                                                                            │ - LTXVideoExtend: Ask your admin to enable Griptape Cloud models.                                          ┃ │
│ ┃                                                                                                            │ - LTXVideoToVideoHDR: Ask your admin to enable Griptape Cloud models.                                      ┃ │
│ ┃                                                                                                            │ - KlingVideoExtension: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - KlingOmniVideoGeneration: Ask your admin to enable Griptape Cloud models.                                ┃ │
│ ┃                                                                                                            │ - KlingMotionControl: Ask your admin to enable Griptape Cloud models.                                      ┃ │
│ ┃                                                                                                            │ - SoraVideoGeneration: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - WanTextToVideoGeneration: Ask your admin to enable Griptape Cloud models.                                ┃ │
│ ┃                                                                                                            │ - Veo3VideoGeneration: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - WanImageToVideoGeneration: Ask your admin to enable Griptape Cloud models.                               ┃ │
│ ┃                                                                                                            │ - WanAnimateGeneration: Ask your admin to enable Griptape Cloud models.                                    ┃ │
│ ┃                                                                                                            │ - WanReferenceToVideoGeneration: Ask your admin to enable Griptape Cloud models.                           ┃ │
│ ┃                                                                                                            │ - GriptapeCloudPrompt: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - SeedreamImageGeneration: Ask your admin to enable Griptape Cloud models.                                 ┃ │
│ ┃                                                                                                            │ - GrokImageGeneration: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - GrokImageEdit: Ask your admin to enable Griptape Cloud models.                                           ┃ │
│ ┃                                                                                                            │ - FluxImageGeneration: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - Flux2ImageGeneration: Ask your admin to enable Griptape Cloud models.                                    ┃ │
│ ┃                                                                                                            │ - QwenImageGeneration: Ask your admin to enable Griptape Cloud models.                                     ┃ │
│ ┃                                                                                                            │ - QwenImageEdit: Ask your admin to enable Griptape Cloud models.                                           ┃ │
│ ┃                                                                                                            │ - WanImageGeneration: Ask your admin to enable Griptape Cloud models.                                      ┃ │
│ ┃                                                                                                            │ - GoogleImageGeneration: Ask your admin to enable Griptape Cloud models.                                   ┃ │
│ ┃                                                                                                            │ - OpenAiImageGeneration: Ask your admin to enable Griptape Cloud models.                                   ┃ │
│ ┃                                                                                                            │ - Rodin23DGeneration: Ask your admin to enable Griptape Cloud models.                                      ┃ │
│ ┃                                                                                                            │ - TripoTextTo3DGeneration: Ask your admin to enable Griptape Cloud models.                                 ┃ │
│ ┃                                                                                                            │ - TripoImageTo3DGeneration: Ask your admin to enable Griptape Cloud models.                                ┃ │
│ ┃                                                                                                            │ - WorldLabsWorldGeneration: Ask your admin to enable Griptape Cloud models.                                ┃ │
│ ┃                                                                                                            │ - TopazImageEnhance: Ask your admin to enable Griptape Cloud models.                                       ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - RunwayML Library v0.1.2 (GOOD)                                                                        │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │                                                                                                            ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

<img width="676" height="440" alt="image" src="https://github.com/user-attachments/assets/94ebce28-ce8f-4807-b7b2-f0e841ad85e1" />


### 6. Model family on a node (`InstantiateNode`)

```cedar
@capability("model-family:openai-via-griptape-cloud")
@advice("Ask your admin to enable OpenAI (via Griptape Cloud) models.")
forbid(principal, action == Action::"InstantiateNode", resource)
  when { resource has model_families && resource.model_families.contains("OpenAI (via Griptape Cloud)") };
```

Expected: same surface for any node binding that family.

Result:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ ! - Griptape Nodes Library v0.79.0 (FLAWED)                                                                │ Some nodes are not permitted by your license:                                                              ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - Agent: Ask your admin to enable OpenAI (via Griptape Cloud) models.                                      ┃ │
│ ┃ des_library.json                                                                                           │ - GriptapeCloudPrompt: Ask your admin to enable OpenAI (via Griptape Cloud) models.                        ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - RunwayML Library v0.1.2 (GOOD)                                                                        │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │                                                                                                            ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

<img width="1065" height="602" alt="image" src="https://github.com/user-attachments/assets/b6e5b9b0-9b5f-4c59-9749-1353a009726b" />


### 7. Specific model on a node (`InstantiateNode`)

```cedar
@capability("model:gtc_gpt_4o")
@advice("Ask your admin to enable GPT-4o (via Griptape Cloud).")
forbid(principal, action == Action::"InstantiateNode", resource)
  when { resource has model_ids && resource.model_ids.contains("gtc_gpt_4o") };
```

Expected: same surface for any node binding that model.

Result:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────── Library Information ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Library                                                                                                    │ Problems                                                                                                   ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ ! - Griptape Nodes Library v0.79.0 (FLAWED)                                                                │ Some nodes are not permitted by your license:                                                              ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-standard/griptape_no │ - Agent: Ask your admin to enable GPT-4o (via Griptape Cloud).                                             ┃ │
│ ┃ des_library.json                                                                                           │ - GriptapeCloudPrompt: Ask your admin to enable GPT-4o (via Griptape Cloud).                               ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - RunwayML Library v0.1.2 (GOOD)                                                                        │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-runwayml/runwayml/gr │                                                                                                            ┃ │
│ ┃ iptape_nodes_library.json                                                                                  │                                                                                                            ┃ │
│ ┠────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────┨ │
│ ┃ OK - Black Forest Labs Library v0.2.1 (GOOD)                                                               │ No problems detected.                                                                                      ┃ │
│ ┃ /Users/collindutter/Projects/griptape/griptape-nodes-libraries/griptape-nodes-library-blackforestlabs/grip │                                                                                                            ┃ │
│ ┃ tape_nodes_library_blackforestlabs/griptape_nodes_library.json                                             │                                                                                                            ┃ │
│ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛ │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
<img width="730" height="505" alt="image" src="https://github.com/user-attachments/assets/e38cd7ab-7d53-40d1-b3fb-4046fee942a1" />


### 8. Can use Project X (`LoadProject` / `ActivateProject`)

```cedar
@capability("project:<your project name>")
@advice("Ask your admin to grant access to this project.")
forbid(principal, action in [Action::"LoadProject", Action::"ActivateProject"], resource)
  when { resource has name && resource.name == "<your project name>" };
```

Expected: load/activate rejected with the advice; current project untouched.

Result:
```
           WARNING  Failed to load registered project '/Users/collindutter/Projects/griptape/griptape-nodes/GriptapeNodes/griptape-nodes-project.yml' on startup: Attempted to load project template from
                    '/Users/collindutter/Projects/griptape/griptape-nodes/GriptapeNodes/griptape-nodes-project.yml'. Failed because: Ask your admin to grant access to this project.
```
<img width="507" height="381" alt="image" src="https://github.com/user-attachments/assets/06abe21e-a3a6-49d0-9d49-65be84110a1d" />


### 9. Model invocation (`InvokeModel`)

```cedar
@capability("model-invocation")
@advice("Ask your admin to enable model invocation.")
forbid(principal, action == Action::"InvokeModel", resource);
```

Run a proxy generation node. Expected: invocation blocked; the node returns a failure carrying the advice instead of calling the model.

Result:
<img width="657" height="790" alt="image" src="https://github.com/user-attachments/assets/dd9a08f5-0a19-4e94-abc7-9cedb8ae3d67" />

