### PR TITLE
fix(execution): resolve data-only referenced subflows end to end

### DIFF
--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -9,7 +9,7 @@ from griptape_nodes.exe_types.node_types import (
     BaseNode,
     NodeResolutionState,
 )
-from griptape_nodes.machines.dag_builder import DagBuilder
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNodeCategories
 from griptape_nodes.machines.fsm import FSM, State
 from griptape_nodes.machines.parallel_resolution import ParallelResolutionMachine
 from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent
@@ -25,6 +25,7 @@ from griptape_nodes.retained_mode.managers.settings import WorkflowExecutionMode
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
     from griptape_nodes.exe_types.flow import ControlFlow
+    from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
 
 
 @dataclass
@@ -253,14 +254,15 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         ):
             await self.update()
 
-    async def _process_nodes_for_dag(self, start_node: BaseNode) -> list[BaseNode]:  # noqa: C901, PLR0912
-        """Process data_nodes from the global queue to build unified DAG.
+    async def _process_nodes_for_dag(self, start_node: BaseNode) -> list[BaseNode]:
+        """Seed the DAG for this run and return the entry (control) nodes.
 
-        This method identifies data_nodes in the execution queue and processes
-        their dependencies into the DAG resolution machine.
-
-        For isolated subflows, this skips the global queue entirely and just
-        processes the start node, as subflows are self-contained.
+        Top-level runs and isolated subflows share one classifier and one seeding routine; they
+        differ only in scope. A top-level run draws its categorized nodes from the global queue
+        (already scoped by get_start_node_queue to exclude referenced subflows and group
+        children). An isolated subflow classifies its own nodes directly, since the global queue
+        deliberately omits referenced subflows. Either way the same seeding logic runs, so a
+        data-only subflow resolves its leaf nodes instead of stopping at the start node.
         """
         # Use the DagBuilder from the resolution machine context (may be isolated or global)
         dag_builder = self._context.resolution_machine.context.dag_builder
@@ -271,68 +273,85 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         # Build with the first node (it should already be the proxy if it's part of a group)
         dag_builder.add_node_with_dependencies(start_node, start_node.name)
 
-        # Check if we're using an isolated DagBuilder (for subflows)
         flow_manager = GriptapeNodes.FlowManager()
         node_manager = GriptapeNodes.NodeManager()
         is_isolated = dag_builder is not flow_manager.global_dag_builder
 
         if is_isolated:
-            # For isolated subflows, we don't process the global queue
-            # Just return the start node - the subflow is self-contained
-            logger.debug(
-                "Using isolated DagBuilder for flow '%s' - skipping global queue processing", self._context.flow_name
-            )
-            return [start_node]
+            subflow = flow_manager.get_flow_by_name(self._context.flow_name)
+            categories = flow_manager.classify_nodes_for_dag(list(subflow.nodes.values()))
+            logger.debug("Seeding isolated subflow '%s' DAG from its own nodes", self._context.flow_name)
+        else:
+            categories = self._drain_global_flow_queue(flow_manager)
 
-        # For main flows using the global DagBuilder, process the global queue
-        start_nodes = [start_node]
+        return self._seed_dag_from_categories(start_node, categories, dag_builder, flow_manager, node_manager)
+
+    @staticmethod
+    def _drain_global_flow_queue(flow_manager: FlowManager) -> DagNodeCategories:
+        """Consume the global flow queue into categorized node lists for seeding.
+
+        The queue is populated (and scoped) by get_start_node_queue before a top-level run. Draining
+        it here preserves the existing contract that the queue is emptied during DAG construction.
+        """
         from griptape_nodes.retained_mode.managers.flow_manager import DagExecutionType
 
-        # PASS 1: Process all control/start nodes first to build control flow graphs
-        queue_items = list(flow_manager.global_flow_queue.queue)
-        for item in queue_items:
-            if item.dag_execution_type in (DagExecutionType.CONTROL_NODE, DagExecutionType.START_NODE):
-                node = item.node
-                node.state = NodeResolutionState.UNRESOLVED
-                # Use proxy node if this node is part of a group, otherwise use original node
-                node_to_add = node
+        start_nodes: list[BaseNode] = []
+        control_nodes: list[BaseNode] = []
+        data_sink_nodes: list[BaseNode] = []
+        for item in list(flow_manager.global_flow_queue.queue):
+            if item.dag_execution_type == DagExecutionType.START_NODE:
+                start_nodes.append(item.node)
+            elif item.dag_execution_type == DagExecutionType.CONTROL_NODE:
+                control_nodes.append(item.node)
+            elif item.dag_execution_type == DagExecutionType.DATA_NODE:
+                data_sink_nodes.append(item.node)
+            flow_manager.global_flow_queue.queue.remove(item)
+        return DagNodeCategories(
+            start_nodes=start_nodes, control_nodes=control_nodes, data_sink_nodes=data_sink_nodes
+        )
 
-                # Only add if not already added (proxy might already be in DAG)
-                if node_to_add.name not in dag_builder.node_to_reference:
-                    dag_builder.add_node_with_dependencies(node_to_add, node_to_add.name)
-                    if node_to_add not in start_nodes:
-                        start_nodes.append(node_to_add)
-                flow_manager.global_flow_queue.queue.remove(item)
+    def _seed_dag_from_categories(
+        self,
+        start_node: BaseNode,
+        categories: DagNodeCategories,
+        dag_builder: DagBuilder,
+        flow_manager: FlowManager,
+        node_manager: NodeManager,
+    ) -> list[BaseNode]:
+        """Seed the DAG from categorized nodes and return the entry (control) nodes.
 
-        # PASS 2: Process all data nodes after control graphs are built
-        queue_items = list(flow_manager.global_flow_queue.queue)
-        for item in queue_items:
-            if item.dag_execution_type == DagExecutionType.DATA_NODE:
-                node = item.node
-                node.state = NodeResolutionState.UNRESOLVED
-                # Use proxy node if this node is part of a group, otherwise use original node
-                node_to_add = node
-                # Only add if not already added (proxy might already be in DAG)
-                disconnected = True
-                if node_to_add.name not in dag_builder.node_to_reference:
-                    # Now, we need to create the DAG, but it can't be queued or used until it's dependencies have been resolved.
-                    # Figure out which graph the data node belongs to, if it belongs to a graph.
-                    for graph_start_node_name in dag_builder.graphs:
-                        graph_start_node = node_manager.get_node_by_name(graph_start_node_name)
-                        # Get boundary nodes (empty list if not connected)
-                        boundary_nodes = flow_manager.is_node_connected(graph_start_node, node)
-                        # This means this node is in the downstream connection of one of this graph.
-                        if boundary_nodes:
-                            # Is the node connected to a graph?
-                            disconnected = False
-                            if node.name not in dag_builder.start_node_candidates:
-                                dag_builder.start_node_candidates[node.name] = {}
-                            dag_builder.start_node_candidates[node.name][graph_start_node_name] = set(boundary_nodes)
-                    if disconnected:
-                        # If the node is not connected to any graph, we can add it as it's own graph here.
-                        # It will not cause any overlapping confusion with existing graphs.
-                        dag_builder.add_node_with_dependencies(node_to_add, node_to_add.name)
-                flow_manager.global_flow_queue.queue.remove(item)
+        PASS 1 adds start/control entry nodes so control-flow graphs exist. PASS 2 adds data
+        sink (terminal/leaf) nodes: a sink reachable from a graph's forward control path is
+        registered as a control-gated candidate (so branches stay gated), while a sink that is
+        only data-connected gets its own graph so its dependencies resolve unconditionally.
+        """
+        start_nodes = [start_node]
+
+        # PASS 1: control/start entries build the control-flow graphs.
+        for node in (*categories.start_nodes, *categories.control_nodes):
+            node.state = NodeResolutionState.UNRESOLVED
+            if node.name not in dag_builder.node_to_reference:
+                dag_builder.add_node_with_dependencies(node, node.name)
+                if node not in start_nodes:
+                    start_nodes.append(node)
+
+        # PASS 2: data sinks, after the control graphs exist.
+        for node in categories.data_sink_nodes:
+            node.state = NodeResolutionState.UNRESOLVED
+            if node.name in dag_builder.node_to_reference:
+                continue
+            disconnected = True
+            for graph_start_node_name in list(dag_builder.graphs):
+                graph_start_node = node_manager.get_node_by_name(graph_start_node_name)
+                boundary_nodes = flow_manager.is_node_connected(graph_start_node, node)
+                if boundary_nodes:
+                    disconnected = False
+                    if node.name not in dag_builder.start_node_candidates:
+                        dag_builder.start_node_candidates[node.name] = {}
+                    dag_builder.start_node_candidates[node.name][graph_start_node_name] = set(boundary_nodes)
+            if disconnected:
+                # Not gated by any control graph - resolve it (and its dependencies) on its own.
+                dag_builder.add_node_with_dependencies(node, node.name)
 
         return start_nodes
 

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -260,9 +260,10 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         Top-level runs and isolated subflows share one classifier and one seeding routine; they
         differ only in scope. A top-level run draws its categorized nodes from the global queue
         (already scoped by get_start_node_queue to exclude referenced subflows and group
-        children). An isolated subflow classifies its own nodes directly, since the global queue
-        deliberately omits referenced subflows. Either way the same seeding logic runs, so a
-        data-only subflow resolves its leaf nodes instead of stopping at the start node.
+        children). An isolated subflow classifies its own nodes directly, applying the same
+        SubflowNodeGroup-child exclusion, since the global queue deliberately omits referenced
+        subflows. Either way the same seeding logic runs, so a data-only subflow resolves its
+        leaf nodes instead of stopping at the start node.
         """
         # Use the DagBuilder from the resolution machine context (may be isolated or global)
         dag_builder = self._context.resolution_machine.context.dag_builder
@@ -279,7 +280,10 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
 
         if is_isolated:
             subflow = flow_manager.get_flow_by_name(self._context.flow_name)
-            categories = flow_manager.classify_nodes_for_dag(list(subflow.nodes.values()))
+            # Same scope decision as get_start_node_queue: SubflowNodeGroup children run inside
+            # their own group's subflow, so they must not be seeded directly into this DAG.
+            scope_nodes = flow_manager.exclude_subflow_group_children(list(subflow.nodes.values()))
+            categories = flow_manager.classify_nodes_for_dag(scope_nodes)
             logger.debug("Seeding isolated subflow '%s' DAG from its own nodes", self._context.flow_name)
         else:
             categories = self._drain_global_flow_queue(flow_manager)
@@ -293,6 +297,8 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         The queue is populated (and scoped) by get_start_node_queue before a top-level run. Draining
         it here preserves the existing contract that the queue is emptied during DAG construction.
         """
+        # Local import: flow_manager imports control_flow (CompleteState, ControlFlowMachine) at
+        # module scope, so importing DagExecutionType at the top would be a circular import.
         from griptape_nodes.retained_mode.managers.flow_manager import DagExecutionType
 
         start_nodes: list[BaseNode] = []
@@ -306,12 +312,10 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
             elif item.dag_execution_type == DagExecutionType.DATA_NODE:
                 data_sink_nodes.append(item.node)
             flow_manager.global_flow_queue.queue.remove(item)
-        return DagNodeCategories(
-            start_nodes=start_nodes, control_nodes=control_nodes, data_sink_nodes=data_sink_nodes
-        )
+        return DagNodeCategories(start_nodes=start_nodes, control_nodes=control_nodes, data_sink_nodes=data_sink_nodes)
 
+    @staticmethod
     def _seed_dag_from_categories(
-        self,
         start_node: BaseNode,
         categories: DagNodeCategories,
         dag_builder: DagBuilder,

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -325,9 +325,11 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         """Seed the DAG from categorized nodes and return the entry (control) nodes.
 
         PASS 1 adds start/control entry nodes so control-flow graphs exist. PASS 2 adds data
-        sink (terminal/leaf) nodes: a sink reachable from a graph's forward control path is
-        registered as a control-gated candidate (so branches stay gated), while a sink that is
-        only data-connected gets its own graph so its dependencies resolve unconditionally.
+        sink (terminal/leaf) nodes. A sink that is only data-connected gets its own graph so its
+        dependencies resolve unconditionally; a sink reachable from a graph's forward control
+        path is instead registered as a control-gated candidate so branches stay gated. The
+        current classifier only routes control-disconnected nodes into data_sink_nodes, so the
+        gated branch is a defensive fallback and the data-connected case is what runs in practice.
         """
         start_nodes = [start_node]
 

--- a/src/griptape_nodes/machines/dag_builder.py
+++ b/src/griptape_nodes/machines/dag_builder.py
@@ -4,7 +4,7 @@ import copy
 import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from griptape_nodes.common.directed_graph import DirectedGraph
 from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeEndNode, BaseIterativeStartNode
@@ -19,6 +19,25 @@ if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
 
 logger = logging.getLogger("griptape_nodes")
+
+
+class DagNodeCategories(NamedTuple):
+    """Nodes bucketed by their role when seeding a DAG.
+
+    Produced by classifying a scope of nodes (a whole flow or a single subflow) and consumed
+    by the DAG-seeding routine. Keeping this scope-agnostic lets top-level flows and isolated
+    subflows share one classification + seeding implementation.
+
+    Attributes:
+        start_nodes: StartNode instances (workflow entry points).
+        control_nodes: Control-flow entry nodes that have no external incoming control connection.
+        data_sink_nodes: Data nodes with no external outgoing connection (terminal/leaf nodes);
+            seeding these resolves their dependencies backward.
+    """
+
+    start_nodes: list[BaseNode]
+    control_nodes: list[BaseNode]
+    data_sink_nodes: list[BaseNode]
 
 
 class NodeState(StrEnum):

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -36,7 +36,7 @@ from griptape_nodes.exe_types.node_types import (
     VariableReference,
 )
 from griptape_nodes.machines.control_flow import CompleteState, ControlFlowMachine
-from griptape_nodes.machines.dag_builder import DagBuilder
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNodeCategories
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import LibraryNameAndNodeType
 from griptape_nodes.retained_mode.events.base_events import (
@@ -4505,39 +4505,62 @@ class FlowManager:
                         return connection.get_source_node()
         return None
 
-    def get_start_node_queue(self) -> Queue | None:  # noqa: C901, PLR0912, PLR0915
-        # For cross-flow execution, we need to consider ALL nodes across ALL flows
-        # Clear and use the global execution queue
+    def get_start_node_queue(self) -> Queue | None:
+        # For cross-flow execution, we consider ALL nodes across ALL (non-referenced) flows.
+        # Referenced subflows are executed explicitly via StartLocalSubflowRequest and must not
+        # participate in the top-level queue; SubflowNodeGroup children run inside their group's
+        # subflow. Both are ownership/scope decisions and live here, NOT in the classifier, so
+        # the classifier stays scope-agnostic and is shared with isolated subflow execution.
         self._global_flow_queue.queue.clear()
 
-        # Get all flows and collect all nodes across all flows.
-        # Exclude nodes from referenced subflows - they are executed explicitly via
-        # StartLocalSubflowRequest and should not participate in the top-level queue.
         all_flows = GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow)
-        all_nodes = []
+        scope_nodes: list[BaseNode] = []
         for current_flow in all_flows.values():
-            if not self.is_referenced_workflow(current_flow):
-                all_nodes.extend(current_flow.nodes.values())
+            if self.is_referenced_workflow(current_flow):
+                continue
+            for node in current_flow.nodes.values():
+                if node.parent_group is not None and isinstance(node.parent_group, SubflowNodeGroup):
+                    continue
+                scope_nodes.append(node)
 
         # if no nodes across all flows, no execution possible
-        if not all_nodes:
+        if not scope_nodes:
             return None
 
-        data_nodes = []
-        valid_data_nodes = []
-        start_nodes = []
-        control_nodes = []
-        cn_mgr = self.get_connections()
-        for node in all_nodes:
-            # Skip nodes that are children of a SubflowNodeGroup - they should not be start nodes
-            if node.parent_group is not None and isinstance(node.parent_group, SubflowNodeGroup):
-                continue
+        categories = self.classify_nodes_for_dag(scope_nodes)
 
-            # if it's a start node, start here! Return the first one!
+        # populate the global flow queue with node type information
+        for node in categories.start_nodes:
+            self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.START_NODE))
+        for node in categories.control_nodes:
+            self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.CONTROL_NODE))
+        for node in categories.data_sink_nodes:
+            self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.DATA_NODE))
+
+        return self._global_flow_queue
+
+    def classify_nodes_for_dag(self, nodes: list[BaseNode]) -> DagNodeCategories:  # noqa: C901, PLR0912, PLR0915
+        """Bucket a scope of nodes into start / control-entry / data-sink roles for DAG seeding.
+
+        This is scope-agnostic: callers decide which nodes are in scope (a whole flow's worth of
+        nodes for a top-level run, or a single subflow's nodes for an isolated subflow run). The
+        same categorization then drives DAG seeding for both, so the two paths cannot drift.
+
+        - StartNode instances are start nodes.
+        - A node with active control parameters is a control-entry node unless it has an external
+          incoming control connection (in which case the forward control walk reaches it).
+        - A node with no active control parameters is a data node; data nodes with no external
+          outgoing connection are terminal/leaf sinks and get seeded so their dependencies resolve.
+        """
+        data_nodes: list[BaseNode] = []
+        start_nodes: list[BaseNode] = []
+        control_nodes: list[BaseNode] = []
+        cn_mgr = self.get_connections()
+        for node in nodes:
+            # if it's a start node, start here!
             if isinstance(node, StartNode):
                 start_nodes.append(node)
                 continue
-            # no start nodes. let's find the first control node.
             # if it's a control node, there could be a flow.
             control_param = False
             for parameter in node.parameters:
@@ -4555,7 +4578,6 @@ class FlowManager:
             if not control_param:
                 # saving this for later
                 data_nodes.append(node)
-                # If this node doesn't have a control connection..
                 continue
             # check if it has an incoming connection. If it does, it's not a start node
             has_control_connection = False
@@ -4598,11 +4620,9 @@ class FlowManager:
             else:
                 control_nodes.append(node)
 
-        # If we've gotten to this point, there are no control parameters
-        # Let's return a data node that has no OUTGOING data connections!
+        # A data node with no OUTGOING (non-internal) data connection is a terminal/leaf sink.
+        valid_data_nodes: list[BaseNode] = []
         for node in data_nodes:
-            cn_mgr = self.get_connections()
-            # Check if the node has any non-internal outgoing connections
             has_external_outgoing = False
             if node.name in cn_mgr.outgoing_index:
                 for param_name in cn_mgr.outgoing_index[node.name]:
@@ -4619,15 +4639,10 @@ class FlowManager:
             # Only add nodes that have no non-internal outgoing connections
             if not has_external_outgoing:
                 valid_data_nodes.append(node)
-        # ok now - populate the global flow queue with node type information
-        for node in start_nodes:
-            self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.START_NODE))
-        for node in control_nodes:
-            self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.CONTROL_NODE))
-        for node in valid_data_nodes:
-            self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.DATA_NODE))
 
-        return self._global_flow_queue
+        return DagNodeCategories(
+            start_nodes=start_nodes, control_nodes=control_nodes, data_sink_nodes=valid_data_nodes
+        )
 
     def get_connected_input_from_node(self, flow: ControlFlow, node: BaseNode) -> list[tuple[BaseNode, Parameter]]:  # noqa: ARG002
         global_connections = self.get_connections()

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4518,10 +4518,8 @@ class FlowManager:
         for current_flow in all_flows.values():
             if self.is_referenced_workflow(current_flow):
                 continue
-            for node in current_flow.nodes.values():
-                if node.parent_group is not None and isinstance(node.parent_group, SubflowNodeGroup):
-                    continue
-                scope_nodes.append(node)
+            scope_nodes.extend(current_flow.nodes.values())
+        scope_nodes = self.exclude_subflow_group_children(scope_nodes)
 
         # if no nodes across all flows, no execution possible
         if not scope_nodes:
@@ -4538,6 +4536,16 @@ class FlowManager:
             self._global_flow_queue.put(QueueItem(node=node, dag_execution_type=DagExecutionType.DATA_NODE))
 
         return self._global_flow_queue
+
+    @staticmethod
+    def exclude_subflow_group_children(nodes: list[BaseNode]) -> list[BaseNode]:
+        """Drop nodes owned by a SubflowNodeGroup; they run inside their group's own subflow.
+
+        This is a scope/ownership decision kept out of classify_nodes_for_dag so the classifier
+        stays scope-agnostic and is shared by both the top-level run and isolated subflow
+        execution. Both callers must apply it so the two paths cannot drift.
+        """
+        return [node for node in nodes if not isinstance(node.parent_group, SubflowNodeGroup)]
 
     def classify_nodes_for_dag(self, nodes: list[BaseNode]) -> DagNodeCategories:  # noqa: C901, PLR0912, PLR0915
         """Bucket a scope of nodes into start / control-entry / data-sink roles for DAG seeding.
@@ -4640,9 +4648,7 @@ class FlowManager:
             if not has_external_outgoing:
                 valid_data_nodes.append(node)
 
-        return DagNodeCategories(
-            start_nodes=start_nodes, control_nodes=control_nodes, data_sink_nodes=valid_data_nodes
-        )
+        return DagNodeCategories(start_nodes=start_nodes, control_nodes=control_nodes, data_sink_nodes=valid_data_nodes)
 
     def get_connected_input_from_node(self, flow: ControlFlow, node: BaseNode) -> list[tuple[BaseNode, Parameter]]:  # noqa: ARG002
         global_connections = self.get_connections()

--- a/tests/e2e/fixtures/subflow_dataflow_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/subflow_dataflow_library/griptape_nodes_library.json
@@ -1,0 +1,46 @@
+{
+  "name": "Subflow Dataflow Library",
+  "library_schema_version": "0.7.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library for the data-only subflow regression test (issue #4993)",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "DataStartNode",
+      "file_path": "subflow_dataflow_nodes.py",
+      "metadata": {"category": "test", "description": "data start", "display_name": "Data Start"}
+    },
+    {
+      "class_name": "DataPassNode",
+      "file_path": "subflow_dataflow_nodes.py",
+      "metadata": {"category": "test", "description": "data pass", "display_name": "Data Pass"}
+    },
+    {
+      "class_name": "DataEndNode",
+      "file_path": "subflow_dataflow_nodes.py",
+      "metadata": {"category": "test", "description": "data end", "display_name": "Data End"}
+    },
+    {
+      "class_name": "RunSubflowNode",
+      "file_path": "subflow_dataflow_nodes.py",
+      "metadata": {"category": "test", "description": "subflow driver", "display_name": "Run Subflow"}
+    }
+  ]
+}

--- a/tests/e2e/fixtures/subflow_dataflow_library/subflow_dataflow_nodes.py
+++ b/tests/e2e/fixtures/subflow_dataflow_library/subflow_dataflow_nodes.py
@@ -1,0 +1,113 @@
+"""Fixture nodes for the data-only subflow regression test (issue #4993).
+
+The subflow is wired with DATA connections only (no control edges):
+
+    DataStartNode.value --> DataPassNode.value --> DataEndNode.value
+
+An isolated subflow used to resolve only the start node and silently skip the
+downstream/leaf nodes when there were no control edges to walk, so DataEndNode
+never ran and produced no outputs. RunSubflowNode drives the subflow exactly the
+way SubflowWorkflowNode does (StartLocalSubflowRequest) and reads the end node's
+outputs back.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import ControlNode, DataNode, EndNode, StartNode
+from griptape_nodes.retained_mode.events.execution_events import (
+    StartLocalSubflowRequest,
+    StartLocalSubflowResultFailure,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class DataStartNode(StartNode):
+    """A StartNode carrying a passthrough ``value`` (mirrors a workflow's Start Flow input)."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["value"] = self.get_parameter_value("value") or ""
+
+
+class DataPassNode(DataNode):
+    """An intermediate data node that copies ``value`` straight through."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["value"] = self.get_parameter_value("value") or ""
+
+
+class DataEndNode(EndNode):
+    """An EndNode carrying a ``value`` output (mirrors a workflow's End Flow output)."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+
+class RunSubflowNode(ControlNode):
+    """Drives a named subflow like SubflowWorkflowNode and collects the end node's output."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="collected_value",
+                type="str",
+                default_value=None,
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    async def aprocess(self) -> None:
+        subflow = self.metadata["subflow_name"]
+        end_node_name = self.metadata["end_node_name"]
+        result = await GriptapeNodes.FlowManager().on_start_local_subflow_request(
+            StartLocalSubflowRequest(flow_name=subflow)
+        )
+        if isinstance(result, StartLocalSubflowResultFailure):
+            self.parameter_output_values["collected_value"] = f"START_FAIL: {result.result_details}"
+            return
+        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow)
+        end_node = flow.nodes[end_node_name]
+        if "value" in end_node.parameter_output_values:
+            self.parameter_output_values["collected_value"] = end_node.parameter_output_values["value"]
+        else:
+            self.parameter_output_values["collected_value"] = end_node.get_parameter_value("value")
+
+    def process(self) -> None:
+        pass

--- a/tests/e2e/test_subflow_dataflow_execution.py
+++ b/tests/e2e/test_subflow_dataflow_execution.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -37,6 +38,9 @@ from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, C
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_dataflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -82,14 +86,32 @@ def _connect(source_node: str, source_param: str, target_node: str, target_param
     assert isinstance(result, CreateConnectionResultSuccess), result
 
 
+@pytest.fixture
+def _clean_engine_state() -> Iterator[None]:
+    """Keep the shared engine singleton clean despite running in-process.
+
+    This test mutates global GriptapeNodes state (the object registry and the workflow context
+    stack) directly instead of in a subprocess, so it clears object state before running and
+    tears down the workflow context plus object state afterwards. Without this teardown the
+    pushed workflow context and registered objects would leak into sibling tests sharing the
+    same pytest-xdist worker.
+    """
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    yield
+    context_manager = GriptapeNodes.ContextManager()
+    while context_manager.has_current_workflow():
+        context_manager.pop_workflow()
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
 @pytest.mark.skipif(
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Subflow Dataflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_clean_engine_state")
 async def test_isolated_subflow_runs_data_only_graph(tmp_path: Path) -> None:
     """A data-only referenced subflow must resolve its downstream/leaf nodes and return outputs."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
     library_json = _materialize_library(tmp_path / "library")
     register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result

--- a/tests/e2e/test_subflow_dataflow_execution.py
+++ b/tests/e2e/test_subflow_dataflow_execution.py
@@ -1,0 +1,148 @@
+"""Regression test for issue #4993: data-only referenced subflows must run end to end.
+
+A referenced workflow wired purely with data connections (Start -> ... -> End with no
+control edges) runs fine on its own, because the top-level scheduler resolves terminal
+data nodes and walks their dependencies backward. When the same workflow is executed as
+an isolated subflow (the path SubflowWorkflowNode uses via StartLocalSubflowRequest), the
+engine used to seed only the start node and walk forward *control* edges. With no control
+edges to follow it resolved just the start node and silently skipped the downstream/leaf
+nodes, so the End node never ran and no outputs came back, while the run still reported
+success.
+
+This test builds that exact data-only shape inside an isolated subflow and asserts the
+end node resolves and its output propagates. It runs in-process (no subprocess) and drives
+the real engine execution path, so a regression in the isolated-subflow DAG seeding fails
+here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_dataflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_dataflow_nodes.py"
+LIBRARY_NAME = "Subflow Dataflow Library"
+_EXPECTED = "value-through-data-only-subflow"
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+def _create_node(node_type: str, node_name: str, flow_name: str) -> str:
+    result = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY_NAME,
+            node_name=node_name,
+            override_parent_flow_name=flow_name,
+        )
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
+    result = GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name=source_param,
+            target_node_name=target_node,
+            target_parameter_name=target_param,
+        )
+    )
+    assert isinstance(result, CreateConnectionResultSuccess), result
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Subflow Dataflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+@pytest.mark.asyncio
+async def test_isolated_subflow_runs_data_only_graph(tmp_path: Path) -> None:
+    """A data-only referenced subflow must resolve its downstream/leaf nodes and return outputs."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    library_json = _materialize_library(tmp_path / "library")
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="subflow_dataflow_wf")
+
+    # Parent flow holds the driver; the subflow is a child flow, like an imported referenced workflow.
+    parent_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
+    parent_flow = parent_result.flow_name
+
+    subflow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=parent_flow, flow_name="SubFlow", set_as_new_context=False)
+    )
+    assert isinstance(subflow_result, CreateFlowResultSuccess), subflow_result
+    subflow = subflow_result.flow_name
+
+    # Subflow: Start -> Pass -> End wired with DATA connections ONLY (no exec_out -> exec_in).
+    _create_node("DataStartNode", "Start", subflow)
+    _create_node("DataPassNode", "Pass", subflow)
+    _create_node("DataEndNode", "End", subflow)
+    _connect("Start", "value", "Pass", "value")
+    _connect("Pass", "value", "End", "value")
+
+    GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="value", node_name="Start", value=_EXPECTED))
+
+    # Driver runs the subflow the way SubflowWorkflowNode does.
+    _create_node("RunSubflowNode", "Driver", parent_flow)
+    driver = GriptapeNodes.NodeManager().get_node_by_name("Driver")
+    driver.metadata["subflow_name"] = subflow
+    driver.metadata["end_node_name"] = "End"
+
+    run_result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=parent_flow,
+            flow_node_name="Driver",
+            wait_for_completion=True,
+            completion_timeout_ms=30000,
+        )
+    )
+    assert isinstance(run_result, StartFlowResultSuccess), run_result
+
+    node_manager = GriptapeNodes.NodeManager()
+    end_node = node_manager.get_node_by_name("End")
+    pass_node = node_manager.get_node_by_name("Pass")
+    driver = node_manager.get_node_by_name("Driver")
+
+    # The downstream/leaf nodes must actually run, not get skipped.
+    assert pass_node.state == NodeResolutionState.RESOLVED, "Pass node did not resolve in the isolated subflow"
+    assert end_node.state == NodeResolutionState.RESOLVED, "End node did not resolve in the isolated subflow"
+
+    # The End node's output must be produced and collectable by the parent.
+    assert end_node.parameter_output_values.get("value") == _EXPECTED
+    assert driver.parameter_output_values.get("collected_value") == _EXPECTED

--- a/tests/e2e/test_subflow_dataflow_execution.py
+++ b/tests/e2e/test_subflow_dataflow_execution.py
@@ -17,6 +17,7 @@ here.
 
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,6 +25,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionRequest,
     CreateConnectionResultSuccess,
@@ -35,7 +37,10 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
-from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+)
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -92,16 +97,22 @@ def _clean_engine_state() -> Iterator[None]:
 
     This test mutates global GriptapeNodes state (the object registry and the workflow context
     stack) directly instead of in a subprocess, so it clears object state before running and
-    tears down the workflow context plus object state afterwards. Without this teardown the
-    pushed workflow context and registered objects would leak into sibling tests sharing the
-    same pytest-xdist worker.
+    tears down object state plus the registered fixture library afterwards. Without this
+    teardown the registered objects/library would leak into sibling tests sharing the same
+    pytest-xdist worker.
     """
     GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
     yield
-    context_manager = GriptapeNodes.ContextManager()
-    while context_manager.has_current_workflow():
-        context_manager.pop_workflow()
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    # ClearAllObjectStateRequest drains the workflow context stack and deletes its flows/nodes in
+    # one step; popping the workflow first would leave has_current_workflow() False and skip that
+    # deletion, so the clear must run against the still-active context.
+    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
+    # ClearAllObjectStateRequest does not touch the LibraryRegistry, so drop the fixture library
+    # explicitly to avoid a dangling entry pointing at a deleted tmp_path directory. The library
+    # is absent if the test failed before registering it.
+    with contextlib.suppress(KeyError):
+        LibraryRegistry.unregister_library(LIBRARY_NAME)
 
 
 @pytest.mark.skipif(

--- a/tests/unit/machines/test_control_flow.py
+++ b/tests/unit/machines/test_control_flow.py
@@ -1,0 +1,162 @@
+"""Tests for ControlFlowMachine DAG-seeding helpers.
+
+These cover the two scope-agnostic helpers that back both the top-level run and the isolated
+subflow run:
+
+- ``_drain_global_flow_queue`` turns the already-scoped global flow queue into categorized node
+  lists (and must empty the queue, preserving the contract that the queue is consumed during DAG
+  construction).
+- ``_seed_dag_from_categories`` seeds a DagBuilder from those categories: PASS 1 adds start/control
+  entry nodes, PASS 2 adds data sinks, either as their own graph (data-only) or as control-gated
+  candidates (reachable from a control graph's forward path).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+from griptape_nodes.machines.control_flow import ControlFlowMachine
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNodeCategories
+from griptape_nodes.retained_mode.managers.flow_manager import DagExecutionType, QueueItem
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+def _mock_node(name: str) -> MagicMock:
+    """A BaseNode stand-in with the surface the seeding helpers touch."""
+    node = MagicMock(spec=BaseNode)
+    node.name = name
+    node.parameters = []
+    node.state = NodeResolutionState.RESOLVED
+    return node
+
+
+class TestDrainGlobalFlowQueue:
+    """Tests for ControlFlowMachine._drain_global_flow_queue."""
+
+    def test_buckets_items_by_type_and_empties_queue(self, griptape_nodes: GriptapeNodes) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+        flow_manager.global_flow_queue.queue.clear()
+
+        start = _mock_node("start")
+        control = _mock_node("control")
+        data = _mock_node("data")
+        flow_manager.global_flow_queue.put(QueueItem(node=start, dag_execution_type=DagExecutionType.START_NODE))
+        flow_manager.global_flow_queue.put(QueueItem(node=control, dag_execution_type=DagExecutionType.CONTROL_NODE))
+        flow_manager.global_flow_queue.put(QueueItem(node=data, dag_execution_type=DagExecutionType.DATA_NODE))
+
+        categories = ControlFlowMachine._drain_global_flow_queue(flow_manager)
+
+        assert [node.name for node in categories.start_nodes] == ["start"]
+        assert [node.name for node in categories.control_nodes] == ["control"]
+        assert [node.name for node in categories.data_sink_nodes] == ["data"]
+        # The queue must be fully drained.
+        assert flow_manager.global_flow_queue.empty()
+
+    def test_empty_queue_yields_empty_categories(self, griptape_nodes: GriptapeNodes) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+        flow_manager.global_flow_queue.queue.clear()
+
+        categories = ControlFlowMachine._drain_global_flow_queue(flow_manager)
+
+        assert categories.start_nodes == []
+        assert categories.control_nodes == []
+        assert categories.data_sink_nodes == []
+
+
+class TestSeedDagFromCategories:
+    """Tests for ControlFlowMachine._seed_dag_from_categories."""
+
+    def test_pass1_adds_start_and_control_entries(self) -> None:
+        start = _mock_node("Start")
+        control = _mock_node("Ctrl")
+        categories = DagNodeCategories(start_nodes=[start], control_nodes=[control], data_sink_nodes=[])
+        flow_manager = MagicMock()
+        node_manager = MagicMock()
+
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.FlowManager") as mock_flow_manager:
+            connections = MagicMock()
+            connections.get_connected_node.return_value = None
+            mock_flow_manager.return_value.get_connections.return_value = connections
+
+            dag_builder = DagBuilder()
+            entry_nodes = ControlFlowMachine._seed_dag_from_categories(
+                start, categories, dag_builder, flow_manager, node_manager
+            )
+
+        # The start node plus every entry node come back so the control flow can begin.
+        assert [node.name for node in entry_nodes] == ["Start", "Ctrl"]
+        assert "Start" in dag_builder.node_to_reference
+        assert "Ctrl" in dag_builder.node_to_reference
+        # Entry nodes are reset so they re-resolve on this run.
+        assert start.state == NodeResolutionState.UNRESOLVED
+        assert control.state == NodeResolutionState.UNRESOLVED
+
+    def test_pass2_disconnected_sink_gets_its_own_graph(self) -> None:
+        start = _mock_node("Start")
+        sink = _mock_node("Sink")
+        categories = DagNodeCategories(start_nodes=[start], control_nodes=[], data_sink_nodes=[sink])
+        # is_node_connected returns [] -> the sink is not gated by any control graph.
+        flow_manager = MagicMock()
+        flow_manager.is_node_connected.return_value = []
+        node_manager = MagicMock()
+
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.FlowManager") as mock_flow_manager:
+            connections = MagicMock()
+            connections.get_connected_node.return_value = None
+            mock_flow_manager.return_value.get_connections.return_value = connections
+
+            dag_builder = DagBuilder()
+            ControlFlowMachine._seed_dag_from_categories(start, categories, dag_builder, flow_manager, node_manager)
+
+        # A data-only sink is seeded directly so its dependencies resolve unconditionally.
+        assert "Sink" in dag_builder.node_to_reference
+        assert dag_builder.start_node_candidates == {}
+
+    def test_pass2_gated_sink_becomes_control_candidate(self) -> None:
+        start = _mock_node("Start")
+        sink = _mock_node("Sink")
+        categories = DagNodeCategories(start_nodes=[start], control_nodes=[], data_sink_nodes=[sink])
+        # is_node_connected returns boundary nodes -> the sink is gated by Start's control graph.
+        flow_manager = MagicMock()
+        flow_manager.is_node_connected.return_value = ["Start"]
+        node_manager = MagicMock()
+        node_manager.get_node_by_name.side_effect = lambda name: start if name == "Start" else None
+
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.FlowManager") as mock_flow_manager:
+            connections = MagicMock()
+            connections.get_connected_node.return_value = None
+            mock_flow_manager.return_value.get_connections.return_value = connections
+
+            dag_builder = DagBuilder()
+            ControlFlowMachine._seed_dag_from_categories(start, categories, dag_builder, flow_manager, node_manager)
+
+        # A gated sink is not seeded directly; it is registered as a candidate keyed by the graph
+        # start so the branch stays control-gated.
+        assert "Sink" not in dag_builder.node_to_reference
+        assert dag_builder.start_node_candidates["Sink"]["Start"] == {"Start"}
+
+    def test_sink_already_in_dag_is_skipped(self) -> None:
+        start = _mock_node("Start")
+        sink = _mock_node("Sink")
+        categories = DagNodeCategories(start_nodes=[start], control_nodes=[], data_sink_nodes=[sink])
+        flow_manager = MagicMock()
+        node_manager = MagicMock()
+
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.FlowManager") as mock_flow_manager:
+            connections = MagicMock()
+            connections.get_connected_node.return_value = None
+            mock_flow_manager.return_value.get_connections.return_value = connections
+
+            dag_builder = DagBuilder()
+            # Pre-seed the sink so PASS 2 sees it already present.
+            dag_builder.add_node(sink)
+
+            ControlFlowMachine._seed_dag_from_categories(start, categories, dag_builder, flow_manager, node_manager)
+
+        # Already-present sinks short-circuit before any connectivity check.
+        flow_manager.is_node_connected.assert_not_called()
+        assert dag_builder.start_node_candidates == {}

--- a/tests/unit/machines/test_dag_builder.py
+++ b/tests/unit/machines/test_dag_builder.py
@@ -6,7 +6,29 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from griptape_nodes.exe_types.node_types import BaseNode
-from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, NodeState
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, DagNodeCategories, NodeState
+
+
+class TestDagNodeCategories:
+    """Test cases for the DagNodeCategories seeding contract.
+
+    The classifier (FlowManager.classify_nodes_for_dag) and the queue drainer
+    (ControlFlowMachine._drain_global_flow_queue) both produce this tuple, and the DAG-seeding
+    routine consumes it positionally, so the field order/names are part of the shared contract.
+    """
+
+    def test_fields_are_accessible_by_name_and_position(self) -> None:
+        start = MagicMock(spec=BaseNode)
+        control = MagicMock(spec=BaseNode)
+        sink = MagicMock(spec=BaseNode)
+
+        categories = DagNodeCategories(start_nodes=[start], control_nodes=[control], data_sink_nodes=[sink])
+
+        assert categories.start_nodes == [start]
+        assert categories.control_nodes == [control]
+        assert categories.data_sink_nodes == [sink]
+        # Positional order backs the tuple-unpacking consumers.
+        assert tuple(categories) == ([start], [control], [sink])
 
 
 class TestDagBuilder:

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -11,6 +11,10 @@ import pytest
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 
+from griptape_nodes.exe_types.connections import Connections
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import BaseNode, ControlNode, DataNode, StartNode
+from griptape_nodes.machines.dag_builder import DagNodeCategories
 from griptape_nodes.retained_mode.events.flow_events import (
     ExtractFlowCommandsFromImageMetadataRequest,
     ExtractFlowCommandsFromImageMetadataResultFailure,
@@ -18,6 +22,54 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+def _data_parameter(name: str = "value") -> Parameter:
+    """A plain data Parameter usable as input, property, and output."""
+    return Parameter(
+        name=name,
+        type="str",
+        default_value="",
+        tooltip="",
+        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+    )
+
+
+def _param(node: BaseNode, name: str) -> Parameter:
+    """Fetch a parameter by name, asserting it exists (keeps the type checker happy)."""
+    parameter = node.get_parameter_by_name(name)
+    assert parameter is not None, f"{node.name} is missing parameter {name!r}"
+    return parameter
+
+
+class _ClassifyStartNode(StartNode):
+    """StartNode carrying a passthrough ``value`` for classifier tests."""
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(_data_parameter())
+
+    def process(self) -> None: ...
+
+
+class _ClassifyDataNode(DataNode):
+    """DataNode carrying a passthrough ``value`` (its control params stay unconnected)."""
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(_data_parameter())
+
+    def process(self) -> None: ...
+
+
+class _ClassifyControlNode(ControlNode):
+    """ControlNode with exec_in/exec_out plus a passthrough ``value``."""
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(_data_parameter())
+
+    def process(self) -> None: ...
 
 
 @pytest.fixture
@@ -609,3 +661,140 @@ class TestAutoLayoutFlowRequest:
         assert result.positioned_nodes == []
 
         self._cleanup(griptape_nodes)
+
+
+class TestExcludeSubflowGroupChildren:
+    """Tests for FlowManager.exclude_subflow_group_children.
+
+    This scope/ownership filter drops nodes owned by a SubflowNodeGroup so they are not seeded
+    directly into a DAG (they run inside their group's own subflow). Both the top-level queue
+    and the isolated-subflow path apply it, so it must behave identically for either caller.
+    """
+
+    def test_drops_only_subflow_group_children(self, griptape_nodes: GriptapeNodes) -> None:
+        from unittest.mock import MagicMock
+
+        from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
+        from griptape_nodes.exe_types.node_types import BaseNode
+
+        flow_manager = griptape_nodes.FlowManager()
+
+        child = MagicMock(spec=BaseNode)
+        child.name = "child"
+        child.parent_group = MagicMock(spec=SubflowNodeGroup)
+
+        free = MagicMock(spec=BaseNode)
+        free.name = "free"
+        free.parent_group = None
+
+        # A parent_group that is not a SubflowNodeGroup must not be excluded.
+        other_group_child = MagicMock(spec=BaseNode)
+        other_group_child.name = "other_group_child"
+        other_group_child.parent_group = MagicMock(spec=BaseNode)
+
+        kept = flow_manager.exclude_subflow_group_children([child, free, other_group_child])
+
+        assert [node.name for node in kept] == ["free", "other_group_child"]
+
+    def test_empty_input_returns_empty(self, griptape_nodes: GriptapeNodes) -> None:
+        flow_manager = griptape_nodes.FlowManager()
+
+        assert flow_manager.exclude_subflow_group_children([]) == []
+
+
+class TestClassifyNodesForDag:
+    """Tests for FlowManager.classify_nodes_for_dag.
+
+    The classifier is scope-agnostic: it buckets an arbitrary list of nodes into start /
+    control-entry / data-sink roles based purely on the connection graph. It backs both the
+    top-level queue and isolated subflow seeding, so these tests lock in each branch. Real node
+    subclasses and a real Connections object are used so the Parameter/Connection semantics match
+    production; only get_connections is patched to hand the classifier the crafted graph.
+    """
+
+    @staticmethod
+    def _classify(griptape_nodes: GriptapeNodes, nodes: list, connections: Connections) -> DagNodeCategories:
+        from unittest.mock import patch
+
+        flow_manager = griptape_nodes.FlowManager()
+        with patch.object(flow_manager, "get_connections", return_value=connections):
+            return flow_manager.classify_nodes_for_dag(nodes)
+
+    def test_start_node_is_a_start_node(self, griptape_nodes: GriptapeNodes) -> None:
+        start = _ClassifyStartNode("Start")
+        data = _ClassifyDataNode("Data")
+        connections = Connections()
+        connections.add_connection(start, _param(start, "value"), data, _param(data, "value"))
+
+        categories = self._classify(griptape_nodes, [start, data], connections)
+
+        assert [node.name for node in categories.start_nodes] == ["Start"]
+        # Data has an incoming data connection and no outgoing one, so it is a terminal sink.
+        assert [node.name for node in categories.data_sink_nodes] == ["Data"]
+        assert categories.control_nodes == []
+
+    def test_data_node_with_external_outgoing_is_not_a_sink(self, griptape_nodes: GriptapeNodes) -> None:
+        upstream = _ClassifyDataNode("Upstream")
+        downstream = _ClassifyDataNode("Downstream")
+        connections = Connections()
+        connections.add_connection(upstream, _param(upstream, "value"), downstream, _param(downstream, "value"))
+
+        categories = self._classify(griptape_nodes, [upstream, downstream], connections)
+
+        # Only the leaf (Downstream) is a sink; Upstream feeds a downstream node so it is skipped.
+        assert [node.name for node in categories.data_sink_nodes] == ["Downstream"]
+        assert categories.start_nodes == []
+        assert categories.control_nodes == []
+
+    def test_control_chain_first_node_is_control_entry(self, griptape_nodes: GriptapeNodes) -> None:
+        first = _ClassifyControlNode("First")
+        second = _ClassifyControlNode("Second")
+        connections = Connections()
+        connections.add_connection(first, _param(first, "exec_out"), second, _param(second, "exec_in"))
+
+        categories = self._classify(griptape_nodes, [first, second], connections)
+
+        # First drives the control flow; Second has an external incoming control edge so the
+        # forward control walk reaches it and it is not seeded as an entry node.
+        assert [node.name for node in categories.control_nodes] == ["First"]
+        assert categories.start_nodes == []
+        assert categories.data_sink_nodes == []
+
+    def test_control_node_without_control_connections_is_treated_as_data_sink(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        lone = _ClassifyControlNode("Lone")
+        connections = Connections()
+
+        categories = self._classify(griptape_nodes, [lone], connections)
+
+        # Control params exist but are unused, so the node is a plain data node with no outgoing
+        # connection, i.e. a terminal sink.
+        assert [node.name for node in categories.data_sink_nodes] == ["Lone"]
+        assert categories.control_nodes == []
+        assert categories.start_nodes == []
+
+    def test_internal_node_group_outgoing_does_not_disqualify_sink(self, griptape_nodes: GriptapeNodes) -> None:
+        source = _ClassifyDataNode("Source")
+        target = _ClassifyDataNode("Target")
+        connections = Connections()
+        connections.add_connection(
+            source,
+            _param(source, "value"),
+            target,
+            _param(target, "value"),
+            is_node_group_internal=True,
+        )
+
+        categories = self._classify(griptape_nodes, [source, target], connections)
+
+        # Internal NodeGroup connections do not count as external outgoing, so both nodes remain
+        # terminal sinks.
+        assert sorted(node.name for node in categories.data_sink_nodes) == ["Source", "Target"]
+
+    def test_empty_scope_returns_empty_categories(self, griptape_nodes: GriptapeNodes) -> None:
+        categories = self._classify(griptape_nodes, [], Connections())
+
+        assert categories.start_nodes == []
+        assert categories.control_nodes == []
+        assert categories.data_sink_nodes == []


### PR DESCRIPTION
A referenced workflow wired purely with data connections (`Start Flow -> ... -> End Flow` with no control edges between nodes) runs correctly on its own but returns nothing when invoked through the Subflow Workflow Node, while still reporting success. Closes #5009.

The cause is that the engine had two separate implementations of turning a flow into a seeded execution DAG. A top-level run classifies every node, seeds the terminal data nodes, and resolves their dependencies backward, so leaf nodes like `End Flow` always run. The isolated subflow path instead seeded only the start node and relied on walking forward control edges; with no control edges to follow it resolved just the start node and silently skipped the downstream nodes, so `End Flow` never executed and `_collect_workflow_outputs` had nothing to read.

Rather than patch the subflow path, this unifies the two. `classify_nodes_for_dag` is now a scope-agnostic classifier and `_seed_dag_from_categories` is the single seeding routine, and both the top-level run and isolated subflow execution feed through them. The ownership decisions that genuinely differ (skip referenced-subflow nodes, skip `SubflowNodeGroup` children via `exclude_subflow_group_children`) live in the callers that gather scope and are applied to both paths so they cannot drift. `is_isolated` now only selects where the node scope comes from, not how the DAG is built.

The follow-on commits apply that same group-child scope filter to the isolated path so nested node groups stay correct, make the seeding helpers static, and fix the in-process regression test teardown: `ClearAllObjectStateRequest` only deletes a workflow's flows/nodes while its context is active, so it has to run before the context is popped or it leaks objects into sibling xdist workers.

Covered by a new in-process e2e test that builds a data-only subflow and asserts the leaf nodes resolve and the outputs propagate to the parent; it fails without the fix.

This does not resolve #4993. That report is a separate, control-flow-connected case where the nodes execute (per the logs) but data is not propagated, and it was not consistently reproducible; its root cause is still unknown. #4993 should stay open.
