### PR TITLE
fix(subflow): prevent flow name collision

### DIFF
--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -122,6 +122,9 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             metadata=subflow_metadata,
         )
         result = GriptapeNodes.handle_request(request)
+        if isinstance(result, CreateFlowResultSuccess):
+            # Final name may be different that initial name due to de-dupe.
+            self.metadata["subflow_name"] = result.flow_name
 
         if not isinstance(result, CreateFlowResultSuccess):
             logger.warning("%s failed to create subflow '%s': %s", self.name, subflow_name, result.result_details)

--- a/tests/e2e/fixtures/subflow_library/subflow_echo_node.py
+++ b/tests/e2e/fixtures/subflow_library/subflow_echo_node.py
@@ -32,7 +32,10 @@ class EchoNode(DataNode):
         )
 
     def process(self) -> None:
-        self.parameter_output_values["text"] = self.get_parameter_value("text") or ""
+        if not self.get_parameter_value("text"):
+            msg = "Echo node must have text input"
+            raise ValueError(msg)
+        self.parameter_output_values["text"] = self.get_parameter_value("text")
 
 
 class TimedEchoNode(DataNode):

--- a/tests/e2e/test_subflow_group_name_collision.py
+++ b/tests/e2e/test_subflow_group_name_collision.py
@@ -1,0 +1,169 @@
+"""Regression test for the SubflowNodeGroup subflow-name collision bug (runtime symptom).
+
+See https://github.com/griptape-ai/griptape-nodes-engine/issues/5126.
+
+Root cause / trigger:
+
+* ``SubflowNodeGroup._create_subflow`` derives ``f"{self.name}_subflow"`` and
+  stores it in ``metadata['subflow_name']`` *before* ``CreateFlowRequest``,
+  never syncing to the deduplicated ``result.flow_name``.
+* Renaming a group frees its default node name; the next group reuses it,
+  recomputes the SAME subflow name, collides on flow creation, and silently
+  keeps the stale (first group's) name -- routing its member into the first
+  group's subflow.
+
+This test reproduces the *runtime* symptom: two groups collide, then running the
+first group also executes the second group's member (on a different fork), which
+raises because it has no valid input.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+    RenameObjectRequest,
+    RenameObjectResultSuccess,
+)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+# Distinct name so the LibraryManager's LOADED bookkeeping doesn't collide with the
+# other in-process subflow tests sharing a worker.
+LIBRARY_NAME = "Subflow Group Metadata Collision Library"
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["name"] = LIBRARY_NAME
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+@pytest.fixture
+def _clean_engine_state() -> Iterator[None]:
+    """Keep the shared engine singleton clean despite running in-process."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    yield
+    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
+    with contextlib.suppress(KeyError):
+        LibraryRegistry.unregister_library(LIBRARY_NAME)
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_clean_engine_state")
+async def test_running_first_group_does_not_execute_second_groups_member(tmp_path: Path) -> None:
+    """Running the first group must execute ONLY its own member, not the second group's.
+
+    Builds the collision trigger (group, rename, group-reusing-the-freed-name), where the
+    first group's member has a valid input and the second group's member has none. Under
+    the bug both members share one subflow, so running the first group also runs the second
+    group's member, which raises ``Echo node must have text input``. After the fix each
+    group owns its own subflow and running the first group succeeds.
+    """
+    library_json = _materialize_library(tmp_path / "library")
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="subflow_collision_wf")
+
+    parent_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
+    parent_flow = parent_result.flow_name
+
+    with GriptapeNodes.ContextManager().flow(parent_flow):
+        # ChildA has a valid input; ChildB has none, so ChildB raises if it is ever executed.
+        child_a = GriptapeNodes.handle_request(
+            CreateNodeRequest(node_type="EchoNode", specific_library_name=LIBRARY_NAME, node_name="ChildA")
+        )
+        assert isinstance(child_a, CreateNodeResultSuccess), child_a
+        child_b = GriptapeNodes.handle_request(
+            CreateNodeRequest(node_type="EchoNode", specific_library_name=LIBRARY_NAME, node_name="ChildB")
+        )
+        assert isinstance(child_b, CreateNodeResultSuccess), child_b
+
+        set_result = GriptapeNodes.handle_request(
+            SetParameterValueRequest(node_name="ChildA", parameter_name="text", value="hello")
+        )
+        assert set_result.succeeded(), set_result
+
+        # --- Group A around ChildA, then rename it (frees the default group name) ---
+        group_a = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="SubflowGroupNode",
+                specific_library_name=LIBRARY_NAME,
+                node_name="G",
+                node_names_to_add=["ChildA"],
+            )
+        )
+        assert isinstance(group_a, CreateNodeResultSuccess), group_a
+        rename_a = GriptapeNodes.handle_request(RenameObjectRequest(object_name="G", requested_name="GroupA"))
+        assert isinstance(rename_a, RenameObjectResultSuccess), rename_a
+
+        # --- Group B reuses the freed name "G", triggering the subflow-name collision ---
+        group_b = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="SubflowGroupNode",
+                specific_library_name=LIBRARY_NAME,
+                node_name="G",
+                node_names_to_add=["ChildB"],
+            )
+        )
+        assert isinstance(group_b, CreateNodeResultSuccess), group_b
+        rename_b = GriptapeNodes.handle_request(RenameObjectRequest(object_name="G", requested_name="GroupB"))
+        assert isinstance(rename_b, RenameObjectResultSuccess), rename_b
+
+    # Run ONLY the first group. It must not drag the second group's member into execution.
+    run_result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=parent_flow,
+            flow_node_name="GroupA",
+            wait_for_completion=True,
+            completion_timeout_ms=30000,
+        )
+    )
+    assert isinstance(run_result, StartFlowResultSuccess), run_result
+
+    node_manager = GriptapeNodes.NodeManager()
+    child_a_node = node_manager.get_node_by_name("ChildA")
+    child_b_node = node_manager.get_node_by_name("ChildB")
+
+    assert child_a_node.state == NodeResolutionState.RESOLVED, child_a_node.state
+    assert child_a_node.parameter_output_values.get("text") == "hello"
+    # ChildB belongs to the OTHER group/fork and must never have executed.
+    assert child_b_node.state == NodeResolutionState.UNRESOLVED, child_b_node.state

--- a/tests/unit/exe_types/node_groups/test_subflow_node_group.py
+++ b/tests/unit/exe_types/node_groups/test_subflow_node_group.py
@@ -1,0 +1,62 @@
+"""Unit tests for SubflowNodeGroup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import create_autospec
+
+from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestSubflowNodeGroupCreateSubflow:
+    """_create_subflow must persist the deduplicated flow name it actually created."""
+
+    def test_records_deduplicated_flow_name_on_collision(
+        self,
+        griptape_nodes: GriptapeNodes,  # noqa: ARG002 - initialises the engine singleton for construction
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The group records the flow name it got back, not the (colliding) name it requested."""
+        group = _MiniSubflowGroup(name="G")
+
+        # Simulate the engine deduplicating the requested "G_subflow" (already taken) to "G_subflow_1".
+        deduped_result = CreateFlowResultSuccess(flow_name="G_subflow_1", result_details="created")
+        mock_handle = create_autospec(GriptapeNodes.handle_request, return_value=deduped_result)
+        monkeypatch.setattr(GriptapeNodes, "handle_request", mock_handle)
+
+        # _create_subflow reads the current flow only to parent the request; keep it off engine state.
+        context_manager = GriptapeNodes.ContextManager()
+        monkeypatch.setattr(
+            context_manager,
+            "get_current_flow",
+            create_autospec(context_manager.get_current_flow, return_value=None),
+        )
+
+        group._create_subflow()
+
+        # The request is derived from the group's own name...
+        mock_handle.assert_called_once_with(
+            CreateFlowRequest(
+                flow_name="G_subflow",
+                parent_flow_name=None,
+                set_as_new_context=False,
+                metadata={"flow_type": "NodeGroupFlow"},
+            )
+        )
+        # ...but the group must record the flow it ACTUALLY got back, not the requested name.
+        assert group.metadata["subflow_name"] == "G_subflow_1"
+
+
+class _MiniSubflowGroup(SubflowNodeGroup):
+    """Minimal concrete SubflowNodeGroup exercising only _create_subflow."""
+
+    async def aprocess(self) -> None:  # pragma: no cover - execution not exercised here
+        await self.execute_subflow()
+
+    def process(self) -> Any:  # pragma: no cover - execution not exercised here
+        return None


### PR DESCRIPTION
Closes #5126.

The name of the flow created by a SubflowNodeGroup is based on the name of the SubflowNodeGroup node itself. If that SubflowNodeGroup node is then renamed, the corresponding flow name is not - it is left as the original name.

A second SubflowNodeGroup can then freely reuse the first node's original name. That reused name will then be used to construct the flow name of the second SubflowNodeGroup, which can then conflict with the flow name of the first SubflowNodeGroup.

Flow names are deduplicated when created. However, the deduplicated flow name was being ignored. So nodes that were passed to
`SubflowNodeGroup.add_nodes_to_group()` were being added to the duplicate flow name (i.e. added to the first flow, rather than the newly created one).

From a user's perspective, this meant that executing one subflow would also execute nodes in the other subflow, even if they were completely disconnected.

So ensure we record the de-duplicated flow name in the metadata, which the nodes will then be added to.