### PR TITLE
fix: handle library update check when current git ref is not on the remote

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -258,6 +258,7 @@ from griptape_nodes.utils.git_utils import (
     is_git_url,
     normalize_github_url,
     parse_git_url_with_ref,
+    remote_ref_exists,
     sparse_checkout_library_json,
     switch_branch_or_tag,
     update_library_git,
@@ -5454,6 +5455,33 @@ class LibraryManager:
 
         # Get local commit SHA
         local_commit = await asyncio.to_thread(get_local_commit_sha, library_dir)
+
+        # If the current ref does not exist on the remote (e.g. a local-only branch that has
+        # not been pushed, or a detached HEAD on a bare commit), there is nothing on the remote
+        # to compare against. Report no update available instead of failing the check.
+        if git_ref is not None:
+            try:
+                ref_on_remote = await asyncio.to_thread(remote_ref_exists, git_remote, git_ref)
+            except GitRemoteError as e:
+                details = f"Failed to query git remote for Library '{library_name}': {e}"
+                return CheckLibraryUpdateResultFailure(result_details=details)
+
+            if not ref_on_remote:
+                details = (
+                    f"Library '{library_name}' is on git ref '{git_ref}', which does not exist on remote "
+                    f"'{git_remote}'. Updates can only be checked against refs that exist on the remote."
+                )
+                logger.info(details)
+                return CheckLibraryUpdateResultSuccess(
+                    has_update=False,
+                    current_version=current_version,
+                    latest_version=current_version,
+                    git_remote=git_remote,
+                    git_ref=git_ref,
+                    local_commit=local_commit,
+                    remote_commit=None,
+                    result_details=details,
+                )
 
         # Clone remote and get latest version and commit SHA (using current ref or HEAD if detached)
         try:

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -1327,3 +1327,82 @@ def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> tuple[st
 
     logger.debug("Git CLI not available, using pygit2 shallow clone from %s", remote_url)
     return _shallow_clone_with_pygit2(remote_url, ref)
+
+
+def _remote_ref_exists_with_git_cli(remote_url: str, ref: str) -> bool:
+    """Check whether a branch or tag ref exists on a remote using the git CLI.
+
+    Args:
+        remote_url: The git repository URL (HTTPS or SSH).
+        ref: The branch or tag name to look for on the remote.
+
+    Returns:
+        bool: True if a matching branch or tag ref exists on the remote, False otherwise.
+
+    Raises:
+        GitRemoteError: If the remote cannot be queried.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["git", "ls-remote", "--heads", "--tags", remote_url, ref],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = f"Failed to query remote refs from {remote_url}: {result.stderr.strip()}"
+        raise GitRemoteError(msg)
+
+    return bool(result.stdout.strip())
+
+
+def _remote_ref_exists_with_pygit2(remote_url: str, ref: str) -> bool:
+    """Check whether a branch or tag ref exists on a remote using pygit2.
+
+    Args:
+        remote_url: The git repository URL (HTTPS or SSH).
+        ref: The branch or tag name to look for on the remote.
+
+    Returns:
+        bool: True if a matching branch or tag ref exists on the remote, False otherwise.
+
+    Raises:
+        GitRemoteError: If the remote cannot be queried.
+    """
+    candidate_names = {f"refs/heads/{ref}", f"refs/tags/{ref}"}
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo = pygit2.init_repository(temp_dir, bare=True)
+        try:
+            remote = repo.remotes.create("origin", remote_url)
+            remote_refs = remote.ls_remotes(callbacks=_CredentialCallbacks())
+        except pygit2.GitError as e:
+            msg = f"Failed to query remote refs from {remote_url}: {e}"
+            raise GitRemoteError(msg) from e
+        finally:
+            repo.free()
+
+    return any(remote_ref.get("name") in candidate_names for remote_ref in remote_refs)
+
+
+def remote_ref_exists(remote_url: str, ref: str) -> bool:
+    """Check whether a branch or tag named ``ref`` exists on a git remote.
+
+    Uses the git CLI when available and falls back to pygit2 otherwise, mirroring
+    sparse_checkout_library_json. Commit SHAs are not advertised as named refs, so a
+    detached HEAD pointing at a bare commit reports False.
+
+    Args:
+        remote_url: The git repository URL (HTTPS or SSH).
+        ref: The branch or tag name to look for on the remote.
+
+    Returns:
+        bool: True if a matching branch or tag exists on the remote, False otherwise.
+
+    Raises:
+        GitRemoteError: If the remote cannot be queried.
+    """
+    if _is_git_available():
+        logger.debug("Using git CLI to check remote ref '%s' on %s", ref, remote_url)
+        return _remote_ref_exists_with_git_cli(remote_url, ref)
+
+    logger.debug("Git CLI not available, using pygit2 to check remote ref '%s' on %s", ref, remote_url)
+    return _remote_ref_exists_with_pygit2(remote_url, ref)

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -28,6 +28,7 @@ from griptape_nodes.utils.git_utils import (
     is_git_url,
     normalize_github_url,
     parse_git_url_with_ref,
+    remote_ref_exists,
     switch_branch,
 )
 
@@ -1153,3 +1154,67 @@ class TestGetGitInfo:
             get_git_info(temp_dir)
 
         mock_repo_class.assert_called_once()
+
+
+class TestRemoteRefExists:
+    """Tests for remote_ref_exists."""
+
+    def test_returns_true_when_git_cli_lists_matching_ref(self) -> None:
+        completed = Mock(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+        with (
+            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=True),
+            patch("griptape_nodes.utils.git_utils.subprocess.run", return_value=completed) as mock_run,
+        ):
+            assert remote_ref_exists("git@github.com:owner/repo.git", "main") is True
+
+        args = mock_run.call_args.args[0]
+        assert args == ["git", "ls-remote", "--heads", "--tags", "git@github.com:owner/repo.git", "main"]
+
+    def test_returns_false_when_git_cli_lists_no_matching_ref(self) -> None:
+        completed = Mock(returncode=0, stdout="\n", stderr="")
+        with (
+            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=True),
+            patch("griptape_nodes.utils.git_utils.subprocess.run", return_value=completed),
+        ):
+            assert remote_ref_exists("git@github.com:owner/repo.git", "local-only-branch") is False
+
+    def test_raises_git_remote_error_when_git_cli_fails(self) -> None:
+        completed = Mock(returncode=128, stdout="", stderr="fatal: could not read from remote\n")
+        with (
+            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=True),
+            patch("griptape_nodes.utils.git_utils.subprocess.run", return_value=completed),
+            pytest.raises(GitRemoteError, match="Failed to query remote refs"),
+        ):
+            remote_ref_exists("git@github.com:owner/repo.git", "main")
+
+    def test_returns_true_when_pygit2_lists_matching_ref(self) -> None:
+        mock_remote = Mock()
+        mock_remote.ls_remotes.return_value = [{"name": "refs/heads/feature/foo"}, {"name": "refs/heads/main"}]
+        mock_repo = Mock()
+        mock_repo.remotes.create.return_value = mock_remote
+        with (
+            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=False),
+            patch("griptape_nodes.utils.git_utils.pygit2.init_repository", return_value=mock_repo),
+        ):
+            assert remote_ref_exists("https://github.com/owner/repo.git", "feature/foo") is True
+
+    def test_returns_false_when_pygit2_lists_no_matching_ref(self) -> None:
+        mock_remote = Mock()
+        mock_remote.ls_remotes.return_value = [{"name": "refs/heads/main"}]
+        mock_repo = Mock()
+        mock_repo.remotes.create.return_value = mock_remote
+        with (
+            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=False),
+            patch("griptape_nodes.utils.git_utils.pygit2.init_repository", return_value=mock_repo),
+        ):
+            assert remote_ref_exists("https://github.com/owner/repo.git", "local-only-branch") is False
+
+    def test_raises_git_remote_error_when_pygit2_fails(self) -> None:
+        mock_repo = Mock()
+        mock_repo.remotes.create.side_effect = pygit2.GitError("auth failed")
+        with (
+            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=False),
+            patch("griptape_nodes.utils.git_utils.pygit2.init_repository", return_value=mock_repo),
+            pytest.raises(GitRemoteError, match="Failed to query remote refs"),
+        ):
+            remote_ref_exists("https://github.com/owner/repo.git", "main")


### PR DESCRIPTION
Closes #4922

Checking a library for updates assumed the library's current git ref always exists on the remote. When it doesn't (a local-only branch, an unpushed branch, a branch deleted upstream, or a detached HEAD on a bare commit), the fetch failed and the whole check returned a failure with a raw git error.

The check now verifies the current ref exists on the remote before attempting to clone it. When the ref is absent there is nothing to compare against, so it reports no update available, mirroring how the existing monorepo case returns a no-update success. A genuine remote-query failure (network or auth) still surfaces as a failure.

`remote_ref_exists` is added to `git_utils` and follows the same git-CLI-with-pygit2-fallback pattern as `sparse_checkout_library_json`.
