### PR TITLE
feat(startup): broadcast engine-ready event for the app to render

### DIFF
--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -128,6 +128,52 @@ class AppConnectionEstablished(AppPayload):
 
 
 @dataclass
+class LibraryLoadStatus:
+    """Load outcome for a single library, used to render the startup status table.
+
+    Carries raw data only; how each fitness value maps to icons, colors, and
+    labels is a presentation choice owned by the application layer.
+
+    Args:
+        library_name: Library name from metadata, or None if never resolved.
+        library_version: Library version string, or None if unknown.
+        library_path: Path to the library JSON file or sandbox directory.
+        fitness: LibraryFitness value (e.g. "GOOD", "FLAWED", "UNUSABLE").
+        disabled: True when the library is disabled in the user's config.
+        problems: Collated problem summary, or None when there are none.
+    """
+
+    library_name: str | None
+    library_version: str | None
+    library_path: str | None
+    fitness: str
+    disabled: bool
+    problems: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class EngineReadyEvent(AppPayload):
+    """Event signaling the engine finished initialization and can receive events.
+
+    Broadcast by the orchestrator at the end of app initialization and again after
+    a library reload, once libraries and workflows have loaded. The application
+    layer listens for this to render its library status table and (on initial
+    start) its "engine ready" banner; presentation is owned by the app, not the
+    engine. Other consumers (the GUI, the desktop app) can react to the same
+    event and its structured library data.
+
+    Args:
+        libraries: Load outcome for every library attempted this pass.
+        is_initial_start: True on first engine startup, False on a reload. The app
+            uses this to show the ready banner only on the initial start.
+    """
+
+    libraries: list[LibraryLoadStatus] = field(default_factory=list)
+    is_initial_start: bool = True
+
+
+@dataclass
 @PayloadRegistry.register
 class AppSessionStartedEvent(AppPayload):
     """Notification that a session has started and workers can be spawned."""

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -24,12 +24,6 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion
 from packaging.version import Version as PackagingVersion
 from pydantic import ValidationError
-from rich.align import Align
-from rich.box import HEAVY_EDGE
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
-from rich.text import Text
 from semver import Version
 from xdg_base_dirs import xdg_data_home
 
@@ -68,11 +62,13 @@ from griptape_nodes.retained_mode.events.app_events import (
     AppInitializationComplete,
     AppSessionStartedEvent,
     EngineInitializationProgress,
+    EngineReadyEvent,
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
     InitializationPhase,
     InitializationStatus,
     LibraryLoadedNotification,
+    LibraryLoadStatus,
     WorkerNodeSchema,
     WorkerParameterSchema,
 )
@@ -275,7 +271,6 @@ from griptape_nodes.utils.library_utils import (
 from griptape_nodes.utils.uv_utils import find_uv_bin, is_venv_functional, venv_python_path
 from griptape_nodes.utils.version_utils import (
     engine_version_failure_detail,
-    get_complete_version_string,
 )
 
 if TYPE_CHECKING:
@@ -288,7 +283,6 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
 
 logger = logging.getLogger("griptape_nodes")
-console = Console()
 
 # Directories to exclude when scanning for Python source files (in addition to any directory starting with '.')
 EXCLUDED_SCAN_DIRECTORIES = frozenset({"venv", "__pycache__"})
@@ -709,82 +703,26 @@ class LibraryManager:
                 library_name,
             )
 
-    def print_library_load_status(self) -> None:
-        library_file_paths = self.get_libraries_attempted_to_load()
-        library_infos = []
-        for library_file_path in library_file_paths:
-            library_info = self.get_library_info_for_attempted_load(library_file_path)
-            library_infos.append(library_info)
+    def _collect_library_load_statuses(self) -> list[LibraryLoadStatus]:
+        """Gather the load outcome for every attempted library as serializable data.
 
-        console = Console()
-
-        # Check if the list is empty
-        if not library_infos:
-            # Display a message indicating no libraries are available
-            empty_message = Text("No library information available", style="italic")
-            panel = Panel(empty_message, title="Library Information", border_style="blue")
-            console.print(panel)
-            return
-
-        # Create a table with two columns and row dividers
-        table = Table(show_header=True, box=HEAVY_EDGE, show_lines=True, expand=True)
-        table.add_column("Library", style="green", ratio=1)
-        table.add_column("Problems", style="yellow", ratio=1)
-
-        # Status emojis mapping
-        status_emoji = {
-            LibraryManager.LibraryFitness.GOOD: "[green]OK[/green]",
-            LibraryManager.LibraryFitness.FLAWED: "[yellow]![/yellow]",
-            LibraryManager.LibraryFitness.UNUSABLE: "[red]X[/red]",
-            LibraryManager.LibraryFitness.MISSING: "[red]?[/red]",
-            LibraryManager.LibraryFitness.NOT_EVALUATED: "[cyan]...[/cyan]",
-        }
-
-        # Status text mapping (colored)
-        status_text = {
-            LibraryManager.LibraryFitness.GOOD: "[green](GOOD)[/green]",
-            LibraryManager.LibraryFitness.FLAWED: "[yellow](FLAWED)[/yellow]",
-            LibraryManager.LibraryFitness.UNUSABLE: "[red](UNUSABLE)[/red]",
-            LibraryManager.LibraryFitness.MISSING: "[red](MISSING)[/red]",
-            LibraryManager.LibraryFitness.NOT_EVALUATED: "[cyan](PENDING)[/cyan]",
-        }
-
-        # Add rows for each library info
-        for lib_info in library_infos:
-            # Library column with emoji, name, version, colored status, and file path underneath
-            is_disabled = lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.DISABLED
-            if is_disabled:
-                emoji = "[dim]-[/dim]"
-                colored_status = "[dim](DISABLED)[/dim]"
-            else:
-                emoji = status_emoji.get(lib_info.fitness, "ERROR: Unknown/Unexpected Library Status")
-                colored_status = status_text.get(lib_info.fitness, "(UNKNOWN)")
-            name = lib_info.library_name or "*UNKNOWN*"
-
-            library_version = lib_info.library_version
-            if library_version:
-                version_str = str(library_version)
-            else:
-                version_str = "*UNKNOWN*"
-
-            file_path = lib_info.library_path
-            library_name_with_details = Text.from_markup(
-                f"{emoji} - {name} v{version_str} {colored_status}\n[cyan dim]{file_path}[/cyan dim]"
+        Presentation (icons, colors, table layout) is owned by the application
+        layer; this returns raw data for it to render.
+        """
+        statuses: list[LibraryLoadStatus] = []
+        for library_file_path in self.get_libraries_attempted_to_load():
+            lib_info = self.get_library_info_for_attempted_load(library_file_path)
+            statuses.append(
+                LibraryLoadStatus(
+                    library_name=lib_info.library_name,
+                    library_version=str(lib_info.library_version) if lib_info.library_version else None,
+                    library_path=lib_info.library_path,
+                    fitness=lib_info.fitness.value,
+                    disabled=lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.DISABLED,
+                    problems=self.collate_problems_for_lib_info(lib_info),
+                )
             )
-            library_name_with_details.overflow = "fold"
-
-            # Problems column - collate by type then format
-            collated = self.collate_problems_for_lib_info(lib_info)
-            problems = collated if collated is not None else "No problems detected."
-
-            # Add the row to the table
-            table.add_row(library_name_with_details, problems)
-
-        # Create a panel containing the table
-        panel = Panel(table, title="Library Information", border_style="blue")
-
-        # Display the panel
-        console.print(panel)
+        return statuses
 
     def get_libraries_attempted_to_load(self) -> list[str]:
         return list(self._library_file_path_to_info.keys())
@@ -3924,11 +3862,6 @@ class LibraryManager:
         if GriptapeNodes.get_session_id():
             await self._await_pending_workers()
 
-        # Print library status after workers have had a chance to report back so worker
-        # libraries show their real fitness rather than NOT_EVALUATED.
-        if not self._is_worker:
-            self.print_library_load_status()
-
         # Register all secrets now that libraries are loaded and settings are merged
         GriptapeNodes.SecretsManager().register_all_secrets()
 
@@ -3941,8 +3874,21 @@ class LibraryManager:
         # Go tell the Workflow Manager that it's turn is now.
         await GriptapeNodes.WorkflowManager().refresh_workflow_registry()
 
-        # Only print the engine ready banner for the orchestrator — not for dedicated library workers.
-        self._maybe_print_engine_ready_banner(is_worker=self._is_worker)
+        # Signal readiness so the application layer can render its library status
+        # table and "engine ready" banner, and other consumers (the GUI, the
+        # desktop app) can react to the same event. Only the orchestrator
+        # announces readiness; dedicated library workers do not. Presentation is
+        # owned by the app, not the engine. The library statuses reflect real
+        # fitness because workers have already reported back above.
+        if not self._is_worker:
+            GriptapeNodes.EventManager().put_event(
+                AppEvent(
+                    payload=EngineReadyEvent(
+                        libraries=self._collect_library_load_statuses(),
+                        is_initial_start=True,
+                    )
+                )
+            )
 
     async def _collect_library_workflow_files(self) -> list[str]:
         """Collect workflow file paths declared by all registered libraries.
@@ -4144,37 +4090,6 @@ class LibraryManager:
             pass
 
         return type(class_name, (BaseNode,), {"__init__": stub_init, "process": stub_process})
-
-    def _maybe_print_engine_ready_banner(self, *, is_worker: bool) -> None:
-        if is_worker:
-            return
-
-        engine_version = get_complete_version_string()
-
-        # Get current session ID
-        session_id = GriptapeNodes.get_session_id()
-        session_info = f" | Session: {session_id[:8]}..." if session_id else " | No Session"
-
-        # Get user and organization
-        user = GriptapeNodes.UserManager().user
-        user_info = f" | User: {user.email if user else 'Not available'}"
-
-        user_organization = GriptapeNodes.UserManager().user_organization
-        org_info = f" | Org: {user_organization.name if user_organization else 'Not available'}"
-
-        nodes_app_url = os.getenv("GRIPTAPE_NODES_UI_BASE_URL", "https://nodes.griptape.ai")
-        message = Panel(
-            Align.center(
-                f"[bold green]Engine is ready to receive events[/bold green]\n"
-                f"[bold blue]Return to: [link={nodes_app_url}]{nodes_app_url}[/link] to access the Workflow Editor[/bold blue]",
-                vertical="middle",
-            ),
-            title="Griptape Nodes Engine Started",
-            subtitle=f"[green]Version: {engine_version}{session_info}{user_info}{org_info}[/green]",
-            border_style="green",
-            padding=(1, 4),
-        )
-        console.print(message)
 
     def _load_advanced_library_module(
         self,
@@ -4928,8 +4843,18 @@ class LibraryManager:
         # must be registered before we respond.
         await self._await_pending_workers()
 
-        # Print after workers have reported back so their real fitness is shown.
-        self.print_library_load_status()
+        # Signal readiness again so the app re-renders the library status table with real
+        # fitness now that workers have reported back. is_initial_start=False so the app
+        # refreshes the table without re-showing the startup banner. Orchestrator only.
+        if not self._is_worker:
+            GriptapeNodes.EventManager().put_event(
+                AppEvent(
+                    payload=EngineReadyEvent(
+                        libraries=self._collect_library_load_statuses(),
+                        is_initial_start=False,
+                    )
+                )
+            )
 
         # Hard activation: a reload is interactive (project switch / explicit reload), so a
         # reconcile failure (bad engine_version gate or a sourced library that could not be

--- a/src/griptape_nodes/utils/version_utils.py
+++ b/src/griptape_nodes/utils/version_utils.py
@@ -14,7 +14,9 @@ from rich.console import Console
 
 console = Console()
 
-engine_version = importlib.metadata.version("griptape-nodes-engine")
+ENGINE_PACKAGE_NAME = "griptape-nodes-engine"
+
+engine_version = importlib.metadata.version(ENGINE_PACKAGE_NAME)
 
 
 def engine_version_failure_detail(spec_string: str | None) -> str | None:
@@ -53,16 +55,22 @@ def get_current_version() -> str:
     return f"v{engine_version}"
 
 
-def get_install_source() -> tuple[Literal["git", "file", "pypi", "unknown"], str | None]:
-    """Determines the install source of the Griptape Nodes package.
+def get_install_source(
+    package_name: str = ENGINE_PACKAGE_NAME,
+) -> tuple[Literal["git", "file", "pypi", "unknown"], str | None]:
+    """Determines the install source of the given Griptape Nodes package.
 
     Searches for the dist-info in the same site-packages directory as the
     running code to correctly identify the source when multiple installations
     of the package exist across different environments on sys.path.
 
+    Args:
+        package_name: Distribution name to inspect (defaults to the engine).
+
     Returns:
         tuple: A tuple containing the install source and commit ID (if applicable).
     """
+    package_aliases = {package_name.lower(), package_name.lower().replace("-", "_")}
     # Search for the dist-info in the same directory as this running module
     # (i.e., the site-packages containing the code that is actually executing).
     # This avoids picking up a different installation that appears earlier in
@@ -78,7 +86,7 @@ def get_install_source() -> tuple[Literal["git", "file", "pypi", "unknown"], str
             (
                 d
                 for d in importlib.metadata.distributions(path=[str(code_site_packages)])
-                if d.metadata.get("Name", "").lower() in ("griptape-nodes-engine", "griptape_nodes_engine")
+                if d.metadata.get("Name", "").lower() in package_aliases
             ),
             None,
         )
@@ -87,7 +95,7 @@ def get_install_source() -> tuple[Literal["git", "file", "pypi", "unknown"], str
     # rather than site-packages, so the dist-info won't be found above.
     if dist is None:
         try:
-            dist = importlib.metadata.distribution("griptape-nodes-engine")
+            dist = importlib.metadata.distribution(package_name)
         except importlib.metadata.PackageNotFoundError:
             return "unknown", None
 
@@ -107,16 +115,26 @@ def get_install_source() -> tuple[Literal["git", "file", "pypi", "unknown"], str
     return "unknown", None
 
 
+def format_version_string(version: str, package_name: str = ENGINE_PACKAGE_NAME) -> str:
+    """Format a version string with its install source and optional commit ID.
+
+    Package-agnostic: pass any distribution name to describe a package other than
+    the engine (e.g. the application layer installed on top of it).
+
+    Format: v1.2.3 (source) or v1.2.3 (source - commit_id)
+    """
+    source, commit_id = get_install_source(package_name)
+    if commit_id is None:
+        return f"{version} ({source})"
+    return f"{version} ({source} - {commit_id})"
+
+
 def get_complete_version_string() -> str:
-    """Returns the complete version string including install source and commit ID.
+    """Returns the complete engine version string including install source and commit ID.
 
     Format: v1.2.3 (source) or v1.2.3 (source - commit_id)
 
     Returns:
         Complete version string with source and commit info.
     """
-    version = get_current_version()
-    source, commit_id = get_install_source()
-    if commit_id is None:
-        return f"{version} ({source})"
-    return f"{version} ({source} - {commit_id})"
+    return format_version_string(get_current_version(), ENGINE_PACKAGE_NAME)

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -3230,6 +3230,57 @@ class TestLibraryManagerMetadataLoadFailureSurfacing:
         assert stored.problems
 
 
+class TestCollectLibraryLoadStatuses:
+    """_collect_library_load_statuses turns LibraryInfo into serializable status data."""
+
+    def test_maps_fields_and_disabled_state(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+        library_manager = griptape_nodes.LibraryManager()
+
+        good = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/libs/good.json",
+            is_sandbox=False,
+            library_name="Good Library",
+            library_version="1.2.3",
+        )
+        disabled = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.DISABLED,
+            fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
+            library_path="/libs/off.json",
+            is_sandbox=False,
+            library_name="Disabled Library",
+            library_version=None,
+        )
+        library_manager._library_file_path_to_info = {
+            "/libs/good.json": good,
+            "/libs/off.json": disabled,
+        }
+
+        statuses = library_manager._collect_library_load_statuses()
+
+        # Unpacking enforces exactly two statuses were produced.
+        good_status, disabled_status = statuses
+
+        assert good_status.library_name == "Good Library"
+        assert good_status.library_version == "1.2.3"
+        assert good_status.library_path == "/libs/good.json"
+        assert good_status.fitness == "GOOD"
+        assert good_status.disabled is False
+        assert good_status.problems is None
+
+        assert disabled_status.disabled is True
+        assert disabled_status.library_version is None
+
+    def test_empty_when_no_libraries(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+        library_manager._library_file_path_to_info = {}
+
+        assert library_manager._collect_library_load_statuses() == []
+
+
 class TestLibraryFitnessAuthorizationCheckpoint:
     """The license-policy checkpoint wired into library fitness evaluation."""
 

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -118,35 +118,6 @@ class TestGetWorkerForLibrary:
                 mgr.get_worker_for_library("my_lib")
 
 
-class TestMaybePrintEngineReadyBanner:
-    def test_skips_when_is_worker(self) -> None:
-        mgr = _make_library_manager()
-
-        with patch("griptape_nodes.retained_mode.managers.library_manager.console") as mock_console:
-            mgr._maybe_print_engine_ready_banner(is_worker=True)
-
-        mock_console.print.assert_not_called()
-
-    def test_prints_panel_when_not_worker(self) -> None:
-        mgr = _make_library_manager()
-
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.get_complete_version_string",
-                return_value="1.0.0",
-            ),
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn,
-            patch("griptape_nodes.retained_mode.managers.library_manager.console") as mock_console,
-        ):
-            mock_gtn.get_session_id.return_value = None
-            mock_gtn.UserManager.return_value.user = None
-            mock_gtn.UserManager.return_value.user_organization = None
-
-            mgr._maybe_print_engine_ready_banner(is_worker=False)
-
-        mock_console.print.assert_called_once()
-
-
 class TestOnLibraryLoadedNotification:
     def _make_lib_info(self, library_name: str) -> LibraryManager.LibraryInfo:
         return LibraryManager.LibraryInfo(

--- a/tests/unit/utils/test_version_utils.py
+++ b/tests/unit/utils/test_version_utils.py
@@ -1,0 +1,80 @@
+"""Unit tests for version_utils module."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.utils import version_utils
+from griptape_nodes.utils.version_utils import (
+    ENGINE_PACKAGE_NAME,
+    format_version_string,
+    get_complete_version_string,
+    get_install_source,
+)
+
+_MODULE = "griptape_nodes.utils.version_utils"
+
+
+class TestFormatVersionString:
+    """Test format_version_string utility function."""
+
+    def test_formats_pypi_source(self) -> None:
+        with patch(f"{_MODULE}.get_install_source", return_value=("pypi", None)):
+            assert format_version_string("v1.2.3", "griptape-nodes") == "v1.2.3 (pypi)"
+
+    def test_formats_git_source_with_commit(self) -> None:
+        with patch(f"{_MODULE}.get_install_source", return_value=("git", "abc1234")) as install_source_mock:
+            assert format_version_string("v1.2.3", "griptape-nodes") == "v1.2.3 (git - abc1234)"
+            install_source_mock.assert_called_once_with("griptape-nodes")
+
+    def test_defaults_to_engine_package(self) -> None:
+        with patch(f"{_MODULE}.get_install_source", return_value=("pypi", None)) as install_source_mock:
+            format_version_string("v1.2.3")
+            install_source_mock.assert_called_once_with(ENGINE_PACKAGE_NAME)
+
+
+class TestGetCompleteVersionString:
+    """Test get_complete_version_string targets the engine package."""
+
+    def test_uses_engine_package(self) -> None:
+        with (
+            patch(f"{_MODULE}.get_current_version", return_value="v9.9.9"),
+            patch(f"{_MODULE}.get_install_source", return_value=("pypi", None)) as install_source_mock,
+        ):
+            assert get_complete_version_string() == "v9.9.9 (pypi)"
+            install_source_mock.assert_called_once_with(ENGINE_PACKAGE_NAME)
+
+
+class TestGetInstallSource:
+    """Test get_install_source respects the requested package name."""
+
+    def test_defaults_to_engine_package(self) -> None:
+        with (
+            patch.object(version_utils.importlib.metadata, "distributions", return_value=[]),
+            patch.object(
+                version_utils.importlib.metadata,
+                "distribution",
+                side_effect=importlib.metadata.PackageNotFoundError,
+            ) as distribution_mock,
+        ):
+            assert get_install_source() == ("unknown", None)
+            distribution_mock.assert_called_once_with(ENGINE_PACKAGE_NAME)
+
+    def test_accepts_explicit_package_name(self) -> None:
+        with (
+            patch.object(version_utils.importlib.metadata, "distributions", return_value=[]),
+            patch.object(
+                version_utils.importlib.metadata,
+                "distribution",
+                side_effect=importlib.metadata.PackageNotFoundError,
+            ) as distribution_mock,
+        ):
+            get_install_source("griptape-nodes")
+            distribution_mock.assert_called_once_with("griptape-nodes")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
The engine rendered the startup "engine ready" banner and the library status table directly to the console, and the banner's single `Version` line reported only the engine version, which reads ambiguously next to the application version. Presentation of these (the banner copy that points users at the workflow editor, the library table styling, how versions are labeled) is an application concern, and having the engine look up the application package to show its version would couple the engine upward to the app.

This moves the rendering out of the engine. At the end of app initialization, and again after a library reload, the orchestrator broadcasts a data-only `EngineReadyEvent` carrying a `LibraryLoadStatus` per library. The application layer owns how that state is presented. `is_initial_start` lets the app show the ready banner only on first start while still refreshing the table on reload, preserving today's behavior where reload updates the table but does not reprint the banner. Workers do not announce readiness, matching the previous worker guard.

`get_install_source` and the new `format_version_string` are now package-agnostic so the app can describe its own distribution, rather than the engine hardcoding the app package name.

Because the event and its structured library data are broadcast (not just printed), other consumers such as the GUI and the desktop app can react to the same signal.

Paired with the `griptape-nodes-app` change that listens for this event and renders the table and banner: griptape-ai/griptape-nodes-app#160. That app PR depends on this landing in a released engine.