### PR TITLE
fix(mcp): shield engine dispatch so a client timeout doesn't cancel in-flight work

### DIFF
--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -387,6 +387,16 @@ async def _dispatch_to_engine(request_payload: RequestPayload, timeout_ms: int |
     on uvicorn's loop, concurrent with the engine instead of serialized onto it). run_coroutine_
     threadsafe schedules the work on the engine loop; wrap_future binds the cross-thread future
     back to the MCP server's loop so it can be awaited and timed out here without blocking.
+
+    The wrapped future is wrapped again in ``asyncio.shield`` so that a client-side timeout
+    (the ``wait_for`` below) or a sibling cancellation in a batch ``gather`` cancels only this
+    coroutine's wait, never the engine-side operation already running on the engine loop. A
+    bare ``wait_for(response_future)`` would, on timeout, cancel ``response_future`` and thereby
+    cancel the engine coroutine mid-flight; for a multi-node resolve that strands the node it
+    was executing in ``RESOLVING`` forever while the orphaned execution task keeps running
+    (griptape-nodes-engine#4883). The pre-in-process WebSocket transport let the engine run a
+    request to completion even after the client stopped waiting, and shielding preserves that
+    contract: the caller still sees a ``TimeoutError`` and can poll for state afterwards.
     """
     engine_loop = GriptapeNodes.EventManager().event_loop
     if engine_loop is None:
@@ -399,8 +409,8 @@ async def _dispatch_to_engine(request_payload: RequestPayload, timeout_ms: int |
         asyncio.run_coroutine_threadsafe(_handle_request_on_engine_loop(request_payload), engine_loop)
     )
     if timeout_ms:
-        return await asyncio.wait_for(response_future, timeout=timeout_ms / 1000)
-    return await response_future
+        return await asyncio.wait_for(asyncio.shield(response_future), timeout=timeout_ms / 1000)
+    return await asyncio.shield(response_future)
 
 
 async def _dispatch_batch_to_engine(pairs: list[tuple[str, dict[str, Any]]], timeout_ms: int) -> list[Any]:

--- a/tests/unit/servers/test_mcp.py
+++ b/tests/unit/servers/test_mcp.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.servers import mcp as mcp_module
 from griptape_nodes.servers.mcp import (
     _BATCH_MAX_AUTO_TIMEOUT_MS,
@@ -260,6 +261,12 @@ class TestDispatchToEngineShield:
     """
 
     @staticmethod
+    def _a_request_payload() -> RequestPayload:
+        # _handle_request_on_engine_loop is patched in these tests, so the payload is never
+        # dispatched; any real RequestPayload satisfies the signature.
+        return SUPPORTED_REQUEST_EVENTS["ListRegisteredLibrariesRequest"]()
+
+    @staticmethod
     def _run_engine_loop_in_thread() -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
         engine_loop = asyncio.new_event_loop()
         thread = threading.Thread(target=engine_loop.run_forever, daemon=True, name="test-engine-loop")
@@ -295,7 +302,7 @@ class TestDispatchToEngineShield:
                 patch.object(mcp_module, "_handle_request_on_engine_loop", slow_engine_handler),
             ):
                 with pytest.raises(TimeoutError):
-                    await _dispatch_to_engine(object(), timeout_ms=50)
+                    await _dispatch_to_engine(self._a_request_payload(), timeout_ms=50)
 
                 # The shielded engine coroutine keeps running on its own loop after the
                 # wait times out; wait long enough for its 0.5s body to finish.
@@ -320,7 +327,7 @@ class TestDispatchToEngineShield:
                 patch.object(mcp_module.GriptapeNodes, "EventManager", return_value=event_manager),
                 patch.object(mcp_module, "_handle_request_on_engine_loop", fast_engine_handler),
             ):
-                result = await _dispatch_to_engine(object(), timeout_ms=5000)
+                result = await _dispatch_to_engine(self._a_request_payload(), timeout_ms=5000)
 
             assert result == {"ok": True}
         finally:

--- a/tests/unit/servers/test_mcp.py
+++ b/tests/unit/servers/test_mcp.py
@@ -1,11 +1,17 @@
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from griptape_nodes.servers import mcp as mcp_module
 from griptape_nodes.servers.mcp import (
     _BATCH_MAX_AUTO_TIMEOUT_MS,
     _BATCH_PER_REQUEST_TIMEOUT_MS,
     EVENT_REQUEST_BATCH_TOOL_NAME,
     SUPPORTED_REQUEST_EVENTS,
     _build_batch_pairs,
+    _dispatch_to_engine,
     _event_request_batch_input_schema,
     _resolve_batch_timeout_ms,
     _summarize_result_details,
@@ -242,3 +248,80 @@ class TestEventRequestBatchToolName:
         # The batch tool is intentionally synthetic; gating it on SUPPORTED_REQUEST_EVENTS would
         # require a fake RequestPayload subclass and break call_tool's payload-class lookup.
         assert EVENT_REQUEST_BATCH_TOOL_NAME not in SUPPORTED_REQUEST_EVENTS
+
+
+class TestDispatchToEngineShield:
+    """A client-side timeout must not cancel the in-flight engine operation.
+
+    Regression coverage for griptape-nodes-engine#4883: when a multi-node resolve runs
+    longer than the MCP dispatch timeout, cancelling the engine coroutine strands the node
+    it is executing in RESOLVING forever. _dispatch_to_engine shields the engine-side future
+    so the timeout raises here while the engine runs to completion on its own loop.
+    """
+
+    @staticmethod
+    def _run_engine_loop_in_thread() -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+        engine_loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=engine_loop.run_forever, daemon=True, name="test-engine-loop")
+        thread.start()
+        return engine_loop, thread
+
+    @staticmethod
+    def _stop_engine_loop(engine_loop: asyncio.AbstractEventLoop, thread: threading.Thread) -> None:
+        engine_loop.call_soon_threadsafe(engine_loop.stop)
+        thread.join(timeout=2)
+        engine_loop.close()
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_cancel_engine_work(self) -> None:
+        engine_loop, thread = self._run_engine_loop_in_thread()
+        completed = threading.Event()
+        cancelled = threading.Event()
+
+        async def slow_engine_handler(_payload: object) -> dict[str, bool]:
+            try:
+                await asyncio.sleep(0.5)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            completed.set()
+            return {"ok": True}
+
+        event_manager = MagicMock()
+        event_manager.event_loop = engine_loop
+        try:
+            with (
+                patch.object(mcp_module.GriptapeNodes, "EventManager", return_value=event_manager),
+                patch.object(mcp_module, "_handle_request_on_engine_loop", slow_engine_handler),
+            ):
+                with pytest.raises(TimeoutError):
+                    await _dispatch_to_engine(object(), timeout_ms=50)
+
+                # The shielded engine coroutine keeps running on its own loop after the
+                # wait times out; wait long enough for its 0.5s body to finish.
+                await asyncio.sleep(0.75)
+
+            assert completed.is_set(), "engine work should run to completion after a client timeout"
+            assert not cancelled.is_set(), "engine work must not be cancelled by a client timeout"
+        finally:
+            self._stop_engine_loop(engine_loop, thread)
+
+    @pytest.mark.asyncio
+    async def test_returns_result_when_engine_finishes_before_timeout(self) -> None:
+        engine_loop, thread = self._run_engine_loop_in_thread()
+
+        async def fast_engine_handler(_payload: object) -> dict[str, bool]:
+            return {"ok": True}
+
+        event_manager = MagicMock()
+        event_manager.event_loop = engine_loop
+        try:
+            with (
+                patch.object(mcp_module.GriptapeNodes, "EventManager", return_value=event_manager),
+                patch.object(mcp_module, "_handle_request_on_engine_loop", fast_engine_handler),
+            ):
+                result = await _dispatch_to_engine(object(), timeout_ms=5000)
+
+            assert result == {"ok": True}
+        finally:
+            self._stop_engine_loop(engine_loop, thread)


### PR DESCRIPTION
`#4758` moved MCP request dispatch from a second WebSocket client onto the engine's own event loop via `run_coroutine_threadsafe` + `asyncio.wait_for`. That coupled two lifetimes that used to be independent: how long the MCP client waits for a reply, and whether the engine operation actually runs to completion. When `wait_for` hits its budget it cancels the wrapped future, which cancels the engine coroutine mid-run.

For a `ResolveNodeRequest` whose upstream dependency is still unresolved, the dependency and the target resolve sequentially in one pass and can run past the 30s budget (two `GoogleImageGeneration` calls, for example). At the timeout the resolution driver is cancelled, but the `execute_node` task it was awaiting is orphaned and keeps running to completion, so the node's output is written to disk while its `resolution_state` is never advanced past `RESOLVING`. The node is stranded and the flow is left half-running. This is what griptape-nodes-engine#4883 reports as an `input_images` / `ParameterList` hang, but the `ParameterList` shape is incidental: any dependency chain that outlasts the timeout reproduces it, and resolving the same consumer once its dependency is already resolved (each step under the budget) succeeds.

Before `#4758` the MCP server was a separate WebSocket client, so a client timeout abandoned the reply while the engine still ran the request to completion and the node reached `RESOLVED`. `asyncio.shield` restores that contract: a timeout, or a sibling cancellation in a batch `gather`, cancels only the MCP server's wait, never the operation on the engine loop. The caller still sees a `TimeoutError` and can poll for state afterwards, but engine state is no longer corrupted.

The 30s budget itself is unchanged. A resolve that outlasts it still surfaces a timeout to the caller, which is pre-existing behavior; the budget value and the absence of a completion signal are a separate concern (griptape-nodes-engine#4532).

Closes #4883.
