### PR TITLE
fix(workflow): route subflow node I/O through import rename map

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Literal
@@ -20,6 +20,11 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 if TYPE_CHECKING:
     # Circular import: flow_events <-> workflow_events
     from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+
+# Key under which a referenced sub-flow's requested -> assigned node-name map is stored on
+# the created flow's metadata. Lets consumers that did not trigger the import (e.g. a node
+# restored during deserialization) translate workflow-shape node names to the live names.
+REFERENCED_SUBFLOW_NODE_NAME_MAP_METADATA_KEY = "referenced_subflow_node_name_map"
 
 
 @dataclass
@@ -346,9 +351,18 @@ class ImportWorkflowAsReferencedSubFlowResultSuccess(WorkflowAlteredMixin, Resul
 
     Args:
         created_flow_name: Name of the created sub-flow
+        node_name_map: Mapping of each node's requested name to the name actually assigned
+            inside the imported sub-flow. Node names are globally unique, so a node whose
+            name collided with an existing object was auto-renamed (e.g. ``Start Flow`` ->
+            ``Start Flow_1``). Consumers that address nodes by the names recorded in the
+            workflow shape must translate through this map. The same mapping is stamped onto
+            the created flow's metadata under
+            ``REFERENCED_SUBFLOW_NODE_NAME_MAP_METADATA_KEY`` so consumers that did not
+            trigger the import (e.g. a node restored during deserialization) can still read it.
     """
 
     created_flow_name: str
+    node_name_map: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -17,7 +17,7 @@ from griptape_nodes.common.strict_mode import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     from griptape_nodes.node_library.library_declarations import LibraryDeclaration, NodeDeclaration
     from griptape_nodes.node_library.library_registry import LibrarySchema
@@ -305,6 +305,14 @@ class NodeManager:
 
     def __init__(self, event_manager: EventManager) -> None:
         self._name_to_parent_flow_name = {}
+
+        # Stack of active node-name remap recorders. While a recorder is on the stack
+        # (see record_node_name_remaps), every node created records its requested ->
+        # assigned name into the top recorder. Referenced-subflow imports use this to
+        # learn which nodes were auto-renamed on a name collision (e.g. a second imported
+        # subflow whose 'Start Flow' became 'Start Flow_1') so they can still route
+        # inputs/outputs by the original name from the workflow shape.
+        self._node_name_remap_recorders: list[dict[str, str]] = []
 
         # Orchestrator-side: node_name → (target_request_id, worker_engine_id, worker_request_topic)
         # for ExecuteNodeRequests currently routed to a worker. Populated in
@@ -667,6 +675,27 @@ class NodeManager:
                 denials[node.class_name] = denial
         return denials
 
+    @contextlib.contextmanager
+    def record_node_name_remaps(self) -> Iterator[dict[str, str]]:
+        """Record requested -> assigned node names for nodes created within this scope.
+
+        Node names are globally unique, so a requested name that collides with an existing
+        object is auto-renamed (``generate_name_for_object`` appends ``_1``, ``_2``, ...).
+        Callers that need to correlate the names they asked for with the names that were
+        actually assigned (notably referenced-subflow imports, where the same workflow can
+        be imported alongside another that shares ``Start Flow`` / ``End Flow`` node names)
+        wrap the work in this context manager and read the yielded mapping afterwards.
+
+        Only the innermost recorder receives each node, so nested imports keep their
+        mappings separate.
+        """
+        recorder: dict[str, str] = {}
+        self._node_name_remap_recorders.append(recorder)
+        try:
+            yield recorder
+        finally:
+            self._node_name_remap_recorders.pop()
+
     def on_create_node_request(self, request: CreateNodeRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         # Validate as much as possible before we actually create one.
         parent_flow_name = request.override_parent_flow_name
@@ -785,6 +814,12 @@ class NodeManager:
         # Record keeping.
         obj_mgr.add_object_by_name(node.name, node)
         self._name_to_parent_flow_name[node.name] = parent_flow_name
+
+        # If a scoped operation is recording node-name remaps (e.g. a referenced-subflow
+        # import), capture the requested -> assigned mapping so it can translate names that
+        # collided and were auto-renamed.
+        if self._node_name_remap_recorders and request.node_name is not None:
+            self._node_name_remap_recorders[-1][request.node_name] = node.name
 
         # We don't want to start in a resolving state, bump it back to unresolved.
         state = request.resolution

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -84,6 +84,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetSituationResultSuccess,
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
+    REFERENCED_SUBFLOW_NODE_NAME_MAP_METADATA_KEY,
     BranchWorkflowRequest,
     BranchWorkflowResultFailure,
     BranchWorkflowResultSuccess,
@@ -5320,7 +5321,11 @@ class WorkflowManager:
         # Execute the workflow within the target flow context.
         # When track_as_referenced is True, wrap in ReferencedWorkflowContext so the flow
         # serializes as an import command. When False, the flow serializes as inline content.
-        with GriptapeNodes.ContextManager().flow(flow_name):
+        # Record node-name remaps during the run so the consumer can tell which nodes were
+        # auto-renamed on a collision (e.g. importing two workflows that both define a
+        # 'Start Flow') and still route inputs/outputs by the workflow-shape node names.
+        node_manager = GriptapeNodes.NodeManager()
+        with node_manager.record_node_name_remaps() as node_name_map, GriptapeNodes.ContextManager().flow(flow_name):
             if request.track_as_referenced:
                 with self.ReferencedWorkflowContext(self, request.workflow_name):
                     workflow_result = await self.run_workflow(workflow_file_path)
@@ -5366,11 +5371,19 @@ class WorkflowManager:
                 "Applied imported flow metadata to '%s': %s", created_flow_name, request.imported_flow_metadata
             )
 
+        # Persist the requested -> assigned node-name map on the created flow so consumers
+        # that did not trigger this import (e.g. a Subflow Workflow Node restored during
+        # deserialization) can translate workflow-shape node names to the live node names.
+        if node_name_map:
+            created_flow = obj_manager.attempt_get_object_by_name_as_type(created_flow_name, ControlFlow)
+            if created_flow is not None:
+                created_flow.metadata[REFERENCED_SUBFLOW_NODE_NAME_MAP_METADATA_KEY] = dict(node_name_map)
+
         details = (
             f"Successfully imported workflow '{request.workflow_name}' as referenced sub flow '{created_flow_name}'"
         )
         return ImportWorkflowAsReferencedSubFlowResultSuccess(
-            created_flow_name=created_flow_name, result_details=details
+            created_flow_name=created_flow_name, node_name_map=dict(node_name_map), result_details=details
         )
 
     def on_branch_workflow_request(self, request: BranchWorkflowRequest) -> ResultPayload:  # noqa: PLR0911

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -890,3 +890,101 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 )
             ],
         )
+
+
+class TestNodeNameRemapRecorder:
+    """record_node_name_remaps captures requested -> assigned node names, including auto-renames.
+
+    Globally unique node names mean a requested name that collides with an existing object is
+    auto-renamed (e.g. 'Start Flow' -> 'Start Flow_1'). Referenced-subflow imports rely on this
+    recorder to learn that mapping so they can still route inputs/outputs by the original name.
+    """
+
+    _LIBRARY_NAME = "node-remap-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):  # noqa: ANN202
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    def _register_probe(self) -> None:
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t", description="d", library_version="1.0.0", engine_version="1.0.0", tags=[]
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_GateProbe, NodeMetadata(category="t", description="d", display_name="Probe"))
+
+    def test_records_requested_to_assigned_name_on_collision(self, griptape_nodes: GriptapeNodes) -> None:
+        """A name collision inside the recorder scope is captured as requested -> renamed."""
+        from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
+        from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        self._register_probe()
+        griptape_nodes.handle_request(
+            EnsureWorkflowAndFlowRequest(workflow_name="remap_workflow", flow_name="remap_flow")
+        )
+
+        first = griptape_nodes.handle_request(
+            CreateNodeRequest(
+                node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME, node_name="Start Flow"
+            )
+        )
+        assert isinstance(first, CreateNodeResultSuccess)
+        assert first.node_name == "Start Flow"
+
+        node_manager = griptape_nodes.NodeManager()
+        with node_manager.record_node_name_remaps() as remap:
+            second = griptape_nodes.handle_request(
+                CreateNodeRequest(
+                    node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME, node_name="Start Flow"
+                )
+            )
+
+        assert isinstance(second, CreateNodeResultSuccess)
+        assert second.node_name == "Start Flow_1"
+        assert remap == {"Start Flow": "Start Flow_1"}
+        # The recorder is popped on context exit.
+        assert node_manager._node_name_remap_recorders == []
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    def test_no_recording_outside_scope(self, griptape_nodes: GriptapeNodes) -> None:
+        """Nodes created outside any recorder scope are not captured (stack stays empty)."""
+        from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
+        from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+        from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        self._register_probe()
+        griptape_nodes.handle_request(
+            EnsureWorkflowAndFlowRequest(workflow_name="remap_workflow_2", flow_name="remap_flow_2")
+        )
+
+        node_manager = griptape_nodes.NodeManager()
+        result = griptape_nodes.handle_request(
+            CreateNodeRequest(
+                node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME, node_name="Lonely Node"
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess)
+        assert node_manager._node_name_remap_recorders == []
+
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))


### PR DESCRIPTION
`SubflowWorkflowNode` runs another workflow and routes its inputs and outputs using the called workflow's saved `workflow_shape`, whose keys are the original node names. Node names are globally unique, so when a caller references more than one subflow and they share the default `Start Flow` / `End Flow` nodes, the second import's nodes are auto-renamed to `Start Flow_1` / `End Flow_1`. The node's `flow.nodes.get(<shape name>)` lookups then miss, the loops skip, and the subflow runs but never receives its inputs and never returns its outputs.

This is not a regression and is not specific to `main`: it reproduces on older engine versions too, and only when a caller references more than one subflow, which is why a freshly created single-subflow caller always worked and bisecting would never find a culprit.

The engine side captures the requested to assigned node-name remaps during a referenced-subflow import via a `NodeManager` recorder, returns them on `ImportWorkflowAsReferencedSubFlowResultSuccess.node_name_map`, and stamps them onto the created sub-flow's metadata under `REFERENCED_SUBFLOW_NODE_NAME_MAP_METADATA_KEY`. The metadata copy is the load-bearing piece: on deserialization the workflow file, not the node, triggers the import, so the node has to read the map from the flow it references rather than from an import result it never sees. The recorder only feeds the innermost active scope so nested imports keep their maps separate.

The `SubflowWorkflowNode` change that consumes the map ships in `griptape-nodes-library-standard` (companion PR linked below); without it this change is inert but harmless.

Part of #4993.

Companion library PR: griptape-ai/griptape-nodes-library-standard#383
