### PR TITLE
feat(events): let nodes subscribe to the execution-event feed

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -243,8 +243,6 @@ class EventManager:
         if self._event_queue is None:
             return
 
-        self._dispatch_to_execution_listeners(event)
-
         if self._is_cross_thread_call() and self._event_loop is not None:
             # We're in a different thread from the event loop, use thread-safe method
             # _is_cross_thread_call() guarantees _event_loop is not None
@@ -252,6 +250,11 @@ class EventManager:
         else:
             # We're on the same thread as the event loop or no loop thread tracked, use direct method
             self._event_queue.put_nowait(event)
+
+        # Dispatch after enqueuing so a callback that re-enters put_event (e.g. writing a
+        # streamed token to a parameter) enqueues its own events *after* the triggering
+        # event, preserving source order on the queue.
+        self._dispatch_to_execution_listeners(event)
 
     async def aput_event(self, event: Any) -> None:
         """Put event into async queue from async context.
@@ -264,8 +267,6 @@ class EventManager:
         if self._event_queue is None:
             return
 
-        self._dispatch_to_execution_listeners(event)
-
         if self._is_cross_thread_call() and self._event_loop is not None:
             # We're in a different thread from the event loop, use thread-safe method
             # _is_cross_thread_call() guarantees _event_loop is not None
@@ -273,6 +274,10 @@ class EventManager:
         else:
             # We're on the same thread as the event loop or no loop thread tracked, use async method
             await self._event_queue.put(event)
+
+        # Dispatch after enqueuing so a re-entrant emission from a callback lands on the
+        # queue after its triggering event (see put_event).
+        self._dispatch_to_execution_listeners(event)
 
     def add_pre_dispatch_hook(
         self,
@@ -873,7 +878,8 @@ class EventManager:
         events should subscribe immediately before it triggers the run and unsubscribe
         as soon as the run returns (see ``remove_listener_for_execution_event``).
         """
-        if inspect.iscoroutinefunction(callback):
+        callback_call = type(callback).__call__
+        if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(callback_call):
             msg = (
                 f"Attempted to subscribe to execution event '{execution_event_type.__name__}'. "
                 f"Failed because callback '{getattr(callback, '__name__', callback)}' is a coroutine "

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -99,6 +99,10 @@ class EventManager:
         # ExecutionPayloads emitted during a run, e.g. AgentStreamEvent). Lets a node
         # tap the feed while it runs and react (e.g. stream tokens to a parameter).
         self._execution_event_listeners: dict[type[ExecutionPayload], set[Callable]] = {}
+        # put_event/aput_event dispatch this feed on whatever thread emitted the event
+        # (often a worker thread), while subscribe/unsubscribe happen on the run's
+        # thread, so guard the dict and snapshot the target set before iterating.
+        self._execution_event_listeners_lock = threading.Lock()
         # Event queue for publishing events
         self._event_queue: asyncio.Queue | None = None
         # Keep track of which thread the event loop runs on
@@ -844,9 +848,7 @@ class EventManager:
 
         listener_set.add(callback)
 
-    def add_listener_to_execution_event(
-        self, execution_event_type: type[EP], callback: Callable[[EP], None]
-    ) -> None:
+    def add_listener_to_execution_event(self, execution_event_type: type[EP], callback: Callable[[EP], None]) -> None:
         """Subscribe to a type of execution event on the live event feed.
 
         Execution events (``ExecutionPayload`` subclasses such as ``AgentStreamEvent``,
@@ -859,26 +861,39 @@ class EventManager:
         is emitted, on whatever thread emitted it. Keep callbacks cheap and non-blocking;
         an exception in a callback is logged and does not interrupt event delivery.
 
+        Only the exact payload type is matched -- subscribing to a base class such as
+        ``ExecutionPayload`` does not receive its subclasses (this mirrors
+        ``add_listener_to_app_event``). Execution events reach subscribers even when the
+        UI consumer suppresses them (suppression is applied downstream, not here), so
+        this feed is deliberately independent of ``should_suppress_event``.
+
         Events carry no run identifier, so a subscriber that only wants its own run's
         events should subscribe immediately before it triggers the run and unsubscribe
         as soon as the run returns (see ``remove_listener_for_execution_event``).
         """
-        listener_set = self._execution_event_listeners.get(execution_event_type)
-        if listener_set is None:
-            listener_set = set()
-            self._execution_event_listeners[execution_event_type] = listener_set
-
-        listener_set.add(callback)
+        with self._execution_event_listeners_lock:
+            listener_set = self._execution_event_listeners.get(execution_event_type)
+            if listener_set is None:
+                listener_set = set()
+                self._execution_event_listeners[execution_event_type] = listener_set
+            listener_set.add(callback)
 
     def remove_listener_for_execution_event(
         self, execution_event_type: type[EP], callback: Callable[[EP], None]
     ) -> None:
-        """Unsubscribe a callback previously registered with ``add_listener_to_execution_event``."""
-        listener_set = self._execution_event_listeners.get(execution_event_type)
-        if listener_set is not None:
-            listener_set.discard(callback)
-            if not listener_set:
-                del self._execution_event_listeners[execution_event_type]
+        """Unsubscribe a callback previously registered with ``add_listener_to_execution_event``.
+
+        Because dispatch invokes callbacks outside the lock (a callback may re-enter
+        ``put_event``), a callback can still fire once more if a concurrent emission on
+        another thread already snapshotted the listener set before this call. Callbacks
+        must tolerate a late invocation after they have been removed.
+        """
+        with self._execution_event_listeners_lock:
+            listener_set = self._execution_event_listeners.get(execution_event_type)
+            if listener_set is not None:
+                listener_set.discard(callback)
+                if not listener_set:
+                    del self._execution_event_listeners[execution_event_type]
 
     def _dispatch_to_execution_listeners(self, event: Any) -> None:
         """Fan a queued execution event out to any subscribers before it reaches the UI.
@@ -886,14 +901,20 @@ class EventManager:
         Only ``ExecutionGriptapeNodeEvent``s carry an ``ExecutionPayload``; everything
         else on the queue is ignored here. Dispatch is synchronous and best-effort so a
         misbehaving subscriber never blocks or breaks the event queue.
+
+        Runs on the emitting thread (frequently a worker thread), so the listener set is
+        snapshotted under the lock and callbacks are invoked outside it -- holding the
+        lock across a callback that re-enters ``put_event`` would deadlock.
         """
-        if not self._execution_event_listeners or not isinstance(event, ExecutionGriptapeNodeEvent):
+        if not isinstance(event, ExecutionGriptapeNodeEvent):
             return
         payload = event.wrapped_event.payload
-        listener_set = self._execution_event_listeners.get(type(payload))
-        if not listener_set:
-            return
-        for callback in list(listener_set):
+        with self._execution_event_listeners_lock:
+            listener_set = self._execution_event_listeners.get(type(payload))
+            if not listener_set:
+                return
+            callbacks = list(listener_set)
+        for callback in callbacks:
             try:
                 callback(payload)
             except Exception:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -851,15 +851,17 @@ class EventManager:
     def add_listener_to_execution_event(self, execution_event_type: type[EP], callback: Callable[[EP], None]) -> None:
         """Subscribe to a type of execution event on the live event feed.
 
-        Execution events (``ExecutionPayload`` subclasses such as ``AgentStreamEvent``,
-        ``AgentToolCallEvent``, ``ProgressEvent``-adjacent run signals) are emitted as
-        events flow through ``put_event``/``aput_event`` on their way to the UI. This
-        lets a node tap that feed while it runs and react in real time -- for example,
-        appending streamed agent tokens onto one of its own parameters.
+        Execution events (``ExecutionPayload`` subclasses such as ``AgentStreamEvent``
+        and ``AgentToolCallEvent``) are emitted as events flow through
+        ``put_event``/``aput_event`` on their way to the UI. This lets a node tap that
+        feed while it runs and react in real time -- for example, appending streamed
+        agent tokens onto one of its own parameters.
 
         The callback is invoked synchronously with the payload as each matching event
         is emitted, on whatever thread emitted it. Keep callbacks cheap and non-blocking;
-        an exception in a callback is logged and does not interrupt event delivery.
+        an exception in a callback is logged and does not interrupt event delivery. Unlike
+        ``add_listener_to_app_event``, async callbacks are not supported and are rejected
+        here rather than silently dropped at dispatch time.
 
         Only the exact payload type is matched -- subscribing to a base class such as
         ``ExecutionPayload`` does not receive its subclasses (this mirrors
@@ -871,6 +873,14 @@ class EventManager:
         events should subscribe immediately before it triggers the run and unsubscribe
         as soon as the run returns (see ``remove_listener_for_execution_event``).
         """
+        if inspect.iscoroutinefunction(callback):
+            msg = (
+                f"Attempted to subscribe to execution event '{execution_event_type.__name__}'. "
+                f"Failed because callback '{getattr(callback, '__name__', callback)}' is a coroutine "
+                f"function; execution-event listeners are invoked synchronously on the emitting "
+                f"thread and must be plain (non-async) callables."
+            )
+            raise TypeError(msg)
         with self._execution_event_listeners_lock:
             listener_set = self._execution_event_listeners.get(execution_event_type)
             if listener_set is None:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -23,6 +23,8 @@ from griptape_nodes.retained_mode.events.base_events import (
     EventRequest,
     EventResultFailure,
     EventResultSuccess,
+    ExecutionGriptapeNodeEvent,
+    ExecutionPayload,
     ProgressEvent,
     RequestPayload,
     ResultDetails,
@@ -48,6 +50,7 @@ if TYPE_CHECKING:
 
 RP = TypeVar("RP", bound=RequestPayload, default=RequestPayload)
 AP = TypeVar("AP", bound=AppPayload, default=AppPayload)
+EP = TypeVar("EP", bound=ExecutionPayload, default=ExecutionPayload)
 
 
 _active_request_type: ContextVar[type[RequestPayload] | None] = ContextVar(
@@ -92,6 +95,10 @@ class EventManager:
         self._request_type_to_manager: dict[type[RequestPayload], Callable] = defaultdict(list)  # pyright: ignore[reportAttributeAccessIssue]
         # Dictionary to store ALL SUBSCRIBERS to app events.
         self._app_event_listeners: dict[type[AppPayload], set[Callable]] = {}
+        # Dictionary to store ALL SUBSCRIBERS to execution events (the live feed of
+        # ExecutionPayloads emitted during a run, e.g. AgentStreamEvent). Lets a node
+        # tap the feed while it runs and react (e.g. stream tokens to a parameter).
+        self._execution_event_listeners: dict[type[ExecutionPayload], set[Callable]] = {}
         # Event queue for publishing events
         self._event_queue: asyncio.Queue | None = None
         # Keep track of which thread the event loop runs on
@@ -232,6 +239,8 @@ class EventManager:
         if self._event_queue is None:
             return
 
+        self._dispatch_to_execution_listeners(event)
+
         if self._is_cross_thread_call() and self._event_loop is not None:
             # We're in a different thread from the event loop, use thread-safe method
             # _is_cross_thread_call() guarantees _event_loop is not None
@@ -250,6 +259,8 @@ class EventManager:
         """
         if self._event_queue is None:
             return
+
+        self._dispatch_to_execution_listeners(event)
 
         if self._is_cross_thread_call() and self._event_loop is not None:
             # We're in a different thread from the event loop, use thread-safe method
@@ -832,6 +843,64 @@ class EventManager:
             self._app_event_listeners[app_event_type] = listener_set
 
         listener_set.add(callback)
+
+    def add_listener_to_execution_event(
+        self, execution_event_type: type[EP], callback: Callable[[EP], None]
+    ) -> None:
+        """Subscribe to a type of execution event on the live event feed.
+
+        Execution events (``ExecutionPayload`` subclasses such as ``AgentStreamEvent``,
+        ``AgentToolCallEvent``, ``ProgressEvent``-adjacent run signals) are emitted as
+        events flow through ``put_event``/``aput_event`` on their way to the UI. This
+        lets a node tap that feed while it runs and react in real time -- for example,
+        appending streamed agent tokens onto one of its own parameters.
+
+        The callback is invoked synchronously with the payload as each matching event
+        is emitted, on whatever thread emitted it. Keep callbacks cheap and non-blocking;
+        an exception in a callback is logged and does not interrupt event delivery.
+
+        Events carry no run identifier, so a subscriber that only wants its own run's
+        events should subscribe immediately before it triggers the run and unsubscribe
+        as soon as the run returns (see ``remove_listener_for_execution_event``).
+        """
+        listener_set = self._execution_event_listeners.get(execution_event_type)
+        if listener_set is None:
+            listener_set = set()
+            self._execution_event_listeners[execution_event_type] = listener_set
+
+        listener_set.add(callback)
+
+    def remove_listener_for_execution_event(
+        self, execution_event_type: type[EP], callback: Callable[[EP], None]
+    ) -> None:
+        """Unsubscribe a callback previously registered with ``add_listener_to_execution_event``."""
+        listener_set = self._execution_event_listeners.get(execution_event_type)
+        if listener_set is not None:
+            listener_set.discard(callback)
+            if not listener_set:
+                del self._execution_event_listeners[execution_event_type]
+
+    def _dispatch_to_execution_listeners(self, event: Any) -> None:
+        """Fan a queued execution event out to any subscribers before it reaches the UI.
+
+        Only ``ExecutionGriptapeNodeEvent``s carry an ``ExecutionPayload``; everything
+        else on the queue is ignored here. Dispatch is synchronous and best-effort so a
+        misbehaving subscriber never blocks or breaks the event queue.
+        """
+        if not self._execution_event_listeners or not isinstance(event, ExecutionGriptapeNodeEvent):
+            return
+        payload = event.wrapped_event.payload
+        listener_set = self._execution_event_listeners.get(type(payload))
+        if not listener_set:
+            return
+        for callback in list(listener_set):
+            try:
+                callback(payload)
+            except Exception:
+                logging.getLogger("griptape_nodes").exception(
+                    "Execution-event listener for %s raised; continuing event delivery.",
+                    type(payload).__name__,
+                )
 
     def remove_listener_for_app_event(
         self, app_event_type: type[AP], callback: Callable[[AP], None] | Callable[[AP], Awaitable[None]]

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -830,6 +830,83 @@ class TestExecutionEventSubscription:
         assert received == ["ok"]
 
     @pytest.mark.asyncio
+    async def test_aput_event_dispatches_to_listener(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+        manager.add_listener_to_execution_event(_FakeStreamEvent, lambda p: received.append(p.text))
+
+        await manager.aput_event(self._wrap(_FakeStreamEvent(text="async")))
+
+        assert received == ["async"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_add_is_idempotent(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+
+        def callback(payload: _FakeStreamEvent) -> None:
+            received.append(payload.text)
+
+        manager.add_listener_to_execution_event(_FakeStreamEvent, callback)
+        manager.add_listener_to_execution_event(_FakeStreamEvent, callback)
+
+        manager.put_event(self._wrap(_FakeStreamEvent(text="once")))
+
+        assert received == ["once"]
+
+    @pytest.mark.asyncio
+    async def test_remove_unregistered_callback_is_noop(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+
+        # Removing a callback that was never registered (and an unknown type) must not raise.
+        manager.remove_listener_for_execution_event(_FakeStreamEvent, lambda _p: None)
+        manager.remove_listener_for_execution_event(_OtherExecEvent, lambda _p: None)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_emit_and_subscribe_is_thread_safe(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+        received_lock = threading.Lock()
+
+        def callback(payload: _FakeStreamEvent) -> None:
+            with received_lock:
+                received.append(payload.text)
+
+        manager.add_listener_to_execution_event(_FakeStreamEvent, callback)
+
+        stop = threading.Event()
+
+        def emit() -> None:
+            while not stop.is_set():
+                manager.put_event(self._wrap(_FakeStreamEvent(text="t")))
+
+        # A worker thread emits continuously (the production path) while the main thread
+        # churns subscribe/unsubscribe. This must never raise "dict changed size during
+        # iteration" or corrupt the listener registry.
+        emitter = threading.Thread(target=emit)
+        emitter.start()
+        try:
+            for _ in range(500):
+                extra = lambda _p: None  # noqa: E731
+                manager.add_listener_to_execution_event(_FakeStreamEvent, extra)
+                manager.remove_listener_for_execution_event(_FakeStreamEvent, extra)
+        finally:
+            stop.set()
+            emitter.join()
+
+        # The originally-registered callback survives the churn and keeps receiving.
+        with received_lock:
+            baseline = len(received)
+        manager.put_event(self._wrap(_FakeStreamEvent(text="final")))
+        with received_lock:
+            assert len(received) == baseline + 1
+            assert received[-1] == "final"
+
+    @pytest.mark.asyncio
     async def test_non_execution_events_are_ignored(self) -> None:
         manager = EventManager()
         manager.initialize_queue(asyncio.Queue())

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -907,6 +907,30 @@ class TestExecutionEventSubscription:
             assert received[-1] == "final"
 
     @pytest.mark.asyncio
+    async def test_base_class_subscription_does_not_receive_subclasses(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[ExecutionPayload] = []
+        # Only the exact payload type is matched; subscribing to the base ExecutionPayload
+        # must not receive concrete subclasses like _FakeStreamEvent.
+        manager.add_listener_to_execution_event(ExecutionPayload, received.append)
+
+        manager.put_event(self._wrap(_FakeStreamEvent(text="x")))
+
+        assert received == []
+
+    @pytest.mark.asyncio
+    async def test_async_callback_is_rejected(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+
+        async def async_callback(_payload: _FakeStreamEvent) -> None:
+            pass
+
+        with pytest.raises(TypeError, match="coroutine"):
+            manager.add_listener_to_execution_event(_FakeStreamEvent, async_callback)  # pyright: ignore[reportArgumentType]
+
+    @pytest.mark.asyncio
     async def test_non_execution_events_are_ignored(self) -> None:
         manager = EventManager()
         manager.initialize_queue(asyncio.Queue())

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -931,6 +931,39 @@ class TestExecutionEventSubscription:
             manager.add_listener_to_execution_event(_FakeStreamEvent, async_callback)  # pyright: ignore[reportArgumentType]
 
     @pytest.mark.asyncio
+    async def test_async_callable_object_is_rejected(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+
+        class AsyncCallable:
+            async def __call__(self, _payload: _FakeStreamEvent) -> None:
+                pass
+
+        with pytest.raises(TypeError, match="coroutine"):
+            manager.add_listener_to_execution_event(_FakeStreamEvent, AsyncCallable())  # pyright: ignore[reportArgumentType]
+
+    @pytest.mark.asyncio
+    async def test_reentrant_emission_is_enqueued_after_trigger(self) -> None:
+        manager = EventManager()
+        queue: asyncio.Queue = asyncio.Queue()
+        manager.initialize_queue(queue)
+
+        # A callback that re-enters put_event (as a node writing a streamed token would)
+        # must enqueue its follow-up event *after* the event that triggered it.
+        def on_stream(_payload: _FakeStreamEvent) -> None:
+            manager.put_event(self._wrap(_OtherExecEvent(value=99)))
+
+        manager.add_listener_to_execution_event(_FakeStreamEvent, on_stream)
+
+        trigger = self._wrap(_FakeStreamEvent(text="a"))
+        manager.put_event(trigger)
+
+        first = queue.get_nowait()
+        second = queue.get_nowait()
+        assert first is trigger
+        assert isinstance(second.wrapped_event.payload, _OtherExecEvent)
+
+    @pytest.mark.asyncio
     async def test_non_execution_events_are_ignored(self) -> None:
         manager = EventManager()
         manager.initialize_queue(asyncio.Queue())

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -12,6 +12,10 @@ from griptape_nodes.app.worker_routing import RemoteHandler
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.events.base_events import (
     EventResultSuccess,
+    ExecutionEvent,
+    ExecutionGriptapeNodeEvent,
+    ExecutionPayload,
+    ProgressEvent,
     RequestPayload,
     ResultDetail,
     ResultDetails,
@@ -746,3 +750,94 @@ class TestAuthorizationCheckpointHooks:
         second = manager.evaluate_authorization_checkpoint(self._checkpoint())
         assert second is None
         assert len(calls) == 2  # noqa: PLR2004
+
+
+@dataclass
+class _FakeStreamEvent(ExecutionPayload):
+    """Minimal ExecutionPayload for exercising the execution-event feed."""
+
+    text: str = ""
+
+
+@dataclass
+class _OtherExecEvent(ExecutionPayload):
+    """A second ExecutionPayload type to prove type-scoped delivery."""
+
+    value: int = 0
+
+
+class TestExecutionEventSubscription:
+    """Nodes can tap the live execution-event feed via add_listener_to_execution_event."""
+
+    @staticmethod
+    def _wrap(payload: ExecutionPayload) -> ExecutionGriptapeNodeEvent:
+        return ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=payload))
+
+    @pytest.mark.asyncio
+    async def test_listener_receives_matching_payloads_in_order(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+        manager.add_listener_to_execution_event(_FakeStreamEvent, lambda p: received.append(p.text))
+
+        manager.put_event(self._wrap(_FakeStreamEvent(text="he")))
+        manager.put_event(self._wrap(_FakeStreamEvent(text="llo")))
+
+        assert received == ["he", "llo"]
+
+    @pytest.mark.asyncio
+    async def test_only_subscribed_payload_type_is_delivered(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+        manager.add_listener_to_execution_event(_FakeStreamEvent, lambda p: received.append(p.text))
+
+        manager.put_event(self._wrap(_OtherExecEvent(value=1)))
+
+        assert received == []
+
+    @pytest.mark.asyncio
+    async def test_remove_listener_stops_delivery(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+
+        def callback(payload: _FakeStreamEvent) -> None:
+            received.append(payload.text)
+
+        manager.add_listener_to_execution_event(_FakeStreamEvent, callback)
+        manager.remove_listener_for_execution_event(_FakeStreamEvent, callback)
+
+        manager.put_event(self._wrap(_FakeStreamEvent(text="x")))
+
+        assert received == []
+
+    @pytest.mark.asyncio
+    async def test_listener_exception_does_not_break_delivery(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[str] = []
+
+        def boom(_payload: _FakeStreamEvent) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        manager.add_listener_to_execution_event(_FakeStreamEvent, boom)
+        manager.add_listener_to_execution_event(_FakeStreamEvent, lambda p: received.append(p.text))
+
+        manager.put_event(self._wrap(_FakeStreamEvent(text="ok")))
+
+        assert received == ["ok"]
+
+    @pytest.mark.asyncio
+    async def test_non_execution_events_are_ignored(self) -> None:
+        manager = EventManager()
+        manager.initialize_queue(asyncio.Queue())
+        received: list[ExecutionPayload] = []
+        manager.add_listener_to_execution_event(_FakeStreamEvent, received.append)
+
+        # A ProgressEvent is not an ExecutionGriptapeNodeEvent; it must neither crash
+        # dispatch nor be delivered to execution listeners.
+        manager.put_event(ProgressEvent(value="x", node_name="n", parameter_name="output"))
+
+        assert received == []


### PR DESCRIPTION
Agent token streaming and other run-time signals are emitted as `ExecutionPayload` events onto the event queue on their way to the UI, but a node had no way to observe them while it runs. The only subscription API, `add_listener_to_app_event`, covers `AppPayload` only, so streaming stayed coupled to whoever drains the queue.

This adds `add_listener_to_execution_event` and `remove_listener_for_execution_event` as the execution-feed parallel to the existing app-event listeners. A node can subscribe to a specific `ExecutionPayload` type (`AgentStreamEvent`, `AgentToolCallEvent`, `AgentThinkingEvent`, node lifecycle events, and so on) for the duration of a request and react in real time, for example appending streamed agent tokens onto its own `output` parameter through the standard `append_value_to_parameter` path, with no new coupling on `RunAgentRequest`.
