### PR TITLE
fix(publishing): skip static file copy when source and destination are the same file

### DIFF
--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -23,6 +23,7 @@ from dotenv.main import DotEnv
 
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_model_parameter import HuggingFaceModelParameter
+from griptape_nodes.files.path_utils import canonicalize_for_identity
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import (
@@ -532,6 +533,18 @@ dependencies = [
                 continue
 
             dest = destination / resolved_relative
+
+            # The destination can resolve to the same file as the source when the package
+            # destination lives inside the project root (e.g. the Nuke publisher writes the
+            # bundle next to files the workflow already references). Copying a file onto
+            # itself raises SameFileError, so treat it as already-in-place and skip.
+            if canonicalize_for_identity(absolute_path) == canonicalize_for_identity(dest):
+                copied.add(absolute_path)
+                logger.info(
+                    "Static file for node '%s' is already in place; skipping copy: %s", node_name, absolute_path
+                )
+                continue
+
             if absolute_path.is_dir():
                 self.copy_tree(absolute_path, dest)
             else:

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -1,5 +1,6 @@
 """Tests for WorkflowPackager transitive library dependency resolution."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
@@ -132,3 +133,53 @@ class TestCollectPipInstallFlagsTransitive:
 
         assert "--extra-index-url=https://a.example.com" in result
         assert "--extra-index-url=https://b.example.com" in result
+
+
+class TestCopyStaticFiles:
+    """copy_static_files handles the case where the destination resolves back onto the source."""
+
+    def test_skips_copy_when_source_and_dest_are_same_file(self, tmp_path: Path) -> None:
+        """A file whose destination resolves to itself is left in place instead of copied."""
+        packager = WorkflowPackager("test_workflow")
+        source = tmp_path / "inputs" / "images" / "img.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        relative = Path("inputs/images/img.jpg")
+
+        # destination is the project root itself, so dest == source.
+        with (
+            patch.object(packager, "_resolve_file_reference", return_value=(source, relative)),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+        ):
+            packager.copy_static_files([("node", "img.jpg")], tmp_path)
+
+        mock_copy_file.assert_not_called()
+        mock_copy_tree.assert_not_called()
+
+    def test_copies_when_source_and_dest_differ(self, tmp_path: Path) -> None:
+        """A file whose destination differs from the source is copied."""
+        packager = WorkflowPackager("test_workflow")
+        source = tmp_path / "inputs" / "images" / "img.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        relative = Path("inputs/images/img.jpg")
+        destination = tmp_path / "bundle"
+
+        with (
+            patch.object(packager, "_resolve_file_reference", return_value=(source, relative)),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
+                return_value=MagicMock(),
+            ),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+        ):
+            packager.copy_static_files([("node", "img.jpg")], destination)
+
+        mock_copy_file.assert_called_once_with(source, destination / relative)
+        mock_copy_tree.assert_not_called()


### PR DESCRIPTION
Publishing a workflow through the Nuke gizmo publisher (and any publisher whose package destination lives inside the project root) fails with `TypeError: Failed to copy file` because `copy_static_files` resolves a destination that points back at the source file already in place. `shutil.copy2` then raises `SameFileError`, which the OS handler surfaces as an I/O failure and aborts the publish.

The gizmo publisher writes its companion bundle next to the files the workflow already references, so a workflow's static assets legitimately resolve to a destination identical to their source. Copying a file onto itself is a no-op, so the packager now detects that case via `canonicalize_for_identity` (which normalizes symlinks and spelling differences) and leaves the file in place instead of attempting the copy.
