### PR TITLE
Fix stale workspace path

### DIFF
--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -28,13 +28,25 @@ class BaseStorageDriver(ABC):
     converting absolute paths to workspace-relative before calling driver methods.
     """
 
-    def __init__(self, workspace_directory: Path) -> None:
+    def __init__(self, workspace_directory: Path) -> None:  # noqa: B027
         """Initialize the storage driver with a workspace directory.
 
         Args:
-            workspace_directory: The base workspace directory path.
+            workspace_directory: The base workspace directory path (unused, kept for compatibility).
         """
-        self.workspace_directory = workspace_directory
+        # Note: workspace_directory parameter is ignored; drivers now fetch the current
+        # workspace fresh from ConfigManager to handle dynamic workspace changes.
+
+    @property
+    def workspace_directory(self) -> Path:
+        """Get the current workspace directory from ConfigManager.
+
+        Returns the workspace path fresh on each access to handle dynamic workspace
+        changes (e.g., project switches, workspace_dir overrides).
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        return GriptapeNodes.ConfigManager().workspace_path
 
     @abstractmethod
     def create_signed_upload_url(

--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -32,10 +32,11 @@ class BaseStorageDriver(ABC):
         """Initialize the storage driver with a workspace directory.
 
         Args:
-            workspace_directory: The base workspace directory path (unused, kept for compatibility).
+            workspace_directory: The base workspace directory path (unused, kept for API compatibility).
+                Drivers now fetch the current workspace dynamically via the workspace_directory property.
         """
-        # Note: workspace_directory parameter is ignored; drivers now fetch the current
-        # workspace fresh from ConfigManager to handle dynamic workspace changes.
+        # workspace_directory parameter is ignored - the property reads from ConfigManager instead.
+        # This ensures drivers always use the current workspace, even if it changes after initialization.
 
     @property
     def workspace_directory(self) -> Path:

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -52,8 +52,11 @@ class LocalStorageDriver(BaseStorageDriver):
         *,
         file_metadata: SidecarContent | None = None,  # noqa: ARG002
     ) -> CreateSignedUploadUrlResponse:
+        # Read current workspace path fresh from ConfigManager
+        current_workspace = GriptapeNodes.ConfigManager().workspace_path
+
         # on_write_file_request seems to work most reliably with an absolute path.
-        absolute_path = resolve_workspace_path(path, self.workspace_directory)
+        absolute_path = resolve_workspace_path(path, current_workspace)
 
         # Always delegate to OSManager for file path resolution and policy handling.
         # Creating an empty file before the upload url gives us a chance to claim ownership
@@ -79,7 +82,7 @@ class LocalStorageDriver(BaseStorageDriver):
         # WriteFileRequest always returns an absolute path; convert back to workspace-relative
         # since the static server upload handler prepends the workspace directory itself.
         # Resolve both sides to ensure drive letters match on Windows (drive-relative vs absolute paths).
-        resolved_path = resolved_path.resolve().relative_to(self.workspace_directory.resolve())
+        resolved_path = resolved_path.resolve().relative_to(current_workspace.resolve())
 
         static_url = urljoin(self.base_url, "/static-upload-urls")
         try:
@@ -129,7 +132,9 @@ class LocalStorageDriver(BaseStorageDriver):
             FileExistsError: When existing_file_policy is FAIL and file already exists.
             RuntimeError: If file write fails.
         """
-        absolute_path = resolve_workspace_path(path, self.workspace_directory)
+        # Read current workspace path fresh from ConfigManager
+        current_workspace = GriptapeNodes.ConfigManager().workspace_path
+        absolute_path = resolve_workspace_path(path, current_workspace)
 
         result = GriptapeNodes.OSManager().on_write_file_request(
             WriteFileRequest(
@@ -148,12 +153,17 @@ class LocalStorageDriver(BaseStorageDriver):
         return result.final_file_path
 
     def create_signed_download_url(self, path: Path) -> str:
+        # Read current workspace path fresh from ConfigManager instead of using cached value
+        # This ensures the URL is resolved against the current workspace, even if the workspace
+        # changed after this driver was initialized (e.g., project switch, workspace_dir override)
+        current_workspace = GriptapeNodes.ConfigManager().workspace_path
+
         # Resolve path, treating relative paths as workspace-relative
-        absolute_path = resolve_workspace_path(path, self.workspace_directory)
+        absolute_path = resolve_workspace_path(path, current_workspace)
 
         # Automatically determine if the file is external to the workspace
         try:
-            workspace_relative_path = absolute_path.relative_to(self.workspace_directory.resolve())
+            workspace_relative_path = absolute_path.relative_to(current_workspace.resolve())
             # Internal files: use workspace-relative path
             url = f"{self.base_url}/{workspace_relative_path.as_posix()}"
         except ValueError:
@@ -222,5 +232,7 @@ class LocalStorageDriver(BaseStorageDriver):
         try:
             resolved_path = Path(destination.resolve())
         except FileLoadError:
-            return str(resolve_workspace_path(path, self.workspace_directory))
+            # Read current workspace path fresh from ConfigManager
+            current_workspace = GriptapeNodes.ConfigManager().workspace_path
+            return str(resolve_workspace_path(path, current_workspace))
         return str(resolved_path)

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -52,11 +52,8 @@ class LocalStorageDriver(BaseStorageDriver):
         *,
         file_metadata: SidecarContent | None = None,  # noqa: ARG002
     ) -> CreateSignedUploadUrlResponse:
-        # Read current workspace path fresh from ConfigManager
-        current_workspace = GriptapeNodes.ConfigManager().workspace_path
-
         # on_write_file_request seems to work most reliably with an absolute path.
-        absolute_path = resolve_workspace_path(path, current_workspace)
+        absolute_path = resolve_workspace_path(path, self.workspace_directory)
 
         # Always delegate to OSManager for file path resolution and policy handling.
         # Creating an empty file before the upload url gives us a chance to claim ownership
@@ -82,7 +79,7 @@ class LocalStorageDriver(BaseStorageDriver):
         # WriteFileRequest always returns an absolute path; convert back to workspace-relative
         # since the static server upload handler prepends the workspace directory itself.
         # Resolve both sides to ensure drive letters match on Windows (drive-relative vs absolute paths).
-        resolved_path = resolved_path.resolve().relative_to(current_workspace.resolve())
+        resolved_path = resolved_path.resolve().relative_to(self.workspace_directory.resolve())
 
         static_url = urljoin(self.base_url, "/static-upload-urls")
         try:
@@ -132,9 +129,7 @@ class LocalStorageDriver(BaseStorageDriver):
             FileExistsError: When existing_file_policy is FAIL and file already exists.
             RuntimeError: If file write fails.
         """
-        # Read current workspace path fresh from ConfigManager
-        current_workspace = GriptapeNodes.ConfigManager().workspace_path
-        absolute_path = resolve_workspace_path(path, current_workspace)
+        absolute_path = resolve_workspace_path(path, self.workspace_directory)
 
         result = GriptapeNodes.OSManager().on_write_file_request(
             WriteFileRequest(
@@ -153,17 +148,12 @@ class LocalStorageDriver(BaseStorageDriver):
         return result.final_file_path
 
     def create_signed_download_url(self, path: Path) -> str:
-        # Read current workspace path fresh from ConfigManager instead of using cached value
-        # This ensures the URL is resolved against the current workspace, even if the workspace
-        # changed after this driver was initialized (e.g., project switch, workspace_dir override)
-        current_workspace = GriptapeNodes.ConfigManager().workspace_path
-
         # Resolve path, treating relative paths as workspace-relative
-        absolute_path = resolve_workspace_path(path, current_workspace)
+        absolute_path = resolve_workspace_path(path, self.workspace_directory)
 
         # Automatically determine if the file is external to the workspace
         try:
-            workspace_relative_path = absolute_path.relative_to(current_workspace.resolve())
+            workspace_relative_path = absolute_path.relative_to(self.workspace_directory.resolve())
             # Internal files: use workspace-relative path
             url = f"{self.base_url}/{workspace_relative_path.as_posix()}"
         except ValueError:
@@ -232,7 +222,5 @@ class LocalStorageDriver(BaseStorageDriver):
         try:
             resolved_path = Path(destination.resolve())
         except FileLoadError:
-            # Read current workspace path fresh from ConfigManager
-            current_workspace = GriptapeNodes.ConfigManager().workspace_path
-            return str(resolve_workspace_path(path, current_workspace))
+            return str(resolve_workspace_path(path, self.workspace_directory))
         return str(resolved_path)

--- a/tests/unit/drivers/storage/test_base_storage_driver.py
+++ b/tests/unit/drivers/storage/test_base_storage_driver.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -66,6 +67,15 @@ class TestBaseStorageDriverUploadFile:
         return self.ConcreteStorageDriver(Path("/workspace"))
 
     @pytest.fixture
+    def mock_workspace_path(self) -> Generator[None, None, None]:
+        """Mock ConfigManager to return /workspace for all tests."""
+        with patch("griptape_nodes.drivers.storage.base_storage_driver.GriptapeNodes") as mock_griptape:
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
+            yield
+
+    @pytest.fixture
     def mock_upload_response(self) -> dict[str, Any]:
         """Standard mock response for create_signed_upload_url."""
         return {
@@ -76,7 +86,9 @@ class TestBaseStorageDriverUploadFile:
         }
 
     def test_upload_file_passes_existing_file_policy_to_create_signed_upload_url(
-        self, base_storage_driver: ConcreteStorageDriver
+        self,
+        base_storage_driver: ConcreteStorageDriver,
+        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test line 95: upload_file passes existing_file_policy to create_signed_upload_url."""
         with (
@@ -100,7 +112,11 @@ class TestBaseStorageDriverUploadFile:
             # Verify create_signed_upload_url was called with correct policy (line 95)
             mock_create_url.assert_called_once_with(TEST_FILE_PATH, ExistingFilePolicy.FAIL)
 
-    def test_upload_file_default_policy_is_overwrite(self, base_storage_driver: ConcreteStorageDriver) -> None:
+    def test_upload_file_default_policy_is_overwrite(
+        self,
+        base_storage_driver: ConcreteStorageDriver,
+        mock_workspace_path: Any,  # noqa: ARG002
+    ) -> None:
         """Test line 95: upload_file defaults to OVERWRITE policy when not specified."""
         with (
             patch.object(base_storage_driver, "create_signed_upload_url") as mock_create_url,
@@ -123,7 +139,11 @@ class TestBaseStorageDriverUploadFile:
             # Verify create_signed_upload_url was called with default OVERWRITE policy (line 95)
             mock_create_url.assert_called_once_with(TEST_FILE_PATH, ExistingFilePolicy.OVERWRITE)
 
-    def test_upload_file_create_new_policy(self, base_storage_driver: ConcreteStorageDriver) -> None:
+    def test_upload_file_create_new_policy(
+        self,
+        base_storage_driver: ConcreteStorageDriver,
+        mock_workspace_path: Any,  # noqa: ARG002
+    ) -> None:
         """Test line 95: upload_file passes CREATE_NEW policy correctly."""
         with (
             patch.object(base_storage_driver, "create_signed_upload_url") as mock_create_url,
@@ -146,7 +166,7 @@ class TestBaseStorageDriverUploadFile:
             # Verify create_signed_upload_url was called with CREATE_NEW policy (line 95)
             mock_create_url.assert_called_once_with(TEST_FILE_PATH, ExistingFilePolicy.CREATE_NEW)
 
-    def test_upload_file_uses_timeout_parameter(self) -> None:
+    def test_upload_file_uses_timeout_parameter(self, mock_workspace_path: Any) -> None:  # noqa: ARG002
         """upload_file should pass timeout parameter to httpx.request."""
         driver = self.ConcreteStorageDriver(Path("/workspace"))
 

--- a/tests/unit/drivers/storage/test_base_storage_driver.py
+++ b/tests/unit/drivers/storage/test_base_storage_driver.py
@@ -69,7 +69,7 @@ class TestBaseStorageDriverUploadFile:
     @pytest.fixture
     def mock_workspace_path(self) -> Generator[None, None, None]:
         """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.drivers.storage.base_storage_driver.GriptapeNodes") as mock_griptape:
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
             mock_config_manager = Mock()
             mock_config_manager.workspace_path = Path("/workspace")
             mock_griptape.ConfigManager.return_value = mock_config_manager

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -61,6 +61,9 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
         ):
             # Setup mocks
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
@@ -91,6 +94,9 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
         ):
             # Setup mocks
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
@@ -131,6 +137,9 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
         ):
             # Setup mocks
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
@@ -157,7 +166,13 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
 
     def test_internal_file_uses_workspace_relative_url(self, local_storage_driver: LocalStorageDriver) -> None:
         """Internal files should produce a workspace-relative URL."""
-        with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
+        with (
+            patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time,
+            patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape,
+        ):
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_time.time.return_value = 1000
             url = local_storage_driver.create_signed_download_url(Path("/workspace/images/photo.png"))
 

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -28,6 +29,15 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
         return LocalStorageDriver(Path("/workspace"))
 
     @pytest.fixture
+    def mock_workspace_path(self) -> Generator[None, None, None]:
+        """Mock ConfigManager to return /workspace for all tests."""
+        with patch("griptape_nodes.drivers.storage.base_storage_driver.GriptapeNodes") as mock_griptape:
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
+            yield
+
+    @pytest.fixture
     def mock_os_manager(self) -> Mock:
         """Mock OSManager for testing."""
         return Mock()
@@ -53,7 +63,11 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
         )
 
     def test_create_signed_upload_url_delegates_to_os_manager_with_policy(
-        self, local_storage_driver: LocalStorageDriver, mock_os_manager: Mock, mock_write_success_result: Any
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_os_manager: Mock,
+        mock_write_success_result: Any,
+        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url delegates to OSManager with correct policy."""
         with (
@@ -83,7 +97,11 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             assert call_args.existing_file_policy == ExistingFilePolicy.FAIL
 
     def test_create_signed_upload_url_uses_resolved_path_from_os_manager(
-        self, local_storage_driver: LocalStorageDriver, mock_os_manager: Mock, mock_write_success_result: Any
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_os_manager: Mock,
+        mock_write_success_result: Any,
+        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url uses resolved filename from OSManager."""
         with (
@@ -107,7 +125,11 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             assert call_kwargs["json"]["file_path"] == str(TEST_RESOLVED_PATH)
 
     def test_create_signed_upload_url_raises_file_exists_error_on_write_failure(
-        self, local_storage_driver: LocalStorageDriver, mock_os_manager: Mock, mock_write_failure_result: Any
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_os_manager: Mock,
+        mock_write_failure_result: Any,
+        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url raises FileExistsError when WriteFileRequest fails."""
         with patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape:
@@ -123,7 +145,11 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             mock_os_manager.on_write_file_request.assert_called_once()
 
     def test_create_signed_upload_url_default_overwrite_policy(
-        self, local_storage_driver: LocalStorageDriver, mock_os_manager: Mock, mock_write_success_result: Any
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_os_manager: Mock,
+        mock_write_success_result: Any,
+        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url defaults to OVERWRITE policy."""
         with (
@@ -155,7 +181,20 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
         """Create LocalStorageDriver instance for testing."""
         return LocalStorageDriver(Path("/workspace"))
 
-    def test_internal_file_uses_workspace_relative_url(self, local_storage_driver: LocalStorageDriver) -> None:
+    @pytest.fixture
+    def mock_workspace_path(self) -> Generator[None, None, None]:
+        """Mock ConfigManager to return /workspace for all tests."""
+        with patch("griptape_nodes.drivers.storage.base_storage_driver.GriptapeNodes") as mock_griptape:
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
+            yield
+
+    def test_internal_file_uses_workspace_relative_url(
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_workspace_path: Any,  # noqa: ARG002
+    ) -> None:
         """Internal files should produce a workspace-relative URL."""
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
             mock_time.time.return_value = 1000
@@ -163,7 +202,11 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
 
         assert url == "http://localhost:8124/workspace/images/photo.png?t=1000"
 
-    def test_external_unix_file_uses_external_url(self, local_storage_driver: LocalStorageDriver) -> None:
+    def test_external_unix_file_uses_external_url(
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_workspace_path: Any,  # noqa: ARG002
+    ) -> None:
         """External Unix files should produce a /external/ URL with forward slashes."""
         with (
             patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time,
@@ -176,7 +219,11 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
 
         assert url == "http://localhost:8124/external/external/video.mp4?t=1000"
 
-    def test_external_windows_file_uses_forward_slashes_in_url(self, local_storage_driver: LocalStorageDriver) -> None:
+    def test_external_windows_file_uses_forward_slashes_in_url(
+        self,
+        local_storage_driver: LocalStorageDriver,
+        mock_workspace_path: Any,  # noqa: ARG002
+    ) -> None:
         """External Windows-style files should produce a URL with forward slashes, not backslashes."""
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
             mock_time.time.return_value = 1000

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -31,7 +31,7 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
     @pytest.fixture
     def mock_workspace_path(self) -> Generator[None, None, None]:
         """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.drivers.storage.base_storage_driver.GriptapeNodes") as mock_griptape:
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
             mock_config_manager = Mock()
             mock_config_manager.workspace_path = Path("/workspace")
             mock_griptape.ConfigManager.return_value = mock_config_manager
@@ -184,7 +184,7 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
     @pytest.fixture
     def mock_workspace_path(self) -> Generator[None, None, None]:
         """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.drivers.storage.base_storage_driver.GriptapeNodes") as mock_griptape:
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
             mock_config_manager = Mock()
             mock_config_manager.workspace_path = Path("/workspace")
             mock_griptape.ConfigManager.return_value = mock_config_manager

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -61,9 +61,6 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
         ):
             # Setup mocks
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
@@ -94,9 +91,6 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
         ):
             # Setup mocks
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
@@ -137,9 +131,6 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
             patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
         ):
             # Setup mocks
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
@@ -166,13 +157,7 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
 
     def test_internal_file_uses_workspace_relative_url(self, local_storage_driver: LocalStorageDriver) -> None:
         """Internal files should produce a workspace-relative URL."""
-        with (
-            patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time,
-            patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape,
-        ):
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
+        with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
             mock_time.time.return_value = 1000
             url = local_storage_driver.create_signed_download_url(Path("/workspace/images/photo.png"))
 


### PR DESCRIPTION
Before: LocalStorageDriver.__init__() cached workspace_directory once → all methods used the stale cached value

After: Each method (create_signed_upload_url(), save_file(), create_signed_download_url(), get_asset_url()) now fetches GriptapeNodes.ConfigManager().workspace_path fresh per call

Closes https://github.com/griptape-ai/internal/issues/148