### PR TITLE
fix: set UNRESOLVED when serializing node with serializable=False params

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -4396,8 +4396,10 @@ class NodeManager:
 
         Returns the command to record on success. Returns None when there is nothing to record:
         either no value was present, the author opted out via serializable=False, or serialization
-        genuinely failed. In the genuine-failure case, also emits a warning and marks the node
-        UNRESOLVED — opt-outs are silent.
+        genuinely failed. Whenever a value was present but could not be recorded (opt-out OR
+        genuine failure) the node is marked UNRESOLVED so it re-runs on load and recomputes the
+        missing value; downstream consumers would otherwise see None (issue #4994). Only the
+        genuine-failure branch also emits a warning — opt-outs are silent.
 
         value_kind is "set" or "output" and is used only in the warning text.
         """
@@ -4416,14 +4418,17 @@ class NodeManager:
         )
         if command is not None:
             return command
+
+        # Non-serialisable parameter means node must be re-resolved when loaded.
+        if isinstance(create_node_request, CreateNodeRequest):
+            create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
+
         # Author opted out via serializable=False — silently skip; not a failure.
         if not parameter.serializable:
             return None
         # Genuine serialization failure — warn and mark unresolved.
         details = f"Attempted to serialize {value_kind} value for parameter '{parameter.name}' on node '{node.name}'. The {value_kind} value will not be restored in anything that attempts to deserialize or save this node. The value for this parameter was not serialized because it did not match Griptape Nodes' criteria for serializability. To remedy, either update the value's type to support serializability or mark the parameter as not serializable by setting serializable=False when creating the parameter."
         logger.warning(details)
-        if isinstance(create_node_request, CreateNodeRequest):
-            create_node_request.resolution = NodeResolutionState.UNRESOLVED.value
         return None
 
     @staticmethod

--- a/tests/e2e/fixtures/nonserializable_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/nonserializable_library/griptape_nodes_library.json
@@ -1,0 +1,36 @@
+{
+  "name": "NonSerializable Library",
+  "library_schema_version": "0.7.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library for the serializable=False resolution-state regression test (issue #4994)",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "ProducerNode",
+      "file_path": "nonserializable_nodes.py",
+      "metadata": {"category": "test", "description": "producer with non-serializable output", "display_name": "Producer"}
+    },
+    {
+      "class_name": "ConsumerNode",
+      "file_path": "nonserializable_nodes.py",
+      "metadata": {"category": "test", "description": "consumer that reads from producer", "display_name": "Consumer"}
+    }
+  ]
+}

--- a/tests/e2e/fixtures/nonserializable_library/nonserializable_nodes.py
+++ b/tests/e2e/fixtures/nonserializable_library/nonserializable_nodes.py
@@ -1,0 +1,76 @@
+"""Fixture nodes for the serializable=False resolution-state regression test (issue #4994).
+
+ProducerNode has a serializable=False output parameter that produces a Session object
+(a non-serializable runtime resource, like a driver or connection handle). ConsumerNode
+reads from the producer's output via a data connection and extracts a string from it.
+
+When the workflow is saved after running, the producer is RESOLVED but its output
+value is not persisted (serializable=False). On load, the producer must NOT remain
+RESOLVED — otherwise the consumer sees None instead of the recomputed value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class Session:
+    """A non-serializable runtime resource (analogous to a driver, connection handle, etc.)."""
+
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+
+class ProducerNode(DataNode):
+    """Produces a non-serializable Session output."""
+
+    EXPECTED_MARKER = "live-session-marker"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="session",
+                type="Session",
+                default_value=None,
+                tooltip="Non-serializable session output",
+                allowed_modes={ParameterMode.OUTPUT},
+                serializable=False,
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["session"] = Session(marker=self.EXPECTED_MARKER)
+
+
+class ConsumerNode(DataNode):
+    """Reads a Session from the producer and extracts its marker."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="session",
+                type="Session",
+                default_value=None,
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                serializable=False,
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="marker",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        session = self.get_parameter_value("session")
+        self.parameter_output_values["marker"] = session.marker

--- a/tests/e2e/test_nonserializable_resolution_state.py
+++ b/tests/e2e/test_nonserializable_resolution_state.py
@@ -1,0 +1,195 @@
+"""Regression test for issue #4994: serializable=False params must not retain RESOLVED state after save/load.
+
+When a node has a serializable=False output parameter and is saved in the RESOLVED state,
+the parameter value is (correctly) not persisted. But the RESOLVED state IS persisted,
+so on load the engine thinks the node has already run and skips recomputation. Any
+downstream node that reads from that parameter sees None instead of the recomputed value.
+
+The fix: nodes with serializable=False parameters that participate in connections must
+not be saved as RESOLVED, so they are recomputed on the next run after load.
+
+This test builds a Producer -> Consumer chain where the producer's output is a
+non-serializable Session object (analogous to a driver or connection handle), runs
+the flow so both nodes resolve, serializes the flow (the "save" step), then
+deserializes into a fresh flow (the "load" step). The producer must NOT be restored
+as RESOLVED, because its output value was not persisted.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    DeserializeFlowFromCommandsRequest,
+    DeserializeFlowFromCommandsResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "nonserializable_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "nonserializable_nodes.py"
+LIBRARY_NAME = "NonSerializable Library"
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+def _create_node(node_type: str, node_name: str, flow_name: str) -> str:
+    result = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY_NAME,
+            node_name=node_name,
+            override_parent_flow_name=flow_name,
+        )
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
+    result = GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name=source_param,
+            target_node_name=target_node,
+            target_parameter_name=target_param,
+        )
+    )
+    assert isinstance(result, CreateConnectionResultSuccess), result
+
+
+@pytest.fixture
+def _clean_engine_state() -> Iterator[None]:
+    """Keep the shared engine singleton clean despite running in-process."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    try:
+        yield
+    finally:
+        clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
+        with contextlib.suppress(KeyError):
+            LibraryRegistry.unregister_library(LIBRARY_NAME)
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"NonSerializable Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_clean_engine_state")
+async def test_serializable_false_output_reresolved_on_load(tmp_path: Path) -> None:
+    """A node with serializable=False output must not be re-resolved after save/load.
+
+    Steps:
+        1. Register fixture library, build Producer -> Consumer flow.
+        2. Run the flow so both nodes resolve and the consumer gets the producer's value.
+        3. Serialize the flow (save).
+        4. Clear state, create a fresh flow, deserialize (load).
+        5. Run the loaded flow — the consumer must get a recomputed Session, not None.
+    """
+    library_json = _materialize_library(tmp_path / "library")
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="nonserializable_test_wf")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="TestFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    flow_name = flow_result.flow_name
+
+    _create_node("ProducerNode", "Producer", flow_name)
+    _create_node("ConsumerNode", "Consumer", flow_name)
+    _connect("Producer", "session", "Consumer", "session")
+
+    # --- Step 2: Run the flow so both nodes become RESOLVED ---
+    run_result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=flow_name,
+            flow_node_name="Consumer",
+            wait_for_completion=True,
+            completion_timeout_ms=30_000,
+        )
+    )
+    assert isinstance(run_result, StartFlowResultSuccess), run_result
+
+    node_manager = GriptapeNodes.NodeManager()
+    producer = node_manager.get_node_by_name("Producer")
+    consumer = node_manager.get_node_by_name("Consumer")
+
+    assert producer.state == NodeResolutionState.RESOLVED, "Producer should be RESOLVED after running"
+    assert consumer.state == NodeResolutionState.RESOLVED, "Consumer should be RESOLVED after running"
+
+    produced_session = producer.parameter_output_values.get("session")
+    assert produced_session is not None, "Producer should have produced a Session"
+    assert produced_session.marker == "live-session-marker"
+    assert consumer.parameter_output_values.get("marker") == "live-session-marker"
+
+    # --- Step 3: Serialize (save) ---
+    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+    saved_commands = serialize_result.serialized_flow_commands
+
+    # --- Step 4: Clear state and deserialize (load) ---
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="nonserializable_test_wf_reloaded")
+
+    deserialize_result = GriptapeNodes.handle_request(
+        DeserializeFlowFromCommandsRequest(serialized_flow_commands=saved_commands)
+    )
+    assert isinstance(deserialize_result, DeserializeFlowFromCommandsResultSuccess), deserialize_result
+    loaded_flow = deserialize_result.flow_name
+
+    # --- Step 5: Run the loaded flow — consumer must get a recomputed Session, not None ---
+    restored_consumer_name = deserialize_result.node_name_mappings.get("Consumer", "Consumer")
+    run_result_2 = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=loaded_flow,
+            flow_node_name=restored_consumer_name,
+            wait_for_completion=True,
+            completion_timeout_ms=30_000,
+        )
+    )
+    assert isinstance(run_result_2, StartFlowResultSuccess), run_result_2
+
+    restored_consumer = node_manager.get_node_by_name(restored_consumer_name)
+    assert restored_consumer.parameter_output_values.get("marker") == "live-session-marker"

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -135,8 +135,15 @@ class TestNodeManagerResolutionStateSerialization:
         # Resolution should be reset to UNRESOLVED due to serialization failure
         assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
 
-    def test_serializable_false_param_does_not_warn_or_unresolve(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A parameter explicitly opting out via serializable=False must not trigger the warning or UNRESOLVED transition."""
+    def test_serializable_false_param_does_not_warn_but_becomes_unresolved(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A parameter opting out via serializable=False must not warn but MUST mark the node UNRESOLVED.
+
+        The value is intentionally not persisted, so the node must be re-run on load to
+        recompute it. Keeping the node RESOLVED would cause downstream consumers to see
+        None instead of the recomputed value (issue #4994).
+        """
         from unittest.mock import MagicMock
 
         from griptape_nodes.exe_types.core_types import Parameter
@@ -158,8 +165,6 @@ class TestNodeManagerResolutionStateSerialization:
             node_type="TestNode", node_name="test_node", resolution=NodeResolutionState.RESOLVED.value
         )
 
-        # Tracker reports NOT_IN_TRACKER so _handle_value_hashing enters the opt-out branch
-        # (parameter.serializable is False) and returns None.
         mock_tracker = MagicMock()
         mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_IN_TRACKER
 
@@ -176,7 +181,7 @@ class TestNodeManagerResolutionStateSerialization:
 
         warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert not any("Attempted to serialize" in msg for msg in warning_messages)
-        assert create_node_request.resolution == NodeResolutionState.RESOLVED.value
+        assert create_node_request.resolution == NodeResolutionState.UNRESOLVED.value
 
     def test_serializable_true_param_with_pickle_failure_still_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         """Genuine serialization failures (serializable=True) must still emit the warning."""


### PR DESCRIPTION
Closes #4994 

When a node has parameters that cannot be serialized, that node should be serialized with a state of UNRESOLVED so that it is always executed when loading a saved workflow, in order to repopulate the non-serializable parameter.

This was broken as a side effect of the fix in #4925, which retained the correct behaviour for a failed serialization, but short-circuited too early in the case of an explicit `serializable=False` parameter.

So move the pinning of the `CreateNodeRequest.resolution` state to `UNRESOLVED` to before the `serializable=False` short-circuit.