### PR TITLE
feat(flows): support "transient" metadata flag to skip serialization

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -3710,6 +3710,11 @@ class FlowManager:
                     details = f"Attempted to serialize Flow '{flow_name}', but no Flow with that name could be found."
                     return SerializeFlowToCommandsResultFailure(result_details=details)
 
+                # Skip transient child flows: they are runtime-only artifacts (e.g. a subflow a node
+                # imports at execution time) and must not be baked into the saved workflow.
+                if child_flow_obj.metadata.get("transient"):
+                    continue
+
                 # Check if this is a referenced workflow
                 if self.is_referenced_workflow(child_flow_obj):
                     # For referenced workflows, create a minimal SerializedFlowCommands with just the import command

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -16,10 +16,15 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode, ControlNode, DataNode, StartNode
 from griptape_nodes.machines.dag_builder import DagNodeCategories
 from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
     ExtractFlowCommandsFromImageMetadataRequest,
     ExtractFlowCommandsFromImageMetadataResultFailure,
     ExtractFlowCommandsFromImageMetadataResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
 )
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -799,3 +804,54 @@ class TestClassifyNodesForDag:
         assert categories.start_nodes == []
         assert categories.control_nodes == []
         assert categories.data_sink_nodes == []
+
+
+@pytest.fixture
+def clean_object_state(griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    """Clear all object state around a test so leftover flows never bleed across tests.
+
+    Yield-based so the teardown clear runs even when the test body fails.
+    """
+    griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    try:
+        yield
+    finally:
+        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+class TestSerializeFlowSkipsTransientChildFlows:
+    """A child flow flagged ``transient`` in its metadata is omitted from serialization.
+
+    Transient flows are runtime-only artifacts (e.g. a subflow a node imports at execution time);
+    they must not be baked into the saved workflow, so ``on_serialize_flow_to_commands`` skips them
+    while still serializing ordinary child flows.
+    """
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_transient_child_flow_is_not_serialized(self, griptape_nodes: GriptapeNodes) -> None:
+        griptape_nodes.ContextManager().push_workflow("transient_wf")
+
+        parent = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="parent", set_as_new_context=True)
+        )
+        assert isinstance(parent, CreateFlowResultSuccess)
+        keep = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="child_keep", set_as_new_context=False)
+        )
+        assert isinstance(keep, CreateFlowResultSuccess)
+        transient = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="child_transient", set_as_new_context=False)
+        )
+        assert isinstance(transient, CreateFlowResultSuccess)
+
+        flow_manager = griptape_nodes.FlowManager()
+        flow_manager.get_flow_by_name(transient.flow_name).metadata["transient"] = True
+
+        result = flow_manager.on_serialize_flow_to_commands(
+            SerializeFlowToCommandsRequest(flow_name=parent.flow_name, include_create_flow_command=True)
+        )
+        assert isinstance(result, SerializeFlowToCommandsResultSuccess)
+
+        serialized_child_flows = {sub.flow_name for sub in result.serialized_flow_commands.sub_flows_commands}
+        assert keep.flow_name in serialized_child_flows
+        assert transient.flow_name not in serialized_child_flows


### PR DESCRIPTION
Part of griptape-ai/griptape-nodes-library-standard#466.  Dependency of https://github.com/griptape-ai/griptape-nodes-library-standard/pull/471.

Allow a flow to opt-out of being serialized with a truthy `"transient"` flag in its metadata.

This is useful for the SubflowWorkflow node, which loads a flow at execution time and keeps it in memory, but does not want it persisted (deserialization can break flow name references due to de-duping, causing a lot of trouble).