### PR TITLE
feat(projects): add ProjectManager.get_project_chain for ancestry resolution

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -368,6 +368,20 @@ class ProjectInfo:
     parsed_directory_schemas: dict[str, ParsedMacro]  # directory_name -> ParsedMacro
 
 
+@dataclass(frozen=True)
+class ProjectChainEntry:
+    """One project in a resolved ancestry chain: its id and best-effort name.
+
+    `id` is the canonical registry key. `name` is the cached template name when the
+    project's template has loaded, otherwise None. Consumers that gate on the chain
+    (e.g. a project-scoped license policy) read `id` to match a project and `name`
+    for display; both mirror the facts a single-project authorization surfaces.
+    """
+
+    id: ProjectID
+    name: str | None = None
+
+
 class _ProjectActivationOutcome(NamedTuple):
     """Result of establishing a project's config/workspace/env layers and reloading.
 
@@ -2141,6 +2155,57 @@ class ProjectManager:
     def _cached_project_name(self, project_id: ProjectID) -> str | None:
         info = self._successfully_loaded_project_templates.get(project_id)
         return getattr(getattr(info, "template", None), "name", None)
+
+    def get_project_chain(self, project_id: ProjectID | None = None) -> list[ProjectChainEntry]:
+        """Resolve a project and its ancestors into an ordered, leaf-first chain.
+
+        Returns the project identified by `project_id` (the current project when
+        None) followed by each ancestor reached through the parent chain
+        (`parent_project_id`, or legacy `parent_project_path`), nearest first. Each
+        entry carries the project id and a best-effort display name (the cached
+        template name; absent when the project's template has not loaded).
+
+        This is the ancestry a project-scoped license policy is evaluated against:
+        loading or working in a child transitively pulls in every ancestor's
+        template (situations, directories, environment), so the policy is screened
+        once per entry and the child is permitted only when the policy permits the
+        child and all of its ancestors.
+
+        The walk consults only the in-memory registry (no disk I/O), in id-space
+        so an opaque GUID id and a legacy path-string id compare consistently: an
+        unregistered or unresolvable parent ends the chain, and a repeated id
+        breaks a cycle, so the result is always finite and free of duplicates. The
+        chain always has at least the starting project, even when it is not
+        registered (its id alone, no name), matching the single-project fact's
+        always-present contract.
+        """
+        start_id: ProjectID = project_id if project_id is not None else self._current_project_id
+
+        # Reverse map so a legacy parent_project_path link resolves to the parent's
+        # real (id-keyed) registry key rather than its path string, matching
+        # _check_parent_chain_cycles.
+        file_path_to_id: dict[Path, ProjectID] = {
+            info.project_file_path: pid
+            for pid, info in self._successfully_loaded_project_templates.items()
+            if info.project_file_path is not None
+        }
+
+        chain: list[ProjectChainEntry] = []
+        visited: set[ProjectID] = set()
+        current_id: ProjectID | None = start_id
+        while current_id is not None and current_id not in visited:
+            visited.add(current_id)
+            info = self._successfully_loaded_project_templates.get(current_id)
+            template = info.template if info is not None else None
+            name = getattr(template, "name", None)
+            chain.append(ProjectChainEntry(id=current_id, name=str(name) if name else None))
+            if template is None:
+                # Unregistered/legacy project: surface its id, but there is no
+                # template to read a parent link from, so the chain ends here.
+                break
+            anchor = info.project_file_path if info is not None else None
+            current_id = self._reduce_parent_link_to_id(template, anchor, file_path_to_id)
+        return chain
 
     async def on_set_current_project_request(
         self, request: SetCurrentProjectRequest

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -9158,3 +9158,119 @@ class TestImportProject:
         import_result = await pm.on_import_project_request(import_request)
         assert isinstance(import_result, ImportProjectResultSuccess)
         assert import_result.project_id in pm._successfully_loaded_project_templates
+
+
+class TestProjectManagerGetProjectChain:
+    """`get_project_chain` resolves a project and its ancestors, leaf-first."""
+
+    @staticmethod
+    def _pm() -> ProjectManager:
+        return ProjectManager(Mock(), Mock(), Mock())
+
+    @staticmethod
+    def _register(
+        pm: ProjectManager,
+        project_id: str,
+        *,
+        name: str | None = None,
+        parent_id: str | None = None,
+        file: Path | None = None,
+    ) -> None:
+        """Register an id-linked project directly in the in-memory registry.
+
+        The parent link is an explicit `parent_project_id`, so the walk resolves it
+        through the registry without touching disk; `name` rides on the template so
+        each chain entry can assert a distinct display name.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+        update: dict[str, Any] = {"id": project_id, "parent_project_id": parent_id}
+        if name is not None:
+            update["name"] = name
+        template = DEFAULT_PROJECT_TEMPLATE.model_copy(update=update)
+        pm._successfully_loaded_project_templates[project_id] = ProjectInfo(
+            project_id=project_id,
+            project_file_path=file,
+            project_base_dir=file.parent if file is not None else Path("/"),
+            template=template,
+            validation=ProjectValidationInfo(status=ProjectValidationStatus.GOOD),
+            parsed_situation_schemas={},
+            parsed_directory_schemas={},
+        )
+
+    def test_chain_for_parentless_project_is_just_itself(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectChainEntry
+
+        pm = self._pm()
+        self._register(pm, "solo", name="Solo")
+        pm._current_project_id = "solo"
+        assert pm.get_project_chain() == [ProjectChainEntry(id="solo", name="Solo")]
+
+    def test_chain_walks_parents_leaf_first(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectChainEntry
+
+        pm = self._pm()
+        self._register(pm, "root", name="Root")
+        self._register(pm, "mid", name="Mid", parent_id="root")
+        self._register(pm, "leaf", name="Leaf", parent_id="mid")
+        pm._current_project_id = "leaf"
+        assert pm.get_project_chain() == [
+            ProjectChainEntry(id="leaf", name="Leaf"),
+            ProjectChainEntry(id="mid", name="Mid"),
+            ProjectChainEntry(id="root", name="Root"),
+        ]
+
+    def test_chain_accepts_explicit_project_id_overriding_current(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectChainEntry
+
+        pm = self._pm()
+        self._register(pm, "root", name="Root")
+        self._register(pm, "leaf", name="Leaf", parent_id="root")
+        pm._current_project_id = "root"
+        assert pm.get_project_chain("leaf") == [
+            ProjectChainEntry(id="leaf", name="Leaf"),
+            ProjectChainEntry(id="root", name="Root"),
+        ]
+
+    def test_chain_breaks_on_cycle_without_repeating(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectChainEntry
+
+        pm = self._pm()
+        # a -> b -> a: the walk must terminate at the first repeated id.
+        self._register(pm, "a", name="A", parent_id="b")
+        self._register(pm, "b", name="B", parent_id="a")
+        pm._current_project_id = "a"
+        assert pm.get_project_chain() == [
+            ProjectChainEntry(id="a", name="A"),
+            ProjectChainEntry(id="b", name="B"),
+        ]
+
+    def test_chain_surfaces_unregistered_parent_by_id_then_stops(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectChainEntry
+
+        pm = self._pm()
+        self._register(pm, "leaf", name="Leaf", parent_id="ghost")
+        pm._current_project_id = "leaf"
+        # The unregistered parent's id is surfaced (so a policy can still match it),
+        # but it has no template to walk further and no resolved name.
+        assert pm.get_project_chain() == [
+            ProjectChainEntry(id="leaf", name="Leaf"),
+            ProjectChainEntry(id="ghost", name=None),
+        ]
+
+    def test_chain_for_unregistered_start_is_just_its_id(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectChainEntry
+
+        pm = self._pm()
+        pm._current_project_id = "missing"
+        assert pm.get_project_chain() == [ProjectChainEntry(id="missing", name=None)]
+
+    def test_chain_defaults_to_current_project(self) -> None:
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
+
+        pm = self._pm()
+        # __init__ registers system defaults and points the current id at them.
+        chain = pm.get_project_chain()
+        assert [entry.id for entry in chain] == [SYSTEM_DEFAULTS_KEY]


### PR DESCRIPTION
The app's Tier-2 license policy gates on the active project, but projects can declare a parent chain (`parent_project_id`, or legacy `parent_project_path`) and a project-scoped policy needs every project in that ancestry, not just the leaf. `get_project_chain` exposes the ancestry as a clean engine surface so the app does not reach into `ProjectManager` internals or re-implement the parent walk.

The chain is leaf-first (the project, then each ancestor) and resolved in id-space through the in-memory registry only, reusing the same `_reduce_parent_link_to_id` reduction the cycle checker uses so a GUID id and a legacy path-string id compare consistently. It surfaces an unregistered parent by id before stopping, so a policy can still match an ancestor whose template failed to load, and always returns at least the starting project to match the always-present contract the consumer relies on. How a consumer combines the per-project decisions (the app uses deny-wins) is its own concern; this only resolves the chain.

For a project `team-acme` whose `parent_project_id` is `org-base`, which is itself unparented, `get_project_chain()` returns the ancestry leaf-first:

```python
[
    ProjectChainEntry(id="team-acme", name="Acme Team"),
    ProjectChainEntry(id="org-base", name="Org Base"),
]
```

An unparented project is a single-entry chain, `[ProjectChainEntry(id="org-base", name="Org Base")]`, and the system-defaults rest state surfaces under its sentinel id, `[ProjectChainEntry(id="<system-defaults>", name="System Defaults")]`. An ancestor whose template is not loaded still surfaces its id with `name=None` and ends the walk there.