### PR TITLE
Use the global workspace relative path for libraries as fallback default

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -174,18 +174,37 @@ class ConfigManager:
         else:
             self._libraries_root_override = str(Path(path).expanduser().resolve())
 
+    def configured_global_workspace_path(self) -> Path:
+        """Return the absolute GLOBAL configured workspace_directory, ignoring per-project overrides.
+
+        Reads workspace_directory from the user config, then the default config, mirroring
+        ProjectManager._decide_workspace_post_inheritance's global-default branch. Unlike
+        `workspace_path`, this never reflects the runtime `_workspace_dir_override` (which pins the
+        active workspace to a self-contained project's own folder), so it is the shared, project-
+        independent workspace root. The Settings default always populates default_config, so
+        workspace_directory is present in at least one layer.
+        """
+        configured = self.get_config_value("workspace_directory", config_source="user_config", default=None)
+        if configured is None:
+            configured = self.get_config_value("workspace_directory", config_source="default_config", default=None)
+        return Path(configured).expanduser().resolve()
+
     def resolved_libraries_root(self) -> Path:
         """Return the absolute directory under which libraries install and resolve.
 
         When a libraries-root override is set (from a project's own or inherited
-        libraries_dir), it is returned verbatim. Otherwise the legacy behavior applies:
-        the workspace-relative libraries_directory config value resolved against the
-        workspace path.
+        libraries_dir), it is returned verbatim. Otherwise the fallback resolves the
+        workspace-relative libraries_directory config value against the GLOBAL configured
+        workspace (configured_global_workspace_path), NOT the active per-project workspace.
+        This keeps libraries in the shared global-workspace `libraries/` folder even for a
+        self-contained project whose workspace_dir pins the active workspace to its own folder,
+        preserving the pre-v1 shared-libraries behavior. A project opts into a project-local
+        libraries dir by declaring an explicit libraries_dir (which sets the override above).
         """
         if self._libraries_root_override is not None:
             return Path(self._libraries_root_override)
         libraries_dir = self.get_config_value("libraries_directory", default="libraries")
-        return resolve_workspace_path(Path(libraries_dir), self.workspace_path)
+        return resolve_workspace_path(Path(libraries_dir), self.configured_global_workspace_path())
 
     def clear_project_layers(self) -> None:
         """Drop all per-activation config state so the next activation starts clean.

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -174,20 +174,42 @@ class ConfigManager:
         else:
             self._libraries_root_override = str(Path(path).expanduser().resolve())
 
-    def configured_global_workspace_path(self) -> Path:
-        """Return the absolute GLOBAL configured workspace_directory, ignoring per-project overrides.
+    def _resolve_configured_workspace_directory(self, *, include_runtime_override: bool) -> str:
+        """Resolve workspace_directory across the config layers, in load_configs' precedence order.
 
-        Reads workspace_directory from the user config, then the default config, mirroring
-        ProjectManager._decide_workspace_post_inheritance's global-default branch. Unlike
-        `workspace_path`, this never reflects the runtime `_workspace_dir_override` (which pins the
-        active workspace to a self-contained project's own folder), so it is the shared, project-
-        independent workspace root. The Settings default always populates default_config, so
-        workspace_directory is present in at least one layer.
+        Single source of truth for how workspace_directory is layered (highest priority first):
+        env var, then the runtime override (only when `include_runtime_override`), then workspace
+        config, project-adjacent config, user config, and finally the Settings default. load_configs
+        uses this WITH the override to set the active workspace_path; configured_global_workspace_path
+        uses it WITHOUT, to get the engine's workspace independent of any single project's pin. Keeping
+        both on this one helper is what stops the two precedences from drifting. The Settings default
+        always populates default_config, so a value is always returned.
         """
-        configured = self.get_config_value("workspace_directory", config_source="user_config", default=None)
-        if configured is None:
-            configured = self.get_config_value("workspace_directory", config_source="default_config", default=None)
-        return Path(configured).expanduser().resolve()
+        # env is applied last in load_configs, so it is highest priority; the runtime override sits
+        # just below env and above the config files.
+        if (env_value := get_dot_value(self.env_config, "workspace_directory", None)) is not None:
+            return env_value
+        if include_runtime_override and self._workspace_dir_override is not None:
+            return self._workspace_dir_override
+        for layer in (self.workspace_config, self.project_config, self.user_config):
+            if (configured := get_dot_value(layer, "workspace_directory", None)) is not None:
+                return configured
+        return self.default_config["workspace_directory"]
+
+    def configured_global_workspace_path(self) -> Path:
+        """Return the workspace_directory as configured, EXCLUDING the runtime per-project override.
+
+        The runtime `_workspace_dir_override` is the only layer that pins the active workspace to a
+        self-contained project's own folder (workspace_dir "./"); everything else (a
+        GTN_CONFIG_WORKSPACE_DIRECTORY env var, a project-adjacent or workspace `workspace_directory`,
+        the user/default config) describes where the ENGINE's workspace lives.
+
+        This is the base for the unset-libraries_dir fallback: libraries follow an engine that
+        relocates its whole workspace via env/adjacent config, but do NOT follow a single project's
+        self-contained workspace_dir pin (so a v1 self-contained project's unset libraries still land
+        in the shared workspace `libraries/`, matching pre-v1 behavior).
+        """
+        return Path(self._resolve_configured_workspace_directory(include_runtime_override=False)).expanduser().resolve()
 
     def resolved_libraries_root(self) -> Path:
         """Return the absolute directory under which libraries install and resolve.
@@ -311,8 +333,10 @@ class ConfigManager:
             merged_config = merge_dicts(merged_config, self.env_config)
             logger.debug("Merged config from environment variables: %s", list(self.env_config.keys()))
 
-        # Re-assign workspace path in case env var or project config overrides it
-        self.workspace_path = merged_config["workspace_directory"]
+        # Re-assign workspace path in case env var or project config overrides it. Uses the shared
+        # precedence resolver (WITH the runtime override) so the active workspace and
+        # configured_global_workspace_path() can never disagree on layer ordering.
+        self.workspace_path = self._resolve_configured_workspace_directory(include_runtime_override=True)
 
         # Validate the full config against the Settings model.
         try:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3407,8 +3407,11 @@ class LibraryManager:
         # Probe the installed versions against the TARGET project's libraries dir, not the
         # live one, so the plan matches what activation would reconcile in that workspace.
         # A project's own/inherited libraries_dir (resolved offline so an unloaded target is
-        # honored) takes precedence; otherwise fall back to the workspace-relative default.
-        # Both keys come from Settings defaults, so they are always present in `merged`.
+        # honored) takes precedence; otherwise fall back to libraries_directory resolved against
+        # the GLOBAL configured workspace (NOT the target's own workspace_dir), mirroring the live
+        # ConfigManager.resolved_libraries_root fallback so the previewed plan cannot diverge from
+        # activation for a self-contained project. libraries_directory still comes from `merged`
+        # (a layer may re-point it); only the base dir is the shared global workspace.
         libraries_root = None
         if request.project_id != SYSTEM_DEFAULTS_KEY:
             libraries_root = await GriptapeNodes.ProjectManager().resolve_libraries_root_for_project_id(
@@ -3419,7 +3422,7 @@ class LibraryManager:
         else:
             libraries_path = resolve_workspace_path(
                 Path(get_dot_value(merged, "libraries_directory")),
-                Path(get_dot_value(merged, "workspace_directory")),
+                config_mgr.configured_global_workspace_path(),
             )
 
         actions = await asyncio.gather(

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -141,47 +141,95 @@ class TestConfigManager:
                 assert manager.workspace_path == override_workspace.resolve()
                 assert manager.get_config_value("workspace_directory") == str(override_workspace)
 
-    def test_resolved_libraries_root_default_is_workspace_relative(self) -> None:
-        """With no override, the root is libraries_directory resolved against workspace_path."""
+    def test_resolved_libraries_root_default_is_global_workspace_relative(self, isolate_user_config: Path) -> None:
+        """With no override, the root is libraries_directory resolved against the GLOBAL workspace.
+
+        The fallback uses configured_global_workspace_path() (the user/default config
+        workspace_directory), NOT the active workspace_path override, so a self-contained project's
+        workspace pin does not relocate the shared libraries dir.
+        """
         with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {}, clear=True):
             workspace = Path(temp_dir) / "ws"
             workspace.mkdir()
+            isolate_user_config.write_text(json.dumps({"workspace_directory": str(workspace)}), encoding="utf-8")
             manager = ConfigManager()
-            manager.workspace_path = workspace
 
-            # default libraries_directory is "libraries" (relative -> under the workspace)
+            # default libraries_directory is "libraries" (relative -> under the global workspace)
             assert manager.resolved_libraries_root() == (workspace / "libraries").resolve()
 
-    def test_resolved_libraries_root_uses_override_verbatim(self) -> None:
-        """When an override is set, it is returned as-is, independent of workspace_path."""
+    def test_resolved_libraries_root_uses_override_verbatim(self, isolate_user_config: Path) -> None:
+        """When an override is set, it is returned as-is, independent of the global workspace."""
         with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {}, clear=True):
             workspace = Path(temp_dir) / "ws"
             workspace.mkdir()
             shared = Path(temp_dir) / "shared-libs"
             shared.mkdir()
+            isolate_user_config.write_text(json.dumps({"workspace_directory": str(workspace)}), encoding="utf-8")
             manager = ConfigManager()
-            manager.workspace_path = workspace
 
             manager.set_libraries_root_override(shared)
             assert manager.resolved_libraries_root() == shared.resolve()
 
-            # Clearing restores the workspace-relative default.
+            # Clearing restores the global-workspace-relative default.
             manager.set_libraries_root_override(None)
             assert manager.resolved_libraries_root() == (workspace / "libraries").resolve()
 
-    def test_clear_project_layers_clears_libraries_root_override(self) -> None:
+    def test_clear_project_layers_clears_libraries_root_override(self, isolate_user_config: Path) -> None:
         with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {}, clear=True):
             workspace = Path(temp_dir) / "ws"
             workspace.mkdir()
             shared = Path(temp_dir) / "shared-libs"
             shared.mkdir()
+            isolate_user_config.write_text(json.dumps({"workspace_directory": str(workspace)}), encoding="utf-8")
             manager = ConfigManager()
-            manager.workspace_path = workspace
             manager.set_libraries_root_override(shared)
 
             manager.clear_project_layers()
 
             assert manager.resolved_libraries_root() == (workspace / "libraries").resolve()
+
+    def test_resolved_libraries_root_fallback_ignores_active_workspace_override(
+        self, isolate_user_config: Path
+    ) -> None:
+        """A self-contained project's workspace override must NOT relocate the unset-libraries fallback.
+
+        Regression guard: with no libraries override, resolved_libraries_root resolves against the
+        GLOBAL configured workspace, not set_workspace_override's per-project pin. This is what keeps a
+        v1 self-contained project (workspace_dir "./") sharing the global libraries dir.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {}, clear=True):
+            global_ws = Path(temp_dir) / "global_ws"
+            global_ws.mkdir()
+            project_dir = Path(temp_dir) / "project"
+            project_dir.mkdir()
+            isolate_user_config.write_text(json.dumps({"workspace_directory": str(global_ws)}), encoding="utf-8")
+            manager = ConfigManager()
+
+            # Simulate activating a self-contained project: its workspace is pinned to its own dir.
+            manager.set_workspace_override(project_dir)
+
+            # Libraries still resolve under the GLOBAL workspace, not the project's own folder.
+            assert manager.resolved_libraries_root() == (global_ws / "libraries").resolve()
+            assert manager.resolved_libraries_root() != (project_dir / "libraries").resolve()
+
+    def test_resolved_libraries_root_v0_style_is_noop(self, isolate_user_config: Path) -> None:
+        """A v0-style project pins its workspace TO the global workspace, so the fallback is unchanged.
+
+        A v0 project has no workspace_dir, so activation sets the override to the global workspace
+        itself. The new global-workspace fallback then yields the same path the old workspace_path
+        fallback did -- documenting that this change is a no-op for v0 and only affects self-contained
+        v1 projects (whose override points at their own dir).
+        """
+        with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {}, clear=True):
+            global_ws = Path(temp_dir) / "global_ws"
+            global_ws.mkdir()
+            isolate_user_config.write_text(json.dumps({"workspace_directory": str(global_ws)}), encoding="utf-8")
+            manager = ConfigManager()
+
+            # v0 activation pins the override to the global workspace (branch 5 of decide_workspace).
+            manager.set_workspace_override(global_ws)
+
+            assert manager.resolved_libraries_root() == (global_ws / "libraries").resolve()
 
     def test_coerce_to_type_bool_from_string(self) -> None:
         """Test that _coerce_to_type correctly converts string values to bool."""
@@ -963,6 +1011,38 @@ class TestProvisioningPreviewMatchesActivation:
         # The workspace layer was actually consumed (not a both-wrong pass).
         assert get_dot_value(live_merged, LIBRARIES_TO_REGISTER_KEY) == expected_libraries
         assert get_dot_value(live_merged, REQUIRES_ENGINE_KEY) == expected_engine_version
+
+    def test_unset_libraries_fallback_live_matches_offline_global(
+        self, tmp_path: Path, isolate_user_config: Path
+    ) -> None:
+        """For an unset libraries_dir, live and offline both fall back to <global workspace>/libraries.
+
+        A self-contained project pins the active workspace to its own dir, but with no libraries_dir
+        override the live ConfigManager.resolved_libraries_root() and the offline preview both resolve
+        libraries_directory against configured_global_workspace_path(). This is the parity guard: the
+        two must compute the SAME path so the previewed SKIP/INSTALL/OVERWRITE plan matches activation.
+        """
+        from griptape_nodes.files.path_utils import resolve_workspace_path
+
+        global_ws = tmp_path / "global_ws"
+        global_ws.mkdir()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        isolate_user_config.write_text(json.dumps({"workspace_directory": str(global_ws)}), encoding="utf-8")
+
+        with patch.dict(os.environ, {}, clear=True):
+            cm = ConfigManager()
+            # Self-contained project activated: workspace pinned to its own dir, no libraries override.
+            cm.set_workspace_override(project_dir)
+            cm.set_libraries_root_override(None)
+
+            live = cm.resolved_libraries_root()
+
+            # Offline preview fallback (library_manager): libraries_directory against the GLOBAL workspace.
+            libraries_directory = cm.get_config_value("libraries_directory", default="libraries")
+            offline = resolve_workspace_path(Path(libraries_directory), cm.configured_global_workspace_path())
+
+            assert live == offline == (global_ws / "libraries").resolve()
 
     def test_project_workspaces_override_branch(self, tmp_path: Path, isolate_user_config: Path) -> None:
         """project_workspaces maps the project to a separate workspace dir (apply_override=True)."""

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -1012,37 +1012,13 @@ class TestProvisioningPreviewMatchesActivation:
         assert get_dot_value(live_merged, LIBRARIES_TO_REGISTER_KEY) == expected_libraries
         assert get_dot_value(live_merged, REQUIRES_ENGINE_KEY) == expected_engine_version
 
-    def test_unset_libraries_fallback_live_matches_offline_global(
-        self, tmp_path: Path, isolate_user_config: Path
-    ) -> None:
-        """For an unset libraries_dir, live and offline both fall back to <global workspace>/libraries.
-
-        A self-contained project pins the active workspace to its own dir, but with no libraries_dir
-        override the live ConfigManager.resolved_libraries_root() and the offline preview both resolve
-        libraries_directory against configured_global_workspace_path(). This is the parity guard: the
-        two must compute the SAME path so the previewed SKIP/INSTALL/OVERWRITE plan matches activation.
-        """
-        from griptape_nodes.files.path_utils import resolve_workspace_path
-
-        global_ws = tmp_path / "global_ws"
-        global_ws.mkdir()
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        isolate_user_config.write_text(json.dumps({"workspace_directory": str(global_ws)}), encoding="utf-8")
-
-        with patch.dict(os.environ, {}, clear=True):
-            cm = ConfigManager()
-            # Self-contained project activated: workspace pinned to its own dir, no libraries override.
-            cm.set_workspace_override(project_dir)
-            cm.set_libraries_root_override(None)
-
-            live = cm.resolved_libraries_root()
-
-            # Offline preview fallback (library_manager): libraries_directory against the GLOBAL workspace.
-            libraries_directory = cm.get_config_value("libraries_directory", default="libraries")
-            offline = resolve_workspace_path(Path(libraries_directory), cm.configured_global_workspace_path())
-
-            assert live == offline == (global_ws / "libraries").resolve()
+    # Live-vs-offline parity for the unset-libraries fallback is covered by REAL-path tests, not a
+    # by-construction replica: the live side by
+    # TestConfigManager.test_resolved_libraries_root_fallback_ignores_active_workspace_override
+    # (resolved_libraries_root -> global, not the project override), and the offline side by
+    # test_library_manager.TestPreviewProjectProvisioning.test_probes_global_workspace_for_unset_libraries_fallback
+    # (drives the real on_preview_project_provisioning_request and fails if it stops probing the global
+    # workspace). Both now resolve against configured_global_workspace_path(), so they agree.
 
     def test_project_workspaces_override_branch(self, tmp_path: Path, isolate_user_config: Path) -> None:
         """project_workspaces maps the project to a separate workspace dir (apply_override=True)."""

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -2470,18 +2470,17 @@ class TestPreviewProjectProvisioning:
         assert result.actions[0].kind == LibraryProvisioningActionKind.INSTALL
 
     @pytest.mark.asyncio
-    async def test_probes_target_workspace_not_live_for_destructive_plan(
+    async def test_probes_global_workspace_for_unset_libraries_fallback(
         self, griptape_nodes: GriptapeNodes, tmp_path: Path
     ) -> None:
-        """The installed-version probe reads the TARGET project's libraries dir.
+        """The unset-libraries_dir probe reads the GLOBAL workspace's libraries dir.
 
-        Guards the defect where the preview resolved the probe against the live
-        (active) workspace: a stale version sitting in the target workspace would
-        be missed, so a destructive OVERWRITE would be under-reported as a
-        non-destructive INSTALL. This exercises the real on-disk probe (no mock of
-        _installed_download_version): the target workspace holds an unsatisfying
-        version, the live config points at an empty dir, and the plan must still be
-        a destructive OVERWRITE.
+        With no own/inherited libraries_dir, the preview fallback resolves libraries_directory against
+        the GLOBAL configured workspace (configured_global_workspace_path), mirroring the live
+        ConfigManager.resolved_libraries_root fallback. A stale, unsatisfying version sitting in the
+        GLOBAL workspace's libraries dir must be found so the plan is a destructive OVERWRITE, not a
+        under-reported non-destructive INSTALL. Exercises the real on-disk probe (no mock of
+        _installed_download_version).
         """
         from griptape_nodes.retained_mode.events.library_events import (
             LibraryProvisioningActionKind,
@@ -2490,18 +2489,19 @@ class TestPreviewProjectProvisioning:
         )
 
         library_manager = griptape_nodes.LibraryManager()
-        target_ws = tmp_path / "target"
-        TestInstalledLibraryVersion._write_manifest(target_ws / "libraries" / "git-lib", "git-lib", "1.0.0")
+        global_ws = tmp_path / "global"
+        TestInstalledLibraryVersion._write_manifest(global_ws / "libraries" / "git-lib", "git-lib", "1.0.0")
         merged = self._merged_config(
             [{"git_url": "griptape-ai/git-lib@v2.0", "version": ">=2.0"}],
-            workspace_directory=str(target_ws),
+            # A self-contained target pins merged workspace_directory to its own dir; the fallback must
+            # NOT probe here (it holds no installed lib), it must probe the global workspace below.
+            workspace_directory=str(tmp_path / "target"),
             libraries_directory="libraries",
         )
-        # Live config points at a different, empty workspace; if the probe used it the
-        # plan would wrongly be a non-destructive INSTALL.
+        # The live config's global workspace is where the stale version actually lives. If the probe
+        # used the target/merged workspace instead, the plan would wrongly be a non-destructive INSTALL.
         live_config = MagicMock()
-        live_config.get_config_value.return_value = str(tmp_path / "live" / "libraries")
-        live_config.workspace_path = str(tmp_path / "live")
+        live_config.configured_global_workspace_path.return_value = global_ws
         with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
             mock_gn.ConfigManager.return_value = live_config
             self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged)
@@ -2957,6 +2957,10 @@ class TestDiscoverDownloadedLibraries:
                 return ["owner/remote_lib"]
             if key == "libraries_directory":
                 return str(libraries_dir)
+            if key == "workspace_directory":
+                # libraries_directory is absolute here, so the global-workspace base is unused for
+                # resolution, but configured_global_workspace_path() must get a real path, not None.
+                return str(tmp_path)
             return None
 
         with patch.object(config_mgr, "get_config_value", side_effect=get_config_value):


### PR DESCRIPTION
Jason requested that the fallback libraries_dir is not derived from the current workflow, but independent from the project's workspace (the global workspace)