### PR TITLE
fix(init): handle object-form library entries when filtering old XDG paths

### DIFF
--- a/src/griptape_nodes/utils/library_utils.py
+++ b/src/griptape_nodes/utils/library_utils.py
@@ -77,8 +77,8 @@ def clone_and_get_library_version(remote_url: str, ref: str = "HEAD") -> Library
     return LibraryVersionInfo(library_version=library_version, commit_sha=commit_sha, engine_version=engine_version)
 
 
-def filter_old_xdg_library_paths(library_paths: list[str]) -> tuple[list[str], set[str]]:
-    """Filter out old XDG library paths from a list of library paths.
+def filter_old_xdg_library_paths(library_paths: list[Any]) -> tuple[list[Any], set[str]]:
+    """Filter out old XDG library paths from a list of library entries.
 
     Removes library paths that were stored in the deprecated XDG data home location
     (~/.local/share/griptape_nodes/libraries/) for the following libraries:
@@ -86,8 +86,12 @@ def filter_old_xdg_library_paths(library_paths: list[str]) -> tuple[list[str], s
     - griptape_nodes_advanced_media_library
     - griptape_cloud
 
+    Entries may be bare path strings or object-form entries (dicts or LibraryRegistration
+    instances) carrying a `path`. The path is extracted for comparison while the original
+    entry is preserved in the filtered output.
+
     Args:
-        library_paths: List of library paths to filter.
+        library_paths: List of library entries to filter.
 
     Returns:
         Tuple of (filtered_list, set of removed library names).
@@ -111,8 +115,10 @@ def filter_old_xdg_library_paths(library_paths: list[str]) -> tuple[list[str], s
 
     for library in library_paths:
         is_old_path = False
-        # Normalize library path for cross-platform comparison
-        normalized_library = str(Path(library))
+        # Extract the path string from string or object-form entries, then normalize
+        # for cross-platform comparison.
+        library_path = extract_library_path(library)
+        normalized_library = str(Path(library_path)) if library_path else ""
 
         for lib_name, prefix in old_path_prefixes.items():
             if normalized_library.startswith(prefix):

--- a/tests/unit/utils/test_library_utils.py
+++ b/tests/unit/utils/test_library_utils.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from griptape_nodes.retained_mode.managers.settings import LibraryDownload
+from griptape_nodes.retained_mode.managers.settings import LibraryDownload, LibraryRegistration
 from griptape_nodes.utils.git_utils import GitCloneError
 from griptape_nodes.utils.library_utils import (
     clone_and_get_library_version,
@@ -213,6 +213,55 @@ class TestFilterOldXdgLibraryPaths:
 
             assert filtered == [custom_path, git_url]
             assert removed == {"griptape_nodes_library"}
+
+    def test_filter_handles_object_form_dict_entries(self) -> None:
+        """Object-form dict entries are filtered by their `path` and preserved otherwise."""
+        with patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg:
+            mock_xdg.return_value = Path("/home/user/.local/share")
+
+            xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
+            old_entry = {"path": f"{xdg_base}/griptape_cloud/lib.json", "enabled": True}
+            custom_entry = {"path": "/custom/path/lib.json", "enabled": False}
+
+            paths = [old_entry, custom_entry]
+
+            filtered, removed = filter_old_xdg_library_paths(paths)
+
+            assert filtered == [custom_entry]
+            assert removed == {"griptape_cloud"}
+
+    def test_filter_handles_library_registration_entries(self) -> None:
+        """Already parsed LibraryRegistration entries are filtered by their `path`."""
+        with patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg:
+            mock_xdg.return_value = Path("/home/user/.local/share")
+
+            xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
+            old_entry = LibraryRegistration(path=f"{xdg_base}/griptape_nodes_library/lib.json")
+            custom_entry = LibraryRegistration(path="/custom/path/lib.json")
+
+            paths = [old_entry, custom_entry]
+
+            filtered, removed = filter_old_xdg_library_paths(paths)
+
+            assert filtered == [custom_entry]
+            assert removed == {"griptape_nodes_library"}
+
+    def test_filter_mixed_string_and_object_entries(self) -> None:
+        """A mix of bare strings and object-form entries is handled without error."""
+        with patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg:
+            mock_xdg.return_value = Path("/home/user/.local/share")
+
+            xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
+            old_string = f"{xdg_base}/griptape_nodes_advanced_media_library/lib.json"
+            old_dict = {"path": f"{xdg_base}/griptape_cloud/lib.json"}
+            custom_string = "/custom/path"
+
+            paths = [old_string, old_dict, custom_string]
+
+            filtered, removed = filter_old_xdg_library_paths(paths)
+
+            assert filtered == [custom_string]
+            assert removed == {"griptape_nodes_advanced_media_library", "griptape_cloud"}
 
 
 class TestNormalizeLibraryDownloads:


### PR DESCRIPTION
A fresh Griptape Nodes Desktop install failed to initialize when importing an existing config, crashing `gtn init` with `TypeError: argument should be a str or an os.PathLike object ... not 'dict'`.

`libraries_to_register` accepts both bare path strings and object-form entries matching the `LibraryRegistration` schema (e.g. `{"path": ..., "enabled": ...}`). `filter_old_xdg_library_paths` assumed every entry was a string and called `Path(library)` directly, so any user whose imported config contained an object-form entry could not get past initialization.

The function now extracts the path via the existing `extract_library_path` helper, which already understands strings, dicts, and `LibraryRegistration` instances, and preserves the original entry in the filtered output. Entries without a usable path are kept rather than silently dropped, since this filter's only job is removing deprecated XDG paths.