### PR TITLE
feat(libraries): add opt-in library update age gating

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -986,11 +986,12 @@ class CheckLibraryUpdateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
         local_commit: The local HEAD commit SHA (None if not a git repository)
         remote_commit: The remote HEAD commit SHA (None if not available)
         update_gated_by_age: True when an update exists but is withheld because the target commit
-            is younger than the configured minimum age (library.update_age_gating_enabled). When
+            is younger than the configured minimum release age (library.minimum_release_age). When
             True, has_update is also True.
         target_commit_age_hours: Age in hours of the target commit at check time, or None when
             unknown (e.g. no update available or the commit timestamp could not be read).
-        update_min_age_hours: The configured minimum age in hours, or None when age gating is disabled.
+        minimum_release_age_hours: The configured minimum release age in hours, or None when the
+            gate is disabled (library.minimum_release_age is 0).
     """
 
     has_update: bool
@@ -1002,7 +1003,7 @@ class CheckLibraryUpdateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
     remote_commit: str | None
     update_gated_by_age: bool = False
     target_commit_age_hours: float | None = None
-    update_min_age_hours: float | None = None
+    minimum_release_age_hours: float | None = None
 
 
 @dataclass
@@ -1060,7 +1061,7 @@ class UpdateLibraryResultFailure(ResultPayloadFailure):
             have to parse it out of the human-readable error message (which is unreliable for paths
             containing ``:``, e.g. Windows drive letters).
         age_gated: True when the update was withheld because the target commit is younger than the
-            configured minimum age (library.update_age_gating_enabled). This is not a hard error;
+            configured minimum release age (library.minimum_release_age). This is not a hard error;
             the update will succeed once the target commit is old enough.
     """
 

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -1253,6 +1253,8 @@ class SyncLibrariesResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
         libraries_downloaded: Number of libraries that were downloaded from git URLs
         libraries_checked: Number of libraries checked for updates
         libraries_updated: Number of libraries that were updated
+        libraries_deferred: Number of libraries with an available update that was withheld by the
+            age gate (soak period) and therefore not applied this sync
         update_summary: Dict mapping library names to their update info (old_version -> new_version, or status for downloads)
     """
 
@@ -1260,6 +1262,7 @@ class SyncLibrariesResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
     libraries_checked: int
     libraries_updated: int
     update_summary: dict[str, dict[str, str]]
+    libraries_deferred: int = 0
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -986,7 +986,7 @@ class CheckLibraryUpdateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
         local_commit: The local HEAD commit SHA (None if not a git repository)
         remote_commit: The remote HEAD commit SHA (None if not available)
         update_gated_by_age: True when an update exists but is withheld because the target commit
-            is younger than the configured soak period (library.update_age_gating_enabled). When
+            is younger than the configured minimum age (library.update_age_gating_enabled). When
             True, has_update is also True.
         target_commit_age_hours: Age in hours of the target commit at check time, or None when
             unknown (e.g. no update available or the commit timestamp could not be read).
@@ -1060,7 +1060,7 @@ class UpdateLibraryResultFailure(ResultPayloadFailure):
             have to parse it out of the human-readable error message (which is unreliable for paths
             containing ``:``, e.g. Windows drive letters).
         age_gated: True when the update was withheld because the target commit is younger than the
-            configured soak period (library.update_age_gating_enabled). This is not a hard error;
+            configured minimum age (library.update_age_gating_enabled). This is not a hard error;
             the update will succeed once the target commit is old enough.
     """
 
@@ -1254,7 +1254,7 @@ class SyncLibrariesResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
         libraries_checked: Number of libraries checked for updates
         libraries_updated: Number of libraries that were updated
         libraries_deferred: Number of libraries with an available update that was withheld by the
-            age gate (soak period) and therefore not applied this sync
+            age gate and therefore not applied this sync
         update_summary: Dict mapping library names to their update info (old_version -> new_version, or status for downloads)
     """
 

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -985,6 +985,12 @@ class CheckLibraryUpdateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
         git_ref: The current git reference (branch, tag, or commit)
         local_commit: The local HEAD commit SHA (None if not a git repository)
         remote_commit: The remote HEAD commit SHA (None if not available)
+        update_gated_by_age: True when an update exists but is withheld because the target commit
+            is younger than the configured soak period (library.update_age_gating_enabled). When
+            True, has_update is also True.
+        target_commit_age_hours: Age in hours of the target commit at check time, or None when
+            unknown (e.g. no update available or the commit timestamp could not be read).
+        update_min_age_hours: The configured minimum age in hours, or None when age gating is disabled.
     """
 
     has_update: bool
@@ -994,6 +1000,9 @@ class CheckLibraryUpdateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
     git_ref: str | None
     local_commit: str | None
     remote_commit: str | None
+    update_gated_by_age: bool = False
+    target_commit_age_hours: float | None = None
+    update_min_age_hours: float | None = None
 
 
 @dataclass
@@ -1050,10 +1059,14 @@ class UpdateLibraryResultFailure(ResultPayloadFailure):
             the absolute path of that directory. Provided as a structured field so clients do not
             have to parse it out of the human-readable error message (which is unreliable for paths
             containing ``:``, e.g. Windows drive letters).
+        age_gated: True when the update was withheld because the target commit is younger than the
+            configured soak period (library.update_age_gating_enabled). This is not a hard error;
+            the update will succeed once the target commit is old enough.
     """
 
     retryable: bool = False
     existing_path: str | None = None
+    age_gated: bool = False
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -336,6 +336,13 @@ class UpdateAgeGateDecision(NamedTuple):
     min_age_hours: float
 
 
+class AgeGateConfig(NamedTuple):
+    """The library update age-gate config, read once so callers avoid duplicate config lookups."""
+
+    enabled: bool
+    min_age_hours: float
+
+
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
     LIBRARY_CONFIG_FILENAME = "griptape_nodes_library.json"
@@ -5363,21 +5370,8 @@ class LibraryManager:
             return None
         return LibraryManager.ResolvedDiscoveryPath(path=library_path, registered_path=entry.path)
 
-    def _evaluate_update_age_gate(self, commit_datetime: datetime | None) -> UpdateAgeGateDecision:
-        """Decide whether an update to a commit is withheld by the update age gate.
-
-        Reads library.update_age_gating_enabled and library.update_min_age_hours from config. When
-        gating is disabled the update is never gated. When enabled but the commit timestamp is
-        unknown, the update is allowed (age cannot be verified) and a warning is logged rather than
-        wedging updates permanently.
-
-        Args:
-            commit_datetime: The timezone-aware timestamp of the commit the update would move to.
-
-        Returns:
-            UpdateAgeGateDecision describing whether gating is enabled, whether this update is gated,
-            the commit's age in hours, and the configured minimum age.
-        """
+    def _read_age_gate_config(self) -> AgeGateConfig:
+        """Read the age-gate config keys once. Centralizes the key literals and default handling."""
         config_mgr = GriptapeNodes.ConfigManager()
         enabled = bool(
             config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
@@ -5385,6 +5379,31 @@ class LibraryManager:
         min_age_hours = float(
             config_mgr.get_config_value(LIBRARY_UPDATE_MIN_AGE_HOURS_KEY, default=24.0, cast_type=float)
         )
+        return AgeGateConfig(enabled=enabled, min_age_hours=min_age_hours)
+
+    def _evaluate_update_age_gate(
+        self, commit_datetime: datetime | None, config: AgeGateConfig | None = None
+    ) -> UpdateAgeGateDecision:
+        """Decide whether an update to a commit is withheld by the update age gate.
+
+        When gating is disabled the update is never gated. When enabled but the commit timestamp is
+        unknown, the update is allowed (age cannot be verified) and a warning is logged rather than
+        wedging updates permanently.
+
+        Args:
+            commit_datetime: The timezone-aware timestamp of the commit the update would move to.
+            config: Pre-read age-gate config. When None, it is read from config. Callers that must
+                inspect ``enabled`` before deciding whether to fetch the commit datetime should read
+                it once via _read_age_gate_config and pass it here to avoid a duplicate lookup.
+
+        Returns:
+            UpdateAgeGateDecision describing whether gating is enabled, whether this update is gated,
+            the commit's age in hours, and the configured minimum age.
+        """
+        if config is None:
+            config = self._read_age_gate_config()
+        enabled = config.enabled
+        min_age_hours = config.min_age_hours
 
         if not enabled:
             return UpdateAgeGateDecision(enabled=False, gated=False, age_hours=None, min_age_hours=min_age_hours)
@@ -5569,16 +5588,25 @@ class LibraryManager:
             )
             return CheckLibraryUpdateResultFailure(result_details=details)
 
-        # When an update exists, evaluate the age gate so callers can surface a "pending soak"
-        # state. version_info.commit_datetime is the timestamp of the commit this update targets.
-        age_gate = self._evaluate_update_age_gate(version_info.commit_datetime if has_update else None)
-        update_gated_by_age = has_update and age_gate.gated
+        # Evaluate the age gate only when an update actually exists, so callers can surface a
+        # "pending soak" state. Skipping the evaluation when up to date avoids a spurious
+        # "timestamp could not be determined" warning (there is simply nothing to gate) and the
+        # cost of the decision on the common no-update path.
+        if has_update:
+            age_gate = self._evaluate_update_age_gate(version_info.commit_datetime)
+            update_gated_by_age = age_gate.gated
+            target_commit_age_hours = age_gate.age_hours
+            update_min_age_hours = age_gate.min_age_hours if age_gate.enabled else None
+        else:
+            update_gated_by_age = False
+            target_commit_age_hours = None
+            update_min_age_hours = None
 
         if update_gated_by_age:
             details = (
                 f"Update available for Library '{library_name}' ({current_version} -> {latest_version}), but the "
-                f"target commit is {age_gate.age_hours:.1f}h old, younger than the required "
-                f"{age_gate.min_age_hours:.1f}h soak period. Update will be available once the target commit ages."
+                f"target commit is {target_commit_age_hours:.1f}h old, younger than the required "
+                f"{update_min_age_hours:.1f}h soak period. Update will be available once the target commit ages."
             )
             logger.info(details)
         else:
@@ -5594,8 +5622,8 @@ class LibraryManager:
             local_commit=local_commit,
             remote_commit=remote_commit,
             update_gated_by_age=update_gated_by_age,
-            target_commit_age_hours=age_gate.age_hours if has_update else None,
-            update_min_age_hours=age_gate.min_age_hours if age_gate.enabled else None,
+            target_commit_age_hours=target_commit_age_hours,
+            update_min_age_hours=update_min_age_hours,
             result_details=details,
         )
 
@@ -5760,13 +5788,10 @@ class LibraryManager:
 
         # Enforce the update age gate (soak period) before mutating the working tree. Only pay the
         # remote round-trip when gating is actually enabled, so the common (disabled) path is free.
-        config_mgr = GriptapeNodes.ConfigManager()
-        age_gating_enabled = bool(
-            config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
-        )
-        if age_gating_enabled:
+        age_gate_config = self._read_age_gate_config()
+        if age_gate_config.enabled:
             target_commit_datetime = await self._get_remote_target_commit_datetime(library_dir)
-            age_gate = self._evaluate_update_age_gate(target_commit_datetime)
+            age_gate = self._evaluate_update_age_gate(target_commit_datetime, config=age_gate_config)
             if age_gate.gated:
                 details = (
                     f"Cannot update Library '{library_name}' yet: the target commit is "

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -6310,6 +6310,24 @@ class LibraryManager:
             update_result = result.result
 
             if not isinstance(update_result, UpdateLibraryResultSuccess):
+                # A commit that was old enough during the check pass can still be refused at update
+                # time if a newer commit landed on the remote in between; that comes back as an
+                # age-gate refusal, not a hard failure. Count it as a deferral (it applies on a later
+                # sync once the target ages) so the summary and counts stay accurate.
+                if isinstance(update_result, UpdateLibraryResultFailure) and update_result.age_gated:
+                    libraries_deferred += 1
+                    logger.info(
+                        "Library '%s' update (%s -> %s) was withheld by the age gate at update time; deferring.",
+                        library_name,
+                        old_version,
+                        new_version,
+                    )
+                    update_summary[library_name] = {
+                        "old_version": old_version,
+                        "new_version": new_version,
+                        "status": "deferred_age_gate",
+                    }
+                    continue
                 logger.error("Failed to update library '%s': %s", library_name, update_result.result_details)
                 update_summary[library_name] = {
                     "old_version": old_version,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -13,6 +13,7 @@ import sys
 import sysconfig
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import StrEnum
 from importlib.resources import files
 from pathlib import Path
@@ -231,6 +232,8 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
+    LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
+    LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
     REQUIRES_ENGINE_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
     LibraryDependencyInstallBehavior,
@@ -317,6 +320,20 @@ class LibraryUpdateResult(NamedTuple):
     old_version: str
     new_version: str
     result: ResultPayload
+
+
+class UpdateAgeGateDecision(NamedTuple):
+    """Outcome of evaluating the library update age gate against a target commit.
+
+    ``gated`` is True only when age gating is enabled and the target commit is younger than the
+    configured minimum age. ``age_hours`` is the target commit's age at evaluation time, or None
+    when the commit timestamp could not be determined.
+    """
+
+    enabled: bool
+    gated: bool
+    age_hours: float | None
+    min_age_hours: float
 
 
 class LibraryManager:
@@ -5346,6 +5363,65 @@ class LibraryManager:
             return None
         return LibraryManager.ResolvedDiscoveryPath(path=library_path, registered_path=entry.path)
 
+    def _evaluate_update_age_gate(self, commit_datetime: datetime | None) -> UpdateAgeGateDecision:
+        """Decide whether an update to a commit is withheld by the update age gate.
+
+        Reads library.update_age_gating_enabled and library.update_min_age_hours from config. When
+        gating is disabled the update is never gated. When enabled but the commit timestamp is
+        unknown, the update is allowed (age cannot be verified) and a warning is logged rather than
+        wedging updates permanently.
+
+        Args:
+            commit_datetime: The timezone-aware timestamp of the commit the update would move to.
+
+        Returns:
+            UpdateAgeGateDecision describing whether gating is enabled, whether this update is gated,
+            the commit's age in hours, and the configured minimum age.
+        """
+        config_mgr = GriptapeNodes.ConfigManager()
+        enabled = bool(
+            config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
+        )
+        min_age_hours = float(
+            config_mgr.get_config_value(LIBRARY_UPDATE_MIN_AGE_HOURS_KEY, default=24.0, cast_type=float)
+        )
+
+        if not enabled:
+            return UpdateAgeGateDecision(enabled=False, gated=False, age_hours=None, min_age_hours=min_age_hours)
+
+        if commit_datetime is None:
+            logger.warning(
+                "Library update age gating is enabled but the target commit timestamp could not be "
+                "determined. Allowing the update without an age check."
+            )
+            return UpdateAgeGateDecision(enabled=True, gated=False, age_hours=None, min_age_hours=min_age_hours)
+
+        # Treat a naive timestamp as UTC so the subtraction below never raises.
+        if commit_datetime.tzinfo is None:
+            commit_datetime = commit_datetime.replace(tzinfo=UTC)
+
+        age_hours = (datetime.now(tz=UTC) - commit_datetime).total_seconds() / 3600.0
+        gated = age_hours < min_age_hours
+        return UpdateAgeGateDecision(enabled=True, gated=gated, age_hours=age_hours, min_age_hours=min_age_hours)
+
+    async def _get_remote_target_commit_datetime(self, library_dir: Path) -> datetime | None:
+        """Fetch the timestamp of the commit an update would move a library to.
+
+        Resolves the library's git remote and current ref, then reads the target commit's metadata
+        from the remote. Returns None when the remote, ref, or timestamp cannot be determined; the
+        age gate treats None as "cannot verify" and allows the update.
+        """
+        try:
+            git_remote = await asyncio.to_thread(get_git_remote, library_dir)
+            if git_remote is None:
+                return None
+            git_ref = await asyncio.to_thread(get_current_ref, library_dir)
+            version_info = await asyncio.to_thread(clone_and_get_library_version, git_remote, git_ref or "HEAD")
+        except GitError as e:
+            logger.warning("Failed to determine target commit age for library at %s: %s", library_dir, e)
+            return None
+        return version_info.commit_datetime
+
     async def check_library_update_request(self, request: CheckLibraryUpdateRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         """Check if a library has updates available via git."""
         library_name = request.library_name
@@ -5493,8 +5569,21 @@ class LibraryManager:
             )
             return CheckLibraryUpdateResultFailure(result_details=details)
 
-        details = f"Successfully checked for updates for Library '{library_name}'. Current version: {current_version}, Latest version: {latest_version}, Has update: {has_update} ({update_reason})"
-        logger.info(details)
+        # When an update exists, evaluate the age gate so callers can surface a "pending soak"
+        # state. version_info.commit_datetime is the timestamp of the commit this update targets.
+        age_gate = self._evaluate_update_age_gate(version_info.commit_datetime if has_update else None)
+        update_gated_by_age = has_update and age_gate.gated
+
+        if update_gated_by_age:
+            details = (
+                f"Update available for Library '{library_name}' ({current_version} -> {latest_version}), but the "
+                f"target commit is {age_gate.age_hours:.1f}h old, younger than the required "
+                f"{age_gate.min_age_hours:.1f}h soak period. Update will be available once the target commit ages."
+            )
+            logger.info(details)
+        else:
+            details = f"Successfully checked for updates for Library '{library_name}'. Current version: {current_version}, Latest version: {latest_version}, Has update: {has_update} ({update_reason})"
+            logger.info(details)
 
         return CheckLibraryUpdateResultSuccess(
             has_update=has_update,
@@ -5504,6 +5593,9 @@ class LibraryManager:
             git_ref=git_ref,
             local_commit=local_commit,
             remote_commit=remote_commit,
+            update_gated_by_age=update_gated_by_age,
+            target_commit_age_hours=age_gate.age_hours if has_update else None,
+            update_min_age_hours=age_gate.min_age_hours if age_gate.enabled else None,
             result_details=details,
         )
 
@@ -5639,7 +5731,7 @@ class LibraryManager:
 
         return new_version
 
-    async def update_library_request(self, request: UpdateLibraryRequest) -> ResultPayload:
+    async def update_library_request(self, request: UpdateLibraryRequest) -> ResultPayload:  # noqa: C901
         """Update a library to the latest version using the appropriate git strategy.
 
         Automatically detects whether the library uses branch-based or tag-based workflow:
@@ -5665,6 +5757,24 @@ class LibraryManager:
         if await asyncio.to_thread(is_monorepo, library_dir):
             details = f"Cannot update Library '{library_name}'. Repository contains multiple libraries and must be updated manually."
             return UpdateLibraryResultFailure(result_details=details)
+
+        # Enforce the update age gate (soak period) before mutating the working tree. Only pay the
+        # remote round-trip when gating is actually enabled, so the common (disabled) path is free.
+        config_mgr = GriptapeNodes.ConfigManager()
+        age_gating_enabled = bool(
+            config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
+        )
+        if age_gating_enabled:
+            target_commit_datetime = await self._get_remote_target_commit_datetime(library_dir)
+            age_gate = self._evaluate_update_age_gate(target_commit_datetime)
+            if age_gate.gated:
+                details = (
+                    f"Cannot update Library '{library_name}' yet: the target commit is "
+                    f"{age_gate.age_hours:.1f}h old, younger than the required {age_gate.min_age_hours:.1f}h "
+                    f"soak period (library.update_age_gating_enabled). Try again once the target commit ages."
+                )
+                logger.info(details)
+                return UpdateLibraryResultFailure(result_details=details, age_gated=True)
 
         # Perform git update (auto-detects branch vs tag workflow)
         try:
@@ -6015,7 +6125,7 @@ class LibraryManager:
             library_name=library_name, dependencies_installed=len(pip_dependencies), result_details=details
         )
 
-    async def sync_libraries_request(self, request: SyncLibrariesRequest) -> ResultPayload:  # noqa: C901, PLR0915
+    async def sync_libraries_request(self, request: SyncLibrariesRequest) -> ResultPayload:  # noqa: C901, PLR0912, PLR0915
         """Sync all libraries to latest versions and ensure dependencies are installed."""
         # Phase 1: Download missing libraries from both config keys
         config_mgr = GriptapeNodes.ConfigManager()
@@ -6094,6 +6204,7 @@ class LibraryManager:
         # Process check results and determine which libraries need updates
         libraries_checked = len(libraries_to_check)
         libraries_updated = 0
+        libraries_deferred = 0
         libraries_to_update: list[LibraryUpdateInfo] = []
 
         for library_name, check_result in check_results.items():
@@ -6107,6 +6218,24 @@ class LibraryManager:
 
             if not check_result.has_update:
                 logger.info("Library '%s' is up to date (version %s)", library_name, check_result.current_version)
+                continue
+
+            # An update exists but is withheld by the age gate: skip it this cycle rather than
+            # attempting an update that update_library_request would refuse. It will apply on a
+            # later sync once the target commit clears the soak period.
+            if check_result.update_gated_by_age:
+                libraries_deferred += 1
+                logger.info(
+                    "Library '%s' has an update (%s -> %s) withheld by the age gate; skipping this sync.",
+                    library_name,
+                    check_result.current_version,
+                    check_result.latest_version,
+                )
+                update_summary[library_name] = {
+                    "old_version": check_result.current_version or "unknown",
+                    "new_version": check_result.current_version or "unknown",
+                    "status": "deferred_age_gate",
+                }
                 continue
 
             # Library has an update available
@@ -6174,6 +6303,8 @@ class LibraryManager:
 
         # Build result details
         details = f"Downloaded {libraries_downloaded} libraries. Checked {libraries_checked} libraries. {libraries_updated} updated."
+        if libraries_deferred:
+            details += f" {libraries_deferred} withheld by age gate."
         logger.info(details)
         return SyncLibrariesResultSuccess(
             libraries_downloaded=libraries_downloaded,
@@ -6194,11 +6325,15 @@ class LibraryManager:
 
         # Perform sparse checkout to get library JSON
         try:
-            library_version, commit_sha, library_data_raw = sparse_checkout_library_json(normalized_url, ref)
+            checkout = sparse_checkout_library_json(normalized_url, ref)
         except GitCloneError as e:
             details = f"Failed to inspect library from {normalized_url}: {e}"
             logger.error(details)
             return InspectLibraryRepoResultFailure(result_details=details)
+
+        library_version = checkout.library_version
+        commit_sha = checkout.commit_sha
+        library_data_raw = checkout.library_data
 
         # Validate and create LibrarySchema
         try:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -6335,6 +6335,7 @@ class LibraryManager:
             libraries_downloaded=libraries_downloaded,
             libraries_checked=libraries_checked,
             libraries_updated=libraries_updated,
+            libraries_deferred=libraries_deferred,
             update_summary=update_summary,
             result_details=details,
         )

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -232,8 +232,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
-    LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
-    LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
+    LIBRARY_MINIMUM_RELEASE_AGE_KEY,
     REQUIRES_ENGINE_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
     LibraryDependencyInstallBehavior,
@@ -325,22 +324,29 @@ class LibraryUpdateResult(NamedTuple):
 class UpdateAgeGateDecision(NamedTuple):
     """Outcome of evaluating the library update age gate against a target commit.
 
-    ``gated`` is True only when age gating is enabled and the target commit is younger than the
-    configured minimum age. ``age_hours`` is the target commit's age at evaluation time, or None
-    when the commit timestamp could not be determined.
+    ``gated`` is True only when the gate is enabled and the target commit is younger than the
+    configured minimum release age. ``age_hours`` is the target commit's age at evaluation time, or
+    None when the commit timestamp could not be determined.
     """
 
     enabled: bool
     gated: bool
     age_hours: float | None
-    min_age_hours: float
+    minimum_release_age_hours: float
 
 
-class AgeGateConfig(NamedTuple):
-    """The library update age-gate config, read once so callers avoid duplicate config lookups."""
+class MinimumReleaseAgeConfig(NamedTuple):
+    """The minimum-release-age setting, read once so callers avoid duplicate config lookups.
 
-    enabled: bool
-    min_age_hours: float
+    ``hours`` is the configured minimum release age in hours; 0 (or negative) disables the gate.
+    ``enabled`` is derived so call sites can branch on intent without re-deriving it.
+    """
+
+    hours: float
+
+    @property
+    def enabled(self) -> bool:
+        return self.hours > 0
 
 
 class LibraryManager:
@@ -5370,61 +5376,65 @@ class LibraryManager:
             return None
         return LibraryManager.ResolvedDiscoveryPath(path=library_path, registered_path=entry.path)
 
-    def _read_age_gate_config(self) -> AgeGateConfig:
-        """Read the age-gate config keys once. Centralizes the key literals and default handling."""
+    def _read_minimum_release_age_config(self) -> MinimumReleaseAgeConfig:
+        """Read the minimum-release-age setting once. Centralizes the key literal and default handling."""
         config_mgr = GriptapeNodes.ConfigManager()
         # get_config_value returns None for an explicit `null` override (it bypasses both cast_type
-        # and the default in that case), so coalesce None back to the defaults here to keep the age
-        # gate fail-open rather than raising when float(None) is attempted.
-        enabled = config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
-        min_age_hours = config_mgr.get_config_value(LIBRARY_UPDATE_MIN_AGE_HOURS_KEY, default=24.0, cast_type=float)
-        if enabled is None:
-            enabled = False
-        if min_age_hours is None:
-            min_age_hours = 24.0
-        return AgeGateConfig(enabled=bool(enabled), min_age_hours=float(min_age_hours))
+        # and the default in that case), so coalesce None back to the default here to keep the gate
+        # fail-open rather than raising when float(None) is attempted.
+        hours = config_mgr.get_config_value(LIBRARY_MINIMUM_RELEASE_AGE_KEY, default=0.0, cast_type=float)
+        if hours is None:
+            hours = 0.0
+        return MinimumReleaseAgeConfig(hours=float(hours))
 
     def _evaluate_update_age_gate(
-        self, commit_datetime: datetime | None, config: AgeGateConfig | None = None
+        self, commit_datetime: datetime | None, config: MinimumReleaseAgeConfig | None = None
     ) -> UpdateAgeGateDecision:
-        """Decide whether an update to a commit is withheld by the update age gate.
+        """Decide whether an update to a commit is withheld by the minimum release age.
 
-        When gating is disabled the update is never gated. When enabled but the commit timestamp is
+        When the gate is disabled the update is never gated. When enabled but the commit timestamp is
         unknown, the update is allowed (age cannot be verified) and a warning is logged rather than
         wedging updates permanently.
 
         Args:
             commit_datetime: The timezone-aware timestamp of the commit the update would move to.
-            config: Pre-read age-gate config. When None, it is read from config. Callers that must
-                inspect ``enabled`` before deciding whether to fetch the commit datetime should read
-                it once via _read_age_gate_config and pass it here to avoid a duplicate lookup.
+            config: Pre-read minimum-release-age config. When None, it is read from config. Callers
+                that must inspect ``enabled`` before deciding whether to fetch the commit datetime
+                should read it once via _read_minimum_release_age_config and pass it here to avoid a
+                duplicate lookup.
 
         Returns:
-            UpdateAgeGateDecision describing whether gating is enabled, whether this update is gated,
-            the commit's age in hours, and the configured minimum age.
+            UpdateAgeGateDecision describing whether the gate is enabled, whether this update is
+            gated, the commit's age in hours, and the configured minimum release age.
         """
         if config is None:
-            config = self._read_age_gate_config()
+            config = self._read_minimum_release_age_config()
         enabled = config.enabled
-        min_age_hours = config.min_age_hours
+        minimum_release_age_hours = config.hours
 
         if not enabled:
-            return UpdateAgeGateDecision(enabled=False, gated=False, age_hours=None, min_age_hours=min_age_hours)
+            return UpdateAgeGateDecision(
+                enabled=False, gated=False, age_hours=None, minimum_release_age_hours=minimum_release_age_hours
+            )
 
         if commit_datetime is None:
             logger.warning(
-                "Library update age gating is enabled but the target commit timestamp could not be "
+                "The library minimum release age is set but the target commit timestamp could not be "
                 "determined. Allowing the update without an age check."
             )
-            return UpdateAgeGateDecision(enabled=True, gated=False, age_hours=None, min_age_hours=min_age_hours)
+            return UpdateAgeGateDecision(
+                enabled=True, gated=False, age_hours=None, minimum_release_age_hours=minimum_release_age_hours
+            )
 
         # Treat a naive timestamp as UTC so the subtraction below never raises.
         if commit_datetime.tzinfo is None:
             commit_datetime = commit_datetime.replace(tzinfo=UTC)
 
         age_hours = (datetime.now(tz=UTC) - commit_datetime).total_seconds() / 3600.0
-        gated = age_hours < min_age_hours
-        return UpdateAgeGateDecision(enabled=True, gated=gated, age_hours=age_hours, min_age_hours=min_age_hours)
+        gated = age_hours < minimum_release_age_hours
+        return UpdateAgeGateDecision(
+            enabled=True, gated=gated, age_hours=age_hours, minimum_release_age_hours=minimum_release_age_hours
+        )
 
     async def _get_remote_target_commit_datetime(self, library_dir: Path) -> datetime | None:
         """Fetch the timestamp of the commit an update would move a library to.
@@ -5599,17 +5609,17 @@ class LibraryManager:
             age_gate = self._evaluate_update_age_gate(version_info.commit_datetime)
             update_gated_by_age = age_gate.gated
             target_commit_age_hours = age_gate.age_hours
-            update_min_age_hours = age_gate.min_age_hours if age_gate.enabled else None
+            minimum_release_age_hours = age_gate.minimum_release_age_hours if age_gate.enabled else None
         else:
             update_gated_by_age = False
             target_commit_age_hours = None
-            update_min_age_hours = None
+            minimum_release_age_hours = None
 
         if update_gated_by_age:
             details = (
                 f"Update available for Library '{library_name}' ({current_version} -> {latest_version}), but the "
                 f"target commit is {target_commit_age_hours:.1f}h old, younger than the required "
-                f"{update_min_age_hours:.1f}h minimum age. Update will be available once the target commit ages."
+                f"{minimum_release_age_hours:.1f}h minimum release age. Update will be available once the target commit ages."
             )
             logger.info(details)
         else:
@@ -5626,7 +5636,7 @@ class LibraryManager:
             remote_commit=remote_commit,
             update_gated_by_age=update_gated_by_age,
             target_commit_age_hours=target_commit_age_hours,
-            update_min_age_hours=update_min_age_hours,
+            minimum_release_age_hours=minimum_release_age_hours,
             result_details=details,
         )
 
@@ -5791,15 +5801,15 @@ class LibraryManager:
 
         # Enforce the update age gate before mutating the working tree. Only pay the
         # remote round-trip when gating is actually enabled, so the common (disabled) path is free.
-        age_gate_config = self._read_age_gate_config()
-        if age_gate_config.enabled:
+        minimum_release_age_config = self._read_minimum_release_age_config()
+        if minimum_release_age_config.enabled:
             target_commit_datetime = await self._get_remote_target_commit_datetime(library_dir)
-            age_gate = self._evaluate_update_age_gate(target_commit_datetime, config=age_gate_config)
+            age_gate = self._evaluate_update_age_gate(target_commit_datetime, config=minimum_release_age_config)
             if age_gate.gated:
                 details = (
                     f"Cannot update Library '{library_name}' yet: the target commit is "
-                    f"{age_gate.age_hours:.1f}h old, younger than the required {age_gate.min_age_hours:.1f}h "
-                    f"minimum age (library.update_age_gating_enabled). Try again once the target commit ages."
+                    f"{age_gate.age_hours:.1f}h old, younger than the required {age_gate.minimum_release_age_hours:.1f}h "
+                    f"minimum release age (library.minimum_release_age). Try again once the target commit ages."
                 )
                 logger.info(details)
                 return UpdateLibraryResultFailure(result_details=details, age_gated=True)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5589,7 +5589,7 @@ class LibraryManager:
             return CheckLibraryUpdateResultFailure(result_details=details)
 
         # Evaluate the age gate only when an update actually exists, so callers can surface a
-        # "pending soak" state. Skipping the evaluation when up to date avoids a spurious
+        # "pending age gate" state. Skipping the evaluation when up to date avoids a spurious
         # "timestamp could not be determined" warning (there is simply nothing to gate) and the
         # cost of the decision on the common no-update path.
         if has_update:
@@ -5606,7 +5606,7 @@ class LibraryManager:
             details = (
                 f"Update available for Library '{library_name}' ({current_version} -> {latest_version}), but the "
                 f"target commit is {target_commit_age_hours:.1f}h old, younger than the required "
-                f"{update_min_age_hours:.1f}h soak period. Update will be available once the target commit ages."
+                f"{update_min_age_hours:.1f}h minimum age. Update will be available once the target commit ages."
             )
             logger.info(details)
         else:
@@ -5786,7 +5786,7 @@ class LibraryManager:
             details = f"Cannot update Library '{library_name}'. Repository contains multiple libraries and must be updated manually."
             return UpdateLibraryResultFailure(result_details=details)
 
-        # Enforce the update age gate (soak period) before mutating the working tree. Only pay the
+        # Enforce the update age gate before mutating the working tree. Only pay the
         # remote round-trip when gating is actually enabled, so the common (disabled) path is free.
         age_gate_config = self._read_age_gate_config()
         if age_gate_config.enabled:
@@ -5796,7 +5796,7 @@ class LibraryManager:
                 details = (
                     f"Cannot update Library '{library_name}' yet: the target commit is "
                     f"{age_gate.age_hours:.1f}h old, younger than the required {age_gate.min_age_hours:.1f}h "
-                    f"soak period (library.update_age_gating_enabled). Try again once the target commit ages."
+                    f"minimum age (library.update_age_gating_enabled). Try again once the target commit ages."
                 )
                 logger.info(details)
                 return UpdateLibraryResultFailure(result_details=details, age_gated=True)
@@ -6247,7 +6247,7 @@ class LibraryManager:
 
             # An update exists but is withheld by the age gate: skip it this cycle rather than
             # attempting an update that update_library_request would refuse. It will apply on a
-            # later sync once the target commit clears the soak period.
+            # later sync once the target commit reaches the minimum age.
             if check_result.update_gated_by_age:
                 libraries_deferred += 1
                 logger.info(

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5373,13 +5373,16 @@ class LibraryManager:
     def _read_age_gate_config(self) -> AgeGateConfig:
         """Read the age-gate config keys once. Centralizes the key literals and default handling."""
         config_mgr = GriptapeNodes.ConfigManager()
-        enabled = bool(
-            config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
-        )
-        min_age_hours = float(
-            config_mgr.get_config_value(LIBRARY_UPDATE_MIN_AGE_HOURS_KEY, default=24.0, cast_type=float)
-        )
-        return AgeGateConfig(enabled=enabled, min_age_hours=min_age_hours)
+        # get_config_value returns None for an explicit `null` override (it bypasses both cast_type
+        # and the default in that case), so coalesce None back to the defaults here to keep the age
+        # gate fail-open rather than raising when float(None) is attempted.
+        enabled = config_mgr.get_config_value(LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY, default=False, cast_type=bool)
+        min_age_hours = config_mgr.get_config_value(LIBRARY_UPDATE_MIN_AGE_HOURS_KEY, default=24.0, cast_type=float)
+        if enabled is None:
+            enabled = False
+        if min_age_hours is None:
+            min_age_hours = 24.0
+        return AgeGateConfig(enabled=bool(enabled), min_age_hours=float(min_age_hours))
 
     def _evaluate_update_age_gate(
         self, commit_datetime: datetime | None, config: AgeGateConfig | None = None
@@ -6256,9 +6259,12 @@ class LibraryManager:
                     check_result.current_version,
                     check_result.latest_version,
                 )
+                # Record the pending target version (not the current one) so consumers can surface
+                # "held at X, pending Y". The `deferred_age_gate` status disambiguates this from an
+                # applied update where old != new.
                 update_summary[library_name] = {
                     "old_version": check_result.current_version or "unknown",
-                    "new_version": check_result.current_version or "unknown",
+                    "new_version": check_result.latest_version or "unknown",
                     "status": "deferred_age_gate",
                 }
                 continue

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -22,8 +22,7 @@ WORKER_HEARTBEAT_TIMEOUT_KEY = "worker.heartbeat_timeout_s"
 WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
-LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY = "library.update_age_gating_enabled"
-LIBRARY_UPDATE_MIN_AGE_HOURS_KEY = "library.update_min_age_hours"
+LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
 
 
 class Category(BaseModel):
@@ -299,25 +298,19 @@ class LibrarySettings(BaseModel):
             "'never' skips installation and marks the library as degraded if required dependencies are missing."
         ),
     )
-    update_age_gating_enabled: bool = Field(
-        default=False,
+    minimum_release_age: float = Field(
+        default=0.0,
         description=(
-            "When True, a library update is withheld until the commit it would update to is at least "
-            "`update_min_age_hours` old (a minimum release age). This guards against automatically adopting a "
-            "freshly-pushed release before there is time to catch and yank a bad one. When False (default), "
-            "updates apply as soon as they are available. If the target commit's age cannot be determined "
-            "(e.g. the remote timestamp is unreadable), the update is allowed (fail-open) and a warning is "
-            "logged, so a metadata hiccup never permanently blocks updates."
-        ),
-    )
-    update_min_age_hours: float = Field(
-        default=24.0,
-        description=(
-            "Minimum age, in hours, of the target commit before an update may be applied. Only enforced when "
-            "`update_age_gating_enabled` is True. Age is measured from the target commit's git committer "
-            "timestamp, which is not necessarily when the release was published: rebased, cherry-picked, "
-            "backdated (GIT_COMMITTER_DATE), or force-moved tags can report an age that differs from the "
-            "actual publish time."
+            "Minimum age, in hours, of the target release before a library update is applied. When 0 (the "
+            "default), updates apply as soon as they are available. When greater than 0, an update is "
+            "withheld until the commit it would move to is at least this many hours old, guarding against "
+            "automatically adopting a freshly-pushed release before there is time to catch and yank a bad "
+            "one. If the target commit's age cannot be determined (e.g. the remote timestamp is unreadable), "
+            "the update is allowed (fail-open) and a warning is logged, so a metadata hiccup never "
+            "permanently blocks updates. Age is measured from the target commit's git committer timestamp, "
+            "which is not necessarily when the release was published: rebased, cherry-picked, backdated "
+            "(GIT_COMMITTER_DATE), or force-moved tags can report an age that differs from the actual publish "
+            "time."
         ),
     )
 

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -303,7 +303,7 @@ class LibrarySettings(BaseModel):
         default=False,
         description=(
             "When True, a library update is withheld until the commit it would update to is at least "
-            "`update_min_age_hours` old (a soak period). This guards against automatically adopting a "
+            "`update_min_age_hours` old (a minimum release age). This guards against automatically adopting a "
             "freshly-pushed release before there is time to catch and yank a bad one. When False (default), "
             "updates apply as soon as they are available. If the target commit's age cannot be determined "
             "(e.g. the remote timestamp is unreadable), the update is allowed (fail-open) and a warning is "

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -305,14 +305,19 @@ class LibrarySettings(BaseModel):
             "When True, a library update is withheld until the commit it would update to is at least "
             "`update_min_age_hours` old (a soak period). This guards against automatically adopting a "
             "freshly-pushed release before there is time to catch and yank a bad one. When False (default), "
-            "updates apply as soon as they are available."
+            "updates apply as soon as they are available. If the target commit's age cannot be determined "
+            "(e.g. the remote timestamp is unreadable), the update is allowed (fail-open) and a warning is "
+            "logged, so a metadata hiccup never permanently blocks updates."
         ),
     )
     update_min_age_hours: float = Field(
         default=24.0,
         description=(
             "Minimum age, in hours, of the target commit before an update may be applied. Only enforced when "
-            "`update_age_gating_enabled` is True. Age is measured from the target commit's git timestamp."
+            "`update_age_gating_enabled` is True. Age is measured from the target commit's git committer "
+            "timestamp, which is not necessarily when the release was published: rebased, cherry-picked, "
+            "backdated (GIT_COMMITTER_DATE), or force-moved tags can report an age that differs from the "
+            "actual publish time."
         ),
     )
 

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -22,6 +22,8 @@ WORKER_HEARTBEAT_TIMEOUT_KEY = "worker.heartbeat_timeout_s"
 WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
+LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY = "library.update_age_gating_enabled"
+LIBRARY_UPDATE_MIN_AGE_HOURS_KEY = "library.update_min_age_hours"
 
 
 class Category(BaseModel):
@@ -295,6 +297,22 @@ class LibrarySettings(BaseModel):
             "Controls automatic installation of library dependencies declared in library manifests. "
             "'always' downloads and installs them on registration. "
             "'never' skips installation and marks the library as degraded if required dependencies are missing."
+        ),
+    )
+    update_age_gating_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, a library update is withheld until the commit it would update to is at least "
+            "`update_min_age_hours` old (a soak period). This guards against automatically adopting a "
+            "freshly-pushed release before there is time to catch and yank a bad one. When False (default), "
+            "updates apply as soon as they are available."
+        ),
+    )
+    update_min_age_hours: float = Field(
+        default=24.0,
+        description=(
+            "Minimum age, in hours, of the target commit before an update may be applied. Only enforced when "
+            "`update_age_gating_enabled` is True. Age is measured from the target commit's git timestamp."
         ),
     )
 

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -6,8 +6,9 @@ import json
 import logging
 import subprocess
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import NamedTuple, cast
 from urllib.parse import urlparse
 
 import pygit2
@@ -53,6 +54,44 @@ class GitUrlWithRef(NamedTuple):
 
     url: str
     ref: str | None
+
+
+class LibraryJsonCheckout(NamedTuple):
+    """Result of fetching a library's JSON metadata from a git remote.
+
+    ``commit_datetime`` is the timezone-aware timestamp of the checked-out commit, or None when
+    it could not be determined.
+    """
+
+    library_version: str
+    commit_sha: str
+    commit_datetime: datetime | None
+    library_data: dict
+
+
+def parse_commit_datetime(iso_string: str) -> datetime | None:
+    """Parse a git commit timestamp in strict ISO 8601 form into a timezone-aware datetime.
+
+    Args:
+        iso_string: The commit timestamp string (e.g. from ``git log --format=%cI``).
+
+    Returns:
+        A timezone-aware datetime, or None if the string is empty or cannot be parsed. Naive
+        timestamps are assumed to be UTC.
+    """
+    iso_string = iso_string.strip()
+    if not iso_string:
+        return None
+
+    try:
+        parsed = datetime.fromisoformat(iso_string)
+    except ValueError:
+        logger.debug("Failed to parse git commit datetime %r", iso_string)
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 def is_git_url(url: str) -> bool:
@@ -1128,7 +1167,7 @@ def _extract_library_version_from_json(json_path: Path, remote_url: str) -> str:
     return library_data["metadata"]["library_version"]
 
 
-def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> tuple[str, str, dict]:
+def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> LibraryJsonCheckout:
     """Perform sparse checkout using git CLI to fetch only library JSON file.
 
     This is the most efficient method as it only downloads files matching the sparse
@@ -1139,7 +1178,7 @@ def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> tuple[str, str, 
         ref: The git reference (branch, tag, or commit) to checkout.
 
     Returns:
-        tuple[str, str, dict]: A tuple of (library_version, commit_sha, library_data).
+        LibraryJsonCheckout: The library version, commit SHA, commit datetime, and library data.
 
     Raises:
         GitCloneError: If sparse checkout fails or library metadata is invalid.
@@ -1205,6 +1244,14 @@ def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> tuple[str, str, 
             )
             commit_sha = rev_parse_result.stdout.strip()
 
+            # Get the committer date of the checked-out commit (strict ISO 8601)
+            commit_date_result = _run_git_command(
+                ["git", "log", "-1", "--format=%cI", "HEAD"],
+                temp_dir,
+                "Git log failed",
+            )
+            commit_datetime = parse_commit_datetime(commit_date_result.stdout.strip())
+
             # Read the JSON data before temp directory is deleted
             try:
                 with library_json_path.open(encoding="utf-8") as f:
@@ -1217,10 +1264,15 @@ def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> tuple[str, str, 
             msg = f"Subprocess error during sparse checkout from {remote_url}: {e}"
             raise GitCloneError(msg) from e
 
-        return (library_version, commit_sha, library_data)
+        return LibraryJsonCheckout(
+            library_version=library_version,
+            commit_sha=commit_sha,
+            commit_datetime=commit_datetime,
+            library_data=library_data,
+        )
 
 
-def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> tuple[str, str, dict]:
+def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> LibraryJsonCheckout:
     """Perform shallow clone using pygit2 to fetch library JSON file.
 
     This is a fallback method when git CLI is not available. It downloads all files
@@ -1231,7 +1283,7 @@ def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> tuple[str, str, dic
         ref: The git reference (branch, tag, or commit) to checkout.
 
     Returns:
-        tuple[str, str, dict]: A tuple of (library_version, commit_sha, library_data).
+        LibraryJsonCheckout: The library version, commit SHA, commit datetime, and library data.
 
     Raises:
         GitCloneError: If clone fails or library metadata is invalid.
@@ -1284,6 +1336,14 @@ def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> tuple[str, str, dic
             # Get commit SHA
             commit_sha = str(repo.head.target)
 
+            # Get the committer date of the checked-out commit
+            commit_datetime = None
+            try:
+                commit_obj = cast("pygit2.Commit", repo[repo.head.target])
+                commit_datetime = datetime.fromtimestamp(commit_obj.commit_time, tz=UTC)
+            except (pygit2.GitError, KeyError, ValueError, OverflowError, OSError) as e:
+                logger.debug("Failed to read commit datetime from clone of %s: %s", remote_url, e)
+
             # Read the JSON data before temp directory is deleted
             try:
                 with library_json_path.open(encoding="utf-8") as f:
@@ -1301,10 +1361,15 @@ def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> tuple[str, str, dic
             if repo is not None:
                 repo.free()
 
-        return (library_version, commit_sha, library_data)
+        return LibraryJsonCheckout(
+            library_version=library_version,
+            commit_sha=commit_sha,
+            commit_datetime=commit_datetime,
+            library_data=library_data,
+        )
 
 
-def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> tuple[str, str, dict]:
+def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> LibraryJsonCheckout:
     """Fetch library JSON file from a git repository.
 
     This function uses the most efficient method available:
@@ -1316,7 +1381,7 @@ def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> tuple[st
         ref: The git reference (branch, tag, or commit) to checkout. Defaults to HEAD.
 
     Returns:
-        tuple[str, str, dict]: A tuple of (library_version, commit_sha, library_data).
+        LibraryJsonCheckout: The library version, commit SHA, commit datetime, and library data.
 
     Raises:
         GitCloneError: If the operation fails or library metadata is invalid.

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -1244,13 +1244,20 @@ def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> LibraryJsonCheck
             )
             commit_sha = rev_parse_result.stdout.strip()
 
-            # Get the committer date of the checked-out commit (strict ISO 8601)
-            commit_date_result = _run_git_command(
-                ["git", "log", "-1", "--format=%cI", "HEAD"],
-                temp_dir,
-                "Git log failed",
-            )
-            commit_datetime = parse_commit_datetime(commit_date_result.stdout.strip())
+            # Get the committer date of the checked-out commit (strict ISO 8601). This is a
+            # best-effort field for the update age gate; a failure here must not fail the whole
+            # checkout, which backs the core version-check path, so degrade to None on error
+            # (mirroring the pygit2 path below).
+            commit_datetime = None
+            try:
+                commit_date_result = _run_git_command(
+                    ["git", "log", "-1", "--format=%cI", "HEAD"],
+                    temp_dir,
+                    "Git log failed",
+                )
+                commit_datetime = parse_commit_datetime(commit_date_result.stdout.strip())
+            except GitCloneError as e:
+                logger.debug("Failed to read commit datetime from sparse checkout of %s: %s", remote_url, e)
 
             # Read the JSON data before temp directory is deleted
             try:
@@ -1336,12 +1343,14 @@ def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> LibraryJsonCheckout
             # Get commit SHA
             commit_sha = str(repo.head.target)
 
-            # Get the committer date of the checked-out commit
+            # Get the committer date of the checked-out commit. Peel to a commit first: for an
+            # annotated tag repo.head.target is the tag OID, and indexing it yields a pygit2.Tag
+            # (no commit_time). This is a best-effort field, so any failure degrades to None.
             commit_datetime = None
             try:
-                commit_obj = cast("pygit2.Commit", repo[repo.head.target])
+                commit_obj = cast("pygit2.Commit", repo[repo.head.target].peel(pygit2.Commit))
                 commit_datetime = datetime.fromtimestamp(commit_obj.commit_time, tz=UTC)
-            except (pygit2.GitError, KeyError, ValueError, OverflowError, OSError) as e:
+            except (pygit2.GitError, KeyError, AttributeError, ValueError, OverflowError, OSError) as e:
                 logger.debug("Failed to read commit datetime from clone of %s: %s", remote_url, e)
 
             # Read the JSON data before temp directory is deleted

--- a/src/griptape_nodes/utils/library_utils.py
+++ b/src/griptape_nodes/utils/library_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pydantic import ValidationError
 from xdg_base_dirs import xdg_data_home
@@ -16,6 +16,9 @@ from griptape_nodes.utils.git_utils import (
     sparse_checkout_library_json,
 )
 
+if TYPE_CHECKING:
+    from datetime import datetime
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,6 +28,7 @@ class LibraryVersionInfo(NamedTuple):
     library_version: str
     commit_sha: str
     engine_version: str
+    commit_datetime: datetime | None = None
 
 
 # Mapping of old XDG library names to their git URLs
@@ -67,14 +71,19 @@ def clone_and_get_library_version(remote_url: str, ref: str = "HEAD") -> Library
         ref: The git reference (branch, tag, or commit SHA) to check. Defaults to "HEAD".
 
     Returns:
-        LibraryVersionInfo: Library version, commit SHA, and engine version from the repository.
+        LibraryVersionInfo: Library version, commit SHA, engine version, and commit datetime from the repository.
 
     Raises:
         GitCloneError: If sparse checkout fails or library metadata is invalid.
     """
-    library_version, commit_sha, library_data = sparse_checkout_library_json(remote_url, ref=ref)
-    engine_version = library_data.get("metadata", {}).get("engine_version", "")
-    return LibraryVersionInfo(library_version=library_version, commit_sha=commit_sha, engine_version=engine_version)
+    checkout = sparse_checkout_library_json(remote_url, ref=ref)
+    engine_version = checkout.library_data.get("metadata", {}).get("engine_version", "")
+    return LibraryVersionInfo(
+        library_version=checkout.library_version,
+        commit_sha=checkout.commit_sha,
+        engine_version=engine_version,
+        commit_datetime=checkout.commit_datetime,
+    )
 
 
 def filter_old_xdg_library_paths(library_paths: list[Any]) -> tuple[list[Any], set[str]]:

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -1,7 +1,7 @@
 """Tests for the library update age gate in LibraryManager.
 
 The age gate withholds a library update until the commit it would move to is at least
-``library.update_min_age_hours`` old, and only when ``library.update_age_gating_enabled`` is set.
+``library.minimum_release_age`` hours old. A value of 0 (the default) disables the gate.
 """
 
 from __future__ import annotations
@@ -27,30 +27,26 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import (
-    AgeGateConfig,
     LibraryGitOperationContext,
     LibraryManager,
+    MinimumReleaseAgeConfig,
 )
 from griptape_nodes.retained_mode.managers.settings import (
-    LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
-    LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
+    LIBRARY_MINIMUM_RELEASE_AGE_KEY,
 )
-from griptape_nodes.utils.git_utils import GitError
 from griptape_nodes.utils.library_utils import LibraryVersionInfo
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
 MIN_AGE_HOURS = 24.0
 
 
-def _config_manager(*, enabled: bool, min_age_hours: float) -> MagicMock:
-    """Build a ConfigManager mock that answers only the two age-gate config keys."""
+def _config_manager(*, minimum_release_age_hours: float) -> MagicMock:
+    """Build a ConfigManager mock that answers only the minimum-release-age config key."""
     config_mgr = MagicMock()
 
     def get_config_value(key: str, **kwargs: object) -> object:
-        if key == LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY:
-            return enabled
-        if key == LIBRARY_UPDATE_MIN_AGE_HOURS_KEY:
-            return min_age_hours
+        if key == LIBRARY_MINIMUM_RELEASE_AGE_KEY:
+            return minimum_release_age_hours
         return kwargs.get("default")
 
     config_mgr.get_config_value.side_effect = get_config_value
@@ -64,9 +60,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
 
-        with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=False, min_age_hours=MIN_AGE_HOURS)
-        ):
+        with patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)):
             decision = library_manager._evaluate_update_age_gate(young_commit)
 
         assert decision.enabled is False
@@ -77,7 +71,7 @@ class TestEvaluateUpdateAgeGate:
         young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
 
         with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         ):
             decision = library_manager._evaluate_update_age_gate(young_commit)
 
@@ -85,14 +79,14 @@ class TestEvaluateUpdateAgeGate:
         assert decision.gated is True
         assert decision.age_hours is not None
         assert decision.age_hours == pytest.approx(1.0, abs=0.1)
-        assert decision.min_age_hours == MIN_AGE_HOURS
+        assert decision.minimum_release_age_hours == MIN_AGE_HOURS
 
     def test_enabled_allows_commit_older_than_threshold(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
         with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         ):
             decision = library_manager._evaluate_update_age_gate(old_commit)
 
@@ -106,7 +100,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
 
         with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         ):
             decision = library_manager._evaluate_update_age_gate(None)
 
@@ -119,7 +113,7 @@ class TestEvaluateUpdateAgeGate:
         naive_young_commit = datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(hours=1)
 
         with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         ):
             decision = library_manager._evaluate_update_age_gate(naive_young_commit)
 
@@ -132,7 +126,7 @@ class TestEvaluateUpdateAgeGate:
 
         with (
             patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
             ),
             caplog.at_level("WARNING"),
         ):
@@ -147,9 +141,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
 
         with (
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=False, min_age_hours=MIN_AGE_HOURS)
-            ),
+            patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)),
             caplog.at_level("WARNING"),
         ):
             decision = library_manager._evaluate_update_age_gate(None)
@@ -160,12 +152,12 @@ class TestEvaluateUpdateAgeGate:
     def test_explicit_config_is_not_re_read_from_config_manager(self, griptape_nodes: GriptapeNodes) -> None:
         """Passing a pre-read config skips the ConfigManager lookup entirely."""
         library_manager = griptape_nodes.LibraryManager()
-        config_mgr = _config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+        config_mgr = _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
         with patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr):
             decision = library_manager._evaluate_update_age_gate(
-                old_commit, config=AgeGateConfig(enabled=True, min_age_hours=MIN_AGE_HOURS)
+                old_commit, config=MinimumReleaseAgeConfig(hours=MIN_AGE_HOURS)
             )
 
         assert decision.enabled is True
@@ -173,21 +165,29 @@ class TestEvaluateUpdateAgeGate:
         config_mgr.get_config_value.assert_not_called()
 
 
-class TestReadAgeGateConfig:
+class TestReadMinimumReleaseAgeConfig:
     """Test the config-reading helper that both the check and update paths share."""
 
-    def test_reads_both_keys(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_reads_configured_hours(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
 
-        with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=12.0)
-        ):
-            config = library_manager._read_age_gate_config()
+        with patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=12.0)):
+            config = library_manager._read_minimum_release_age_config()
 
-        assert config == AgeGateConfig(enabled=True, min_age_hours=12.0)
+        assert config == MinimumReleaseAgeConfig(hours=12.0)
+        assert config.enabled is True
 
-    def test_explicit_null_override_falls_back_to_defaults(self, griptape_nodes: GriptapeNodes) -> None:
-        """An explicit ``null`` in config resolves to None (bypassing cast_type); coalesce to defaults.
+    def test_zero_hours_disables_the_gate(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        with patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)):
+            config = library_manager._read_minimum_release_age_config()
+
+        assert config == MinimumReleaseAgeConfig(hours=0.0)
+        assert config.enabled is False
+
+    def test_explicit_null_override_falls_back_to_default(self, griptape_nodes: GriptapeNodes) -> None:
+        """An explicit ``null`` in config resolves to None (bypassing cast_type); coalesce to the default.
 
         Reading the config must never raise (e.g. ``float(None)``), otherwise a malformed config
         would wedge every update instead of failing open.
@@ -197,9 +197,10 @@ class TestReadAgeGateConfig:
         null_config_mgr.get_config_value.return_value = None
 
         with patch.object(GriptapeNodes, "ConfigManager", return_value=null_config_mgr):
-            config = library_manager._read_age_gate_config()
+            config = library_manager._read_minimum_release_age_config()
 
-        assert config == AgeGateConfig(enabled=False, min_age_hours=24.0)
+        assert config == MinimumReleaseAgeConfig(hours=0.0)
+        assert config.enabled is False
 
 
 class TestUpdateLibraryRequestAgeGate:
@@ -228,7 +229,7 @@ class TestUpdateLibraryRequestAgeGate:
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
             patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
             ),
             patch.object(
                 library_manager,
@@ -260,7 +261,7 @@ class TestUpdateLibraryRequestAgeGate:
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
             patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
             ),
             patch.object(
                 library_manager,
@@ -296,9 +297,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=False, min_age_hours=MIN_AGE_HOURS)
-            ),
+            patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -318,77 +317,6 @@ class TestUpdateLibraryRequestAgeGate:
 
         assert isinstance(result, UpdateLibraryResultSuccess)
         mock_remote_age.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_unknown_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
-        """Fail-open: when the target commit timestamp cannot be read, the update still proceeds."""
-        library_manager = griptape_nodes.LibraryManager()
-        library_dir = Path("/var/lib/test_lib")
-
-        with (
-            patch.object(
-                library_manager,
-                "_validate_and_prepare_library_for_git_operation",
-                new=AsyncMock(return_value=self._validation_context(library_dir)),
-            ),
-            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
-            ),
-            patch.object(
-                library_manager,
-                "_get_remote_target_commit_datetime",
-                new=AsyncMock(return_value=None),
-            ),
-            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git") as mock_update_git,
-            patch(f"{LIBRARY_MANAGER_MODULE}.is_on_tag", return_value=False),
-            patch.object(
-                library_manager,
-                "_reload_library_after_git_operation",
-                new=AsyncMock(return_value="2.0.0"),
-            ),
-        ):
-            result = await library_manager.update_library_request(
-                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
-            )
-
-        assert isinstance(result, UpdateLibraryResultSuccess)
-        mock_update_git.assert_called_once()
-
-
-class TestGetRemoteTargetCommitDatetime:
-    """Test the remote target-commit timestamp helper that feeds the update-path age gate."""
-
-    @pytest.mark.asyncio
-    async def test_returns_none_when_no_remote(self, griptape_nodes: GriptapeNodes) -> None:
-        """A library with no git remote cannot be age-checked, so the helper returns None."""
-        library_manager = griptape_nodes.LibraryManager()
-
-        with (
-            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value=None),
-            patch(f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version") as mock_clone,
-        ):
-            result = await library_manager._get_remote_target_commit_datetime(Path("/var/lib/test_lib"))
-
-        assert result is None
-        mock_clone.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_git_error(self, griptape_nodes: GriptapeNodes) -> None:
-        """A git failure while reading the remote commit degrades to None (fail-open)."""
-        library_manager = griptape_nodes.LibraryManager()
-
-        with (
-            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value="https://example.com/repo.git"),
-            patch(f"{LIBRARY_MANAGER_MODULE}.get_current_ref", return_value="main"),
-            patch(
-                f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version",
-                side_effect=GitError("boom"),
-            ),
-        ):
-            result = await library_manager._get_remote_target_commit_datetime(Path("/var/lib/test_lib"))
-
-        assert result is None
 
 
 class TestCheckLibraryUpdateRequestAgeGate:
@@ -422,6 +350,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
             engine_version="",
             commit_datetime=commit_datetime,
         )
+        minimum_release_age_hours = MIN_AGE_HOURS if enabled else 0.0
 
         with (
             patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=library),
@@ -436,7 +365,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
             patch.object(
                 GriptapeNodes,
                 "ConfigManager",
-                return_value=_config_manager(enabled=enabled, min_age_hours=MIN_AGE_HOURS),
+                return_value=_config_manager(minimum_release_age_hours=minimum_release_age_hours),
             ),
         ):
             result = await library_manager.check_library_update_request(
@@ -458,7 +387,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
         assert result.update_gated_by_age is True
         assert result.target_commit_age_hours is not None
         assert result.target_commit_age_hours == pytest.approx(2.0, abs=0.1)
-        assert result.update_min_age_hours == MIN_AGE_HOURS
+        assert result.minimum_release_age_hours == MIN_AGE_HOURS
 
     @pytest.mark.asyncio
     async def test_ungated_update_reports_age_fields(self, griptape_nodes: GriptapeNodes) -> None:
@@ -472,7 +401,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
         assert result.update_gated_by_age is False
         assert result.target_commit_age_hours is not None
         assert result.target_commit_age_hours == pytest.approx(48.0, abs=0.1)
-        assert result.update_min_age_hours == MIN_AGE_HOURS
+        assert result.minimum_release_age_hours == MIN_AGE_HOURS
 
     @pytest.mark.asyncio
     async def test_disabled_leaves_min_age_none(self, griptape_nodes: GriptapeNodes) -> None:
@@ -484,7 +413,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
 
         assert result.has_update is True
         assert result.update_gated_by_age is False
-        assert result.update_min_age_hours is None
+        assert result.minimum_release_age_hours is None
 
     @pytest.mark.asyncio
     async def test_no_update_leaves_age_fields_default(self, griptape_nodes: GriptapeNodes) -> None:
@@ -502,7 +431,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
         assert result.has_update is False
         assert result.update_gated_by_age is False
         assert result.target_commit_age_hours is None
-        assert result.update_min_age_hours is None
+        assert result.minimum_release_age_hours is None
 
 
 class TestSyncLibrariesRequestAgeGate:
@@ -522,7 +451,7 @@ class TestSyncLibrariesRequestAgeGate:
             remote_commit="remotesha" if has_update else "localsha",
             update_gated_by_age=gated,
             target_commit_age_hours=2.0 if gated else None,
-            update_min_age_hours=MIN_AGE_HOURS if gated else None,
+            minimum_release_age_hours=MIN_AGE_HOURS if gated else None,
             result_details="checked",
         )
 
@@ -554,7 +483,7 @@ class TestSyncLibrariesRequestAgeGate:
             patch.object(
                 GriptapeNodes,
                 "ConfigManager",
-                return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS),
+                return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS),
             ),
             patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
         ):
@@ -574,46 +503,3 @@ class TestSyncLibrariesRequestAgeGate:
         }
         assert result.update_summary["updatable"]["status"] == "updated"
         assert "up_to_date" not in result.update_summary
-
-    @pytest.mark.asyncio
-    async def test_update_pass_age_gate_refusal_counts_as_deferred(self, griptape_nodes: GriptapeNodes) -> None:
-        """A library that passes the check but is refused by the update pass age gate is deferred, not failed.
-
-        This models a newer commit landing on the remote between the check and update passes: the
-        update request comes back as UpdateLibraryResultFailure(age_gated=True) rather than success.
-        """
-        library_manager = griptape_nodes.LibraryManager()
-        check_results = {
-            "raced": self._check_result(has_update=True, gated=False),
-        }
-
-        def dispatch(request: object) -> object:
-            if isinstance(request, LoadLibrariesRequest):
-                return LoadLibrariesResultSuccess(result_details="loaded")
-            if isinstance(request, ListRegisteredLibrariesRequest):
-                return ListRegisteredLibrariesResultSuccess(libraries=list(check_results), result_details="listed")
-            if isinstance(request, CheckLibraryUpdateRequest):
-                return check_results[request.library_name]
-            if isinstance(request, UpdateLibraryRequest):
-                return UpdateLibraryResultFailure(result_details="too young", age_gated=True)
-            error = f"Unexpected request routed through ahandle_request: {request!r}"
-            raise AssertionError(error)
-
-        with (
-            patch.object(
-                GriptapeNodes,
-                "ConfigManager",
-                return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS),
-            ),
-            patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
-        ):
-            result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
-
-        assert isinstance(result, SyncLibrariesResultSuccess)
-        assert result.libraries_updated == 0
-        assert result.libraries_deferred == 1
-        assert result.update_summary["raced"] == {
-            "old_version": "1.0.0",
-            "new_version": "2.0.0",
-            "status": "deferred_age_gate",
-        }

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -34,6 +34,7 @@ from griptape_nodes.retained_mode.managers.library_manager import (
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARY_MINIMUM_RELEASE_AGE_KEY,
 )
+from griptape_nodes.utils.git_utils import GitError
 from griptape_nodes.utils.library_utils import LibraryVersionInfo
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
@@ -318,6 +319,77 @@ class TestUpdateLibraryRequestAgeGate:
         assert isinstance(result, UpdateLibraryResultSuccess)
         mock_remote_age.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_unknown_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
+        """Fail-open: when the target commit timestamp cannot be read, the update still proceeds."""
+        library_manager = griptape_nodes.LibraryManager()
+        library_dir = Path("/var/lib/test_lib")
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=self._validation_context(library_dir)),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
+            ),
+            patch.object(
+                library_manager,
+                "_get_remote_target_commit_datetime",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git") as mock_update_git,
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_on_tag", return_value=False),
+            patch.object(
+                library_manager,
+                "_reload_library_after_git_operation",
+                new=AsyncMock(return_value="2.0.0"),
+            ),
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultSuccess)
+        mock_update_git.assert_called_once()
+
+
+class TestGetRemoteTargetCommitDatetime:
+    """Test the remote target-commit timestamp helper that feeds the update-path age gate."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_remote(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library with no git remote cannot be age-checked, so the helper returns None."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value=None),
+            patch(f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version") as mock_clone,
+        ):
+            result = await library_manager._get_remote_target_commit_datetime(Path("/var/lib/test_lib"))
+
+        assert result is None
+        mock_clone.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_git_error(self, griptape_nodes: GriptapeNodes) -> None:
+        """A git failure while reading the remote commit degrades to None (fail-open)."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value="https://example.com/repo.git"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_current_ref", return_value="main"),
+            patch(
+                f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version",
+                side_effect=GitError("boom"),
+            ),
+        ):
+            result = await library_manager._get_remote_target_commit_datetime(Path("/var/lib/test_lib"))
+
+        assert result is None
+
 
 class TestCheckLibraryUpdateRequestAgeGate:
     """Test that check_library_update_request surfaces the age-gate fields."""
@@ -503,3 +575,46 @@ class TestSyncLibrariesRequestAgeGate:
         }
         assert result.update_summary["updatable"]["status"] == "updated"
         assert "up_to_date" not in result.update_summary
+
+    @pytest.mark.asyncio
+    async def test_update_pass_age_gate_refusal_counts_as_deferred(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library that passes the check but is refused by the update pass age gate is deferred, not failed.
+
+        This models a newer commit landing on the remote between the check and update passes: the
+        update request comes back as UpdateLibraryResultFailure(age_gated=True) rather than success.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        check_results = {
+            "raced": self._check_result(has_update=True, gated=False),
+        }
+
+        def dispatch(request: object) -> object:
+            if isinstance(request, LoadLibrariesRequest):
+                return LoadLibrariesResultSuccess(result_details="loaded")
+            if isinstance(request, ListRegisteredLibrariesRequest):
+                return ListRegisteredLibrariesResultSuccess(libraries=list(check_results), result_details="listed")
+            if isinstance(request, CheckLibraryUpdateRequest):
+                return check_results[request.library_name]
+            if isinstance(request, UpdateLibraryRequest):
+                return UpdateLibraryResultFailure(result_details="too young", age_gated=True)
+            error = f"Unexpected request routed through ahandle_request: {request!r}"
+            raise AssertionError(error)
+
+        with (
+            patch.object(
+                GriptapeNodes,
+                "ConfigManager",
+                return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS),
+            ),
+            patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
+        ):
+            result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
+
+        assert isinstance(result, SyncLibrariesResultSuccess)
+        assert result.libraries_updated == 0
+        assert result.libraries_deferred == 1
+        assert result.update_summary["raced"] == {
+            "old_version": "1.0.0",
+            "new_version": "2.0.0",
+            "status": "deferred_age_gate",
+        }

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -13,16 +13,29 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from griptape_nodes.retained_mode.events.library_events import (
+    CheckLibraryUpdateRequest,
+    CheckLibraryUpdateResultSuccess,
+    ListRegisteredLibrariesRequest,
+    ListRegisteredLibrariesResultSuccess,
+    LoadLibrariesRequest,
+    LoadLibrariesResultSuccess,
+    SyncLibrariesRequest,
+    SyncLibrariesResultSuccess,
     UpdateLibraryRequest,
     UpdateLibraryResultFailure,
     UpdateLibraryResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.library_manager import AgeGateConfig, LibraryGitOperationContext
+from griptape_nodes.retained_mode.managers.library_manager import (
+    AgeGateConfig,
+    LibraryGitOperationContext,
+    LibraryManager,
+)
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
     LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
 )
+from griptape_nodes.utils.library_utils import LibraryVersionInfo
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
 MIN_AGE_HOURS = 24.0
@@ -172,6 +185,21 @@ class TestReadAgeGateConfig:
 
         assert config == AgeGateConfig(enabled=True, min_age_hours=12.0)
 
+    def test_explicit_null_override_falls_back_to_defaults(self, griptape_nodes: GriptapeNodes) -> None:
+        """An explicit ``null`` in config resolves to None (bypassing cast_type); coalesce to defaults.
+
+        Reading the config must never raise (e.g. ``float(None)``), otherwise a malformed config
+        would wedge every update instead of failing open.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        null_config_mgr = MagicMock()
+        null_config_mgr.get_config_value.return_value = None
+
+        with patch.object(GriptapeNodes, "ConfigManager", return_value=null_config_mgr):
+            config = library_manager._read_age_gate_config()
+
+        assert config == AgeGateConfig(enabled=False, min_age_hours=24.0)
+
 
 class TestUpdateLibraryRequestAgeGate:
     """Test enforcement of the age gate inside update_library_request."""
@@ -289,3 +317,188 @@ class TestUpdateLibraryRequestAgeGate:
 
         assert isinstance(result, UpdateLibraryResultSuccess)
         mock_remote_age.assert_not_called()
+
+
+class TestCheckLibraryUpdateRequestAgeGate:
+    """Test that check_library_update_request surfaces the age-gate fields."""
+
+    async def _run_check(
+        self,
+        library_manager: LibraryManager,
+        *,
+        commit_datetime: datetime | None,
+        enabled: bool,
+        has_update: bool = True,
+    ) -> CheckLibraryUpdateResultSuccess:
+        """Run check_library_update_request with all git/registry access mocked out.
+
+        When has_update is False the remote reports the same version and commit as local, so the
+        handler reports no update and skips the age-gate evaluation entirely.
+        """
+        library_dir = Path("/var/lib/test_lib")
+        current_version = "1.0.0"
+        latest_version = "2.0.0" if has_update else current_version
+        local_commit = "localsha"
+        remote_commit = "remotesha" if has_update else local_commit
+        library = MagicMock()
+        library.get_metadata.return_value = MagicMock(library_version=current_version)
+        library_info = MagicMock()
+        library_info.library_path = str(library_dir / "griptape_nodes_library.json")
+        version_info = LibraryVersionInfo(
+            library_version=latest_version,
+            commit_sha=remote_commit,
+            engine_version="",
+            commit_datetime=commit_datetime,
+        )
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=library),
+            patch.object(library_manager, "get_library_info_by_library_name", return_value=library_info),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value="https://example.com/repo.git"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_current_ref", return_value="main"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_local_commit_sha", return_value=local_commit),
+            patch(f"{LIBRARY_MANAGER_MODULE}.remote_ref_exists", return_value=True),
+            patch(f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version", return_value=version_info),
+            patch.object(library_manager, "_check_engine_version_compatibility", return_value=(True, "1.0.0")),
+            patch.object(
+                GriptapeNodes,
+                "ConfigManager",
+                return_value=_config_manager(enabled=enabled, min_age_hours=MIN_AGE_HOURS),
+            ),
+        ):
+            result = await library_manager.check_library_update_request(
+                CheckLibraryUpdateRequest(library_name="test_lib")
+            )
+
+        assert isinstance(result, CheckLibraryUpdateResultSuccess)
+        return result
+
+    @pytest.mark.asyncio
+    async def test_gated_update_reports_age_fields(self, griptape_nodes: GriptapeNodes) -> None:
+        """A young target commit yields has_update=True with update_gated_by_age=True and the age/min fields."""
+        library_manager = griptape_nodes.LibraryManager()
+        young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
+
+        result = await self._run_check(library_manager, commit_datetime=young_commit, enabled=True)
+
+        assert result.has_update is True
+        assert result.update_gated_by_age is True
+        assert result.target_commit_age_hours is not None
+        assert result.target_commit_age_hours == pytest.approx(2.0, abs=0.1)
+        assert result.update_min_age_hours == MIN_AGE_HOURS
+
+    @pytest.mark.asyncio
+    async def test_ungated_update_reports_age_fields(self, griptape_nodes: GriptapeNodes) -> None:
+        """An old target commit is not gated, but the age and min fields are still populated when enabled."""
+        library_manager = griptape_nodes.LibraryManager()
+        old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
+
+        result = await self._run_check(library_manager, commit_datetime=old_commit, enabled=True)
+
+        assert result.has_update is True
+        assert result.update_gated_by_age is False
+        assert result.target_commit_age_hours is not None
+        assert result.target_commit_age_hours == pytest.approx(48.0, abs=0.1)
+        assert result.update_min_age_hours == MIN_AGE_HOURS
+
+    @pytest.mark.asyncio
+    async def test_disabled_leaves_min_age_none(self, griptape_nodes: GriptapeNodes) -> None:
+        """With gating disabled, an available update is never gated and reports no configured minimum."""
+        library_manager = griptape_nodes.LibraryManager()
+        young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
+
+        result = await self._run_check(library_manager, commit_datetime=young_commit, enabled=False)
+
+        assert result.has_update is True
+        assert result.update_gated_by_age is False
+        assert result.update_min_age_hours is None
+
+    @pytest.mark.asyncio
+    async def test_no_update_leaves_age_fields_default(self, griptape_nodes: GriptapeNodes) -> None:
+        """When there is no update, the age gate is not evaluated and its fields stay at defaults."""
+        library_manager = griptape_nodes.LibraryManager()
+        young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
+
+        result = await self._run_check(
+            library_manager,
+            commit_datetime=young_commit,
+            enabled=True,
+            has_update=False,
+        )
+
+        assert result.has_update is False
+        assert result.update_gated_by_age is False
+        assert result.target_commit_age_hours is None
+        assert result.update_min_age_hours is None
+
+
+class TestSyncLibrariesRequestAgeGate:
+    """Test that sync_libraries_request defers age-gated updates rather than applying them."""
+
+    @staticmethod
+    def _check_result(
+        *, has_update: bool, gated: bool = False, latest_version: str = "2.0.0"
+    ) -> CheckLibraryUpdateResultSuccess:
+        return CheckLibraryUpdateResultSuccess(
+            has_update=has_update,
+            current_version="1.0.0",
+            latest_version=latest_version if has_update else "1.0.0",
+            git_remote="https://example.com/repo.git",
+            git_ref="main",
+            local_commit="localsha",
+            remote_commit="remotesha" if has_update else "localsha",
+            update_gated_by_age=gated,
+            target_commit_age_hours=2.0 if gated else None,
+            update_min_age_hours=MIN_AGE_HOURS if gated else None,
+            result_details="checked",
+        )
+
+    @pytest.mark.asyncio
+    async def test_deferred_library_counted_and_not_updated(self, griptape_nodes: GriptapeNodes) -> None:
+        """A gated library is counted in libraries_deferred, summarized, and skipped by the update pass."""
+        library_manager = griptape_nodes.LibraryManager()
+        check_results = {
+            "up_to_date": self._check_result(has_update=False),
+            "gated": self._check_result(has_update=True, gated=True, latest_version="2.0.0"),
+            "updatable": self._check_result(has_update=True, gated=False),
+        }
+        update_calls: list[str] = []
+
+        def dispatch(request: object) -> object:
+            if isinstance(request, LoadLibrariesRequest):
+                return LoadLibrariesResultSuccess(result_details="loaded")
+            if isinstance(request, ListRegisteredLibrariesRequest):
+                return ListRegisteredLibrariesResultSuccess(libraries=list(check_results), result_details="listed")
+            if isinstance(request, CheckLibraryUpdateRequest):
+                return check_results[request.library_name]
+            if isinstance(request, UpdateLibraryRequest):
+                update_calls.append(request.library_name)
+                return UpdateLibraryResultSuccess(old_version="1.0.0", new_version="2.0.0", result_details="updated")
+            error = f"Unexpected request routed through ahandle_request: {request!r}"
+            raise AssertionError(error)
+
+        with (
+            patch.object(
+                GriptapeNodes,
+                "ConfigManager",
+                return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS),
+            ),
+            patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
+        ):
+            result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
+
+        assert isinstance(result, SyncLibrariesResultSuccess)
+        assert result.libraries_checked == len(check_results)
+        assert result.libraries_deferred == 1
+        assert result.libraries_updated == 1
+        # The gated library must never reach the update pass.
+        assert update_calls == ["updatable"]
+        # The deferred summary records the pending target version, not the current one.
+        assert result.update_summary["gated"] == {
+            "old_version": "1.0.0",
+            "new_version": "2.0.0",
+            "status": "deferred_age_gate",
+        }
+        assert result.update_summary["updatable"]["status"] == "updated"
+        assert "up_to_date" not in result.update_summary

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -35,6 +35,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
     LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
 )
+from griptape_nodes.utils.git_utils import GitError
 from griptape_nodes.utils.library_utils import LibraryVersionInfo
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
@@ -318,6 +319,77 @@ class TestUpdateLibraryRequestAgeGate:
         assert isinstance(result, UpdateLibraryResultSuccess)
         mock_remote_age.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_unknown_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
+        """Fail-open: when the target commit timestamp cannot be read, the update still proceeds."""
+        library_manager = griptape_nodes.LibraryManager()
+        library_dir = Path("/var/lib/test_lib")
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=self._validation_context(library_dir)),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            ),
+            patch.object(
+                library_manager,
+                "_get_remote_target_commit_datetime",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git") as mock_update_git,
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_on_tag", return_value=False),
+            patch.object(
+                library_manager,
+                "_reload_library_after_git_operation",
+                new=AsyncMock(return_value="2.0.0"),
+            ),
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultSuccess)
+        mock_update_git.assert_called_once()
+
+
+class TestGetRemoteTargetCommitDatetime:
+    """Test the remote target-commit timestamp helper that feeds the update-path age gate."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_remote(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library with no git remote cannot be age-checked, so the helper returns None."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value=None),
+            patch(f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version") as mock_clone,
+        ):
+            result = await library_manager._get_remote_target_commit_datetime(Path("/var/lib/test_lib"))
+
+        assert result is None
+        mock_clone.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_git_error(self, griptape_nodes: GriptapeNodes) -> None:
+        """A git failure while reading the remote commit degrades to None (fail-open)."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value="https://example.com/repo.git"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_current_ref", return_value="main"),
+            patch(
+                f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version",
+                side_effect=GitError("boom"),
+            ),
+        ):
+            result = await library_manager._get_remote_target_commit_datetime(Path("/var/lib/test_lib"))
+
+        assert result is None
+
 
 class TestCheckLibraryUpdateRequestAgeGate:
     """Test that check_library_update_request surfaces the age-gate fields."""
@@ -502,3 +574,46 @@ class TestSyncLibrariesRequestAgeGate:
         }
         assert result.update_summary["updatable"]["status"] == "updated"
         assert "up_to_date" not in result.update_summary
+
+    @pytest.mark.asyncio
+    async def test_update_pass_age_gate_refusal_counts_as_deferred(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library that passes the check but is refused by the update pass age gate is deferred, not failed.
+
+        This models a newer commit landing on the remote between the check and update passes: the
+        update request comes back as UpdateLibraryResultFailure(age_gated=True) rather than success.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        check_results = {
+            "raced": self._check_result(has_update=True, gated=False),
+        }
+
+        def dispatch(request: object) -> object:
+            if isinstance(request, LoadLibrariesRequest):
+                return LoadLibrariesResultSuccess(result_details="loaded")
+            if isinstance(request, ListRegisteredLibrariesRequest):
+                return ListRegisteredLibrariesResultSuccess(libraries=list(check_results), result_details="listed")
+            if isinstance(request, CheckLibraryUpdateRequest):
+                return check_results[request.library_name]
+            if isinstance(request, UpdateLibraryRequest):
+                return UpdateLibraryResultFailure(result_details="too young", age_gated=True)
+            error = f"Unexpected request routed through ahandle_request: {request!r}"
+            raise AssertionError(error)
+
+        with (
+            patch.object(
+                GriptapeNodes,
+                "ConfigManager",
+                return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS),
+            ),
+            patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
+        ):
+            result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
+
+        assert isinstance(result, SyncLibrariesResultSuccess)
+        assert result.libraries_updated == 0
+        assert result.libraries_deferred == 1
+        assert result.update_summary["raced"] == {
+            "old_version": "1.0.0",
+            "new_version": "2.0.0",
+            "status": "deferred_age_gate",
+        }

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -1,0 +1,230 @@
+"""Tests for the library update age gate in LibraryManager.
+
+The age gate withholds a library update until the commit it would move to is at least
+``library.update_min_age_hours`` old, and only when ``library.update_age_gating_enabled`` is set.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.retained_mode.events.library_events import (
+    UpdateLibraryRequest,
+    UpdateLibraryResultFailure,
+    UpdateLibraryResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.library_manager import LibraryGitOperationContext
+from griptape_nodes.retained_mode.managers.settings import (
+    LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
+    LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
+)
+
+LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
+MIN_AGE_HOURS = 24.0
+
+
+def _config_manager(*, enabled: bool, min_age_hours: float) -> MagicMock:
+    """Build a ConfigManager mock that answers only the two age-gate config keys."""
+    config_mgr = MagicMock()
+
+    def get_config_value(key: str, **kwargs: object) -> object:
+        if key == LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY:
+            return enabled
+        if key == LIBRARY_UPDATE_MIN_AGE_HOURS_KEY:
+            return min_age_hours
+        return kwargs.get("default")
+
+    config_mgr.get_config_value.side_effect = get_config_value
+    return config_mgr
+
+
+class TestEvaluateUpdateAgeGate:
+    """Test the pure age-gate decision helper."""
+
+    def test_disabled_never_gates(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+        young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
+
+        with patch.object(
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=False, min_age_hours=MIN_AGE_HOURS)
+        ):
+            decision = library_manager._evaluate_update_age_gate(young_commit)
+
+        assert decision.enabled is False
+        assert decision.gated is False
+
+    def test_enabled_gates_commit_younger_than_threshold(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+        young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
+
+        with patch.object(
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+        ):
+            decision = library_manager._evaluate_update_age_gate(young_commit)
+
+        assert decision.enabled is True
+        assert decision.gated is True
+        assert decision.age_hours is not None
+        assert decision.age_hours == pytest.approx(1.0, abs=0.1)
+        assert decision.min_age_hours == MIN_AGE_HOURS
+
+    def test_enabled_allows_commit_older_than_threshold(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+        old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
+
+        with patch.object(
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+        ):
+            decision = library_manager._evaluate_update_age_gate(old_commit)
+
+        assert decision.enabled is True
+        assert decision.gated is False
+        assert decision.age_hours is not None
+        assert decision.age_hours == pytest.approx(48.0, abs=0.1)
+
+    def test_enabled_allows_when_commit_datetime_unknown(self, griptape_nodes: GriptapeNodes) -> None:
+        """A missing commit timestamp cannot be verified, so the update is allowed (not wedged)."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with patch.object(
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+        ):
+            decision = library_manager._evaluate_update_age_gate(None)
+
+        assert decision.enabled is True
+        assert decision.gated is False
+        assert decision.age_hours is None
+
+    def test_naive_commit_datetime_is_treated_as_utc(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+        naive_young_commit = datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(hours=1)
+
+        with patch.object(
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+        ):
+            decision = library_manager._evaluate_update_age_gate(naive_young_commit)
+
+        assert decision.gated is True
+
+
+class TestUpdateLibraryRequestAgeGate:
+    """Test enforcement of the age gate inside update_library_request."""
+
+    def _validation_context(self, library_dir: Path) -> LibraryGitOperationContext:
+        return LibraryGitOperationContext(
+            library=MagicMock(),
+            old_version="1.0.0",
+            library_file_path=str(library_dir / "griptape_nodes_library.json"),
+            library_dir=library_dir,
+        )
+
+    @pytest.mark.asyncio
+    async def test_young_target_commit_blocks_update(self, griptape_nodes: GriptapeNodes) -> None:
+        """A target commit younger than the soak period blocks the update without touching git."""
+        library_manager = griptape_nodes.LibraryManager()
+        library_dir = Path("/var/lib/test_lib")
+        young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=self._validation_context(library_dir)),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            ),
+            patch.object(
+                library_manager,
+                "_get_remote_target_commit_datetime",
+                new=AsyncMock(return_value=young_commit),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git") as mock_update_git,
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultFailure)
+        assert result.age_gated is True
+        mock_update_git.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_old_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
+        """A target commit older than the soak period is allowed through to the git update."""
+        library_manager = griptape_nodes.LibraryManager()
+        library_dir = Path("/var/lib/test_lib")
+        old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=self._validation_context(library_dir)),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            ),
+            patch.object(
+                library_manager,
+                "_get_remote_target_commit_datetime",
+                new=AsyncMock(return_value=old_commit),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git") as mock_update_git,
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_on_tag", return_value=False),
+            patch.object(
+                library_manager,
+                "_reload_library_after_git_operation",
+                new=AsyncMock(return_value="2.0.0"),
+            ),
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultSuccess)
+        assert result.new_version == "2.0.0"
+        mock_update_git.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disabled_skips_remote_age_lookup(self, griptape_nodes: GriptapeNodes) -> None:
+        """When gating is disabled, the update path never pays for the remote age round-trip."""
+        library_manager = griptape_nodes.LibraryManager()
+        library_dir = Path("/var/lib/test_lib")
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=self._validation_context(library_dir)),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=False, min_age_hours=MIN_AGE_HOURS)
+            ),
+            patch.object(
+                library_manager,
+                "_get_remote_target_commit_datetime",
+                new=AsyncMock(return_value=None),
+            ) as mock_remote_age,
+            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_on_tag", return_value=False),
+            patch.object(
+                library_manager,
+                "_reload_library_after_git_operation",
+                new=AsyncMock(return_value="2.0.0"),
+            ),
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultSuccess)
+        mock_remote_age.assert_not_called()

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -186,7 +186,7 @@ class TestUpdateLibraryRequestAgeGate:
 
     @pytest.mark.asyncio
     async def test_young_target_commit_blocks_update(self, griptape_nodes: GriptapeNodes) -> None:
-        """A target commit younger than the soak period blocks the update without touching git."""
+        """A target commit younger than the minimum age blocks the update without touching git."""
         library_manager = griptape_nodes.LibraryManager()
         library_dir = Path("/var/lib/test_lib")
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
@@ -218,7 +218,7 @@ class TestUpdateLibraryRequestAgeGate:
 
     @pytest.mark.asyncio
     async def test_old_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
-        """A target commit older than the soak period is allowed through to the git update."""
+        """A target commit older than the minimum age is allowed through to the git update."""
         library_manager = griptape_nodes.LibraryManager()
         library_dir = Path("/var/lib/test_lib")
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -18,7 +18,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     UpdateLibraryResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.managers.library_manager import LibraryGitOperationContext
+from griptape_nodes.retained_mode.managers.library_manager import AgeGateConfig, LibraryGitOperationContext
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARY_UPDATE_AGE_GATING_ENABLED_KEY,
     LIBRARY_UPDATE_MIN_AGE_HOURS_KEY,
@@ -110,6 +110,67 @@ class TestEvaluateUpdateAgeGate:
             decision = library_manager._evaluate_update_age_gate(naive_young_commit)
 
         assert decision.gated is True
+
+    def test_enabled_unknown_timestamp_logs_fail_open_warning(
+        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            decision = library_manager._evaluate_update_age_gate(None)
+
+        assert decision.gated is False
+        assert any("could not be determined" in message for message in caplog.messages)
+
+    def test_disabled_unknown_timestamp_does_not_warn(
+        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch.object(
+                GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=False, min_age_hours=MIN_AGE_HOURS)
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            decision = library_manager._evaluate_update_age_gate(None)
+
+        assert decision.enabled is False
+        assert not any("could not be determined" in message for message in caplog.messages)
+
+    def test_explicit_config_is_not_re_read_from_config_manager(self, griptape_nodes: GriptapeNodes) -> None:
+        """Passing a pre-read config skips the ConfigManager lookup entirely."""
+        library_manager = griptape_nodes.LibraryManager()
+        config_mgr = _config_manager(enabled=True, min_age_hours=MIN_AGE_HOURS)
+        old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
+
+        with patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr):
+            decision = library_manager._evaluate_update_age_gate(
+                old_commit, config=AgeGateConfig(enabled=True, min_age_hours=MIN_AGE_HOURS)
+            )
+
+        assert decision.enabled is True
+        assert decision.gated is False
+        config_mgr.get_config_value.assert_not_called()
+
+
+class TestReadAgeGateConfig:
+    """Test the config-reading helper that both the check and update paths share."""
+
+    def test_reads_both_keys(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        with patch.object(
+            GriptapeNodes, "ConfigManager", return_value=_config_manager(enabled=True, min_age_hours=12.0)
+        ):
+            config = library_manager._read_age_gate_config()
+
+        assert config == AgeGateConfig(enabled=True, min_age_hours=12.0)
 
 
 class TestUpdateLibraryRequestAgeGate:

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -1253,5 +1253,5 @@ class TestParseCommitDatetime:
         assert parse_commit_datetime("") is None
         assert parse_commit_datetime("   ") is None
 
-    def test_returns_none_for_unparseable_string(self) -> None:
+    def test_returns_none_for_unparsable_string(self) -> None:
         assert parse_commit_datetime("not-a-date") is None

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
@@ -27,6 +28,7 @@ from griptape_nodes.utils.git_utils import (
     is_git_repository,
     is_git_url,
     normalize_github_url,
+    parse_commit_datetime,
     parse_git_url_with_ref,
     remote_ref_exists,
     switch_branch,
@@ -1218,3 +1220,38 @@ class TestRemoteRefExists:
             pytest.raises(GitRemoteError, match="Failed to query remote refs"),
         ):
             remote_ref_exists("https://github.com/owner/repo.git", "main")
+
+
+class TestParseCommitDatetime:
+    """Test parse_commit_datetime function."""
+
+    def test_parses_iso_8601_with_offset(self) -> None:
+        result = parse_commit_datetime("2024-01-15T12:30:00+00:00")
+
+        assert result == datetime(2024, 1, 15, 12, 30, 0, tzinfo=UTC)
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_parses_iso_8601_with_non_utc_offset(self) -> None:
+        result = parse_commit_datetime("2024-01-15T12:30:00-05:00")
+
+        assert result is not None
+        # Same instant, expressed in UTC.
+        assert result.astimezone(UTC) == datetime(2024, 1, 15, 17, 30, 0, tzinfo=UTC)
+
+    def test_assumes_utc_for_naive_timestamp(self) -> None:
+        result = parse_commit_datetime("2024-01-15T12:30:00")
+
+        assert result == datetime(2024, 1, 15, 12, 30, 0, tzinfo=UTC)
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        result = parse_commit_datetime("  2024-01-15T12:30:00+00:00\n")
+
+        assert result == datetime(2024, 1, 15, 12, 30, 0, tzinfo=UTC)
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert parse_commit_datetime("") is None
+        assert parse_commit_datetime("   ") is None
+
+    def test_returns_none_for_unparseable_string(self) -> None:
+        assert parse_commit_datetime("not-a-date") is None

--- a/tests/unit/utils/test_library_utils.py
+++ b/tests/unit/utils/test_library_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -10,7 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from griptape_nodes.retained_mode.managers.settings import LibraryDownload, LibraryRegistration
-from griptape_nodes.utils.git_utils import GitCloneError
+from griptape_nodes.utils.git_utils import GitCloneError, LibraryJsonCheckout
 from griptape_nodes.utils.library_utils import (
     clone_and_get_library_version,
     filter_old_xdg_library_paths,
@@ -102,27 +103,37 @@ class TestCloneAndGetLibraryVersion:
     def test_clone_and_get_library_version_calls_sparse_checkout(self) -> None:
         """Test that clone_and_get_library_version delegates to sparse_checkout_library_json."""
         with patch("griptape_nodes.utils.library_utils.sparse_checkout_library_json") as mock_sparse:
-            mock_sparse.return_value = ("1.0.0", "abc123def456", {"metadata": {"engine_version": "0.70.0"}})
+            mock_sparse.return_value = LibraryJsonCheckout(
+                library_version="1.0.0",
+                commit_sha="abc123def456",
+                commit_datetime=None,
+                library_data={"metadata": {"engine_version": "0.70.0"}},
+            )
 
             result = clone_and_get_library_version("https://github.com/user/repo.git")
 
             mock_sparse.assert_called_once_with("https://github.com/user/repo.git", ref="HEAD")
-            assert result == ("1.0.0", "abc123def456", "0.70.0")
+            assert result == ("1.0.0", "abc123def456", "0.70.0", None)
 
     def test_clone_and_get_library_version_returns_version_commit_and_engine_version(self) -> None:
-        """Test that clone_and_get_library_version returns version, commit, and engine_version."""
+        """Test that clone_and_get_library_version returns version, commit, engine_version, and commit datetime."""
+        commit_datetime = datetime(2024, 1, 15, 12, 30, tzinfo=UTC)
         with patch("griptape_nodes.utils.library_utils.sparse_checkout_library_json") as mock_sparse:
-            mock_sparse.return_value = ("2.5.1", "def789ghi012", {"metadata": {"engine_version": "0.71.0"}})
+            mock_sparse.return_value = LibraryJsonCheckout(
+                library_version="2.5.1",
+                commit_sha="def789ghi012",
+                commit_datetime=commit_datetime,
+                library_data={"metadata": {"engine_version": "0.71.0"}},
+            )
 
             result = clone_and_get_library_version("https://github.com/user/repo.git")
 
-            # Verify returns tuple of (version, commit, engine_version)
-            assert result == ("2.5.1", "def789ghi012", "0.71.0")
-            assert isinstance(result, tuple)
-            version, commit, engine_version = result
-            assert version == "2.5.1"
-            assert commit == "def789ghi012"
-            assert engine_version == "0.71.0"
+            # Verify returns (version, commit, engine_version, commit_datetime)
+            assert result == ("2.5.1", "def789ghi012", "0.71.0", commit_datetime)
+            assert result.library_version == "2.5.1"
+            assert result.commit_sha == "def789ghi012"
+            assert result.engine_version == "0.71.0"
+            assert result.commit_datetime == commit_datetime
 
     def test_clone_and_get_library_version_propagates_errors(self) -> None:
         """Test that errors from sparse_checkout_library_json are propagated."""


### PR DESCRIPTION
An opt-in age gate for library updates so operators can hold an update until the release it points to has had time to settle, rather than adopting a freshly-published release the moment it appears. Closes #5096.

A single `library.minimum_release_age` setting (in hours; `0`, the default, disables it) controls the delay, mirroring the `minimumReleaseAge` cooldown that pnpm and Renovate use against the same supply-chain risk. It keys off the target commit's committer timestamp, which is not necessarily when the release was published (rebased, backdated, or force-moved tags can misreport it), so this is a best-effort delay rather than a hard guarantee. When the timestamp cannot be read the update is allowed (fail-open) and a warning is logged, so a metadata hiccup can never permanently wedge updates.

Unit tests cover the decision logic and the check, update, and sync enforcement paths, but a proper end-to-end check requires a real library release: cut a fresh release on a git-backed library and confirm the gate withholds it while it is younger than `library.minimum_release_age`, then confirm it applies once the release is older than that. Temporarily lowering the value shortens the wait while verifying.

The editor-side changes that surface this in the UI (the held-update indicator, the settings field, and the informational toasts) are in griptape-ai/griptape-vsl-gui#2637.
