### PR TITLE
fix(publishing): pin engine dependency to full commit SHA

### DIFF
--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -319,7 +319,7 @@ class WorkflowPackager:
                 git_root = next(p for p in (pkg_dir, *pkg_dir.parents) if (p / ".git").is_dir())
                 commit = (
                     subprocess.check_output(  # noqa: S603
-                        [git_exe, "rev-parse", "--short", "HEAD"],
+                        [git_exe, "rev-parse", "HEAD"],
                         cwd=git_root,
                         stderr=subprocess.DEVNULL,
                     )
@@ -332,7 +332,9 @@ class WorkflowPackager:
                 return "git", commit
 
         if "vcs_info" in direct_url_info:
-            commit_id = direct_url_info["vcs_info"].get("commit_id", "")[:7]
+            commit_id = direct_url_info["vcs_info"].get("commit_id", "")
+            if not commit_id:
+                return "pypi", None
             return "git", commit_id
 
         return "pypi", None

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -17,6 +17,8 @@ import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from dotenv import set_key
 from dotenv.main import DotEnv
@@ -309,24 +311,26 @@ class WorkflowPackager:
             return "pypi", None
         direct_url_info = json.loads(direct_url_text)
         url = direct_url_info.get("url", "")
-        commit = None
         if url.startswith("file://"):
             git_exe = shutil.which("git")
             if git_exe is None:
                 return "file", None
+            # For editable installs, dist.locate_file("") points at the ephemeral venv's
+            # site-packages, not the source checkout. The checkout (which holds the .git
+            # metadata) is recorded in direct_url.json's url, so resolve the commit from
+            # there. `git -C ... rev-parse` also handles worktrees, whose .git is a file
+            # rather than a directory.
+            source_dir = Path(url2pathname(urlparse(url).path))
             try:
-                pkg_dir = Path(str(dist.locate_file(""))).resolve()
-                git_root = next(p for p in (pkg_dir, *pkg_dir.parents) if (p / ".git").is_dir())
                 commit = (
                     subprocess.check_output(  # noqa: S603
-                        [git_exe, "rev-parse", "HEAD"],
-                        cwd=git_root,
+                        [git_exe, "-C", str(source_dir), "rev-parse", "HEAD"],
                         stderr=subprocess.DEVNULL,
                     )
                     .decode()
                     .strip()
                 )
-            except (StopIteration, subprocess.CalledProcessError):
+            except (subprocess.CalledProcessError, OSError):
                 return "file", None
             else:
                 return "git", commit

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -4,6 +4,8 @@ import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 from griptape_nodes.retained_mode.publishing.workflow_packager import WorkflowPackager
@@ -223,10 +225,9 @@ class TestGetInstallSource:
         """An editable (file://) install resolves the commit from the checkout url, not site-packages."""
         packager = WorkflowPackager("test_workflow")
         full_sha = "a11a1dd14af250387e60127a1ed63841f0950db3"
+        url = "file:///Users/dev/griptape-nodes-engine"
         dist = MagicMock()
-        dist.read_text.return_value = json.dumps(
-            {"url": "file:///Users/dev/griptape-nodes-engine", "dir_info": {"editable": True}}
-        )
+        dist.read_text.return_value = json.dumps({"url": url, "dir_info": {"editable": True}})
 
         with (
             patch.object(packager, "find_griptape_nodes_distribution", return_value=dist),
@@ -244,9 +245,10 @@ class TestGetInstallSource:
         assert source == "git"
         assert commit == full_sha
         # The commit is resolved against the checkout path from the url, not site-packages.
-        called_args = mock_check_output.call_args.args[0]
-        assert called_args[:3] == ["/usr/bin/git", "-C", "/Users/dev/griptape-nodes-engine"]
-        assert called_args[-2:] == ["rev-parse", "HEAD"]
+        # Compare against the same file://-to-path conversion the code uses so the assertion
+        # holds on both POSIX and Windows path separators.
+        expected_checkout = str(Path(url2pathname(urlparse(url).path)))
+        assert mock_check_output.call_args.args[0] == ["/usr/bin/git", "-C", expected_checkout, "rev-parse", "HEAD"]
 
     def test_editable_install_without_git_repo_falls_back_to_file(self) -> None:
         """A file:// install whose checkout is not a git repo reports 'file' with no commit."""

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -1,5 +1,6 @@
 """Tests for WorkflowPackager transitive library dependency resolution."""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -183,3 +184,75 @@ class TestCopyStaticFiles:
 
         mock_copy_file.assert_called_once_with(source, destination / relative)
         mock_copy_tree.assert_not_called()
+
+
+class TestGetInstallSource:
+    """get_install_source pins the full commit SHA so the git ref is fetchable from the remote."""
+
+    def test_vcs_info_returns_full_commit_id(self) -> None:
+        """A git install exposes the full 40-char commit SHA, not an abbreviated one."""
+        packager = WorkflowPackager("test_workflow")
+        full_sha = "d1e0a500e25ced659d30d82f0cae4073523e42a5"
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {"url": "https://github.com/griptape-ai/griptape-nodes.git", "vcs_info": {"commit_id": full_sha}}
+        )
+
+        with patch.object(packager, "find_griptape_nodes_distribution", return_value=dist):
+            source, commit = packager.get_install_source()
+
+        assert source == "git"
+        assert commit == full_sha
+
+    def test_vcs_info_without_commit_falls_back_to_pypi(self) -> None:
+        """A git install missing its commit id falls back to pypi instead of an empty ref."""
+        packager = WorkflowPackager("test_workflow")
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {"url": "https://github.com/griptape-ai/griptape-nodes.git", "vcs_info": {}}
+        )
+
+        with patch.object(packager, "find_griptape_nodes_distribution", return_value=dist):
+            source, commit = packager.get_install_source()
+
+        assert source == "pypi"
+        assert commit is None
+
+
+class TestCollectDependenciesEnginePin:
+    """collect_dependencies pins the engine to the full commit SHA for git installs."""
+
+    def test_pins_full_git_sha(self) -> None:
+        """The engine dependency uses the full SHA returned by get_install_source verbatim."""
+        packager = WorkflowPackager("test_workflow")
+        workflow = _make_workflow_mock([])
+        full_sha = "d1e0a500e25ced659d30d82f0cae4073523e42a5"
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.LibraryManager",
+                return_value=_make_lib_manager_mock([]),
+            ),
+            patch.object(packager, "get_engine_version", return_value="v0.92.0"),
+            patch.object(packager, "get_install_source", return_value=("git", full_sha)),
+        ):
+            result = packager.collect_dependencies(workflow)
+
+        assert f"griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@{full_sha}" in result
+
+    def test_pins_engine_version_tag_for_pypi(self) -> None:
+        """A pypi install pins the released version tag rather than a commit."""
+        packager = WorkflowPackager("test_workflow")
+        workflow = _make_workflow_mock([])
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.LibraryManager",
+                return_value=_make_lib_manager_mock([]),
+            ),
+            patch.object(packager, "get_engine_version", return_value="v0.92.0"),
+            patch.object(packager, "get_install_source", return_value=("pypi", None)),
+        ):
+            result = packager.collect_dependencies(workflow)
+
+        assert "griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@v0.92.0" in result

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -4,8 +4,6 @@ import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from urllib.parse import urlparse
-from urllib.request import url2pathname
 
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 from griptape_nodes.retained_mode.publishing.workflow_packager import WorkflowPackager
@@ -226,6 +224,7 @@ class TestGetInstallSource:
         packager = WorkflowPackager("test_workflow")
         full_sha = "a11a1dd14af250387e60127a1ed63841f0950db3"
         url = "file:///Users/dev/griptape-nodes-engine"
+        checkout = "/checkout/griptape-nodes-engine"
         dist = MagicMock()
         dist.read_text.return_value = json.dumps({"url": url, "dir_info": {"editable": True}})
 
@@ -236,6 +235,10 @@ class TestGetInstallSource:
                 return_value="/usr/bin/git",
             ),
             patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.url2pathname",
+                return_value=checkout,
+            ) as mock_url2pathname,
+            patch(
                 "griptape_nodes.retained_mode.publishing.workflow_packager.subprocess.check_output",
                 return_value=(full_sha + "\n").encode(),
             ) as mock_check_output,
@@ -244,11 +247,11 @@ class TestGetInstallSource:
 
         assert source == "git"
         assert commit == full_sha
-        # The commit is resolved against the checkout path from the url, not site-packages.
-        # Compare against the same file://-to-path conversion the code uses so the assertion
-        # holds on both POSIX and Windows path separators.
-        expected_checkout = str(Path(url2pathname(urlparse(url).path)))
-        assert mock_check_output.call_args.args[0] == ["/usr/bin/git", "-C", expected_checkout, "rev-parse", "HEAD"]
+        # The path handed to the filesystem converter comes from the url's path component
+        # (the checkout), not from dist.locate_file()/site-packages.
+        mock_url2pathname.assert_called_once_with("/Users/dev/griptape-nodes-engine")
+        # git resolves the commit in that checkout directory.
+        assert mock_check_output.call_args.args[0] == ["/usr/bin/git", "-C", str(Path(checkout)), "rev-parse", "HEAD"]
 
     def test_editable_install_without_git_repo_falls_back_to_file(self) -> None:
         """A file:// install whose checkout is not a git repo reports 'file' with no commit."""

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -1,6 +1,7 @@
 """Tests for WorkflowPackager transitive library dependency resolution."""
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -216,6 +217,59 @@ class TestGetInstallSource:
             source, commit = packager.get_install_source()
 
         assert source == "pypi"
+        assert commit is None
+
+    def test_editable_install_resolves_commit_from_source_checkout(self) -> None:
+        """An editable (file://) install resolves the commit from the checkout url, not site-packages."""
+        packager = WorkflowPackager("test_workflow")
+        full_sha = "a11a1dd14af250387e60127a1ed63841f0950db3"
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {"url": "file:///Users/dev/griptape-nodes-engine", "dir_info": {"editable": True}}
+        )
+
+        with (
+            patch.object(packager, "find_griptape_nodes_distribution", return_value=dist),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.shutil.which",
+                return_value="/usr/bin/git",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.subprocess.check_output",
+                return_value=(full_sha + "\n").encode(),
+            ) as mock_check_output,
+        ):
+            source, commit = packager.get_install_source()
+
+        assert source == "git"
+        assert commit == full_sha
+        # The commit is resolved against the checkout path from the url, not site-packages.
+        called_args = mock_check_output.call_args.args[0]
+        assert called_args[:3] == ["/usr/bin/git", "-C", "/Users/dev/griptape-nodes-engine"]
+        assert called_args[-2:] == ["rev-parse", "HEAD"]
+
+    def test_editable_install_without_git_repo_falls_back_to_file(self) -> None:
+        """A file:// install whose checkout is not a git repo reports 'file' with no commit."""
+        packager = WorkflowPackager("test_workflow")
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {"url": "file:///Users/dev/griptape-nodes-engine", "dir_info": {"editable": True}}
+        )
+
+        with (
+            patch.object(packager, "find_griptape_nodes_distribution", return_value=dist),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.shutil.which",
+                return_value="/usr/bin/git",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.subprocess.check_output",
+                side_effect=subprocess.CalledProcessError(128, "git"),
+            ),
+        ):
+            source, commit = packager.get_install_source()
+
+        assert source == "file"
         assert commit is None
 
 


### PR DESCRIPTION
Publishing a workflow while the engine itself is a git or editable install produced a bundle whose `pyproject.toml` pinned `griptape-nodes-engine @ git+https://github.com/griptape-ai/griptape-nodes.git@<sha>` using an abbreviated commit SHA. `uv run` then failed at the `Updating https://github.com/griptape-ai/griptape-nodes.git` step because git cannot resolve an abbreviated SHA against a remote: only named refs and full 40-char reachable SHAs are fetchable (`git fetch <url> <short-sha>` returns `fatal: couldn't find remote ref`).

The abbreviation happened in two spots in the packager's `get_install_source`: `git rev-parse --short HEAD` for file installs and `commit_id[:7]` for git installs. Both now return the full SHA so the published ref is fetchable. This surfaced when running the engine off `main`, but it also affects anyone who installed the engine from git, since the `vcs_info` path truncated a perfectly good full SHA down to something git can no longer fetch.

A local commit that has not been pushed to the publish target remote still will not resolve even with the full SHA; handling that dev-only case (reachability check with a fallback to the released tag) is left for a follow-up.

The `get_install_source` helper in `version_utils` is intentionally left untouched: it feeds human-readable version strings where a short SHA is the desired form.
