### PR TITLE
scrub non-serializable values from exported workflow code

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4033,6 +4033,98 @@ class WorkflowManager:
         code_blocks.append(if_stmt)
         return code_blocks
 
+    class _ScrubResult(NamedTuple):
+        """Result of scrubbing a value for inline AST emission."""
+
+        value: Any
+        dropped: bool
+
+    @staticmethod
+    def _is_ast_constant_safe(value: Any) -> bool:
+        """True if value is composed only of literals ``ast.unparse`` can round-trip.
+
+        Anything else (e.g. a Button trait object mistakenly placed in ``ui_options``)
+        would be rendered by ``ast.Constant`` via its ``repr()``, which is not valid
+        Python and breaks reopening the saved workflow.
+        """
+        primitives = (str, bytes, bool, int, float, complex, type(None))
+        if isinstance(value, primitives):
+            return True
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return all(WorkflowManager._is_ast_constant_safe(item) for item in value)
+        if isinstance(value, dict):
+            return all(
+                WorkflowManager._is_ast_constant_safe(key) and WorkflowManager._is_ast_constant_safe(item)
+                for key, item in value.items()
+            )
+        return False
+
+    @staticmethod
+    def _scrub_for_ast_constant(value: Any) -> WorkflowManager._ScrubResult:
+        """Return a copy of value with any non-literal leaves removed.
+
+        Recurses through dict/list/tuple/set, dropping keys (for dicts) or elements
+        (for sequences) whose values cannot be emitted as an ``ast.Constant``. The
+        boolean flags whether anything was dropped so callers can warn.
+
+        A bare unsafe scalar with no surrounding container is replaced with ``None``.
+        """
+        containers = (dict, list, tuple, set, frozenset)
+
+        if WorkflowManager._is_ast_constant_safe(value):
+            return WorkflowManager._ScrubResult(value=value, dropped=False)
+
+        if isinstance(value, dict):
+            scrubbed_dict = {}
+            dropped = False
+            for key, item in value.items():
+                # An unsafe key or an unsafe non-container value means we drop the entry entirely.
+                if not WorkflowManager._is_ast_constant_safe(key) or (
+                    not isinstance(item, containers) and not WorkflowManager._is_ast_constant_safe(item)
+                ):
+                    dropped = True
+                    continue
+                item_result = WorkflowManager._scrub_for_ast_constant(item)
+                scrubbed_dict[key] = item_result.value
+                dropped = dropped or item_result.dropped
+            return WorkflowManager._ScrubResult(value=scrubbed_dict, dropped=dropped)
+
+        if isinstance(value, (list, tuple, set, frozenset)):
+            scrubbed_items = []
+            dropped = False
+            for item in value:
+                # An unsafe non-container element is dropped; containers are recursed into.
+                if not isinstance(item, containers) and not WorkflowManager._is_ast_constant_safe(item):
+                    dropped = True
+                    continue
+                item_result = WorkflowManager._scrub_for_ast_constant(item)
+                scrubbed_items.append(item_result.value)
+                dropped = dropped or item_result.dropped
+            return WorkflowManager._ScrubResult(value=type(value)(scrubbed_items), dropped=dropped)
+
+        # A bare unsafe scalar (e.g. a callable or trait object) with no container to
+        # prune: signal that it was dropped and return None as a safe placeholder.
+        return WorkflowManager._ScrubResult(value=None, dropped=True)
+
+    @staticmethod
+    def _keyword_from_field_value(arg_name: str, field_value: Any, command: Any) -> ast.keyword:
+        """Build an ``ast.keyword`` for a command field, scrubbing unsafe content.
+
+        Non-serializable content (e.g. a Button trait object mistakenly placed in
+        ``ui_options`` instead of attached via ``traits=``) is dropped so the saved
+        workflow stays valid Python and can be reopened.
+        """
+        scrub_result = WorkflowManager._scrub_for_ast_constant(field_value)
+        if scrub_result.dropped:
+            logger.warning(
+                "Omitting non-serializable content from field '%s' of %s while saving the workflow. "
+                "This usually means a UI object (e.g. a Button) was placed in ui_options instead of "
+                "being attached as a trait.",
+                arg_name,
+                type(command).__name__,
+            )
+        return ast.keyword(arg=arg_name, value=ast.Constant(value=scrub_result.value, lineno=1, col_offset=0))
+
     def _generate_unique_values_code(
         self,
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
@@ -4174,7 +4266,7 @@ class WorkflowManager:
                         )
                     else:
                         create_flow_request_args.append(
-                            ast.keyword(arg=field.name, value=ast.Constant(value=field_value, lineno=1, col_offset=0))
+                            self._keyword_from_field_value(field.name, field_value, create_flow_command)
                         )
 
         # Create a comment explaining the behavior
@@ -4267,7 +4359,7 @@ class WorkflowManager:
                 field_value = getattr(import_workflow_command, field.name)
                 if field_value != field.default:
                     import_workflow_request_args.append(
-                        ast.keyword(arg=field.name, value=ast.Constant(value=field_value, lineno=1, col_offset=0))
+                        self._keyword_from_field_value(field.name, field_value, import_workflow_command)
                     )
 
         # Construct the AST for importing the workflow
@@ -4495,7 +4587,7 @@ class WorkflowManager:
                             )
                     else:
                         create_node_request_args.append(
-                            ast.keyword(arg=field.name, value=ast.Constant(value=field_value, lineno=1, col_offset=0))
+                            self._keyword_from_field_value(field.name, field_value, create_node_request)
                         )
 
         # After processing all fields, handle subflow_name from metadata
@@ -4602,9 +4694,7 @@ class WorkflowManager:
                         field_value = getattr(element_command, field.name)
                         if field_value != field.default:
                             element_command_args.append(
-                                ast.keyword(
-                                    arg=field.name, value=ast.Constant(value=field_value, lineno=1, col_offset=0)
-                                )
+                                self._keyword_from_field_value(field.name, field_value, element_command)
                             )
 
                 # Create the await ahandle_request call

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4069,42 +4069,63 @@ class WorkflowManager:
 
         A bare unsafe scalar with no surrounding container is replaced with ``None``.
         """
-        containers = (dict, list, tuple, set, frozenset)
-
         if WorkflowManager._is_ast_constant_safe(value):
             return WorkflowManager._ScrubResult(value=value, dropped=False)
 
         if isinstance(value, dict):
-            scrubbed_dict = {}
-            dropped = False
-            for key, item in value.items():
-                # An unsafe key or an unsafe non-container value means we drop the entry entirely.
-                if not WorkflowManager._is_ast_constant_safe(key) or (
-                    not isinstance(item, containers) and not WorkflowManager._is_ast_constant_safe(item)
-                ):
-                    dropped = True
-                    continue
-                item_result = WorkflowManager._scrub_for_ast_constant(item)
-                scrubbed_dict[key] = item_result.value
-                dropped = dropped or item_result.dropped
-            return WorkflowManager._ScrubResult(value=scrubbed_dict, dropped=dropped)
+            return WorkflowManager._scrub_dict(value)
 
         if isinstance(value, (list, tuple, set, frozenset)):
-            scrubbed_items = []
-            dropped = False
-            for item in value:
-                # An unsafe non-container element is dropped; containers are recursed into.
-                if not isinstance(item, containers) and not WorkflowManager._is_ast_constant_safe(item):
-                    dropped = True
-                    continue
-                item_result = WorkflowManager._scrub_for_ast_constant(item)
-                scrubbed_items.append(item_result.value)
-                dropped = dropped or item_result.dropped
-            return WorkflowManager._ScrubResult(value=type(value)(scrubbed_items), dropped=dropped)
+            return WorkflowManager._scrub_sequence(value)
 
         # A bare unsafe scalar (e.g. a callable or trait object) with no container to
         # prune: signal that it was dropped and return None as a safe placeholder.
         return WorkflowManager._ScrubResult(value=None, dropped=True)
+
+    @staticmethod
+    def _scrub_dict(value: dict) -> WorkflowManager._ScrubResult:
+        """Scrub a dict, dropping entries whose key or (non-container) value is unsafe."""
+        containers = (dict, list, tuple, set, frozenset)
+        scrubbed_dict = {}
+        dropped = False
+        for key, item in value.items():
+            # An unsafe key or an unsafe non-container value means we drop the entry entirely.
+            if not WorkflowManager._is_ast_constant_safe(key) or (
+                not isinstance(item, containers) and not WorkflowManager._is_ast_constant_safe(item)
+            ):
+                dropped = True
+                continue
+            item_result = WorkflowManager._scrub_for_ast_constant(item)
+            scrubbed_dict[key] = item_result.value
+            dropped = dropped or item_result.dropped
+        return WorkflowManager._ScrubResult(value=scrubbed_dict, dropped=dropped)
+
+    @staticmethod
+    def _scrub_sequence(value: list | tuple | set | frozenset) -> WorkflowManager._ScrubResult:
+        """Scrub a sequence, dropping unsafe non-container elements and recursing into containers."""
+        containers = (dict, list, tuple, set, frozenset)
+        scrubbed_items = []
+        dropped = False
+        for item in value:
+            # An unsafe non-container element is dropped; containers are recursed into.
+            if not isinstance(item, containers) and not WorkflowManager._is_ast_constant_safe(item):
+                dropped = True
+                continue
+            item_result = WorkflowManager._scrub_for_ast_constant(item)
+            scrubbed_items.append(item_result.value)
+            dropped = dropped or item_result.dropped
+        # Rebuild using the nearest builtin constructor rather than type(value)(...),
+        # so a tuple subclass like a namedtuple (whose __new__ takes positional fields,
+        # not an iterable) becomes a plain tuple instead of raising TypeError.
+        if isinstance(value, list):
+            rebuilt: Any = scrubbed_items
+        elif isinstance(value, tuple):
+            rebuilt = tuple(scrubbed_items)
+        elif isinstance(value, frozenset):
+            rebuilt = frozenset(scrubbed_items)
+        else:
+            rebuilt = set(scrubbed_items)
+        return WorkflowManager._ScrubResult(value=rebuilt, dropped=dropped)
 
     @staticmethod
     def _keyword_from_field_value(arg_name: str, field_value: Any, command: Any) -> ast.keyword:

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -3023,3 +3023,91 @@ class TestScrubForAstConstant:
         assert "<function" not in source
         assert "Button(" not in source
         ast.parse(source)
+
+    def test_scrub_namedtuple_with_unsafe_leaf_does_not_crash(self) -> None:
+        """A namedtuple (tuple subclass) containing an unsafe leaf must not raise.
+
+        ``type(value)(scrubbed_items)`` would call the namedtuple's positional
+        ``__new__`` with a single list arg and raise TypeError, turning graceful
+        degradation into a hard crash of the whole save. It must degrade to a plain
+        tuple instead.
+        """
+
+        class Point(NamedTuple):
+            x: int
+            handler: object
+
+        value = Point(1, lambda: None)
+        result = WorkflowManager._scrub_for_ast_constant(value)
+
+        assert result.dropped is True
+        # Reconstructed as a plain tuple with the unsafe leaf removed.
+        assert result.value == (1,)
+        assert type(result.value) is tuple
+
+    def test_generate_workflow_file_content_scrubs_button_in_ui_options(self, griptape_nodes: GriptapeNodes) -> None:
+        """End-to-end regression for #5013: a Button in ui_options must not break the saved file.
+
+        Drives the real generator (``_generate_workflow_file_content``) with a node whose
+        AlterParameterDetailsRequest carries a Button inside ``ui_options`` (the exact shape
+        the standalone ElevenLabs library produced). The emitted module must be valid,
+        reopenable Python with no function repr leaking through.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+        from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, SerializedNodeCommands
+        from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest
+        from griptape_nodes.traits.button import Button
+
+        button = Button(size="icon", icon="audio-lines", tooltip="Search", button_link="https://example.com")
+        alter_request = AlterParameterDetailsRequest(
+            parameter_name="custom_voice_id",
+            ui_options={
+                "display_name": "Custom Voice ID",
+                "hide": False,
+                "traits": [button],
+            },
+            initial_setup=True,
+        )
+        node_command = SerializedNodeCommands(
+            create_node_command=CreateNodeRequest(
+                node_type="SomeNode",
+                specific_library_name="Some Library",
+                node_name="Node_1",
+            ),
+            element_modification_commands=[alter_request],
+            node_dependencies=NodeDependencies(),
+        )
+        flow_commands = SerializedFlowCommands(
+            flow_initialization_command=None,
+            serialized_node_commands=[node_command],
+            serialized_connections=[],
+            unique_parameter_uuid_to_values={},
+            set_parameter_value_commands={},
+            set_lock_commands_per_node={},
+            sub_flows_commands=[],
+            node_dependencies=NodeDependencies(
+                libraries={LibraryNameAndVersion(library_name="Some Library", library_version="0.1.0")}
+            ),
+            node_types_used=set(),
+        )
+
+        metadata = WorkflowMetadata(
+            name="test_workflow",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="1.0.0",
+            node_libraries_referenced=[],
+            workflow_shape=None,
+        )
+        content = griptape_nodes.WorkflowManager()._generate_workflow_file_content(
+            serialized_flow_commands=flow_commands,
+            workflow_metadata=metadata,
+        )
+
+        # The generated file must be valid, reopenable Python with no leaked function repr,
+        # and the surviving ui_options must keep its safe keys with an emptied traits list.
+        assert "<function" not in content
+        assert "at 0x" not in content
+        assert "_create_button_link_handler" not in content
+        ast.parse(content)
+        assert "'traits': []" in content
+        assert "'display_name': 'Custom Voice ID'" in content

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2954,3 +2954,72 @@ class TestCreateVersionedWorkflow:
             # the unresolved (pre-seed) form.
             assert target.relative_file_path == "brand_new_flow.py"
             assert target.file_path is None
+
+
+class TestScrubForAstConstant:
+    """Regression coverage for griptape-nodes-engine#5013.
+
+    A Button trait object placed inside a parameter's ``ui_options`` dict (instead of
+    attached via ``traits=``) survives serialization and, when emitted by codegen via
+    ``ast.Constant``, is rendered as its ``repr()`` (``<function ... at 0x...>``), which
+    is invalid Python and prevents the saved workflow from reopening.
+    """
+
+    def test_primitive_values_are_safe(self) -> None:
+        for value in ["s", b"b", True, 1, 1.5, None]:
+            assert WorkflowManager._is_ast_constant_safe(value) is True
+
+    def test_nested_container_of_primitives_is_safe(self) -> None:
+        value = {"a": [1, 2, {"b": ("x", None)}], "c": {1, 2}}
+        assert WorkflowManager._is_ast_constant_safe(value) is True
+
+    def test_callable_leaf_is_unsafe(self) -> None:
+        assert WorkflowManager._is_ast_constant_safe(lambda: None) is False
+
+    def test_scrub_leaves_safe_value_untouched(self) -> None:
+        value = {"display_name": "X", "hide": True, "nums": [1, 2]}
+        result = WorkflowManager._scrub_for_ast_constant(value)
+        assert result.dropped is False
+        assert result.value == value
+
+    def test_scrub_drops_button_in_ui_options_traits(self) -> None:
+        from griptape_nodes.traits.button import Button
+
+        button = Button(size="icon", icon="audio-lines", tooltip="Search", button_link="https://example.com")
+        ui_options = {
+            "display_name": "Custom Voice ID",
+            "hide": True,
+            "placeholder_text": "e.g., 21m00Tcm4TlvDq8ikWAM",
+            "traits": [button],
+        }
+
+        result = WorkflowManager._scrub_for_ast_constant(ui_options)
+
+        assert result.dropped is True
+        # Safe keys are preserved; the unsafe Button is removed, leaving an empty traits list.
+        assert result.value == {
+            "display_name": "Custom Voice ID",
+            "hide": True,
+            "placeholder_text": "e.g., 21m00Tcm4TlvDq8ikWAM",
+            "traits": [],
+        }
+
+    def test_keyword_from_field_value_emits_valid_python(self) -> None:
+        from griptape_nodes.traits.button import Button
+
+        button = Button(icon="key", tooltip="Open", button_link="https://example.com")
+        ui_options = {"display_name": "X", "traits": [button]}
+
+        keyword = WorkflowManager._keyword_from_field_value("ui_options", ui_options, object())
+        call_node = ast.Call(
+            func=ast.Name(id="Req", ctx=ast.Load()),
+            args=[],
+            keywords=[keyword],
+        )
+        source = ast.unparse(ast.fix_missing_locations(call_node))
+
+        # The rendered source must be free of the invalid function repr and must parse.
+        assert "0x" not in source
+        assert "<function" not in source
+        assert "Button(" not in source
+        ast.parse(source)


### PR DESCRIPTION
Prevents https://github.com/griptape-ai/griptape-nodes-engine/issues/5013 like bugs from preventing workflows from opening. This occurred previously when nodes improperly serialized content like in https://github.com/griptape-ai/griptape-nodes-library-elevenlabs/pull/8