### PR TITLE
feat(workflows): let RenameWorkflowRequest opt into preserving the display name (#4992)

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -260,6 +260,28 @@ class DeleteWorkflowResultFailure(ResultPayloadFailure):
     """Workflow deletion failed. Common causes: workflow not found, deletion not allowed, registry error."""
 
 
+class RenameDisplayNameBehavior(StrEnum):
+    """Controls what happens to ``WorkflowMetadata.name`` (the human-facing display name) on rename.
+
+    Rename is always a file-name operation; the display name is independent metadata. This enum
+    lets callers decide whether the rename should touch it.
+
+    Values:
+        MATCH_FILE_NAME: Overwrite the display name with the (unsanitized) requested new name.
+            Historical behavior and the default so on-the-wire parity with existing callers is
+            preserved.
+        PRESERVE_EXISTING: Leave the current display name untouched. Opt-in; the file moves but
+            ``metadata.name`` stays put. Use this to fix the "renaming a workflow silently rewrites
+            its display name" corruption path (engine #4992).
+        OVERRIDE: Set the display name to the caller-supplied ``display_name`` value, independent
+            of the file name. Requires ``display_name`` to be non-empty.
+    """
+
+    PRESERVE_EXISTING = "preserve_existing"
+    MATCH_FILE_NAME = "match_file_name"
+    OVERRIDE = "override"
+
+
 @dataclass
 @PayloadRegistry.register
 class RenameWorkflowRequest(RequestPayload):
@@ -270,13 +292,22 @@ class RenameWorkflowRequest(RequestPayload):
 
     Args:
         workflow_name: Current name of the workflow
-        requested_name: New name for the workflow
+        requested_name: New name for the workflow (drives the on-disk filename)
+        display_name_behavior: How to treat ``WorkflowMetadata.name`` on rename. Defaults to
+            ``MATCH_FILE_NAME`` to preserve historical wire behavior — callers who want the
+            display name preserved on rename must opt in with ``PRESERVE_EXISTING``. See
+            :class:`RenameDisplayNameBehavior`.
+        display_name: New display name. Required (non-empty) when ``display_name_behavior`` is
+            ``OVERRIDE``. MUST be ``None`` for the other behaviors — supplying it there is
+            rejected up front to catch callers who set it thinking it will take effect.
 
     Results: RenameWorkflowResultSuccess | RenameWorkflowResultFailure (workflow not found, name conflict)
     """
 
     workflow_name: str
     requested_name: str
+    display_name_behavior: RenameDisplayNameBehavior = RenameDisplayNameBehavior.MATCH_FILE_NAME
+    display_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1157,19 +1157,26 @@ class WorkflowManager:
         if display_name_error is not None:
             return RenameWorkflowResultFailure(result_details=display_name_error)
 
-        display_name = self._resolve_rename_display_name(request)
+        # Single source-of-truth lookup for the workflow being renamed. Threaded through the
+        # display-name resolver and post-save bookkeeping so we don't re-query the registry
+        # three more times (and can't disagree with ourselves mid-handler).
+        source = (
+            WorkflowRegistry.get_workflow_by_name(request.workflow_name)
+            if WorkflowRegistry.has_workflow_with_name(request.workflow_name)
+            else None
+        )
+
+        display_name = self._resolve_rename_display_name(request, source=source)
 
         # Rename keeps the workflow's location (unlike Move). Inherit the source workflow's
         # directory and prepend it to the sanitized stem so the renamed file stays put:
         # a workspace sub-dir ("bar/new_name") or an external absolute path ("/ext/new_name").
         # The combined name is NOT re-run through normalize_display_name, so its "/" survives.
         requested_file_name = sanitized_stem
-        if WorkflowRegistry.has_workflow_with_name(request.workflow_name):
-            source = WorkflowRegistry.get_workflow_by_name(request.workflow_name)
-            if source.file_path:
-                source_dir = PurePosixPath(source.file_path.replace("\\", "/")).parent
-                if str(source_dir) not in ("", "."):
-                    requested_file_name = f"{source_dir}/{sanitized_stem}"
+        if source is not None and source.file_path:
+            source_dir = PurePosixPath(source.file_path.replace("\\", "/")).parent
+            if str(source_dir) not in ("", "."):
+                requested_file_name = f"{source_dir}/{sanitized_stem}"
 
         save_workflow_request = await GriptapeNodes.ahandle_request(
             SaveWorkflowRequest(file_name=requested_file_name, display_name=display_name)
@@ -1182,6 +1189,7 @@ class WorkflowManager:
         reconcile_error = await self._reconcile_rename_bookkeeping(
             old_workflow_name=request.workflow_name,
             save_result=save_workflow_request,
+            source=source,
         )
         if reconcile_error is not None:
             return RenameWorkflowResultFailure(result_details=reconcile_error)
@@ -1224,27 +1232,34 @@ class WorkflowManager:
             "or use PRESERVE_EXISTING / MATCH_FILE_NAME behavior."
         )
 
-    def _resolve_rename_display_name(self, request: RenameWorkflowRequest) -> str | None:
+    def _resolve_rename_display_name(self, request: RenameWorkflowRequest, *, source: Workflow | None) -> str:
         """Compute the display name (``metadata.name``) to pass into the follow-up SaveWorkflowRequest.
 
+        ``source`` is the already-resolved registry entry for ``request.workflow_name`` (or ``None``
+        when the workflow isn't registered) — passed in so we don't re-query the registry here.
+
         * ``OVERRIDE`` — return the caller-supplied ``display_name`` stripped of surrounding
-          whitespace. Matches ``_validate_rename_display_name``'s ``strip()``-based non-empty
-          gate so validation and resolution share one canonical form; a padded-but-valid
-          input like ``"  My Name  "`` can't leak whitespace into ``metadata.name``.
-        * ``PRESERVE_EXISTING`` — return the source workflow's current ``metadata.name``. If the source
-          isn't in the registry (uncommon Save-As-style path), fall through to the requested name so
-          the on-disk file still gets a sensible display name.
-        * ``MATCH_FILE_NAME`` — return the raw ``requested_name`` (legacy behavior; display name tracks
-          the new file name).
+          whitespace. ``_validate_rename_display_name`` guarantees it's non-empty after strip;
+          if this invariant is ever violated that's a genuine engine bug, so ``assert`` is
+          used to document it rather than a defensive fallback.
+        * ``PRESERVE_EXISTING`` — return the source workflow's current ``metadata.name`` (stripped).
+          If the source isn't registered OR its ``metadata.name`` is blank, fall through to the
+          requested name — better a sensible file-stem-derived label than propagating a corrupt
+          empty display name onto the renamed workflow.
+        * ``MATCH_FILE_NAME`` — return the raw ``requested_name`` (legacy behavior; display name
+          tracks the new file name).
         """
         if request.display_name_behavior is RenameDisplayNameBehavior.OVERRIDE:
-            # display_name is guaranteed non-empty after strip() by _validate_rename_display_name.
-            return request.display_name.strip() if request.display_name else request.display_name
-        if (
-            request.display_name_behavior is RenameDisplayNameBehavior.PRESERVE_EXISTING
-            and WorkflowRegistry.has_workflow_with_name(request.workflow_name)
-        ):
-            return WorkflowRegistry.get_workflow_by_name(request.workflow_name).metadata.name
+            # Invariant established by _validate_rename_display_name — reaching this branch
+            # with display_name=None is a genuine engine bug, so surface it loudly.
+            if request.display_name is None:
+                msg = "OVERRIDE reached _resolve_rename_display_name with display_name=None"
+                raise RuntimeError(msg)
+            return request.display_name.strip()
+        if request.display_name_behavior is RenameDisplayNameBehavior.PRESERVE_EXISTING and source is not None:
+            preserved = (source.metadata.name or "").strip()
+            if preserved:
+                return preserved
         return request.requested_name
 
     async def _reconcile_rename_bookkeeping(
@@ -1252,8 +1267,12 @@ class WorkflowManager:
         *,
         old_workflow_name: str,
         save_result: SaveWorkflowResultSuccess,
+        source: Workflow | None,
     ) -> str | None:
         """Post-save bookkeeping for a rename: rekey flags, persist external reg, delete old entry, sync context.
+
+        ``source`` is the pre-resolved registry entry for ``old_workflow_name`` (or ``None`` when
+        the workflow wasn't registered). Threaded from the outer handler so we don't re-query.
 
         Returns a failure message when the delete step fails; otherwise None. Extracted so the outer
         handler doesn't blow past the McCabe branch limit.
@@ -1271,7 +1290,7 @@ class WorkflowManager:
         # If the original workflow isn't registered, treat this as a Save As and skip deletion.
         # Also skip when the key is unchanged (e.g. renaming to the same on-disk name) so we
         # don't delete the file we just saved.
-        if WorkflowRegistry.has_workflow_with_name(old_workflow_name) and new_workflow_name != old_workflow_name:
+        if source is not None and new_workflow_name != old_workflow_name:
             delete_workflow_result = await GriptapeNodes.ahandle_request(DeleteWorkflowRequest(name=old_workflow_name))
             if isinstance(delete_workflow_result, DeleteWorkflowResultFailure):
                 return (

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -145,6 +145,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     RegisterWorkflowsFromConfigRequest,
     RegisterWorkflowsFromConfigResultFailure,
     RegisterWorkflowsFromConfigResultSuccess,
+    RenameDisplayNameBehavior,
     RenameWorkflowRequest,
     RenameWorkflowResultFailure,
     RenameWorkflowResultSuccess,
@@ -1146,13 +1147,17 @@ class WorkflowManager:
         )
 
     async def on_rename_workflow_request(self, request: RenameWorkflowRequest) -> ResultPayload:
-        # Preserve the raw user input as the display name (metadata.name).
-        display_name = request.requested_name
         # Sanitize to a Python module-friendly name for the file stem (registry key).
         sanitized_stem = normalize_display_name(request.requested_name)
         if not sanitized_stem:
             details = f"Attempted to rename workflow '{request.workflow_name}'. The requested name '{request.requested_name}' produced an empty file name after sanitization."
             return RenameWorkflowResultFailure(result_details=details)
+
+        display_name_error = self._validate_rename_display_name(request)
+        if display_name_error is not None:
+            return RenameWorkflowResultFailure(result_details=display_name_error)
+
+        display_name = self._resolve_rename_display_name(request)
 
         # Rename keeps the workflow's location (unlike Move). Inherit the source workflow's
         # directory and prepend it to the sanitized stem so the renamed file stays put:
@@ -1174,48 +1179,109 @@ class WorkflowManager:
             details = f"Attempted to rename workflow '{request.workflow_name}' to '{requested_file_name}'. Failed while attempting to save."
             return RenameWorkflowResultFailure(result_details=details)
 
+        reconcile_error = await self._reconcile_rename_bookkeeping(
+            old_workflow_name=request.workflow_name,
+            save_result=save_workflow_request,
+        )
+        if reconcile_error is not None:
+            return RenameWorkflowResultFailure(result_details=reconcile_error)
+
         new_workflow_name = save_workflow_request.workflow_name
-
-        # Transfer the substitution flag to the new name before the delete call removes the old entry.
-        if new_workflow_name != request.workflow_name:
-            self._rekey_substitution_flag(request.workflow_name, new_workflow_name)
-
-        # If the renamed file landed outside the workspace, keep it registered at its new path
-        # (the old path's registration is stripped by the delete below).
-        self._persist_external_workflow_registration(str(save_workflow_request.file_path))
-
-        # If the original workflow isn't registered, treat this as a Save As and skip deletion.
-        # Also skip when the key is unchanged (e.g. renaming to the same on-disk name) so we
-        # don't delete the file we just saved.
-        if (
-            WorkflowRegistry.has_workflow_with_name(request.workflow_name)
-            and new_workflow_name != request.workflow_name
-        ):
-            delete_workflow_result = await GriptapeNodes.ahandle_request(
-                DeleteWorkflowRequest(name=request.workflow_name)
-            )
-            if isinstance(delete_workflow_result, DeleteWorkflowResultFailure):
-                details = (
-                    f"Attempted to rename workflow '{request.workflow_name}' to '{new_workflow_name}'. "
-                    "Failed while attempting to remove the original file name from the registry."
-                )
-                return RenameWorkflowResultFailure(result_details=details)
-
-        # If the renamed workflow is the current context, update the context name so the
-        # heartbeat and other callers reflect the new registry key immediately.
-        context_manager = GriptapeNodes.ContextManager()
-        if (
-            context_manager.has_current_workflow()
-            and context_manager.get_current_workflow_name() == request.workflow_name
-        ):
-            context_manager.set_current_workflow_name(new_workflow_name)
-
         return RenameWorkflowResultSuccess(
             new_workflow_name=new_workflow_name,
             result_details=ResultDetails(
                 message=f"Successfully renamed workflow to: {new_workflow_name}", level=logging.INFO
             ),
         )
+
+    def _validate_rename_display_name(self, request: RenameWorkflowRequest) -> str | None:
+        """Return a failure message when the request's display-name arguments are invalid, else None.
+
+        Two failure conditions:
+        * ``display_name`` supplied with a non-OVERRIDE behavior — the field would be silently
+          ignored, which is almost always a caller mistake (e.g. picked OVERRIDE mentally but
+          forgot to switch the enum).
+        * OVERRIDE with a missing or blank ``display_name`` — the field is the whole point of
+          OVERRIDE mode and must carry a non-empty value.
+
+        PRESERVE_EXISTING and MATCH_FILE_NAME with ``display_name=None`` derive the value from
+        existing state or the requested file name and have nothing to check.
+        """
+        if request.display_name is not None and request.display_name_behavior is not RenameDisplayNameBehavior.OVERRIDE:
+            return (
+                f"Attempted to rename workflow '{request.workflow_name}' with "
+                f"display_name_behavior={request.display_name_behavior.value} and display_name="
+                f"{request.display_name!r}. Failed because 'display_name' is only consulted when "
+                "display_name_behavior=OVERRIDE. Either switch to OVERRIDE, or remove display_name."
+            )
+        if request.display_name_behavior is not RenameDisplayNameBehavior.OVERRIDE:
+            return None
+        if request.display_name and request.display_name.strip():
+            return None
+        return (
+            f"Attempted to rename workflow '{request.workflow_name}' with display_name_behavior=OVERRIDE. "
+            "Failed because 'display_name' was not provided or was empty. Provide a non-empty display_name, "
+            "or use PRESERVE_EXISTING / MATCH_FILE_NAME behavior."
+        )
+
+    def _resolve_rename_display_name(self, request: RenameWorkflowRequest) -> str | None:
+        """Compute the display name (``metadata.name``) to pass into the follow-up SaveWorkflowRequest.
+
+        * ``OVERRIDE`` — return the caller-supplied ``display_name`` verbatim.
+        * ``PRESERVE_EXISTING`` — return the source workflow's current ``metadata.name``. If the source
+          isn't in the registry (uncommon Save-As-style path), fall through to the requested name so
+          the on-disk file still gets a sensible display name.
+        * ``MATCH_FILE_NAME`` — return the raw ``requested_name`` (legacy behavior; display name tracks
+          the new file name).
+        """
+        if request.display_name_behavior is RenameDisplayNameBehavior.OVERRIDE:
+            return request.display_name
+        if (
+            request.display_name_behavior is RenameDisplayNameBehavior.PRESERVE_EXISTING
+            and WorkflowRegistry.has_workflow_with_name(request.workflow_name)
+        ):
+            return WorkflowRegistry.get_workflow_by_name(request.workflow_name).metadata.name
+        return request.requested_name
+
+    async def _reconcile_rename_bookkeeping(
+        self,
+        *,
+        old_workflow_name: str,
+        save_result: SaveWorkflowResultSuccess,
+    ) -> str | None:
+        """Post-save bookkeeping for a rename: rekey flags, persist external reg, delete old entry, sync context.
+
+        Returns a failure message when the delete step fails; otherwise None. Extracted so the outer
+        handler doesn't blow past the McCabe branch limit.
+        """
+        new_workflow_name = save_result.workflow_name
+
+        # Transfer the substitution flag to the new name before the delete call removes the old entry.
+        if new_workflow_name != old_workflow_name:
+            self._rekey_substitution_flag(old_workflow_name, new_workflow_name)
+
+        # If the renamed file landed outside the workspace, keep it registered at its new path
+        # (the old path's registration is stripped by the delete below).
+        self._persist_external_workflow_registration(str(save_result.file_path))
+
+        # If the original workflow isn't registered, treat this as a Save As and skip deletion.
+        # Also skip when the key is unchanged (e.g. renaming to the same on-disk name) so we
+        # don't delete the file we just saved.
+        if WorkflowRegistry.has_workflow_with_name(old_workflow_name) and new_workflow_name != old_workflow_name:
+            delete_workflow_result = await GriptapeNodes.ahandle_request(DeleteWorkflowRequest(name=old_workflow_name))
+            if isinstance(delete_workflow_result, DeleteWorkflowResultFailure):
+                return (
+                    f"Attempted to rename workflow '{old_workflow_name}' to '{new_workflow_name}'. "
+                    "Failed while attempting to remove the original file name from the registry."
+                )
+
+        # If the renamed workflow is the current context, update the context name so the
+        # heartbeat and other callers reflect the new registry key immediately.
+        context_manager = GriptapeNodes.ContextManager()
+        if context_manager.has_current_workflow() and context_manager.get_current_workflow_name() == old_workflow_name:
+            context_manager.set_current_workflow_name(new_workflow_name)
+
+        return None
 
     def _build_workflow_info_key(self, file_path: str) -> str:
         """Build the key used to look up a workflow in _workflow_file_path_to_info.

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1227,7 +1227,10 @@ class WorkflowManager:
     def _resolve_rename_display_name(self, request: RenameWorkflowRequest) -> str | None:
         """Compute the display name (``metadata.name``) to pass into the follow-up SaveWorkflowRequest.
 
-        * ``OVERRIDE`` — return the caller-supplied ``display_name`` verbatim.
+        * ``OVERRIDE`` — return the caller-supplied ``display_name`` stripped of surrounding
+          whitespace. Matches ``_validate_rename_display_name``'s ``strip()``-based non-empty
+          gate so validation and resolution share one canonical form; a padded-but-valid
+          input like ``"  My Name  "`` can't leak whitespace into ``metadata.name``.
         * ``PRESERVE_EXISTING`` — return the source workflow's current ``metadata.name``. If the source
           isn't in the registry (uncommon Save-As-style path), fall through to the requested name so
           the on-disk file still gets a sensible display name.
@@ -1235,7 +1238,8 @@ class WorkflowManager:
           the new file name).
         """
         if request.display_name_behavior is RenameDisplayNameBehavior.OVERRIDE:
-            return request.display_name
+            # display_name is guaranteed non-empty after strip() by _validate_rename_display_name.
+            return request.display_name.strip() if request.display_name else request.display_name
         if (
             request.display_name_behavior is RenameDisplayNameBehavior.PRESERVE_EXISTING
             and WorkflowRegistry.has_workflow_with_name(request.workflow_name)

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1312,8 +1312,10 @@ class TestWorkflowManager:
             )
 
         assert isinstance(result, RenameWorkflowResultFailure)
-        assert "old" in str(result.result_details)
-        assert "new" in str(result.result_details)
+        # Match the quoted-name form the failure message renders so the assertions
+        # don't pass on incidental substrings ("renew", "olden", ...).
+        assert "'old'" in str(result.result_details)
+        assert "'new'" in str(result.result_details)
 
     def test_resolve_named_save_path_absolute_skips_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
         """An absolute requested name routes the full path to _build_workflow_save_path with no sub_dirs."""

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1188,6 +1188,106 @@ class TestWorkflowManager:
         assert isinstance(result, RenameWorkflowResultFailure)
         assert "OVERRIDE" in str(result.result_details)
 
+    def test_rename_preserve_existing_falls_back_to_requested_name_when_source_missing(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """PRESERVE_EXISTING with an unregistered source workflow falls back to the requested name.
+
+        Save-As-style path: caller asks to rename a workflow that isn't in the registry (e.g. the
+        entry was already deleted, or this is a first-save-as flow). We can't preserve a name we
+        don't have, so we hand the requested name through to SaveWorkflowRequest — better than
+        letting the save chain fall further and derive from the file stem.
+        """
+        from griptape_nodes.retained_mode.events.workflow_events import (
+            RenameDisplayNameBehavior,
+            RenameWorkflowRequest,
+            RenameWorkflowResultSuccess,
+            SaveWorkflowRequest,
+            SaveWorkflowResultSuccess,
+        )
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        captured: dict[str, object] = {}
+
+        async def fake_ahandle_request(req: object) -> object:
+            if isinstance(req, SaveWorkflowRequest):
+                captured["save_display_name"] = req.display_name
+                return SaveWorkflowResultSuccess(
+                    file_path="/workspace/never_registered_renamed.py",
+                    workflow_name="never_registered_renamed",
+                    result_details="ok",
+                )
+            msg = f"Unexpected request in save-as fallback test: {type(req).__name__}"
+            raise AssertionError(msg)
+
+        with (
+            # Force the source lookup to miss — no registry entry to preserve from.
+            patch.object(WorkflowRegistry, "has_workflow_with_name", return_value=False),
+            patch.object(workflow_manager, "_persist_external_workflow_registration"),
+            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+        ):
+            result = asyncio.run(
+                workflow_manager.on_rename_workflow_request(
+                    RenameWorkflowRequest(
+                        workflow_name="never_registered",
+                        requested_name="never_registered_renamed",
+                        display_name_behavior=RenameDisplayNameBehavior.PRESERVE_EXISTING,
+                    )
+                )
+            )
+
+        assert isinstance(result, RenameWorkflowResultSuccess)
+        assert captured["save_display_name"] == "never_registered_renamed"
+
+    def test_rename_surfaces_delete_failure_from_bookkeeping(self, griptape_nodes: GriptapeNodes) -> None:
+        """When the post-save delete of the old registry entry fails, rename surfaces RenameWorkflowResultFailure.
+
+        Save succeeds, but the follow-up DeleteWorkflowRequest for the old key comes back as
+        DeleteWorkflowResultFailure. The bookkeeping helper must translate that into a rename
+        failure so the caller doesn't see a bogus success while the registry is half-migrated.
+        """
+        from griptape_nodes.retained_mode.events.workflow_events import (
+            DeleteWorkflowRequest,
+            DeleteWorkflowResultFailure,
+            RenameWorkflowRequest,
+            RenameWorkflowResultFailure,
+            SaveWorkflowRequest,
+            SaveWorkflowResultSuccess,
+        )
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        mock_source = MagicMock()
+        mock_source.file_path = "old.py"
+        mock_source.metadata.name = "Old Display"
+
+        async def fake_ahandle_request(req: object) -> object:
+            if isinstance(req, SaveWorkflowRequest):
+                return SaveWorkflowResultSuccess(
+                    file_path="/workspace/new.py",
+                    workflow_name="new",
+                    result_details="ok",
+                )
+            if isinstance(req, DeleteWorkflowRequest):
+                return DeleteWorkflowResultFailure(result_details="registry locked")
+            msg = f"Unexpected request in delete-failure test: {type(req).__name__}"
+            raise AssertionError(msg)
+
+        with (
+            patch.object(WorkflowRegistry, "has_workflow_with_name", return_value=True),
+            patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_source),
+            patch.object(workflow_manager, "_persist_external_workflow_registration"),
+            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+        ):
+            result = asyncio.run(
+                workflow_manager.on_rename_workflow_request(
+                    RenameWorkflowRequest(workflow_name="old", requested_name="new")
+                )
+            )
+
+        assert isinstance(result, RenameWorkflowResultFailure)
+        assert "old" in str(result.result_details)
+        assert "new" in str(result.result_details)
+
     def test_resolve_named_save_path_absolute_skips_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
         """An absolute requested name routes the full path to _build_workflow_save_path with no sub_dirs."""
         workflow_manager = griptape_nodes.WorkflowManager()

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1215,6 +1215,32 @@ class TestWorkflowManager:
         assert isinstance(result, RenameWorkflowResultFailure)
         assert "OVERRIDE" in str(result.result_details)
 
+    def test_rename_preserve_existing_falls_back_to_requested_name_when_source_display_name_blank(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """PRESERVE_EXISTING with a blank source metadata.name falls back to the requested name.
+
+        The source is registered but its ``metadata.name`` is empty (or whitespace-only). Rather
+        than propagating that corrupt-ish value onto the renamed workflow — where the save
+        handler would treat "" as an explicit override and persist it — degrade gracefully to the
+        requested name so the on-disk file still gets a sensible display name.
+        """
+        from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
+
+        captured = self._run_rename(
+            griptape_nodes.WorkflowManager(),
+            self._RenameScenario(
+                workflow_name="my_workflow",
+                requested_name="my_workflow_renamed",
+                source_file_path="my_workflow.py",
+                save_file_path="/workspace/my_workflow_renamed.py",
+                save_workflow_name="my_workflow_renamed",
+                source_display_name="   ",  # whitespace-only: strip()==""
+            ),
+            request_kwargs={"display_name_behavior": RenameDisplayNameBehavior.PRESERVE_EXISTING},
+        )
+        assert captured["save_display_name"] == "my_workflow_renamed"
+
     def test_rename_preserve_existing_falls_back_to_requested_name_when_source_missing(
         self, griptape_nodes: GriptapeNodes
     ) -> None:

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1114,6 +1114,33 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "Renamed On Purpose"
 
+    def test_rename_override_strips_surrounding_whitespace(self, griptape_nodes: GriptapeNodes) -> None:
+        """OVERRIDE forwards ``display_name`` stripped so validation and resolution agree on the canonical form.
+
+        Regression coverage: ``_validate_rename_display_name`` gates OVERRIDE on
+        ``display_name.strip()`` being truthy, so a padded input like ``"  My Name  "``
+        passes validation. Without a matching ``strip()`` in ``_resolve_rename_display_name``,
+        the whitespace would leak into ``metadata.name``.
+        """
+        from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
+
+        captured = self._run_rename(
+            griptape_nodes.WorkflowManager(),
+            self._RenameScenario(
+                workflow_name="my_workflow",
+                requested_name="my_workflow_renamed",
+                source_file_path="my_workflow.py",
+                save_file_path="/workspace/my_workflow_renamed.py",
+                save_workflow_name="my_workflow_renamed",
+                source_display_name="My Cool Workflow",
+            ),
+            request_kwargs={
+                "display_name_behavior": RenameDisplayNameBehavior.OVERRIDE,
+                "display_name": "  My Name  ",
+            },
+        )
+        assert captured["save_display_name"] == "My Name"
+
     @pytest.mark.parametrize(
         "non_override_behavior",
         [

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2,7 +2,7 @@ import ast
 import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import anyio
@@ -934,9 +934,20 @@ class TestWorkflowManager:
         source_file_path: str
         save_file_path: str
         save_workflow_name: str
+        source_display_name: str = "source-display-name"
 
-    def _run_rename(self, workflow_manager: WorkflowManager, scenario: "TestWorkflowManager._RenameScenario") -> dict:
-        """Drive on_rename_workflow_request with mocked save/delete, capturing the SaveWorkflowRequest."""
+    def _run_rename(
+        self,
+        workflow_manager: WorkflowManager,
+        scenario: "TestWorkflowManager._RenameScenario",
+        *,
+        request_kwargs: dict[str, Any] | None = None,
+    ) -> dict:
+        """Drive on_rename_workflow_request with mocked save/delete, capturing the SaveWorkflowRequest.
+
+        ``request_kwargs`` is merged into the RenameWorkflowRequest constructor so individual tests can
+        exercise display_name_behavior / display_name without changing the shared scenario tuple.
+        """
         from griptape_nodes.retained_mode.events.workflow_events import (
             DeleteWorkflowResultSuccess,
             RenameWorkflowRequest,
@@ -947,11 +958,13 @@ class TestWorkflowManager:
 
         mock_source = MagicMock()
         mock_source.file_path = scenario.source_file_path
+        mock_source.metadata.name = scenario.source_display_name
         captured: dict[str, object] = {}
 
         async def fake_ahandle_request(req: object) -> object:
             if isinstance(req, SaveWorkflowRequest):
                 captured["save_file_name"] = req.file_name
+                captured["save_display_name"] = req.display_name
                 return SaveWorkflowResultSuccess(
                     file_path=scenario.save_file_path,
                     workflow_name=scenario.save_workflow_name,
@@ -967,7 +980,11 @@ class TestWorkflowManager:
         ):
             result = asyncio.run(
                 workflow_manager.on_rename_workflow_request(
-                    RenameWorkflowRequest(workflow_name=scenario.workflow_name, requested_name=scenario.requested_name)
+                    RenameWorkflowRequest(
+                        workflow_name=scenario.workflow_name,
+                        requested_name=scenario.requested_name,
+                        **(request_kwargs or {}),
+                    )
                 )
             )
 
@@ -1034,6 +1051,142 @@ class TestWorkflowManager:
             ),
         )
         assert captured["result_new_name"] == "bar/new_name"
+
+    def test_rename_default_matches_file_name(self, griptape_nodes: GriptapeNodes) -> None:
+        """Default behavior (MATCH_FILE_NAME): display name tracks the new file basename.
+
+        Preserves historical wire behavior — callers who don't set display_name_behavior see the
+        same result they did before the enum was introduced.
+        """
+        captured = self._run_rename(
+            griptape_nodes.WorkflowManager(),
+            self._RenameScenario(
+                workflow_name="my_workflow",
+                requested_name="my_workflow_renamed",
+                source_file_path="my_workflow.py",
+                save_file_path="/workspace/my_workflow_renamed.py",
+                save_workflow_name="my_workflow_renamed",
+                source_display_name="My Cool Workflow",
+            ),
+        )
+        assert captured["save_display_name"] == "my_workflow_renamed"
+
+    def test_rename_preserve_existing_keeps_display_name(self, griptape_nodes: GriptapeNodes) -> None:
+        """PRESERVE_EXISTING opt-in: SaveWorkflowRequest receives the source's metadata.name, not the new file stem.
+
+        Fix for issue #4992 — with this enum value, renaming a workflow whose display name diverges
+        from its filename no longer overwrites metadata.name.
+        """
+        from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
+
+        captured = self._run_rename(
+            griptape_nodes.WorkflowManager(),
+            self._RenameScenario(
+                workflow_name="my_workflow",
+                requested_name="my_workflow_renamed",
+                source_file_path="my_workflow.py",
+                save_file_path="/workspace/my_workflow_renamed.py",
+                save_workflow_name="my_workflow_renamed",
+                source_display_name="My Cool Workflow",
+            ),
+            request_kwargs={"display_name_behavior": RenameDisplayNameBehavior.PRESERVE_EXISTING},
+        )
+        assert captured["save_display_name"] == "My Cool Workflow"
+
+    def test_rename_override_uses_provided_display_name(self, griptape_nodes: GriptapeNodes) -> None:
+        """OVERRIDE forwards the caller-supplied display_name to SaveWorkflowRequest."""
+        from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
+
+        captured = self._run_rename(
+            griptape_nodes.WorkflowManager(),
+            self._RenameScenario(
+                workflow_name="my_workflow",
+                requested_name="my_workflow_renamed",
+                source_file_path="my_workflow.py",
+                save_file_path="/workspace/my_workflow_renamed.py",
+                save_workflow_name="my_workflow_renamed",
+                source_display_name="My Cool Workflow",
+            ),
+            request_kwargs={
+                "display_name_behavior": RenameDisplayNameBehavior.OVERRIDE,
+                "display_name": "Renamed On Purpose",
+            },
+        )
+        assert captured["save_display_name"] == "Renamed On Purpose"
+
+    @pytest.mark.parametrize(
+        "non_override_behavior",
+        [
+            "PRESERVE_EXISTING",
+            "MATCH_FILE_NAME",
+        ],
+    )
+    def test_rename_rejects_display_name_without_override(
+        self,
+        griptape_nodes: GriptapeNodes,
+        non_override_behavior: str,
+    ) -> None:
+        """Supplying display_name with a non-OVERRIDE behavior fails fast so it can't be silently ignored."""
+        from griptape_nodes.retained_mode.events.workflow_events import (
+            RenameDisplayNameBehavior,
+            RenameWorkflowRequest,
+            RenameWorkflowResultFailure,
+        )
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+
+        async def fake_ahandle_request(req: object) -> object:
+            msg = f"Save/delete must not run when display_name is used with non-OVERRIDE; got {type(req).__name__}"
+            raise AssertionError(msg)
+
+        with patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request):
+            result = asyncio.run(
+                workflow_manager.on_rename_workflow_request(
+                    RenameWorkflowRequest(
+                        workflow_name="my_workflow",
+                        requested_name="my_workflow_renamed",
+                        display_name_behavior=RenameDisplayNameBehavior[non_override_behavior],
+                        display_name="Silently Ignored",
+                    )
+                )
+            )
+
+        assert isinstance(result, RenameWorkflowResultFailure)
+        assert "only consulted when display_name_behavior=OVERRIDE" in str(result.result_details)
+
+    @pytest.mark.parametrize("empty_display_name", [None, "", "   "])
+    def test_rename_override_rejects_missing_display_name(
+        self,
+        griptape_nodes: GriptapeNodes,
+        empty_display_name: str | None,
+    ) -> None:
+        """OVERRIDE without a non-empty display_name fails fast without invoking the save pipeline."""
+        from griptape_nodes.retained_mode.events.workflow_events import (
+            RenameDisplayNameBehavior,
+            RenameWorkflowRequest,
+            RenameWorkflowResultFailure,
+        )
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+
+        async def fake_ahandle_request(req: object) -> object:
+            msg = f"Save/delete must not run when OVERRIDE has no display_name; got {type(req).__name__}"
+            raise AssertionError(msg)
+
+        with patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request):
+            result = asyncio.run(
+                workflow_manager.on_rename_workflow_request(
+                    RenameWorkflowRequest(
+                        workflow_name="my_workflow",
+                        requested_name="my_workflow_renamed",
+                        display_name_behavior=RenameDisplayNameBehavior.OVERRIDE,
+                        display_name=empty_display_name,
+                    )
+                )
+            )
+
+        assert isinstance(result, RenameWorkflowResultFailure)
+        assert "OVERRIDE" in str(result.result_details)
 
     def test_resolve_named_save_path_absolute_skips_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
         """An absolute requested name routes the full path to _build_workflow_save_path with no sub_dirs."""


### PR DESCRIPTION
## Summary

Fixes engine issue #4992. Renaming a workflow whose display name diverges from its filename (e.g. `"My Cool Workflow"` on `my_workflow.py`) silently overwrote `WorkflowMetadata.name` to the new file basename — the caller had no way to keep or independently set the display name.

`RenameWorkflowRequest` now carries a `RenameDisplayNameBehavior` selector:

- **`MATCH_FILE_NAME`** — default; identical to today's wire behavior (display name tracks the new file basename). Preserves parity for every existing caller that doesn't pass the enum.
- **`PRESERVE_EXISTING`** — leave `WorkflowMetadata.name` alone. This is the value the GUI must adopt to stop the corruption path (tracked in griptape-ai/griptape-vsl-gui#2578).
- **`OVERRIDE`** — set the display name to `request.display_name`, independent of the file name. Must be non-empty.

The handler also validates that `display_name` is only supplied when `display_name_behavior=OVERRIDE`; supplying it under a different mode fails fast rather than being silently dropped.

To keep `on_rename_workflow_request` under the McCabe threshold after adding the new branches, the display-name resolution and the post-save reconciliation tail were extracted into three private helpers (`_validate_rename_display_name`, `_resolve_rename_display_name`, `_reconcile_rename_bookkeeping`). No behavioral change vs. the pre-refactor code path for the extracted tail.

### Deviation from #4992

Issue #4992 proposed a `keep / set-new / match-file-name` shape with `match-file-name` as the default. This PR uses `PRESERVE_EXISTING / OVERRIDE / MATCH_FILE_NAME` and keeps `MATCH_FILE_NAME` as the default — the GUI (the only current caller) will opt in to `PRESERVE_EXISTING` from GUI issue 2578 rather than every existing caller silently changing behavior on upgrade.

## Test plan

- [x] Six new unit tests in `tests/unit/retained_mode/managers/test_workflow_manager.py` covering:
  - Default `MATCH_FILE_NAME` behavior (wire parity)
  - Explicit `PRESERVE_EXISTING` (the #4992 fix)
  - Explicit `OVERRIDE` with a value
  - Parametrized: `OVERRIDE` with `None` / `""` / `"   "` display_name → fail fast
  - Parametrized: `display_name` set with `PRESERVE_EXISTING` / `MATCH_FILE_NAME` → fail fast
- [x] All 12 rename tests pass; 110-case `test_workflow_manager.py` slice passes
- [x] `make check` clean (format + lint + types)
- [x] End-to-end verification via a scratch harness that boots the engine, registers real workflows on a temp workspace, drives `RenameWorkflowRequest` for each behavior, and asserts on-disk `metadata.name` — all five scenarios (three happy paths + two fail-fast paths) confirmed against real save output

### Post-review polish

Two small tightenings from a pre-merge code review. No behavior changes visible to callers.

- **Whitespace strip in `_resolve_rename_display_name` (OVERRIDE).** The validator gates on `display_name.strip()`, but the resolver returned `display_name` verbatim — so `"  My Name  "` passed validation and leaked whitespace into `metadata.name`. Strip in the resolver so validation and resolution share one canonical form. New test `test_rename_override_strips_surrounding_whitespace` pins the invariant.
- **Tightened delete-failure assertions.** Replaced `assert "old" in ...` / `assert "new" in ...` with the quoted forms `"'old'"` / `"'new'"` — matches how the failure message actually renders, so the test can't pass on incidental substrings like `"renew"` or `"olden"`.

## Related

- Engine: fixes #4992
- GUI follow-up: griptape-ai/griptape-vsl-gui#2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)
