### PR TITLE
fix(engine): make recursive deleted_paths opt-in on DeleteFileRequest

### DIFF
--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -896,6 +896,11 @@ class DeleteFileRequest(RequestPayload):
         file_entry: FileSystemEntry from directory listing (mutually exclusive with path)
         workspace_only: If True, constrain to workspace directory
         deletion_behavior: How to handle deletion (permanent, recycle bin only, or prefer recycle bin)
+        collect_deleted_paths: If True, recursively enumerate every descendant of a deleted
+            directory into the result's deleted_paths. Off by default because for large
+            directory trees this list can grow to many megabytes, bloating the broadcast
+            result. Callers that need the full list (e.g. reporting individual deletions)
+            opt in explicitly.
 
     Results: DeleteFileResultSuccess | DeleteFileResultFailure
     """
@@ -904,6 +909,7 @@ class DeleteFileRequest(RequestPayload):
     file_entry: FileSystemEntry | None = None
     workspace_only: bool | None = True
     deletion_behavior: DeletionBehavior = DeletionBehavior.PREFER_RECYCLE_BIN
+    collect_deleted_paths: bool = False
 
 
 @dataclass
@@ -914,7 +920,9 @@ class DeleteFileResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     Attributes:
         deleted_path: The absolute path that was deleted (primary path)
         was_directory: Whether the deleted item was a directory
-        deleted_paths: List of all paths that were deleted (for recursive deletes, includes all files/dirs)
+        deleted_paths: Paths that were deleted. Contains just the primary path unless the request
+            set collect_deleted_paths=True, in which case a deleted directory expands to every
+            descendant file/dir.
         outcome: The actual outcome of the deletion (permanently deleted or sent to recycle bin)
     """
 

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -3811,7 +3811,7 @@ class OSManager:
         is_directory = await anyio.Path(resolved_path).is_dir()
 
         # Collect all paths that will be deleted (for reporting)
-        if is_directory:
+        if is_directory and request.collect_deleted_paths:
             # Collect all file and directory paths before deletion
             deleted_paths = [str(item) async for item in anyio.Path(resolved_path).rglob("*")]
             deleted_paths.append(str(resolved_path))

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -1358,7 +1358,7 @@ class TestDeleteFileRequest:
         subdir.mkdir()
         (subdir / "file3.txt").write_text("content3")
 
-        request = DeleteFileRequest(path=str(dir_path), workspace_only=False)
+        request = DeleteFileRequest(path=str(dir_path), workspace_only=False, collect_deleted_paths=True)
 
         result = await os_manager.on_delete_file_request(request)
 
@@ -1370,6 +1370,28 @@ class TestDeleteFileRequest:
         assert any(str(dir_path / "file1.txt") in path for path in result.deleted_paths)
         assert any(str(dir_path / "file2.txt") in path for path in result.deleted_paths)
         assert any(str(subdir / "file3.txt") in path for path in result.deleted_paths)
+        assert not dir_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_directory_without_collect_returns_only_top_level(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Test that deleting a directory without collect_deleted_paths returns only the top-level path."""
+        os_manager = griptape_nodes.OSManager()
+        dir_path = temp_dir / "testdir"
+        dir_path.mkdir()
+        (dir_path / "file1.txt").write_text("content1")
+        subdir = dir_path / "subdir"
+        subdir.mkdir()
+        (subdir / "file2.txt").write_text("content2")
+
+        request = DeleteFileRequest(path=str(dir_path), workspace_only=False)
+
+        result = await os_manager.on_delete_file_request(request)
+
+        assert isinstance(result, DeleteFileResultSuccess)
+        assert result.was_directory is True
+        assert result.deleted_paths == [result.deleted_path]
         assert not dir_path.exists()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #5098

Deleting a directory recursively globbed every descendant into `DeleteFileResultSuccess.deleted_paths`, and since results are broadcast over the websocket the whole list went out on the wire. The only caller that generates huge lists, library overwrite-download, never reads the field, so it was paying to enumerate, serialize, and ship megabytes for nothing.

`DeleteFileRequest` now gates the recursive enumeration behind `collect_deleted_paths` (default off). When off, `deleted_paths` carries just the primary deleted path; when on, a deleted directory still expands to every descendant. The standard-library `delete_file` node, which surfaces the full list as an output, opts in on its side so its behavior is unchanged.

The 8.4MB overwrite-download payload collapses to a single path. Callers that genuinely want the per-file breakdown still get it by asking.