### PR TITLE
feat(access): per-model OFFER_MODEL checkpoint + AccessManager

### DIFF
--- a/src/griptape_nodes/node_library/library_declarations.py
+++ b/src/griptape_nodes/node_library/library_declarations.py
@@ -265,6 +265,16 @@ def requires_worker_process(declarations: Sequence[LibraryDeclaration]) -> bool:
     return suggested.mode is WorkerMode.WORKER
 
 
+def find_model_catalog(declarations: Sequence[LibraryDeclaration]) -> ModelCatalogLibraryProperty | None:
+    """Return the library's `model_catalog` declaration, or `None` when it declares none.
+
+    The single primitive every catalog consumer builds on: callers that want the
+    resolved models pair this with `iter_catalog_models` / `resolve_node_models`,
+    callers that only need the declaration (e.g. an existence check) use it alone.
+    """
+    return next((d for d in declarations if isinstance(d, ModelCatalogLibraryProperty)), None)
+
+
 class ResolvedModel(NamedTuple):
     """A model paired with its parent provider's identifier and object."""
 

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -15,6 +15,7 @@ from griptape_nodes.node_library.library_declarations import (
     WorkerCompatibility,
     WorkerMode,
     WorkerModeCompatibility,
+    find_model_catalog,
     resolve_node_models,
 )
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries.duplicate_node_registration_problem import (
@@ -246,6 +247,20 @@ class LibraryRegistry(metaclass=SingletonMeta):
     _collision_node_names_to_library_names: ClassVar[dict[str, list[str]]] = {}
     # Track registered widgets per library: {library_name: set(widget_names)}
     _registered_widgets: ClassVar[dict[str, set[str]]] = {}
+
+    @classmethod
+    def reset_for_testing(cls) -> None:
+        """Clear every registry store. Test-only: localizes the private-store coupling here.
+
+        Tests that register throwaway libraries call this in setup/teardown rather
+        than reaching into the `ClassVar` stores by name, so renaming a store
+        updates this one method instead of silently degrading each test's cleanup
+        to a no-op.
+        """
+        cls._libraries.clear()
+        cls._node_aliases.clear()
+        cls._collision_node_names_to_library_names.clear()
+        cls._registered_widgets.clear()
 
     @classmethod
     def generate_new_library(
@@ -608,10 +623,7 @@ class Library:
         if node_metadata is None:
             msg = f"Node type '{node_type}' not found in library '{self._library_data.name}'"
             raise KeyError(msg)
-        catalog = next(
-            (d for d in self._library_data.metadata.declarations if isinstance(d, ModelCatalogLibraryProperty)),
-            None,
-        )
+        catalog = find_model_catalog(self._library_data.metadata.declarations)
         if catalog is None:
             return []
         return resolve_node_models(catalog, node_metadata.declarations)

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -131,9 +131,9 @@ class LibraryMetadata(BaseModel):
     @model_validator(mode="after")
     def _reject_multiple_model_catalogs(self) -> LibraryMetadata:
         # Node references and the duplicate-id check assume a single catalog
-        # (see library_validation._find_model_catalog). Two catalogs would let
-        # the second one's models go unseen, so reject the ambiguity here where
-        # all declarations are visible together.
+        # (see library_declarations.find_model_catalog, which returns the first).
+        # Two catalogs would let the second one's models go unseen, so reject the
+        # ambiguity here where all declarations are visible together.
         catalog_count = sum(1 for d in self.declarations if isinstance(d, ModelCatalogLibraryProperty))
         if catalog_count > 1:
             msg = (

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -249,13 +249,12 @@ class LibraryRegistry(metaclass=SingletonMeta):
     _registered_widgets: ClassVar[dict[str, set[str]]] = {}
 
     @classmethod
-    def reset_for_testing(cls) -> None:
-        """Clear every registry store. Test-only: localizes the private-store coupling here.
+    def _clear(cls) -> None:
+        """Drop every registered library and its tracking state.
 
-        Tests that register throwaway libraries call this in setup/teardown rather
-        than reaching into the `ClassVar` stores by name, so renaming a store
-        updates this one method instead of silently degrading each test's cleanup
-        to a no-op.
+        Used by tests to reset the singleton between cases. Centralizes the store
+        list here so renaming a `ClassVar` updates this one method rather than
+        silently degrading callers that would otherwise clear stores by name.
         """
         cls._libraries.clear()
         cls._node_aliases.clear()

--- a/src/griptape_nodes/node_library/library_validation.py
+++ b/src/griptape_nodes/node_library/library_validation.py
@@ -23,6 +23,7 @@ from griptape_nodes.node_library.library_declarations import (
     ModelCatalogLibraryProperty,
     ModelProviderUsageNodeProperty,
     ModelUsageNodeProperty,
+    find_model_catalog,
     iter_catalog_models,
 )
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
@@ -57,7 +58,7 @@ def validate_library_declarations(library_data: LibrarySchema) -> list[LibraryPr
     problems: list[LibraryProblem] = []
     library_name = library_data.name
 
-    catalog = _find_model_catalog(library_data)
+    catalog = find_model_catalog(library_data.metadata.declarations)
     declared_model_ids: set[str] = set()
     declared_provider_ids: set[str] = set()
     if catalog is not None:
@@ -115,13 +116,6 @@ def detect_retired_node_declarations(library_json: dict[str, Any]) -> list[Libra
                 )
             )
     return problems
-
-
-def _find_model_catalog(library_data: LibrarySchema) -> ModelCatalogLibraryProperty | None:
-    for decl in library_data.metadata.declarations:
-        if isinstance(decl, ModelCatalogLibraryProperty):
-            return decl
-    return None
 
 
 def _check_duplicate_model_ids(

--- a/src/griptape_nodes/retained_mode/events/access_events.py
+++ b/src/griptape_nodes/retained_mode/events/access_events.py
@@ -72,8 +72,8 @@ class QueryModelAccessResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucces
 class QueryModelAccessForNodeRequest(RequestPayload):
     """Node-attributed: 'on behalf of this node, are these ids allowed?'.
 
-    The checkpoint carries ``ID = node_type``, ``MODEL_ID``, and (when the id
-    resolves against the node's library catalog) ``PROVIDER_ID`` and
+    The checkpoint carries ``NODE_TYPE = node_type``, ``MODEL_ID``, and (when the
+    id resolves against the node's library catalog) ``PROVIDER_ID`` and
     ``MODEL_FAMILIES``. When ``candidate_model_ids`` is ``None`` the engine
     derives the list from the node's ``ModelUsageNodeProperty`` plus
     ``ModelProviderUsageNodeProperty`` expansion -- the canonical "populate a
@@ -102,7 +102,11 @@ class QueryModelAccessForNodeRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class QueryModelAccessForNodeResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    """One verdict per candidate, in declaration / input order, de-duplicated.
+    """One verdict per candidate, in declaration order (derived) or input order (explicit).
+
+    De-duplication applies only to engine-derived candidates (when
+    ``candidate_model_ids`` is omitted); an explicit ``candidate_model_ids`` list
+    is evaluated as-is, one verdict per entry including any duplicates.
 
     Args:
         verdicts: Ordered list of per-model verdicts. Empty when the node
@@ -124,7 +128,7 @@ class QueryModelAccessForCatalogRequest(RequestPayload):
     """Catalog-scoped: caller has a library in mind but no node.
 
     The checkpoint carries ``MODEL_ID`` and (when the id resolves against that
-    library's catalog) ``PROVIDER_ID`` and ``MODEL_FAMILIES``. No ``ID``
+    library's catalog) ``PROVIDER_ID`` and ``MODEL_FAMILIES``. No ``NODE_TYPE``
     attribute -- the query is not attributed to a node. Distinct from
     ``QueryModelAccessRequest`` because the caller is telling the engine WHICH
     library catalog to use for enrichment.

--- a/src/griptape_nodes/retained_mode/events/access_events.py
+++ b/src/griptape_nodes/retained_mode/events/access_events.py
@@ -40,9 +40,9 @@ class QueryModelAccessRequest(RequestPayload):
 
     Use from non-node callers (sidebar agent, ``ModelManager`` Hugging Face
     enumeration, scripted callers) when there is no engine-side context to
-    attribute the query to. The checkpoint carries only ``MODEL_ID`` per
-    candidate -- no ``ID``, no ``PROVIDER_ID``, no ``MODEL_FAMILIES``. A policy
-    matching on the bare model id still fires.
+    attribute the query to. The checkpoint carries only ``ID`` (the model id) per
+    candidate -- no ``NODE_TYPE``, no ``PROVIDER_ID``, no ``MODEL_FAMILIES``. A
+    policy matching on the bare model id still fires.
 
     Args:
         candidate_model_ids: Catalog keys to evaluate, in input order.
@@ -72,8 +72,8 @@ class QueryModelAccessResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucces
 class QueryModelAccessForNodeRequest(RequestPayload):
     """Node-attributed: 'on behalf of this node, are these ids allowed?'.
 
-    The checkpoint carries ``NODE_TYPE = node_type``, ``MODEL_ID``, and (when the
-    id resolves against the node's library catalog) ``PROVIDER_ID`` and
+    The checkpoint carries ``ID`` (the model id), ``NODE_TYPE = node_type``, and
+    (when the id resolves against the node's library catalog) ``PROVIDER_ID`` and
     ``MODEL_FAMILIES``. When ``candidate_model_ids`` is ``None`` the engine
     derives the list from the node's ``ModelUsageNodeProperty`` plus
     ``ModelProviderUsageNodeProperty`` expansion -- the canonical "populate a
@@ -127,14 +127,14 @@ class QueryModelAccessForNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloa
 class QueryModelAccessForCatalogRequest(RequestPayload):
     """Catalog-scoped: caller has a library in mind but no node.
 
-    The checkpoint carries ``MODEL_ID`` and (when the id resolves against that
-    library's catalog) ``PROVIDER_ID`` and ``MODEL_FAMILIES``. No ``NODE_TYPE``
+    The checkpoint carries ``ID`` (the model id) and (when the id resolves against
+    that library's catalog) ``PROVIDER_ID`` and ``MODEL_FAMILIES``. No ``NODE_TYPE``
     attribute -- the query is not attributed to a node. Distinct from
     ``QueryModelAccessRequest`` because the caller is telling the engine WHICH
     library catalog to use for enrichment.
 
     A ``library_name`` that does not resolve is not an error -- the
-    handler returns ``Success`` with bare ``MODEL_ID``-only verdicts. Callers
+    handler returns ``Success`` with bare ``ID``-only verdicts. Callers
     are expected to know their library; a missing library means the catalog
     has shifted out from under a stale name and a policy can still match on
     the bare ids.

--- a/src/griptape_nodes/retained_mode/events/access_events.py
+++ b/src/griptape_nodes/retained_mode/events/access_events.py
@@ -14,11 +14,14 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import Check
 class ModelAccessVerdict:
     """The per-model authorization verdict for one candidate.
 
-    `model_id` is the catalog key the engine evaluated (e.g. ``gtc_claude_opus_4_7``).
+    `model_id` is the catalog key the engine evaluated (e.g. ``gtc_claude_opus_4_7``);
+    always populated, so it is the field to match a verdict back to a candidate.
     `provider_model_id` is the upstream provider's name for that model (e.g.
-    ``claude-opus-4-7``); populated from the library catalog when the candidate
-    resolves to a known entry, ``None`` otherwise. Nodes match verdicts against
-    their own dropdown choices via this field.
+    ``claude-opus-4-7``), populated from the library catalog when the candidate
+    resolves to a known entry. It is ``None`` both when the candidate did not
+    resolve AND when it resolved to an entry that declares no ``provider_model_id``,
+    so ``None`` cannot be read as "unresolved" -- match on `model_id` for identity
+    and treat `provider_model_id` purely as the upstream display handle.
 
     `denial` is ``None`` when the model is allowed; a ``CheckpointDenial``
     otherwise, carrying the same failure tuple any other denied checkpoint
@@ -62,16 +65,6 @@ class QueryModelAccessResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucces
     """
 
     verdicts: list[ModelAccessVerdict] = field(default_factory=list)
-
-
-@dataclass
-@PayloadRegistry.register
-class QueryModelAccessResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
-    """Bare access query failed.
-
-    The bare form has no lookups that can miss, so this is reserved for
-    unexpected internal errors.
-    """
 
 
 @dataclass
@@ -136,14 +129,14 @@ class QueryModelAccessForCatalogRequest(RequestPayload):
     ``QueryModelAccessRequest`` because the caller is telling the engine WHICH
     library catalog to use for enrichment.
 
-    A ``specific_library_name`` that does not resolve is not an error -- the
+    A ``library_name`` that does not resolve is not an error -- the
     handler returns ``Success`` with bare ``MODEL_ID``-only verdicts. Callers
     are expected to know their library; a missing library means the catalog
     has shifted out from under a stale name and a policy can still match on
     the bare ids.
 
     Args:
-        specific_library_name: Library whose catalog supplies provider / family
+        library_name: Library whose catalog supplies provider / family
             enrichment.
         candidate_model_ids: Catalog keys to evaluate, in input order.
 
@@ -151,7 +144,7 @@ class QueryModelAccessForCatalogRequest(RequestPayload):
         candidate, in input order).
     """
 
-    specific_library_name: str
+    library_name: str
     candidate_model_ids: list[str] = field(default_factory=list)
 
 
@@ -165,13 +158,3 @@ class QueryModelAccessForCatalogResultSuccess(WorkflowNotAlteredMixin, ResultPay
     """
 
     verdicts: list[ModelAccessVerdict] = field(default_factory=list)
-
-
-@dataclass
-@PayloadRegistry.register
-class QueryModelAccessForCatalogResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
-    """Catalog-scoped access query failed.
-
-    Reserved for unexpected internal errors; an unknown library name returns
-    ``Success`` with bare verdicts.
-    """

--- a/src/griptape_nodes/retained_mode/events/access_events.py
+++ b/src/griptape_nodes/retained_mode/events/access_events.py
@@ -1,0 +1,177 @@
+from dataclasses import dataclass, field
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+
+
+@dataclass(frozen=True)
+class ModelAccessVerdict:
+    """The per-model authorization verdict for one candidate.
+
+    `model_id` is the catalog key the engine evaluated (e.g. ``gtc_claude_opus_4_7``).
+    `provider_model_id` is the upstream provider's name for that model (e.g.
+    ``claude-opus-4-7``); populated from the library catalog when the candidate
+    resolves to a known entry, ``None`` otherwise. Nodes match verdicts against
+    their own dropdown choices via this field.
+
+    `denial` is ``None`` when the model is allowed; a ``CheckpointDenial``
+    otherwise, carrying the same failure tuple any other denied checkpoint
+    surfaces (so the UI renders identical reason text).
+    """
+
+    model_id: str
+    provider_model_id: str | None
+    denial: CheckpointDenial | None
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessRequest(RequestPayload):
+    """The bare form: 'are these model ids allowed?' No node, no catalog scope.
+
+    Use from non-node callers (sidebar agent, ``ModelManager`` Hugging Face
+    enumeration, scripted callers) when there is no engine-side context to
+    attribute the query to. The checkpoint carries only ``MODEL_ID`` per
+    candidate -- no ``ID``, no ``PROVIDER_ID``, no ``MODEL_FAMILIES``. A policy
+    matching on the bare model id still fires.
+
+    Args:
+        candidate_model_ids: Catalog keys to evaluate, in input order.
+
+    Results: ``QueryModelAccessResultSuccess`` (one verdict per candidate, in
+        input order; ``provider_model_id`` is always ``None`` since no catalog
+        is consulted).
+    """
+
+    candidate_model_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """One verdict per candidate, in input order. Length equals the request's candidate count.
+
+    Args:
+        verdicts: Ordered list of per-model verdicts.
+    """
+
+    verdicts: list[ModelAccessVerdict] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Bare access query failed.
+
+    The bare form has no lookups that can miss, so this is reserved for
+    unexpected internal errors.
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessForNodeRequest(RequestPayload):
+    """Node-attributed: 'on behalf of this node, are these ids allowed?'.
+
+    The checkpoint carries ``ID = node_type``, ``MODEL_ID``, and (when the id
+    resolves against the node's library catalog) ``PROVIDER_ID`` and
+    ``MODEL_FAMILIES``. When ``candidate_model_ids`` is ``None`` the engine
+    derives the list from the node's ``ModelUsageNodeProperty`` plus
+    ``ModelProviderUsageNodeProperty`` expansion -- the canonical "populate a
+    statically declared dropdown" flow.
+
+    Args:
+        node_type: The node class name (e.g. ``"DescribeImage"``).
+        specific_library_name: Optional disambiguator when multiple libraries
+            register the same node type.
+        candidate_model_ids: When ``None`` (default), the engine derives
+            candidates from the node's declarations. When a list is supplied,
+            it overrides the derivation -- useful when the caller has already
+            narrowed the set or is querying a subset for badge details.
+
+    Results: ``QueryModelAccessForNodeResultSuccess`` (one verdict per
+        candidate, in declaration / input order) |
+        ``QueryModelAccessForNodeResultFailure`` (node type or library not
+        found).
+    """
+
+    node_type: str
+    specific_library_name: str | None = None
+    candidate_model_ids: list[str] | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessForNodeResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """One verdict per candidate, in declaration / input order, de-duplicated.
+
+    Args:
+        verdicts: Ordered list of per-model verdicts. Empty when the node
+            declares no models and no explicit candidates were supplied.
+    """
+
+    verdicts: list[ModelAccessVerdict] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessForNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Per-node access query failed. Common cause: node type not registered."""
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessForCatalogRequest(RequestPayload):
+    """Catalog-scoped: caller has a library in mind but no node.
+
+    The checkpoint carries ``MODEL_ID`` and (when the id resolves against that
+    library's catalog) ``PROVIDER_ID`` and ``MODEL_FAMILIES``. No ``ID``
+    attribute -- the query is not attributed to a node. Distinct from
+    ``QueryModelAccessRequest`` because the caller is telling the engine WHICH
+    library catalog to use for enrichment.
+
+    A ``specific_library_name`` that does not resolve is not an error -- the
+    handler returns ``Success`` with bare ``MODEL_ID``-only verdicts. Callers
+    are expected to know their library; a missing library means the catalog
+    has shifted out from under a stale name and a policy can still match on
+    the bare ids.
+
+    Args:
+        specific_library_name: Library whose catalog supplies provider / family
+            enrichment.
+        candidate_model_ids: Catalog keys to evaluate, in input order.
+
+    Results: ``QueryModelAccessForCatalogResultSuccess`` (one verdict per
+        candidate, in input order).
+    """
+
+    specific_library_name: str
+    candidate_model_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessForCatalogResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """One verdict per candidate, in input order. Length equals the request's candidate count.
+
+    Args:
+        verdicts: Ordered list of per-model verdicts.
+    """
+
+    verdicts: list[ModelAccessVerdict] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class QueryModelAccessForCatalogResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Catalog-scoped access query failed.
+
+    Reserved for unexpected internal errors; an unknown library name returns
+    ``Success`` with bare verdicts.
+    """

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         RequestPayload,
         ResultPayload,
     )
+    from griptape_nodes.retained_mode.managers.access_manager import AccessManager
     from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
     from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
         ArbitraryCodeExecManager,
@@ -89,6 +90,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
     _context_manager: ContextManager
     _library_manager: LibraryManager
     _model_manager: ModelManager
+    _access_manager: AccessManager
     _workflow_manager: WorkflowManager
     _workflow_variables_manager: VariablesManager
     _arbitrary_code_exec_manager: ArbitraryCodeExecManager
@@ -108,6 +110,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
     _worker_manager: WorkerManager
 
     def __init__(self) -> None:  # noqa: PLR0915
+        from griptape_nodes.retained_mode.managers.access_manager import AccessManager
         from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
         from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
             ArbitraryCodeExecManager,
@@ -162,6 +165,7 @@ class GriptapeNodes(metaclass=SingletonMeta):
             self._worker_manager = WorkerManager(griptape_nodes=self, event_manager=self._event_manager)
             self._library_manager = LibraryManager(self._event_manager, worker_manager=self._worker_manager)
             self._model_manager = ModelManager(self._event_manager)
+            self._access_manager = AccessManager(self._event_manager)
             self._workflow_manager = WorkflowManager(self._event_manager)
             self._workflow_variables_manager = VariablesManager(self._event_manager)
             self._arbitrary_code_exec_manager = ArbitraryCodeExecManager(self._event_manager)
@@ -280,6 +284,10 @@ class GriptapeNodes(metaclass=SingletonMeta):
     @classmethod
     def ModelManager(cls) -> ModelManager:
         return GriptapeNodes.get_instance()._model_manager
+
+    @classmethod
+    def AccessManager(cls) -> AccessManager:
+        return GriptapeNodes.get_instance()._access_manager
 
     @classmethod
     def ObjectManager(cls) -> ObjectManager:

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -1,0 +1,308 @@
+"""Per-candidate authorization queries: the `OFFER_MODEL` checkpoint, asked once per id.
+
+The node-instantiation checkpoint (`INSTANTIATE_NODE`) is a binary gate over the
+*union* of a node's declared models -- correct for a node dedicated to one model,
+but useless for nodes that offer a dropdown of many. This manager is the engine's
+answer to "of these N candidates, which are allowed under the current policy, and
+why?" -- one verdict per candidate, each carrying a `CheckpointDenial` or `None`.
+
+Three request types, named by what attribution the engine adds to each checkpoint:
+
+  - `QueryModelAccessRequest` -- bare. Caller supplies ids only. Checkpoint
+    attributes carry only `MODEL_ID`. For non-node callers (sidebar, scripted
+    enumerations) where no engine-side context attributes the query.
+
+  - `QueryModelAccessForNodeRequest` -- node-attributed. Caller supplies a node
+    type and, optionally, an explicit candidate list. When candidates are
+    omitted the engine derives them from the node's `ModelUsageNodeProperty`
+    plus `ModelProviderUsageNodeProperty` expansion. Checkpoint attributes
+    carry `ID = node_type`, `MODEL_ID`, plus catalog-resolved `PROVIDER_ID` and
+    `MODEL_FAMILIES` when the id is in the node's library catalog.
+
+  - `QueryModelAccessForCatalogRequest` -- catalog-scoped. Caller supplies a
+    library name and ids. Checkpoint attributes carry `MODEL_ID` plus
+    catalog-resolved `PROVIDER_ID` / `MODEL_FAMILIES`. No `ID` attribute --
+    the caller has a library in mind but no node to attribute the query to.
+
+All three paths share `_evaluate`, which iterates candidates and asks the
+authorization hook chain once per id. The chain's recursion guard
+(`EventManager._hook_evaluation.authorizing`) is reset after each evaluation, so
+N sequential calls from one handler produce N independent verdicts.
+
+This manager depends only on the event bus (for the hook chain) and the
+`LibraryRegistry` (for catalog resolution). It does not depend on `NodeManager`
+or `ModelManager`. Future "can I use this?" queries beyond models (e.g. listing
+codecs allowed for the current context) are the natural extension here; the
+per-operation runtime checks (e.g. "am I allowed this codec for this file?")
+belong with the manager that owns the operation -- same way `INVOKE_MODEL`
+fires from `ModelManager`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.node_library.library_declarations import (
+    ModelCatalogLibraryProperty,
+    ModelProviderUsageNodeProperty,
+    ModelUsageNodeProperty,
+    ResolvedModel,
+    iter_catalog_models,
+    resolve_node_models,
+)
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.access_events import (
+    ModelAccessVerdict,
+    QueryModelAccessForCatalogRequest,
+    QueryModelAccessForCatalogResultSuccess,
+    QueryModelAccessForNodeRequest,
+    QueryModelAccessForNodeResultFailure,
+    QueryModelAccessForNodeResultSuccess,
+    QueryModelAccessRequest,
+    QueryModelAccessResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointSubjectType,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from griptape_nodes.node_library.library_declarations import LibraryDeclaration, NodeDeclaration
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+
+class AccessManager:
+    """Answers per-candidate authorization queries via the `OFFER_MODEL` checkpoint."""
+
+    def __init__(self, event_manager: EventManager | None = None) -> None:
+        if event_manager is not None:
+            event_manager.assign_manager_to_request_type(QueryModelAccessRequest, self.on_query_model_access_request)
+            event_manager.assign_manager_to_request_type(
+                QueryModelAccessForNodeRequest, self.on_query_model_access_for_node_request
+            )
+            event_manager.assign_manager_to_request_type(
+                QueryModelAccessForCatalogRequest, self.on_query_model_access_for_catalog_request
+            )
+
+    def on_query_model_access_request(self, request: QueryModelAccessRequest) -> ResultPayload:
+        """Bare form. Hook sees `MODEL_ID` per candidate; no `ID`, no catalog enrichment."""
+        verdicts = self._evaluate(
+            candidate_model_ids=request.candidate_model_ids,
+            node_type=None,
+            resolved_by_id={},
+        )
+        return QueryModelAccessResultSuccess(
+            verdicts=verdicts,
+            result_details=f"Evaluated {len(verdicts)} candidate model(s).",
+        )
+
+    def on_query_model_access_for_node_request(self, request: QueryModelAccessForNodeRequest) -> ResultPayload:
+        """Node-attributed. Engine derives candidates from declarations unless caller overrides."""
+        resolution = self._resolve_node_library(request.node_type, request.specific_library_name)
+        if resolution.error is not None:
+            return QueryModelAccessForNodeResultFailure(result_details=resolution.error)
+
+        if request.candidate_model_ids is None:
+            candidates = self._declared_model_ids(
+                node_declarations=resolution.node_declarations,
+                library_declarations=resolution.library_declarations,
+            )
+        else:
+            candidates = list(request.candidate_model_ids)
+
+        verdicts = self._evaluate(
+            candidate_model_ids=candidates,
+            node_type=request.node_type,
+            resolved_by_id=resolution.resolved_by_id,
+        )
+        return QueryModelAccessForNodeResultSuccess(
+            verdicts=verdicts,
+            result_details=f"Evaluated {len(verdicts)} model(s) for '{request.node_type}'.",
+        )
+
+    def on_query_model_access_for_catalog_request(self, request: QueryModelAccessForCatalogRequest) -> ResultPayload:
+        """Catalog-scoped. Hook sees `MODEL_ID` plus enrichment when the id resolves.
+
+        A missing library is not fatal -- callers (sidebar, scripts) may name a
+        library that's not currently registered; the handler falls through to
+        bare verdicts so a policy can still match on `MODEL_ID`.
+        """
+        try:
+            library = LibraryRegistry.get_library(request.specific_library_name)
+        except KeyError:
+            resolved_by_id: dict[str, ResolvedModel] = {}
+        else:
+            resolved_by_id = self._index_catalog(library.get_metadata().declarations)
+
+        verdicts = self._evaluate(
+            candidate_model_ids=request.candidate_model_ids,
+            node_type=None,
+            resolved_by_id=resolved_by_id,
+        )
+        return QueryModelAccessForCatalogResultSuccess(
+            verdicts=verdicts,
+            result_details=f"Evaluated {len(verdicts)} candidate model(s) in catalog '{request.specific_library_name}'.",
+        )
+
+    def _resolve_node_library(self, node_type: str, specific_library_name: str | None) -> _NodeResolution:
+        """Look up the node's library and return its declarations plus a model-id index.
+
+        Returns an error string when the lookup fails so the per-node handler can
+        map it onto a `Failure` result; on success ``error`` is ``None`` and the
+        other fields are populated.
+        """
+        try:
+            library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
+        except KeyError as exc:
+            return _NodeResolution(
+                error=(
+                    f"Attempted to query model access for node type '{node_type}'. "
+                    f"Failed because the library lookup raised KeyError: {exc}."
+                ),
+                node_declarations=(),
+                library_declarations=(),
+                resolved_by_id={},
+            )
+
+        try:
+            node_metadata = library.get_node_metadata(node_type)
+        except KeyError as exc:
+            return _NodeResolution(
+                error=(
+                    f"Attempted to query model access for node type '{node_type}'. "
+                    f"Failed because the node type was not found in its library: {exc}."
+                ),
+                node_declarations=(),
+                library_declarations=(),
+                resolved_by_id={},
+            )
+
+        node_declarations = node_metadata.declarations
+        library_declarations = library.get_metadata().declarations
+        return _NodeResolution(
+            error=None,
+            node_declarations=node_declarations,
+            library_declarations=library_declarations,
+            resolved_by_id=self._index_catalog(library_declarations),
+        )
+
+    @staticmethod
+    def _index_catalog(library_declarations: Sequence[LibraryDeclaration]) -> dict[str, ResolvedModel]:
+        """Build a `{model_id: ResolvedModel}` index from a library's catalog, empty if none."""
+        catalog = next(
+            (d for d in library_declarations if isinstance(d, ModelCatalogLibraryProperty)),
+            None,
+        )
+        if catalog is None:
+            return {}
+        return {resolved.model_id: resolved for resolved in iter_catalog_models(catalog)}
+
+    @staticmethod
+    def _declared_model_ids(
+        *,
+        node_declarations: Sequence[NodeDeclaration],
+        library_declarations: Sequence[LibraryDeclaration],
+    ) -> list[str]:
+        """Union of catalog ids from `model_usage` plus `model_provider_usage` expansion.
+
+        Order: each ``ModelUsageNodeProperty.model_ids`` entry in declaration order,
+        then provider-expanded ids in catalog order, de-duplicated. A node that
+        declares no model usage returns an empty list (zero verdicts).
+        """
+        ordered: list[str] = []
+        seen: set[str] = set()
+        for declaration in node_declarations:
+            if isinstance(declaration, ModelUsageNodeProperty):
+                for model_id in declaration.model_ids:
+                    if model_id not in seen:
+                        seen.add(model_id)
+                        ordered.append(model_id)
+
+        catalog = next(
+            (d for d in library_declarations if isinstance(d, ModelCatalogLibraryProperty)),
+            None,
+        )
+        if catalog is None:
+            return ordered
+
+        provider_declarations = [d for d in node_declarations if isinstance(d, ModelProviderUsageNodeProperty)]
+        if not provider_declarations:
+            return ordered
+
+        for resolved in resolve_node_models(catalog, provider_declarations):
+            if resolved.model_id not in seen:
+                seen.add(resolved.model_id)
+                ordered.append(resolved.model_id)
+        return ordered
+
+    @staticmethod
+    def _evaluate(
+        *,
+        candidate_model_ids: Sequence[str],
+        node_type: str | None,
+        resolved_by_id: dict[str, ResolvedModel],
+    ) -> list[ModelAccessVerdict]:
+        """Ask the authorization hook chain once per candidate; collect one verdict each.
+
+        Attribute composition:
+          - ``ID = node_type`` only when ``node_type`` is supplied (per-node form).
+          - ``MODEL_ID`` always.
+          - ``PROVIDER_ID`` and ``MODEL_FAMILIES`` only when the id resolves in
+            ``resolved_by_id`` (the per-node and catalog-scoped forms supply this;
+            the bare form does not).
+
+        An unknown id is still asked of the hook with ``MODEL_ID`` only, so a
+        policy can still match on the bare key.
+
+        Sequential calls reset the hook chain's recursion guard between
+        iterations; the guard only short-circuits when a hook itself re-enters a
+        guarded engine operation, not when one handler loops over candidates.
+        """
+        event_manager = GriptapeNodes.EventManager()
+        verdicts: list[ModelAccessVerdict] = []
+        for model_id in candidate_model_ids:
+            attributes: dict[str, Any] = {CheckpointAttribute.MODEL_ID: model_id}
+            if node_type is not None:
+                attributes[CheckpointAttribute.ID] = node_type
+            resolved = resolved_by_id.get(model_id)
+            provider_model_id: str | None = None
+            if resolved is not None:
+                attributes[CheckpointAttribute.PROVIDER_ID] = resolved.provider_id
+                if resolved.model.family:
+                    attributes[CheckpointAttribute.MODEL_FAMILIES] = [resolved.model.family]
+                provider_model_id = resolved.model.provider_model_id
+            denial = event_manager.evaluate_authorization_checkpoint(
+                AuthorizationCheckpoint(
+                    action=CheckpointAction.OFFER_MODEL,
+                    subject_type=CheckpointSubjectType.MODEL,
+                    subject_id=model_id,
+                    attributes=attributes,
+                )
+            )
+            verdicts.append(ModelAccessVerdict(model_id=model_id, provider_model_id=provider_model_id, denial=denial))
+        return verdicts
+
+
+class _NodeResolution:
+    """Result of looking up a node's library: declarations plus a catalog index, or an error."""
+
+    __slots__ = ("error", "library_declarations", "node_declarations", "resolved_by_id")
+
+    def __init__(
+        self,
+        *,
+        error: str | None,
+        node_declarations: Sequence[NodeDeclaration],
+        library_declarations: Sequence[LibraryDeclaration],
+        resolved_by_id: dict[str, ResolvedModel],
+    ) -> None:
+        self.error = error
+        self.node_declarations = node_declarations
+        self.library_declarations = library_declarations
+        self.resolved_by_id = resolved_by_id

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -16,12 +16,12 @@ Three request types, named by what attribution the engine adds to each checkpoin
     type and, optionally, an explicit candidate list. When candidates are
     omitted the engine derives them from the node's `ModelUsageNodeProperty`
     plus `ModelProviderUsageNodeProperty` expansion. Checkpoint attributes
-    carry `ID = node_type`, `MODEL_ID`, plus catalog-resolved `PROVIDER_ID` and
-    `MODEL_FAMILIES` when the id is in the node's library catalog.
+    carry `NODE_TYPE = node_type`, `MODEL_ID`, plus catalog-resolved `PROVIDER_ID`
+    and `MODEL_FAMILIES` when the id is in the node's library catalog.
 
   - `QueryModelAccessForCatalogRequest` -- catalog-scoped. Caller supplies a
     library name and ids. Checkpoint attributes carry `MODEL_ID` plus
-    catalog-resolved `PROVIDER_ID` / `MODEL_FAMILIES`. No `ID` attribute --
+    catalog-resolved `PROVIDER_ID` / `MODEL_FAMILIES`. No `NODE_TYPE` attribute --
     the caller has a library in mind but no node to attribute the query to.
 
 All three paths share `_evaluate`, which iterates candidates and asks the
@@ -73,21 +73,30 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from griptape_nodes.node_library.library_declarations import LibraryDeclaration, NodeDeclaration
+    from griptape_nodes.node_library.library_declarations import ModelCatalogLibraryProperty, NodeDeclaration
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 
+class _NodeLookupError(Exception):
+    """A node's library or metadata could not be resolved for a model-access query.
+
+    Carries an already-formatted sentence (free of `KeyError`'s quote/tuple
+    `repr`) that the per-node handler surfaces verbatim on a `Failure` result.
+    """
+
+
 @dataclass(frozen=True, kw_only=True, slots=True)
 class _NodeResolution:
-    """A node's library context: the node's declarations, the library's, and a catalog index.
+    """A node's library context: its declarations, its library's model catalog, and a model-id index.
 
     Built only on the success path of `AccessManager._resolve_node_library`; a
-    failed lookup raises instead of producing a half-populated instance.
+    failed lookup raises `_NodeLookupError` instead of producing a half-populated
+    instance.
     """
 
     node_declarations: Sequence[NodeDeclaration]
-    library_declarations: Sequence[LibraryDeclaration]
+    catalog: ModelCatalogLibraryProperty | None
     resolved_by_id: dict[str, ResolvedModel]
 
 
@@ -120,13 +129,13 @@ class AccessManager:
         """Node-attributed. Engine derives candidates from declarations unless caller overrides."""
         try:
             resolution = self._resolve_node_library(request.node_type, request.specific_library_name)
-        except KeyError as exc:
+        except _NodeLookupError as exc:
             return QueryModelAccessForNodeResultFailure(result_details=str(exc))
 
         if request.candidate_model_ids is None:
             candidates = self._declared_model_ids(
                 node_declarations=resolution.node_declarations,
-                library_declarations=resolution.library_declarations,
+                catalog=resolution.catalog,
             )
         else:
             candidates = list(request.candidate_model_ids)
@@ -153,7 +162,7 @@ class AccessManager:
         except KeyError:
             resolved_by_id: dict[str, ResolvedModel] = {}
         else:
-            resolved_by_id = self._index_catalog(library.get_metadata().declarations)
+            resolved_by_id = self._index_catalog(find_model_catalog(library.get_metadata().declarations))
 
         verdicts = self._evaluate(
             candidate_model_ids=request.candidate_model_ids,
@@ -169,40 +178,41 @@ class AccessManager:
         """Look up the node's library and return its declarations plus a model-id index.
 
         Raises:
-            KeyError: when the node type's library is not registered, or the node
-                type is not found within that library. The message names the node
-                type so the per-node handler can surface it verbatim on a
+            _NodeLookupError: when the node type's library is not registered, or
+                the node type is not found within that library. Its message is a
+                clean sentence the per-node handler surfaces verbatim on a
                 ``Failure`` result.
         """
         try:
             library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
         except KeyError as exc:
+            detail = exc.args[0] if exc.args else str(exc)
             msg = (
                 f"Attempted to query model access for node type '{node_type}'. "
-                f"Failed because the library lookup raised KeyError: {exc}."
+                f"Failed because the library could not be resolved: {detail}"
             )
-            raise KeyError(msg) from exc
+            raise _NodeLookupError(msg) from exc
 
         try:
             node_metadata = library.get_node_metadata(node_type)
         except KeyError as exc:
+            library_name = exc.args[0] if exc.args else specific_library_name
             msg = (
                 f"Attempted to query model access for node type '{node_type}'. "
-                f"Failed because the node type was not found in its library: {exc}."
+                f"Failed because it is not registered in library '{library_name}'."
             )
-            raise KeyError(msg) from exc
+            raise _NodeLookupError(msg) from exc
 
-        library_declarations = library.get_metadata().declarations
+        catalog = find_model_catalog(library.get_metadata().declarations)
         return _NodeResolution(
             node_declarations=node_metadata.declarations,
-            library_declarations=library_declarations,
-            resolved_by_id=self._index_catalog(library_declarations),
+            catalog=catalog,
+            resolved_by_id=self._index_catalog(catalog),
         )
 
     @staticmethod
-    def _index_catalog(library_declarations: Sequence[LibraryDeclaration]) -> dict[str, ResolvedModel]:
-        """Build a `{model_id: ResolvedModel}` index from a library's catalog, empty if none."""
-        catalog = find_model_catalog(library_declarations)
+    def _index_catalog(catalog: ModelCatalogLibraryProperty | None) -> dict[str, ResolvedModel]:
+        """Build a `{model_id: ResolvedModel}` index from a catalog, empty when there is none."""
         if catalog is None:
             return {}
         return {resolved.model_id: resolved for resolved in iter_catalog_models(catalog)}
@@ -211,7 +221,7 @@ class AccessManager:
     def _declared_model_ids(
         *,
         node_declarations: Sequence[NodeDeclaration],
-        library_declarations: Sequence[LibraryDeclaration],
+        catalog: ModelCatalogLibraryProperty | None,
     ) -> list[str]:
         """Union of catalog ids from `model_usage` plus `model_provider_usage` expansion.
 
@@ -228,7 +238,6 @@ class AccessManager:
                         seen.add(model_id)
                         ordered.append(model_id)
 
-        catalog = find_model_catalog(library_declarations)
         if catalog is None:
             return ordered
 
@@ -252,7 +261,7 @@ class AccessManager:
         """Ask the authorization hook chain once per candidate; collect one verdict each.
 
         Attribute composition:
-          - ``ID = node_type`` only when ``node_type`` is supplied (per-node form).
+          - ``NODE_TYPE = node_type`` only when ``node_type`` is supplied (per-node form).
           - ``MODEL_ID`` always.
           - ``PROVIDER_ID`` and ``MODEL_FAMILIES`` only when the id resolves in
             ``resolved_by_id`` (the per-node and catalog-scoped forms supply this;
@@ -270,7 +279,7 @@ class AccessManager:
         for model_id in candidate_model_ids:
             attributes: dict[str, Any] = {CheckpointAttribute.MODEL_ID: model_id}
             if node_type is not None:
-                attributes[CheckpointAttribute.ID] = node_type
+                attributes[CheckpointAttribute.NODE_TYPE] = node_type
             resolved = resolved_by_id.get(model_id)
             provider_model_id: str | None = None
             if resolved is not None:

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -9,18 +9,18 @@ why?" -- one verdict per candidate, each carrying a `CheckpointDenial` or `None`
 Three request types, named by what attribution the engine adds to each checkpoint:
 
   - `QueryModelAccessRequest` -- bare. Caller supplies ids only. Checkpoint
-    attributes carry only `MODEL_ID`. For non-node callers (sidebar, scripted
-    enumerations) where no engine-side context attributes the query.
+    attributes carry only `ID` (the model id). For non-node callers (sidebar,
+    scripted enumerations) where no engine-side context attributes the query.
 
   - `QueryModelAccessForNodeRequest` -- node-attributed. Caller supplies a node
     type and, optionally, an explicit candidate list. When candidates are
     omitted the engine derives them from the node's `ModelUsageNodeProperty`
     plus `ModelProviderUsageNodeProperty` expansion. Checkpoint attributes
-    carry `NODE_TYPE = node_type`, `MODEL_ID`, plus catalog-resolved `PROVIDER_ID`
-    and `MODEL_FAMILIES` when the id is in the node's library catalog.
+    carry `ID` (the model id), `NODE_TYPE = node_type`, plus catalog-resolved
+    `PROVIDER_ID` and `MODEL_FAMILIES` when the id is in the node's library catalog.
 
   - `QueryModelAccessForCatalogRequest` -- catalog-scoped. Caller supplies a
-    library name and ids. Checkpoint attributes carry `MODEL_ID` plus
+    library name and ids. Checkpoint attributes carry `ID` (the model id) plus
     catalog-resolved `PROVIDER_ID` / `MODEL_FAMILIES`. No `NODE_TYPE` attribute --
     the caller has a library in mind but no node to attribute the query to.
 
@@ -114,7 +114,7 @@ class AccessManager:
             )
 
     def on_query_model_access_request(self, request: QueryModelAccessRequest) -> ResultPayload:
-        """Bare form. Hook sees `MODEL_ID` per candidate; no `ID`, no catalog enrichment."""
+        """Bare form. Hook sees `ID` (the model id) per candidate; no `NODE_TYPE`, no catalog enrichment."""
         verdicts = self._evaluate(
             candidate_model_ids=request.candidate_model_ids,
             node_type=None,
@@ -151,11 +151,11 @@ class AccessManager:
         )
 
     def on_query_model_access_for_catalog_request(self, request: QueryModelAccessForCatalogRequest) -> ResultPayload:
-        """Catalog-scoped. Hook sees `MODEL_ID` plus enrichment when the id resolves.
+        """Catalog-scoped. Hook sees `ID` (the model id) plus enrichment when the id resolves.
 
         A missing library is not fatal -- callers (sidebar, scripts) may name a
         library that's not currently registered; the handler falls through to
-        bare verdicts so a policy can still match on `MODEL_ID`.
+        bare verdicts so a policy can still match on `ID`.
         """
         try:
             library = LibraryRegistry.get_library(request.library_name)
@@ -261,13 +261,13 @@ class AccessManager:
         """Ask the authorization hook chain once per candidate; collect one verdict each.
 
         Attribute composition:
+          - ``ID`` (the model id, mirroring ``subject_id``) always.
           - ``NODE_TYPE = node_type`` only when ``node_type`` is supplied (per-node form).
-          - ``MODEL_ID`` always.
           - ``PROVIDER_ID`` and ``MODEL_FAMILIES`` only when the id resolves in
             ``resolved_by_id`` (the per-node and catalog-scoped forms supply this;
             the bare form does not).
 
-        An unknown id is still asked of the hook with ``MODEL_ID`` only, so a
+        An unknown id is still asked of the hook with ``ID`` only, so a
         policy can still match on the bare key.
 
         Sequential calls reset the hook chain's recursion guard between
@@ -277,7 +277,7 @@ class AccessManager:
         event_manager = GriptapeNodes.EventManager()
         verdicts: list[ModelAccessVerdict] = []
         for model_id in candidate_model_ids:
-            attributes: dict[str, Any] = {CheckpointAttribute.MODEL_ID: model_id}
+            attributes: dict[str, Any] = {CheckpointAttribute.ID: model_id}
             if node_type is not None:
                 attributes[CheckpointAttribute.NODE_TYPE] = node_type
             resolved = resolved_by_id.get(model_id)

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -228,6 +228,13 @@ class AccessManager:
         Order: each ``ModelUsageNodeProperty.model_ids`` entry in declaration order,
         then provider-expanded ids in catalog order, de-duplicated. A node that
         declares no model usage returns an empty list (zero verdicts).
+
+        This deliberately does NOT reuse ``resolve_node_models``: that helper drops
+        ``model_usage`` ids absent from the catalog, but a per-candidate access
+        query must keep them so a policy can explicitly deny an unknown id rather
+        than have it silently vanish from the offered set. Only the provider
+        expansion (which is meaningless without a catalog) goes through the
+        resolver.
         """
         ordered: list[str] = []
         seen: set[str] = set()

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -40,13 +40,14 @@ fires from `ModelManager`.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.node_library.library_declarations import (
-    ModelCatalogLibraryProperty,
     ModelProviderUsageNodeProperty,
     ModelUsageNodeProperty,
     ResolvedModel,
+    find_model_catalog,
     iter_catalog_models,
     resolve_node_models,
 )
@@ -77,6 +78,19 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class _NodeResolution:
+    """A node's library context: the node's declarations, the library's, and a catalog index.
+
+    Built only on the success path of `AccessManager._resolve_node_library`; a
+    failed lookup raises instead of producing a half-populated instance.
+    """
+
+    node_declarations: Sequence[NodeDeclaration]
+    library_declarations: Sequence[LibraryDeclaration]
+    resolved_by_id: dict[str, ResolvedModel]
+
+
 class AccessManager:
     """Answers per-candidate authorization queries via the `OFFER_MODEL` checkpoint."""
 
@@ -104,9 +118,10 @@ class AccessManager:
 
     def on_query_model_access_for_node_request(self, request: QueryModelAccessForNodeRequest) -> ResultPayload:
         """Node-attributed. Engine derives candidates from declarations unless caller overrides."""
-        resolution = self._resolve_node_library(request.node_type, request.specific_library_name)
-        if resolution.error is not None:
-            return QueryModelAccessForNodeResultFailure(result_details=resolution.error)
+        try:
+            resolution = self._resolve_node_library(request.node_type, request.specific_library_name)
+        except KeyError as exc:
+            return QueryModelAccessForNodeResultFailure(result_details=str(exc))
 
         if request.candidate_model_ids is None:
             candidates = self._declared_model_ids(
@@ -134,7 +149,7 @@ class AccessManager:
         bare verdicts so a policy can still match on `MODEL_ID`.
         """
         try:
-            library = LibraryRegistry.get_library(request.specific_library_name)
+            library = LibraryRegistry.get_library(request.library_name)
         except KeyError:
             resolved_by_id: dict[str, ResolvedModel] = {}
         else:
@@ -147,47 +162,39 @@ class AccessManager:
         )
         return QueryModelAccessForCatalogResultSuccess(
             verdicts=verdicts,
-            result_details=f"Evaluated {len(verdicts)} candidate model(s) in catalog '{request.specific_library_name}'.",
+            result_details=f"Evaluated {len(verdicts)} candidate model(s) in catalog '{request.library_name}'.",
         )
 
     def _resolve_node_library(self, node_type: str, specific_library_name: str | None) -> _NodeResolution:
         """Look up the node's library and return its declarations plus a model-id index.
 
-        Returns an error string when the lookup fails so the per-node handler can
-        map it onto a `Failure` result; on success ``error`` is ``None`` and the
-        other fields are populated.
+        Raises:
+            KeyError: when the node type's library is not registered, or the node
+                type is not found within that library. The message names the node
+                type so the per-node handler can surface it verbatim on a
+                ``Failure`` result.
         """
         try:
             library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
         except KeyError as exc:
-            return _NodeResolution(
-                error=(
-                    f"Attempted to query model access for node type '{node_type}'. "
-                    f"Failed because the library lookup raised KeyError: {exc}."
-                ),
-                node_declarations=(),
-                library_declarations=(),
-                resolved_by_id={},
+            msg = (
+                f"Attempted to query model access for node type '{node_type}'. "
+                f"Failed because the library lookup raised KeyError: {exc}."
             )
+            raise KeyError(msg) from exc
 
         try:
             node_metadata = library.get_node_metadata(node_type)
         except KeyError as exc:
-            return _NodeResolution(
-                error=(
-                    f"Attempted to query model access for node type '{node_type}'. "
-                    f"Failed because the node type was not found in its library: {exc}."
-                ),
-                node_declarations=(),
-                library_declarations=(),
-                resolved_by_id={},
+            msg = (
+                f"Attempted to query model access for node type '{node_type}'. "
+                f"Failed because the node type was not found in its library: {exc}."
             )
+            raise KeyError(msg) from exc
 
-        node_declarations = node_metadata.declarations
         library_declarations = library.get_metadata().declarations
         return _NodeResolution(
-            error=None,
-            node_declarations=node_declarations,
+            node_declarations=node_metadata.declarations,
             library_declarations=library_declarations,
             resolved_by_id=self._index_catalog(library_declarations),
         )
@@ -195,10 +202,7 @@ class AccessManager:
     @staticmethod
     def _index_catalog(library_declarations: Sequence[LibraryDeclaration]) -> dict[str, ResolvedModel]:
         """Build a `{model_id: ResolvedModel}` index from a library's catalog, empty if none."""
-        catalog = next(
-            (d for d in library_declarations if isinstance(d, ModelCatalogLibraryProperty)),
-            None,
-        )
+        catalog = find_model_catalog(library_declarations)
         if catalog is None:
             return {}
         return {resolved.model_id: resolved for resolved in iter_catalog_models(catalog)}
@@ -224,10 +228,7 @@ class AccessManager:
                         seen.add(model_id)
                         ordered.append(model_id)
 
-        catalog = next(
-            (d for d in library_declarations if isinstance(d, ModelCatalogLibraryProperty)),
-            None,
-        )
+        catalog = find_model_catalog(library_declarations)
         if catalog is None:
             return ordered
 
@@ -287,22 +288,3 @@ class AccessManager:
             )
             verdicts.append(ModelAccessVerdict(model_id=model_id, provider_model_id=provider_model_id, denial=denial))
         return verdicts
-
-
-class _NodeResolution:
-    """Result of looking up a node's library: declarations plus a catalog index, or an error."""
-
-    __slots__ = ("error", "library_declarations", "node_declarations", "resolved_by_id")
-
-    def __init__(
-        self,
-        *,
-        error: str | None,
-        node_declarations: Sequence[NodeDeclaration],
-        library_declarations: Sequence[LibraryDeclaration],
-        resolved_by_id: dict[str, ResolvedModel],
-    ) -> None:
-        self.error = error
-        self.node_declarations = node_declarations
-        self.library_declarations = library_declarations
-        self.resolved_by_id = resolved_by_id

--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -68,7 +68,6 @@ class CheckpointAttribute(StrEnum):
     PROVIDER_ID = "provider_id"
     EXECUTES_ARBITRARY_CODE = "executes_arbitrary_code"
     NAME = "name"
-    MODEL_ID = "model_id"
     MODEL_IDS = "model_ids"
     PROVIDER_IDS = "provider_ids"
     MODEL_FAMILIES = "model_families"

--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -56,6 +56,11 @@ class CheckpointAttribute(StrEnum):
     fills only the keys it has resolved for a given checkpoint; a hook reads
     whichever it cares about. Members are `str` values, so they serve as dict keys
     that compare equal to their literal spelling on the reading side.
+
+    ``ID`` mirrors the checkpoint's ``subject_id`` (the identifier of the thing
+    being acted on). ``NODE_TYPE`` is supplementary node attribution for
+    checkpoints whose subject is not the node itself -- e.g. ``OFFER_MODEL``,
+    whose subject is the model but which is asked on behalf of a node.
     """
 
     ID = "id"
@@ -67,6 +72,7 @@ class CheckpointAttribute(StrEnum):
     MODEL_IDS = "model_ids"
     PROVIDER_IDS = "provider_ids"
     MODEL_FAMILIES = "model_families"
+    NODE_TYPE = "node_type"
 
 
 @dataclass(frozen=True)

--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -34,6 +34,7 @@ class CheckpointAction(StrEnum):
     LOAD_LIBRARY = "LoadLibrary"
     INSTANTIATE_NODE = "InstantiateNode"
     INVOKE_MODEL = "InvokeModel"
+    OFFER_MODEL = "OfferModel"
     LOAD_PROJECT = "LoadProject"
     ACTIVATE_PROJECT = "ActivateProject"
 
@@ -62,6 +63,7 @@ class CheckpointAttribute(StrEnum):
     PROVIDER_ID = "provider_id"
     EXECUTES_ARBITRARY_CODE = "executes_arbitrary_code"
     NAME = "name"
+    MODEL_ID = "model_id"
     MODEL_IDS = "model_ids"
     PROVIDER_IDS = "provider_ids"
     MODEL_FAMILIES = "model_families"

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -56,9 +56,9 @@ from griptape_nodes.node_library.library_declarations import (
     ArbitraryPythonExecutionNodeProperty,
     LifecycleStageLibraryProperty,
     LifecycleStageNodeProperty,
-    ModelCatalogLibraryProperty,
     ModelProviderUsageNodeProperty,
     ModelUsageNodeProperty,
+    find_model_catalog,
     resolve_node_models,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
@@ -575,14 +575,7 @@ class NodeManager:
         model_ids = list(declared_model_ids)
         provider_ids = list(declared_provider_ids)
         families: list[str] = []
-        catalog = next(
-            (
-                declaration
-                for declaration in library_declarations
-                if isinstance(declaration, ModelCatalogLibraryProperty)
-            ),
-            None,
-        )
+        catalog = find_model_catalog(library_declarations)
         if catalog is not None:
             for resolved in resolve_node_models(catalog, node_declarations):
                 model_ids.append(resolved.model_id)

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -31,12 +31,9 @@ class TestAccessManager:
     def _clean_registry(self):  # noqa: ANN202
         from griptape_nodes.node_library.library_registry import LibraryRegistry
 
-        stores = ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets")
-        for store in stores:
-            getattr(LibraryRegistry, store).clear()
+        LibraryRegistry.reset_for_testing()
         yield
-        for store in stores:
-            getattr(LibraryRegistry, store).clear()
+        LibraryRegistry.reset_for_testing()
 
     def _register(self, node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN202
         from griptape_nodes.node_library.library_registry import (
@@ -477,7 +474,7 @@ class TestAccessManager:
         try:
             GriptapeNodes.handle_request(
                 QueryModelAccessForCatalogRequest(
-                    specific_library_name=self._LIBRARY_NAME,
+                    library_name=self._LIBRARY_NAME,
                     candidate_model_ids=["gtc_claude_opus_4_7"],
                 )
             )
@@ -511,7 +508,7 @@ class TestAccessManager:
         try:
             result = GriptapeNodes.handle_request(
                 QueryModelAccessForCatalogRequest(
-                    specific_library_name="library-that-does-not-exist",
+                    library_name="library-that-does-not-exist",
                     candidate_model_ids=["gtc_claude_opus_4_7"],
                 )
             )
@@ -541,7 +538,7 @@ class TestAccessManager:
         try:
             result = GriptapeNodes.handle_request(
                 QueryModelAccessForCatalogRequest(
-                    specific_library_name=self._LIBRARY_NAME,
+                    library_name=self._LIBRARY_NAME,
                     candidate_model_ids=["not_in_catalog"],
                 )
             )

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -425,7 +425,7 @@ class TestAccessManager:
     # ---------- Bare request (QueryModelAccessRequest) ----------
 
     def test_bare_request_no_node_no_catalog_attributes(self, griptape_nodes: GriptapeNodes) -> None:
-        """Bare request: hook sees `MODEL_ID` only, even when a library is registered.
+        """Bare request: hook sees `ID` only, even when a library is registered.
 
         The bare form must NOT enrich opportunistically -- it has no library scope
         to draw from, so policies operate on the bare model id regardless of what

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -1,0 +1,554 @@
+"""Unit tests for `AccessManager`: per-candidate `OFFER_MODEL` authorization queries.
+
+Covers the three request types -- bare, node-attributed, catalog-scoped -- plus
+catalog enrichment of checkpoint attributes, the hook chain's recursion-guard
+behavior across a per-candidate loop, and failure paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class _ProbeNode(BaseNode):
+    """Concrete `BaseNode` used as the registered node type under test."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+
+
+class TestAccessManager:
+    """Per-candidate `OFFER_MODEL` authorization query manager."""
+
+    _LIBRARY_NAME = "access-manager-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):  # noqa: ANN202
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        stores = ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets")
+        for store in stores:
+            getattr(LibraryRegistry, store).clear()
+        yield
+        for store in stores:
+            getattr(LibraryRegistry, store).clear()
+
+    def _register(self, node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN202
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t",
+                description="d",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=list(library_declarations),
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(
+            _ProbeNode,
+            NodeMetadata(category="t", description="d", display_name="Probe", declarations=list(node_declarations)),
+        )
+        return library
+
+    @staticmethod
+    def _catalog():  # noqa: ANN205
+        from griptape_nodes.node_library.library_declarations import (
+            KeySupport,
+            Model,
+            ModelCatalogLibraryProperty,
+            ModelProvider,
+        )
+
+        return ModelCatalogLibraryProperty(
+            providers={
+                "anthropic": ModelProvider(
+                    display_name="Anthropic",
+                    models={
+                        "gtc_claude_opus_4_7": Model(
+                            display_name="Claude Opus 4.7",
+                            family="Claude 4",
+                            provider_model_id="claude-opus-4-7",
+                            key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
+                        ),
+                        "gtc_claude_sonnet_4_6": Model(
+                            display_name="Claude Sonnet 4.6",
+                            family="Claude 4",
+                            provider_model_id="claude-sonnet-4-6",
+                            key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
+                        ),
+                    },
+                )
+            }
+        )
+
+    # ---------- Per-node request ----------
+
+    def test_for_node_unknown_node_type_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultFailure,
+        )
+
+        result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type="Missing"))
+        assert isinstance(result, QueryModelAccessForNodeResultFailure)
+
+    def test_for_node_no_hook_all_models_allowed(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(
+            node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"])],
+            library_declarations=[self._catalog()],
+        )
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert [v.model_id for v in result.verdicts] == ["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"]
+        assert all(v.denial is None for v in result.verdicts)
+
+    def test_for_node_hook_denies_one_model_only(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        self._register(
+            node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"])],
+            library_declarations=[self._catalog()],
+        )
+
+        def deny(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("model_id") == "gtc_claude_opus_4_7":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Opus is not in your plan."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny)
+
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        denied = [v for v in result.verdicts if v.denial is not None]
+        allowed = [v for v in result.verdicts if v.denial is None]
+        assert [v.model_id for v in denied] == ["gtc_claude_opus_4_7"]
+        assert [v.model_id for v in allowed] == ["gtc_claude_sonnet_4_6"]
+        assert denied[0].denial is not None
+        assert denied[0].denial.messages() == ["Opus is not in your plan."]
+
+    def test_for_node_verdict_carries_provider_model_id(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(
+            node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_claude_opus_4_7"])],
+            library_declarations=[self._catalog()],
+        )
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert len(result.verdicts) == 1
+        assert result.verdicts[0].model_id == "gtc_claude_opus_4_7"
+        assert result.verdicts[0].provider_model_id == "claude-opus-4-7"
+
+    def test_for_node_unknown_candidate_no_catalog_enrichment(self, griptape_nodes: GriptapeNodes) -> None:
+        """Per-node request with an EXPLICIT candidate list including an unknown id.
+
+        Verifies the explicit-override path: the engine asks the hook for the id
+        but skips enrichment since the id is not in the catalog.
+        """
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(library_declarations=[self._catalog()])
+
+        seen_attributes: list[dict[str, Any]] = []
+
+        def record(checkpoint: object) -> None:
+            seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessForNodeRequest(
+                    node_type=_ProbeNode.__name__,
+                    candidate_model_ids=["not_in_catalog"],
+                    specific_library_name=self._LIBRARY_NAME,
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert result.verdicts[0].model_id == "not_in_catalog"
+        assert result.verdicts[0].provider_model_id is None
+        assert seen_attributes == [{"id": _ProbeNode.__name__, "model_id": "not_in_catalog"}]
+
+    def test_for_node_per_candidate_loop_does_not_trip_recursion_guard(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(library_declarations=[self._catalog()])
+
+        seen_model_ids: list[str] = []
+
+        def record(checkpoint: object) -> None:
+            seen_model_ids.append(checkpoint.attributes["model_id"])  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessForNodeRequest(
+                    node_type=_ProbeNode.__name__,
+                    candidate_model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6", "not_in_catalog"],
+                    specific_library_name=self._LIBRARY_NAME,
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        # Each candidate produces exactly one verdict and one hook call -- the
+        # recursion guard does NOT short-circuit subsequent evaluations.
+        assert seen_model_ids == ["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6", "not_in_catalog"]
+        assert [v.model_id for v in result.verdicts] == seen_model_ids
+
+    def test_for_node_action_is_offer_model(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeRequest
+
+        self._register(library_declarations=[self._catalog()])
+
+        seen_actions: list[str] = []
+
+        def record(checkpoint: object) -> None:
+            seen_actions.append(checkpoint.action)  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            GriptapeNodes.handle_request(
+                QueryModelAccessForNodeRequest(
+                    node_type=_ProbeNode.__name__,
+                    candidate_model_ids=["gtc_claude_opus_4_7"],
+                    specific_library_name=self._LIBRARY_NAME,
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert seen_actions == ["OfferModel"]
+
+    def test_for_node_request_derives_model_ids_from_declarations(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(
+            node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_claude_opus_4_7"])],
+            library_declarations=[self._catalog()],
+        )
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert [v.model_id for v in result.verdicts] == ["gtc_claude_opus_4_7"]
+
+    def test_for_node_request_expands_provider_usage(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.node_library.library_declarations import ModelProviderUsageNodeProperty
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(
+            node_declarations=[ModelProviderUsageNodeProperty(provider_ids=["anthropic"])],
+            library_declarations=[self._catalog()],
+        )
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        # Whole provider expands to its catalog models in catalog order.
+        assert [v.model_id for v in result.verdicts] == ["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"]
+
+    def test_for_node_request_with_no_model_declarations_returns_empty_verdicts(
+        self,
+        griptape_nodes: GriptapeNodes,  # noqa: ARG002
+    ) -> None:
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(library_declarations=[self._catalog()])
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert result.verdicts == []
+
+    def test_for_node_explicit_candidates_override_declarations(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(
+            # Node declares two models, but caller asks about only one of them.
+            node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"])],
+            library_declarations=[self._catalog()],
+        )
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(
+                node_type=_ProbeNode.__name__,
+                specific_library_name=self._LIBRARY_NAME,
+                candidate_model_ids=["gtc_claude_sonnet_4_6"],
+            )
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert [v.model_id for v in result.verdicts] == ["gtc_claude_sonnet_4_6"]
+
+    def test_for_node_preserves_candidate_input_order(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultSuccess,
+        )
+
+        self._register(library_declarations=[self._catalog()])
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(
+                node_type=_ProbeNode.__name__,
+                candidate_model_ids=["gtc_claude_sonnet_4_6", "gtc_claude_opus_4_7"],
+                specific_library_name=self._LIBRARY_NAME,
+            )
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultSuccess)
+        assert [v.model_id for v in result.verdicts] == ["gtc_claude_sonnet_4_6", "gtc_claude_opus_4_7"]
+
+    def test_for_node_catalog_enrichment_attributes_reach_the_hook(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeRequest
+
+        self._register(library_declarations=[self._catalog()])
+
+        seen_attributes: list[dict[str, Any]] = []
+
+        def record(checkpoint: object) -> None:
+            seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            GriptapeNodes.handle_request(
+                QueryModelAccessForNodeRequest(
+                    node_type=_ProbeNode.__name__,
+                    candidate_model_ids=["gtc_claude_opus_4_7"],
+                    specific_library_name=self._LIBRARY_NAME,
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert seen_attributes == [
+            {
+                "id": _ProbeNode.__name__,
+                "model_id": "gtc_claude_opus_4_7",
+                "provider_id": "anthropic",
+                "model_families": ["Claude 4"],
+            }
+        ]
+
+    # ---------- Bare request (QueryModelAccessRequest) ----------
+
+    def test_bare_request_no_node_no_catalog_attributes(self, griptape_nodes: GriptapeNodes) -> None:
+        """Bare request: hook sees `MODEL_ID` only, even when a library is registered.
+
+        The bare form must NOT enrich opportunistically -- it has no library scope
+        to draw from, so policies operate on the bare model id regardless of what
+        catalogs happen to be loaded.
+        """
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessRequest,
+            QueryModelAccessResultSuccess,
+        )
+
+        # Register a library whose catalog HAS the id we're about to query, just
+        # to prove the bare form ignores it.
+        self._register(library_declarations=[self._catalog()])
+
+        seen_attributes: list[dict[str, Any]] = []
+
+        def record(checkpoint: object) -> None:
+            seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessRequest(candidate_model_ids=["gtc_claude_opus_4_7", "anything"])
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert isinstance(result, QueryModelAccessResultSuccess)
+        # `provider_model_id` is None because the bare form does NOT consult any catalog.
+        assert all(v.provider_model_id is None for v in result.verdicts)
+        assert seen_attributes == [
+            {"model_id": "gtc_claude_opus_4_7"},
+            {"model_id": "anything"},
+        ]
+
+    def test_bare_request_hook_can_deny_on_bare_model_id(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessRequest,
+            QueryModelAccessResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("model_id") == "gtc_claude_opus_4_7":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Opus is not in your plan."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessRequest(candidate_model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"])
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny)
+
+        assert isinstance(result, QueryModelAccessResultSuccess)
+        denied = [v for v in result.verdicts if v.denial is not None]
+        assert [v.model_id for v in denied] == ["gtc_claude_opus_4_7"]
+
+    # ---------- Catalog-scoped request (QueryModelAccessForCatalogRequest) ----------
+
+    def test_for_catalog_enriches_when_id_resolves(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForCatalogRequest
+
+        self._register(library_declarations=[self._catalog()])
+
+        seen_attributes: list[dict[str, Any]] = []
+
+        def record(checkpoint: object) -> None:
+            seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            GriptapeNodes.handle_request(
+                QueryModelAccessForCatalogRequest(
+                    specific_library_name=self._LIBRARY_NAME,
+                    candidate_model_ids=["gtc_claude_opus_4_7"],
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        # No "id" attribute -- catalog-scoped form has no node attribution.
+        assert seen_attributes == [
+            {
+                "model_id": "gtc_claude_opus_4_7",
+                "provider_id": "anthropic",
+                "model_families": ["Claude 4"],
+            }
+        ]
+
+    def test_for_catalog_unknown_library_returns_success_with_bare_verdicts(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForCatalogRequest,
+            QueryModelAccessForCatalogResultSuccess,
+        )
+
+        # No library registered at this name.
+        seen_attributes: list[dict[str, Any]] = []
+
+        def record(checkpoint: object) -> None:
+            seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessForCatalogRequest(
+                    specific_library_name="library-that-does-not-exist",
+                    candidate_model_ids=["gtc_claude_opus_4_7"],
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert isinstance(result, QueryModelAccessForCatalogResultSuccess)
+        assert result.verdicts[0].model_id == "gtc_claude_opus_4_7"
+        assert result.verdicts[0].provider_model_id is None
+        # Hook still got the bare model_id, no enrichment.
+        assert seen_attributes == [{"model_id": "gtc_claude_opus_4_7"}]
+
+    def test_for_catalog_unknown_id_no_enrichment_but_query_still_happens(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForCatalogRequest,
+            QueryModelAccessForCatalogResultSuccess,
+        )
+
+        self._register(library_declarations=[self._catalog()])
+
+        seen_attributes: list[dict[str, Any]] = []
+
+        def record(checkpoint: object) -> None:
+            seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
+
+        griptape_nodes.EventManager().add_authorization_hook(record)
+        try:
+            result = GriptapeNodes.handle_request(
+                QueryModelAccessForCatalogRequest(
+                    specific_library_name=self._LIBRARY_NAME,
+                    candidate_model_ids=["not_in_catalog"],
+                )
+            )
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(record)
+
+        assert isinstance(result, QueryModelAccessForCatalogResultSuccess)
+        assert result.verdicts[0].model_id == "not_in_catalog"
+        assert result.verdicts[0].provider_model_id is None
+        assert seen_attributes == [{"model_id": "not_in_catalog"}]

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -105,6 +105,33 @@ class TestAccessManager:
 
         result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type="Missing"))
         assert isinstance(result, QueryModelAccessForNodeResultFailure)
+        # Message is clean prose: names the node type, no KeyError quote/tuple repr.
+        details = str(result.result_details)
+        assert "Missing" in details
+        assert not details.startswith('"')
+        assert "('" not in details
+
+    def test_for_node_missing_in_specified_library_returns_clean_failure(
+        self,
+        griptape_nodes: GriptapeNodes,  # noqa: ARG002
+    ) -> None:
+        from griptape_nodes.retained_mode.events.access_events import (
+            QueryModelAccessForNodeRequest,
+            QueryModelAccessForNodeResultFailure,
+        )
+
+        self._register()
+
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(node_type="NotRegistered", specific_library_name=self._LIBRARY_NAME)
+        )
+        assert isinstance(result, QueryModelAccessForNodeResultFailure)
+        # The node-not-found path stringifies a KeyError(library, node_type) tuple; the
+        # handler must surface clean prose naming both, not the raw tuple repr.
+        details = str(result.result_details)
+        assert "NotRegistered" in details
+        assert self._LIBRARY_NAME in details
+        assert "('" not in details
 
     def test_for_node_no_hook_all_models_allowed(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
@@ -212,7 +239,7 @@ class TestAccessManager:
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert result.verdicts[0].model_id == "not_in_catalog"
         assert result.verdicts[0].provider_model_id is None
-        assert seen_attributes == [{"id": _ProbeNode.__name__, "model_id": "not_in_catalog"}]
+        assert seen_attributes == [{"node_type": _ProbeNode.__name__, "model_id": "not_in_catalog"}]
 
     def test_for_node_per_candidate_loop_does_not_trip_recursion_guard(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
@@ -388,7 +415,7 @@ class TestAccessManager:
 
         assert seen_attributes == [
             {
-                "id": _ProbeNode.__name__,
+                "node_type": _ProbeNode.__name__,
                 "model_id": "gtc_claude_opus_4_7",
                 "provider_id": "anthropic",
                 "model_families": ["Claude 4"],
@@ -481,7 +508,7 @@ class TestAccessManager:
         finally:
             griptape_nodes.EventManager().remove_authorization_hook(record)
 
-        # No "id" attribute -- catalog-scoped form has no node attribution.
+        # No "node_type" attribute -- catalog-scoped form has no node attribution.
         assert seen_attributes == [
             {
                 "model_id": "gtc_claude_opus_4_7",

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -166,7 +166,7 @@ class TestAccessManager:
         )
 
         def deny(checkpoint: object) -> CheckpointDenial | None:
-            if checkpoint.attributes.get("model_id") == "gtc_claude_opus_4_7":  # type: ignore[attr-defined]
+            if checkpoint.attributes.get("id") == "gtc_claude_opus_4_7":  # type: ignore[attr-defined]
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Opus is not in your plan."),))
             return None
 
@@ -239,7 +239,7 @@ class TestAccessManager:
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert result.verdicts[0].model_id == "not_in_catalog"
         assert result.verdicts[0].provider_model_id is None
-        assert seen_attributes == [{"node_type": _ProbeNode.__name__, "model_id": "not_in_catalog"}]
+        assert seen_attributes == [{"node_type": _ProbeNode.__name__, "id": "not_in_catalog"}]
 
     def test_for_node_per_candidate_loop_does_not_trip_recursion_guard(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
@@ -252,7 +252,7 @@ class TestAccessManager:
         seen_model_ids: list[str] = []
 
         def record(checkpoint: object) -> None:
-            seen_model_ids.append(checkpoint.attributes["model_id"])  # type: ignore[attr-defined]
+            seen_model_ids.append(checkpoint.attributes["id"])  # type: ignore[attr-defined]
 
         griptape_nodes.EventManager().add_authorization_hook(record)
         try:
@@ -416,7 +416,7 @@ class TestAccessManager:
         assert seen_attributes == [
             {
                 "node_type": _ProbeNode.__name__,
-                "model_id": "gtc_claude_opus_4_7",
+                "id": "gtc_claude_opus_4_7",
                 "provider_id": "anthropic",
                 "model_families": ["Claude 4"],
             }
@@ -457,8 +457,8 @@ class TestAccessManager:
         # `provider_model_id` is None because the bare form does NOT consult any catalog.
         assert all(v.provider_model_id is None for v in result.verdicts)
         assert seen_attributes == [
-            {"model_id": "gtc_claude_opus_4_7"},
-            {"model_id": "anything"},
+            {"id": "gtc_claude_opus_4_7"},
+            {"id": "anything"},
         ]
 
     def test_bare_request_hook_can_deny_on_bare_model_id(self, griptape_nodes: GriptapeNodes) -> None:
@@ -469,7 +469,7 @@ class TestAccessManager:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny(checkpoint: object) -> CheckpointDenial | None:
-            if checkpoint.attributes.get("model_id") == "gtc_claude_opus_4_7":  # type: ignore[attr-defined]
+            if checkpoint.attributes.get("id") == "gtc_claude_opus_4_7":  # type: ignore[attr-defined]
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Opus is not in your plan."),))
             return None
 
@@ -511,7 +511,7 @@ class TestAccessManager:
         # No "node_type" attribute -- catalog-scoped form has no node attribution.
         assert seen_attributes == [
             {
-                "model_id": "gtc_claude_opus_4_7",
+                "id": "gtc_claude_opus_4_7",
                 "provider_id": "anthropic",
                 "model_families": ["Claude 4"],
             }
@@ -546,7 +546,7 @@ class TestAccessManager:
         assert result.verdicts[0].model_id == "gtc_claude_opus_4_7"
         assert result.verdicts[0].provider_model_id is None
         # Hook still got the bare model_id, no enrichment.
-        assert seen_attributes == [{"model_id": "gtc_claude_opus_4_7"}]
+        assert seen_attributes == [{"id": "gtc_claude_opus_4_7"}]
 
     def test_for_catalog_unknown_id_no_enrichment_but_query_still_happens(self, griptape_nodes: GriptapeNodes) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
@@ -575,4 +575,4 @@ class TestAccessManager:
         assert isinstance(result, QueryModelAccessForCatalogResultSuccess)
         assert result.verdicts[0].model_id == "not_in_catalog"
         assert result.verdicts[0].provider_model_id is None
-        assert seen_attributes == [{"model_id": "not_in_catalog"}]
+        assert seen_attributes == [{"id": "not_in_catalog"}]

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -31,9 +31,9 @@ class TestAccessManager:
     def _clean_registry(self):  # noqa: ANN202
         from griptape_nodes.node_library.library_registry import LibraryRegistry
 
-        LibraryRegistry.reset_for_testing()
+        LibraryRegistry._clear()
         yield
-        LibraryRegistry.reset_for_testing()
+        LibraryRegistry._clear()
 
     def _register(self, node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN202
         from griptape_nodes.node_library.library_registry import (

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1295,10 +1295,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             LibraryManager as _LibraryManager,
         )
 
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
 
         sandbox_dir = tmp_path / "sandbox"
         sandbox_dir.mkdir()
@@ -1335,10 +1332,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             try:
                 yield sandbox_dir
             finally:
-                LibraryRegistry._libraries.clear()
-                LibraryRegistry._node_aliases.clear()
-                LibraryRegistry._collision_node_names_to_library_names.clear()
-                LibraryRegistry._registered_widgets.clear()
+                LibraryRegistry._clear()
 
     def test_imports_existing_file_and_registers_node_type(
         self,
@@ -1586,15 +1580,9 @@ class TestDescribeNodeTypeRequest:
     @pytest.fixture(autouse=True)
     def _clean_registry(self) -> Generator[None, None, None]:
         """LibraryRegistry holds class-level state that survives the singleton reset fixture."""
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
         yield
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
 
     def _register_probe_library(self) -> None:
         schema = LibrarySchema(
@@ -1803,15 +1791,9 @@ class TestLibraryNodeMetadataInjection:
 
     @pytest.fixture(autouse=True)
     def _clean_registry(self) -> Generator[None, None, None]:
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
         yield
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
 
     def _register_probe_library(self, node_metadata: NodeMetadata) -> None:
         schema = LibrarySchema(
@@ -3041,15 +3023,9 @@ class TestModelCatalogResolution:
 
     @pytest.fixture(autouse=True)
     def _clean_registry(self) -> Generator[None, None, None]:
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
         yield
-        LibraryRegistry._libraries.clear()
-        LibraryRegistry._node_aliases.clear()
-        LibraryRegistry._collision_node_names_to_library_names.clear()
-        LibraryRegistry._registered_widgets.clear()
+        LibraryRegistry._clear()
 
     @staticmethod
     def _catalog() -> ModelCatalogLibraryProperty:

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -508,12 +508,9 @@ class TestNodeInstantiationAuthorizationCheckpoint:
     def _clean_registry(self):  # noqa: ANN202
         from griptape_nodes.node_library.library_registry import LibraryRegistry
 
-        stores = ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets")
-        for store in stores:
-            getattr(LibraryRegistry, store).clear()
+        LibraryRegistry._clear()
         yield
-        for store in stores:
-            getattr(LibraryRegistry, store).clear()
+        LibraryRegistry._clear()
 
     def _register(self, node_declarations=(), library_declarations=()):  # noqa: ANN001, ANN202
         from griptape_nodes.node_library.library_registry import (
@@ -580,10 +577,9 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         assert self._attrs(inherit)["lifecycle_stage"] == "BETA"
 
         # Re-register with neither stated -> lifecycle_stage omitted entirely.
-        for store in ("_libraries", "_node_aliases", "_collision_node_names_to_library_names", "_registered_widgets"):
-            from griptape_nodes.node_library.library_registry import LibraryRegistry
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
 
-            getattr(LibraryRegistry, store).clear()
+        LibraryRegistry._clear()
         unstated = self._register()
         assert "lifecycle_stage" not in self._attrs(unstated)
 


### PR DESCRIPTION
Closes #4958. Engine half of [internal#50](https://github.com/griptape-ai/internal/issues/50). Library follow-up in [griptape-ai/griptape-nodes-library-standard#367](https://github.com/griptape-ai/griptape-nodes-library-standard/issues/367) (draft PR — depends on this engine release).

## Summary

Today the engine gates **node instantiation** as a binary yes/no over the union of model IDs a node declares. That's correct for a dedicated-model node, but wrong for nodes that offer a model dropdown: a hook that wants to deny 1 of 15 models must either deny the whole node or let everything through. This PR adds the per-model gate the library needs to decorate denied dropdown rows and explain *why* they're denied.

## What lands

- **`CheckpointAction.OFFER_MODEL`** + **`CheckpointAttribute.MODEL_ID`** (singular, sibling of plural `MODEL_IDS`). `INSTANTIATE_NODE` semantics unchanged.
- **`AccessManager`** (`src/griptape_nodes/retained_mode/managers/access_manager.py`) — three handlers, one shared `_evaluate()` helper.
- **Three request types** in `access_events.py`, named by attribution (what context the engine adds to each checkpoint):
  - `QueryModelAccessRequest` — bare; hook sees `MODEL_ID` only. Most code uses this.
  - `QueryModelAccessForNodeRequest` — node-attributed. Engine derives candidates from `ModelUsageNodeProperty` when omitted.
  - `QueryModelAccessForCatalogRequest` — catalog-scoped; engine enriches with `PROVIDER_ID` / `MODEL_FAMILIES`.
- 18 unit tests in `tests/unit/retained_mode/managers/test_access_manager.py`.

Engine ships **no hook implementations** — this is purely the question. The license/policy app installs an authorization hook via `EventManager.add_authorization_hook` to answer it.

## Naming rationale

Existing `CheckpointAction` values (`LOAD_LIBRARY`, `INSTANTIATE_NODE`, `INVOKE_MODEL`, `LOAD_PROJECT`, `ACTIVATE_PROJECT`) all name the **engine operation being gated**, not the hook's verdict. `OFFER_MODEL` follows that pattern: the engine is about to offer this model as a selectable option; the hook either allows or denies.

The three request type names express **what attribution the engine adds**, not what the caller passes. The bare name lands on the un-attributed form (which most callers use) and the more-attributed forms get explicit suffixes.

## Testing this manually

Drop one of the snippets below into a scratch script or REPL (engine running, no hooks installed by default). The hook returns `CheckpointDenial` to deny a model or `None` to allow.

```python
from griptape_nodes.retained_mode.events.access_events import (
    QueryModelAccessRequest,
    QueryModelAccessResultSuccess,
)
from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
    CheckpointDenial,
    CheckpointFailure,
)

# Stub: deny a specific catalog id. Real hooks read attributes['model_id'] etc.
DENIED_MODEL_IDS = {
    "gtc_gpt_5_2": "GPT-5.2 is not enabled on your license. Contact your administrator to enable it.",
    "gtc_claude_opus_4_7": "Claude Opus 4.7 is not enabled on your license. Contact your administrator to enable it.",
}

def deny_stub(checkpoint):
    reason = DENIED_MODEL_IDS.get(checkpoint.attributes.get("model_id"))
    if reason is None:
        return None
    return CheckpointDenial(failures=(CheckpointFailure(detail=reason),))

GriptapeNodes.EventManager().add_authorization_hook(deny_stub)

# Bare query
result = GriptapeNodes.handle_request(
    QueryModelAccessRequest(candidate_model_ids=["gtc_gpt_5_2", "gtc_claude_sonnet_4_6"])
)
for v in result.verdicts:
    print(v.model_id, "->", v.denial.reason() if v.denial else "allowed")
```

```python
# Per-node query (engine derives candidates from the node's model_usage declaration)
from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeRequest

result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type="DescribeImage"))
for v in result.verdicts:
    status = v.denial.reason() if v.denial else "allowed"
    print(f"  {v.provider_model_id or v.model_id}: {status}")
```

```python
# Catalog-scoped query (caller knows the library but not a specific node)
from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForCatalogRequest

result = GriptapeNodes.handle_request(
    QueryModelAccessForCatalogRequest(
        specific_library_name="griptape-nodes-library-standard",
        candidate_model_ids=["gtc_gpt_5_2", "gtc_gpt_4o"],
    )
)
for v in result.verdicts:
    print(v.model_id, "/", v.provider_model_id, "->", v.denial.reason() if v.denial else "allowed")
```

To clear the hook between trials: `GriptapeNodes.EventManager().remove_authorization_hook(deny_stub)`.

## Out of scope (follow-ups)

- **Library UX** — dropdown decoration + per-parameter badges + runtime enforcement on selection are in the [library PR](https://github.com/griptape-ai/griptape-nodes-library-standard/issues/367). That PR is draft and blocked on this engine release shipping a tagged version.
- **Sidebar gating** — wiring `on_handle_list_agent_models_request` and `on_handle_list_provider_models_request` (from #4937, just merged) through these new request types is a separate follow-up. The contracts are durable; no engine API will change.
- **Codec / per-operation gates** — future `CheckpointAction.USE_CODEC`-style checks will live alongside this in `AccessManager` or fire directly from the manager that owns the operation, same way `INVOKE_MODEL` fires from `ModelManager`. Tracked separately.

## Test plan

- [x] `make check` passes
- [x] 18 unit tests in `test_access_manager.py` pass; coverage spans bare / per-node / catalog-scoped requests, catalog enrichment, recursion-guard correctness, failure paths.
- [ ] Reviewer: register the deny stub above; confirm each of the three request types behaves as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
