### PR TITLE
fix(execution): run independent nodes in a subflow group in parallel

### DIFF
--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -260,10 +260,14 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         Top-level runs and isolated subflows share one classifier and one seeding routine; they
         differ only in scope. A top-level run draws its categorized nodes from the global queue
         (already scoped by get_start_node_queue to exclude referenced subflows and group
-        children). An isolated subflow classifies its own nodes directly, applying the same
-        SubflowNodeGroup-child exclusion, since the global queue deliberately omits referenced
-        subflows. Either way the same seeding logic runs, so a data-only subflow resolves its
-        leaf nodes instead of stopping at the start node.
+        children). An isolated subflow classifies its own direct nodes and, unlike the top-level
+        run, does NOT drop group children: a node carries a parent_group only when it belongs to
+        the group that owns this very subflow (members are moved into their group's subflow), so
+        those children are exactly the nodes this run must resolve. A nested group appears as its
+        proxy node, which resolves here and executes its own subflow in turn, so nothing is
+        double-executed. Either way the same seeding logic runs, so a data-only subflow (or a
+        group of independent nodes) resolves all its leaf nodes in parallel instead of stopping
+        at the start node.
         """
         # Use the DagBuilder from the resolution machine context (may be isolated or global)
         dag_builder = self._context.resolution_machine.context.dag_builder
@@ -280,9 +284,13 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
 
         if is_isolated:
             subflow = flow_manager.get_flow_by_name(self._context.flow_name)
-            # Same scope decision as get_start_node_queue: SubflowNodeGroup children run inside
-            # their own group's subflow, so they must not be seeded directly into this DAG.
-            scope_nodes = flow_manager.exclude_subflow_group_children(list(subflow.nodes.values()))
+            # Scope is this subflow's own direct nodes. Do NOT apply exclude_subflow_group_children
+            # here (unlike get_start_node_queue): a node carries a parent_group only when it belongs
+            # to the group that owns this exact subflow, so its "group children" are precisely the
+            # nodes this run must resolve. A nested group is represented by its proxy node, whose
+            # own members live in the nested group's subflow, so excluding here would strand this
+            # group's independent nodes and let only the start node run.
+            scope_nodes = list(subflow.nodes.values())
             categories = flow_manager.classify_nodes_for_dag(scope_nodes)
             logger.debug("Seeding isolated subflow '%s' DAG from its own nodes", self._context.flow_name)
         else:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4542,8 +4542,11 @@ class FlowManager:
         """Drop nodes owned by a SubflowNodeGroup; they run inside their group's own subflow.
 
         This is a scope/ownership decision kept out of classify_nodes_for_dag so the classifier
-        stays scope-agnostic and is shared by both the top-level run and isolated subflow
-        execution. Both callers must apply it so the two paths cannot drift.
+        stays scope-agnostic. Only the top-level run (get_start_node_queue) applies it, to keep a
+        group's members from being seeded into the cross-flow DAG (they run when the group's proxy
+        node executes its subflow). The isolated-subflow path must NOT apply it: inside a group's
+        own subflow every member carries that group as its parent_group, so excluding them would
+        strand the members and seed only the start node.
         """
         return [node for node in nodes if not isinstance(node.parent_group, SubflowNodeGroup)]
 

--- a/tests/e2e/fixtures/subflow_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/subflow_library/griptape_nodes_library.json
@@ -32,6 +32,15 @@
       }
     },
     {
+      "class_name": "TimedEchoNode",
+      "file_path": "subflow_echo_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Async echo node that records start/end times for parallelism tests",
+        "display_name": "Timed Echo"
+      }
+    },
+    {
       "class_name": "SubflowGroupNode",
       "file_path": "subflow_echo_node.py",
       "metadata": {

--- a/tests/e2e/fixtures/subflow_library/subflow_echo_node.py
+++ b/tests/e2e/fixtures/subflow_library/subflow_echo_node.py
@@ -9,6 +9,8 @@ the subflow round-trip without corruption.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
@@ -31,6 +33,60 @@ class EchoNode(DataNode):
 
     def process(self) -> None:
         self.parameter_output_values["text"] = self.get_parameter_value("text") or ""
+
+
+class TimedEchoNode(DataNode):
+    """Echo node whose aprocess sleeps and records its start/end wall-clock times.
+
+    Independent instances that resolve concurrently will have overlapping
+    [start_ts, end_ts] intervals; instances forced to run serially will not.
+    Used to assert parallel execution inside a SubflowNodeGroup.
+    """
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="Text to echo",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="delay",
+                tooltip="Seconds to sleep during processing",
+                type="float",
+                default_value=0.3,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="start_ts",
+                tooltip="monotonic() time when processing started",
+                type="float",
+                default_value=0.0,
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="end_ts",
+                tooltip="monotonic() time when processing finished",
+                type="float",
+                default_value=0.0,
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    async def aprocess(self) -> None:
+        self.parameter_output_values["start_ts"] = time.monotonic()
+        await asyncio.sleep(self.get_parameter_value("delay") or 0.0)
+        self.parameter_output_values["text"] = self.get_parameter_value("text") or ""
+        self.parameter_output_values["end_ts"] = time.monotonic()
 
 
 class SubflowGroupNode(SubflowNodeGroup):

--- a/tests/e2e/test_subflow_group_parallel_execution.py
+++ b/tests/e2e/test_subflow_group_parallel_execution.py
@@ -1,0 +1,166 @@
+"""Regression test for issue #4920: independent nodes in a SubflowNodeGroup must run in parallel.
+
+Running a Subflow Node Group executes the group's own subflow through the isolated-subflow DAG
+path. That path used to reuse the top-level `exclude_subflow_group_children` scope filter, which
+drops every node whose `parent_group` is set. Inside a group's own subflow *all* members carry
+that parent_group, so the filter stranded them: only the single start node got seeded and the
+other independent nodes never resolved (let alone ran concurrently).
+
+This test builds a group of independent nodes, runs it under PARALLEL mode, and asserts every
+child resolves and their processing intervals overlap, matching the parallel behavior of a
+top-level workflow run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+# Distinct from the "Subflow Library" name used by test_subflow_execution.py: both register the
+# fixture in-process, and the LibraryManager's LOADED bookkeeping leaks across tests sharing a
+# worker, so a shared name makes whichever test runs second fail to re-register.
+LIBRARY_NAME = "Subflow Group Parallel Library"
+_NODE_COUNT = 3
+_DELAY_SECONDS = 0.4
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["name"] = LIBRARY_NAME
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+@pytest.fixture
+def _clean_engine_state() -> Iterator[None]:
+    """Keep the shared engine singleton clean despite running in-process."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    yield
+    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
+    with contextlib.suppress(KeyError):
+        LibraryRegistry.unregister_library(LIBRARY_NAME)
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_clean_engine_state")
+async def test_group_runs_independent_nodes_in_parallel(tmp_path: Path) -> None:
+    """Every independent child of a group resolves, and they overlap in time under PARALLEL mode."""
+    library_json = _materialize_library(tmp_path / "library")
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    config_manager = GriptapeNodes.ConfigManager()
+    prior_mode = config_manager.get_config_value("workflow_execution_mode")
+    prior_max = config_manager.get_config_value("max_nodes_in_parallel")
+    config_manager.set_config_value("workflow_execution_mode", "parallel")
+    config_manager.set_config_value("max_nodes_in_parallel", 5)
+
+    try:
+        GriptapeNodes.ContextManager().push_workflow(workflow_name="repro_4920_wf")
+
+        parent_result = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+        )
+        assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
+        parent_flow = parent_result.flow_name
+
+        with GriptapeNodes.ContextManager().flow(parent_flow):
+            group_result = GriptapeNodes.handle_request(
+                CreateNodeRequest(
+                    node_type="SubflowGroupNode",
+                    specific_library_name=LIBRARY_NAME,
+                    node_name="Group_1",
+                )
+            )
+            assert isinstance(group_result, CreateNodeResultSuccess), group_result
+
+            node_names = []
+            for i in range(_NODE_COUNT):
+                node_result = GriptapeNodes.handle_request(
+                    CreateNodeRequest(
+                        node_type="TimedEchoNode",
+                        specific_library_name=LIBRARY_NAME,
+                        node_name=f"Timed_{i}",
+                        parent_group_name=group_result.node_name,
+                    )
+                )
+                assert isinstance(node_result, CreateNodeResultSuccess), node_result
+                node_names.append(node_result.node_name)
+
+        for i, name in enumerate(node_names):
+            GriptapeNodes.handle_request(
+                SetParameterValueRequest(parameter_name="text", node_name=name, value=f"n-{i}")
+            )
+            GriptapeNodes.handle_request(
+                SetParameterValueRequest(parameter_name="delay", node_name=name, value=_DELAY_SECONDS)
+            )
+
+        run_result = await GriptapeNodes.ahandle_request(
+            StartFlowRequest(
+                flow_name=parent_flow,
+                flow_node_name=group_result.node_name,
+                wait_for_completion=True,
+                completion_timeout_ms=30000,
+            )
+        )
+        assert isinstance(run_result, StartFlowResultSuccess), run_result
+    finally:
+        config_manager.set_config_value("workflow_execution_mode", prior_mode)
+        config_manager.set_config_value("max_nodes_in_parallel", prior_max)
+
+    node_manager = GriptapeNodes.NodeManager()
+    intervals = []
+    for i, name in enumerate(node_names):
+        node = node_manager.get_node_by_name(name)
+        # Before the fix only the first child was seeded; the rest stayed unresolved.
+        assert node.state == NodeResolutionState.RESOLVED, f"{name} did not resolve (state={node.state})"
+        assert node.parameter_output_values.get("text") == f"n-{i}"
+        start = node.parameter_output_values.get("start_ts")
+        end = node.parameter_output_values.get("end_ts")
+        assert start, f"{name} missing start_ts output"
+        assert end, f"{name} missing end_ts output"
+        intervals.append((start, end))
+
+    # Concurrent execution means the latest start happens before the earliest end.
+    latest_start = max(start for start, _ in intervals)
+    earliest_end = min(end for _, end in intervals)
+    assert latest_start < earliest_end, (
+        f"Independent group nodes did not overlap in time (serial execution): intervals={intervals}"
+    )

--- a/tests/unit/machines/test_control_flow.py
+++ b/tests/unit/machines/test_control_flow.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
 from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.machines.control_flow import ControlFlowMachine
 from griptape_nodes.machines.dag_builder import DagBuilder, DagNodeCategories
@@ -160,3 +163,52 @@ class TestSeedDagFromCategories:
         # Already-present sinks short-circuit before any connectivity check.
         flow_manager.is_node_connected.assert_not_called()
         assert dag_builder.start_node_candidates == {}
+
+
+class TestProcessNodesForDagIsolatedScope:
+    """Tests for ControlFlowMachine._process_nodes_for_dag isolated-subflow scope selection.
+
+    A SubflowNodeGroup's own subflow runs on the isolated path, and its direct nodes are the
+    group's members, which all carry the owning group as their parent_group. The isolated scope
+    must therefore be the subflow's nodes as-is: running them through the top-level
+    exclude_subflow_group_children filter would drop every member and seed only the start node,
+    so only one node would resolve.
+    """
+
+    @pytest.mark.asyncio
+    async def test_isolated_scope_keeps_group_children(self, griptape_nodes: GriptapeNodes) -> None:
+        machine = ControlFlowMachine("grp_subflow", is_isolated=True)
+        # Swap the fresh DagBuilder for a stub: add_node_with_dependencies becomes a no-op, and the
+        # is_isolated check (dag_builder is not the global one) still holds for a MagicMock.
+        machine.context.resolution_machine.context.dag_builder = MagicMock()
+
+        group = MagicMock(spec=SubflowNodeGroup)
+        child_a = _mock_node("child_a")
+        child_a.parent_group = group
+        child_b = _mock_node("child_b")
+        child_b.parent_group = group
+        subflow = MagicMock()
+        subflow.nodes = {"child_a": child_a, "child_b": child_b}
+
+        flow_manager = griptape_nodes.FlowManager()
+        captured: dict[str, list[BaseNode]] = {}
+
+        def fake_classify(nodes: list[BaseNode]) -> DagNodeCategories:
+            captured["scope"] = list(nodes)
+            return DagNodeCategories(start_nodes=[], control_nodes=[], data_sink_nodes=list(nodes))
+
+        with (
+            patch.object(flow_manager, "get_flow_by_name", return_value=subflow),
+            patch.object(flow_manager, "classify_nodes_for_dag", side_effect=fake_classify),
+            patch.object(ControlFlowMachine, "_seed_dag_from_categories", return_value=[child_a]) as seed,
+        ):
+            entry_nodes = await machine._process_nodes_for_dag(child_a)
+
+        # Both group members reach the classifier; the group-child filter is not applied here.
+        assert {node.name for node in captured["scope"]} == {"child_a", "child_b"}
+        # Applying the top-level filter to this scope would drop everything, which is exactly the
+        # behavior the isolated path must avoid.
+        assert flow_manager.exclude_subflow_group_children(captured["scope"]) == []
+        # The categories built from the full scope are what get seeded.
+        assert entry_nodes == [child_a]
+        seed.assert_called_once()

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -667,8 +667,9 @@ class TestExcludeSubflowGroupChildren:
     """Tests for FlowManager.exclude_subflow_group_children.
 
     This scope/ownership filter drops nodes owned by a SubflowNodeGroup so they are not seeded
-    directly into a DAG (they run inside their group's own subflow). Both the top-level queue
-    and the isolated-subflow path apply it, so it must behave identically for either caller.
+    directly into a DAG (they run inside their group's own subflow). The top-level queue applies
+    it to keep group members out of the cross-flow run; the isolated-subflow path deliberately
+    does NOT, because within a group's own subflow those members are exactly what must resolve.
     """
 
     def test_drops_only_subflow_group_children(self, griptape_nodes: GriptapeNodes) -> None:


### PR DESCRIPTION
Closes #4920. Closes #5032.

Running a Subflow Node Group executes the group's own subflow through the isolated-subflow DAG path in `_process_nodes_for_dag`. That path reused the top-level `exclude_subflow_group_children` scope filter, which drops every node whose `parent_group` is set. Inside a group's own subflow every member carries that group as its `parent_group`, so the filter stranded them.

That single filter caused two observable bugs. `_process_nodes_for_dag` seeds one explicit start node up front and then relies on the classified scope for the rest; with the scope emptied by the filter, the DAG contained only that one seeded node. For a group of independent nodes this meant only the first node ran and the others were skipped entirely while the run still reported success (#5032). For connected members the forward-control walk still dragged nodes in but ran them one after another instead of concurrently (#4920).

The filter is only meaningful for the top-level run, where it keeps a group's members out of the cross-flow DAG so they run when the group's proxy node executes its subflow. The isolated path instead seeds the subflow's own direct nodes as-is: a node carries a `parent_group` only when it belongs to the group that owns that exact subflow, so those members are precisely what the run must resolve. A nested group still shows up as its proxy node and executes its own subflow in turn, so nothing runs twice, and the referenced-subflow case is unaffected because those flows have no group-child direct nodes.

With seeding fixed, the group's subflow resolves through the same `ParallelResolutionMachine` and `max_nodes_in_parallel` config as a top-level run, so every independent member resolves and they run concurrently. The new e2e test builds a group of independent nodes, runs it under `parallel` mode, and asserts every child resolves and their processing intervals overlap.