### PR TITLE
fix(os): sniff bytes before scan/write to prevent CREATE_NEW clobber (#4924)

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -2269,6 +2269,52 @@ class OSManager:
                 result_details=msg,
             )
 
+        # Sniff bytes ONCE and align the destination suffix to the sniffed format
+        # before any scan, write, or candidate generation runs. Without this, the
+        # scan globs the template's suffix while the post-write rename moves the
+        # file to the sniffed suffix; the next CREATE_NEW save with the same bytes
+        # globs the wrong family, returns an already-used index, writes, and the
+        # rename clobbers the prior save. (https://github.com/griptape-ai/griptape-nodes-engine/issues/4924)
+        # Strict mode fails here before touching the disk.
+        sniffed_ext: str | None = None
+        if isinstance(request.content, bytes):
+            sniffed = GriptapeNodes.ArtifactManager().sniff_extension(request.content)
+            destination_suffix = file_path.suffix.lstrip(".").lower()
+            if sniffed is None and destination_suffix:
+                logger.warning(
+                    "Attempted to identify the format of bytes destined for '%s'. "
+                    "Could not recognize the bytes as a known file format, so the file will be written "
+                    "with its requested '.%s' extension unchanged.",
+                    file_path,
+                    destination_suffix,
+                )
+            elif (
+                sniffed is not None
+                and destination_suffix
+                and canonical_extension(destination_suffix) != canonical_extension(sniffed)
+            ):
+                if not request.coerce_extension_to_match_bytes:
+                    msg = (
+                        f"Attempted to write to file '{file_path}' with bytes that look like '.{sniffed}'. "
+                        f"Failed because the requested extension '.{destination_suffix}' does not match the "
+                        f"byte content and coerce_extension_to_match_bytes=False. Either rename the destination "
+                        f"to '.{sniffed}' or supply bytes that match '.{destination_suffix}'."
+                    )
+                    return WriteFileResultFailure(
+                        failure_reason=FileIOFailureReason.EXTENSION_MISMATCH,
+                        result_details=msg,
+                    )
+                sniffed_ext = sniffed
+                coerced_file_path = file_path.with_suffix(f".{sniffed}")
+                logger.warning(
+                    "Attempted to write '%s'. The bytes look like '.%s', so the destination has been "
+                    "adjusted to '%s' to match the byte content.",
+                    file_path,
+                    sniffed,
+                    coerced_file_path,
+                )
+                file_path = coerced_file_path
+
         # Normalize path
         normalized_path = normalize_path_for_platform(file_path)
 
@@ -2474,6 +2520,15 @@ class OSManager:
                                 result_details=msg,
                             )
 
+                        # Align the candidate suffix with the sniffed extension so the
+                        # walked candidate ends up on disk at the same suffix as the
+                        # try-first attempt. The synthesized-macro path inherits this
+                        # because its template comes from the already-swapped file_path;
+                        # the walking-original path uses the user's original suffix and
+                        # needs this swap every iteration.
+                        if sniffed_ext is not None:
+                            candidate_path = candidate_path.with_suffix(f".{sniffed_ext}")
+
                         # Ensure parent directory for this candidate
                         parent_failure_reason = self._ensure_parent_directory_ready(
                             candidate_path,
@@ -2521,14 +2576,18 @@ class OSManager:
             msg = "Internal error: success path reached but file path or bytes not set"
             raise RuntimeError(msg)
 
-        # Reconcile the on-disk suffix with the actual byte content. When the
-        # caller passes coerce_extension_to_match_bytes=True (the default) we
-        # rename to match the sniffed format; when False, mismatched bytes are
-        # treated as a hard failure and the just-written file is removed.
-        coercion_result = self._apply_extension_coercion(request, final_file_path)
-        if isinstance(coercion_result, WriteFileResultFailure):
-            return coercion_result
-        final_file_path = coercion_result
+        # Sidecar provenance must reflect the on-disk extension, not the requested one.
+        # The actual reconciliation already happened at the top of the handler via
+        # the sniff-and-swap; this just keeps the sidecar's file_extension variable
+        # (when present) consistent with what the bytes turned out to be.
+        if (
+            sniffed_ext is not None
+            and request.file_metadata is not None
+            and request.file_metadata.situation is not None
+        ):
+            sidecar_variables = request.file_metadata.situation.variables
+            if sidecar_variables is not None and "file_extension" in sidecar_variables:
+                sidecar_variables["file_extension"] = sniffed_ext
 
         # Write sidecar metadata file if caller opted in by providing file_metadata
         if request.file_metadata is not None:
@@ -2545,88 +2604,6 @@ class OSManager:
             bytes_written=final_bytes_written,
             result_details=result_details,
         )
-
-    def _apply_extension_coercion(  # noqa: PLR0911
-        self,
-        request: WriteFileRequest,
-        final_file_path: Path,
-    ) -> Path | WriteFileResultFailure:
-        """Reconcile the on-disk suffix with the sniffed byte format.
-
-        Runs only for binary content. Sniffs via the registered artifact
-        providers; when the sniffed canonical extension disagrees with the
-        path's suffix the behavior is controlled by the request flag:
-
-        - ``coerce_extension_to_match_bytes=True`` (default): rename the file
-          to use the sniffed extension and (when present) update the
-          ``file_extension`` variable on the sidecar's situation metadata so
-          provenance reflects the actual on-disk extension.
-        - ``coerce_extension_to_match_bytes=False``: delete the just-written
-          file and return ``WriteFileResultFailure`` with
-          ``EXTENSION_MISMATCH``, preserving the original strict behavior.
-        """
-        content = request.content
-        if not isinstance(content, bytes):
-            return final_file_path
-
-        suffix = final_file_path.suffix.lstrip(".").lower()
-        if not suffix:
-            return final_file_path
-
-        sniffed = GriptapeNodes.ArtifactManager().sniff_extension(content)
-        if sniffed is None:
-            logger.warning(
-                "Could not identify byte content for '%s'; writing through without extension coercion.",
-                final_file_path,
-            )
-            return final_file_path
-
-        if canonical_extension(suffix) == canonical_extension(sniffed):
-            return final_file_path
-
-        if not request.coerce_extension_to_match_bytes:
-            try:
-                final_file_path.unlink(missing_ok=True)
-            except OSError as e:
-                logger.warning(
-                    "Failed to remove '%s' after EXTENSION_MISMATCH: %s",
-                    final_file_path,
-                    e,
-                )
-            msg = (
-                f"Refusing to write {sniffed.upper()} bytes to '{final_file_path}' "
-                f"(extension '.{suffix}'). The file extension must match the byte content; "
-                f"either rename the destination to '.{sniffed}' or supply bytes that match '.{suffix}'."
-            )
-            return WriteFileResultFailure(
-                failure_reason=FileIOFailureReason.EXTENSION_MISMATCH,
-                result_details=msg,
-            )
-
-        coerced_path = final_file_path.with_suffix(f".{sniffed}")
-        try:
-            final_file_path.rename(coerced_path)
-        except OSError as e:
-            logger.warning(
-                "Failed to rename '%s' to '%s' during extension coercion: %s; leaving original suffix.",
-                final_file_path,
-                coerced_path,
-                e,
-            )
-            return final_file_path
-
-        logger.warning(
-            "Coerced file extension to match byte content: '%s' -> '%s'.",
-            final_file_path,
-            coerced_path,
-        )
-
-        if request.file_metadata is not None and request.file_metadata.situation is not None:
-            variables = request.file_metadata.situation.variables
-            if variables is not None and "file_extension" in variables:
-                variables["file_extension"] = sniffed
-
-        return coerced_path
 
     def _ensure_parent_directory_ready(
         self,

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -174,6 +174,23 @@ class FileWriteAttemptResult(NamedTuple):
     error_message: str | None
 
 
+class ExtensionAlignment(NamedTuple):
+    """Result of aligning a destination path's suffix to the sniffed byte format.
+
+    Attributes:
+        aligned_path: The path the write should target. Equal to the requested path
+            when the suffix already matches, when bytes were unrecognizable, or for
+            non-bytes content. Otherwise the requested path with its suffix replaced
+            by the sniffed extension.
+        sniffed_ext: The sniffed extension (e.g. ``"jpg"``) when a swap occurred,
+            None otherwise. Downstream code carries this forward so the indexed
+            walk and the sidecar update agree on the final extension.
+    """
+
+    aligned_path: Path
+    sniffed_ext: str | None
+
+
 @dataclass
 class CopyTreeValidationResult:
     """Result from validating copy tree paths."""
@@ -2276,44 +2293,11 @@ class OSManager:
         # globs the wrong family, returns an already-used index, writes, and the
         # rename clobbers the prior save. (https://github.com/griptape-ai/griptape-nodes-engine/issues/4924)
         # Strict mode fails here before touching the disk.
-        sniffed_ext: str | None = None
-        if isinstance(request.content, bytes):
-            sniffed = GriptapeNodes.ArtifactManager().sniff_extension(request.content)
-            destination_suffix = file_path.suffix.lstrip(".").lower()
-            if sniffed is None and destination_suffix:
-                logger.warning(
-                    "Attempted to identify the format of bytes destined for '%s'. "
-                    "Could not recognize the bytes as a known file format, so the file will be written "
-                    "with its requested '.%s' extension unchanged.",
-                    file_path,
-                    destination_suffix,
-                )
-            elif (
-                sniffed is not None
-                and destination_suffix
-                and canonical_extension(destination_suffix) != canonical_extension(sniffed)
-            ):
-                if not request.coerce_extension_to_match_bytes:
-                    msg = (
-                        f"Attempted to write to file '{file_path}' with bytes that look like '.{sniffed}'. "
-                        f"Failed because the requested extension '.{destination_suffix}' does not match the "
-                        f"byte content and coerce_extension_to_match_bytes=False. Either rename the destination "
-                        f"to '.{sniffed}' or supply bytes that match '.{destination_suffix}'."
-                    )
-                    return WriteFileResultFailure(
-                        failure_reason=FileIOFailureReason.EXTENSION_MISMATCH,
-                        result_details=msg,
-                    )
-                sniffed_ext = sniffed
-                coerced_file_path = file_path.with_suffix(f".{sniffed}")
-                logger.warning(
-                    "Attempted to write '%s'. The bytes look like '.%s', so the destination has been "
-                    "adjusted to '%s' to match the byte content.",
-                    file_path,
-                    sniffed,
-                    coerced_file_path,
-                )
-                file_path = coerced_file_path
+        alignment = self._apply_extension_coercion(request, file_path)
+        if isinstance(alignment, WriteFileResultFailure):
+            return alignment
+        sniffed_ext = alignment.sniffed_ext
+        file_path = alignment.aligned_path
 
         # Normalize path
         normalized_path = normalize_path_for_platform(file_path)
@@ -2604,6 +2588,72 @@ class OSManager:
             bytes_written=final_bytes_written,
             result_details=result_details,
         )
+
+    def _apply_extension_coercion(
+        self,
+        request: WriteFileRequest,
+        file_path: Path,
+    ) -> ExtensionAlignment | WriteFileResultFailure:
+        """Reconcile the destination suffix with the sniffed byte format.
+
+        Runs once at the top of ``on_write_file_request`` so the planner and the
+        on-disk filename agree on the extension before any scan or write begins.
+        The two relevant signals are the sniffed canonical extension and the
+        path's current suffix:
+
+        - No bytes / unrecognized bytes / empty suffix → no swap; pass the path
+          through unchanged. An unrecognized-bytes case logs a warning so callers
+          can spot it in logs.
+        - Sniffed matches the path's canonical suffix → no swap.
+        - Sniffed differs and ``coerce_extension_to_match_bytes=True`` (default)
+          → swap to the sniffed suffix and return the new path.
+        - Sniffed differs and ``coerce_extension_to_match_bytes=False`` → return
+          a ``WriteFileResultFailure`` with ``EXTENSION_MISMATCH`` so the caller
+          can early-exit before touching the disk.
+        """
+        content = request.content
+        if not isinstance(content, bytes):
+            return ExtensionAlignment(aligned_path=file_path, sniffed_ext=None)
+
+        destination_suffix = file_path.suffix.lstrip(".").lower()
+        if not destination_suffix:
+            return ExtensionAlignment(aligned_path=file_path, sniffed_ext=None)
+
+        sniffed = GriptapeNodes.ArtifactManager().sniff_extension(content)
+        if sniffed is None:
+            logger.warning(
+                "Attempted to identify the format of bytes destined for '%s'. "
+                "Could not recognize the bytes as a known file format, so the file will be written "
+                "with its requested '.%s' extension unchanged.",
+                file_path,
+                destination_suffix,
+            )
+            return ExtensionAlignment(aligned_path=file_path, sniffed_ext=None)
+
+        if canonical_extension(destination_suffix) == canonical_extension(sniffed):
+            return ExtensionAlignment(aligned_path=file_path, sniffed_ext=None)
+
+        if not request.coerce_extension_to_match_bytes:
+            msg = (
+                f"Attempted to write to file '{file_path}' with bytes that look like '.{sniffed}'. "
+                f"Failed because the requested extension '.{destination_suffix}' does not match the "
+                f"byte content and coerce_extension_to_match_bytes=False. Either rename the destination "
+                f"to '.{sniffed}' or supply bytes that match '.{destination_suffix}'."
+            )
+            return WriteFileResultFailure(
+                failure_reason=FileIOFailureReason.EXTENSION_MISMATCH,
+                result_details=msg,
+            )
+
+        aligned_path = file_path.with_suffix(f".{sniffed}")
+        logger.warning(
+            "Attempted to write '%s'. The bytes look like '.%s', so the destination has been "
+            "adjusted to '%s' to match the byte content.",
+            file_path,
+            sniffed,
+            aligned_path,
+        )
+        return ExtensionAlignment(aligned_path=aligned_path, sniffed_ext=sniffed)
 
     def _ensure_parent_directory_ready(
         self,

--- a/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
+++ b/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
@@ -702,7 +702,7 @@ class TestExtensionCoercion:
         assert Path(result.final_file_path) == coerced_path
         assert coerced_path.exists()
         assert not requested_path.exists()
-        assert any("Coerced file extension" in r.message for r in caplog.records)
+        assert any("destination has been adjusted" in r.message for r in caplog.records)
 
     def test_strict_mode_returns_extension_mismatch_failure(
         self, griptape_nodes: GriptapeNodes, temp_dir: Path
@@ -748,7 +748,7 @@ class TestExtensionCoercion:
 
         assert isinstance(result, WriteFileResultSuccess)
         assert Path(result.final_file_path) == requested_path
-        assert any("Could not identify byte content" in r.message for r in caplog.records)
+        assert any("Could not recognize the bytes as a known file format" in r.message for r in caplog.records)
 
     def test_coerce_updates_sidecar_file_extension_variable(
         self, griptape_nodes: GriptapeNodes, temp_dir: Path
@@ -790,6 +790,106 @@ class TestExtensionCoercion:
 
         assert isinstance(result, WriteFileResultSuccess)
         assert Path(result.final_file_path) == requested_path
+
+
+class TestExtensionCoercionDoesNotClobberPriorSave:
+    """Regression for issue #4924.
+
+    Before the fix, CREATE_NEW saves whose bytes coerced to a different suffix than the
+    template's would silently overwrite a prior save: the index scan globbed the template's
+    suffix, missed the previously-coerced file, returned the same index, and the post-write
+    rename clobbered it. After the fix the planner sniffs once up front and every candidate
+    path (try-first, scan glob, indexed-walk) ends at the sniffed suffix, so each save
+    lands on a distinct index.
+    """
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir).resolve()
+
+    @pytest.fixture(autouse=True)
+    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+
+        project_yml = temp_dir / "project_template.yml"
+        project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
+        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        if isinstance(load_result, LoadProjectTemplateResultSuccess):
+            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+
+        griptape_nodes.ArtifactManager().on_handle_register_artifact_provider_request(
+            RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
+        )
+
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+
+        yield
+
+        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @pytest.fixture
+    def outputs_dir(self, temp_dir: Path, setup_project: None) -> Path:  # noqa: ARG002
+        outputs = temp_dir / "outputs"
+        outputs.mkdir(parents=True, exist_ok=True)
+        return outputs
+
+    def test_padded_index_macro_does_not_clobber_previously_coerced_save(self, outputs_dir: Path) -> None:
+        """The exact scenario from issue #4924.
+
+        Macro declares ``.png`` but the bytes sniff as JPEG. Two CREATE_NEW saves with the
+        same JPEG bytes should produce ``render_v001.jpg`` AND ``render_v002.jpg``, with
+        the first save intact. Before the fix the second save overwrote the first.
+        """
+        macro_path = MacroPath(ParsedMacro("{outputs}/render_v{_index:03}.png"), {})
+
+        first_payload = _jpeg_bytes()
+        FileDestination(macro_path, existing_file_policy=ExistingFilePolicy.CREATE_NEW).write_bytes(first_payload)
+
+        second_payload = _jpeg_bytes()
+        FileDestination(macro_path, existing_file_policy=ExistingFilePolicy.CREATE_NEW).write_bytes(second_payload)
+
+        v001 = outputs_dir / "render_v001.jpg"
+        v002 = outputs_dir / "render_v002.jpg"
+
+        assert v001.exists(), "First coerced save must still exist after the second save"
+        assert v002.exists(), "Second save must land at v002, not clobber v001"
+        # The template's .png suffix must never appear on disk for these saves.
+        assert not (outputs_dir / "render_v001.png").exists()
+        assert not (outputs_dir / "render_v002.png").exists()
+
+    def test_plain_path_create_new_with_mismatched_bytes_does_not_clobber(
+        self, griptape_nodes: GriptapeNodes, outputs_dir: Path
+    ) -> None:
+        """Plain string path variant: two JPEG saves to ``output.png`` produce two .jpg files."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = outputs_dir / "output.png"
+
+        first_result = os_manager.on_write_file_request(
+            WriteFileRequest(
+                file_path=str(requested_path),
+                content=_jpeg_bytes(),
+                existing_file_policy=ExistingFilePolicy.CREATE_NEW,
+            )
+        )
+        second_result = os_manager.on_write_file_request(
+            WriteFileRequest(
+                file_path=str(requested_path),
+                content=_jpeg_bytes(),
+                existing_file_policy=ExistingFilePolicy.CREATE_NEW,
+            )
+        )
+
+        assert isinstance(first_result, WriteFileResultSuccess)
+        assert isinstance(second_result, WriteFileResultSuccess)
+        first_path = Path(first_result.final_file_path)
+        second_path = Path(second_result.final_file_path)
+        assert first_path != second_path, "Second save must not reuse the first save's path"
+        assert first_path.exists()
+        assert second_path.exists()
+        assert first_path.suffix == ".jpg"
+        assert second_path.suffix == ".jpg"
 
 
 class TestCreateNewMacroIndexSeed:


### PR DESCRIPTION
## Summary

Fixes #4924.

`OSManager.on_write_file_request` ran two passes that disagreed on the file's extension when the written bytes didn't match the template's suffix:

1. **Index scan** globbed the template's suffix (e.g. `render_v???.png`) to find the next free index.
2. **Extension coercion** ran *after* the exclusive `mode="x"` write and renamed the file to the sniffed suffix (`.png` → `.jpg`).

Two distinct clobber paths fell out of that mismatch:

- **Try-first clobber.** Second JPEG save against a `.png` template re-seeded to `render_v001.png` (no `.png` on disk — the prior save lived at `.jpg`), `mode="x"` succeeded, and the rename overwrote the prior save.
- **Scan clobber.** When the walk fired, the scan globbed `.png` and missed every `.jpg` from prior coerced saves, returning an already-used index. The rename then overwrote whatever `.jpg` lived at that index.

## Fix

Sniff bytes once at the top of `on_write_file_request` and swap the destination suffix with `Path.with_suffix` on every candidate path emitted by macro resolution (try-first, scan, indexed walk). The post-write rename window is gone — `_apply_extension_coercion` deleted entirely. The sidecar `file_extension`-variable update is kept inline on the success path.

Strict mode (`coerce_extension_to_match_bytes=False`) now fails before touching the disk rather than writing-then-unlinking — same observable behavior, cleaner control flow.

`Path.with_suffix` only touches the trailing extension, so it does the right thing for static-tail macros (`render_v{_index:03}.png`), variable-tail macros (`{base}.{ext}`), and plain string paths (`output.png`) without depending on macro variable naming conventions.

## Test plan

**Automated**
- New `TestExtensionCoercionDoesNotClobberPriorSave` class in `tests/unit/retained_mode/managers/test_os_manager_write_file_request.py` covers the macro-with-padded-index repro and the plain-string-path variant.
- Existing `TestExtensionCoercion` suite still passes (final paths and `bytes_written` are observationally identical; strict-mode test updated for early-fail path).
- `make check` clean.

**Manual — reproduces the issue end-to-end in the editor**

Set up a simple flow with two nodes:

1. **A node that produces JPEG bytes** — e.g. a Load Image node pointed at any `.jpg` on disk, or a Generate Image node configured to output JPEG.
2. **A Save File node** wired to receive the JPEG bytes, configured with:
   - Filename macro: `{outputs}/render_v{_index:03}.png` (note: template ends in `.png`, deliberately mismatching the JPEG bytes)
   - Existing-file policy: `CREATE_NEW`

Steps:

- [ ] Run the flow once. Inspect `{outputs}/` — expect `render_v001.jpg`.
- [ ] Run the flow a second time (do not clear outputs between runs). Expect `render_v002.jpg` to appear alongside `render_v001.jpg`. Pre-fix: only `render_v001.jpg` exists, its content overwritten by the second save.
- [ ] Open `render_v001.jpg` and `render_v002.jpg`; confirm they are the JPEG output from runs 1 and 2 respectively (distinct content if the upstream node parameters differ between runs).

Plain-string-path variant (no macro, no padded index):

- [ ] Same flow, but configure the Save node with a plain filename `output.png` (still `CREATE_NEW`).
- [ ] Run twice. Expect `output.jpg` and `output_1.jpg` both present in the outputs directory.

Strict mode sanity check:

- [ ] If your Save node exposes `coerce_extension_to_match_bytes`, set it to `false`, run once with mismatched bytes. Expect the save to fail with `EXTENSION_MISMATCH` and no file left on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)