### PR TITLE
feat(manifest): expose the aggregated model catalog

### DIFF
--- a/src/griptape_nodes/common/manifests/manifest.py
+++ b/src/griptape_nodes/common/manifests/manifest.py
@@ -64,6 +64,39 @@ class ProjectTemplateManifestEntry(BaseModel):
     path: str | None = None
 
 
+class ModelProviderManifestEntry(BaseModel):
+    """A model provider declared by a library's model catalog.
+
+    Attributes:
+        provider_id: Catalog handle for the provider (matched by policies as
+            ``ModelProvider::"<provider_id>"`` and declared by a node's
+            ``provider_id``). Consumers must not parse or construct it.
+        display_name: Human-readable provider name, when declared.
+    """
+
+    provider_id: str
+    display_name: str | None = None
+
+
+class ModelManifestEntry(BaseModel):
+    """A single model declared by a library's model catalog.
+
+    Attributes:
+        model_id: Catalog handle for the model (matched by policies as
+            ``resource.id`` and declared by a node's ``model``). Unique within a
+            library; consumers must not parse or construct it.
+        provider_id: The provider this model is served by, matchable against a
+            ``ModelProviderManifestEntry.provider_id``.
+        display_name: Human-readable model name, when declared.
+        family: Optional grouping tag (e.g. "Claude 4"), when declared.
+    """
+
+    model_id: str
+    provider_id: str
+    display_name: str | None = None
+    family: str | None = None
+
+
 class Manifest(BaseModel):
     """A snapshot of the engine's registered libraries and project templates.
 
@@ -75,6 +108,10 @@ class Manifest(BaseModel):
         engine_version: Engine version string (``major.minor.patch``), when known.
         libraries: Registered libraries included in this manifest.
         project_templates: Loaded project templates included in this manifest.
+        model_providers: Model providers aggregated from loaded libraries' model
+            catalogs, deduplicated by ``provider_id``.
+        models: Models aggregated from loaded libraries' model catalogs,
+            deduplicated by ``model_id``.
     """
 
     schema_version: str = MANIFEST_SCHEMA_VERSION
@@ -83,3 +120,5 @@ class Manifest(BaseModel):
     engine_version: str | None = None
     libraries: list[LibraryManifestEntry] = Field(default_factory=list)
     project_templates: list[ProjectTemplateManifestEntry] = Field(default_factory=list)
+    model_providers: list[ModelProviderManifestEntry] = Field(default_factory=list)
+    models: list[ModelManifestEntry] = Field(default_factory=list)

--- a/src/griptape_nodes/common/manifests/manifest.py
+++ b/src/griptape_nodes/common/manifests/manifest.py
@@ -72,10 +72,12 @@ class ModelProviderManifestEntry(BaseModel):
             ``ModelProvider::"<provider_id>"`` and declared by a node's
             ``provider_id``). Consumers must not parse or construct it.
         display_name: Human-readable provider name, when declared.
+        terms_url: Link to the provider's terms of service, when declared.
     """
 
     provider_id: str
     display_name: str | None = None
+    terms_url: str | None = None
 
 
 class ModelManifestEntry(BaseModel):
@@ -89,12 +91,14 @@ class ModelManifestEntry(BaseModel):
             ``ModelProviderManifestEntry.provider_id``.
         display_name: Human-readable model name, when declared.
         family: Optional grouping tag (e.g. "Claude 4"), when declared.
+        terms_url: Link to the model's terms of service, when declared.
     """
 
     model_id: str
     provider_id: str
     display_name: str | None = None
     family: str | None = None
+    terms_url: str | None = None
 
 
 class Manifest(BaseModel):

--- a/src/griptape_nodes/retained_mode/events/manifest_events.py
+++ b/src/griptape_nodes/retained_mode/events/manifest_events.py
@@ -29,12 +29,15 @@ class GenerateManifestRequest(RequestPayload):
     Args:
         include_libraries: Include registered libraries in the manifest.
         include_project_templates: Include loaded project templates in the manifest.
+        include_model_catalog: Include the aggregated model catalog (providers and
+            models declared by loaded libraries) in the manifest.
 
     Results: GenerateManifestResultSuccess | GenerateManifestResultFailure
     """
 
     include_libraries: bool = True
     include_project_templates: bool = True
+    include_model_catalog: bool = True
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/manifest_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/manifest_manager.py
@@ -9,8 +9,11 @@ from typing import TYPE_CHECKING
 from griptape_nodes.common.manifests.manifest import (
     LibraryManifestEntry,
     Manifest,
+    ModelManifestEntry,
+    ModelProviderManifestEntry,
     ProjectTemplateManifestEntry,
 )
+from griptape_nodes.node_library.library_declarations import ModelCatalogLibraryProperty
 from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
@@ -60,14 +63,25 @@ class ManifestManager:
         self, request: GenerateManifestRequest
     ) -> GenerateManifestResultSuccess | GenerateManifestResultFailure:
         """Build a manifest from the engine's currently registered resources."""
-        libraries: list[LibraryManifestEntry] = []
-        if request.include_libraries:
+        # Libraries are listed once when either the library entries or the model
+        # catalog (aggregated from library declarations) is requested.
+        library_names: list[str] = []
+        if request.include_libraries or request.include_model_catalog:
             list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
             if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
                 return GenerateManifestResultFailure(
                     result_details=f"Attempted to generate manifest. Failed to list registered libraries: {list_result.result_details}"
                 )
-            libraries = await self._build_library_entries(list_result.libraries)
+            library_names = list_result.libraries
+
+        libraries: list[LibraryManifestEntry] = []
+        if request.include_libraries:
+            libraries = await self._build_library_entries(library_names)
+
+        model_providers: list[ModelProviderManifestEntry] = []
+        models: list[ModelManifestEntry] = []
+        if request.include_model_catalog:
+            model_providers, models = await self._build_model_catalog_entries(library_names)
 
         projects: list[ProjectTemplateManifestEntry] = []
         if request.include_project_templates:
@@ -89,11 +103,16 @@ class ManifestManager:
             engine_version=await self._resolve_engine_version(),
             libraries=libraries,
             project_templates=projects,
+            model_providers=model_providers,
+            models=models,
         )
 
         return GenerateManifestResultSuccess(
             manifest=manifest,
-            result_details=f"Successfully generated manifest with {len(libraries)} library/libraries and {len(projects)} project template(s).",
+            result_details=(
+                f"Successfully generated manifest with {len(libraries)} library/libraries, "
+                f"{len(projects)} project template(s), and {len(model_providers)} model provider(s)."
+            ),
         )
 
     async def _build_library_entries(self, library_names: list[str]) -> list[LibraryManifestEntry]:
@@ -142,6 +161,54 @@ class ManifestManager:
                 )
             )
         return entries
+
+    async def _build_model_catalog_entries(
+        self, library_names: list[str]
+    ) -> tuple[list[ModelProviderManifestEntry], list[ModelManifestEntry]]:
+        """Aggregate the model catalog declared across the registered libraries.
+
+        Each library may declare a ``ModelCatalogLibraryProperty`` (providers ->
+        models). Providers are deduplicated by ``provider_id`` and models by
+        ``model_id`` (first declaration wins), so the manifest carries one entry
+        per handle even when several libraries declare overlapping catalogs. A
+        library whose metadata cannot be resolved is skipped with a warning
+        rather than failing the whole manifest. Entries are sorted by id for
+        stable output.
+        """
+        providers: dict[str, ModelProviderManifestEntry] = {}
+        models: dict[str, ModelManifestEntry] = {}
+        for name in library_names:
+            metadata_result = await GriptapeNodes.ahandle_request(
+                GetLibraryMetadataRequest(library=name, broadcast_result=False)
+            )
+            if not isinstance(metadata_result, GetLibraryMetadataResultSuccess):
+                logger.warning(
+                    "Could not load metadata for library '%s' while aggregating the model catalog: %s",
+                    name,
+                    metadata_result.result_details,
+                )
+                continue
+            for declaration in metadata_result.metadata.declarations:
+                if not isinstance(declaration, ModelCatalogLibraryProperty):
+                    continue
+                for provider_id, provider in declaration.providers.items():
+                    providers.setdefault(
+                        provider_id,
+                        ModelProviderManifestEntry(provider_id=provider_id, display_name=provider.display_name),
+                    )
+                    for model_id, model in provider.models.items():
+                        models.setdefault(
+                            model_id,
+                            ModelManifestEntry(
+                                model_id=model_id,
+                                provider_id=provider_id,
+                                display_name=model.display_name,
+                                family=model.family,
+                            ),
+                        )
+        sorted_providers = [providers[key] for key in sorted(providers)]
+        sorted_models = [models[key] for key in sorted(models)]
+        return sorted_providers, sorted_models
 
     def _build_project_template_entries(
         self, project_infos: list[ProjectTemplateInfo]

--- a/src/griptape_nodes/retained_mode/managers/manifest_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/manifest_manager.py
@@ -194,7 +194,11 @@ class ManifestManager:
                 for provider_id, provider in declaration.providers.items():
                     providers.setdefault(
                         provider_id,
-                        ModelProviderManifestEntry(provider_id=provider_id, display_name=provider.display_name),
+                        ModelProviderManifestEntry(
+                            provider_id=provider_id,
+                            display_name=provider.display_name,
+                            terms_url=provider.terms_url,
+                        ),
                     )
                     for model_id, model in provider.models.items():
                         models.setdefault(
@@ -204,6 +208,7 @@ class ManifestManager:
                                 provider_id=provider_id,
                                 display_name=model.display_name,
                                 family=model.family,
+                                terms_url=model.terms_url,
                             ),
                         )
         sorted_providers = [providers[key] for key in sorted(providers)]

--- a/tests/unit/retained_mode/managers/test_manifest_manager.py
+++ b/tests/unit/retained_mode/managers/test_manifest_manager.py
@@ -81,7 +81,9 @@ class TestManifestManager:
                 ]
             )
 
-            result = await manifest_manager.on_generate_manifest_request(GenerateManifestRequest())
+            result = await manifest_manager.on_generate_manifest_request(
+                GenerateManifestRequest(include_model_catalog=False)
+            )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         manifest = result.manifest
@@ -119,7 +121,9 @@ class TestManifestManager:
                 side_effect=[ListRegisteredLibrariesResultFailure(result_details="registry down")]
             )
 
-            result = await manifest_manager.on_generate_manifest_request(GenerateManifestRequest())
+            result = await manifest_manager.on_generate_manifest_request(
+                GenerateManifestRequest(include_model_catalog=False)
+            )
 
         assert isinstance(result, GenerateManifestResultFailure)
 
@@ -149,7 +153,9 @@ class TestManifestManager:
                 ]
             )
 
-            result = await manifest_manager.on_generate_manifest_request(GenerateManifestRequest())
+            result = await manifest_manager.on_generate_manifest_request(
+                GenerateManifestRequest(include_model_catalog=False)
+            )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         assert len(result.manifest.libraries) == 1
@@ -183,7 +189,7 @@ class TestManifestManager:
             )
 
             result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_libraries=False)
+                GenerateManifestRequest(include_libraries=False, include_model_catalog=False)
             )
 
         assert isinstance(result, GenerateManifestResultSuccess)
@@ -203,7 +209,9 @@ class TestManifestManager:
             )
 
             result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_libraries=False, include_project_templates=False)
+                GenerateManifestRequest(
+                    include_libraries=False, include_project_templates=False, include_model_catalog=False
+                )
             )
 
         assert isinstance(result, GenerateManifestResultSuccess)
@@ -211,3 +219,60 @@ class TestManifestManager:
         assert result.manifest.project_templates == []
         assert result.manifest.engine_version == "2.0.0"
         assert mock_gn.ahandle_request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_manifest_aggregates_model_catalog(self, manifest_manager: ManifestManager) -> None:
+        """The model catalog is aggregated from loaded libraries' declarations."""
+        from griptape_nodes.node_library.library_declarations import (
+            KeySupport,
+            Model,
+            ModelCatalogLibraryProperty,
+            ModelProvider,
+        )
+
+        metadata = LibraryMetadata(
+            author="a",
+            description="d",
+            library_version="1.0.0",
+            engine_version="0.86.0",
+            tags=[],
+            declarations=[
+                ModelCatalogLibraryProperty(
+                    providers={
+                        "anthropic": ModelProvider(
+                            display_name="Anthropic",
+                            models={
+                                "claude-opus-4": Model(
+                                    display_name="Claude Opus 4",
+                                    family="Claude 4",
+                                    key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                                )
+                            },
+                        )
+                    }
+                )
+            ],
+        )
+
+        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
+            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
+            mock_gn.ahandle_request = AsyncMock(
+                side_effect=[
+                    ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
+                    GetLibraryMetadataResultSuccess(metadata=metadata, result_details="ok"),
+                    GetEngineVersionResultSuccess(major=1, minor=0, patch=0, result_details="ok"),
+                ]
+            )
+
+            result = await manifest_manager.on_generate_manifest_request(
+                GenerateManifestRequest(include_libraries=False, include_project_templates=False)
+            )
+
+        assert isinstance(result, GenerateManifestResultSuccess)
+        assert [provider.provider_id for provider in result.manifest.model_providers] == ["anthropic"]
+        assert result.manifest.model_providers[0].display_name == "Anthropic"
+        assert [model.model_id for model in result.manifest.models] == ["claude-opus-4"]
+        model = result.manifest.models[0]
+        assert model.provider_id == "anthropic"
+        assert model.display_name == "Claude Opus 4"
+        assert model.family == "Claude 4"

--- a/tests/unit/retained_mode/managers/test_manifest_manager.py
+++ b/tests/unit/retained_mode/managers/test_manifest_manager.py
@@ -241,11 +241,13 @@ class TestManifestManager:
                     providers={
                         "anthropic": ModelProvider(
                             display_name="Anthropic",
+                            terms_url="https://anthropic.com/terms",
                             models={
                                 "claude-opus-4": Model(
                                     display_name="Claude Opus 4",
                                     family="Claude 4",
                                     key_support=KeySupport.REQUIRES_CUSTOMER_KEY,
+                                    terms_url="https://anthropic.com/model-terms",
                                 )
                             },
                         )
@@ -271,8 +273,10 @@ class TestManifestManager:
         assert isinstance(result, GenerateManifestResultSuccess)
         assert [provider.provider_id for provider in result.manifest.model_providers] == ["anthropic"]
         assert result.manifest.model_providers[0].display_name == "Anthropic"
+        assert result.manifest.model_providers[0].terms_url == "https://anthropic.com/terms"
         assert [model.model_id for model in result.manifest.models] == ["claude-opus-4"]
         model = result.manifest.models[0]
         assert model.provider_id == "anthropic"
         assert model.display_name == "Claude Opus 4"
         assert model.family == "Claude 4"
+        assert model.terms_url == "https://anthropic.com/model-terms"


### PR DESCRIPTION
The policy builder gates model invocation by provider and by specific model, but the manifest only described libraries and project templates, so those pickers had no model candidates to offer. This aggregates the model catalog already declared across loaded libraries (the `model_catalog` library property, which carries providers and their models) into the manifest as `model_providers` and `models`, deduplicated by handle, behind a new `include_model_catalog` toggle on `GenerateManifestRequest`.

Split out of #4899 because it stands on its own: it shares no code with the authorization layer and only depends on the pre-existing `model_catalog` library declaration.
