### PR TITLE
fix(agent): persist provider enabled/icon fields

### DIFF
--- a/src/griptape_nodes/retained_mode/events/agent_events.py
+++ b/src/griptape_nodes/retained_mode/events/agent_events.py
@@ -22,6 +22,8 @@ class ProviderConfig(BaseModel):
     model: str
     base_url: str | None = None
     api_key_secret_name: str | None = None
+    enabled: bool = True
+    icon: str | None = None
 
 
 class PromptDriverConfig(BaseModel):
@@ -40,6 +42,8 @@ class CreateProviderPayload(BaseModel):
     model: str = ""
     base_url: str | None = None
     api_key_secret_name: str | None = None
+    enabled: bool = True
+    icon: str | None = None
 
 
 class UpdateProviderPayload(BaseModel):
@@ -49,6 +53,8 @@ class UpdateProviderPayload(BaseModel):
     model: str | None = None
     base_url: str | None = None
     api_key_secret_name: str | None = None
+    enabled: bool | None = None
+    icon: str | None = None
 
     @field_validator("type", "model")
     @classmethod

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -781,6 +781,8 @@ class AgentManager:
             model=pd.model or (MODEL_CHOICES[0] if MODEL_CHOICES else "gpt-4o"),
             base_url=pd.base_url or None,
             api_key_secret_name=api_key_secret_name,
+            enabled=pd.enabled,
+            icon=pd.icon or None,
         )
         self._providers.append(provider)
         self._persist_providers()
@@ -798,6 +800,10 @@ class AgentManager:
             return UpdateAgentProviderResultFailure(
                 result_details=f"Attempted to update provider '{request.name}'. Failed because type '{pd.type}' is not a known preset id."
             )
+        if pd.enabled is False and request.name == _PROTECTED_PROVIDER_NAME:
+            return UpdateAgentProviderResultFailure(
+                result_details=f"Attempted to update provider '{request.name}'. Failed because it is a protected provider and cannot be disabled."
+            )
         if pd.type is not None:
             existing.type = pd.type
         if pd.model is not None:
@@ -807,6 +813,10 @@ class AgentManager:
         if "api_key_secret_name" in pd.model_fields_set and provider_accepts_customer_key(existing.type):
             raw = pd.api_key_secret_name or ""
             existing.api_key_secret_name = SecretsManager._apply_secret_name_compliance(raw) if raw else None
+        if pd.enabled is not None:
+            existing.enabled = pd.enabled
+        if "icon" in pd.model_fields_set:
+            existing.icon = pd.icon or None
         self._persist_providers()
         self._runner_cache.clear()
         return UpdateAgentProviderResultSuccess(result_details=f"Provider '{request.name}' updated successfully.")

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -417,6 +417,27 @@ class TestCreateAgentProvider:
         assert isinstance(result, CreateAgentProviderResultFailure)
         assert "vllm" in str(result.result_details)
 
+    def test_create_persists_enabled_and_icon(self, providers_manager: AgentManager) -> None:
+        result = providers_manager.on_handle_create_agent_provider_request(
+            CreateAgentProviderRequest(
+                provider=CreateProviderPayload(name="home-ollama", type="ollama", enabled=False, icon="server")
+            )
+        )
+
+        assert isinstance(result, CreateAgentProviderResultSuccess)
+        created = next(p for p in providers_manager._providers if p.name == "home-ollama")
+        assert created.enabled is False
+        assert created.icon == "server"
+
+    def test_create_defaults_to_enabled(self, providers_manager: AgentManager) -> None:
+        providers_manager.on_handle_create_agent_provider_request(
+            CreateAgentProviderRequest(provider=CreateProviderPayload(name="home-ollama", type="ollama"))
+        )
+
+        created = next(p for p in providers_manager._providers if p.name == "home-ollama")
+        assert created.enabled is True
+        assert created.icon is None
+
     def test_create_all_valid_types_accepted(self, providers_manager: AgentManager) -> None:
         for provider_type in _VALID_PROVIDER_TYPES:
             unique_name = f"test-{provider_type}"
@@ -479,6 +500,56 @@ class TestUpdateAgentProvider:
 
         assert isinstance(result, UpdateAgentProviderResultFailure)
         assert "sglang" in str(result.result_details)
+
+    def test_update_toggles_enabled(self, providers_manager: AgentManager) -> None:
+        result = providers_manager.on_handle_update_agent_provider_request(
+            UpdateAgentProviderRequest(name="my-ollama", provider=UpdateProviderPayload(enabled=False))
+        )
+
+        assert isinstance(result, UpdateAgentProviderResultSuccess)
+        updated = next(p for p in providers_manager._providers if p.name == "my-ollama")
+        assert updated.enabled is False
+        assert updated.model == "llama3.2"  # untouched
+
+        providers_manager.on_handle_update_agent_provider_request(
+            UpdateAgentProviderRequest(name="my-ollama", provider=UpdateProviderPayload(enabled=True))
+        )
+
+        assert updated.enabled is True
+
+    def test_update_preserves_enabled_when_omitted(self, providers_manager: AgentManager) -> None:
+        provider = next(p for p in providers_manager._providers if p.name == "my-ollama")
+        provider.enabled = False
+
+        providers_manager.on_handle_update_agent_provider_request(
+            UpdateAgentProviderRequest(name="my-ollama", provider=UpdateProviderPayload(model="phi3"))
+        )
+
+        assert provider.enabled is False
+
+    def test_update_sets_and_clears_icon(self, providers_manager: AgentManager) -> None:
+        providers_manager.on_handle_update_agent_provider_request(
+            UpdateAgentProviderRequest(name="my-ollama", provider=UpdateProviderPayload(icon="server"))
+        )
+
+        updated = next(p for p in providers_manager._providers if p.name == "my-ollama")
+        assert updated.icon == "server"
+
+        providers_manager.on_handle_update_agent_provider_request(
+            UpdateAgentProviderRequest(name="my-ollama", provider=UpdateProviderPayload(icon=""))
+        )
+
+        assert updated.icon is None
+
+    def test_update_fails_when_disabling_protected_provider(self, providers_manager: AgentManager) -> None:
+        result = providers_manager.on_handle_update_agent_provider_request(
+            UpdateAgentProviderRequest(name="griptape_cloud", provider=UpdateProviderPayload(enabled=False))
+        )
+
+        assert isinstance(result, UpdateAgentProviderResultFailure)
+        assert "protected" in str(result.result_details)
+        protected = next(p for p in providers_manager._providers if p.name == "griptape_cloud")
+        assert protected.enabled is True
 
     def test_update_valid_type_change_succeeds(self, providers_manager: AgentManager) -> None:
         result = providers_manager.on_handle_update_agent_provider_request(


### PR DESCRIPTION
The sidebar agent provider enable/disable toggle never survived a reload. The GUI sends `enabled` (and `icon`) on `CreateAgentProviderRequest`/`UpdateAgentProviderRequest`, but `ProviderConfig` and the create/update payloads had no such fields, so pydantic silently dropped them and the request still reported success. On the next `ListAgentProvidersRequest` the field came back absent and the UI treats that as enabled, so a disabled provider snapped back on every session. Same gap for custom provider icons.

Both fields now live on `ProviderConfig`, which persists them to `agent.providers` for free via the existing `model_dump`/`model_validate` round trip. The update handler applies them with the same `model_fields_set` partial-update semantics as `base_url`, and `griptape_cloud` cannot be disabled since it is synthesized on load and its row hides the toggle anyway.

Verified end to end in an isolated engine+editor stack: toggling a local Ollama provider off, reloading the editor, and confirming the row stays disabled and `agent.providers[].enabled` is written to the config file.
(underwhelming AI video, I verified this myself too)
[provider-persist-demo.webm](https://github.com/user-attachments/assets/88cd7e99-6364-4d2d-ae8e-f9545f3bca7c)


Fixes griptape-ai/griptape-vsl-gui#2615.
