### PR TITLE
feat(hf-param): replace download badges with inline dropdown UX

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -4,7 +4,10 @@ from abc import ABC, abstractmethod
 
 from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.model_events import ListModelDownloadsRequest, ListModelDownloadsResultSuccess
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload, OnClickMessageResultPayload
 from griptape_nodes.traits.options import Options
 
@@ -14,25 +17,39 @@ _NO_MODELS_PLACEHOLDER = "No models downloaded — visit Model Manager"
 
 
 class HuggingFaceModelParameter(ABC):
+    """Mixin component that adds an inline model-selection dropdown to a node.
+
+    The dropdown shows all models — downloaded and not yet downloaded — with
+    per-row icons and subtitles ("Downloaded", "Downloading…", "Not downloaded").
+    A secondary button appears below the dropdown when the selected model needs
+    attention (not downloaded, or currently downloading) and navigates the user
+    to the Model Manager.
+
+    Subclasses implement fetch_repo_revisions(), get_download_commands(), and
+    get_download_models() to define which models appear in the list.
+    """
+
     @classmethod
     def _repo_revision_to_key(cls, repo_revision: tuple[str, str]) -> str:
         return f"{repo_revision[0]} ({repo_revision[1]})"
 
     @classmethod
     def _key_to_repo_revision(cls, key: str) -> tuple[str, str]:
-        # Check if key has hash format using regex
+        # Keys with multiple cached revisions embed a 40-char hash: "owner/repo (deadbeef…)"
         hash_pattern = r"^(.+) \(([a-f0-9]{40})\)$"
         match = re.match(hash_pattern, key)
         if match:
             return match.group(1), match.group(2)
 
-        # Key is just the model name (no hash)
         return key, ""
 
     def __init__(self, node: BaseNode, parameter_name: str):
         self._node = node
         self._parameter_name = parameter_name
-        self._repo_revisions = []
+        self._repo_revisions: list[tuple[str, str]] = []
+        # Cached at refresh time only — never fetched from inside a callback to
+        # avoid nested GriptapeNodes.handle_request() calls that cause recursion.
+        self._downloading_model_ids: set[str] = set()
 
     @property
     def _download_param_name(self) -> str:
@@ -48,6 +65,9 @@ class HuggingFaceModelParameter(ABC):
             )
             return
 
+        # Snapshot active downloads before rebuilding choices so the dropdown
+        # subtitles and button visibility reflect the current download state.
+        self._refresh_downloading_model_ids()
         choices = self.get_choices()
 
         if choices:
@@ -73,6 +93,10 @@ class HuggingFaceModelParameter(ABC):
         display_choices = choices or [_NO_MODELS_PLACEHOLDER]
         default_value = choices[0] if choices else _NO_MODELS_PLACEHOLDER
 
+        # Main model dropdown. The refresh button (list-restart) sits inline
+        # inside the dropdown row via the Button trait alongside Options.
+        # The converter fires on every value change so the download button
+        # visibility updates immediately when the user picks a different model.
         parameter = ParameterString(
             name=self._parameter_name,
             default_value=default_value,
@@ -88,6 +112,7 @@ class HuggingFaceModelParameter(ABC):
             },
             tooltip=self._parameter_name,
             allowed_modes={ParameterMode.PROPERTY},
+            converters=[self._on_selection_changed],
             accept_any=False,
         )
 
@@ -96,25 +121,20 @@ class HuggingFaceModelParameter(ABC):
 
         self._apply_data_choices(parameter)
 
-        download_button = ParameterString(
+        # Download button starts hidden; _update_download_button_visibility()
+        # shows it when the selected model is not downloaded or is downloading.
+        download_button = ParameterButton(
             name=self._download_param_name,
-            default_value="",
-            display_name="",
-            traits={
-                Button(
-                    label="Open Model Manager to Download",
-                    icon="download",
-                    variant="secondary",
-                    full_width=True,
-                    on_click=self._on_download_click,
-                ),
-            },
+            label="Open Model Manager to Download",
+            icon="download",
+            variant="secondary",
+            full_width=True,
+            on_click=self._on_download_click,
             tooltip="Open Model Manager to download the selected model",
+            hide=True,
             allowed_modes={ParameterMode.PROPERTY},
-            accept_any=False,
         )
         self._node.add_parameter(download_button)
-        self._node.hide_parameter_by_name(self._download_param_name)
 
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
@@ -123,6 +143,9 @@ class HuggingFaceModelParameter(ABC):
     def get_choices(self) -> list[str]:
         self._repo_revisions = self.fetch_repo_revisions()
 
+        # When the same repo has multiple cached revisions, show "repo (hash)"
+        # so the user can distinguish them. If there's only one, show just the
+        # repo ID for a cleaner display.
         model_counts: dict[str, int] = {}
         for repo_id, _ in self.list_repo_revisions():
             model_counts[repo_id] = model_counts.get(repo_id, 0) + 1
@@ -145,15 +168,31 @@ class HuggingFaceModelParameter(ABC):
         downloaded_repo_ids = {repo_id for repo_id, _ in self.list_repo_revisions()}
         return [m for m in self.get_download_models() if m not in downloaded_repo_ids]
 
+    def _refresh_downloading_model_ids(self) -> None:
+        # Only called from refresh_parameters() — never from inside a button
+        # callback — to avoid nested handle_request() calls that cause recursion.
+        result = GriptapeNodes.handle_request(ListModelDownloadsRequest())
+        if not isinstance(result, ListModelDownloadsResultSuccess):
+            self._downloading_model_ids = set()
+            return
+        self._downloading_model_ids = {s.model_id for s in result.downloads if s.status == "downloading"}
+
     def _build_data_choices(self) -> list[dict]:
         downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
         not_downloaded = set(self.get_not_downloaded_choices())
+        downloading = self._downloading_model_ids
         choices = self.get_choices()
 
         data = []
         for choice in choices:
             repo_id, _ = self._key_to_repo_revision(choice)
-            if repo_id in downloaded_keys or choice in downloaded_keys:
+            # Downloading check must come before downloaded: HuggingFace creates
+            # cache entries as soon as a download starts, so a partially-downloaded
+            # model appears in fetch_repo_revisions() and would otherwise show
+            # as "Downloaded" while still in progress.
+            if repo_id in downloading or choice in downloading:
+                data.append({"name": choice, "icon": "loader", "subtitle": "Downloading…"})
+            elif repo_id in downloaded_keys or choice in downloaded_keys:
                 data.append({"name": choice, "icon": "check-circle", "subtitle": "Downloaded"})
             elif choice in not_downloaded or repo_id in not_downloaded:
                 data.append({"name": choice, "icon": "download", "subtitle": "Not downloaded"})
@@ -174,12 +213,30 @@ class HuggingFaceModelParameter(ABC):
         repo_id, _ = self._key_to_repo_revision(choice)
         return repo_id
 
-    def _update_download_button_visibility(self) -> None:
+    def _on_selection_changed(self, value: object) -> object:
+        # Converter attached to the model parameter; fires on every value change
+        # so the download button shows/hides as the user switches models.
+        self._update_download_button_visibility(str(value))
+        return value
+
+    def _update_download_button_visibility(self, value: str | None = None) -> None:
         if self._node.get_parameter_by_name(self._download_param_name) is None:
             return
-        has_missing = bool(self.get_not_downloaded_choices())
-        if has_missing:
+        if value is None:
+            value = str(self._node.get_parameter_value(self._parameter_name) or "")
+
+        not_downloaded = set(self.get_not_downloaded_choices())
+        search_term = self._get_model_search_term(value)
+        is_downloading = search_term in self._downloading_model_ids
+        should_show = value in not_downloaded or is_downloading
+
+        if should_show:
             self._node.show_parameter_by_name(self._download_param_name)
+            # Update the button label to match context so the call-to-action
+            # makes sense whether the model is queued to download or already downloading.
+            download_param = self._node.get_parameter_by_name(self._download_param_name)
+            if isinstance(download_param, ParameterButton):
+                download_param.label = "View Download Progress" if is_downloading else "Open Model Manager to Download"
         else:
             self._node.hide_parameter_by_name(self._download_param_name)
 
@@ -224,12 +281,20 @@ class HuggingFaceModelParameter(ABC):
     ) -> NodeMessageResult | None:
         value = self._node.get_parameter_value(self._parameter_name)
         search_term = self._get_model_search_term(str(value))
+        # Use the cached downloading state — calling handle_request() here would
+        # create a nested request inside the button-click handler and cause recursion.
+        if search_term in self._downloading_model_ids:
+            # Already downloading: open the downloads view pre-filtered to this model.
+            href = f"#model-management?filter={search_term}"
+        else:
+            # Not yet downloaded: open model search so the user can start the download.
+            href = f"#model-management?search={search_term}"
         return NodeMessageResult(
             success=True,
             details="Opening Model Manager",
             response=OnClickMessageResultPayload(
                 button_details=button_details,
-                href=f"#model-management?search={search_term}",
+                href=href,
             ),
             altered_workflow_state=False,
         )

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -79,6 +79,7 @@ class HuggingFaceModelParameter(ABC):
                     size="icon",
                     variant="secondary",
                     on_click=self._on_refresh_click,
+                    get_button_state=self._get_button_state,
                 ),
             },
             tooltip=self._parameter_name,
@@ -178,20 +179,40 @@ class HuggingFaceModelParameter(ABC):
 
         return repo_id, revision
 
+    def _is_current_value_downloaded(self) -> bool:
+        value = self._node.get_parameter_value(self._parameter_name)
+        if value is None or value == _NO_MODELS_PLACEHOLDER:
+            return True
+        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
+        if value in downloaded_keys:
+            return True
+        repo_id, _ = self._key_to_repo_revision(str(value))
+        return repo_id in downloaded_keys
+
+    def _get_button_state(
+        self, _button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:
+        if self._is_current_value_downloaded():
+            return None
+        return NodeMessageResult(
+            success=True,
+            details="Button state retrieved",
+            response=ButtonDetailsMessagePayload(
+                label=button_details.label,
+                variant="destructive",
+                size=button_details.size,
+                state=button_details.state,
+                icon="download",
+                tooltip="Open Model Manager to download this model",
+            ),
+            altered_workflow_state=False,
+        )
+
     def _on_refresh_click(
         self, _button: Button, button_details: ButtonDetailsMessagePayload
     ) -> NodeMessageResult | None:
-        value = self._node.get_parameter_value(self._parameter_name)
-        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
-
-        is_downloaded = value in downloaded_keys
-        if not is_downloaded and value is not None:
-            repo_id, _ = self._key_to_repo_revision(str(value))
-            is_downloaded = repo_id in downloaded_keys
-
-        value_is_placeholder = value == _NO_MODELS_PLACEHOLDER or value is None
-
-        if not is_downloaded and not value_is_placeholder:
+        if not self._is_current_value_downloaded():
+            value = self._node.get_parameter_value(self._parameter_name)
             search_term = self._get_model_search_term(str(value))
             return NodeMessageResult(
                 success=True,

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -61,7 +61,7 @@ class HuggingFaceModelParameter(ABC):
 
         self._node.set_parameter_value(self._parameter_name, default_value)
 
-        parameter.update_ui_options_key("data", self._build_data_choices())
+        self._apply_data_choices(parameter)
         self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
@@ -91,7 +91,7 @@ class HuggingFaceModelParameter(ABC):
         self._node.add_parameter(parameter)
         self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
 
-        parameter.update_ui_options_key("data", self._build_data_choices())
+        self._apply_data_choices(parameter)
         self._update_download_button(default_value, parameter)
 
     def remove_input_parameters(self) -> None:
@@ -134,12 +134,21 @@ class HuggingFaceModelParameter(ABC):
         for choice in choices:
             repo_id, _ = self._key_to_repo_revision(choice)
             if repo_id in downloaded_keys or choice in downloaded_keys:
-                data.append({"name": choice, "args": {}, "icon": "check-circle", "subtitle": "Downloaded"})
+                data.append({"name": choice, "icon": "check-circle", "subtitle": "Downloaded"})
             elif choice in not_downloaded or repo_id in not_downloaded:
-                data.append({"name": choice, "args": {}, "icon": "download", "subtitle": "Not downloaded"})
+                data.append({"name": choice, "icon": "download", "subtitle": "Not downloaded"})
             else:
-                data.append({"name": choice, "args": {}})
+                data.append({"name": choice})
         return data
+
+    def _apply_data_choices(self, parameter: Parameter) -> None:
+        parameter.update_ui_options(
+            {
+                "data": self._build_data_choices(),
+                "dropdown_row_icons": True,
+                "dropdown_row_subtitles": True,
+            }
+        )
 
     def _get_model_search_term(self, choice: str) -> str:
         repo_id, _ = self._key_to_repo_revision(choice)

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -2,7 +2,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 
-from griptape_nodes.exe_types.core_types import BadgeData, NodeMessageResult, ParameterMode
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -10,7 +10,7 @@ from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
 
-_NO_MODELS_PLACEHOLDER = "No models downloaded — see badge"
+_NO_MODELS_PLACEHOLDER = "No models downloaded — visit Model Manager"
 
 
 class HuggingFaceModelParameter(ABC):
@@ -33,6 +33,7 @@ class HuggingFaceModelParameter(ABC):
         self._node = node
         self._parameter_name = parameter_name
         self._repo_revisions = []
+        self._download_button: Button | None = None
 
     def refresh_parameters(self) -> None:
         parameter = self._node.get_parameter_by_name(self._parameter_name)
@@ -60,21 +61,11 @@ class HuggingFaceModelParameter(ABC):
 
         self._node.set_parameter_value(self._parameter_name, default_value)
 
-        badge = self._build_model_badge()
-        if badge is None:
-            parameter.clear_badge()
-        else:
-            parameter.set_badge(
-                variant=badge.variant,
-                title=badge.title,
-                message=badge.message,
-                icon=badge.icon,
-                hide_clear_button=badge.hide_clear_button,
-            )
+        parameter.ui_options["data"] = self._build_data_choices()
+        self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
         choices = self.get_choices()
-        badge = self._build_model_badge()
 
         display_choices = choices or [_NO_MODELS_PLACEHOLDER]
         default_value = choices[0] if choices else _NO_MODELS_PLACEHOLDER
@@ -95,11 +86,13 @@ class HuggingFaceModelParameter(ABC):
             tooltip=self._parameter_name,
             allowed_modes={ParameterMode.PROPERTY},
             accept_any=False,
-            badge=badge,
         )
 
         self._node.add_parameter(parameter)
         self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
+
+        parameter.ui_options["data"] = self._build_data_choices()
+        self._update_download_button(default_value, parameter)
 
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
@@ -107,23 +100,50 @@ class HuggingFaceModelParameter(ABC):
     def get_choices(self) -> list[str]:
         # Ensure the latest repo revisions are fetched
         self._repo_revisions = self.fetch_repo_revisions()
-        # Count occurrences of each model name
-        model_counts = {}
+
+        # Count occurrences of each model name to detect duplicates
+        model_counts: dict[str, int] = {}
         for repo_id, _ in self.list_repo_revisions():
             model_counts[repo_id] = model_counts.get(repo_id, 0) + 1
 
-        # Generate choices with hash only when there are duplicates
-        choices = []
+        # Generate keys for downloaded models (hash only when there are duplicates)
+        downloaded_choices = []
         for repo_revision in self.list_repo_revisions():
             repo_id, _ = repo_revision
             if model_counts[repo_id] > 1:
-                # Multiple versions exist, show hash for disambiguation
-                choices.append(self._repo_revision_to_key(repo_revision))
+                downloaded_choices.append(self._repo_revision_to_key(repo_revision))
             else:
-                # Only one version, show just the model name
-                choices.append(repo_id)
-        logger.debug("Available choices for parameter '%s': %s", self._parameter_name, choices)
-        return choices
+                downloaded_choices.append(repo_id)
+
+        not_downloaded = self.get_not_downloaded_choices()
+
+        all_choices = downloaded_choices + not_downloaded
+        logger.debug("Available choices for parameter '%s': %s", self._parameter_name, all_choices)
+        return all_choices
+
+    def get_not_downloaded_choices(self) -> list[str]:
+        downloaded_repo_ids = {repo_id for repo_id, _ in self.list_repo_revisions()}
+        return [m for m in self.get_download_models() if m not in downloaded_repo_ids]
+
+    def _build_data_choices(self) -> list[dict]:
+        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
+        not_downloaded = set(self.get_not_downloaded_choices())
+        choices = self.get_choices()
+
+        data = []
+        for choice in choices:
+            repo_id, _ = self._key_to_repo_revision(choice)
+            if repo_id in downloaded_keys or choice in downloaded_keys:
+                data.append({"name": choice, "args": {}, "icon": "check-circle", "subtitle": "Downloaded"})
+            elif choice in not_downloaded or repo_id in not_downloaded:
+                data.append({"name": choice, "args": {}, "icon": "download", "subtitle": "Not downloaded"})
+            else:
+                data.append({"name": choice, "args": {}})
+        return data
+
+    def _get_model_search_term(self, choice: str) -> str:
+        repo_id, _ = self._key_to_repo_revision(choice)
+        return repo_id
 
     def validate_before_node_run(self) -> list[Exception] | None:
         self.refresh_parameters()
@@ -159,42 +179,47 @@ class HuggingFaceModelParameter(ABC):
         # If revision was provided, return it directly
         return repo_id, revision
 
+    def after_value_set(self, parameter: Parameter, value: object) -> None:
+        if parameter.name != self._parameter_name:
+            return
+        self._update_download_button(value, parameter)
+
+    def _update_download_button(self, value: object, parameter: Parameter) -> None:
+        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
+
+        # Determine if the selected value is a downloaded model
+        is_downloaded = value in downloaded_keys or str(value) in downloaded_keys
+        if not is_downloaded:
+            repo_id, _ = self._key_to_repo_revision(str(value)) if value else ("", "")
+            is_downloaded = repo_id in downloaded_keys
+
+        value_is_placeholder = value == _NO_MODELS_PLACEHOLDER or value is None
+
+        if not is_downloaded and not value_is_placeholder:
+            # Remove old button if present
+            if self._download_button is not None:
+                parameter.remove_trait(self._download_button)
+                self._download_button = None
+
+            search_term = self._get_model_search_term(str(value))
+            button = Button(
+                icon="download",
+                size="icon",
+                variant="secondary",
+                tooltip="Open in Model Manager to download",
+                button_link=f"#model-management?search={search_term}",
+            )
+            parameter.add_trait(button)
+            self._download_button = button
+        elif self._download_button is not None:
+            parameter.remove_trait(self._download_button)
+            self._download_button = None
+
     def _on_refresh_click(
         self, _button: Button, _button_details: ButtonDetailsMessagePayload
     ) -> NodeMessageResult | None:
         self.refresh_parameters()
         return None
-
-    def _build_model_badge(self) -> BadgeData | None:
-        download_models = self.get_download_models()
-        downloaded_repo_ids = {repo_id for repo_id, _ in self.list_repo_revisions()}
-
-        missing = [m for m in download_models if m not in downloaded_repo_ids]
-        if not missing:
-            return None
-
-        model_lines = []
-        for model in download_models:
-            hf_link = f"[↗](https://huggingface.co/{model})"
-            if model in downloaded_repo_ids:
-                model_lines.append(f"✓ {model} {hf_link}")
-            else:
-                model_lines.append(f"[↓ {model}](#model-management?search={model}) {hf_link}")
-
-        message = (
-            "Model download required to continue.\n\n"
-            "Click a model name below to open it in Model Management, then click the download button:\n\n"
-            + "\n\n".join(model_lines)
-            + "\n\nAfter downloading, a dropdown with available models will appear."
-        )
-
-        return BadgeData(
-            variant="warning",
-            title="Download Required",
-            message=message,
-            icon="hard-drive",
-            hide_clear_button=True,
-        )
 
     @abstractmethod
     def fetch_repo_revisions(self) -> list[tuple[str, str]]: ...

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -65,7 +65,7 @@ class HuggingFaceModelParameter(ABC):
         self._node.set_parameter_value(self._parameter_name, default_value)
 
         self._apply_data_choices(parameter)
-        self._update_download_button_visibility(default_value)
+        self._update_download_button_visibility()
 
     def add_input_parameters(self) -> None:
         choices = self.get_choices()
@@ -174,27 +174,14 @@ class HuggingFaceModelParameter(ABC):
         repo_id, _ = self._key_to_repo_revision(choice)
         return repo_id
 
-    def _is_value_downloaded(self, value: object) -> bool:
-        if value is None or value == _NO_MODELS_PLACEHOLDER:
-            return True
-        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
-        if value in downloaded_keys:
-            return True
-        repo_id, _ = self._key_to_repo_revision(str(value))
-        return repo_id in downloaded_keys
-
-    def _update_download_button_visibility(self, value: object) -> None:
+    def _update_download_button_visibility(self) -> None:
         if self._node.get_parameter_by_name(self._download_param_name) is None:
             return
-        if self._is_value_downloaded(value):
-            self._node.hide_parameter_by_name(self._download_param_name)
-        else:
+        has_missing = bool(self.get_not_downloaded_choices())
+        if has_missing:
             self._node.show_parameter_by_name(self._download_param_name)
-
-    def after_value_set(self, parameter: Parameter, value: object) -> None:
-        if parameter.name != self._parameter_name:
-            return
-        self._update_download_button_visibility(value)
+        else:
+            self._node.hide_parameter_by_name(self._download_param_name)
 
     def validate_before_node_run(self) -> list[Exception] | None:
         self.refresh_parameters()

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -61,7 +61,7 @@ class HuggingFaceModelParameter(ABC):
 
         self._node.set_parameter_value(self._parameter_name, default_value)
 
-        parameter.ui_options["data"] = self._build_data_choices()
+        parameter._ui_options["data"] = self._build_data_choices()
         self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
@@ -91,7 +91,7 @@ class HuggingFaceModelParameter(ABC):
         self._node.add_parameter(parameter)
         self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
 
-        parameter.ui_options["data"] = self._build_data_choices()
+        parameter._ui_options["data"] = self._build_data_choices()
         self._update_download_button(default_value, parameter)
 
     def remove_input_parameters(self) -> None:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -34,6 +34,10 @@ class HuggingFaceModelParameter(ABC):
         self._parameter_name = parameter_name
         self._repo_revisions = []
 
+    @property
+    def _download_param_name(self) -> str:
+        return f"{self._parameter_name}_download"
+
     def refresh_parameters(self) -> None:
         parameter = self._node.get_parameter_by_name(self._parameter_name)
         if parameter is None:
@@ -61,6 +65,7 @@ class HuggingFaceModelParameter(ABC):
         self._node.set_parameter_value(self._parameter_name, default_value)
 
         self._apply_data_choices(parameter)
+        self._update_download_button_visibility(default_value)
 
     def add_input_parameters(self) -> None:
         choices = self.get_choices()
@@ -79,7 +84,6 @@ class HuggingFaceModelParameter(ABC):
                     size="icon",
                     variant="secondary",
                     on_click=self._on_refresh_click,
-                    get_button_state=self._get_button_state,
                 ),
             },
             tooltip=self._parameter_name,
@@ -92,8 +96,29 @@ class HuggingFaceModelParameter(ABC):
 
         self._apply_data_choices(parameter)
 
+        download_button = ParameterString(
+            name=self._download_param_name,
+            default_value="",
+            display_name="",
+            traits={
+                Button(
+                    label="Open Model Manager to Download",
+                    icon="download",
+                    variant="secondary",
+                    full_width=True,
+                    on_click=self._on_download_click,
+                ),
+            },
+            tooltip="Open Model Manager to download the selected model",
+            allowed_modes={ParameterMode.PROPERTY},
+            accept_any=False,
+        )
+        self._node.add_parameter(download_button)
+        self._node.hide_parameter_by_name(self._download_param_name)
+
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
+        self._node.remove_parameter_element_by_name(self._download_param_name)
 
     def get_choices(self) -> list[str]:
         self._repo_revisions = self.fetch_repo_revisions()
@@ -149,6 +174,28 @@ class HuggingFaceModelParameter(ABC):
         repo_id, _ = self._key_to_repo_revision(choice)
         return repo_id
 
+    def _is_value_downloaded(self, value: object) -> bool:
+        if value is None or value == _NO_MODELS_PLACEHOLDER:
+            return True
+        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
+        if value in downloaded_keys:
+            return True
+        repo_id, _ = self._key_to_repo_revision(str(value))
+        return repo_id in downloaded_keys
+
+    def _update_download_button_visibility(self, value: object) -> None:
+        if self._node.get_parameter_by_name(self._download_param_name) is None:
+            return
+        if self._is_value_downloaded(value):
+            self._node.hide_parameter_by_name(self._download_param_name)
+        else:
+            self._node.show_parameter_by_name(self._download_param_name)
+
+    def after_value_set(self, parameter: Parameter, value: object) -> None:
+        if parameter.name != self._parameter_name:
+            return
+        self._update_download_button_visibility(value)
+
     def validate_before_node_run(self) -> list[Exception] | None:
         self.refresh_parameters()
         try:
@@ -179,53 +226,26 @@ class HuggingFaceModelParameter(ABC):
 
         return repo_id, revision
 
-    def _is_current_value_downloaded(self) -> bool:
-        value = self._node.get_parameter_value(self._parameter_name)
-        if value is None or value == _NO_MODELS_PLACEHOLDER:
-            return True
-        downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
-        if value in downloaded_keys:
-            return True
-        repo_id, _ = self._key_to_repo_revision(str(value))
-        return repo_id in downloaded_keys
+    def _on_refresh_click(
+        self, _button: Button, _button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:
+        self.refresh_parameters()
+        return None
 
-    def _get_button_state(
+    def _on_download_click(
         self, _button: Button, button_details: ButtonDetailsMessagePayload
     ) -> NodeMessageResult | None:
-        if self._is_current_value_downloaded():
-            return None
+        value = self._node.get_parameter_value(self._parameter_name)
+        search_term = self._get_model_search_term(str(value))
         return NodeMessageResult(
             success=True,
-            details="Button state retrieved",
-            response=ButtonDetailsMessagePayload(
-                label=button_details.label,
-                variant="destructive",
-                size=button_details.size,
-                state=button_details.state,
-                icon="download",
-                tooltip="Open Model Manager to download this model",
+            details="Opening Model Manager",
+            response=OnClickMessageResultPayload(
+                button_details=button_details,
+                href=f"#model-management?search={search_term}",
             ),
             altered_workflow_state=False,
         )
-
-    def _on_refresh_click(
-        self, _button: Button, button_details: ButtonDetailsMessagePayload
-    ) -> NodeMessageResult | None:
-        if not self._is_current_value_downloaded():
-            value = self._node.get_parameter_value(self._parameter_name)
-            search_term = self._get_model_search_term(str(value))
-            return NodeMessageResult(
-                success=True,
-                details="Opening Model Manager",
-                response=OnClickMessageResultPayload(
-                    button_details=button_details,
-                    href=f"#model-management?search={search_term}",
-                ),
-                altered_workflow_state=False,
-            )
-
-        self.refresh_parameters()
-        return None
 
     @abstractmethod
     def fetch_repo_revisions(self) -> list[tuple[str, str]]: ...

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -108,6 +108,7 @@ class HuggingFaceModelParameter(ABC):
                     size="icon",
                     variant="secondary",
                     on_click=self._on_refresh_click,
+                    tooltip="Refresh model list",
                 ),
             },
             tooltip=self._parameter_name,

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -61,7 +61,7 @@ class HuggingFaceModelParameter(ABC):
 
         self._node.set_parameter_value(self._parameter_name, default_value)
 
-        parameter._ui_options["data"] = self._build_data_choices()
+        parameter.update_ui_options_key("data", self._build_data_choices())
         self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
@@ -91,7 +91,7 @@ class HuggingFaceModelParameter(ABC):
         self._node.add_parameter(parameter)
         self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
 
-        parameter._ui_options["data"] = self._build_data_choices()
+        parameter.update_ui_options_key("data", self._build_data_choices())
         self._update_download_button(default_value, parameter)
 
     def remove_input_parameters(self) -> None:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -84,7 +84,7 @@ class HuggingFaceModelParameter(ABC):
 
         self._node.set_parameter_value(self._parameter_name, default_value)
 
-        self._apply_data_choices(parameter)
+        self._apply_data_choices(parameter, display_choices)
         self._update_download_button_visibility()
 
     def add_input_parameters(self) -> None:
@@ -120,7 +120,7 @@ class HuggingFaceModelParameter(ABC):
         self._node.add_parameter(parameter)
         self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
 
-        self._apply_data_choices(parameter)
+        self._apply_data_choices(parameter, display_choices)
 
         # Download button starts hidden; _update_download_button_visibility()
         # shows it when the selected model is not downloaded or is downloading.
@@ -178,11 +178,10 @@ class HuggingFaceModelParameter(ABC):
             return
         self._downloading_model_ids = {s.model_id for s in result.downloads if s.status == "downloading"}
 
-    def _build_data_choices(self) -> list[dict]:
+    def _build_data_choices(self, choices: list[str]) -> list[dict]:
         downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
         not_downloaded = set(self.get_not_downloaded_choices())
         downloading = self._downloading_model_ids
-        choices = self.get_choices()
 
         data = []
         for choice in choices:
@@ -201,10 +200,10 @@ class HuggingFaceModelParameter(ABC):
                 data.append({"name": choice})
         return data
 
-    def _apply_data_choices(self, parameter: Parameter) -> None:
+    def _apply_data_choices(self, parameter: Parameter, choices: list[str]) -> None:
         parameter.update_ui_options(
             {
-                "data": self._build_data_choices(),
+                "data": self._build_data_choices(choices),
                 "dropdown_row_icons": True,
                 "dropdown_row_subtitles": True,
             }

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload, OnClickMessageResultPayload
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
@@ -33,7 +33,6 @@ class HuggingFaceModelParameter(ABC):
         self._node = node
         self._parameter_name = parameter_name
         self._repo_revisions = []
-        self._download_button: Button | None = None
 
     def refresh_parameters(self) -> None:
         parameter = self._node.get_parameter_by_name(self._parameter_name)
@@ -62,7 +61,6 @@ class HuggingFaceModelParameter(ABC):
         self._node.set_parameter_value(self._parameter_name, default_value)
 
         self._apply_data_choices(parameter)
-        self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
         choices = self.get_choices()
@@ -92,21 +90,17 @@ class HuggingFaceModelParameter(ABC):
         self._node.set_parameter_value(self._parameter_name, default_value, initial_setup=True)
 
         self._apply_data_choices(parameter)
-        self._update_download_button(default_value, parameter)
 
     def remove_input_parameters(self) -> None:
         self._node.remove_parameter_element_by_name(self._parameter_name)
 
     def get_choices(self) -> list[str]:
-        # Ensure the latest repo revisions are fetched
         self._repo_revisions = self.fetch_repo_revisions()
 
-        # Count occurrences of each model name to detect duplicates
         model_counts: dict[str, int] = {}
         for repo_id, _ in self.list_repo_revisions():
             model_counts[repo_id] = model_counts.get(repo_id, 0) + 1
 
-        # Generate keys for downloaded models (hash only when there are duplicates)
         downloaded_choices = []
         for repo_revision in self.list_repo_revisions():
             repo_id, _ = repo_revision
@@ -172,61 +166,43 @@ class HuggingFaceModelParameter(ABC):
             msg = "Model download required!"
             raise RuntimeError(msg)
 
-        # Parse the value using _key_to_repo_revision
         repo_id, revision = self._key_to_repo_revision(value)
 
-        # If revision is empty (just model name), find it in our stored list
         if not revision:
             for stored_repo_id, stored_revision in self._repo_revisions:
                 if stored_repo_id == repo_id:
                     logger.debug("Using revision '%s' for model '%s'", stored_revision, repo_id)
                     return stored_repo_id, stored_revision
-            # If not found, raise an error
             msg = f"Model '{repo_id}' not found in available models!"
             raise RuntimeError(msg)
 
-        # If revision was provided, return it directly
         return repo_id, revision
 
-    def after_value_set(self, parameter: Parameter, value: object) -> None:
-        if parameter.name != self._parameter_name:
-            return
-        self._update_download_button(value, parameter)
-
-    def _update_download_button(self, value: object, parameter: Parameter) -> None:
+    def _on_refresh_click(
+        self, _button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:
+        value = self._node.get_parameter_value(self._parameter_name)
         downloaded_keys = {repo_id for repo_id, _ in self.list_repo_revisions()}
 
-        # Determine if the selected value is a downloaded model
-        is_downloaded = value in downloaded_keys or str(value) in downloaded_keys
-        if not is_downloaded:
-            repo_id, _ = self._key_to_repo_revision(str(value)) if value else ("", "")
+        is_downloaded = value in downloaded_keys
+        if not is_downloaded and value is not None:
+            repo_id, _ = self._key_to_repo_revision(str(value))
             is_downloaded = repo_id in downloaded_keys
 
         value_is_placeholder = value == _NO_MODELS_PLACEHOLDER or value is None
 
         if not is_downloaded and not value_is_placeholder:
-            # Remove old button if present
-            if self._download_button is not None:
-                parameter.remove_trait(self._download_button)
-                self._download_button = None
-
             search_term = self._get_model_search_term(str(value))
-            button = Button(
-                icon="download",
-                size="icon",
-                variant="secondary",
-                tooltip="Open in Model Manager to download",
-                button_link=f"#model-management?search={search_term}",
+            return NodeMessageResult(
+                success=True,
+                details="Opening Model Manager",
+                response=OnClickMessageResultPayload(
+                    button_details=button_details,
+                    href=f"#model-management?search={search_term}",
+                ),
+                altered_workflow_state=False,
             )
-            parameter.add_trait(button)
-            self._download_button = button
-        elif self._download_button is not None:
-            parameter.remove_trait(self._download_button)
-            self._download_button = None
 
-    def _on_refresh_click(
-        self, _button: Button, _button_details: ButtonDetailsMessagePayload
-    ) -> NodeMessageResult | None:
         self.refresh_parameters()
         return None
 

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -87,6 +87,9 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
+        parameter.ui_options["data"] = self._build_data_choices()
+        self._update_download_button(default_value, parameter)
+
     def get_download_commands(self) -> list[str]:
         return [
             f'huggingface-cli download "{repo}" "{file}"'

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -87,7 +87,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        parameter._ui_options["data"] = self._build_data_choices()
+        parameter.update_ui_options_key("data", self._build_data_choices())
         self._update_download_button(default_value, parameter)
 
     def get_download_commands(self) -> list[str]:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -88,7 +88,6 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
             parameter.add_trait(Options(choices=filtered_choices))
 
         self._apply_data_choices(parameter)
-        self._update_download_button(default_value, parameter)
 
     def get_download_commands(self) -> list[str]:
         return [

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -88,7 +88,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        self._apply_data_choices(parameter)
+        self._apply_data_choices(parameter, filtered_choices)
         self._update_download_button_visibility()
 
     def get_download_commands(self) -> list[str]:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -88,7 +88,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
             parameter.add_trait(Options(choices=filtered_choices))
 
         self._apply_data_choices(parameter)
-        self._update_download_button_visibility(default_value)
+        self._update_download_button_visibility()
 
     def get_download_commands(self) -> list[str]:
         return [

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -52,6 +52,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
             )
             return
 
+        self._refresh_downloading_model_ids()
         # Get all cached models
         all_choices = self.get_choices()
         if not all_choices:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -87,7 +87,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        parameter.update_ui_options_key("data", self._build_data_choices())
+        self._apply_data_choices(parameter)
         self._update_download_button(default_value, parameter)
 
     def get_download_commands(self) -> list[str]:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -87,7 +87,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        parameter.ui_options["data"] = self._build_data_choices()
+        parameter._ui_options["data"] = self._build_data_choices()
         self._update_download_button(default_value, parameter)
 
     def get_download_commands(self) -> list[str]:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_file_parameter.py
@@ -88,6 +88,7 @@ class HuggingFaceRepoFileParameter(HuggingFaceModelParameter):
             parameter.add_trait(Options(choices=filtered_choices))
 
         self._apply_data_choices(parameter)
+        self._update_download_button_visibility(default_value)
 
     def get_download_commands(self) -> list[str]:
         return [

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -92,6 +92,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             parameter.add_trait(Options(choices=filtered_choices))
 
         self._apply_data_choices(parameter)
+        self._update_download_button_visibility(default_value)
 
     def add_input_parameters(self) -> None:
         """Override to apply deprecated model filtering after parameter creation."""

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -91,7 +91,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        parameter.ui_options["data"] = self._build_data_choices()
+        parameter._ui_options["data"] = self._build_data_choices()
         self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -91,7 +91,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        parameter.update_ui_options_key("data", self._build_data_choices())
+        self._apply_data_choices(parameter)
         self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -8,8 +8,6 @@ from griptape_nodes.exe_types.param_components.huggingface.huggingface_utils imp
 )
 from griptape_nodes.traits.options import Options
 
-
-
 logger = logging.getLogger("griptape_nodes")
 
 

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -91,7 +91,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        parameter._ui_options["data"] = self._build_data_choices()
+        parameter.update_ui_options_key("data", self._build_data_choices())
         self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -8,6 +8,8 @@ from griptape_nodes.exe_types.param_components.huggingface.huggingface_utils imp
 )
 from griptape_nodes.traits.options import Options
 
+
+
 logger = logging.getLogger("griptape_nodes")
 
 
@@ -91,18 +93,8 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        # Update badge to reflect current download status
-        badge = self._build_model_badge()
-        if badge is None:
-            parameter.clear_badge()
-        else:
-            parameter.set_badge(
-                variant=badge.variant,
-                title=badge.title,
-                message=badge.message,
-                icon=badge.icon,
-                hide_clear_button=badge.hide_clear_button,
-            )
+        parameter.ui_options["data"] = self._build_data_choices()
+        self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
         """Override to apply deprecated model filtering after parameter creation."""

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -92,7 +92,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             parameter.add_trait(Options(choices=filtered_choices))
 
         self._apply_data_choices(parameter)
-        self._update_download_button_visibility(default_value)
+        self._update_download_button_visibility()
 
     def add_input_parameters(self) -> None:
         """Override to apply deprecated model filtering after parameter creation."""

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -92,7 +92,6 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             parameter.add_trait(Options(choices=filtered_choices))
 
         self._apply_data_choices(parameter)
-        self._update_download_button(default_value, parameter)
 
     def add_input_parameters(self) -> None:
         """Override to apply deprecated model filtering after parameter creation."""

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -92,7 +92,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
         else:
             parameter.add_trait(Options(choices=filtered_choices))
 
-        self._apply_data_choices(parameter)
+        self._apply_data_choices(parameter, filtered_choices)
         self._update_download_button_visibility()
 
     def add_input_parameters(self) -> None:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_parameter.py
@@ -54,6 +54,7 @@ class HuggingFaceRepoParameter(HuggingFaceModelParameter):
             )
             return
 
+        self._refresh_downloading_model_ids()
         # Get all cached models
         all_choices = self.get_choices()
         if not all_choices:

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_variant_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_repo_variant_parameter.py
@@ -141,6 +141,18 @@ class HuggingFaceRepoVariantParameter(HuggingFaceModelParameter):
         """Return list of model names for download."""
         return [self._repo_id]
 
+    def get_not_downloaded_choices(self) -> list[str]:
+        downloaded_keys = {key for key, _ in self.list_repo_revisions()}
+        return [
+            self._repo_variant_to_key(self._repo_id, v)
+            for v in self._variants
+            if self._repo_variant_to_key(self._repo_id, v) not in downloaded_keys
+        ]
+
+    def _get_model_search_term(self, choice: str) -> str:
+        repo_id, _ = self._key_to_repo_variant(choice)
+        return repo_id
+
     def get_repo_variant_revision(self) -> tuple[str, str, str]:
         """Get the selected repo_id, variant, and revision.
 


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/ae074025-07d1-4d65-bc77-470d63a07d21


- Replaces the confusing model download badge UI with a fully inline dropdown experience — all models (downloaded and not-downloaded) appear directly in the dropdown with per-row icons and subtitles
- A `ParameterButton` appears below the dropdown only when the selected model needs attention (not downloaded or currently downloading), and navigates to the Model Manager with appropriate URL params
- Downloading state (`Downloading…` subtitle + `loader` icon) is detected via `ListModelDownloadsRequest` and cached at `refresh_parameters()` time to avoid nested `handle_request()` calls from converters
- No changes required to existing node files

## Changes

- `huggingface_model_parameter.py` — core logic: inline data choices with icons/subtitles, `ParameterButton` (hidden by default), converter-driven button show/hide, download button label updates for in-progress vs not-started
- `huggingface_repo_parameter.py` — calls `_refresh_downloading_model_ids()` at top of overridden `refresh_parameters()` so the downloading cache is always populated
- `huggingface_repo_file_parameter.py` — same fix as above
- `huggingface_repo_variant_parameter.py` — overrides `get_not_downloaded_choices()` and `_get_model_search_term()` for variant-based repos

## Test plan

- [ ] Load a node where all models are downloaded → no download button visible, all entries show `check-circle` icon and "Downloaded" subtitle
- [ ] Load a node where some models are not downloaded → not-downloaded entries show `download` icon and "Not downloaded" subtitle; selecting one shows the download button
- [ ] While a download is in progress, hit refresh → entry shows `loader` icon and "Downloading…" subtitle; selecting it shows button labeled "View Download Progress"
- [ ] Click download button (not started) → opens Model Manager at `?search=<repo-id>`
- [ ] Click download button (in progress) → opens Model Manager at `?filter=<repo-id>`
- [ ] Refresh button (list-restart icon) still works and updates the dropdown

Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/4881

🤖 Generated with [Claude Code](https://claude.com/claude-code)