### PR TITLE
Add orchestrator_engine_id to EngineHeartbeatResultSuccess

### DIFF
--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -441,6 +441,9 @@ class EngineHeartbeatResultSuccess(ResultPayloadSuccess):
         engine_name: Human-readable engine name
         user: User information including ID, email, and name (None if not logged in)
         user_organization: User's organization information including ID and name (None if not logged in)
+        orchestrator_engine_id: Engine id of the orchestrator that spawned this engine as a
+            worker process, or None when this engine IS the orchestrator. A discovery client
+            treats a non-None value as "this is a worker engine, nest it under that orchestrator".
     """
 
     heartbeat_id: str
@@ -463,6 +466,11 @@ class EngineHeartbeatResultSuccess(ResultPayloadSuccess):
     # empty workflow list; the live EngineInitializationProgress stream fills in the detail.
     # Defaulted for backward compatibility with older clients.
     is_initializing: bool = False
+    # Set on worker engines to the id of the orchestrator that spawned them; None on the
+    # orchestrator itself. A discovery client uses this both to identify a worker engine
+    # (worker <=> orchestrator_engine_id is not None) and to nest it under its parent.
+    # Defaulted for backward compatibility with older clients.
+    orchestrator_engine_id: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -475,6 +475,9 @@ class GriptapeNodes(metaclass=SingletonMeta):
                 user=user,
                 user_organization=user_organization,
                 is_initializing=GriptapeNodes.LibraryManager().is_initializing(),
+                # Set on worker processes (injected at spawn by WorkerManager), unset on the
+                # orchestrator. Lets a discovery client tell workers apart and nest them.
+                orchestrator_engine_id=os.getenv("GTN_ORCHESTRATOR_ENGINE_ID"),
                 result_details="Engine heartbeat successful",
                 **instance_info,
                 **workflow_info,

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -327,7 +327,15 @@ class WorkerManager:
         # would bake the orchestrator's current-project env vars into the worker's restore
         # baseline, leaving the worker unable to unset them on a later project switch.
         base_environ = self._griptape_nodes.ProjectManager().get_pre_project_environ()
-        proc = await asyncio.create_subprocess_exec(*args, env={**base_environ, "GTN_ENGINE_ID": str(uuid.uuid4())})
+        worker_environ = {**base_environ, "GTN_ENGINE_ID": str(uuid.uuid4())}
+        # Stamp the spawning orchestrator's id so the worker can report it in its discovery
+        # heartbeat (orchestrator_engine_id), letting clients identify and nest worker engines.
+        # The orchestrator always has an id by the time it spawns a worker; guard the None
+        # case anyway so a subprocess env value is never None.
+        orchestrator_engine_id = self._griptape_nodes.EngineIdentityManager().active_engine_id
+        if orchestrator_engine_id is not None:
+            worker_environ["GTN_ORCHESTRATOR_ENGINE_ID"] = orchestrator_engine_id
+        proc = await asyncio.create_subprocess_exec(*args, env=worker_environ)
         # Record the loop that owns this subprocess so termination can hop back to it.
         # All spawns run on the engine event-queue loop, so this is idempotent.
         self._spawn_loop = asyncio.get_running_loop()

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -462,6 +462,32 @@ class TestSpawnWorker:
         mock_exec.assert_called_once_with(*args, env=ANY)
         assert worker_manager._managed_worker_processes["My Library"] is mock_proc
 
+    @pytest.mark.asyncio
+    async def test_spawn_env_stamps_orchestrator_engine_id(self, worker_manager: WorkerManager) -> None:
+        # The worker must learn its parent orchestrator's id so it can report it in its
+        # discovery heartbeat (orchestrator_engine_id), which the GUI uses to nest workers.
+        worker_manager._griptape_nodes.EngineIdentityManager().active_engine_id = _ENGINE  # type: ignore[union-attr]
+
+        with patch("asyncio.create_subprocess_exec", return_value=MagicMock()) as mock_exec:
+            await worker_manager.spawn_worker(["/usr/bin/gtn", "engine"], "my-key")
+
+        env = mock_exec.call_args.kwargs["env"]
+        assert env["GTN_ORCHESTRATOR_ENGINE_ID"] == _ENGINE
+        # The worker still gets its own fresh engine id, distinct from the orchestrator's.
+        assert env["GTN_ENGINE_ID"] != _ENGINE
+
+    @pytest.mark.asyncio
+    async def test_spawn_env_omits_orchestrator_id_when_unknown(self, worker_manager: WorkerManager) -> None:
+        # Defensive: never put a None into the subprocess env dict. If the orchestrator has
+        # no id yet, the key is simply absent (worker heartbeats as an orchestrator).
+        worker_manager._griptape_nodes.EngineIdentityManager().active_engine_id = None  # type: ignore[union-attr]
+
+        with patch("asyncio.create_subprocess_exec", return_value=MagicMock()) as mock_exec:
+            await worker_manager.spawn_worker(["/usr/bin/gtn", "engine"], "my-key")
+
+        env = mock_exec.call_args.kwargs["env"]
+        assert "GTN_ORCHESTRATOR_ENGINE_ID" not in env
+
 
 class TestResetWorkers:
     @pytest.mark.asyncio

--- a/tests/unit/retained_mode/test_engine_heartbeat.py
+++ b/tests/unit/retained_mode/test_engine_heartbeat.py
@@ -1,0 +1,42 @@
+"""Tests for the engine discovery heartbeat handler."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from griptape_nodes.retained_mode.events.app_events import (
+    EngineHeartbeatRequest,
+    EngineHeartbeatResultSuccess,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class TestEngineHeartbeatOrchestratorId:
+    """Heartbeat reports orchestrator_engine_id so clients can tell workers from the orchestrator.
+
+    A worker process is spawned with GTN_ORCHESTRATOR_ENGINE_ID set to its parent's id; the
+    orchestrator has no such env var. The heartbeat echoes it so a discovery client can both
+    identify a worker engine and nest it under its orchestrator.
+    """
+
+    def test_orchestrator_reports_none(self, griptape_nodes: GriptapeNodes) -> None:
+        # No GTN_ORCHESTRATOR_ENGINE_ID in the environment -> this engine IS the orchestrator.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GTN_ORCHESTRATOR_ENGINE_ID", None)
+            result = griptape_nodes.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-orch"))
+
+        assert isinstance(result, EngineHeartbeatResultSuccess)
+        assert result.orchestrator_engine_id is None
+
+    def test_worker_reports_spawning_orchestrator_id(self, griptape_nodes: GriptapeNodes) -> None:
+        # A worker process is spawned with GTN_ORCHESTRATOR_ENGINE_ID set to its parent's id;
+        # the heartbeat echoes it so the client can nest this worker under that orchestrator.
+        with patch.dict(os.environ, {"GTN_ORCHESTRATOR_ENGINE_ID": "eng-orchestrator"}):
+            result = griptape_nodes.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-worker"))
+
+        assert isinstance(result, EngineHeartbeatResultSuccess)
+        assert result.orchestrator_engine_id == "eng-orchestrator"


### PR DESCRIPTION
Part of https://github.com/griptape-ai/internal/issues/177
Enables https://github.com/griptape-ai/griptape-vsl-gui/pull/2644