### PR TITLE
feat(nodes): give policy-denied proxy nodes a warning treatment

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1938,26 +1938,34 @@ class EndNode(BaseNode):
 
 
 class ErrorProxyNode(BaseNode):
-    """A proxy node that substitutes for nodes that failed to create due to missing dependencies or errors.
+    """A proxy node that substitutes for nodes that failed to create due to missing dependencies, policy denials, or errors.
 
     This node maintains the original node type information and allows workflows to continue loading
     even when some node types are unavailable. It generates parameters dynamically as connections
     and values are assigned to maintain workflow structure.
+
+    A node denied by an authorization policy is a recoverable restriction rather than a broken node,
+    so `denied_by_policy` substitutes a warning treatment for the hard-error one and explains the
+    cause as a permission gate instead of a load failure. The engine stays policy-agnostic: the
+    specific reason text arrives in `failure_reason` from whatever hook denied the node.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         name: str,
         original_node_type: str,
         original_library_name: str,
         failure_reason: str,
         metadata: dict[Any, Any] | None = None,
+        *,
+        denied_by_policy: bool = False,
     ) -> None:
         super().__init__(name, metadata)
 
         self.original_node_type = original_node_type
         self.original_library_name = original_library_name
         self.failure_reason = failure_reason
+        self.denied_by_policy = denied_by_policy
 
         # The owning library/node type are normally injected into metadata by
         # LibraryRegistry.create_node, but a proxy is created precisely because that
@@ -1972,17 +1980,29 @@ class ErrorProxyNode(BaseNode):
         # Track if user has made connection modifications after initial setup
         self._has_connection_modifications: bool = False
 
-        # Add error message parameter explaining the failure
+        # A policy denial is a recoverable "not yet permitted" state, not a broken
+        # node, so it surfaces as a warning rather than an error. Markdown lets the
+        # message emphasize that distinction; the editor renders both the variant and the markdown.
         self._error_message = ParameterMessage(
             name="error_proxy_message",
-            variant="error",
+            variant="warning" if denied_by_policy else "error",
             value="",  # Will be set by _update_error_message
+            markdown=denied_by_policy,
         )
         self.add_node_element(self._error_message)
         self._update_error_message()
 
     def _get_base_error_message(self) -> str:
         """Generate the base error message for this ErrorProxyNode."""
+        if self.denied_by_policy:
+            return (
+                f"**Permission denied**\n\n"
+                f"You don't have permission to use the **{self.original_node_type}** node from the "
+                f"**{self.original_library_name}** library, so this placeholder is holding its spot.\n\n"
+                f"{self.failure_reason}\n\n"
+                f"Your original node will be restored automatically once permission is granted. "
+                f"Contact your administrator if you need this capability enabled."
+            )
         return (
             f"This placeholder stands in for the '{self.original_node_type}' node "
             f"from the '{self.original_library_name}' library, which could not be loaded.\n\n"

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -740,17 +740,24 @@ class NodeManager:
             # Check if we should create an Error Proxy node instead of failing
             if request.create_error_proxy_on_failure:
                 try:
-                    # Use fitness problem details if available for a more actionable error message
-                    library_metadata_result = GriptapeNodes.handle_request(
-                        GetLibraryMetadataRequest(library=request.specific_library_name or "")
-                    )
-                    if (
-                        isinstance(library_metadata_result, GetLibraryMetadataResultFailure)
-                        and library_metadata_result.problems is not None
-                    ):
-                        failure_reason = library_metadata_result.problems
-                    else:
+                    # A policy denial is a recoverable restriction rather than a broken
+                    # node, so the proxy carries the denial reason and renders as a warning
+                    # instead of surfacing library-load diagnostics as a hard error.
+                    denied_by_policy = isinstance(err, _NodeInstantiationDeniedError)
+                    if denied_by_policy:
                         failure_reason = str(err)
+                    else:
+                        # Use fitness problem details if available for a more actionable error message
+                        library_metadata_result = GriptapeNodes.handle_request(
+                            GetLibraryMetadataRequest(library=request.specific_library_name or "")
+                        )
+                        if (
+                            isinstance(library_metadata_result, GetLibraryMetadataResultFailure)
+                            and library_metadata_result.problems is not None
+                        ):
+                            failure_reason = library_metadata_result.problems
+                        else:
+                            failure_reason = str(err)
 
                     # Create ErrorProxyNode directly since it needs special initialization
                     node = ErrorProxyNode(
@@ -759,6 +766,7 @@ class NodeManager:
                         original_library_name=request.specific_library_name or "Unknown",
                         failure_reason=failure_reason,
                         metadata=request.metadata,
+                        denied_by_policy=denied_by_policy,
                     )
 
                     logger.warning(

--- a/tests/unit/exe_types/test_node_types.py
+++ b/tests/unit/exe_types/test_node_types.py
@@ -178,3 +178,51 @@ class TestTrackedParameterOutputValuesSetItem:
             tracked["out"] = None
 
         mock_emit.assert_not_called()
+
+
+class TestErrorProxyNode:
+    """The placeholder substituted for a node that could not be created."""
+
+    @staticmethod
+    def _message(node):  # noqa: ANN001, ANN205
+        from griptape_nodes.exe_types.core_types import ParameterMessage
+
+        message = node.get_message_by_name_or_element_id("error_proxy_message")
+        assert isinstance(message, ParameterMessage)
+        return message
+
+    def test_load_failure_reads_as_error(self) -> None:
+        """A missing dependency / load failure keeps the hard-error treatment."""
+        from griptape_nodes.exe_types.node_types import ErrorProxyNode
+
+        node = ErrorProxyNode(
+            name="proxy",
+            original_node_type="FancyNode",
+            original_library_name="fancy-lib",
+            failure_reason="No module named 'fancy'",
+        )
+
+        message = self._message(node)
+        assert node.denied_by_policy is False
+        assert message.variant == "error"
+        assert message.markdown is False
+        assert "could not be loaded" in message.value
+
+    def test_policy_denial_reads_as_warning(self) -> None:
+        """A policy denial is recoverable, so it reads as a warning that surfaces the hook's reason."""
+        from griptape_nodes.exe_types.node_types import ErrorProxyNode
+
+        node = ErrorProxyNode(
+            name="proxy",
+            original_node_type="FancyNode",
+            original_library_name="fancy-lib",
+            failure_reason="Ask your admin to enable Labs nodes.",
+            denied_by_policy=True,
+        )
+
+        message = self._message(node)
+        assert node.denied_by_policy is True
+        assert message.variant == "warning"
+        assert message.markdown is True
+        assert "**Permission denied**" in message.value
+        assert "Ask your admin to enable Labs nodes." in message.value


### PR DESCRIPTION
When a node type is denied at an authorization checkpoint, node creation falls into the same `ErrorProxyNode` substitution path as a node whose library failed to load, so the editor rendered the placeholder as a hard red error. A denial is recoverable: the original node returns once it is permitted, so treating it as a hard failure misrepresented the cause and hid that the node is gated by policy rather than broken.

The engine deliberately knows nothing about the license or whatever policy the wrapping app enforces (see `authorization_checkpoint.py`), so the proxy keys off the generic signal the engine already owns: whether the caught failure was a `_NodeInstantiationDeniedError` (a checkpoint said no) rather than a load error. `ErrorProxyNode` now takes `denied_by_policy`, set by `on_create_node_request` in that case. The `error_proxy_message` is then emitted as a `warning` variant with markdown enabled, leads with a bolded `Permission denied`, and carries the hook-supplied reason via `failure_reason` instead of library-load diagnostics. No license vocabulary lives in the engine; the specific wording comes from whatever hook denied the node. The editor already renders the message variant and markdown from `ui_options`, so this needs no frontend change. The library-load failure path keeps its existing `error` treatment and wording.

<img width="1386" height="848" alt="image" src="https://github.com/user-attachments/assets/86dce0d7-5bb9-41e9-88d2-67dccd228a04" />


Closes griptape-ai/griptape-vsl-gui#2570
