### PR TITLE
feat(libraries): lazy node loading to speed up engine startup

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -513,6 +513,46 @@ class LibraryRegistry(metaclass=SingletonMeta):
         return schemas
 
 
+class NodeTypeEntry:
+    """A node type registered in a Library, resolved to its class on demand.
+
+    Holds the node's class name plus either an already-imported class (eager
+    registration) or a zero-argument loader that imports the class on first
+    ``resolve()`` (lazy registration). Either way the resolved class is cached,
+    so a node's module is imported at most once. When registered lazily, the
+    module is imported the first time the class is actually needed (node
+    creation, execution, or introspection) rather than at library load time, so
+    startup never pays the import cost of node modules that are never used, and
+    an import failure surfaces to whichever caller first resolves the entry.
+    """
+
+    def __init__(
+        self,
+        class_name: str,
+        *,
+        node_class: type[BaseNode] | None = None,
+        loader: Callable[[], type[BaseNode]] | None = None,
+    ) -> None:
+        self.class_name = class_name
+        self._resolved = node_class
+        self._loader = loader
+
+    def resolve(self) -> type[BaseNode]:
+        """Return the node class, importing its module on first use for a lazy entry.
+
+        Not thread-safe: assumes resolution happens on a single thread (the event loop).
+        Concurrent callers could each run the loader (a double import). This holds today
+        because lazy entries are only resolved on the event loop -- workers force eager
+        loading, so their entries are already resolved before any threaded access.
+        """
+        if self._resolved is None:
+            if self._loader is None:
+                msg = f"Node type '{self.class_name}' has neither a resolved class nor a loader."
+                raise RuntimeError(msg)
+            self._resolved = self._loader()
+        return self._resolved
+
+
 class Library:
     """A collection of nodes curated by library author.
 
@@ -521,8 +561,9 @@ class Library:
 
     _library_data: LibrarySchema
     _is_default_library: bool
-    # Maintain fast lookups for node class name to class and to its metadata.
-    _node_types: dict[str, type[BaseNode]]
+    # Fast lookup from node class name to its registration entry (which resolves
+    # the class on demand -- see NodeTypeEntry) and to its metadata.
+    _node_types: dict[str, NodeTypeEntry]
     _node_metadata: dict[str, NodeMetadata]
     _advanced_library: AdvancedNodeLibrary | None
     # Tracks handlers registered on behalf of this library so they can be
@@ -583,8 +624,27 @@ class Library:
             library=self, node_class_name=node_class_as_str
         )
 
-        self._node_types[node_class_as_str] = node_class
+        self._node_types[node_class_as_str] = NodeTypeEntry(node_class_as_str, node_class=node_class)
         self._node_metadata[node_class_as_str] = metadata
+        return library_problem
+
+    def register_lazy_node_type(
+        self, node_class_name: str, metadata: NodeMetadata, loader: Callable[[], type[BaseNode]]
+    ) -> LibraryProblem | None:
+        """Register a node type without importing its module yet.
+
+        The class is imported on first use via ``loader`` (see ``NodeTypeEntry``),
+        so an import failure surfaces when the node is first created rather than
+        at library load time. The registry key is the caller-supplied
+        ``node_class_name`` (the library JSON's declared class name), since the
+        class is not imported here to read its ``__name__``. Returns a
+        LibraryProblem if registration fails (e.g. a cross-library name
+        collision), or None if all clear.
+        """
+        library_problem = LibraryRegistry.register_node_type_from_library(library=self, node_class_name=node_class_name)
+
+        self._node_types[node_class_name] = NodeTypeEntry(class_name=node_class_name, loader=loader)
+        self._node_metadata[node_class_name] = metadata
         return library_problem
 
     def unregister_node_type(self, node_class_name: str) -> None:
@@ -634,10 +694,13 @@ class Library:
         metadata: dict[Any, Any] | None = None,
     ) -> BaseNode:
         """Create a new node instance of the specified type."""
-        node_class = self._node_types.get(node_type)
-        if not node_class:
+        if not self.has_node_type(node_type):
             msg = f"Node type '{node_type}' not found in library '{self._library_data.name}'"
             raise KeyError(msg)
+        # Resolve the class, importing its module now if it was registered lazily.
+        # An import failure propagates to the caller (e.g. the CreateNode handler,
+        # which substitutes an Error Proxy node carrying the failure reason).
+        node_class = self._node_types[node_type].resolve()
         # Inject the metadata ABOUT the node from the Library
         # into the node's metadata blob.
         if metadata is None:
@@ -676,10 +739,13 @@ class Library:
         For callers that need the class itself, e.g. classmethod checks like
         `allow_outgoing_connection_by_class`, rather than an instance produced
         by `create_node`.
+
+        Imports the node's module now if it was registered lazily; the import
+        failure propagates to the caller.
         """
         if node_type not in self._node_types:
             raise KeyError(self._library_data.name, node_type)
-        return self._node_types[node_type]
+        return self._node_types[node_type].resolve()
 
     def get_categories(self) -> list[dict[str, CategoryDefinition]]:
         return self._library_data.categories
@@ -701,6 +767,11 @@ class Library:
     def get_nodes_by_base_type(self, base_type: type) -> list[str]:
         """Get all node types in this library that are subclasses of the specified base type.
 
+        Resolving a lazily-registered node type imports its module, so the first call on a
+        lazily-loaded library imports every node module in it (to test each against
+        ``base_type``); a node whose module fails to import is skipped rather than aborting
+        the scan. Callers on the event loop should be aware this can block on those imports.
+
         Args:
             base_type: The base class to filter by (e.g., StartNode, ControlNode)
 
@@ -708,7 +779,18 @@ class Library:
             List of node type names that extend the base type
         """
         matching_nodes = []
-        for node_type, node_class in self._node_types.items():
+        for node_type, entry in self._node_types.items():
+            try:
+                node_class = entry.resolve()
+            except (ImportError, AttributeError, TypeError):
+                logger.debug(
+                    "Skipping node type '%s' in library '%s' while scanning for base type '%s': module failed to import.",
+                    node_type,
+                    self._library_data.name,
+                    base_type.__name__,
+                    exc_info=True,
+                )
+                continue
             if issubclass(node_class, base_type):
                 matching_nodes.append(node_type)
         return matching_nodes

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3256,30 +3256,6 @@ class LibraryManager:
 
         return module
 
-    def _load_class_from_file(self, file_path: Path | str, class_name: str, library_name: str) -> type[BaseNode]:
-        """Dynamically load a class from a Python file with support for hot reloading.
-
-        Args:
-            file_path: Path to the Python file
-            class_name: Name of the class to load
-            library_name: Name of the library
-
-        Returns:
-            The loaded class
-
-        Raises:
-            ImportError: If the module cannot be imported
-            AttributeError: If the class doesn't exist in the module
-            TypeError: If the loaded class isn't a BaseNode-derived class
-        """
-        try:
-            module = self._load_module_from_file(file_path, library_name)
-        except ImportError as err:
-            msg = f"Attempted to load class '{class_name}'. Error: {err}"
-            raise ImportError(msg) from err
-
-        return self._get_node_class_from_module(module, class_name, file_path)
-
     @staticmethod
     def _get_node_class_from_module(module: ModuleType, class_name: str, file_path: Path | str) -> type[BaseNode]:
         """Extract and validate a BaseNode subclass from an already-imported module.
@@ -4820,13 +4796,16 @@ class LibraryManager:
         library_info.problems.extend(problems)
 
         # Load nodes into the library (modifies library_info in place)
-        # Note: library_info is passed as parameter from lifecycle handler
+        # Note: library_info is passed as parameter from lifecycle handler.
+        # Sandbox nodes always load eagerly (not gated on library.lazy_node_loading): they are
+        # being actively authored, so import errors should surface immediately, not on first use.
         await asyncio.to_thread(
             self._attempt_load_nodes_from_library,
             library_data=library_data,
             library=library,
             base_dir=sandbox_library_dir,
             library_info=library_info,
+            lazy_loading=False,
         )
 
     def _find_files_in_dir(self, directory: Path, extension: str) -> list[Path]:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -232,6 +232,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
+    LIBRARY_LAZY_NODE_LOADING_KEY,
     LIBRARY_MINIMUM_RELEASE_AGE_KEY,
     REQUIRES_ENGINE_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
@@ -1774,7 +1775,32 @@ class LibraryManager:
         # In that case we still return a success payload with the library-level metadata and a
         # WARNING entry in result_details, so callers can present the node at all instead of
         # getting an opaque failure for every such node type.
-        node_class = library.get_node_class(request.node_type)
+        # Resolving the class imports the node's module (lazy registration defers this to
+        # first use). A broken module raises here; return the library-level metadata with a
+        # WARNING rather than an opaque failure, matching the probe-failure path below.
+        try:
+            node_class = library.get_node_class(request.node_type)
+        except (ImportError, AttributeError, TypeError) as err:
+            import_error = f"{type(err).__name__}: {err}"
+            return DescribeNodeTypeResultSuccess(
+                library=library_name,
+                node_type=request.node_type,
+                metadata=node_metadata,
+                parameters=[],
+                result_details=ResultDetails(
+                    ResultDetail(
+                        level=logging.INFO,
+                        message=(
+                            f"Described node type '{request.node_type}' in Library '{library_name}' "
+                            "with library metadata only."
+                        ),
+                    ),
+                    ResultDetail(
+                        level=logging.WARNING,
+                        message=f"Node module failed to import: {import_error}",
+                    ),
+                ),
+            )
         probe_name = f"__describe_node_type_probe__{request.node_type}"
         try:
             # Wrap in ``LibraryRegistry.constructing_node()`` so the
@@ -2319,13 +2345,14 @@ class LibraryManager:
                             library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
                             self._library_file_path_to_info[file_path] = library_info
                         else:
-                            # Attempt to load nodes from the library (modifies library_info in place)
+                            # Attempt to load nodes from the library (modifies library_info in place).
                             await asyncio.to_thread(
                                 self._attempt_load_nodes_from_library,
                                 library_data=library_data,
                                 library=library,
                                 base_dir=base_dir,
                                 library_info=library_info,
+                                lazy_loading=self._should_lazy_load_nodes(),
                             )
                             self._library_file_path_to_info[file_path] = library_info
 
@@ -3251,19 +3278,74 @@ class LibraryManager:
             msg = f"Attempted to load class '{class_name}'. Error: {err}"
             raise ImportError(msg) from err
 
-        # Get the class
+        return self._get_node_class_from_module(module, class_name, file_path)
+
+    @staticmethod
+    def _get_node_class_from_module(module: ModuleType, class_name: str, file_path: Path | str) -> type[BaseNode]:
+        """Extract and validate a BaseNode subclass from an already-imported module.
+
+        Raises:
+            AttributeError: If the class doesn't exist in the module
+            TypeError: If the named object isn't a BaseNode-derived class
+        """
         try:
             node_class = getattr(module, class_name)
         except AttributeError as err:
             msg = f"Class '{class_name}' not found in module '{file_path}'"
             raise AttributeError(msg) from err
 
-        # Verify it's a BaseNode subclass
         if not issubclass(node_class, BaseNode):
             msg = f"'{class_name}' must inherit from BaseNode"
             raise TypeError(msg)
 
         return node_class
+
+    def _make_memoized_module_loader(self, node_file_path: Path, library_name: str) -> Callable[[], ModuleType]:
+        """Return a loader that imports a file's module at most once, caching the result.
+
+        ``_load_module_from_file`` re-executes a module that is already in ``sys.modules`` (its
+        hot-reload path). Without memoization, resolving several node classes that share one file
+        would re-run that file's top-level code once per class and bind the classes to different
+        module objects. Memoizing per file makes the module import (and its top-level side
+        effects) happen exactly once per library load, whether its classes are resolved eagerly in
+        a burst or lazily at scattered points in the session. A fresh cache is created per
+        ``_attempt_load_nodes_from_library`` call, so a reload still re-imports the file once.
+        """
+        cache: dict[str, ModuleType] = {}
+
+        def load_module() -> ModuleType:
+            module = cache.get("module")
+            if module is None:
+                module = self._load_module_from_file(node_file_path, library_name)
+                cache["module"] = module
+            return module
+
+        return load_module
+
+    def _make_node_class_loader(
+        self,
+        node_file_path: Path,
+        class_name: str,
+        library_name: str,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> Callable[[], type[BaseNode]]:
+        """Return a zero-argument loader that imports and returns a node class on demand.
+
+        Node classes that share a file reuse a single memoized module loader from
+        ``module_loaders`` (keyed by resolved file path), so the file's module is imported once
+        even when its classes are resolved at different times. Binds its arguments as method
+        parameters (not loop variables), so the closure is safe to build inside a per-node loop.
+        """
+        module_loader = module_loaders.get(node_file_path)
+        if module_loader is None:
+            module_loader = self._make_memoized_module_loader(node_file_path, library_name)
+            module_loaders[node_file_path] = module_loader
+
+        def load() -> type[BaseNode]:
+            module = module_loader()
+            return self._get_node_class_from_module(module, class_name, node_file_path)
+
+        return load
 
     async def _load_and_track_library(self, lib_path: str, index: int, total: int) -> None:
         """Load a single library and emit the corresponding progress event."""
@@ -4229,12 +4311,110 @@ class LibraryManager:
 
         return advanced_library_instance
 
+    def _should_lazy_load_nodes(self) -> bool:
+        """Return whether node modules should be imported lazily for this process.
+
+        Lazy loading is the default (fast startup); set ``library.lazy_node_loading`` to False
+        to load eagerly so node import errors surface at startup while authoring. A worker always
+        loads eagerly regardless of the setting: it imports every node anyway to serialize schemas
+        back to the orchestrator, and eager load lets it report import problems.
+        """
+        if self._is_worker:
+            return False
+        return bool(GriptapeNodes.ConfigManager().get_config_value(LIBRARY_LAZY_NODE_LOADING_KEY, default=True))
+
+    def _register_node_eager(
+        self,
+        node_definition: NodeDefinition,
+        node_file_path: Path,
+        library: Library,
+        library_info: LibraryInfo,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> bool:
+        """Import a node's module now and register its class, recording any load problem.
+
+        Returns True if the node type was registered, False if its module failed to import
+        (a problem is appended to ``library_info`` in that case).
+        """
+        library_name = library.get_library_data().name
+        try:
+            node_class = self._make_node_class_loader(
+                node_file_path, node_definition.class_name, library_name, module_loaders
+            )()
+        except ImportError as err:
+            root_cause = self._get_root_cause_from_exception(err)
+            library_info.problems.append(
+                NodeModuleImportProblem(
+                    class_name=node_definition.class_name,
+                    file_path=str(node_file_path),
+                    error_message=str(err),
+                    root_cause=str(root_cause),
+                )
+            )
+            logger.error(
+                "Attempted to load node '%s' from '%s'. Failed because module could not be imported: %s",
+                node_definition.class_name,
+                node_file_path,
+                err,
+            )
+            return False
+        except AttributeError:
+            library_info.problems.append(
+                NodeClassNotFoundProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
+            )
+            logger.error(
+                "Attempted to load node '%s' from '%s'. Failed because class not found in module",
+                node_definition.class_name,
+                node_file_path,
+            )
+            return False
+        except TypeError:
+            library_info.problems.append(
+                NodeClassNotBaseNodeProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
+            )
+            logger.error(
+                "Attempted to load node '%s' from '%s'. Failed because class doesn't inherit from BaseNode",
+                node_definition.class_name,
+                node_file_path,
+            )
+            return False
+
+        library_problem = library.register_new_node_type(node_class, metadata=node_definition.metadata)
+        if library_problem is not None:
+            library_info.problems.append(library_problem)
+        return True
+
+    def _register_node_lazy(
+        self,
+        node_definition: NodeDefinition,
+        node_file_path: Path,
+        library: Library,
+        library_info: LibraryInfo,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> bool:
+        """Register a node type with a deferred loader; its module imports on first use.
+
+        Always returns True: registration itself does not import the module, so an import
+        error cannot be detected here (it surfaces when the node is first used).
+        """
+        loader = self._make_node_class_loader(
+            node_file_path, node_definition.class_name, library.get_library_data().name, module_loaders
+        )
+        library_problem = library.register_lazy_node_type(
+            node_definition.class_name, metadata=node_definition.metadata, loader=loader
+        )
+        if library_problem is not None:
+            library_info.problems.append(library_problem)
+        return True
+
     def _attempt_load_nodes_from_library(  # noqa: PLR0912, PLR0915, C901
         self,
         library_data: LibrarySchema,
         library: Library,
         base_dir: Path,
         library_info: LibraryInfo,
+        *,
+        lazy_loading: bool = False,
     ) -> None:
         """Load nodes from library and update library_info in place.
 
@@ -4243,6 +4423,9 @@ class LibraryManager:
             library: Library instance to register nodes with
             base_dir: Base directory for resolving relative paths
             library_info: LibraryInfo to update with problems and fitness
+            lazy_loading: When False (default), each node's module is imported now so import
+                errors surface here as library problems. When True, node types are registered
+                with a deferred loader and their modules are imported on first use instead.
         """
         any_nodes_loaded_successfully = False
 
@@ -4279,49 +4462,31 @@ class LibraryManager:
                 )
                 logger.error(details)
 
-        # Process each node in the metadata
+        # Process each node in the metadata. Lazy loading (the default) registers each type with
+        # a deferred loader and imports the module on first use, keeping startup from paying the
+        # import cost (often heavy deps like torch/diffusers) of node modules that are never used;
+        # the tradeoff is that an import error is not reported until the node is first used (the
+        # CreateNode handler then substitutes an Error Proxy). Eager loading (library.lazy_node_loading
+        # = False, and always for the sandbox library) instead imports each node's module now so a
+        # broken node surfaces as a library problem at startup, before it is placed on a canvas.
+        # module_loaders memoizes each file's module import so classes sharing a file (whether
+        # resolved eagerly here or lazily later) import it once rather than re-executing per class.
+        module_loaders: dict[Path, Callable[[], ModuleType]] = {}
         for node_definition in library_data.nodes:
             # Resolve relative path to absolute path
             node_file_path = resolve_workspace_path(Path(node_definition.file_path), base_dir)
 
-            try:
-                # Dynamically load the module containing the node class
-                node_class = self._load_class_from_file(node_file_path, node_definition.class_name, library_data.name)
-            except ImportError as err:
-                root_cause = self._get_root_cause_from_exception(err)
-                library_info.problems.append(
-                    NodeModuleImportProblem(
-                        class_name=node_definition.class_name,
-                        file_path=str(node_file_path),
-                        error_message=str(err),
-                        root_cause=str(root_cause),
-                    )
+            if lazy_loading:
+                node_registered = self._register_node_lazy(
+                    node_definition, node_file_path, library, library_info, module_loaders
                 )
-                details = f"Attempted to load node '{node_definition.class_name}' from '{node_file_path}'. Failed because module could not be imported: {err}"
-                logger.error(details)
-                continue  # SKIP IT
-            except AttributeError:
-                library_info.problems.append(
-                    NodeClassNotFoundProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
+            else:
+                node_registered = self._register_node_eager(
+                    node_definition, node_file_path, library, library_info, module_loaders
                 )
-                details = f"Attempted to load node '{node_definition.class_name}' from '{node_file_path}'. Failed because class not found in module"
-                logger.error(details)
-                continue  # SKIP IT
-            except TypeError:
-                library_info.problems.append(
-                    NodeClassNotBaseNodeProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
-                )
-                details = f"Attempted to load node '{node_definition.class_name}' from '{node_file_path}'. Failed because class doesn't inherit from BaseNode"
-                logger.error(details)
-                continue  # SKIP IT
 
-            # Register the node type with the library
-            library_problem = library.register_new_node_type(node_class, metadata=node_definition.metadata)
-            if library_problem is not None:
-                library_info.problems.append(library_problem)
-
-            # If we got here, at least one node came in.
-            any_nodes_loaded_successfully = True
+            if node_registered:
+                any_nodes_loaded_successfully = True
 
         # Register widgets and check for duplicates
         if library_data.widgets:

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -23,6 +23,7 @@ WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
+LIBRARY_LAZY_NODE_LOADING_KEY = "library.lazy_node_loading"
 
 
 class Category(BaseModel):
@@ -296,6 +297,19 @@ class LibrarySettings(BaseModel):
             "Controls automatic installation of library dependencies declared in library manifests. "
             "'always' downloads and installs them on registration. "
             "'never' skips installation and marks the library as degraded if required dependencies are missing."
+        ),
+    )
+    lazy_node_loading: bool = Field(
+        default=True,
+        description=(
+            "When True (the default), node modules are imported lazily on first use (creating, "
+            "executing, or introspecting a node of that type) rather than at startup, which speeds "
+            "up engine startup for libraries with many or heavy nodes. The tradeoff is that a broken "
+            "node's import error is not reported until that node is first used. When False, the engine "
+            "imports every node's Python module at startup, so an import error surfaces immediately as "
+            "a library problem, before the node is placed on a canvas; set this while authoring nodes "
+            "if you want that check. Nodes in the sandbox library are always loaded eagerly regardless "
+            "of this setting."
         ),
     )
     minimum_release_age: float = Field(

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -302,14 +302,14 @@ class LibrarySettings(BaseModel):
     lazy_node_loading: bool = Field(
         default=True,
         description=(
-            "When True (the default), node modules are imported lazily on first use (creating, "
-            "executing, or introspecting a node of that type) rather than at startup, which speeds "
-            "up engine startup for libraries with many or heavy nodes. The tradeoff is that a broken "
-            "node's import error is not reported until that node is first used. When False, the engine "
-            "imports every node's Python module at startup, so an import error surfaces immediately as "
-            "a library problem, before the node is placed on a canvas; set this while authoring nodes "
-            "if you want that check. Nodes in the sandbox library are always loaded eagerly regardless "
-            "of this setting."
+            "When True (the default), a node's Python module is imported lazily the first time a node "
+            "of that type is created (or the type is otherwise resolved, such as when introspected) "
+            "rather than at startup, which speeds up engine startup for libraries with many or heavy "
+            "nodes. The tradeoff is that a broken node's import error is not reported until that type is "
+            "first created. When False, the engine imports every node's Python module at startup, so an "
+            "import error surfaces immediately as a library problem, before the node is placed on a "
+            "canvas; set this while authoring nodes if you want that check. Nodes in the sandbox library "
+            "are always loaded eagerly regardless of this setting."
         ),
     )
     minimum_release_age: float = Field(

--- a/tests/unit/node_library/test_lazy_node_loading.py
+++ b/tests/unit/node_library/test_lazy_node_loading.py
@@ -1,0 +1,177 @@
+"""Tests for lazy node-type registration on Library.
+
+A node type registered via ``register_lazy_node_type`` records its metadata and a
+loader but does not import the node's Python module until the real class is first
+needed (creation, execution, or introspection). Import failures surface to that
+first caller rather than at library-load time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode
+from griptape_nodes.node_library.library_registry import Library, LibrarySchema, NodeMetadata
+
+
+class _LazyMockNode(BaseNode):
+    def __init__(self, name: str = "mock", **kwargs: Any) -> None:
+        super().__init__(name=name, **kwargs)
+
+    def process(self) -> AsyncResult | None:
+        return None
+
+
+class _AlphaNode(_LazyMockNode):
+    pass
+
+
+class _BetaNode(_LazyMockNode):
+    pass
+
+
+def _make_library(name: str = "TestLib") -> Library:
+    schema = MagicMock(spec=LibrarySchema)
+    schema.is_default_library = False
+    schema.name = name
+    return Library(library_data=schema)
+
+
+def _metadata(display_name: str = "Node") -> NodeMetadata:
+    return NodeMetadata(category="test", description="desc", display_name=display_name)
+
+
+class TestLazyRegistration:
+    def test_register_lazy_does_not_invoke_loader(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=loader)
+
+        loader.assert_not_called()
+        assert lib.has_node_type("_LazyMockNode")
+        assert "_LazyMockNode" in lib.get_registered_nodes()
+
+    def test_metadata_available_without_resolution(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+        metadata = _metadata(display_name="Fancy Node")
+
+        lib.register_lazy_node_type("_LazyMockNode", metadata=metadata, loader=loader)
+
+        assert lib.get_node_metadata("_LazyMockNode") is metadata
+        loader.assert_not_called()
+
+
+class TestLazyResolution:
+    def test_create_node_resolves_loader_once(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=loader)
+
+        first = lib.create_node(node_type="_LazyMockNode", name="a")
+        second = lib.create_node(node_type="_LazyMockNode", name="b")
+
+        assert isinstance(first, _LazyMockNode)
+        assert isinstance(second, _LazyMockNode)
+        # Loader runs once; the resolved class is promoted and reused thereafter.
+        loader.assert_called_once()
+
+    def test_get_node_class_resolves_and_caches(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=loader)
+
+        assert lib.get_node_class("_LazyMockNode") is _LazyMockNode
+        assert lib.get_node_class("_LazyMockNode") is _LazyMockNode
+        # The module is imported at most once; the resolved class is cached.
+        loader.assert_called_once()
+
+    def test_get_node_class_unknown_type_raises_keyerror(self) -> None:
+        lib = _make_library()
+        with pytest.raises(KeyError):
+            lib.get_node_class("DoesNotExist")
+
+    def test_create_node_unknown_type_raises_keyerror(self) -> None:
+        lib = _make_library()
+        with pytest.raises(KeyError):
+            lib.create_node(node_type="DoesNotExist", name="a")
+
+
+class TestImportFailureSurfacesOnFirstUse:
+    def test_create_node_propagates_import_error(self) -> None:
+        lib = _make_library()
+
+        def boom() -> type[BaseNode]:
+            msg = "module import blew up"
+            raise ImportError(msg)
+
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=boom)
+
+        # Registration and metadata lookups succeed; the failure is deferred to first use.
+        assert lib.has_node_type("_LazyMockNode")
+        assert lib.get_node_metadata("_LazyMockNode").display_name == "Node"
+
+        with pytest.raises(ImportError, match="module import blew up"):
+            lib.create_node(node_type="_LazyMockNode", name="a")
+
+
+class TestGetNodesByBaseType:
+    def test_resolves_lazy_types(self) -> None:
+        lib = _make_library()
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=lambda: _AlphaNode)
+        lib.register_lazy_node_type("_BetaNode", metadata=_metadata(), loader=lambda: _BetaNode)
+
+        assert lib.get_nodes_by_base_type(_AlphaNode) == ["_AlphaNode"]
+
+    def test_skips_types_whose_module_fails_to_import(self) -> None:
+        lib = _make_library()
+
+        def boom() -> type[BaseNode]:
+            raise ImportError
+
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=lambda: _AlphaNode)
+        lib.register_lazy_node_type("_Broken", metadata=_metadata(), loader=boom)
+
+        # The broken type is skipped; the scan still finds the importable one.
+        assert lib.get_nodes_by_base_type(_LazyMockNode) == ["_AlphaNode"]
+
+
+class TestSupersedeSemantics:
+    def test_eager_registration_supersedes_lazy(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_AlphaNode)
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=loader)
+
+        lib.register_new_node_type(_AlphaNode, metadata=_metadata())
+
+        assert lib.get_node_class("_AlphaNode") is _AlphaNode
+        loader.assert_not_called()
+
+    def test_lazy_registration_supersedes_eager(self) -> None:
+        lib = _make_library()
+        lib.register_new_node_type(_AlphaNode, metadata=_metadata())
+
+        loader = MagicMock(return_value=_BetaNode)
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=loader)
+
+        assert lib.get_node_class("_AlphaNode") is _BetaNode
+        loader.assert_called_once()
+
+
+class TestUnregister:
+    def test_unregister_removes_lazy_type(self) -> None:
+        lib = _make_library()
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=lambda: _LazyMockNode)
+
+        lib.unregister_node_type("_LazyMockNode")
+
+        assert not lib.has_node_type("_LazyMockNode")
+
+    def test_unregister_unknown_type_raises_keyerror(self) -> None:
+        lib = _make_library()
+        with pytest.raises(KeyError):
+            lib.unregister_node_type("DoesNotExist")

--- a/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
@@ -1,0 +1,268 @@
+"""Tests for the opt-in lazy node-loading flag in LibraryManager.
+
+Eager loading (the default) imports each node's module at load time, so a broken node
+surfaces as a library problem immediately. Lazy loading registers node types with a
+deferred loader and imports on first use, so a broken node is not reported until used.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import (
+    CategoryDefinition,
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+    NodeDefinition,
+    NodeMetadata,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    DescribeNodeTypeRequest,
+    DescribeNodeTypeResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.node_module_import_problem import (
+    NodeModuleImportProblem,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.retained_mode.managers.settings import LibrarySettings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+_GOOD_NODE_SOURCE = """
+from griptape_nodes.exe_types.node_types import BaseNode
+
+
+class GoodNode(BaseNode):
+    def process(self):
+        return None
+"""
+
+_BROKEN_NODE_SOURCE = """
+import definitely_not_a_real_module_zzz  # noqa: F401
+
+from griptape_nodes.exe_types.node_types import BaseNode
+
+
+class BrokenNode(BaseNode):
+    def process(self):
+        return None
+"""
+
+# Two node classes in one file, plus a top-level side effect that appends to a marker file on
+# every module execution. Used to prove the module is imported exactly once even when its two
+# classes are resolved separately.
+_SIBLINGS_SOURCE = """
+from pathlib import Path
+
+from griptape_nodes.exe_types.node_types import BaseNode
+
+Path({marker!r}).open("a").write("x")
+
+
+class SiblingA(BaseNode):
+    def process(self):
+        return None
+
+
+class SiblingB(BaseNode):
+    def process(self):
+        return None
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Iterator[None]:
+    # LibraryRegistry._libraries is a ClassVar, so it survives the conftest singleton reset.
+    # Clear it around each test so re-registering the same library name does not collide.
+    LibraryRegistry._clear()
+    yield
+    LibraryRegistry._clear()
+
+
+def _node_metadata(display_name: str) -> NodeMetadata:
+    return NodeMetadata(category="Test", description="test node", display_name=display_name)
+
+
+def _write_library(tmp_path: Path) -> LibrarySchema:
+    (tmp_path / "good_node.py").write_text(_GOOD_NODE_SOURCE)
+    (tmp_path / "broken_node.py").write_text(_BROKEN_NODE_SOURCE)
+    return LibrarySchema(
+        name="Lazy Flag Test Library",
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test",
+            description="test",
+            library_version="1.0.0",
+            engine_version="1.0.0",
+            tags=[],
+        ),
+        categories=[{"Test": CategoryDefinition(title="Test", description="test", color="#000", icon="Folder")}],
+        nodes=[
+            NodeDefinition(class_name="GoodNode", file_path="good_node.py", metadata=_node_metadata("Good")),
+            NodeDefinition(class_name="BrokenNode", file_path="broken_node.py", metadata=_node_metadata("Broken")),
+        ],
+    )
+
+
+def _library_info(schema: LibrarySchema, tmp_path: Path) -> LibraryManager.LibraryInfo:
+    return LibraryManager.LibraryInfo(
+        lifecycle_state=LibraryManager.LibraryLifecycleState.METADATA_LOADED,
+        library_path=str(tmp_path / "griptape_nodes_library.json"),
+        is_sandbox=False,
+        library_name=schema.name,
+        library_version="1.0.0",
+        fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
+        problems=[],
+    )
+
+
+def _schema(name: str, nodes: list[NodeDefinition]) -> LibrarySchema:
+    return LibrarySchema(
+        name=name,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test", description="test", library_version="1.0.0", engine_version="1.0.0", tags=[]
+        ),
+        categories=[{"Test": CategoryDefinition(title="Test", description="test", color="#000", icon="Folder")}],
+        nodes=nodes,
+    )
+
+
+class TestLazyNodeLoadingDefault:
+    def test_setting_defaults_to_lazy(self) -> None:
+        assert LibrarySettings().lazy_node_loading is True
+
+
+class TestEagerLoading:
+    def test_broken_node_is_reported_at_load(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=False
+        )
+
+        # The importable node registers; the broken one does not, and its failure is a problem now.
+        assert library.has_node_type("GoodNode")
+        assert not library.has_node_type("BrokenNode")
+        assert any(isinstance(p, NodeModuleImportProblem) for p in info.problems)
+        # Some nodes loaded, but with problems -> FLAWED.
+        assert info.fitness is LibraryManager.LibraryFitness.FLAWED
+
+
+class TestLazyLoading:
+    def test_broken_node_is_not_reported_until_used(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        # Both types register without importing; no import problem is recorded at load.
+        assert library.has_node_type("GoodNode")
+        assert library.has_node_type("BrokenNode")
+        assert not any(isinstance(p, NodeModuleImportProblem) for p in info.problems)
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+        # The good node imports on first use; the broken one raises only when first used.
+        assert library.create_node(node_type="GoodNode", name="g") is not None
+        with pytest.raises(ImportError):
+            library.get_node_class("BrokenNode")
+
+
+class TestShouldLazyLoadNodes:
+    def test_worker_always_eager(self, griptape_nodes: GriptapeNodes) -> None:
+        manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        # Even with the setting on, a worker loads eagerly.
+        with (
+            patch.object(manager, "_is_worker", True),
+            patch.object(config_mgr, "get_config_value", return_value=True),
+        ):
+            assert manager._should_lazy_load_nodes() is False
+
+    def test_orchestrator_honors_setting_enabled(self, griptape_nodes: GriptapeNodes) -> None:
+        manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        with (
+            patch.object(manager, "_is_worker", False),
+            patch.object(config_mgr, "get_config_value", return_value=True),
+        ):
+            assert manager._should_lazy_load_nodes() is True
+
+    def test_orchestrator_honors_setting_disabled(self, griptape_nodes: GriptapeNodes) -> None:
+        manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        with (
+            patch.object(manager, "_is_worker", False),
+            patch.object(config_mgr, "get_config_value", return_value=False),
+        ):
+            assert manager._should_lazy_load_nodes() is False
+
+
+class TestMultipleNodesPerFile:
+    def test_sibling_classes_share_a_single_module_import(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager = griptape_nodes.LibraryManager()
+        marker = tmp_path / "import_count.txt"
+        (tmp_path / "siblings.py").write_text(_SIBLINGS_SOURCE.format(marker=str(marker)))
+        schema = _schema(
+            "Siblings Library",
+            [
+                NodeDefinition(class_name="SiblingA", file_path="siblings.py", metadata=_node_metadata("A")),
+                NodeDefinition(class_name="SiblingB", file_path="siblings.py", metadata=_node_metadata("B")),
+            ],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        # Registration imports nothing.
+        assert not marker.exists()
+
+        node_a = library.get_node_class("SiblingA")
+        node_b = library.get_node_class("SiblingB")
+
+        # The shared file's module is imported exactly once (its top-level code ran once),
+        # even though the two classes resolved separately.
+        assert marker.read_text() == "x"
+        # Both classes come from the same module object, so identity/side effects stay consistent.
+        assert sys.modules[node_a.__module__] is sys.modules[node_b.__module__]
+        assert sys.modules[node_a.__module__].SiblingA is node_a
+
+
+class TestDescribeNodeTypeWithLazyImportFailure:
+    def test_describe_returns_metadata_only_when_lazy_import_fails(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        result = manager.describe_node_type_request(
+            DescribeNodeTypeRequest(node_type="BrokenNode", library=schema.name)
+        )
+
+        # A broken lazy import yields a usable (metadata-only) description rather than a failure.
+        assert isinstance(result, DescribeNodeTypeResultSuccess)
+        assert result.parameters == []


### PR DESCRIPTION
Engine startup imports every node's Python module from every registered library, even nodes that are never used in a session. For the standard library that is 200+ imports, and libraries such as the advanced media library pull in `torch`/`diffusers`/`transformers`, so this dominates cold start.

This registers node types from each library's JSON manifest plus a deferred loader and imports a node's module the first time that type is actually needed (created, executed, or introspected). The node palette is unaffected because it is built from the manifest (metadata, categories, type names), not from imported classes, and an import failure surfaces on first use through the existing `CreateNode` path that already substitutes an `ErrorProxyNode` carrying the reason.

The tradeoff is that a broken node's import error no longer appears at startup as a library problem, only when the node is first touched. That fast-fail is valuable while authoring, so the behavior is gated by a new `library.lazy_node_loading` setting: it defaults to on for fast startup, and setting it `false` restores eager loading and startup-time validation. Worker processes and the sandbox library always load eagerly regardless of the setting, since workers import every node anyway to serialize schemas back to the orchestrator (and can then report import problems), and sandbox nodes are being actively authored and should fail fast.

Because `_load_module_from_file` re-executes a module already in `sys.modules` (its hot-reload path), node modules are memoized per file for the duration of a library load, so classes sharing one file import it once instead of re-running the file's top-level code and binding the classes to different module objects per class.

> [!NOTE]
> This PR description was written by AI.
