### PR TITLE
fix: tolerate missing library metadata when serializing proxy nodes

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1958,6 +1958,14 @@ class ErrorProxyNode(BaseNode):
         self.original_node_type = original_node_type
         self.original_library_name = original_library_name
         self.failure_reason = failure_reason
+
+        # The owning library/node type are normally injected into metadata by
+        # LibraryRegistry.create_node, but a proxy is created precisely because that
+        # path failed, so the keys may be absent. Record the original library and node
+        # type here (without clobbering anything a round-tripped workflow already
+        # carried) so serialization can resolve the library and the proxy round-trips.
+        self.metadata.setdefault("library", original_library_name)
+        self.metadata.setdefault("node_type", original_node_type)
         # Record ALL initial_setup=True requests in order for 1:1 replay
         self._recorded_initialization_requests: list[RequestPayload] = []
 

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3420,8 +3420,19 @@ class NodeManager:
 
         # This is our current dude.
         with GriptapeNodes.ContextManager().node(node=node):
-            # Get the library and version details for all nodes
-            library_used = node.metadata["library"]
+            # Get the library and version details for all nodes.
+            # A node's owning library is normally injected into metadata by
+            # LibraryRegistry.create_node, but proxy/placeholder nodes can be created
+            # without it when that path fails. Fall back to the proxy's recorded
+            # original library, and tolerate a missing key rather than crashing the
+            # entire save.
+            library_used = node.metadata.get("library")
+            if library_used is None and isinstance(node, ErrorProxyNode):
+                library_used = node.original_library_name
+            if library_used is None:
+                # No owning library could be determined. Use an empty name so the
+                # metadata lookup below fails cleanly instead of crashing the save.
+                library_used = ""
             # For SubflowNodeGroup, also check if execution environment uses a special library
             execution_env_library_details = None
             if isinstance(node, SubflowNodeGroup):

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -216,6 +216,80 @@ class TestNodeManagerResolutionStateSerialization:
         assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
 
 
+class TestSerializeNodeWithoutLibraryMetadata:
+    """Serializing a node whose metadata lacks a 'library' key must not crash the save."""
+
+    def test_error_proxy_node_records_original_library_in_metadata(self) -> None:
+        """A proxy created without library metadata adopts its original library/node type."""
+        from griptape_nodes.exe_types.node_types import ErrorProxyNode
+
+        node = ErrorProxyNode(
+            name="Execute Python",
+            original_node_type="ExecutePython",
+            original_library_name="Missing Library",
+            failure_reason="library failed to load",
+            metadata={},
+        )
+
+        assert node.metadata["library"] == "Missing Library"
+        assert node.metadata["node_type"] == "ExecutePython"
+
+    def test_error_proxy_node_does_not_clobber_existing_metadata(self) -> None:
+        """Library/node type already present in metadata (e.g. from a round trip) is preserved."""
+        from griptape_nodes.exe_types.node_types import ErrorProxyNode
+
+        node = ErrorProxyNode(
+            name="Execute Python",
+            original_node_type="ExecutePython",
+            original_library_name="Missing Library",
+            failure_reason="library failed to load",
+            metadata={"library": "Original Library", "node_type": "OriginalType"},
+        )
+
+        assert node.metadata["library"] == "Original Library"
+        assert node.metadata["node_type"] == "OriginalType"
+
+    def test_serialize_node_without_library_metadata_does_not_crash(self, griptape_nodes: GriptapeNodes) -> None:
+        """Regression for griptape-ai/griptape-nodes-app#154: a missing 'library' key must not raise."""
+        from griptape_nodes.exe_types.node_types import ErrorProxyNode
+        from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
+        from griptape_nodes.retained_mode.events.node_events import (
+            SerializeNodeToCommandsRequest,
+            SerializeNodeToCommandsResultSuccess,
+        )
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        griptape_nodes.handle_request(
+            EnsureWorkflowAndFlowRequest(workflow_name="proxy_workflow", flow_name="proxy_flow")
+        )
+
+        node = ErrorProxyNode(
+            name="Execute Python",
+            original_node_type="ExecutePython",
+            original_library_name="Missing Library",
+            failure_reason="library failed to load",
+            metadata={},
+        )
+        # Simulate a proxy whose metadata never received a 'library' key, which is the
+        # exact condition that previously raised KeyError: 'library' during serialization.
+        node.metadata.pop("library", None)
+        assert "library" not in node.metadata
+
+        GriptapeNodes.ObjectManager().add_object_by_name(node.name, node)
+
+        result = griptape_nodes.NodeManager().on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name=node.name)
+        )
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        create_command = result.serialized_node_commands.create_node_command
+        assert create_command.node_type == "ExecutePython"
+        assert create_command.specific_library_name == "Missing Library"
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
 class TestNodeManagerAlterParameterDetailsClearDefaultValue:
     """Test AlterParameterDetailsRequest behavior when clear_default_value and default_value are both set."""
 


### PR DESCRIPTION
Saving a workflow that contained a proxy/placeholder node crashed serialization with `KeyError: 'library'`. A node's owning library name is normally injected into `node.metadata["library"]` by `LibraryRegistry.create_node`, but an `ErrorProxyNode` only exists because that creation path failed, so the key can be absent. `on_serialize_node_to_commands` read `node.metadata["library"]` unconditionally, so the missing key aborted the entire save (observed as `Attempted to serialize Flow 'ControlFlow_1'. Failed while attempting to serialize Node 'Execute Python'`).

`ErrorProxyNode` now records its `original_library_name` and `original_node_type` into its metadata at construction, using `setdefault` so a value carried over from a round-tripped workflow is never clobbered. This lets a proxy round-trip its intended library instead of losing it. The serialize path additionally falls back to the proxy's `original_library_name` and tolerates a genuinely absent key rather than raising, so a node without library metadata degrades to a clean failure instead of crashing the save.


Closes https://github.com/griptape-ai/griptape-nodes-app/issues/154
