### PR TITLE
fix(files): anchor relative File.resolve() paths to the workspace

### DIFF
--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
+from griptape_nodes.files.path_utils import parse_file_uri, resolve_file_path
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     FileIOFailureReason,
@@ -173,6 +174,29 @@ async def _aresolve_file_path(file_path: str | MacroPath) -> str:
     return await _aresolve_macro_path(file_path)
 
 
+def _resolve_plain_path(path_str: str) -> str:
+    """Resolve a plain (non-macro) path string to an absolute path.
+
+    Relative paths are anchored to the current workspace directory, matching how
+    OSManager resolves ReadFileRequest/WriteFileRequest paths. This keeps
+    resolve() reporting the same on-disk location the read/write pipeline
+    targets, instead of a bare relative path that a caller would resolve against
+    the process working directory. Absolute paths, ``~``/environment-variable
+    paths, and ``file://`` URIs are absolutized in place.
+
+    Args:
+        path_str: A plain path string containing no macro variables.
+
+    Returns:
+        An absolute path string.
+    """
+    local_path = parse_file_uri(path_str)
+    if local_path is not None:
+        path_str = local_path
+    workspace_path = GriptapeNodes.ConfigManager().workspace_path
+    return str(resolve_file_path(path_str, workspace_path))
+
+
 # Pairs of suffixes that should be treated as equivalent when comparing a
 # user-supplied filename extension against the canonical extension reported
 # by ArtifactManager.sniff_extension. Keys and values are lowercase, no
@@ -247,7 +271,10 @@ class File:
         """Resolve and return the absolute path string for this file.
 
         Useful when a caller needs the path for writing (not reading). Macro
-        variables in the path are resolved against the current project at call time.
+        variables in the path are resolved against the current project at call
+        time; plain relative paths are anchored to the workspace directory (the
+        same base the read/write pipeline uses), so the returned path is always
+        absolute.
 
         Returns:
             Absolute path string.
@@ -255,7 +282,9 @@ class File:
         Raises:
             FileLoadError: If macro resolution fails (e.g. no project loaded).
         """
-        return _resolve_file_path(self._file_path)
+        if isinstance(self._file_path, MacroPath):
+            return _resolve_macro_path(self._file_path)
+        return _resolve_plain_path(self._file_path)
 
     @property
     def location(self) -> str:

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -33,6 +33,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 
 HANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.handle_request"
 AHANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.ahandle_request"
+CONFIG_MANAGER_PATH = "griptape_nodes.files.file.GriptapeNodes.ConfigManager"
 
 
 class TestFileConstructor:
@@ -860,10 +861,14 @@ class TestFileDestinationWrite:
         request = mock_handle.call_args.args[0]
         assert request.encoding == "latin-1"
 
-    def test_resolve_returns_path_string(self) -> None:
-        dest = FileDestination("workspace/output.png")
+    def test_resolve_anchors_relative_path_to_workspace(self) -> None:
+        dest = FileDestination("output.png")
 
-        assert dest.resolve() == "workspace/output.png"
+        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
+            mock_config_manager.return_value.workspace_path = Path("/workspace")
+            resolved = dest.resolve()
+
+        assert Path(resolved) == Path("/workspace/output.png")
 
 
 class TestFileDestinationAsync:
@@ -1109,6 +1114,14 @@ class TestFileResolve:
     def test_resolve_plain_string(self) -> None:
         f = File("/absolute/path/image.png")
         assert Path(f.resolve()) == Path("/absolute/path/image.png")
+
+    def test_resolve_anchors_relative_path_to_workspace(self) -> None:
+        """A workspace-relative path resolves against the workspace, not the process CWD."""
+        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
+            mock_config_manager.return_value.workspace_path = Path("/workspace")
+            result = File("outputs/images/result.png").resolve()
+
+        assert Path(result) == Path("/workspace/outputs/images/result.png")
 
     def test_resolve_macro_path_calls_handle_request(self) -> None:
         resolve_result = GetPathForMacroResultSuccess(

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -805,7 +805,7 @@ class TestFileDestinationWrite:
         with patch(HANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
             result = dest.write_bytes(b"\x89PNG")
 
-        assert Path(result.resolve()) == Path("/workspace/output_1.png")
+        assert Path(result.location) == Path("/workspace/output_1.png")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.CREATE_NEW
 
@@ -844,7 +844,7 @@ class TestFileDestinationWrite:
         with patch(HANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
             result = dest.write_text("hello")
 
-        assert Path(result.resolve()) == Path("/workspace/output.txt")
+        assert Path(result.location) == Path("/workspace/output.txt")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.FAIL
 
@@ -861,14 +861,14 @@ class TestFileDestinationWrite:
         request = mock_handle.call_args.args[0]
         assert request.encoding == "latin-1"
 
-    def test_resolve_anchors_relative_path_to_workspace(self) -> None:
+    def test_resolve_anchors_relative_path_to_workspace(self, tmp_path: Path) -> None:
         dest = FileDestination("output.png")
 
         with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = Path("/workspace")
+            mock_config_manager.return_value.workspace_path = tmp_path
             resolved = dest.resolve()
 
-        assert Path(resolved) == Path("/workspace/output.png")
+        assert Path(resolved) == tmp_path / "output.png"
 
 
 class TestFileDestinationAsync:
@@ -885,7 +885,7 @@ class TestFileDestinationAsync:
         with patch(AHANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
             result = await dest.awrite_bytes(b"\x89PNG")
 
-        assert Path(result.resolve()) == Path("/workspace/output_1.png")
+        assert Path(result.location) == Path("/workspace/output_1.png")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.CREATE_NEW
 
@@ -910,7 +910,7 @@ class TestFileDestinationAsync:
         with patch(AHANDLE_REQUEST_PATH, return_value=success_result) as mock_handle:
             result = await dest.awrite_text("hello")
 
-        assert Path(result.resolve()) == Path("/workspace/output.txt")
+        assert Path(result.location) == Path("/workspace/output.txt")
         request = mock_handle.call_args.args[0]
         assert request.existing_file_policy == ExistingFilePolicy.FAIL
 
@@ -1111,17 +1111,21 @@ class TestFileDestinationName:
 class TestFileResolve:
     """Tests for File.resolve() method."""
 
-    def test_resolve_plain_string(self) -> None:
-        f = File("/absolute/path/image.png")
-        assert Path(f.resolve()) == Path("/absolute/path/image.png")
+    def test_resolve_absolute_path_passes_through(self, tmp_path: Path) -> None:
+        abs_path = tmp_path / "absolute" / "image.png"
+        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
+            mock_config_manager.return_value.workspace_path = tmp_path
+            result = File(str(abs_path)).resolve()
 
-    def test_resolve_anchors_relative_path_to_workspace(self) -> None:
+        assert Path(result) == abs_path
+
+    def test_resolve_anchors_relative_path_to_workspace(self, tmp_path: Path) -> None:
         """A workspace-relative path resolves against the workspace, not the process CWD."""
         with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = Path("/workspace")
+            mock_config_manager.return_value.workspace_path = tmp_path
             result = File("outputs/images/result.png").resolve()
 
-        assert Path(result) == Path("/workspace/outputs/images/result.png")
+        assert Path(result) == tmp_path / "outputs" / "images" / "result.png"
 
     def test_resolve_macro_path_calls_handle_request(self) -> None:
         resolve_result = GetPathForMacroResultSuccess(


### PR DESCRIPTION
`File.resolve()` documents that it returns an absolute path, but for a plain relative string it returned the string verbatim, leaving the caller to resolve it against the process working directory. Everything else in the engine treats file paths as workspace-relative (the OSManager anchors `ReadFileRequest`/`WriteFileRequest` paths to `workspace_path`), so a relative path that escapes to a caller resolves against the wrong base.

This surfaced as near-total failure of the standard library's workflow integration tests. Generation nodes write outputs under `{workspace}/outputs/...` and expose them as workspace-relative artifact values; the testing library's `AssertFileExists` node calls `File(path).resolve()` and then checks `Path(...).exists()`. Because `resolve()` handed back `outputs/images/x.png` unchanged, the existence check ran against the repo root instead of the workspace and failed for every workflow whose terminal assertion checks a generated file.

`resolve()` now anchors plain relative paths to `workspace_path`, the same base the read/write pipeline uses, so it reports the location a read or write would actually target. Absolute, `~`/env-var, and `file://` inputs are absolutized in place, and macro paths resolve as before. The read and write paths are untouched. The previous passthrough was itself the defect, so the test that asserted a relative string round-tripped through `resolve()` now expects the anchored absolute path.

> [!NOTE]
> Beep boop. This PR description was written by AI.
