### PR TITLE
fix(libraries): rebuild a corrupt library venv and retry dependency install

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -6084,7 +6084,14 @@ class LibraryManager:
         )
 
     async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:  # noqa: PLR0911
-        """Install dependencies for a library."""
+        """Install a library's dependencies, recovering from a corrupt reused venv.
+
+        Advanced library hooks (before_library_nodes_loaded) expect the venv to exist, so the
+        venv is always initialized even when there are no dependencies to install. When the
+        venv is reused from a previous session it may be corrupt (e.g. a dist-info directory
+        missing its METADATA file), which makes uv fail while planning the install; in that
+        case the venv is rebuilt once and the install retried against a clean environment.
+        """
         library_file_path = request.library_file_path
 
         # Load library metadata from file
@@ -6109,6 +6116,10 @@ class LibraryManager:
         # Advanced library hooks (before_library_nodes_loaded) expect the venv to exist.
         venv_path = self._get_library_venv_path(library_name, library_file_path)
 
+        # A functional venv here is reused by _init_library_venv rather than rebuilt. The
+        # recovery path below relies on this to decide whether a failed install is worth
+        # rebuilding for.
+        venv_reused = is_venv_functional(venv_path)
         try:
             library_venv_python_path = await self._init_library_venv(venv_path)
         except RuntimeError as e:
@@ -6140,30 +6151,128 @@ class LibraryManager:
         is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
 
         try:
-            await subprocess_run(
-                [
-                    sys.executable,
-                    "-m",
-                    "uv",
-                    "pip",
-                    "install",
-                    *pip_dependencies,
-                    *pip_install_flags,
-                    "--python",
-                    str(library_venv_python_path),
-                ],
-                check=True,
-                capture_output=not is_debug,
-                text=True,
-            )
+            if venv_reused:
+                # A reused venv may be corrupt (e.g. a dist-info directory missing its
+                # METADATA file), which makes uv fail while planning the install. Rebuild it
+                # once and retry against a clean environment.
+                await self._install_deps_with_recovery(
+                    venv_path=venv_path,
+                    library_venv_python_path=library_venv_python_path,
+                    pip_dependencies=pip_dependencies,
+                    pip_install_flags=pip_install_flags,
+                    capture_output=not is_debug,
+                )
+            else:
+                # A freshly built venv cannot be corrupt, so an install failure is a genuine
+                # problem (bad package, version conflict, network). Fail fast instead of
+                # destroying and rebuilding a brand-new environment.
+                await self._run_uv_pip_install(
+                    library_venv_python_path, pip_dependencies, pip_install_flags, capture_output=not is_debug
+                )
         except subprocess.CalledProcessError as e:
             details = f"Failed to install dependencies for library '{library_name}': return code={e.returncode}, stderr={e.stderr}"
+            return InstallLibraryDependenciesResultFailure(result_details=details)
+        except RuntimeError as e:
+            details = f"Failed to rebuild venv for library '{library_name}': {e}"
             return InstallLibraryDependenciesResultFailure(result_details=details)
 
         details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
         logger.info(details)
         return InstallLibraryDependenciesResultSuccess(
             library_name=library_name, dependencies_installed=len(pip_dependencies), result_details=details
+        )
+
+    async def _reset_and_init_library_venv(self, venv_path: Path) -> Path:
+        """Delete the venv (if present) and recreate it from scratch.
+
+        Used when a reused venv cannot be trusted: an in-place dependency install failed in a
+        way that indicates a corrupt environment.
+
+        Args:
+            venv_path: Path to the virtual environment directory
+
+        Returns:
+            Path to the Python executable in the freshly created virtual environment
+
+        Raises:
+            RuntimeError: If the existing venv cannot be removed or the new one cannot be created.
+        """
+        if await anyio.Path(venv_path).exists():
+            logger.info("Rebuilding virtual environment at %s", venv_path)
+            try:
+                await asyncio.to_thread(shutil.rmtree, venv_path, onexc=OSManager.remove_readonly)
+            except OSError as e:
+                msg = f"Failed to remove virtual environment at {venv_path}: {e}"
+                raise RuntimeError(msg) from e
+        return await self._init_library_venv(venv_path)
+
+    async def _install_deps_with_recovery(
+        self,
+        *,
+        venv_path: Path,
+        library_venv_python_path: Path,
+        pip_dependencies: list[str],
+        pip_install_flags: list[str],
+        capture_output: bool,
+    ) -> None:
+        """Install pip dependencies into the venv, rebuilding it once on failure.
+
+        A plain ``uv pip install`` fails hard when the reused venv is corrupt (e.g. a
+        dist-info directory missing its METADATA file), because uv reads installed package
+        metadata while planning the install. Retrying into the same venv would hit the same
+        broken files, so on the first failure the venv is recreated from scratch and the
+        install is attempted once more against the clean environment.
+
+        Raises:
+            subprocess.CalledProcessError: If the install fails again after the rebuild.
+            RuntimeError: If the venv cannot be rebuilt.
+        """
+        try:
+            await self._run_uv_pip_install(
+                library_venv_python_path, pip_dependencies, pip_install_flags, capture_output=capture_output
+            )
+        except subprocess.CalledProcessError as first_error:
+            logger.warning(
+                "Dependency install into %s failed (return code=%s); rebuilding the venv and retrying once.",
+                venv_path,
+                first_error.returncode,
+            )
+        else:
+            return
+
+        library_venv_python_path = await self._reset_and_init_library_venv(venv_path)
+        await self._run_uv_pip_install(
+            library_venv_python_path, pip_dependencies, pip_install_flags, capture_output=capture_output
+        )
+
+    async def _run_uv_pip_install(
+        self,
+        library_venv_python_path: Path,
+        pip_dependencies: list[str],
+        pip_install_flags: list[str],
+        *,
+        capture_output: bool,
+    ) -> None:
+        """Run ``uv pip install`` for the given dependencies against a venv.
+
+        Raises:
+            subprocess.CalledProcessError: If uv exits with a non-zero status.
+        """
+        await subprocess_run(
+            [
+                sys.executable,
+                "-m",
+                "uv",
+                "pip",
+                "install",
+                *pip_dependencies,
+                *pip_install_flags,
+                "--python",
+                str(library_venv_python_path),
+            ],
+            check=True,
+            capture_output=capture_output,
+            text=True,
         )
 
     async def sync_libraries_request(self, request: SyncLibrariesRequest) -> ResultPayload:  # noqa: C901, PLR0912, PLR0915

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -349,6 +349,14 @@ class MinimumReleaseAgeConfig(NamedTuple):
         return self.hours > 0
 
 
+class LibraryVenvInitResult(NamedTuple):
+    """Result of initializing a library virtual environment."""
+
+    python_path: Path
+    reused: bool
+
+
+
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
     LIBRARY_CONFIG_FILENAME = "griptape_nodes_library.json"
@@ -2482,18 +2490,16 @@ class LibraryManager:
             # Determine venv path for dependency installation
             venv_path = self._get_library_venv_path(package_name, None)
 
-            # Check if a functional venv already exists; a broken directory will be
-            # recreated by _init_library_venv, in which case dependencies must be installed.
-            venv_already_exists = is_venv_functional(venv_path)
-
-            # Only install dependencies if conditions are met
+            # A broken directory is recreated by _init_library_venv, in which case dependencies
+            # must be installed; a reused functional venv already has them.
             try:
-                library_python_venv_path = await self._init_library_venv(venv_path)
+                venv_init = await self._init_library_venv(venv_path)
             except RuntimeError as e:
                 details = f"Attempted to install library '{request.requirement_specifier}'. Failed when creating the virtual environment: {e}"
                 return RegisterLibraryFromRequirementSpecifierResultFailure(result_details=details)
+            library_python_venv_path = venv_init.python_path
 
-            if venv_already_exists:
+            if venv_init.reused:
                 logger.debug(
                     "Skipping dependency installation for package '%s' - venv already exists at %s",
                     package_name,
@@ -2550,7 +2556,7 @@ class LibraryManager:
             result_details=f"Successfully registered library from requirement specifier: {request.requirement_specifier}",
         )
 
-    async def _init_library_venv(self, library_venv_path: Path) -> Path:
+    async def _init_library_venv(self, library_venv_path: Path) -> LibraryVenvInitResult:
         """Initialize a virtual environment for the library.
 
         If a functional virtual environment already exists at the path, it is reused.
@@ -2562,7 +2568,7 @@ class LibraryManager:
             library_venv_path: Path to the virtual environment directory
 
         Returns:
-            Path to the Python executable in the virtual environment
+            The Python executable path and whether an existing functional venv was reused.
 
         Raises:
             RuntimeError: If the virtual environment cannot be created.
@@ -2571,7 +2577,7 @@ class LibraryManager:
 
         if is_venv_functional(library_venv_path):
             logger.debug("Reusing existing virtual environment at %s", library_venv_path)
-            return venv_python_path(library_venv_path)
+            return LibraryVenvInitResult(python_path=venv_python_path(library_venv_path), reused=True)
 
         if await anyio.Path(library_venv_path).exists():
             logger.warning(
@@ -2609,7 +2615,7 @@ class LibraryManager:
             raise RuntimeError(msg) from e
         logger.debug("Created virtual environment at %s", library_venv_path)
 
-        return venv_python_path(library_venv_path)
+        return LibraryVenvInitResult(python_path=venv_python_path(library_venv_path), reused=False)
 
     def _check_library_requirements(
         self, requirements: dict[str, Any], library_name: str
@@ -6116,15 +6122,12 @@ class LibraryManager:
         # Advanced library hooks (before_library_nodes_loaded) expect the venv to exist.
         venv_path = self._get_library_venv_path(library_name, library_file_path)
 
-        # A functional venv here is reused by _init_library_venv rather than rebuilt. The
-        # recovery path below relies on this to decide whether a failed install is worth
-        # rebuilding for.
-        venv_reused = is_venv_functional(venv_path)
         try:
-            library_venv_python_path = await self._init_library_venv(venv_path)
+            venv_init = await self._init_library_venv(venv_path)
         except RuntimeError as e:
             details = f"Failed to initialize venv for library '{library_name}': {e}"
             return InstallLibraryDependenciesResultFailure(result_details=details)
+        library_venv_python_path = venv_init.python_path
 
         if not self._can_write_to_venv_location(library_venv_python_path):
             details = f"Venv location for library '{library_name}' at {venv_path} is not writable"
@@ -6151,7 +6154,7 @@ class LibraryManager:
         is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
 
         try:
-            if venv_reused:
+            if venv_init.reused:
                 # A reused venv may be corrupt (e.g. a dist-info directory missing its
                 # METADATA file), which makes uv fail while planning the install. Rebuild it
                 # once and retry against a clean environment.
@@ -6181,30 +6184,6 @@ class LibraryManager:
         return InstallLibraryDependenciesResultSuccess(
             library_name=library_name, dependencies_installed=len(pip_dependencies), result_details=details
         )
-
-    async def _reset_and_init_library_venv(self, venv_path: Path) -> Path:
-        """Delete the venv (if present) and recreate it from scratch.
-
-        Used when a reused venv cannot be trusted: an in-place dependency install failed in a
-        way that indicates a corrupt environment.
-
-        Args:
-            venv_path: Path to the virtual environment directory
-
-        Returns:
-            Path to the Python executable in the freshly created virtual environment
-
-        Raises:
-            RuntimeError: If the existing venv cannot be removed or the new one cannot be created.
-        """
-        if await anyio.Path(venv_path).exists():
-            logger.info("Rebuilding virtual environment at %s", venv_path)
-            try:
-                await asyncio.to_thread(shutil.rmtree, venv_path, onexc=OSManager.remove_readonly)
-            except OSError as e:
-                msg = f"Failed to remove virtual environment at {venv_path}: {e}"
-                raise RuntimeError(msg) from e
-        return await self._init_library_venv(venv_path)
 
     async def _install_deps_with_recovery(
         self,
@@ -6244,6 +6223,30 @@ class LibraryManager:
         await self._run_uv_pip_install(
             library_venv_python_path, pip_dependencies, pip_install_flags, capture_output=capture_output
         )
+
+    async def _reset_and_init_library_venv(self, venv_path: Path) -> Path:
+        """Delete the venv (if present) and recreate it from scratch.
+
+        Used when a reused venv cannot be trusted: an in-place dependency install failed in a
+        way that indicates a corrupt environment.
+
+        Args:
+            venv_path: Path to the virtual environment directory
+
+        Returns:
+            Path to the Python executable in the freshly created virtual environment
+
+        Raises:
+            RuntimeError: If the existing venv cannot be removed or the new one cannot be created.
+        """
+        if await anyio.Path(venv_path).exists():
+            logger.info("Rebuilding virtual environment at %s", venv_path)
+            try:
+                await asyncio.to_thread(shutil.rmtree, venv_path, onexc=OSManager.remove_readonly)
+            except OSError as e:
+                msg = f"Failed to remove virtual environment at {venv_path}: {e}"
+                raise RuntimeError(msg) from e
+        return (await self._init_library_venv(venv_path)).python_path
 
     async def _run_uv_pip_install(
         self,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -356,7 +356,6 @@ class LibraryVenvInitResult(NamedTuple):
     reused: bool
 
 
-
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
     LIBRARY_CONFIG_FILENAME = "griptape_nodes_library.json"
@@ -2495,7 +2494,7 @@ class LibraryManager:
             try:
                 venv_init = await self._init_library_venv(venv_path)
             except RuntimeError as e:
-                details = f"Attempted to install library '{request.requirement_specifier}'. Failed when creating the virtual environment: {e}"
+                details = f"Attempted to prepare the environment for library '{request.requirement_specifier}'. Failed due to: {e}"
                 return RegisterLibraryFromRequirementSpecifierResultFailure(result_details=details)
             library_python_venv_path = venv_init.python_path
 
@@ -6105,7 +6104,7 @@ class LibraryManager:
         metadata_result = self.load_library_metadata_from_file_request(metadata_request)
 
         if not isinstance(metadata_result, LoadLibraryMetadataFromFileResultSuccess):
-            details = f"Failed to load library metadata from {library_file_path}: {metadata_result.result_details}"
+            details = f"Attempted to read the library configuration at {library_file_path}. Failed due to: {metadata_result.result_details}"
             return InstallLibraryDependenciesResultFailure(result_details=details)
 
         library_data = metadata_result.library_schema
@@ -6125,12 +6124,12 @@ class LibraryManager:
         try:
             venv_init = await self._init_library_venv(venv_path)
         except RuntimeError as e:
-            details = f"Failed to initialize venv for library '{library_name}': {e}"
+            details = f"Attempted to prepare the environment for library '{library_name}'. Failed due to: {e}"
             return InstallLibraryDependenciesResultFailure(result_details=details)
         library_venv_python_path = venv_init.python_path
 
         if not self._can_write_to_venv_location(library_venv_python_path):
-            details = f"Venv location for library '{library_name}' at {venv_path} is not writable"
+            details = f"Attempted to set up the environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
             logger.warning(details)
             return InstallLibraryDependenciesResultFailure(result_details=details)
 
@@ -6139,7 +6138,7 @@ class LibraryManager:
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
         if not OSManager.check_available_disk_space(Path(venv_path), min_space_gb):
             error_msg = OSManager.format_disk_space_error(Path(venv_path))
-            details = f"Insufficient disk space for dependencies (requires {min_space_gb} GB) for library '{library_name}': {error_msg}"
+            details = f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
             return InstallLibraryDependenciesResultFailure(result_details=details)
 
         if not pip_dependencies:
@@ -6173,10 +6172,13 @@ class LibraryManager:
                     library_venv_python_path, pip_dependencies, pip_install_flags, capture_output=not is_debug
                 )
         except subprocess.CalledProcessError as e:
-            details = f"Failed to install dependencies for library '{library_name}': return code={e.returncode}, stderr={e.stderr}"
+            reason = e.stderr or f"the installer exited with code {e.returncode}"
+            details = (
+                f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
+            )
             return InstallLibraryDependenciesResultFailure(result_details=details)
         except RuntimeError as e:
-            details = f"Failed to rebuild venv for library '{library_name}': {e}"
+            details = f"Attempted to rebuild the environment for library '{library_name}'. Failed due to: {e}"
             return InstallLibraryDependenciesResultFailure(result_details=details)
 
         details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
@@ -6244,7 +6246,7 @@ class LibraryManager:
             try:
                 await asyncio.to_thread(shutil.rmtree, venv_path, onexc=OSManager.remove_readonly)
             except OSError as e:
-                msg = f"Failed to remove virtual environment at {venv_path}: {e}"
+                msg = f"the existing environment at {venv_path} could not be removed: {e}"
                 raise RuntimeError(msg) from e
         return (await self._init_library_venv(venv_path)).python_path
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -824,13 +824,15 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
-        mock_python_path = MagicMock()
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
             patch.object(
-                mgr, "_init_library_venv", new_callable=AsyncMock, return_value=mock_python_path
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=False),
             ) as mock_init_venv,
             patch.object(mgr, "_can_write_to_venv_location", return_value=True),
             patch(
@@ -855,13 +857,15 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies = None
-        mock_python_path = MagicMock()
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
             patch.object(
-                mgr, "_init_library_venv", new_callable=AsyncMock, return_value=mock_python_path
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=False),
             ) as mock_init_venv,
             patch.object(mgr, "_can_write_to_venv_location", return_value=True),
             patch(
@@ -913,7 +917,12 @@ class TestLibraryManagerInstallLibraryDependencies:
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
-            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
+            patch.object(
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=False),
+            ),
             patch.object(mgr, "_can_write_to_venv_location", return_value=False),
         ):
             result = await mgr.install_library_dependencies_request(
@@ -937,7 +946,12 @@ class TestLibraryManagerInstallLibraryDependencies:
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
-            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
+            patch.object(
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=False),
+            ),
             patch.object(mgr, "_can_write_to_venv_location", return_value=True),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
@@ -954,6 +968,46 @@ class TestLibraryManagerInstallLibraryDependencies:
             )
 
         assert isinstance(result, InstallLibraryDependenciesResultFailure)
+
+    @pytest.mark.asyncio
+    async def test_reused_venv_with_successful_install_is_not_rebuilt(self, griptape_nodes: GriptapeNodes) -> None:
+        """A reused venv whose first install succeeds must not be rebuilt."""
+        mgr = griptape_nodes.LibraryManager()
+        schema = MagicMock()
+        schema.name = "test_lib"
+        schema.metadata.library_version = "1.0.0"
+        schema.metadata.dependencies.pip_dependencies = ["a==1"]
+        schema.metadata.dependencies.pip_install_flags = []
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
+            patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
+            patch.object(
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=True),
+            ),
+            patch.object(mgr, "_reset_and_init_library_venv", new_callable=AsyncMock) as mock_reset,
+            patch.object(mgr, "_can_write_to_venv_location", return_value=True),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                new_callable=AsyncMock,
+            ) as mock_subprocess,
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            result = await mgr.install_library_dependencies_request(
+                InstallLibraryDependenciesRequest(library_file_path="/mock.json")
+            )
+
+        assert isinstance(result, InstallLibraryDependenciesResultSuccess)
+        assert result.dependencies_installed == 1
+        mock_reset.assert_not_called()
+        mock_subprocess.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_rebuilds_reused_venv_and_retries_when_install_fails(self, griptape_nodes: GriptapeNodes) -> None:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import subprocess
 import sys
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -952,6 +953,136 @@ class TestLibraryManagerInstallLibraryDependencies:
             )
 
         assert isinstance(result, InstallLibraryDependenciesResultFailure)
+
+    @pytest.mark.asyncio
+    async def test_rebuilds_reused_venv_and_retries_when_install_fails(self, griptape_nodes: GriptapeNodes) -> None:
+        """A reused venv that fails to install is rebuilt once and the install retried."""
+        mgr = griptape_nodes.LibraryManager()
+        schema = MagicMock()
+        schema.name = "test_lib"
+        schema.metadata.library_version = "1.0.0"
+        schema.metadata.dependencies.pip_dependencies = ["a==1"]
+        schema.metadata.dependencies.pip_install_flags = []
+        expected_attempts = 2
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
+            patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.is_venv_functional",
+                return_value=True,
+            ),
+            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
+            patch.object(
+                mgr, "_reset_and_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()
+            ) as mock_reset,
+            patch.object(mgr, "_can_write_to_venv_location", return_value=True),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                new_callable=AsyncMock,
+                side_effect=[
+                    subprocess.CalledProcessError(returncode=2, cmd=["uv"], stderr="corrupt METADATA"),
+                    MagicMock(),
+                ],
+            ) as mock_subprocess,
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            result = await mgr.install_library_dependencies_request(
+                InstallLibraryDependenciesRequest(library_file_path="/mock.json")
+            )
+
+        assert isinstance(result, InstallLibraryDependenciesResultSuccess)
+        assert result.dependencies_installed == 1
+        mock_reset.assert_called_once()
+        assert mock_subprocess.await_count == expected_attempts
+
+    @pytest.mark.asyncio
+    async def test_does_not_rebuild_freshly_built_venv_on_install_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """A freshly built venv that fails to install fails fast without a rebuild."""
+        mgr = griptape_nodes.LibraryManager()
+        schema = MagicMock()
+        schema.name = "test_lib"
+        schema.metadata.library_version = "1.0.0"
+        schema.metadata.dependencies.pip_dependencies = ["a==1"]
+        schema.metadata.dependencies.pip_install_flags = []
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
+            patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.is_venv_functional",
+                return_value=False,
+            ),
+            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
+            patch.object(mgr, "_reset_and_init_library_venv", new_callable=AsyncMock) as mock_reset,
+            patch.object(mgr, "_can_write_to_venv_location", return_value=True),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                new_callable=AsyncMock,
+                side_effect=subprocess.CalledProcessError(returncode=2, cmd=["uv"], stderr="bad package"),
+            ) as mock_subprocess,
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            result = await mgr.install_library_dependencies_request(
+                InstallLibraryDependenciesRequest(library_file_path="/mock.json")
+            )
+
+        assert isinstance(result, InstallLibraryDependenciesResultFailure)
+        mock_reset.assert_not_called()
+        mock_subprocess.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_install_fails_after_rebuild(self, griptape_nodes: GriptapeNodes) -> None:
+        """If the install still fails after the venv rebuild, the request fails."""
+        mgr = griptape_nodes.LibraryManager()
+        schema = MagicMock()
+        schema.name = "test_lib"
+        schema.metadata.library_version = "1.0.0"
+        schema.metadata.dependencies.pip_dependencies = ["a==1"]
+        schema.metadata.dependencies.pip_install_flags = []
+        expected_attempts = 2
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
+            patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.is_venv_functional",
+                return_value=True,
+            ),
+            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
+            patch.object(
+                mgr, "_reset_and_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()
+            ) as mock_reset,
+            patch.object(mgr, "_can_write_to_venv_location", return_value=True),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                new_callable=AsyncMock,
+                side_effect=[
+                    subprocess.CalledProcessError(returncode=2, cmd=["uv"], stderr="corrupt METADATA"),
+                    subprocess.CalledProcessError(returncode=2, cmd=["uv"], stderr="still broken"),
+                ],
+            ) as mock_subprocess,
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            result = await mgr.install_library_dependencies_request(
+                InstallLibraryDependenciesRequest(library_file_path="/mock.json")
+            )
+
+        assert isinstance(result, InstallLibraryDependenciesResultFailure)
+        mock_reset.assert_called_once()
+        assert mock_subprocess.await_count == expected_attempts
 
 
 def _fake_config_value(key: str, **_: object) -> object:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1315,7 +1315,7 @@ class TestLibraryManagerVenvHealth:
                 "griptape_nodes.retained_mode.managers.library_manager.shutil.rmtree",
                 side_effect=OSError("permission denied"),
             ),
-            pytest.raises(RuntimeError, match="Failed to remove virtual environment"),
+            pytest.raises(RuntimeError, match="could not be removed"),
         ):
             await mgr._reset_and_init_library_venv(venv_path)
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -53,6 +53,7 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager as _LibraryManager
+from griptape_nodes.retained_mode.managers.library_manager import LibraryVenvInitResult
 from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
@@ -968,11 +969,12 @@ class TestLibraryManagerInstallLibraryDependencies:
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.is_venv_functional",
-                return_value=True,
+            patch.object(
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=True),
             ),
-            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
             patch.object(
                 mgr, "_reset_and_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()
             ) as mock_reset,
@@ -1013,11 +1015,12 @@ class TestLibraryManagerInstallLibraryDependencies:
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.is_venv_functional",
-                return_value=False,
+            patch.object(
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=False),
             ),
-            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
             patch.object(mgr, "_reset_and_init_library_venv", new_callable=AsyncMock) as mock_reset,
             patch.object(mgr, "_can_write_to_venv_location", return_value=True),
             patch(
@@ -1053,11 +1056,12 @@ class TestLibraryManagerInstallLibraryDependencies:
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
             patch.object(mgr, "_get_library_venv_path", return_value=MagicMock()),
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.is_venv_functional",
-                return_value=True,
+            patch.object(
+                mgr,
+                "_init_library_venv",
+                new_callable=AsyncMock,
+                return_value=LibraryVenvInitResult(python_path=MagicMock(), reused=True),
             ),
-            patch.object(mgr, "_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()),
             patch.object(
                 mgr, "_reset_and_init_library_venv", new_callable=AsyncMock, return_value=MagicMock()
             ) as mock_reset,
@@ -1129,7 +1133,8 @@ class TestLibraryManagerVenvHealth:
         ):
             python_path = await mgr._init_library_venv(venv_path)
 
-        assert python_path == expected_python
+        assert python_path.python_path == expected_python
+        assert python_path.reused is True
         mock_subprocess.assert_not_called()
         mock_find_uv.assert_not_called()
         assert (venv_path / "pyvenv.cfg").exists()
@@ -1169,7 +1174,8 @@ class TestLibraryManagerVenvHealth:
             python_path = await mgr._init_library_venv(venv_path)
 
         mock_subprocess.assert_called_once()
-        assert python_path == recreated_python_path["path"]
+        assert python_path.python_path == recreated_python_path["path"]
+        assert python_path.reused is False
         assert not (venv_path / "stray.txt").exists()
 
     @pytest.mark.asyncio
@@ -1199,8 +1205,65 @@ class TestLibraryManagerVenvHealth:
             python_path = await mgr._init_library_venv(venv_path)
 
         mock_subprocess.assert_called_once()
-        assert python_path.exists()
+        assert python_path.python_path.exists()
+        assert python_path.reused is False
         assert (venv_path / "pyvenv.cfg").exists()
+
+    @pytest.mark.asyncio
+    async def test_reset_wipes_functional_venv_and_recreates_it(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """_reset_and_init_library_venv wipes even a functional venv, unlike _init_library_venv."""
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        self._make_functional_venv(venv_path)
+        # A functional venv would be reused by _init_library_venv; prove reset wipes it anyway.
+        (venv_path / "stray.txt").write_text("old")
+
+        recreated_python_path: dict[str, Path] = {}
+
+        async def fake_subprocess_run(args: list[str], **_: object) -> MagicMock:
+            recreated_python_path["path"] = self._make_functional_venv(Path(args[2]))
+            return MagicMock()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
+                side_effect=fake_subprocess_run,
+            ) as mock_subprocess,
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.find_uv_bin",
+                return_value="/fake/uv",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
+                return_value=True,
+            ),
+            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+        ):
+            python_path = await mgr._reset_and_init_library_venv(venv_path)
+
+        mock_subprocess.assert_called_once()
+        assert python_path == recreated_python_path["path"]
+        assert not (venv_path / "stray.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_reset_raises_runtime_error_when_removal_fails(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """A failure to remove the existing venv surfaces as RuntimeError."""
+        mgr = griptape_nodes.LibraryManager()
+        venv_path = tmp_path / ".venv"
+        self._make_functional_venv(venv_path)
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.shutil.rmtree",
+                side_effect=OSError("permission denied"),
+            ),
+            pytest.raises(RuntimeError, match="Failed to remove virtual environment"),
+        ):
+            await mgr._reset_and_init_library_venv(venv_path)
 
 
 class TestListRegisteredLibraries:


### PR DESCRIPTION
A library venv reused from a previous session can be left in a corrupt state, most visibly a `dist-info` directory whose `METADATA` file is missing. uv reads installed package metadata while planning an install, so `uv pip install` fails hard against such a venv, and because we install the declared deps on every load, a plain retry re-scans the same broken files and fails identically. The practical result is a library update that can never complete: this is what surfaced when the Advanced Media Library dependency change went out and users with prior installs got stuck.

When the venv was reused, an install failure now rebuilds it from scratch and retries once against the clean environment. A freshly built venv is deliberately never rebuilt on failure: it cannot be corrupt, so an error there is a genuine dependency problem (bad package, version conflict, network) that should surface immediately rather than trigger a pointless teardown and retry.