### PR TITLE
StaticFiles to handle workspace change events in engine lifecycle

### DIFF
--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -252,6 +252,34 @@ async def _serve_external_file(file_path: str) -> FileResponse:
     return FileResponse(absolute_path)
 
 
+class WorkspaceStaticFiles(StaticFiles):
+    """A StaticFiles mount whose served directory tracks the active workspace.
+
+    Starlette's StaticFiles freezes its directory list at construction. The engine's
+    workspace can change at runtime (project switches, workspace_dir overrides), so this
+    subclass recomputes the served directory from ConfigManager on every lookup, mirroring
+    how the storage drivers read workspace_directory live rather than caching it.
+    """
+
+    def __init__(self, *, subdirectory: str | None = None) -> None:
+        self._subdirectory = subdirectory
+        # check_dir=False: the live workspace directory may not exist yet at construction
+        # time, and it can change after the server starts.
+        super().__init__(directory=self._current_directory(), check_dir=False)
+
+    def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
+        # Refresh the served directory so it follows the active workspace before delegating
+        # to Starlette's path-traversal-safe lookup.
+        self.all_directories = [self._current_directory()]
+        return super().lookup_path(path)
+
+    def _current_directory(self) -> Path:
+        workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+        if self._subdirectory is None:
+            return workspace_directory
+        return workspace_directory / self._subdirectory
+
+
 def start_static_server(sock: socket.socket) -> None:
     """Run uvicorn server synchronously using a pre-bound socket.
 
@@ -302,13 +330,14 @@ def start_static_server(sock: socket.socket) -> None:
         allow_private_network=True,  # Required for Starlette 0.51+ to allow localhost access from public origins
     )
 
-    # Mount static files
+    # Mount static files. The served directories resolve the workspace live on each request
+    # (see WorkspaceStaticFiles) so they follow runtime workspace changes such as project switches.
     workspace_directory = GriptapeNodes.ConfigManager().workspace_path
-    static_files_directory = Path(GriptapeNodes.ConfigManager().get_config_value("static_files_directory"))
+    static_files_directory = GriptapeNodes.ConfigManager().get_config_value("static_files_directory")
 
     app.mount(
         STATIC_SERVER_URL,
-        StaticFiles(directory=workspace_directory),
+        WorkspaceStaticFiles(),
         name="workspace",
     )
     static_files_path = workspace_directory / static_files_directory
@@ -316,7 +345,7 @@ def start_static_server(sock: socket.socket) -> None:
     # For legacy urls
     app.mount(
         "/static",
-        StaticFiles(directory=workspace_directory / static_files_directory),
+        WorkspaceStaticFiles(subdirectory=static_files_directory),
         name="static",
     )
 

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -1,9 +1,10 @@
+from contextlib import AbstractContextManager
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from griptape_nodes.servers.static import _serve_external_file
+from griptape_nodes.servers.static import WorkspaceStaticFiles, _serve_external_file
 
 
 class TestServeExternalFile:
@@ -49,3 +50,63 @@ class TestServeExternalFile:
             # Path() should have been called with the raw path, not with "/" prepended
             mock_path_cls.assert_called_once_with(already_absolute_path)
             mock_response.assert_called_once_with(mock_candidate)
+
+
+class TestWorkspaceStaticFiles:
+    """Test that WorkspaceStaticFiles resolves the served directory live, per request."""
+
+    def _patch_workspace(self, workspace: Path) -> AbstractContextManager[MagicMock]:
+        """Patch ConfigManager().workspace_path to return the given directory."""
+        config_manager = MagicMock()
+        config_manager.workspace_path = workspace
+        griptape_nodes = MagicMock()
+        griptape_nodes.ConfigManager.return_value = config_manager
+        return patch("griptape_nodes.servers.static.GriptapeNodes", griptape_nodes)
+
+    def test_lookup_follows_workspace_change(self, tmp_path: Path) -> None:
+        """A file written under the new workspace resolves after the workspace changes at runtime."""
+        boot_workspace = tmp_path / "boot"
+        new_workspace = tmp_path / "project"
+        new_workspace.mkdir()
+        (new_workspace / "outputs").mkdir()
+        served = new_workspace / "outputs" / "image.png"
+        served.write_bytes(b"fake png")
+
+        # Construct against the boot workspace, then switch the active workspace.
+        with self._patch_workspace(boot_workspace):
+            static = WorkspaceStaticFiles()
+
+        with self._patch_workspace(new_workspace):
+            full_path, stat_result = static.lookup_path("outputs/image.png")
+
+        assert Path(full_path) == served
+        assert stat_result is not None
+
+    def test_subdirectory_is_appended_to_live_workspace(self, tmp_path: Path) -> None:
+        """The legacy /static mount serves from <workspace>/<subdirectory>, resolved live."""
+        workspace = tmp_path / "ws"
+        static_dir = workspace / "staticfiles"
+        static_dir.mkdir(parents=True)
+        served = static_dir / "asset.bin"
+        served.write_bytes(b"data")
+
+        with self._patch_workspace(workspace):
+            static = WorkspaceStaticFiles(subdirectory="staticfiles")
+            full_path, stat_result = static.lookup_path("asset.bin")
+
+        assert Path(full_path) == served
+        assert stat_result is not None
+
+    def test_path_traversal_is_rejected(self, tmp_path: Path) -> None:
+        """A path escaping the workspace must not resolve, even with the live directory."""
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"top secret")
+
+        with self._patch_workspace(workspace):
+            static = WorkspaceStaticFiles()
+            full_path, stat_result = static.lookup_path("../secret.txt")
+
+        assert full_path == ""
+        assert stat_result is None


### PR DESCRIPTION
Jason hit this issue, extension/continuation of https://github.com/griptape-ai/griptape-nodes-engine/commit/3eedd1fa62b695435a8c35da4e7547558593d663