### PR TITLE
get_library_info_by_library_name to return valid library

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -241,6 +241,7 @@ from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, normaliz
 from griptape_nodes.utils.file_utils import find_file_in_directory, find_files_recursive
 from griptape_nodes.utils.git_utils import (
     GitCloneError,
+    GitError,
     GitPullError,
     GitRefError,
     GitRemoteError,
@@ -252,6 +253,7 @@ from griptape_nodes.utils.git_utils import (
     get_git_remote,
     get_local_commit_sha,
     is_git_url,
+    is_on_tag,
     normalize_github_url,
     parse_git_url_with_ref,
     remote_ref_exists,
@@ -731,10 +733,21 @@ class LibraryManager:
         return self._library_file_path_to_info[library_file_path]
 
     def get_library_info_by_library_name(self, library_name: str) -> LibraryInfo | None:
-        for library_info in self._library_file_path_to_info.values():
-            if library_info.library_name == library_name:
+        # A library name can have more than one entry: a duplicate install registers a second
+        # copy that fails with DuplicateLibraryProblem but is deliberately kept in the dict
+        # (marked FAILURE) so the GUI can surface it, and filename variations / download +
+        # discovery collisions can key the same name under two paths. Prefer the copy that is
+        # actually LOADED (the one in LibraryRegistry, whose version the update-check reads) so
+        # every caller resolves the live copy rather than a dead duplicate. This keeps the
+        # update path, the update-check path, and the on-disk copy consistent (issue #5039).
+        # Fall back to first-match when nothing is loaded yet (e.g. discovery / worker-pending).
+        matches = [info for info in self._library_file_path_to_info.values() if info.library_name == library_name]
+        if not matches:
+            return None
+        for library_info in matches:
+            if library_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED:
                 return library_info
-        return None
+        return matches[0]
 
     def resolve_transitive_library_deps(
         self,
@@ -2737,10 +2750,17 @@ class LibraryManager:
         self._unregister_all_stable_module_aliases_for_library(request.library_name)
 
         # Remove the library from our library info list. This prevents it from still showing
-        # up in the table of attempted library loads.
-        lib_info = self.get_library_info_by_library_name(request.library_name)
-        if lib_info:
-            del self._library_file_path_to_info[lib_info.library_path]
+        # up in the table of attempted library loads. Remove ALL entries for this name, not
+        # just the first: a duplicately-registered library (e.g. two on-disk copies, or a
+        # filename variation left behind by a git operation) would otherwise keep a stale
+        # entry alive, which desynchronizes the update and update-check paths.
+        stale_paths = [
+            file_path
+            for file_path, library_info in self._library_file_path_to_info.items()
+            if library_info.library_name == request.library_name
+        ]
+        for file_path in stale_paths:
+            del self._library_file_path_to_info[file_path]
         details = f"Successfully unloaded (and unregistered) library '{request.library_name}'."
         return UnloadLibraryFromRegistryResultSuccess(result_details=details)
 
@@ -5321,16 +5341,14 @@ class LibraryManager:
             details = f"Attempted to check for updates for Library '{library_name}'. Failed because no Library with that name was registered."
             return CheckLibraryUpdateResultFailure(result_details=details)
 
-        # Find the library file path
-        library_file_path = None
-        for file_path, library_info in self._library_file_path_to_info.items():
-            if library_info.library_name == library_name:
-                library_file_path = file_path
-                break
-
-        if library_file_path is None:
+        # Find the library file path. Route through the shared resolver so the update path
+        # (_validate_and_prepare_library_for_git_operation) and this check path can never
+        # disagree about which on-disk copy a duplicately-registered library maps to.
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None:
             details = f"Attempted to check for updates for Library '{library_name}'. Failed because no file path could be found for this library."
             return CheckLibraryUpdateResultFailure(result_details=details)
+        library_file_path = library_info.library_path
 
         # Get the library directory (parent of the JSON file)
         library_dir = Path(library_file_path).parent.absolute()
@@ -5503,16 +5521,14 @@ class LibraryManager:
             details = f"Library '{library_name}' has no version information."
             return failure_result_class(result_details=details)
 
-        # Find the library file path
-        library_file_path = None
-        for file_path, library_info in self._library_file_path_to_info.items():
-            if library_info.library_name == library_name:
-                library_file_path = file_path
-                break
-
-        if library_file_path is None:
+        # Find the library file path. Route through the shared resolver so this update path
+        # and check_library_update_request can never disagree about which on-disk copy a
+        # duplicately-registered library maps to.
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None:
             details = f"Attempted to {operation_description} Library '{library_name}'. Failed because no file path could be found for this library."
             return failure_result_class(result_details=details)
+        library_file_path = library_info.library_path
 
         # Get the library directory (parent of the JSON file)
         library_dir = Path(library_file_path).parent.absolute()
@@ -5561,6 +5577,20 @@ class LibraryManager:
 
         # Use the found file path for reloading
         actual_library_file_path = str(actual_library_file)
+
+        # Drop any lingering entries for this library before reinserting. The git operation may
+        # resolve the JSON under a different filename (griptape_nodes_library.json vs
+        # griptape-nodes-library.json), which would otherwise leave the pre-operation entry keyed
+        # under the old filename alongside the new one. Two live entries for one name let the
+        # update and update-check paths resolve different on-disk copies, producing a permanent
+        # "update available" loop.
+        stale_paths = [
+            file_path
+            for file_path, existing_info in self._library_file_path_to_info.items()
+            if existing_info.library_name == library_name
+        ]
+        for file_path in stale_paths:
+            del self._library_file_path_to_info[file_path]
 
         # Create LibraryInfo for tracking this library reload
         lib_info = LibraryManager.LibraryInfo(
@@ -5639,6 +5669,31 @@ class LibraryManager:
                 retryable=retryable,
                 existing_path=str(library_dir) if retryable else None,
             )
+
+        # After a moving-tag update, the local HEAD should match the commit the remote tag
+        # resolves to. If it does not, the next update check will report "update available"
+        # forever (the loop from issue #5039). Surface it loudly rather than looping silently.
+        # This is diagnostic only and never fails the update. Restricted to tag-based (detached
+        # HEAD) libraries: a branch update does `git reset --hard` to remote HEAD, so it always
+        # converges and would only pay for an extra remote clone with nothing to report.
+        try:
+            if await asyncio.to_thread(is_on_tag, library_dir):
+                local_commit = await asyncio.to_thread(get_local_commit_sha, library_dir)
+                git_remote = await asyncio.to_thread(get_git_remote, library_dir)
+                git_ref = await asyncio.to_thread(get_current_ref, library_dir)
+                if local_commit is not None and git_remote is not None:
+                    version_info = await asyncio.to_thread(clone_and_get_library_version, git_remote, git_ref or "HEAD")
+                    if local_commit != version_info.commit_sha:
+                        logger.warning(
+                            "After updating Library '%s' on ref '%s', local commit %s does not match "
+                            "remote commit %s. Update checks may keep reporting an available update.",
+                            library_name,
+                            git_ref,
+                            local_commit,
+                            version_info.commit_sha,
+                        )
+        except GitError as e:
+            logger.debug("Skipped post-update commit verification for Library '%s': %s", library_name, e)
 
         # Reload library
         reload_result = await self._reload_library_after_git_operation(

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -46,6 +46,9 @@ from griptape_nodes.retained_mode.events.library_events import (
     LoadLibraryMetadataFromFileResultSuccess,
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultFailure,
+    RegisterLibraryFromFileResultSuccess,
+    UnloadLibraryFromRegistryRequest,
+    UnloadLibraryFromRegistryResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager as _LibraryManager
@@ -3452,3 +3455,164 @@ class TestLibraryFitnessAuthorizationCheckpoint:
         assert len(problems) == 1
         assert problems[0].node_type == "LabsNode"
         assert "Ask your admin to enable Labs nodes." in problems[0].collate_problems_for_display(problems)
+
+
+class TestLibraryManagerDuplicateEntryHygiene:
+    """Regression tests for issue #5039.
+
+    A library that ends up with more than one entry in `_library_file_path_to_info` (a duplicate
+    install, or a filename variation left behind by a git operation) desynchronizes the update and
+    update-check paths, producing a permanent "update available" loop. The fix keeps the dict free
+    of duplicates and routes both paths through the same resolver.
+    """
+
+    def _lib_info(
+        self,
+        library_manager: _LibraryManager,
+        path: str,
+        name: str,
+        lifecycle_state: _LibraryManager.LibraryLifecycleState = _LibraryManager.LibraryLifecycleState.LOADED,
+    ) -> _LibraryManager.LibraryInfo:
+        return library_manager.LibraryInfo(
+            lifecycle_state=lifecycle_state,
+            library_path=path,
+            is_sandbox=False,
+            library_name=name,
+            library_version="0.81.0",
+            fitness=_LibraryManager.LibraryFitness.GOOD,
+            problems=[],
+        )
+
+    def test_unload_removes_all_entries_for_library_name(self, griptape_nodes: GriptapeNodes) -> None:
+        """Unload must drop every entry for the name, not just the first, so no stale copy lingers."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        # Two on-disk copies registered under one name: one on `main`, one on `stable`. Both
+        # report the same version but live at different paths (the #5039 scenario).
+        entries = {
+            "/libs/copyA/griptape_nodes_library.json": self._lib_info(
+                library_manager, "/libs/copyA/griptape_nodes_library.json", "MyLib"
+            ),
+            "/libs/copyB/griptape-nodes-library.json": self._lib_info(
+                library_manager, "/libs/copyB/griptape-nodes-library.json", "MyLib"
+            ),
+        }
+
+        with (
+            patch.object(library_manager, "_library_file_path_to_info", entries),
+            patch.object(LibraryRegistry, "unregister_library"),
+            patch.object(library_manager, "_unregister_all_stable_module_aliases_for_library"),
+        ):
+            result = library_manager.unload_library_from_registry_request(
+                UnloadLibraryFromRegistryRequest(library_name="MyLib")
+            )
+
+        assert isinstance(result, UnloadLibraryFromRegistryResultSuccess)
+        # No entry for MyLib should survive the unload.
+        remaining = [info for info in entries.values() if info.library_name == "MyLib"]
+        assert remaining == []
+        assert entries == {}
+
+    def test_reload_collapses_duplicate_entries_to_one(self, griptape_nodes: GriptapeNodes) -> None:
+        """Reload must collapse duplicate entries to one.
+
+        It must not leave a pre-operation entry alongside the reloaded one when the git operation
+        resolves the JSON under a different filename.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+
+        # Pre-operation entry keyed under the dashed filename.
+        old_path = "/libs/copy/griptape-nodes-library.json"
+        # The git operation resolves the underscore filename on disk.
+        new_path = "/libs/copy/griptape_nodes_library.json"
+        entries = {old_path: self._lib_info(library_manager, old_path, "MyLib")}
+
+        mock_library = MagicMock()
+        mock_library.get_metadata.return_value = MagicMock(library_version="0.81.0")
+
+        with (
+            patch.object(library_manager, "_library_file_path_to_info", entries),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.handle_request",
+                return_value=UnloadLibraryFromRegistryResultSuccess(result_details="ok"),
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.find_file_in_directory",
+                return_value=Path(new_path),
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ahandle_request",
+                AsyncMock(return_value=RegisterLibraryFromFileResultSuccess(library_name="MyLib", result_details="ok")),
+            ),
+            patch.object(LibraryRegistry, "get_library", return_value=mock_library),
+        ):
+            result = asyncio.run(
+                library_manager._reload_library_after_git_operation(
+                    library_name="MyLib",
+                    library_file_path=old_path,
+                    failure_result_class=RegisterLibraryFromFileResultFailure,
+                )
+            )
+
+        assert result == "0.81.0"
+        # Exactly one entry for MyLib, keyed under the reloaded filename.
+        mylib_paths = [path for path, info in entries.items() if info.library_name == "MyLib"]
+        assert mylib_paths == [new_path]
+
+    def test_resolver_prefers_loaded_copy_over_failed_duplicate(self, griptape_nodes: GriptapeNodes) -> None:
+        """The resolver must return the LOADED copy, not a dead duplicate.
+
+        A duplicate install keeps a second entry marked FAILURE (DuplicateLibraryProblem) in the
+        dict, inserted BEFORE the loaded copy in some orderings. First-match would resolve the
+        dead copy whose on-disk state the update path can never make agree with the loaded copy's
+        version, producing a permanent "update available" loop (issue #5039). Preferring the LOADED
+        entry keeps path resolution consistent with the copy whose version the check reads.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+
+        # The FAILURE duplicate is inserted first, so first-match would pick it.
+        entries = {
+            "/libs/dead/griptape_nodes_library.json": self._lib_info(
+                library_manager,
+                "/libs/dead/griptape_nodes_library.json",
+                "MyLib",
+                lifecycle_state=_LibraryManager.LibraryLifecycleState.FAILURE,
+            ),
+            "/libs/loaded/griptape_nodes_library.json": self._lib_info(
+                library_manager,
+                "/libs/loaded/griptape_nodes_library.json",
+                "MyLib",
+                lifecycle_state=_LibraryManager.LibraryLifecycleState.LOADED,
+            ),
+        }
+
+        with patch.object(library_manager, "_library_file_path_to_info", entries):
+            info = library_manager.get_library_info_by_library_name("MyLib")
+
+        assert info is not None
+        assert info.library_path == "/libs/loaded/griptape_nodes_library.json"
+
+    def test_resolver_falls_back_to_first_match_when_none_loaded(self, griptape_nodes: GriptapeNodes) -> None:
+        """With no LOADED copy (e.g. discovery / worker-pending), the resolver keeps first-match."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        entries = {
+            "/libs/copyA/griptape_nodes_library.json": self._lib_info(
+                library_manager,
+                "/libs/copyA/griptape_nodes_library.json",
+                "MyLib",
+                lifecycle_state=_LibraryManager.LibraryLifecycleState.WORKER_PENDING,
+            ),
+            "/libs/copyB/griptape_nodes_library.json": self._lib_info(
+                library_manager,
+                "/libs/copyB/griptape_nodes_library.json",
+                "MyLib",
+                lifecycle_state=_LibraryManager.LibraryLifecycleState.DISCOVERED,
+            ),
+        }
+
+        with patch.object(library_manager, "_library_file_path_to_info", entries):
+            info = library_manager.get_library_info_by_library_name("MyLib")
+
+        assert info is not None
+        assert info.library_path == "/libs/copyA/griptape_nodes_library.json"

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -3555,9 +3555,11 @@ class TestLibraryManagerDuplicateEntryHygiene:
             )
 
         assert result == "0.81.0"
-        # Exactly one entry for MyLib, keyed under the reloaded filename.
+        # Exactly one entry for MyLib, keyed under the reloaded filename. The reload stores
+        # str(Path(...)), so normalize the expected key the same way for cross-platform parity
+        # (Windows renders the separators as backslashes).
         mylib_paths = [path for path, info in entries.items() if info.library_name == "MyLib"]
-        assert mylib_paths == [new_path]
+        assert mylib_paths == [str(Path(new_path))]
 
     def test_resolver_prefers_loaded_copy_over_failed_duplicate(self, griptape_nodes: GriptapeNodes) -> None:
         """The resolver must return the LOADED copy, not a dead duplicate.


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/5039

Before: get_library_info_by_library_name returned the first dict match. With a duplicate library, that could be the dead FAILURE copy instead of the LOADED one. That's a latent bug affecting 14 call sites — update, update-check, switch-ref, workflow packaging, the static server, dependency resolution. Any of them could operate on a dead copy.

After: they all resolve the copy that's actually loaded and in LibraryRegistry.