### PR TITLE
feat(workflows): add create_versioned_workflow situation + per-save flag; close #4945

### DIFF
--- a/docs/projects/situations.md
+++ b/docs/projects/situations.md
@@ -121,9 +121,7 @@ policy:   overwrite, create_dirs: true
 fallback: save_file
 ```
 
-Used when a workflow is saved. The workflow file goes into the workspace root, preserving any sub-directory hierarchy via the optional `{sub_dirs?:/}` prefix. By default, saving a workflow overwrites the existing file rather than versioning it.
-
-A project can customize `save_workflow` like any other situation. For example, setting the macro to `{workspace_dir}/{sub_dirs?:/}{file_name_base}_v{_index:03}.{file_extension}` with the `create_new` policy produces a versioned sequence (`my_workflow_v001.py`, `my_workflow_v002.py`, …) — see [Macros — Numeric padding](macros.md#numeric-padding) for the auto-index contract.
+Used when a workflow is saved. The workflow file goes into the workspace root, preserving any sub-directory hierarchy via the optional `{sub_dirs?:/}` prefix. Saving a workflow overwrites the existing file rather than versioning it; to produce a numbered sequence of saves instead, see [`create_versioned_workflow`](#create_versioned_workflow) below.
 
 **Example:**
 
@@ -133,6 +131,29 @@ workspace_dir="/projects/demo", file_name_base="my_workflow", file_extension="py
 
 sub_dirs="archived", file_name_base="my_workflow", file_extension="py"
 → /projects/demo/archived/my_workflow.py
+```
+
+### `create_versioned_workflow`
+
+```
+macro:    {workspace_dir}/{sub_dirs?:/}{file_name_base}_v{_index:03}.{file_extension}
+policy:   create_new, create_dirs: true
+fallback: save_file
+```
+
+Used when a workflow is saved with the versioned-save intent. Every save produces a new file with the next padded index in the sequence — `my_workflow_v001.py`, `my_workflow_v002.py`, … — so users can keep snapshots without overwriting earlier work. The trailing `_v###` suffix on the previous save is stripped before the next index is computed, so the sequence stays anchored to the base name.
+
+This situation is selected at the API layer by passing `create_versioned=True` on `SaveWorkflowRequest`; the UI exposes it as a separate menu item (e.g. "Save New Version"). See [Macros — Numeric padding](macros.md#numeric-padding) for the auto-index contract.
+
+> **Note**: Customizing `save_workflow` to use `create_new` directly (instead of using `create_versioned_workflow` + the flag) emits a warning at save time. The configuration still works — the first save lands at `_v001` — but every subsequent save hits the in-place overwrite branch and writes back to `_v001` rather than advancing to `_v002`. Use `create_versioned_workflow` for true versioning.
+
+**Example:**
+
+```
+workspace_dir="/projects/demo", file_name_base="my_workflow", file_extension="py"
+  First save  → /projects/demo/my_workflow_v001.py
+  Second save → /projects/demo/my_workflow_v002.py
+  Third save  → /projects/demo/my_workflow_v003.py
 ```
 
 ## How nodes use situations

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Self
 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.common.macro_parser.core import ParsedMacro
+from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
@@ -283,10 +284,13 @@ class LocalWorkflowExecutor(WorkflowExecutor):
 
         # Empty sentinel — use the save_failed_workflow situation
         situation_result = await GriptapeNodes.ahandle_request(
-            GetSituationRequest(situation_name="save_failed_workflow")
+            GetSituationRequest(situation_name=BuiltInSituation.SAVE_FAILED_WORKFLOW)
         )
         if not isinstance(situation_result, GetSituationResultSuccess):
-            logger.warning("Could not find 'save_failed_workflow' situation; falling back to workspace root.")
+            logger.warning(
+                "Could not find '%s' situation; falling back to workspace root.",
+                BuiltInSituation.SAVE_FAILED_WORKFLOW,
+            )
             return fallback
 
         parsed_macro = ParsedMacro(template=situation_result.situation.macro)

--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -3,6 +3,7 @@
 from griptape_nodes.common.project_templates.directory import DirectoryDefinition
 from griptape_nodes.common.project_templates.project import ProjectTemplate
 from griptape_nodes.common.project_templates.situation import (
+    BuiltInSituation,
     SituationFilePolicy,
     SituationPolicy,
     SituationTemplate,
@@ -77,8 +78,8 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
         "py": "python",
     },
     situations={
-        "save_file": SituationTemplate(
-            name="save_file",
+        BuiltInSituation.SAVE_FILE: SituationTemplate(
+            name=BuiltInSituation.SAVE_FILE,
             description="Generic file save operation",
             macro="{file_name_base}{_index?:03}.{file_extension}",
             policy=SituationPolicy(
@@ -87,123 +88,123 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             ),
             fallback=None,
         ),
-        "copy_external_file": SituationTemplate(
-            name="copy_external_file",
+        BuiltInSituation.COPY_EXTERNAL_FILE: SituationTemplate(
+            name=BuiltInSituation.COPY_EXTERNAL_FILE,
             description="User copies external file to project",
             macro="{inputs}/{node_name?:_}{parameter_name?:_}{file_name_base}{_index?:03}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.CREATE_NEW,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
-        "download_url": SituationTemplate(
-            name="download_url",
+        BuiltInSituation.DOWNLOAD_URL: SituationTemplate(
+            name=BuiltInSituation.DOWNLOAD_URL,
             description="Download file from URL",
             macro="{inputs}/{sanitized_url}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
-        "save_node_output": SituationTemplate(
-            name="save_node_output",
+        BuiltInSituation.SAVE_NODE_OUTPUT: SituationTemplate(
+            name=BuiltInSituation.SAVE_NODE_OUTPUT,
             description="Node generates and saves output",
             macro="{outputs}/{sub_dirs?:/}{node_name?:_}{file_name_base}{_index?:03}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.CREATE_NEW,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
-        "save_griptape_nodes_preview": SituationTemplate(
-            name="save_griptape_nodes_preview",
+        BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW: SituationTemplate(
+            name=BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW,
             description="Generate preview/thumbnail with preserved directory hierarchy",
             macro="{griptape-nodes-previews}/{drive_volume_mount?:/}{source_relative_path?:/}{source_file_name}.{preview_format}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
-        "save_static_file": SituationTemplate(
-            name="save_static_file",
+        BuiltInSituation.SAVE_STATIC_FILE: SituationTemplate(
+            name=BuiltInSituation.SAVE_STATIC_FILE,
             description="Save static file to workflow-relative staticfiles directory. Required for projects using StaticFilesManager.save_static_file.",
             macro="{workflow_dir?:/}{static_files_dir}/{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
-        "save_griptape_nodes_metadata": SituationTemplate(
-            name="save_griptape_nodes_metadata",
+        BuiltInSituation.SAVE_GRIPTAPE_NODES_METADATA: SituationTemplate(
+            name=BuiltInSituation.SAVE_GRIPTAPE_NODES_METADATA,
             description="Save sidecar metadata file with preserved directory hierarchy",
             macro="{griptape-nodes-metadata}/{source_relative_path?:/}{source_file_name}.json",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
         # Workflows save into the workspace root today for backward compatibility.
         # Migrating to a dedicated subdirectory is tracked in
         # https://github.com/griptape-ai/griptape-nodes/issues/2047.
-        "save_workflow": SituationTemplate(
-            name="save_workflow",
+        BuiltInSituation.SAVE_WORKFLOW: SituationTemplate(
+            name=BuiltInSituation.SAVE_WORKFLOW,
             description="Save a workflow Python file, preserving any sub-directory hierarchy",
             macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
         # Versioned workflow save: every save bumps the padded `{_index:03}` slot, so
         # successive saves produce a sequence (foo_v001.py, foo_v002.py, ...). Selected
         # via SaveWorkflowRequest.create_versioned=True. The macro and CREATE_NEW policy
         # are user-customizable like any other situation.
         # https://github.com/griptape-ai/griptape-nodes-engine/issues/4945
-        "create_versioned_workflow": SituationTemplate(
-            name="create_versioned_workflow",
+        BuiltInSituation.CREATE_VERSIONED_WORKFLOW: SituationTemplate(
+            name=BuiltInSituation.CREATE_VERSIONED_WORKFLOW,
             description="Save a new version of a workflow with a padded index suffix",
             macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}_v{_index:03}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.CREATE_NEW,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
-        "save_workflow_thumbnail": SituationTemplate(
-            name="save_workflow_thumbnail",
+        BuiltInSituation.SAVE_WORKFLOW_THUMBNAIL: SituationTemplate(
+            name=BuiltInSituation.SAVE_WORKFLOW_THUMBNAIL,
             description="Save a workflow thumbnail image into the hidden workspace thumbnails directory",
             macro="{griptape-nodes-thumbnails}/{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_static_file",
+            fallback=BuiltInSituation.SAVE_STATIC_FILE,
         ),
-        "save_failed_workflow": SituationTemplate(
-            name="save_failed_workflow",
+        BuiltInSituation.SAVE_FAILED_WORKFLOW: SituationTemplate(
+            name=BuiltInSituation.SAVE_FAILED_WORKFLOW,
             description="Save a failed workflow snapshot for post-mortem debugging",
             macro="{workspace_dir}/failures/{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.CREATE_NEW,
                 create_dirs=True,
             ),
-            fallback="save_workflow",
+            fallback=BuiltInSituation.SAVE_WORKFLOW,
         ),
-        "save_temp_file": SituationTemplate(
-            name="save_temp_file",
+        BuiltInSituation.SAVE_TEMP_FILE: SituationTemplate(
+            name=BuiltInSituation.SAVE_TEMP_FILE,
             description="Save a temporary scratch file (e.g. intermediate processing artifacts)",
             macro="{temp}/{node_name?:_}{file_name_base}{_index?:03}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
-            fallback="save_file",
+            fallback=BuiltInSituation.SAVE_FILE,
         ),
     },
 )

--- a/src/griptape_nodes/common/project_templates/default_project_template.py
+++ b/src/griptape_nodes/common/project_templates/default_project_template.py
@@ -160,6 +160,21 @@ DEFAULT_PROJECT_TEMPLATE = ProjectTemplate(
             ),
             fallback="save_file",
         ),
+        # Versioned workflow save: every save bumps the padded `{_index:03}` slot, so
+        # successive saves produce a sequence (foo_v001.py, foo_v002.py, ...). Selected
+        # via SaveWorkflowRequest.create_versioned=True. The macro and CREATE_NEW policy
+        # are user-customizable like any other situation.
+        # https://github.com/griptape-ai/griptape-nodes-engine/issues/4945
+        "create_versioned_workflow": SituationTemplate(
+            name="create_versioned_workflow",
+            description="Save a new version of a workflow with a padded index suffix",
+            macro="{workspace_dir}/{sub_dirs?:/}{file_name_base}_v{_index:03}.{file_extension}",
+            policy=SituationPolicy(
+                on_collision=SituationFilePolicy.CREATE_NEW,
+                create_dirs=True,
+            ),
+            fallback="save_file",
+        ),
         "save_workflow_thumbnail": SituationTemplate(
             name="save_workflow_thumbnail",
             description="Save a workflow thumbnail image into the hidden workspace thumbnails directory",

--- a/src/griptape_nodes/common/project_templates/situation.py
+++ b/src/griptape_nodes/common/project_templates/situation.py
@@ -27,6 +27,33 @@ class SituationFilePolicy(StrEnum):
     PROMPT = "prompt"  # Special UI handling
 
 
+class BuiltInSituation(StrEnum):
+    """Names of the situations shipped in ``DEFAULT_PROJECT_TEMPLATE``.
+
+    Use these constants instead of raw strings when registering a situation,
+    looking one up via ``GetSituationRequest``, or wiring a destination via
+    ``ProjectFileDestination.from_situation``. The enum members are ``str``
+    subclasses (``StrEnum``), so existing string-typed APIs accept them
+    without changes.
+
+    Projects may add or override situations beyond these built-ins; this
+    enum is only the canonical name registry for the defaults.
+    """
+
+    SAVE_FILE = "save_file"
+    COPY_EXTERNAL_FILE = "copy_external_file"
+    DOWNLOAD_URL = "download_url"
+    SAVE_NODE_OUTPUT = "save_node_output"
+    SAVE_GRIPTAPE_NODES_PREVIEW = "save_griptape_nodes_preview"
+    SAVE_STATIC_FILE = "save_static_file"
+    SAVE_GRIPTAPE_NODES_METADATA = "save_griptape_nodes_metadata"
+    SAVE_WORKFLOW = "save_workflow"
+    CREATE_VERSIONED_WORKFLOW = "create_versioned_workflow"
+    SAVE_WORKFLOW_THUMBNAIL = "save_workflow_thumbnail"
+    SAVE_FAILED_WORKFLOW = "save_failed_workflow"
+    SAVE_TEMP_FILE = "save_temp_file"
+
+
 class SituationPolicy(BaseModel):
     """Policy for file operations in a situation."""
 

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 import httpx
 
+from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
 from griptape_nodes.files.file import FileLoadError
 from griptape_nodes.files.project_file import ProjectFileDestination
@@ -217,7 +218,7 @@ class LocalStorageDriver(BaseStorageDriver):
         Returns:
             Absolute path string for the resolved asset path
         """
-        destination = ProjectFileDestination.from_situation(path.name, "copy_external_file")
+        destination = ProjectFileDestination.from_situation(path.name, BuiltInSituation.COPY_EXTERNAL_FILE)
         try:
             resolved_path = Path(destination.resolve())
         except FileLoadError:

--- a/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.file import FileDestination, FileDestinationProvider
@@ -38,7 +39,7 @@ class ProjectFileParameter:
         output_file = self._file_param.build_file(sub_dirs="renders")
     """
 
-    DEFAULT_SITUATION = "save_node_output"
+    DEFAULT_SITUATION = BuiltInSituation.SAVE_NODE_OUTPUT
 
     def __init__(  # noqa: PLR0913
         self,

--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 
 from griptape_nodes.common.macro_parser import MacroVariables
+from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -72,7 +73,7 @@ class CreateStaticFileUploadUrlRequest(RequestPayload):
     """
 
     file_name: str
-    situation_name: str = "copy_external_file"
+    situation_name: str = BuiltInSituation.COPY_EXTERNAL_FILE
 
 
 @dataclass
@@ -123,7 +124,7 @@ class CreateStaticFileDownloadUrlRequest(RequestPayload):
     """
 
     file_name: str
-    situation_name: str = "copy_external_file"
+    situation_name: str = BuiltInSituation.COPY_EXTERNAL_FILE
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -310,6 +310,7 @@ class SaveWorkflowRequest(RequestPayload):
         image_path: Path to save workflow image/thumbnail (None for no image)
         pickle_control_flow_result: Whether to use pickle-based serialization for control flow results (None for default behavior)
         display_name: Optional display name (metadata.name). If provided, overrides the existing display name instead of preserving it.
+        create_versioned: When True, route the save through the ``create_versioned_workflow`` situation so each save produces a new versioned file (e.g. ``my_workflow_v001.py``, ``my_workflow_v002.py``, ...). When False (default), route through ``save_workflow``, which overwrites the existing file in place.
 
     Results: SaveWorkflowResultSuccess (with file path) | SaveWorkflowResultFailure (save error)
     """
@@ -318,6 +319,7 @@ class SaveWorkflowRequest(RequestPayload):
     image_path: str | None = None
     pickle_control_flow_result: bool | None = None
     display_name: str | None = None
+    create_versioned: bool = False
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/file_metadata/sidecar_metadata.py
+++ b/src/griptape_nodes/retained_mode/file_metadata/sidecar_metadata.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel
 
 from griptape_nodes.common.macro_parser import ParsedMacro
-from griptape_nodes.common.project_templates.situation import SituationFilePolicy
+from griptape_nodes.common.project_templates.situation import BuiltInSituation, SituationFilePolicy
 from griptape_nodes.files.path_utils import decompose_source_path
 from griptape_nodes.retained_mode.events.project_events import (
     GetCurrentProjectRequest,
@@ -90,10 +90,10 @@ def _resolve_sidecar_path(file_path: Path) -> Path:
     decomposed = decompose_source_path(file_path, workspace_dir)
 
     get_situation_result = GriptapeNodes.handle_request(
-        GetSituationRequest(situation_name="save_griptape_nodes_metadata")
+        GetSituationRequest(situation_name=BuiltInSituation.SAVE_GRIPTAPE_NODES_METADATA)
     )
     if not isinstance(get_situation_result, GetSituationResultSuccess):
-        msg = "save_griptape_nodes_metadata situation not found in project template"
+        msg = f"{BuiltInSituation.SAVE_GRIPTAPE_NODES_METADATA} situation not found in project template"
         raise RuntimeError(msg)  # noqa: TRY004
 
     variables: dict[str, str | int] = {"source_file_name": decomposed.source_file_name}

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -10,6 +10,7 @@ import semver
 from pydantic import BaseModel, ValidationError
 
 from griptape_nodes.common.macro_parser import MacroVariables, ParsedMacro
+from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.files.path_utils import decompose_source_path
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.artifact_events import (
@@ -1481,11 +1482,11 @@ class ArtifactManager:
         decomposed = decompose_source_path(source_path_obj, workspace_dir)
 
         # Get save_griptape_nodes_preview situation template
-        get_situation_request = GetSituationRequest(situation_name="save_griptape_nodes_preview")
+        get_situation_request = GetSituationRequest(situation_name=BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW)
         get_situation_result = GriptapeNodes.handle_request(get_situation_request)
 
         if not isinstance(get_situation_result, GetSituationResultSuccess):
-            msg = "save_griptape_nodes_preview situation not found in project template"
+            msg = f"{BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW} situation not found in project template"
             raise RuntimeError(msg)  # noqa: TRY004
 
         # Build variables dict for macro resolution
@@ -1515,7 +1516,7 @@ class ArtifactManager:
         full_preview_path = path_result.absolute_path
         preview_file_metadata = SidecarContent(
             situation=SituationMetadata(
-                name="save_griptape_nodes_preview",
+                name=BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW,
                 macro=situation.macro,
                 policy=SituationPolicy(
                     on_collision=situation.policy.on_collision,

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
-from griptape_nodes.common.project_templates.situation import SituationFilePolicy
+from griptape_nodes.common.project_templates.situation import BuiltInSituation, SituationFilePolicy
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
@@ -54,8 +54,6 @@ from griptape_nodes.servers.static import STATIC_SERVER_HOST, STATIC_SERVER_PORT
 from griptape_nodes.utils.url_utils import uri_to_path
 
 logger = logging.getLogger("griptape_nodes")
-
-SAVE_STATIC_FILE_SITUATION = "save_static_file"
 
 USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config.json"
 
@@ -452,7 +450,7 @@ class StaticFilesManager:
         """
         resolved = self._resolve_static_file_path(file_name)
         if resolved is None:
-            msg = f"Attempted to save static file '{file_name}'. Failed because the project template is missing the '{SAVE_STATIC_FILE_SITUATION}' situation."
+            msg = f"Attempted to save static file '{file_name}'. Failed because the project template is missing the '{BuiltInSituation.SAVE_STATIC_FILE}' situation."
             raise RuntimeError(msg)
 
         file_path = resolved.path
@@ -479,7 +477,7 @@ class StaticFilesManager:
         return self.storage_driver.create_signed_download_url(Path(saved_path))
 
     def _resolve_static_file_path(
-        self, file_name: str, situation_name: str = SAVE_STATIC_FILE_SITUATION
+        self, file_name: str, situation_name: str = BuiltInSituation.SAVE_STATIC_FILE
     ) -> ResolvedStaticFilePath | None:
         """Resolve the file path for a static file using the given situation.
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -23,6 +23,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from griptape_nodes.common.project_templates.situation import SituationFilePolicy
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode, EndNode, StartNode
@@ -77,6 +78,10 @@ from griptape_nodes.retained_mode.events.os_events import (
     GetFileInfoRequest,
     GetFileInfoResultFailure,
     GetFileInfoResultSuccess,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    GetSituationRequest,
+    GetSituationResultSuccess,
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
     BranchWorkflowRequest,
@@ -304,6 +309,7 @@ class WorkflowManager:
         OVERWRITE_EXISTING = "overwrite_existing"  # Save existing workflow to same name
         SAVE_AS = "save_as"  # Save existing workflow with new name
         SAVE_FROM_TEMPLATE = "save_from_template"  # Save from a template
+        CREATE_VERSIONED = "create_versioned"  # Save a new version via create_versioned_workflow situation
 
     @dataclass
     class SaveWorkflowTargetInfo:
@@ -1965,8 +1971,13 @@ class WorkflowManager:
         destination: ProjectFileDestination
         relative_file_path: str
 
-    def _build_workflow_save_path(self, file_name: str, sub_dirs: str | None = None) -> WorkflowSavePath:
-        """Build a workflow save destination via the ``save_workflow`` situation.
+    def _build_workflow_save_path(
+        self,
+        file_name: str,
+        sub_dirs: str | None = None,
+        situation_name: str = "save_workflow",
+    ) -> WorkflowSavePath:
+        """Build a workflow save destination via a named situation.
 
         Returns an unresolved ``ProjectFileDestination`` plus a registry-relative
         display string. The destination's macro is resolved inside
@@ -1976,12 +1987,16 @@ class WorkflowManager:
         ``relative_file_path`` is computed from the user-supplied name and
         sub-directory directly; out-of-workspace handling and macro-form
         portability happen post-write via ``ProjectFileDestination._map_to_macro_file``.
+
+        ``situation_name`` defaults to ``save_workflow`` (overwrite-in-place
+        semantics). Pass ``create_versioned_workflow`` for the versioned-save
+        flow that bumps the padded index every save (issue #4945).
         """
         extra_vars: dict[str, str | int] = {}
         if sub_dirs:
             extra_vars["sub_dirs"] = sub_dirs
 
-        destination = ProjectFileDestination.from_situation(file_name, "save_workflow", **extra_vars)
+        destination = ProjectFileDestination.from_situation(file_name, situation_name, **extra_vars)
         relative_file_path = str(Path(sub_dirs) / file_name) if sub_dirs else file_name
         return WorkflowManager.WorkflowSavePath(
             destination=destination,
@@ -2008,7 +2023,11 @@ class WorkflowManager:
             return str(path)
         return str(relative)
 
-    def _resolve_named_save_path(self, requested_file_name: str) -> NamedSavePath:
+    def _resolve_named_save_path(
+        self,
+        requested_file_name: str,
+        situation_name: str = "save_workflow",
+    ) -> NamedSavePath:
         """Resolve a user-supplied save name (possibly carrying a directory) to a save destination.
 
         A relative name like "episode/my_wf" splits into sub-directory + stem and routes
@@ -2016,13 +2035,20 @@ class WorkflowManager:
         when renaming an externally-registered workflow) is honored verbatim:
         ProjectFileDestination.from_situation bypasses the workspace macro for absolute
         filenames.
+
+        ``situation_name`` selects which situation drives the save (default
+        ``save_workflow``; pass ``create_versioned_workflow`` for versioned saves).
         """
         parts = FilenameParts.from_filename(f"{requested_file_name}.py")
         if parts.directory.is_absolute():
-            destination, relative_file_path = self._build_workflow_save_path(f"{requested_file_name}.py")
+            destination, relative_file_path = self._build_workflow_save_path(
+                f"{requested_file_name}.py", situation_name=situation_name
+            )
         else:
             sub_dirs = str(parts.directory) if str(parts.directory) != "." else None
-            destination, relative_file_path = self._build_workflow_save_path(f"{parts.stem}.py", sub_dirs=sub_dirs)
+            destination, relative_file_path = self._build_workflow_save_path(
+                f"{parts.stem}.py", sub_dirs=sub_dirs, situation_name=situation_name
+            )
         return WorkflowManager.NamedSavePath(
             file_name=parts.stem, destination=destination, relative_file_path=relative_file_path
         )
@@ -2111,6 +2137,7 @@ class WorkflowManager:
             save_target = self._determine_save_target(
                 requested_file_name=request.file_name,
                 current_workflow_name=current_workflow_name,
+                create_versioned=request.create_versioned,
             )
         except ValueError as e:
             details = f"Attempted to save workflow. Failed when determining save target: {e}"
@@ -2324,14 +2351,24 @@ class WorkflowManager:
                 return candidate_name
             curr_idx += 1
 
-    def _determine_save_target(
-        self, requested_file_name: str | None, current_workflow_name: str | None
+    def _determine_save_target(  # noqa: C901, PLR0912, PLR0915
+        self,
+        requested_file_name: str | None,
+        current_workflow_name: str | None,
+        *,
+        create_versioned: bool = False,
     ) -> SaveWorkflowTargetInfo:
         """Determine the target file path, name, and metadata for saving a workflow.
 
         Args:
             requested_file_name: The name the user wants to save as (can be None)
             current_workflow_name: The workflow currently loaded in context (can be None)
+            create_versioned: When True, route every save through the
+                ``create_versioned_workflow`` situation so each save produces a
+                new versioned file (e.g. ``foo_v001.py``, ``foo_v002.py``, ...).
+                When False (default), the standard scenarios apply
+                (FIRST_SAVE / OVERWRITE_EXISTING / SAVE_AS / SAVE_FROM_TEMPLATE)
+                via the ``save_workflow`` situation.
 
         Returns:
             SaveWorkflowTargetInfo with all information needed to save the workflow
@@ -2353,6 +2390,43 @@ class WorkflowManager:
         current_workflow = None
         if current_workflow_name and WorkflowRegistry.has_workflow_with_name(current_workflow_name):
             current_workflow = WorkflowRegistry.get_workflow_by_name(current_workflow_name)
+
+        # Pick the situation up-front: create_versioned diverts EVERY save through
+        # create_versioned_workflow (with CREATE_NEW + a padded slot) so each save
+        # bumps the version. Without it, the standard save_workflow situation applies.
+        situation_name = "create_versioned_workflow" if create_versioned else "save_workflow"
+        self._warn_if_situation_policy_mismatches_intent(situation_name, create_versioned=create_versioned)
+
+        # CREATE_VERSIONED short-circuits the OVERWRITE_EXISTING branch. Even when
+        # the workflow is already in the registry with a saved file_path, a versioned
+        # save re-resolves the macro so OSManager's seed-and-retry walks past
+        # existing versions and produces the next one. We still need a base filename;
+        # prefer the user's requested name → current workflow's display name →
+        # registry-derived stem from the existing file_path.
+        if create_versioned:
+            base_name = self._derive_versioned_base_name(
+                requested_file_name=requested_file_name,
+                current_workflow=current_workflow,
+                target_workflow=target_workflow,
+            )
+            file_name, destination, relative_file_path = self._resolve_named_save_path(
+                base_name, situation_name=situation_name
+            )
+            creation_date = (
+                current_workflow.metadata.creation_date if current_workflow is not None else datetime.now(tz=UTC)
+            )
+            branched_from = current_workflow.metadata.branched_from if current_workflow is not None else None
+            if (creation_date is None) or (creation_date == WorkflowManager.EPOCH_START):
+                creation_date = datetime.now(tz=UTC)
+            return WorkflowManager.SaveWorkflowTargetInfo(
+                scenario=WorkflowManager.SaveWorkflowScenario.CREATE_VERSIONED,
+                file_name=file_name,
+                destination=destination,
+                file_path=None,
+                relative_file_path=relative_file_path,
+                creation_date=creation_date,
+                branched_from=branched_from,
+            )
 
         # Determine scenario and build target info
         # Only treat as SAVE_FROM_TEMPLATE if this is a Griptape-provided template.
@@ -2434,6 +2508,77 @@ class WorkflowManager:
             creation_date=creation_date,
             branched_from=branched_from,
         )
+
+    @staticmethod
+    def _derive_versioned_base_name(
+        *,
+        requested_file_name: str | None,
+        current_workflow: Workflow | None,
+        target_workflow: Workflow | None,
+    ) -> str:
+        """Pick the base filename for a versioned save.
+
+        Priority:
+        1. Explicit ``requested_file_name`` (user typed it).
+        2. The current workflow's display name (``metadata.name``), sanitized.
+        3. The current workflow's existing on-disk stem with any trailing
+           ``_v###`` version suffix stripped — so saving over ``foo_v001.py``
+           produces ``foo_v002.py`` (not ``foo_v001_v001.py``).
+        4. The target workflow's on-disk stem (same suffix strip), if no
+           current workflow is in scope.
+        5. A timestamp fallback when no other source is available.
+        """
+        if requested_file_name:
+            return requested_file_name
+
+        candidate_workflow = current_workflow if current_workflow is not None else target_workflow
+        if candidate_workflow is not None:
+            display_name = (candidate_workflow.metadata.name or "").strip()
+            sanitized = re.sub(r"[^A-Za-z0-9._/-]+", "_", display_name).strip("_/")
+            if sanitized:
+                return sanitized
+            if candidate_workflow.file_path is not None:
+                stem = derive_registry_key(candidate_workflow.file_path)
+                # Strip a trailing _v### so the next versioned save bumps the
+                # index against the same base name.
+                return re.sub(r"_v\d+$", "", stem)
+
+        return datetime.now(tz=UTC).strftime("%d.%m_%H.%M")
+
+    def _warn_if_situation_policy_mismatches_intent(self, situation_name: str, *, create_versioned: bool) -> None:
+        """Log a warning when a situation's policy doesn't match the caller's intent.
+
+        - ``create_versioned=True`` expects an unresolved padded slot; warn when
+          the chosen situation uses ``overwrite``.
+        - ``create_versioned=False`` expects in-place overwrite; warn when
+          ``save_workflow`` has been customized to ``create_new``.
+
+        These mismatches are configuration smells, not hard errors:
+        CREATE_NEW without a ``{x:NN}`` slot still works (OSManager's collision
+        fallback synthesizes ``_1``, ``_2``, ...), and OVERWRITE with an
+        ``{_index:NN}`` slot renders a literal ``_v000``. We surface the
+        mismatch so the user can correct the situation if it doesn't reflect
+        their intent.
+        """
+        result = GriptapeNodes.handle_request(GetSituationRequest(situation_name=situation_name))
+        if not isinstance(result, GetSituationResultSuccess):
+            return  # Missing situation surfaces as a load failure elsewhere; nothing useful to warn about here.
+
+        on_collision = result.situation.policy.on_collision
+        if create_versioned and on_collision != SituationFilePolicy.CREATE_NEW:
+            logger.warning(
+                "Versioned save requested but situation '%s' uses '%s' policy; saves may overwrite in place. "
+                "Set the situation's policy to 'create_new' (with a padded `{_index:NN}` slot) for true versioning.",
+                situation_name,
+                on_collision.value,
+            )
+        elif not create_versioned and on_collision == SituationFilePolicy.CREATE_NEW:
+            logger.warning(
+                "Non-versioned save requested but situation '%s' uses 'create_new' policy; saves will produce "
+                "auto-indexed files instead of overwriting in place. Set the situation's policy to 'overwrite' "
+                "for in-place saves, or use create_versioned=True for explicit versioning.",
+                situation_name,
+            )
 
     async def on_save_workflow_file_from_serialized_flow_request(
         self, request: SaveWorkflowFileFromSerializedFlowRequest

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -23,7 +23,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from griptape_nodes.common.project_templates.situation import SituationFilePolicy
+from griptape_nodes.common.project_templates.situation import BuiltInSituation, SituationFilePolicy
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode, EndNode, StartNode
@@ -1975,7 +1975,7 @@ class WorkflowManager:
         self,
         file_name: str,
         sub_dirs: str | None = None,
-        situation_name: str = "save_workflow",
+        situation_name: str = BuiltInSituation.SAVE_WORKFLOW,
     ) -> WorkflowSavePath:
         """Build a workflow save destination via a named situation.
 
@@ -2026,7 +2026,7 @@ class WorkflowManager:
     def _resolve_named_save_path(
         self,
         requested_file_name: str,
-        situation_name: str = "save_workflow",
+        situation_name: str = BuiltInSituation.SAVE_WORKFLOW,
     ) -> NamedSavePath:
         """Resolve a user-supplied save name (possibly carrying a directory) to a save destination.
 
@@ -2394,7 +2394,9 @@ class WorkflowManager:
         # Pick the situation up-front: create_versioned diverts EVERY save through
         # create_versioned_workflow (with CREATE_NEW + a padded slot) so each save
         # bumps the version. Without it, the standard save_workflow situation applies.
-        situation_name = "create_versioned_workflow" if create_versioned else "save_workflow"
+        situation_name = (
+            BuiltInSituation.CREATE_VERSIONED_WORKFLOW if create_versioned else BuiltInSituation.SAVE_WORKFLOW
+        )
         self._warn_if_situation_policy_mismatches_intent(situation_name, create_versioned=create_versioned)
 
         # CREATE_VERSIONED short-circuits the OVERWRITE_EXISTING branch. Even when

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2863,3 +2863,94 @@ class TestCreateVersionedWorkflow:
         assert any("uses 'create_new' policy" in record.message for record in caplog.records), (
             f"Expected warning about save_workflow policy mismatch, got: {[r.message for r in caplog.records]}"
         )
+
+    def test_warning_logged_when_create_versioned_workflow_customized_to_overwrite(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Inverse mismatch: create_versioned=True against a `create_versioned_workflow` flipped to overwrite.
+
+        A project author who keeps `save_workflow` at its default but flips
+        `create_versioned_workflow` to `overwrite` has broken the contract of
+        the per-save flag — `create_versioned=True` saves will overwrite in
+        place. Surface a warning so the misconfiguration doesn't sit silently.
+        """
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.common.project_templates.situation import (
+            BuiltInSituation,
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+            SetCurrentProjectRequest,
+        )
+
+        flipped = SituationTemplate(
+            name=BuiltInSituation.CREATE_VERSIONED_WORKFLOW,
+            description="Customized to overwrite",
+            macro="{workspace_dir}/{file_name_base}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.OVERWRITE, create_dirs=True),
+            fallback=BuiltInSituation.SAVE_FILE,
+        )
+        custom = DEFAULT_PROJECT_TEMPLATE.model_copy(
+            update={
+                "situations": {
+                    **DEFAULT_PROJECT_TEMPLATE.situations,
+                    BuiltInSituation.CREATE_VERSIONED_WORKFLOW: flipped,
+                }
+            }
+        )
+        project_yml = temp_dir / "project_template.yml"
+        project_yml.write_text(custom.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
+        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        assert isinstance(load_result, LoadProjectTemplateResultSuccess)
+        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True), caplog.at_level("WARNING"):
+            self._determine(
+                griptape_nodes,
+                requested_file_name="my_flow",
+                current_workflow_name=None,
+                create_versioned=True,
+            )
+
+        assert any("Versioned save requested" in record.message for record in caplog.records), (
+            f"Expected warning about create_versioned_workflow policy mismatch, got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_create_versioned_workflow_in_default_template(self) -> None:
+        """``BuiltInSituation.CREATE_VERSIONED_WORKFLOW`` must be present in the default template.
+
+        Sanity guard: if the enum value gets out of sync with the default
+        ``DEFAULT_PROJECT_TEMPLATE.situations`` dict, every `create_versioned=True`
+        save against an unmodified project would silently fall through and warn,
+        not save versioned.
+        """
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.common.project_templates.situation import BuiltInSituation, SituationFilePolicy
+
+        situation = DEFAULT_PROJECT_TEMPLATE.situations.get(BuiltInSituation.CREATE_VERSIONED_WORKFLOW)
+        assert situation is not None, "create_versioned_workflow missing from DEFAULT_PROJECT_TEMPLATE"
+        assert situation.policy.on_collision == SituationFilePolicy.CREATE_NEW
+        # Padded `{_index:NN}` slot is what makes the seed-and-retry produce v001/v002/...
+        assert "_index" in situation.macro
+
+    def test_first_versioned_save_with_no_registry_entry(self, griptape_nodes: GriptapeNodes) -> None:
+        """create_versioned=True on a brand-new workflow uses the requested name and lands at CREATE_VERSIONED."""
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            target = self._determine(
+                griptape_nodes,
+                requested_file_name="brand_new_flow",
+                current_workflow_name=None,
+                create_versioned=True,
+            )
+
+            assert target.scenario == WorkflowManager.SaveWorkflowScenario.CREATE_VERSIONED
+            assert target.destination is not None
+            assert "_index" in target.destination._file.location
+            # Base name comes from the explicit request; relative_file_path reflects
+            # the unresolved (pre-seed) form.
+            assert target.relative_file_path == "brand_new_flow.py"
+            assert target.file_path is None

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -997,7 +997,7 @@ class TestWorkflowManager:
         ) as mock_build:
             resolved = workflow_manager._resolve_named_save_path(str(abs_requested))
 
-        mock_build.assert_called_once_with(f"{abs_requested}.py")
+        mock_build.assert_called_once_with(f"{abs_requested}.py", situation_name="save_workflow")
         assert resolved.file_name == "new_name"
         assert resolved.relative_file_path == str(abs_path)
 
@@ -1015,7 +1015,7 @@ class TestWorkflowManager:
         ) as mock_build:
             resolved = workflow_manager._resolve_named_save_path("team/new_name")
 
-        mock_build.assert_called_once_with("new_name.py", sub_dirs="team")
+        mock_build.assert_called_once_with("new_name.py", sub_dirs="team", situation_name="save_workflow")
         assert resolved.file_name == "new_name"
 
     def test_delete_active_workflow_clears_context_stack(self, griptape_nodes: GriptapeNodes) -> None:
@@ -2657,3 +2657,209 @@ class TestWorkflowSaveSituationMacro:
         assert isinstance(result, SaveWorkflowFileFromSerializedFlowResultSuccess)
         assert Path(result.file_path) == temp_dir / "episode" / "my_workflow_v001.py"
         assert (temp_dir / "episode" / "my_workflow_v001.py").exists()
+
+
+class TestCreateVersionedWorkflow:
+    """Regression coverage for #4945: ``create_versioned=True`` produces a fresh version every save.
+
+    Drives ``on_save_workflow_request`` end-to-end (rather than the inner
+    ``_save_workflow_file_inline``) so we exercise the dispatch logic in
+    ``_determine_save_target`` — that's where the OVERWRITE_EXISTING vs.
+    CREATE_VERSIONED choice happens.
+    """
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        return tmp_path.resolve()
+
+    @pytest.fixture(autouse=True)
+    def setup_default_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> "Generator[None, None, None]":
+        """Load the default project template (which ships create_versioned_workflow).
+
+        Same fixture ordering as TestWorkflowSaveSituationMacro: load + activate
+        first, then force workspace_path so SetCurrentProjectRequest's internal
+        re-derivation doesn't clobber the test workspace.
+        """
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+            SetCurrentProjectRequest,
+        )
+
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+
+        project_yml = temp_dir / "project_template.yml"
+        project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
+        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        assert isinstance(load_result, LoadProjectTemplateResultSuccess)
+        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+
+        yield
+
+        WorkflowRegistry._workflows.clear()
+        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @staticmethod
+    def _determine(
+        griptape_nodes: GriptapeNodes,
+        *,
+        requested_file_name: str | None,
+        current_workflow_name: str | None,
+        create_versioned: bool,
+    ) -> WorkflowManager.SaveWorkflowTargetInfo:
+        return griptape_nodes.WorkflowManager()._determine_save_target(
+            requested_file_name=requested_file_name,
+            current_workflow_name=current_workflow_name,
+            create_versioned=create_versioned,
+        )
+
+    @staticmethod
+    def _register_saved_workflow(temp_dir: Path, *, registry_key: str, file_name: str, display_name: str) -> None:
+        """Materialize a fake saved workflow on disk + in registry.
+
+        Workflow.from_disk verifies the file exists, so we touch a stub file.
+        Real save tests need the file to genuinely be the prior save's content;
+        for dispatch-logic tests, an empty stub suffices.
+        """
+        (temp_dir / file_name).write_text("# stub")
+        metadata = WorkflowMetadata(
+            name=display_name,
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="test",
+            node_libraries_referenced=[],
+            creation_date=datetime.now(UTC),
+        )
+        WorkflowRegistry.generate_new_workflow(registry_key=registry_key, metadata=metadata, file_path=file_name)
+
+    def test_create_versioned_short_circuits_overwrite_existing(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Even when the workflow is already saved, create_versioned=True routes through the versioned situation.
+
+        Without this fix, the OVERWRITE_EXISTING branch would win on the second
+        save and write back to the same file_path — the user's reported symptom
+        ("always get v001 / overwrite in place"). With it, we get a
+        CREATE_VERSIONED scenario whose destination carries the unresolved macro.
+        """
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            self._register_saved_workflow(
+                temp_dir, registry_key="my_flow_v001", file_name="my_flow_v001.py", display_name="my_flow"
+            )
+
+            target = self._determine(
+                griptape_nodes,
+                requested_file_name="my_flow_v001",
+                current_workflow_name="my_flow_v001",
+                create_versioned=True,
+            )
+
+            assert target.scenario == WorkflowManager.SaveWorkflowScenario.CREATE_VERSIONED
+            # The destination carries the create_versioned_workflow macro (unresolved
+            # `{_index:03}`), so OSManager's seed walks past existing v001 and lands
+            # at v002 on write.
+            assert target.destination is not None
+            assert "_index" in target.destination._file.location
+            # The OVERWRITE_EXISTING path-mode is NOT taken.
+            assert target.file_path is None
+
+    def test_create_versioned_strips_existing_version_suffix_from_base(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Saving over `my_flow_v001` produces a destination based on `my_flow`, not `my_flow_v001`.
+
+        Otherwise we'd get `my_flow_v001_v002.py` instead of `my_flow_v002.py`
+        on the second versioned save.
+        """
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            self._register_saved_workflow(
+                temp_dir,
+                registry_key="my_flow_v001",
+                file_name="my_flow_v001.py",
+                display_name="",  # Empty forces the file-stem fallback in _derive_versioned_base_name.
+            )
+
+            target = self._determine(
+                griptape_nodes,
+                requested_file_name=None,
+                current_workflow_name="my_flow_v001",
+                create_versioned=True,
+            )
+
+            # The relative_file_path is computed against the macro-stripped stem
+            # ("my_flow.py"), not the suffixed one.
+            assert target.relative_file_path == "my_flow.py"
+
+    def test_create_versioned_false_preserves_overwrite_existing(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """create_versioned=False against a saved workflow keeps the standard OVERWRITE_EXISTING path."""
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            self._register_saved_workflow(
+                temp_dir, registry_key="my_flow", file_name="my_flow.py", display_name="my_flow"
+            )
+
+            target = self._determine(
+                griptape_nodes,
+                requested_file_name="my_flow",
+                current_workflow_name="my_flow",
+                create_versioned=False,
+            )
+
+            assert target.scenario == WorkflowManager.SaveWorkflowScenario.OVERWRITE_EXISTING
+            assert target.destination is None
+            assert target.file_path is not None
+            assert target.file_path.name == "my_flow.py"
+
+    def test_warning_logged_when_save_workflow_customized_to_create_new(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A project that flips `save_workflow` to create_new triggers a warning on non-versioned saves.
+
+        The save still completes (the configuration isn't broken), but the user
+        sees a heads-up that their `save_workflow` situation now auto-indexes
+        and they may have meant to set `create_versioned=True` instead.
+        """
+        from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+        from griptape_nodes.common.project_templates.situation import (
+            SituationFilePolicy,
+            SituationPolicy,
+            SituationTemplate,
+        )
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+            SetCurrentProjectRequest,
+        )
+
+        # Replace the in-memory project's save_workflow with a CREATE_NEW variant.
+        flipped = SituationTemplate(
+            name="save_workflow",
+            description="Customized to create_new",
+            macro="{workspace_dir}/{file_name_base}_v{_index:03}.{file_extension}",
+            policy=SituationPolicy(on_collision=SituationFilePolicy.CREATE_NEW, create_dirs=True),
+            fallback="save_file",
+        )
+        custom = DEFAULT_PROJECT_TEMPLATE.model_copy(
+            update={"situations": {**DEFAULT_PROJECT_TEMPLATE.situations, "save_workflow": flipped}}
+        )
+        project_yml = temp_dir / "project_template.yml"
+        project_yml.write_text(custom.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
+        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        assert isinstance(load_result, LoadProjectTemplateResultSuccess)
+        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True), caplog.at_level("WARNING"):
+            self._determine(
+                griptape_nodes,
+                requested_file_name="my_flow",
+                current_workflow_name=None,
+                create_versioned=False,
+            )
+
+        assert any("uses 'create_new' policy" in record.message for record in caplog.records), (
+            f"Expected warning about save_workflow policy mismatch, got: {[r.message for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

Closes #4945. Builds on [#4944](https://github.com/griptape-ai/griptape-nodes-engine/pull/4944) (now merged; this PR rebased onto main).

Adds a new `create_versioned_workflow` situation alongside the existing `save_workflow`, plus a `create_versioned: bool` flag on `SaveWorkflowRequest`. When set, every save routes through the versioned situation — even when the workflow is already in the registry — so successive saves produce `_v001`, `_v002`, `_v003`, … instead of getting trapped in the OVERWRITE_EXISTING branch's in-place overwrite.

Also folds the codebase-wide raw situation-name strings into a `BuiltInSituation(StrEnum)` for type-safety and rename protection.

## Why

#4944 makes the *first* save under a customized `create_new` + `{_index:03}` situation work. But the second save hits the hard-wired OVERWRITE_EXISTING branch in `_determine_save_target` and writes back to `foo_v001.py` instead of advancing to `foo_v002.py`. The root cause: OVERWRITE_EXISTING ignores the situation's collision policy.

Rather than overload `save_workflow` semantics (where the default policy is `overwrite` for good reason — most users want in-place saves), this PR splits the two intents into distinct situations and lets the caller pick per-save.

## What changes

### Feature

- **New situation `create_versioned_workflow`** in `DEFAULT_PROJECT_TEMPLATE`:
  - Default macro: `{workspace_dir}/{sub_dirs?:/}{file_name_base}_v{_index:03}.{file_extension}`
  - Default policy: `create_new` + `create_dirs: true`
  - Default fallback: `save_file`
  - User-customizable like any other situation.

- **New `create_versioned: bool = False`** field on `SaveWorkflowRequest`. When `True`, the request routes through `create_versioned_workflow` for every save.

- **New `SaveWorkflowScenario.CREATE_VERSIONED`** that short-circuits the OVERWRITE_EXISTING branch. The destination it produces carries the unresolved macro, so OSManager's seed-and-retry walks past existing versions on the second save (and the third, fourth, …).

- **Base-name derivation** strips trailing `_v###` from the current workflow's file stem so saving over `foo_v001.py` produces `foo_v002.py` (not `foo_v001_v002.py`).

- **Warning-level diagnostics** when the picked situation's policy doesn't match the caller's intent:
  - `create_versioned=True` but the situation uses `overwrite`.
  - `create_versioned=False` but `save_workflow` has been customized to `create_new`.

  Per the issue discussion, these are warnings (not hard errors) because both configurations still work — they're just probably mistakes.

- **`_build_workflow_save_path` / `_resolve_named_save_path`** accept an optional `situation_name` parameter (defaults to `save_workflow` so existing callers are unchanged).

### Cleanup

- **`BuiltInSituation(StrEnum)`** in `src/griptape_nodes/common/project_templates/situation.py` covering all 12 default-template situation names. Replaces raw string literals across 9 src/ files. StrEnum members are str instances, so existing string-typed APIs accept them unchanged.

- The ad-hoc `SAVE_STATIC_FILE_SITUATION` module constant in `static_files_manager.py` folds into the enum.

- Test literals intentionally left as raw strings so they catch silent renames.

## Behavior contract

| Request | Workflow state | Behavior |
| --- | --- | --- |
| `create_versioned=False` (default) | Not in registry | FIRST_SAVE → `foo.py` |
| `create_versioned=False` | In registry, saved | OVERWRITE_EXISTING → in-place overwrite |
| `create_versioned=True` | Not in registry | CREATE_VERSIONED → `foo_v001.py` |
| `create_versioned=True`, prior `foo_v001.py` | In registry | CREATE_VERSIONED → `foo_v002.py` (advances) |
| Mixed: versioned first, then non-versioned | Saved as `foo_v003.py` | Overwrites `foo_v003.py` in place (acceptable; user explicitly asked) |

## Tests

`TestCreateVersionedWorkflow` class with 7 tests:

- [x] `test_create_versioned_short_circuits_overwrite_existing` — even a saved workflow routes through CREATE_VERSIONED when `create_versioned=True`. **Direct regression test for the user-reported "always get v001" symptom.**
- [x] `test_create_versioned_strips_existing_version_suffix_from_base` — saving over `foo_v001` produces a base of `foo`, not `foo_v001`.
- [x] `test_create_versioned_false_preserves_overwrite_existing` — without the flag, the standard OVERWRITE_EXISTING path is unchanged.
- [x] `test_warning_logged_when_save_workflow_customized_to_create_new` — locks in the warning for `save_workflow` mis-customized to create_new.
- [x] `test_warning_logged_when_create_versioned_workflow_customized_to_overwrite` — inverse warning (versioned save + customized-to-overwrite situation).
- [x] `test_create_versioned_workflow_in_default_template` — sanity guard against enum / template drift.
- [x] `test_first_versioned_save_with_no_registry_entry` — exercises the FIRST_SAVE-equivalent path under `create_versioned=True`.

Two existing `_resolve_named_save_path` tests updated for the new `situation_name` kwarg.

`make check` clean. 2807 unit tests pass, 11 skipped.

## Docs

- [docs/projects/situations.md](docs/projects/situations.md) — new `create_versioned_workflow` section with worked v001/v002/v003 example. Rewrote `save_workflow` description to redirect users away from the now-discouraged "customize to create_new" pattern.

## Out of scope (separate follow-ups)

- UI changes to expose the `create_versioned` flag (the engine ships the request field; the UI/app side can adopt independently).
- Migration tooling for users who already customized `save_workflow` to `create_new` + `{_index:NN}`. They keep working for the first save; subsequent saves overwrite (per the new contract). The warning hints at the fix.
- Per-workflow `create_versioned` metadata stickiness — if it turns out users want "this workflow is always versioned," lift it from the per-save flag to metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)