### PR TITLE
Use _load_and_cache_project_template across all Project load mechanisms

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -42,7 +42,7 @@ from griptape_nodes.common.project_templates import (
     select_project_path,
 )
 from griptape_nodes.files.derivation import DERIVATION_RULES, apply_derivation_rules
-from griptape_nodes.files.file import File, FileLoadError, FileWriteError
+from griptape_nodes.files.file import File, FileWriteError
 from griptape_nodes.files.path_utils import (
     canonicalize_for_identity,
     resolve_file_path,
@@ -3390,6 +3390,13 @@ class ProjectManager:
             self._initialization_complete = True
             return
 
+        # Build the id -> path index before activating the seed. The seed loads through
+        # the shared parent-chain-aware loader, which resolves an id-based parent via this
+        # index; without it a child seed whose parent lives only in projects_to_register
+        # could not locate its parent (the registry is still empty this early in boot).
+        # _load_registered_projects clears the index in its finally below.
+        await self._build_boot_id_index()
+
         # Activate the seeded boot project first (project_file config, else the
         # workspace-default griptape-nodes-project.yml). Fall back to system defaults
         # only when there is no seed or the seed fails to load or activate.
@@ -3868,12 +3875,17 @@ class ProjectManager:
 
         return workspace_project_path
 
-    async def _load_workspace_project(self) -> str | None:  # noqa: PLR0911
-        """Load workspace-level project template overlay if present.
+    async def _load_workspace_project(self) -> str | None:
+        """Load the seeded boot project (project_file config, else workspace default) if present.
 
-        Checks for a project file using _resolve_project_file_path. If found, loads
-        it as an overlay on top of system defaults and sets it as the current project.
-        If no file is found, the system defaults remain current.
+        Checks for a project file using _resolve_project_file_path. If found, loads it
+        through the shared _load_and_cache_project_template loader -- so it resolves the
+        parent chain, runs the id-collision guard, parses macros, and applies the
+        LOAD_PROJECT license checkpoint exactly like every other project -- then sets it
+        as the current project. If no file is found, the system defaults remain current.
+
+        The seed is loaded with persist_path=False: it is already discovered each boot via
+        project_file / workspace default, so it must not be appended to projects_to_register.
 
         Returns a failure-detail string when a resolved project file fails to load or
         activate (the same text that is logged), or None on success or when no project
@@ -3884,81 +3896,20 @@ class ProjectManager:
         if workspace_project_path is None:
             return None
 
-        workspace_project_path = workspace_project_path.resolve()
         logger.debug("Found workspace project file at '%s', loading", workspace_project_path)
 
-        try:
-            yaml_text = await File(str(workspace_project_path)).aread_text()
-        except FileLoadError as e:
+        # Delegate load/merge/cache to the shared loader. persist_path=False keeps the
+        # seed out of projects_to_register (it is re-discovered from config each boot).
+        load_result = await self._load_and_cache_project_template(workspace_project_path, persist_path=False)
+        if isinstance(load_result, LoadProjectTemplateResultFailure):
             logger.error(
-                "Attempted to read workspace project file at '%s'. Failed with: %s",
+                "Attempted to load workspace project from '%s'. Failed with: %s",
                 workspace_project_path,
-                e.result_details,
+                load_result.result_details,
             )
-            return f"the project file could not be read: {e.result_details}"
+            return f"the project failed to load: {load_result.result_details}"
 
-        validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
-        overlay = load_partial_project_template(yaml_text, validation)
-
-        if overlay is None:
-            logger.error(
-                "Attempted to load workspace project from '%s'. Failed because YAML could not be parsed",
-                workspace_project_path,
-            )
-            return "the project YAML could not be parsed"
-
-        # Derive the project id (the registry key). An explicit overlay id wins;
-        # a legacy project with no id falls back to the file path string. From
-        # here on the id identifies the project and the path is only a locator.
-        project_id = overlay.id if overlay.id is not None else str(workspace_project_path)
-
-        # Fail closed on an id collision: a *different* file already holds this
-        # id. Reloading the same file (same id, same path) is a no-op refresh.
-        existing = self._successfully_loaded_project_templates.get(project_id)
-        if existing is not None and existing.project_file_path != workspace_project_path:
-            logger.error(
-                "Attempted to load workspace project from '%s'. Failed because its id '%s' is already used by a "
-                "different project at '%s'.",
-                workspace_project_path,
-                project_id,
-                existing.project_file_path,
-            )
-            return f"its id '{project_id}' is already used by a different project at '{existing.project_file_path}'"
-
-        template = ProjectTemplate.merge(
-            default_template_for_version(overlay.project_template_schema_version), overlay, validation
-        )
-
-        if not validation.is_usable():
-            problem_details = "; ".join(
-                f"{p.field_path} (line {p.line_number}): {p.message}"
-                if p.line_number is not None
-                else f"{p.field_path}: {p.message}"
-                for p in validation.problems
-            )
-            logger.error(
-                "Attempted to load workspace project from '%s'. Failed because template is not usable (status: %s). Problems: %s",
-                workspace_project_path,
-                validation.status,
-                problem_details,
-            )
-            return f"the project template is not usable (status: {validation.status}). Problems: {problem_details}"
-
-        situation_schemas = self._parse_situation_macros(template.situations, validation)
-        directory_schemas = self._parse_directory_macros(template.directories, validation)
-
-        project_info = ProjectInfo(
-            project_id=project_id,
-            project_file_path=workspace_project_path,
-            project_base_dir=workspace_project_path.parent,
-            template=template,
-            validation=validation,
-            parsed_situation_schemas=situation_schemas,
-            parsed_directory_schemas=directory_schemas,
-        )
-        self._successfully_loaded_project_templates[project_id] = project_info
-        self._registered_template_status[workspace_project_path] = validation
-
+        project_id = load_result.project_id
         set_request = SetCurrentProjectRequest(project_id=project_id)
         set_result = await self.on_set_current_project_request(set_request)
 
@@ -3998,17 +3949,12 @@ class ProjectManager:
         directory_paths = [path for path in resolved_paths if path.is_dir()]
         file_paths = [path for path in resolved_paths if not path.is_dir()]
 
-        # Pre-pass: index id -> canonical path so child-before-parent ordering
-        # still resolves id-based parents (which carry no path) during the load
-        # loop below.
-        self._boot_id_to_file_path = {}
-        for canonical_path in file_paths:
-            read_load = await self._read_overlay(canonical_path)
-            if isinstance(read_load, LoadProjectTemplateResultFailure):
-                continue
-            _, overlay = read_load
-            if overlay.id is not None:
-                self._boot_id_to_file_path[overlay.id] = canonical_path
+        # Ensure the id -> canonical path index is built so child-before-parent
+        # ordering resolves id-based parents (which carry no path) during the load
+        # loop below. on_app_initialization_complete may have already built it
+        # before activating the boot seed; _build_boot_id_index is idempotent and
+        # a no-op when the index is already populated.
+        await self._build_boot_id_index(file_paths)
 
         try:
             for canonical_path in file_paths:
@@ -4037,6 +3983,35 @@ class ProjectManager:
         finally:
             # The index is only meaningful during boot.
             self._boot_id_to_file_path = {}
+
+    async def _build_boot_id_index(self, file_paths: list[Path] | None = None) -> None:
+        """Populate `_boot_id_to_file_path` (id -> canonical path) for registered project files.
+
+        Lets `_resolve_parent_chain` locate an id-based parent even when the child is
+        loaded before its parent during boot (e.g. the child is the activated seed and
+        its parent is only in projects_to_register). At runtime the live registry serves
+        parent lookups, so this index is boot-only and cleared once boot loading finishes.
+
+        Idempotent: a no-op when the index is already populated, so the seed-activation
+        pre-build and the `_load_registered_projects` rebuild don't read every overlay
+        twice. `file_paths` defaults to the resolved registered file entries.
+        """
+        if self._boot_id_to_file_path:
+            return
+        if file_paths is None:
+            registered_entries: list[str | dict | PerPlatformProjectPath] = (
+                self._config_manager.get_config_value(PROJECTS_TO_REGISTER_KEY, default=[]) or []
+            )
+            resolved_paths = self._resolve_registered_entry_paths(registered_entries)
+            file_paths = [path for path in resolved_paths if not path.is_dir()]
+
+        for canonical_path in file_paths:
+            read_load = await self._read_overlay(canonical_path)
+            if isinstance(read_load, LoadProjectTemplateResultFailure):
+                continue
+            _, overlay = read_load
+            if overlay.id is not None:
+                self._boot_id_to_file_path[overlay.id] = canonical_path
 
     def _resolve_registered_entry_paths(
         self, registered_entries: list[str | dict | PerPlatformProjectPath]

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -3903,10 +3903,12 @@ class ProjectManager:
         logger.debug("Found workspace project file at '%s', loading", workspace_project_path)
 
         # Build the id-index so the seed's parent chain can resolve an id-based parent that
-        # is only registered (not yet loaded). Cleared in the finally so runtime parent
-        # lookups fall through to the live registry.
-        await self._build_boot_id_index()
+        # is only registered (not yet loaded). Inside the try so a raise mid-build still hits
+        # the finally clear; cleared after so runtime parent lookups fall through to the
+        # live registry.
         try:
+            await self._build_boot_id_index()
+
             # Delegate load/merge/cache to the shared loader. persist_path=False keeps the
             # seed out of projects_to_register (it is re-discovered from config each boot).
             load_result = await self._load_and_cache_project_template(workspace_project_path, persist_path=False)

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -534,10 +534,14 @@ class ProjectManager:
         self._applied_env_snapshot: dict[str, str | None] = {}
 
         # Transient id -> file path index used during boot to resolve id-based
-        # parents whose child may load before the parent. Populated by a pre-pass
-        # in _load_registered_projects and consulted by _resolve_parent_chain;
-        # empty (and ignored) outside boot, where the live registry suffices.
+        # parents whose child may load before the parent. Built by
+        # _build_boot_id_index (before the seed and again in _load_registered_projects)
+        # and consulted by _resolve_parent_chain; empty (and ignored) outside boot,
+        # where the live registry suffices. `_boot_id_index_built` guards against
+        # re-reading every overlay when the index is legitimately empty (registered
+        # files exist but none declare an id).
         self._boot_id_to_file_path: dict[str, Path] = {}
+        self._boot_id_index_built: bool = False
 
         # Register event handlers
         event_manager.assign_manager_to_request_type(LoadProjectTemplateRequest, self.on_load_project_template_request)
@@ -971,9 +975,10 @@ class ProjectManager:
         """Locate a parent project's file path from its opaque id.
 
         Checks the live registry first (the parent is normally already loaded at
-        runtime), then the transient boot index built by _load_registered_projects
-        for the child-before-parent case during startup. Returns None when the id
-        is not registered on this engine, which the caller treats as fail-closed.
+        runtime), then the transient boot index built by _build_boot_id_index
+        (during seed activation and registered-project loading) for the
+        child-before-parent case during startup. Returns None when the id is not
+        registered on this engine, which the caller treats as fail-closed.
         """
         existing = self._successfully_loaded_project_templates.get(parent_project_id)
         if existing is not None and existing.project_file_path is not None:
@@ -3390,13 +3395,6 @@ class ProjectManager:
             self._initialization_complete = True
             return
 
-        # Build the id -> path index before activating the seed. The seed loads through
-        # the shared parent-chain-aware loader, which resolves an id-based parent via this
-        # index; without it a child seed whose parent lives only in projects_to_register
-        # could not locate its parent (the registry is still empty this early in boot).
-        # _load_registered_projects clears the index in its finally below.
-        await self._build_boot_id_index()
-
         # Activate the seeded boot project first (project_file config, else the
         # workspace-default griptape-nodes-project.yml). Fall back to system defaults
         # only when there is no seed or the seed fails to load or activate.
@@ -3887,6 +3885,12 @@ class ProjectManager:
         The seed is loaded with persist_path=False: it is already discovered each boot via
         project_file / workspace default, so it must not be appended to projects_to_register.
 
+        Builds the boot id-index around the load so a child seed can resolve an id-based
+        parent that has not been loaded yet (registered only in projects_to_register, hence
+        absent from the live registry this early in boot). Both boot seams that reach here --
+        on_app_initialization_complete and on_activate_workspace_project_request -- get the
+        index for free, and the finally clears it so no stale boot state leaks into runtime.
+
         Returns a failure-detail string when a resolved project file fails to load or
         activate (the same text that is logged), or None on success or when no project
         file is present. Callers that report activation outcome use this signal directly
@@ -3898,31 +3902,38 @@ class ProjectManager:
 
         logger.debug("Found workspace project file at '%s', loading", workspace_project_path)
 
-        # Delegate load/merge/cache to the shared loader. persist_path=False keeps the
-        # seed out of projects_to_register (it is re-discovered from config each boot).
-        load_result = await self._load_and_cache_project_template(workspace_project_path, persist_path=False)
-        if isinstance(load_result, LoadProjectTemplateResultFailure):
-            logger.error(
-                "Attempted to load workspace project from '%s'. Failed with: %s",
-                workspace_project_path,
-                load_result.result_details,
-            )
-            return f"the project failed to load: {load_result.result_details}"
+        # Build the id-index so the seed's parent chain can resolve an id-based parent that
+        # is only registered (not yet loaded). Cleared in the finally so runtime parent
+        # lookups fall through to the live registry.
+        await self._build_boot_id_index()
+        try:
+            # Delegate load/merge/cache to the shared loader. persist_path=False keeps the
+            # seed out of projects_to_register (it is re-discovered from config each boot).
+            load_result = await self._load_and_cache_project_template(workspace_project_path, persist_path=False)
+            if isinstance(load_result, LoadProjectTemplateResultFailure):
+                logger.error(
+                    "Attempted to load workspace project from '%s'. Failed with: %s",
+                    workspace_project_path,
+                    load_result.result_details,
+                )
+                return f"the project failed to load: {load_result.result_details}"
 
-        project_id = load_result.project_id
-        set_request = SetCurrentProjectRequest(project_id=project_id)
-        set_result = await self.on_set_current_project_request(set_request)
+            project_id = load_result.project_id
+            set_request = SetCurrentProjectRequest(project_id=project_id)
+            set_result = await self.on_set_current_project_request(set_request)
 
-        if set_result.failed():
-            logger.error(
-                "Attempted to set workspace project '%s' as current. Failed with: %s",
-                workspace_project_path,
-                set_result.result_details,
-            )
-            return f"setting it as the current project failed: {set_result.result_details}"
+            if set_result.failed():
+                logger.error(
+                    "Attempted to set workspace project '%s' as current. Failed with: %s",
+                    workspace_project_path,
+                    set_result.result_details,
+                )
+                return f"setting it as the current project failed: {set_result.result_details}"
 
-        logger.debug("Successfully loaded workspace project from '%s'", workspace_project_path)
-        return None
+            logger.debug("Successfully loaded workspace project from '%s'", workspace_project_path)
+            return None
+        finally:
+            self._clear_boot_id_index()
 
     async def _load_registered_projects(self) -> None:
         """Load project templates from paths persisted in user config.
@@ -3982,7 +3993,7 @@ class ProjectManager:
                 await self._load_projects_from_directory(directory)
         finally:
             # The index is only meaningful during boot.
-            self._boot_id_to_file_path = {}
+            self._clear_boot_id_index()
 
     async def _build_boot_id_index(self, file_paths: list[Path] | None = None) -> None:
         """Populate `_boot_id_to_file_path` (id -> canonical path) for registered project files.
@@ -3990,13 +4001,15 @@ class ProjectManager:
         Lets `_resolve_parent_chain` locate an id-based parent even when the child is
         loaded before its parent during boot (e.g. the child is the activated seed and
         its parent is only in projects_to_register). At runtime the live registry serves
-        parent lookups, so this index is boot-only and cleared once boot loading finishes.
+        parent lookups, so this index is boot-only and cleared once each boot loader
+        finishes (see `_clear_boot_id_index`).
 
-        Idempotent: a no-op when the index is already populated, so the seed-activation
-        pre-build and the `_load_registered_projects` rebuild don't read every overlay
-        twice. `file_paths` defaults to the resolved registered file entries.
+        Idempotent within a build/clear cycle: guarded by `_boot_id_index_built` (not the
+        dict's emptiness) so a legitimately empty index -- registered files exist but none
+        declare an id -- is not rebuilt by re-reading every overlay. `file_paths` defaults
+        to the resolved registered file entries.
         """
-        if self._boot_id_to_file_path:
+        if self._boot_id_index_built:
             return
         if file_paths is None:
             registered_entries: list[str | dict | PerPlatformProjectPath] = (
@@ -4012,6 +4025,12 @@ class ProjectManager:
             _, overlay = read_load
             if overlay.id is not None:
                 self._boot_id_to_file_path[overlay.id] = canonical_path
+        self._boot_id_index_built = True
+
+    def _clear_boot_id_index(self) -> None:
+        """Reset the boot id-index and its built-guard so a later boot loader rebuilds it."""
+        self._boot_id_to_file_path = {}
+        self._boot_id_index_built = False
 
     def _resolve_registered_entry_paths(
         self, registered_entries: list[str | dict | PerPlatformProjectPath]

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -2117,16 +2117,20 @@ situations:
 
     @pytest.mark.asyncio
     async def test_load_workspace_project_read_failure_keeps_defaults(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """A file read failure leaves system defaults as current project."""
-        from griptape_nodes.files.file import FileLoadError
-        from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+        """A file read failure leaves system defaults as current project.
+
+        _load_workspace_project now delegates to _load_and_cache_project_template, which
+        reads via ReadFileRequest. Make the seed path a directory: it passes the
+        _resolve_project_file_path existence check but fails the file read, so the
+        delegated load returns a failure and the seed activation is skipped.
+        """
         from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY, WORKSPACE_PROJECT_FILE
 
         self._setup_system_defaults(pm, str(tmp_path))
 
-        # Create the file so the existence check passes
+        # A directory at the seed path exists but cannot be read as a file.
         workspace_project_path = tmp_path / WORKSPACE_PROJECT_FILE
-        workspace_project_path.write_text(self.VALID_PROJECT_YAML)
+        workspace_project_path.mkdir()
 
         def get_config_value_side_effect(key: str, **_: object) -> str | dict | None:
             if key == "project_file":
@@ -2138,17 +2142,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
         cast("Mock", pm._config_manager).workspace_path = tmp_path
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
-            mock_file_instance = Mock()
-            mock_file_instance.aread_text = AsyncMock(
-                side_effect=FileLoadError(
-                    failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
-                    result_details="permission denied",
-                )
-            )
-            mock_file_cls.return_value = mock_file_instance
-
-            await pm._load_workspace_project()
+        await pm._load_workspace_project()
 
         assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
 
@@ -2159,8 +2153,10 @@ situations:
 
         self._setup_system_defaults(pm, str(tmp_path))
 
+        # Invalid YAML on disk: the delegated loader reads it via ReadFileRequest, fails
+        # to parse it into an overlay, and returns a failure without activating.
         workspace_project_path = tmp_path / WORKSPACE_PROJECT_FILE
-        workspace_project_path.write_text(self.VALID_PROJECT_YAML)
+        workspace_project_path.write_text("not: valid: yaml: ][")
 
         def get_config_value_side_effect(key: str, **_: object) -> str | dict | None:
             if key == "project_file":
@@ -2172,12 +2168,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
         cast("Mock", pm._config_manager).workspace_path = tmp_path
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
-            mock_file_instance = Mock()
-            mock_file_instance.aread_text = AsyncMock(return_value="not: valid: yaml: ][")
-            mock_file_cls.return_value = mock_file_instance
-
-            await pm._load_workspace_project()
+        await pm._load_workspace_project()
 
         assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
 
@@ -2509,6 +2500,131 @@ situations:
             await pm._load_workspace_project()
 
         assert pm._current_project_id == str(workspace_project_path)
+
+    @pytest.mark.asyncio
+    async def test_seed_child_inherits_parent_situations_and_directories(
+        self, pm: ProjectManager, tmp_path: Path
+    ) -> None:
+        """A child activated as the boot seed inherits its parent's situations/directories.
+
+        Regression for the bug where the seed loader merged only onto system defaults and
+        dropped the parent chain (so a child seed lost its parent's situations/directories
+        until a manual Reload from Disk). The seed now loads through the shared
+        parent-chain-aware loader, so inheritance resolves on boot.
+        """
+        from griptape_nodes.retained_mode.managers.project_manager import WORKSPACE_PROJECT_FILE
+
+        self._setup_system_defaults(pm, str(tmp_path))
+
+        # Parent (registered elsewhere) defines a situation + directory the child does not.
+        parent_dir = tmp_path / "parent"
+        parent_dir.mkdir()
+        parent_path = parent_dir / "griptape-nodes-project.yml"
+        parent_path.write_text(
+            "project_template_schema_version: '1.0.0'\n"
+            "name: Parent\n"
+            "id: parent-abc\n"
+            "situations:\n"
+            "  save_prompt:\n"
+            "    macro: '{prompts}/{file_name_base}.{file_extension}'\n"
+            "    policy:\n"
+            "      on_collision: create_new\n"
+            "      create_dirs: true\n"
+            "directories:\n"
+            "  prompts:\n"
+            "    path_macro: prompts\n"
+        )
+        await pm._load_and_cache_project_template(parent_path, persist_path=False)
+
+        # Child is the workspace seed and declares only its parent link + an env var.
+        child_path = tmp_path / WORKSPACE_PROJECT_FILE
+        child_path.write_text(
+            "project_template_schema_version: '1.0.0'\n"
+            "name: Child\n"
+            "id: child-xyz\n"
+            "parent_project_id: 'parent-abc'\n"
+            "environment:\n"
+            "  SHOW: child\n"
+        )
+
+        def get_config_value_side_effect(key: str, **_: object) -> str | dict | None:
+            if key == "project_file":
+                return None
+            if "project_workspaces" in key:
+                return {}
+            return str(tmp_path)
+
+        cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
+        # Activation resolves the workspace via adjacent project config; return no
+        # workspace_directory so the decision falls through to the global default.
+        cast("Mock", pm._config_manager).read_config_file.return_value = {}
+
+        await pm._load_workspace_project()
+
+        assert pm._current_project_id == "child-xyz"
+        child_info = pm._successfully_loaded_project_templates["child-xyz"]
+        # Inherited from the parent (would be absent under the old defaults-only merge).
+        assert "save_prompt" in child_info.template.situations
+        assert "prompts" in child_info.template.directories
+        # The child's own override is still applied.
+        assert child_info.template.environment.get("SHOW") == "child"
+
+    @pytest.mark.asyncio
+    async def test_seed_child_resolves_id_parent_registered_only_in_config(
+        self, pm: ProjectManager, tmp_path: Path
+    ) -> None:
+        """Boot resolves a child seed's id-parent that lives only in projects_to_register.
+
+        Covers the ordering fix: on_app_initialization_complete builds the boot id-index
+        before activating the seed, so an id-based parent that has not been loaded yet
+        (only registered in projects_to_register) is still locatable when the seed's
+        parent chain resolves.
+        """
+        from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+        from griptape_nodes.retained_mode.managers.project_manager import WORKSPACE_PROJECT_FILE
+        from griptape_nodes.retained_mode.managers.settings import PROJECTS_TO_REGISTER_KEY
+
+        self._setup_system_defaults(pm, str(tmp_path))
+
+        parent_dir = tmp_path / "parent"
+        parent_dir.mkdir()
+        parent_path = parent_dir / "griptape-nodes-project.yml"
+        parent_path.write_text(
+            "project_template_schema_version: '1.0.0'\n"
+            "name: Parent\n"
+            "id: parent-abc\n"
+            "directories:\n"
+            "  prompts:\n"
+            "    path_macro: prompts\n"
+        )
+
+        # Child is the workspace-dir seed; only the parent is in projects_to_register.
+        child_path = tmp_path / WORKSPACE_PROJECT_FILE
+        child_path.write_text(
+            "project_template_schema_version: '1.0.0'\nname: Child\nid: child-xyz\nparent_project_id: 'parent-abc'\n"
+        )
+
+        def get_config_value_side_effect(key: str, **_: object) -> object:
+            if key == "project_file":
+                return None
+            if key == PROJECTS_TO_REGISTER_KEY:
+                return [str(parent_path)]
+            if "project_workspaces" in key:
+                return {}
+            return str(tmp_path)
+
+        cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
+        cast("Mock", pm._config_manager).read_config_file.return_value = {}
+
+        await pm.on_app_initialization_complete(AppInitializationComplete())
+
+        assert pm._current_project_id == "child-xyz"
+        child_info = pm._successfully_loaded_project_templates["child-xyz"]
+        assert "prompts" in child_info.template.directories
+        # The boot id-index is boot-only and cleared once loading finishes.
+        assert pm._boot_id_to_file_path == {}
 
 
 class TestLoadSelectsDefaultByMajor:
@@ -8092,9 +8208,12 @@ situations:
 
     @pytest.mark.asyncio
     async def test_unloadable_workspace_project_is_failure(self, pm: ProjectManager, tmp_path: Path) -> None:
-        """A project file that resolves but fails to load returns Failure (still on system defaults)."""
-        from griptape_nodes.files.file import FileLoadError
-        from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+        """A project file that resolves but fails to load returns Failure (still on system defaults).
+
+        The seed loads through _load_and_cache_project_template (ReadFileRequest). A directory
+        at the seed path passes the existence check but fails the file read, so activation
+        never takes and the handler returns Failure.
+        """
         from griptape_nodes.retained_mode.events.project_events import (
             ActivateWorkspaceProjectRequest,
             ActivateWorkspaceProjectResultFailure,
@@ -8103,9 +8222,9 @@ situations:
 
         self._setup_system_defaults(pm, str(tmp_path))
 
-        # File exists so the path resolves, but the read fails so activation cannot take.
+        # A directory at the seed path exists (path resolves) but cannot be read as a file.
         workspace_project_path = tmp_path / WORKSPACE_PROJECT_FILE
-        workspace_project_path.write_text(self.VALID_PROJECT_YAML)
+        workspace_project_path.mkdir()
 
         def get_config_value_side_effect(key: str, **_: object) -> str | dict | None:
             if key == "project_file":
@@ -8117,17 +8236,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
         cast("Mock", pm._config_manager).workspace_path = tmp_path
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
-            mock_file_instance = Mock()
-            mock_file_instance.aread_text = AsyncMock(
-                side_effect=FileLoadError(
-                    failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
-                    result_details="permission denied",
-                )
-            )
-            mock_file_cls.return_value = mock_file_instance
-
-            result = await pm.on_activate_workspace_project_request(ActivateWorkspaceProjectRequest())
+        result = await pm.on_activate_workspace_project_request(ActivateWorkspaceProjectRequest())
 
         assert isinstance(result, ActivateWorkspaceProjectResultFailure)
         assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
@@ -8151,6 +8260,8 @@ situations:
 
         self._setup_system_defaults(pm, str(tmp_path))
 
+        # Malformed YAML on disk: the delegated loader reads it via ReadFileRequest and
+        # fails to parse it, so the handler surfaces the failure detail.
         workspace_project_path = tmp_path / WORKSPACE_PROJECT_FILE
         workspace_project_path.write_text("not: valid: yaml: : :\n  - broken")
 
@@ -8164,12 +8275,7 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
         cast("Mock", pm._config_manager).workspace_path = tmp_path
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
-            mock_file_instance = Mock()
-            mock_file_instance.aread_text = AsyncMock(return_value="not: valid: yaml: : :\n  - broken")
-            mock_file_cls.return_value = mock_file_instance
-
-            result = await pm.on_activate_workspace_project_request(ActivateWorkspaceProjectRequest())
+        result = await pm.on_activate_workspace_project_request(ActivateWorkspaceProjectRequest())
 
         assert isinstance(result, ActivateWorkspaceProjectResultFailure)
         assert str(workspace_project_path) in str(result.result_details)

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -8281,6 +8281,68 @@ situations:
         assert str(workspace_project_path) in str(result.result_details)
         assert "Failed because" in str(result.result_details)
 
+    @pytest.mark.asyncio
+    async def test_activate_child_seed_resolves_id_parent_registered_only_in_config(
+        self, pm: ProjectManager, tmp_path: Path
+    ) -> None:
+        """The app-orchestrator seam resolves a child seed's id-parent that is only registered.
+
+        This is the seam GUI boot drives (on_activate_workspace_project_request runs before
+        _load_registered_projects, so the live registry is empty). The seed's parent chain
+        must still resolve via the boot id-index that _load_workspace_project builds, so a
+        child whose parent lives only in projects_to_register inherits the parent's
+        directories on boot rather than silently dropping them.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            ActivateWorkspaceProjectRequest,
+            ActivateWorkspaceProjectResultSuccess,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import WORKSPACE_PROJECT_FILE
+        from griptape_nodes.retained_mode.managers.settings import PROJECTS_TO_REGISTER_KEY
+
+        self._setup_system_defaults(pm, str(tmp_path))
+
+        parent_dir = tmp_path / "parent"
+        parent_dir.mkdir()
+        parent_path = parent_dir / "griptape-nodes-project.yml"
+        parent_path.write_text(
+            "project_template_schema_version: '1.0.0'\n"
+            "name: Parent\n"
+            "id: parent-abc\n"
+            "directories:\n"
+            "  prompts:\n"
+            "    path_macro: prompts\n"
+        )
+
+        # Child is the workspace-dir seed; only the parent is in projects_to_register, so
+        # it is NOT in the live registry when the seam runs.
+        child_path = tmp_path / WORKSPACE_PROJECT_FILE
+        child_path.write_text(
+            "project_template_schema_version: '1.0.0'\nname: Child\nid: child-xyz\nparent_project_id: 'parent-abc'\n"
+        )
+
+        def get_config_value_side_effect(key: str, **_: object) -> object:
+            if key == "project_file":
+                return None
+            if key == PROJECTS_TO_REGISTER_KEY:
+                return [str(parent_path)]
+            if "project_workspaces" in key:
+                return {}
+            return str(tmp_path)
+
+        cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
+        cast("Mock", pm._config_manager).read_config_file.return_value = {}
+
+        result = await pm.on_activate_workspace_project_request(ActivateWorkspaceProjectRequest())
+
+        assert isinstance(result, ActivateWorkspaceProjectResultSuccess)
+        assert pm._current_project_id == "child-xyz"
+        child_info = pm._successfully_loaded_project_templates["child-xyz"]
+        assert "prompts" in child_info.template.directories
+        # The boot id-index is boot-only and cleared once the seed load finishes.
+        assert pm._boot_id_to_file_path == {}
+
 
 class TestProjectId:
     """Tests for opaque project ids (internal#110) and id-based parent links (engine#4806).


### PR DESCRIPTION
_load_workspace_project (the boot-seed loader) merged the project overlay only onto DEFAULT_PROJECT_TEMPLATE, never calling _resolve_parent_chain. So a child project activated as the boot seed (like la-bestia) was merged straight onto system defaults, silently dropping its parent siggraph-2026's situations and directories. "Reload from Disk" went through the correct loader (_load_and_cache_project_template), which resolves the parent chain — hence the inconsistency.