### PR TITLE
fix(subflow): select correct top-level parent of nested subflows

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -5837,17 +5837,7 @@ class WorkflowManager:
             details = f"Attempted to import workflow '{request.workflow_name}' as referenced sub flow. Failed because no new flow was created"
             return ImportWorkflowAsReferencedSubFlowResultFailure(result_details=details)
 
-        # For now, use the first created flow as the main imported flow
-        # This handles nested workflows correctly since sub-flows are expected
-        created_flow_name = next(iter(new_flows))
-
-        if len(new_flows) > 1:
-            logger.debug(
-                "Multiple flows created during import of '%s'. Main flow: %s, Sub-flows: %s",
-                request.workflow_name,
-                created_flow_name,
-                [flow for flow in new_flows if flow != created_flow_name],
-            )
+        created_flow_name = self._select_top_level_imported_flow(new_flows, flow_name, request.workflow_name)
 
         # Apply imported flow metadata if provided
         if request.imported_flow_metadata:
@@ -5870,6 +5860,45 @@ class WorkflowManager:
         return ImportWorkflowAsReferencedSubFlowResultSuccess(
             created_flow_name=created_flow_name, result_details=details
         )
+
+    @staticmethod
+    def _select_top_level_imported_flow(new_flows: set[str], parent_flow_name: str, workflow_name: str) -> str:
+        """Select the top-level flow among those created by importing a referenced workflow.
+
+        A workflow that contains node groups (ForEach, etc.) imports as more than one flow: its
+        top-level flow plus each group's body flow. The caller wants the top-level flow (the one
+        holding the Start/End nodes). It is the new flow whose parent is the import target.
+
+        Args:
+            new_flows: Names of the flows created during the import.
+            parent_flow_name: The flow the workflow was imported into (the import target).
+            workflow_name: Name of the imported workflow, for diagnostics.
+
+        Returns:
+            The name of the top-level imported flow.
+        """
+        flow_manager = GriptapeNodes.FlowManager()
+        top_level_flows = [flow for flow in new_flows if flow_manager.get_parent_flow(flow) == parent_flow_name]
+
+        if len(top_level_flows) == 1:
+            return top_level_flows[0]
+
+        # Not exactly one flow parented to the target -- unexpected for a well-formed single-workflow
+        # import. Fall back to a deterministic (sorted) choice rather than hash-ordered set iteration,
+        # and log for diagnosis.
+        candidates = top_level_flows or list(new_flows)
+        selected = sorted(candidates)[0]
+        logger.warning(
+            "Import of '%s' created %d flow(s) with %d parented to target '%s'; expected exactly one "
+            "top-level flow. Using '%s'. All new flows: %s",
+            workflow_name,
+            len(new_flows),
+            len(top_level_flows),
+            parent_flow_name,
+            selected,
+            sorted(new_flows),
+        )
+        return selected
 
     def on_branch_workflow_request(self, request: BranchWorkflowRequest) -> ResultPayload:  # noqa: PLR0911
         """Create a branch (copy) of an existing workflow with branch tracking."""

--- a/tests/e2e/test_subflow_import_flow_selection.py
+++ b/tests/e2e/test_subflow_import_flow_selection.py
@@ -1,0 +1,177 @@
+"""Regression test for issue #5124: importing a referenced workflow that contains a node group.
+
+A workflow that contains a node group (ForEach, etc.) serializes as MORE THAN ONE flow — its
+top-level ``ControlFlow`` plus the group's body flow. When such a workflow is imported as a
+referenced sub-flow, ``WorkflowManager._execute_workflow_import`` must bind to the TOP-LEVEL
+imported flow (the one that holds the Start/End nodes), because that is what the Workflow node
+records as its ``subflow_name`` and routes I/O through.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    ImportWorkflowAsReferencedSubFlowResultSuccess,
+    ImportWorkflowRequest,
+    ImportWorkflowResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+# Distinct name so the LibraryManager's LOADED bookkeeping doesn't collide with the other
+# in-process subflow tests sharing a worker.
+LIBRARY_NAME = "Subflow Import Flow Selection Library"
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["name"] = LIBRARY_NAME
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+@pytest.fixture
+def _clean_engine_state() -> Iterator[None]:
+    """Keep the shared engine singleton clean despite running in-process."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    yield
+    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
+    with contextlib.suppress(KeyError):
+        LibraryRegistry.unregister_library(LIBRARY_NAME)
+
+
+def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> None:
+    """Write a self-contained grouped workflow ``.py`` to ``workflow_path``.
+
+    Builds a flow whose only node is a group (which owns a nested body flow), serializes it to a
+    self-contained module, and clears the in-process build so the import starts from a clean slate.
+    """
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="grouped_inner_workflow")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    flow_name = flow_result.flow_name
+
+    with GriptapeNodes.ContextManager().flow(flow_name):
+        group_result = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="SubflowGroupNode",
+                specific_library_name=LIBRARY_NAME,
+                node_name="SubflowGroup_1",
+                initial_setup=True,
+            )
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        echo_result = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="EchoNode",
+                specific_library_name=LIBRARY_NAME,
+                node_name="Echo_1",
+                initial_setup=True,
+                parent_group_name=group_result.node_name,
+            )
+        )
+        assert isinstance(echo_result, CreateNodeResultSuccess), echo_result
+
+    serialize_result = GriptapeNodes.handle_request(
+        SerializeFlowToCommandsRequest(flow_name=flow_name, include_create_flow_command=True)
+    )
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+
+    metadata = WorkflowMetadata(
+        name="grouped_inner_workflow",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
+        workflow_shape=None,
+    )
+    content = GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        workflow_metadata=metadata,
+    )
+    workflow_path.write_text(content)
+
+    # Drop the in-process build so the import below starts from a clean parent flow.
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_clean_engine_state")
+async def test_import_binds_to_top_level_flow_not_group_body(tmp_path: Path) -> None:
+    """Importing a group-containing workflow must return the top-level imported flow."""
+    library_json = _materialize_library(tmp_path / "library")
+    workflow_path = tmp_path / "grouped_inner_workflow.py"
+    _write_grouped_workflow_file(library_json, workflow_path)
+
+    # Register the workflow file so it can be imported by name.
+    import_workflow_result = await GriptapeNodes.ahandle_request(ImportWorkflowRequest(file_path=str(workflow_path)))
+    assert isinstance(import_workflow_result, ImportWorkflowResultSuccess), import_workflow_result
+    workflow_name = import_workflow_result.workflow_name
+
+    # Fresh parent flow to import into.
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="parent_workflow")
+    parent_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
+    parent_flow = parent_result.flow_name
+
+    import_result = await GriptapeNodes.ahandle_request(
+        ImportWorkflowAsReferencedSubFlowRequest(workflow_name=workflow_name, flow_name=parent_flow)
+    )
+    assert isinstance(import_result, ImportWorkflowAsReferencedSubFlowResultSuccess), import_result
+
+    # The imported workflow created two flows (its top-level flow + the group's body flow). The
+    # returned flow must be the TOP-LEVEL one, i.e. the flow whose parent is the import target.
+    # The group's body flow is parented to that top-level flow, so returning it would be the bug.
+    flow_manager = GriptapeNodes.FlowManager()
+    created_flow = import_result.created_flow_name
+    assert flow_manager.get_parent_flow(created_flow) == parent_flow, (
+        f"import bound to '{created_flow}' (parent '{flow_manager.get_parent_flow(created_flow)}') "
+        f"instead of the top-level flow parented to '{parent_flow}'"
+    )

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1,10 +1,11 @@
 import ast
 import asyncio
+import logging
 import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, create_autospec, patch
 
 import anyio
 import pytest
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import NodeDependencies
-from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.node_library.workflow_registry import Workflow, WorkflowMetadata, WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 from griptape_nodes.retained_mode.events.workflow_events import (
@@ -32,6 +33,8 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     GetWorkflowMetadataRequest,
     GetWorkflowMetadataResultFailure,
     GetWorkflowMetadataResultSuccess,
+    ImportWorkflowAsReferencedSubFlowRequest,
+    ImportWorkflowAsReferencedSubFlowResultSuccess,
     ImportWorkflowRequest,
     ImportWorkflowResultFailure,
     ImportWorkflowResultSuccess,
@@ -53,6 +56,9 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     WorkflowStatus,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.context_manager import ContextManager
+from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
+from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
 from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
 
@@ -4072,3 +4078,107 @@ class TestScrubForAstConstant:
         ast.parse(content)
         assert "'traits': []" in content
         assert "'display_name': 'Custom Voice ID'" in content
+
+
+class TestSelectTopLevelImportedFlow:
+    """WorkflowManager._select_top_level_imported_flow picks the top-level imported flow."""
+
+    def _flow_manager_with_parents(self, monkeypatch: pytest.MonkeyPatch, parents: dict[str, str]) -> None:
+        """Stub GriptapeNodes.FlowManager().get_parent_flow via the given name->parent mapping."""
+        flow_manager = Mock(spec=FlowManager)
+        flow_manager.get_parent_flow.side_effect = lambda flow: parents[flow]
+        monkeypatch.setattr(GriptapeNodes, "FlowManager", lambda: flow_manager)
+
+    def test_selects_flow_parented_to_import_target(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workflow_manager = griptape_nodes.WorkflowManager()
+        # Top-level flow is parented to the target; the group's body flow is parented to the top-level.
+        self._flow_manager_with_parents(monkeypatch, {"ControlFlow_2": "ParentFlow", "Group_subflow": "ControlFlow_2"})
+
+        selected = workflow_manager._select_top_level_imported_flow(
+            {"ControlFlow_2", "Group_subflow"}, "ParentFlow", "grouped_inner_workflow"
+        )
+
+        assert selected == "ControlFlow_2"
+
+    def test_falls_back_deterministically_when_none_parented_to_target(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        workflow_manager = griptape_nodes.WorkflowManager()
+        self._flow_manager_with_parents(monkeypatch, {"Zeta_flow": "Other", "Alpha_flow": "Other"})
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            selected = workflow_manager._select_top_level_imported_flow({"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf")
+
+        # No flow parented to the target: deterministic sorted fallback, never hash-ordered.
+        assert selected == "Alpha_flow"
+        assert any(
+            record.levelno == logging.WARNING and "expected exactly one top-level flow" in record.getMessage()
+            for record in caplog.records
+        ), f"expected a fallback warning, got: {[r.getMessage() for r in caplog.records]}"
+
+    def test_falls_back_deterministically_when_multiple_parented_to_target(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        workflow_manager = griptape_nodes.WorkflowManager()
+        self._flow_manager_with_parents(monkeypatch, {"Zeta_flow": "ParentFlow", "Alpha_flow": "ParentFlow"})
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            selected = workflow_manager._select_top_level_imported_flow({"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf")
+
+        # More than one candidate parented to the target: deterministic sorted fallback.
+        assert selected == "Alpha_flow"
+        assert any(
+            record.levelno == logging.WARNING and "expected exactly one top-level flow" in record.getMessage()
+            for record in caplog.records
+        ), f"expected a fallback warning, got: {[r.getMessage() for r in caplog.records]}"
+
+
+class TestExecuteWorkflowImport:
+    """WorkflowManager._execute_workflow_import tests."""
+
+    @pytest.mark.asyncio
+    async def test_returns_top_level_imported_flow(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workflow_manager = griptape_nodes.WorkflowManager()
+
+        request = ImportWorkflowAsReferencedSubFlowRequest(
+            workflow_name="wf", flow_name="ParentFlow", imported_flow_metadata=None, track_as_referenced=False
+        )
+        workflow = Mock(spec=Workflow)
+        workflow.file_path = "workflows/wf.py"
+
+        # The import creates two new flows (a top-level flow + a group's body flow). The dict
+        # values are never inspected -- only the keys form the new-flows set.
+        object_manager = Mock(spec=ObjectManager)
+        object_manager.get_filtered_subset.side_effect = [
+            {"ParentFlow": object()},
+            {"ParentFlow": object(), "ControlFlow_2": object(), "Group_subflow": object()},
+        ]
+        monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+
+        # ContextManager().flow(...) is used purely as a context manager wrapping the import.
+        context_manager = MagicMock(spec=ContextManager)
+        monkeypatch.setattr(GriptapeNodes, "ContextManager", lambda: context_manager)
+
+        monkeypatch.setattr(
+            workflow_manager,
+            "run_workflow",
+            AsyncMock(
+                return_value=WorkflowManager.WorkflowExecutionResult(execution_successful=True, execution_details="ok")
+            ),
+        )
+
+        # Spy the selection helper (its own logic is covered by TestSelectTopLevelImportedFlow).
+        select_mock = create_autospec(workflow_manager._select_top_level_imported_flow, return_value="ControlFlow_2")
+        monkeypatch.setattr(workflow_manager, "_select_top_level_imported_flow", select_mock)
+
+        result = await workflow_manager._execute_workflow_import(request, workflow, "ParentFlow")
+
+        # It selects via the helper (passing the new-flows set, target flow, and workflow name)...
+        select_mock.assert_called_once_with({"ControlFlow_2", "Group_subflow"}, "ParentFlow", "wf")
+        # ...and returns exactly what the helper chose.
+        assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess)
+        assert result.created_flow_name == "ControlFlow_2"


### PR DESCRIPTION
Closes #5124.

The standard library SubflowWorkflowNode makes use of `ImportWorkflowAsReferencedSubFlowRequest` to load its child workflow. The SubflowWorkflowNode expects the response object attribute `ImportWorkflowAsReferencedSubFlowResultSuccess.created_flow_name` to be the top-level flow within the child flow.

However, we were selecting an arbitrary flow out of the set of available flows (top-level flow and its nested sub-flows) as the `created_flow_name`. This meant that executing the SubflowWorkflowNode could end up erroneously executing a child flow of the target flow, rather than the target flow itself.

So choose the top-level flow within the child by finding the flow whose direct parent is the importing flow.

Add an e2e regression test reproducing the issue. Note that even prior to the fix, this test does not always fail, given the non-deterministic nature of the bug, unless `PYTHONHASHSEED` is pinned to a value known to reproduce the bug reliably (e.g. `PYTHONHASHSEED=2` is known to on some systems).