### PR TITLE
fix: suppress save warning when parameter.serializable=False (#4795)

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4324,42 +4324,83 @@ class NodeManager:
             or (parameter.default_value is not None and effective_value == parameter.default_value)
         ):
             internal_value = effective_value
-        # A parameter can have BOTH an internal (set) value and an output value, and each is
-        # serialized independently against the same tracker/uniques map. The two passes share
-        # identical handling — hash the value, emit a command, or warn on genuine failure — so
-        # we iterate over (value, is_output, value_kind) rather than duplicating the body.
-        # value_kind is the human-readable label ("set" / "output") used only in the warning text.
+        # A parameter can have BOTH an internal (set) value and an output value; each is
+        # serialized independently against the same tracker/uniques map.
         commands = []
-        for value, is_output, value_kind in (
-            (internal_value, False, "set"),
-            (output_value, True, "output"),
-        ):
-            # No value of this kind was set on the node — nothing to serialize.
-            if value is None:
-                continue
-            command = NodeManager._handle_value_hashing(
-                value=value,
-                serialized_parameter_value_tracker=serialized_parameter_value_tracker,
-                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
-                parameter=parameter,
-                is_output=is_output,
-                parameter_name=parameter.name,
-                node_name=node.name,
-                use_pickling=use_pickling,
-            )
-            if command is None:
-                # Author opted out via serializable=False — silently skip; not a failure.
-                if not parameter.serializable:
-                    continue
-                # Genuine serialization failure — warn and mark unresolved.
-                details = f"Attempted to serialize {value_kind} value for parameter '{parameter.name}' on node '{node.name}'. The {value_kind} value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
-                logger.warning(details)
-                if isinstance(create_node_request, CreateNodeRequest):
-                    create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
-                # Failure already handled above — move on to the next value kind.
-                continue
-            commands.append(command)
+        internal_command = NodeManager._serialize_one_parameter_value_for_save(
+            value=internal_value,
+            value_kind="set",
+            is_output=False,
+            parameter=parameter,
+            node=node,
+            unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+            serialized_parameter_value_tracker=serialized_parameter_value_tracker,
+            create_node_request=create_node_request,
+            use_pickling=use_pickling,
+        )
+        if internal_command is not None:
+            commands.append(internal_command)
+        output_command = NodeManager._serialize_one_parameter_value_for_save(
+            value=output_value,
+            value_kind="output",
+            is_output=True,
+            parameter=parameter,
+            node=node,
+            unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+            serialized_parameter_value_tracker=serialized_parameter_value_tracker,
+            create_node_request=create_node_request,
+            use_pickling=use_pickling,
+        )
+        if output_command is not None:
+            commands.append(output_command)
         return commands or None
+
+    @staticmethod
+    def _serialize_one_parameter_value_for_save(  # noqa: PLR0913
+        *,
+        value: Any,
+        value_kind: str,
+        is_output: bool,
+        parameter: Parameter,
+        node: BaseNode,
+        unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
+        serialized_parameter_value_tracker: SerializedParameterValueTracker,
+        create_node_request: CreateNodeRequest,
+        use_pickling: bool,
+    ) -> SerializedNodeCommands.IndirectSetParameterValueCommand | None:
+        """Serialize one of a parameter's values (internal-set or output) for workflow save.
+
+        Returns the command to record on success. Returns None when there is nothing to record:
+        either no value was present, the author opted out via serializable=False, or serialization
+        genuinely failed. In the genuine-failure case, also emits a warning and marks the node
+        UNRESOLVED — opt-outs are silent.
+
+        value_kind is "set" or "output" and is used only in the warning text.
+        """
+        # No value of this kind was set on the node.
+        if value is None:
+            return None
+        command = NodeManager._handle_value_hashing(
+            value=value,
+            serialized_parameter_value_tracker=serialized_parameter_value_tracker,
+            unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
+            parameter=parameter,
+            is_output=is_output,
+            parameter_name=parameter.name,
+            node_name=node.name,
+            use_pickling=use_pickling,
+        )
+        if command is not None:
+            return command
+        # Author opted out via serializable=False — silently skip; not a failure.
+        if not parameter.serializable:
+            return None
+        # Genuine serialization failure — warn and mark unresolved.
+        details = f"Attempted to serialize {value_kind} value for parameter '{parameter.name}' on node '{node.name}'. The {value_kind} value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
+        logger.warning(details)
+        if isinstance(create_node_request, CreateNodeRequest):
+            create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
+        return None
 
     @staticmethod
     def serialize_parameter_output_values(node: BaseNode, *, use_pickling: bool = False) -> SerializedParameterValues:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4324,47 +4324,41 @@ class NodeManager:
             or (parameter.default_value is not None and effective_value == parameter.default_value)
         ):
             internal_value = effective_value
-        # We have a value. Attempt to get a hash for it to see if it matches one
-        # we've already indexed.
+        # A parameter can have BOTH an internal (set) value and an output value, and each is
+        # serialized independently against the same tracker/uniques map. The two passes share
+        # identical handling — hash the value, emit a command, or warn on genuine failure — so
+        # we iterate over (value, is_output, value_kind) rather than duplicating the body.
+        # value_kind is the human-readable label ("set" / "output") used only in the warning text.
         commands = []
-        if internal_value is not None:
-            internal_command = NodeManager._handle_value_hashing(
-                value=internal_value,
+        for value, is_output, value_kind in (
+            (internal_value, False, "set"),
+            (output_value, True, "output"),
+        ):
+            # No value of this kind was set on the node — nothing to serialize.
+            if value is None:
+                continue
+            command = NodeManager._handle_value_hashing(
+                value=value,
                 serialized_parameter_value_tracker=serialized_parameter_value_tracker,
                 unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
                 parameter=parameter,
-                is_output=False,
+                is_output=is_output,
                 parameter_name=parameter.name,
                 node_name=node.name,
                 use_pickling=use_pickling,
             )
-            if internal_command is None:
-                details = f"Attempted to serialize set value for parameter '{parameter.name}' on node '{node.name}'. The set value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
+            if command is None:
+                # Author opted out via serializable=False — silently skip; not a failure.
+                if not parameter.serializable:
+                    continue
+                # Genuine serialization failure — warn and mark unresolved.
+                details = f"Attempted to serialize {value_kind} value for parameter '{parameter.name}' on node '{node.name}'. The {value_kind} value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
                 logger.warning(details)
-                # Set node to unresolved when serialization fails (only for CreateNodeRequest)
                 if isinstance(create_node_request, CreateNodeRequest):
                     create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
-            else:
-                commands.append(internal_command)
-        if output_value is not None:
-            output_command = NodeManager._handle_value_hashing(
-                value=output_value,
-                serialized_parameter_value_tracker=serialized_parameter_value_tracker,
-                unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
-                parameter=parameter,
-                is_output=True,
-                parameter_name=parameter.name,
-                node_name=node.name,
-                use_pickling=use_pickling,
-            )
-            if output_command is None:
-                details = f"Attempted to serialize output value for parameter '{parameter.name}' on node '{node.name}'. The output value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
-                logger.warning(details)
-                # Set node to unresolved when serialization fails (only for CreateNodeRequest)
-                if isinstance(create_node_request, CreateNodeRequest):
-                    create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
-            else:
-                commands.append(output_command)
+                # Failure already handled above — move on to the next value kind.
+                continue
+            commands.append(command)
         return commands or None
 
     @staticmethod

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -131,6 +131,90 @@ class TestNodeManagerResolutionStateSerialization:
         # Resolution should be reset to UNRESOLVED due to serialization failure
         assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
 
+    def test_serializable_false_param_does_not_warn_or_unresolve(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A parameter explicitly opting out via serializable=False must not trigger the warning or UNRESOLVED transition."""
+        from unittest.mock import MagicMock
+
+        from griptape_nodes.exe_types.core_types import Parameter
+        from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+        from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager, SerializedParameterValueTracker
+
+        mock_parameter = MagicMock(spec=Parameter)
+        mock_parameter.name = "session"
+        mock_parameter.serializable = False
+
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.parameter_values = {}
+        mock_node.parameter_output_values = {"session": object()}
+        mock_node.get_parameter_value.return_value = None
+
+        create_node_request = CreateNodeRequest(
+            node_type="TestNode", node_name="test_node", resolution=NodeResolutionState.RESOLVED.value
+        )
+
+        # Tracker reports NOT_IN_TRACKER so _handle_value_hashing enters the opt-out branch
+        # (parameter.serializable is False) and returns None.
+        mock_tracker = MagicMock()
+        mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_IN_TRACKER
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+
+        NodeManager.handle_parameter_value_saving(
+            parameter=mock_parameter,
+            node=mock_node,
+            unique_parameter_uuid_to_values={},
+            serialized_parameter_value_tracker=mock_tracker,
+            create_node_request=create_node_request,
+        )
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("Attempted to serialize" in msg for msg in warning_messages)
+        assert create_node_request.resolution == NodeResolutionState.RESOLVED.value
+
+    def test_serializable_true_param_with_pickle_failure_still_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Genuine serialization failures (serializable=True) must still emit the warning."""
+        from unittest.mock import MagicMock
+
+        from griptape_nodes.exe_types.core_types import Parameter
+        from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+        from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager, SerializedParameterValueTracker
+
+        mock_parameter = MagicMock(spec=Parameter)
+        mock_parameter.name = "test_param"
+        mock_parameter.serializable = True
+
+        mock_node = MagicMock(spec=BaseNode)
+        mock_node.name = "test_node"
+        mock_node.parameter_values = {"test_param": "has_value"}
+        mock_node.parameter_output_values = {}
+        mock_node.get_parameter_value.return_value = "some_value"
+
+        create_node_request = CreateNodeRequest(
+            node_type="TestNode", node_name="test_node", resolution=NodeResolutionState.RESOLVED.value
+        )
+
+        mock_tracker = MagicMock()
+        mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_SERIALIZABLE
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+
+        NodeManager.handle_parameter_value_saving(
+            parameter=mock_parameter,
+            node=mock_node,
+            unique_parameter_uuid_to_values={},
+            serialized_parameter_value_tracker=mock_tracker,
+            create_node_request=create_node_request,
+        )
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Attempted to serialize set value for parameter 'test_param'" in msg for msg in warning_messages)
+        assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
+
 
 class TestNodeManagerAlterParameterDetailsClearDefaultValue:
     """Test AlterParameterDetailsRequest behavior when clear_default_value and default_value are both set."""


### PR DESCRIPTION
## Summary
- Resolves [#4795](https://github.com/griptape-ai/griptape-nodes-engine/issues/4795). `NodeManager.handle_parameter_value_saving` no longer emits the `Attempted to serialize ... value for parameter` warning, nor flips the node to `UNRESOLVED`, when the parameter declares `serializable=False`. Genuine pickle failures on `serializable=True` parameters still warn and still mark the node `UNRESOLVED`, preserving today's behavior.
- Refactor: the duplicated internal-value / output-value branches are now one helper, `_serialize_one_parameter_value_for_save`, called twice with keyword args. Failure cases (no value, opt-out, genuine failure) sit at the top of the helper with explicit early returns, success path at the bottom.

## Test plan
- [x] `uv run pytest tests/unit/retained_mode/managers/test_node_manager.py::TestNodeManagerResolutionStateSerialization -v` — added two new cases:
  - `test_serializable_false_param_does_not_warn_or_unresolve` — opt-out is silent and resolution stays `RESOLVED`.
  - `test_serializable_true_param_with_pickle_failure_still_warns` — genuine failure still warns and flips to `UNRESOLVED`.
- [x] `make check` — clean.
- [ ] Manual repro from the issue: node with `serializable=False` parameter holding a non-pickleable value → execute → save. Confirm no `Attempted to serialize` warning appears and the node remains `RESOLVED` after save/reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)