### PR TITLE
refactor(model-events): identify declared invocations by stable model_id

### DIFF
--- a/src/griptape_nodes/retained_mode/events/model_events.py
+++ b/src/griptape_nodes/retained_mode/events/model_events.py
@@ -350,7 +350,7 @@ class GetModelInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
 @dataclass
 @PayloadRegistry.register
 class DeclareModelInvocationRequest(RequestPayload):
-    """Declare that a node is about to invoke a model, so the call is subject to entitlements.
+    """Declare that a node is about to invoke a catalog model, so the call is subject to entitlements.
 
     This is how a well-intentioned node opts into the permission system: before
     invoking a model it declares the invocation, and the pre-dispatch hook chain
@@ -360,35 +360,30 @@ class DeclareModelInvocationRequest(RequestPayload):
     and the node should not run it.
 
     Enforcement is advisory in the sense that it relies on the node to declare.
-    It is the engine-side point that sees every model invocation a node
-    performs, whatever the routing: a call routed through the Griptape cloud
-    proxy, a locally-run model, or a third-party API called directly. The proxy
-    independently enforces the calls that flow through it; this declaration is
-    the engine's own gate, seeing and recording every invocation uniformly
-    regardless of how it is routed, and the natural place to meter or audit.
+    It is the engine-side gate the permission system sees and records every
+    declared invocation through, and the natural place to meter or audit. The
+    proxy independently enforces the calls that flow through it; this is the
+    engine's own gate.
 
-    The declaration carries the two facts the node owns at call time: the
-    concrete `model` being invoked and the `provider_id` it routes to. Coarser
-    catalog structure (family, offering, key support) is not declared here — the
-    permission evaluator owns the model catalog and resolves those from
-    `(provider_id, model)` itself. `provider_id` is included because it is not
-    derivable from `model`: the same model is served by multiple providers
-    (e.g. Groq, NVIDIA NIM, and Ollama all serve Llama 3.3), and only the node
-    knows which one it actually called.
+    The declaration identifies the model by its `model_id`: the stable catalog
+    key, unique across the whole library. That key alone resolves to a single
+    catalog entry, so the permission evaluator (which owns the catalog) derives
+    the provider, family, and key support from it -- nothing coarser is
+    declared here. Only catalog models can be declared; the stable key is the
+    contract, and a concrete provider model id or `(provider, model)` pair is
+    deliberately not accepted.
 
-    Use when: A node is about to invoke a model and wants the call gated by
-    (and visible to) the permission system.
+    Use when: A node is about to invoke a catalog model and wants the call
+    gated by (and visible to) the permission system.
 
     Args:
-        model: Concrete model being invoked (e.g., "claude-opus-4-7")
-        provider_id: Catalog provider handle the call routes to (e.g., "anthropic", "ollama")
+        model_id: Stable catalog key of the model being invoked (e.g., "gtc_claude_opus_4_7")
         node_name: Name of the node instance declaring the invocation, when invoked from a node
 
     Results: DeclareModelInvocationResultSuccess (cleared to proceed) | DeclareModelInvocationResultFailure (not permitted)
     """
 
-    model: str
-    provider_id: str | None = None
+    model_id: str
     node_name: str | None = None
 
 
@@ -398,10 +393,10 @@ class DeclareModelInvocationResultSuccess(WorkflowNotAlteredMixin, ResultPayload
     """The declared model invocation is permitted; the node may proceed.
 
     Args:
-        model: The concrete upstream model cleared for invocation
+        model_id: The stable catalog key cleared for invocation
     """
 
-    model: str
+    model_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -754,7 +754,7 @@ class ModelManager:
         inference itself; this handler does not run any backend.
 
         Args:
-            request: The declared invocation, identifying the model and task
+            request: The declared invocation, identifying the catalog model
 
         Returns:
             ResultPayload: Success, meaning the node is cleared to proceed
@@ -777,8 +777,8 @@ class ModelManager:
                 result_details=f"Model invocation denied for '{request.model}'. {reason}"
             )
         return DeclareModelInvocationResultSuccess(
-            model=request.model,
-            result_details=f"Model invocation permitted for '{request.model}'.",
+            model_id=request.model_id,
+            result_details=f"Model invocation permitted for '{request.model_id}'.",
         )
 
     def _search_models(self, request: SearchModelsRequest) -> SearchResultsData:

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -734,14 +734,11 @@ class ModelManager:
     def _model_checkpoint_attributes(request: DeclareModelInvocationRequest) -> dict[str, Any]:
         """Resolve the facts a hook may gate a model invocation on.
 
-        `id` is the concrete model; `provider_id` is the catalog provider the call
-        routes to (when the node declared one). The app maps `provider_id` onto
-        the `Model in ModelProvider` hierarchy a policy walks via `in`.
+        `id` is the stable catalog key the node declared. The app owns the model
+        catalog and resolves the provider, family, and key support from that key,
+        mapping it onto the `Model in ModelProvider` hierarchy a policy walks via `in`.
         """
-        attributes: dict[str, Any] = {CheckpointAttribute.ID: request.model}
-        if request.provider_id:
-            attributes[CheckpointAttribute.PROVIDER_ID] = request.provider_id
-        return attributes
+        return {CheckpointAttribute.ID: request.model_id}
 
     def on_handle_declare_model_invocation_request(self, request: DeclareModelInvocationRequest) -> ResultPayload:
         """Acknowledge a node's declaration that it is about to invoke a model.
@@ -759,22 +756,22 @@ class ModelManager:
         Returns:
             ResultPayload: Success, meaning the node is cleared to proceed
         """
-        # License-policy checkpoint: gate the declared invocation on the model and
-        # its provider. The node already opted in by declaring; a denial returns a
+        # License-policy checkpoint: gate the declared invocation on the stable
+        # catalog key. The node already opted in by declaring; a denial returns a
         # failure so the node does not invoke the model. Provider/family hierarchy
-        # is resolved app-side from the declared provider_id.
+        # is resolved app-side from the declared model_id.
         denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.INVOKE_MODEL,
                 subject_type=CheckpointSubjectType.MODEL,
-                subject_id=request.model,
+                subject_id=request.model_id,
                 attributes=self._model_checkpoint_attributes(request),
             )
         )
         if denial is not None:
             reason = denial.reason()
             return DeclareModelInvocationResultFailure(
-                result_details=f"Model invocation denied for '{request.model}'. {reason}"
+                result_details=f"Model invocation denied for '{request.model_id}'. {reason}"
             )
         return DeclareModelInvocationResultSuccess(
             model_id=request.model_id,

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -197,41 +197,38 @@ class TestOnHandleDeclareModelInvocationRequest:
         # declaration, so the node is cleared to invoke the model itself.
         result = model_manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(
-                model="claude-opus-4-7",
-                provider_id="anthropic",
+                model_id="gtc_claude_opus_4_7",
                 node_name="Agent_1",
             )
         )
 
         assert isinstance(result, DeclareModelInvocationResultSuccess)
-        assert result.model == "claude-opus-4-7"
+        assert result.model_id == "gtc_claude_opus_4_7"
 
     def test_a_denying_pre_dispatch_hook_short_circuits_before_the_handler(self) -> None:
         # End to end: enforcement lives in the pre-dispatch chain, not the
         # handler. A hook that denies the declaration short-circuits with its
         # own failure; an allowed declaration reaches the handler and comes
-        # back as a clear-to-proceed success. Policies gate the shared catalog
-        # handles (here, the provider), not the concrete model string.
+        # back as a clear-to-proceed success. Policies gate the stable catalog
+        # model key, the only handle the declaration carries.
         event_manager = EventManager()
         ModelManager(event_manager)
 
         def deny(request: RequestPayload, _context: object) -> DeclareModelInvocationResultFailure | None:
-            if isinstance(request, DeclareModelInvocationRequest) and request.provider_id == "blocked_provider":
-                return DeclareModelInvocationResultFailure(result_details="This provider is blocked by your license.")
+            if isinstance(request, DeclareModelInvocationRequest) and request.model_id == "blocked_model":
+                return DeclareModelInvocationResultFailure(result_details="This model is blocked by your license.")
             return None
 
         event_manager.add_pre_dispatch_hook(deny)
 
-        denied = event_manager.handle_request(
-            DeclareModelInvocationRequest(model="blocked-model", provider_id="blocked_provider")
-        )
-        allowed = event_manager.handle_request(DeclareModelInvocationRequest(model="gpt-ok", provider_id="openai"))
+        denied = event_manager.handle_request(DeclareModelInvocationRequest(model_id="blocked_model"))
+        allowed = event_manager.handle_request(DeclareModelInvocationRequest(model_id="gtc_gpt_5"))
 
         assert isinstance(denied.result, DeclareModelInvocationResultFailure)
         assert "blocked by your license" in str(denied.result.result_details)
         # The allowed declaration reached the handler, which cleared it.
         assert isinstance(allowed.result, DeclareModelInvocationResultSuccess)
-        assert allowed.result.model == "gpt-ok"
+        assert allowed.result.model_id == "gtc_gpt_5"
 
     def test_authorization_checkpoint_denial_blocks_invocation(self) -> None:
         # The InvokeModel checkpoint gates the declared invocation: a denial from

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -233,7 +233,8 @@ class TestOnHandleDeclareModelInvocationRequest:
     def test_authorization_checkpoint_denial_blocks_invocation(self) -> None:
         # The InvokeModel checkpoint gates the declared invocation: a denial from
         # a registered authorization hook turns into a failure so the node does
-        # not invoke the model. The handler resolves the model + provider facts.
+        # not invoke the model. The handler passes the stable catalog key; the app
+        # resolves the provider and family from it.
         from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
@@ -246,8 +247,8 @@ class TestOnHandleDeclareModelInvocationRequest:
         def deny(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
             seen["action"] = checkpoint.action
             seen["subject_id"] = checkpoint.subject_id
-            seen["provider_id"] = checkpoint.attributes.get("provider_id")
-            if checkpoint.attributes.get("provider_id") == "anthropic":
+            seen["id"] = checkpoint.attributes.get("id")
+            if checkpoint.subject_id == "gtc_claude_opus_4_7":
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Anthropic models are not enabled."),))
             return None
 
@@ -255,14 +256,14 @@ class TestOnHandleDeclareModelInvocationRequest:
         manager = ModelManager.__new__(ModelManager)
 
         denied = manager.on_handle_declare_model_invocation_request(
-            DeclareModelInvocationRequest(model="claude-opus-4", provider_id="anthropic")
+            DeclareModelInvocationRequest(model_id="gtc_claude_opus_4_7")
         )
         assert isinstance(denied, DeclareModelInvocationResultFailure)
         assert "Anthropic models are not enabled." in str(denied.result_details)
-        assert seen == {"action": "InvokeModel", "subject_id": "claude-opus-4", "provider_id": "anthropic"}
+        assert seen == {"action": "InvokeModel", "subject_id": "gtc_claude_opus_4_7", "id": "gtc_claude_opus_4_7"}
 
         allowed = manager.on_handle_declare_model_invocation_request(
-            DeclareModelInvocationRequest(model="gpt-4o", provider_id="openai")
+            DeclareModelInvocationRequest(model_id="gtc_gpt_5")
         )
         assert isinstance(allowed, DeclareModelInvocationResultSuccess)
 
@@ -282,7 +283,7 @@ class TestOnHandleDeclareModelInvocationRequest:
         manager = ModelManager.__new__(ModelManager)
 
         denied = manager.on_handle_declare_model_invocation_request(
-            DeclareModelInvocationRequest(model="claude-opus-4", provider_id="anthropic")
+            DeclareModelInvocationRequest(model_id="gtc_claude_opus_4_7")
         )
         assert isinstance(denied, DeclareModelInvocationResultFailure)
         assert "Denied by the license policy." in str(denied.result_details)


### PR DESCRIPTION
`DeclareModelInvocationRequest` identified the model with a concrete `model` (the upstream wire id, e.g. `claude-opus-4-7`) plus a `provider_id` to disambiguate it. The provider field only existed because a wire id isn't unique on its own: the same model is served by multiple providers. But the catalog already has a globally-unique stable key per model, and that key resolves to exactly one catalog entry, so the permission evaluator can derive the provider and key support from it.

This swaps the two fields for a single `model_id` stable catalog key. Carrying a redundant `provider_id` alongside an identifier that already pins the provider invited inconsistency: a caller could pass a `model_id` whose catalog provider disagreed with the `provider_id`, and the evaluator would have to pick a winner. The stable key also disambiguates the same-model-different-key-support case that `(provider_id, model)` cannot, since those are distinct catalog entries with distinct keys.

Scope is deliberately catalog-only. The old docstring claimed this gate observed every invocation regardless of routing, including off-catalog local and direct third-party calls, which have no stable key. We don't gate those, so the contract is now explicitly the stable catalog key.

Callers live in the node libraries and need a coordinated update to pass `model_id` instead of `model`/`provider_id`; those nodes already hold the stable key via their `model_usage` declarations.