### PR TITLE
feat: scaffold workspace skills directory when building agent runner

### DIFF
--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -69,6 +69,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
+DEFAULT_SKILLS_DIRECTORY = ".agents/skills"
+
 
 TokenSink = "Callable[[str], Awaitable[None] | None]"
 """Callback that receives streamed text tokens for relay to clients."""
@@ -159,7 +161,7 @@ class PydanticAgentRunner:
     image_config: ImageGenerationToolsetConfig | None = None
     static_files_manager: StaticFilesManager | None = None
     auto_load_skills: bool = True
-    skills_directory: str = ".agents/skills"
+    skills_directory: str = DEFAULT_SKILLS_DIRECTORY
     usage_limits: UsageLimits | None = None
 
     _agent: Agent[Any, str] = field(init=False)

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -38,6 +38,7 @@ from xdg_base_dirs import xdg_data_home
 from griptape_nodes.agents.pydantic_ai.image_tools import GRIPTAPE_CLOUD_BASE_URL, ImageGenerationToolsetConfig
 from griptape_nodes.agents.pydantic_ai.mcp_servers import mcp_server_from_config, streamable_http_local
 from griptape_nodes.agents.pydantic_ai.runner import (
+    DEFAULT_SKILLS_DIRECTORY,
     PydanticAgentRunner,
     RunEvent,
     TextDelta,
@@ -231,6 +232,34 @@ DEFAULT_AGENT_USAGE_LIMITS = UsageLimits(request_limit=60)
 # response header nor the URL extension identifies one.
 _ATTACHMENT_DOWNLOAD_TIMEOUT_SECONDS = 30.0
 _DEFAULT_IMAGE_MEDIA_TYPE = "image/png"
+
+# Written into the workspace skills directory the first time a runner is
+# built, so users discovering the folder know what belongs in it.
+_SKILLS_README = """\
+# Agent Skills
+
+Skills placed in this directory are loaded automatically by the Griptape Nodes
+agent. Each skill lives in its own subdirectory containing a `SKILL.md` file:
+
+    .agents/skills/
+        my-skill/
+            SKILL.md
+
+`SKILL.md` starts with YAML frontmatter declaring `name` (which must match the
+directory name) and `description`, followed by the skill's instructions:
+
+    ---
+    name: my-skill
+    description: When to use this skill and what it does.
+    ---
+
+    Step-by-step guidance for the agent goes here.
+
+The agent re-scans this directory before each run, so new or edited skills
+take effect without restarting the engine.
+
+Skills here follow the Agent Skills specification: https://agentskills.io
+"""
 
 
 @dataclass
@@ -717,6 +746,7 @@ class AgentManager:
             return cached
 
         workspace_root = Path(config_manager.workspace_path)
+        self._ensure_skills_directory(workspace_root)
         mcp_servers: list[AbstractToolset[Any]] = [
             streamable_http_local(
                 f"http://localhost:{self._mcp_server_port}/mcp/",
@@ -748,6 +778,25 @@ class AgentManager:
         )
         self._runner_cache[cache_key] = runner
         return runner
+
+    def _ensure_skills_directory(self, workspace_root: Path) -> None:
+        """Scaffold `<workspace>/.agents/skills` so the runner always builds a skills capability.
+
+        Called before every runner construction: the runner only attaches a
+        `SkillsCapability` when the directory exists at construction time, and
+        runners are cached, so creating the directory here guarantees skills
+        added mid-session are picked up on the next scan. Seeds a README the
+        first time so users discovering the folder know what belongs in it.
+        Failure to scaffold is logged but never blocks building the agent.
+        """
+        skills_dir = workspace_root / DEFAULT_SKILLS_DIRECTORY
+        try:
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            readme = skills_dir / "README.md"
+            if not readme.exists():
+                readme.write_text(_SKILLS_README, encoding="utf-8")
+        except OSError as e:
+            logger.warning("Attempted to scaffold skills directory at %s. Failed because of: %s", skills_dir, e)
 
     def on_handle_list_agent_providers_request(self, _: ListAgentProvidersRequest) -> ResultPayload:
         return ListAgentProvidersResultSuccess(

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -9,6 +9,7 @@ the real config system.
 import asyncio
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import httpx
 import pytest
@@ -55,6 +56,7 @@ from griptape_nodes.retained_mode.events.agent_events import (
 )
 from griptape_nodes.retained_mode.managers.agent_manager import (
     _PROTECTED_PROVIDER_NAME,
+    _SKILLS_README,
     _VALID_PROVIDER_TYPES,
     AgentManager,
     _ActiveRun,
@@ -86,6 +88,33 @@ def providers_manager(monkeypatch: pytest.MonkeyPatch) -> AgentManager:
     manager._image_model_name = IMAGE_MODEL_CHOICES[0] if IMAGE_MODEL_CHOICES else "gpt-image-1-mini"
     monkeypatch.setattr(manager, "_persist_providers", lambda: None)
     return manager
+
+
+class TestEnsureSkillsDirectory:
+    """`_ensure_skills_directory` scaffolds `.agents/skills` without ever raising."""
+
+    def test_creates_directory_and_readme(self, agent_manager: AgentManager, tmp_path: Path) -> None:
+        agent_manager._ensure_skills_directory(tmp_path)
+
+        skills_dir = tmp_path / ".agents/skills"
+        assert skills_dir.is_dir()
+        assert (skills_dir / "README.md").read_text(encoding="utf-8") == _SKILLS_README
+
+    def test_existing_readme_is_not_overwritten(self, agent_manager: AgentManager, tmp_path: Path) -> None:
+        skills_dir = tmp_path / ".agents/skills"
+        skills_dir.mkdir(parents=True)
+        readme = skills_dir / "README.md"
+        readme.write_text("user edits", encoding="utf-8")
+
+        agent_manager._ensure_skills_directory(tmp_path)
+
+        assert readme.read_text(encoding="utf-8") == "user edits"
+
+    def test_scaffold_failure_does_not_raise(self, agent_manager: AgentManager, tmp_path: Path) -> None:
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("", encoding="utf-8")
+
+        agent_manager._ensure_skills_directory(blocker)
 
 
 class TestComposeInstructions:


### PR DESCRIPTION
The chat agent only attaches a `SkillsCapability` when `<workspace>/.agents/skills` exists at runner construction time, and runners are cached. A user who creates the skills directory mid-session gets a cached runner with no capability at all, so their skills are silently ignored until something unrelated (adding an MCP server, changing the system prompt, restarting the engine) happens to invalidate the cache. This came up in Slack where a user concluded skills required granting the agent a filesystem MCP server, when in reality the MCP server just changed the runner cache key.

Scaffolding the directory before every runner construction guarantees the capability is always attached, letting `auto_reload` pick up skills added mid-session. The directory is also seeded with a README (only when absent) so users who find the folder know the expected `SKILL.md` layout, with a link to the Agent Skills spec. Scaffold failures are logged and never block building the agent.