### PR TITLE
docs: add editor, workflows, and CLI reference documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,20 @@ Instance methods come first because they can call anything. Class methods come n
 
 **Prefer the named helpers over composing primitives** - `sanitize_path_string`, `expand_path`, `resolve_path_safely`, and `normalize_path_for_platform` are building blocks. If you find yourself chaining them, use one of the two canonicalize helpers instead so behavior stays consistent across call sites.
 
+## Documentation
+
+**Update docs with user-facing changes** - When a change affects what users see or do, update the documentation in the same PR. Common mappings:
+
+- New or changed CLI commands/flags → `docs/reference/command_line_interface.md`
+- New or changed settings → `docs/reference/configuration_reference.md` (and `docs/guides/configuration.md` if it needs explanation)
+- New user-facing features or request event families → the relevant page under `docs/guides/`, or a new page
+- Editor-facing behavior changes (shortcuts, menus, panels) → `docs/guides/editor/`
+- Deprecated or renamed nodes → `MIGRATION.md` and the node's doc page
+
+**Wire new pages into mkdocs.yml twice** - A new docs page must be added to both the `nav` section and the `llmstxt` plugin sections in `mkdocs.yml`. Verify with `uv run mkdocs build --strict`.
+
+**Write for artists** - Docs follow the same rule as error messages: understandable by artists, not just engineers. Use exact UI labels, menu paths, and shortcuts. Match the voice of existing pages such as `docs/guides/libraries.md`.
+
 ## Architecture
 
 **Singleton managers** - `GriptapeNodes` is a singleton holding 25+ managers (e.g., `FlowManager`, `NodeManager`), each accessed via `GriptapeNodes.ManagerName()` classmethods.

--- a/docs/development/custom_nodes/comprehensive_guide.md
+++ b/docs/development/custom_nodes/comprehensive_guide.md
@@ -159,6 +159,8 @@ Add functionality via `add_trait()`:
 - **ColorPicker**: `ColorPicker(format="hex")`
 - **FileSystemPicker**: `FileSystemPicker(...)` (file/directory selection UI)
 
+For the full list of traits, the widgets they render, and the `ui_options` keys they manage, see the [Parameter UI Reference](parameter_ui_reference.md).
+
 ### Parameter helper constructs (`ParameterString`, `ParameterInt`, ...)
 
 Griptape Nodes includes a set of convenience Parameter subclasses under `griptape_nodes.exe_types.param_types.*`.

--- a/docs/development/custom_nodes/parameter_ui_reference.md
+++ b/docs/development/custom_nodes/parameter_ui_reference.md
@@ -1,0 +1,135 @@
+# Parameter UI Reference
+
+This page maps what you declare on a `Parameter` in Python to what the editor renders for it. Three things determine a parameter's UI:
+
+1. **The parameter's `type`** selects the widget: `str` gets a text field, `bool` gets a toggle, `ImageArtifact` gets the image viewer, and so on.
+1. **`ui_options`** tweaks that widget: hide it, stretch it full-width, make a text field multiline, add a webcam capture button.
+1. **Traits** bundle UI and behavior together: `Slider` renders a slider *and* validates the range, `Options` renders a dropdown *and* constrains the value to its choices. Under the hood, a trait writes its own keys into `ui_options` — traits are the supported way to get those keys right.
+
+Prefer the [parameter helper classes](comprehensive_guide.md#parameter-helper-constructs-parameterstring-parameterint) (`ParameterString`, `ParameterImage`, ...) and traits when one exists for what you want; reach for raw `ui_options` keys only for the presentation tweaks listed here.
+
+!!! warning "Undocumented keys are internal"
+
+    The editor reads more `ui_options` keys than are listed on this page. Anything not listed here (or emitted by a trait) is editor-internal and may change or disappear without notice.
+
+## How the widget is chosen
+
+For each parameter, the editor picks a widget in this order:
+
+1. If `ui_options` carries `widget` and `library` (set by the [`Widget` trait](#traits)), the editor loads that custom widget from the library.
+1. Otherwise, the parameter's `type` selects a built-in widget from the table below. A `list[...]` type (any element type) selects the list widget.
+1. A type with no mapping gets no inline widget at all — the parameter still shows its label and connection handles, but there's nothing to edit in place.
+
+## Type-to-widget mapping
+
+| `type`                                                                                                                                                                                         | Widget                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `str`                                                                                                                                                                                          | Single-line text field (multiline, Markdown, and picker variants via `ui_options` and traits below)                          |
+| `int`, `float`                                                                                                                                                                                 | Number input (slider via the `Slider` trait; step size via `step`)                                                           |
+| `bool`                                                                                                                                                                                         | Toggle switch                                                                                                                |
+| `json`, `JsonArtifact`                                                                                                                                                                         | JSON viewer/editor                                                                                                           |
+| `python`, `yaml`                                                                                                                                                                               | Syntax-highlighted code editor                                                                                               |
+| `html`, `xml`                                                                                                                                                                                  | Code editor in HTML/XML mode                                                                                                 |
+| `dict`                                                                                                                                                                                         | Key-value editor; also hosts the image/video comparison sliders (see [dict options](#dict))                                  |
+| `list`, `list[...]`                                                                                                                                                                            | List editor rendering one item widget per element                                                                            |
+| `button`                                                                                                                                                                                       | Clickable button (configure with the `Button` trait)                                                                         |
+| `Status`                                                                                                                                                                                       | Status/message block                                                                                                         |
+| `UrlArtifact`                                                                                                                                                                                  | URL display                                                                                                                  |
+| `ImageArtifact` / `ImageUrlArtifact`, `VideoArtifact` / `VideoUrlArtifact`, `AudioArtifact` / `AudioUrlArtifact`, `ThreeDArtifact` / `ThreeDUrlArtifact`, `SplatArtifact` / `SplatUrlArtifact` | The media viewers and editors — see [Media Viewers and Editors](../../guides/editor/media_editors.md) for what each one does |
+| anything else                                                                                                                                                                                  | No inline widget; label and connection handles only                                                                          |
+
+`GLTFArtifact` / `GLTFUrlArtifact` still render (as the 3D viewer) for backward compatibility; use the `ThreeD` types in new nodes.
+
+## Common `ui_options` (any type)
+
+| Key                         | Effect                                                                                                |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `hide`                      | Hide the parameter entirely (label, widget, and handles).                                             |
+| `hide_label`                | Hide the name label, keep the widget.                                                                 |
+| `hide_property`             | Hide the inline widget, keep the label and connection handles.                                        |
+| `display_name`              | Label text shown in the UI, when it should differ from the parameter's name.                          |
+| `is_full_width`             | Stretch the widget across the node's full width.                                                      |
+| `parameter_render_location` | Where the parameter renders relative to its siblings: `"top"`, `"in-order"` (default), or `"bottom"`. |
+
+## Per-type `ui_options`
+
+### `str`
+
+| Key                | Effect                                                                   |
+| ------------------ | ------------------------------------------------------------------------ |
+| `multiline`        | Multi-line text area instead of a single-line field.                     |
+| `markdown`         | Render/edit the text as Markdown.                                        |
+| `placeholder_text` | Placeholder shown while the field is empty (also works on code editors). |
+
+### `int` / `float`
+
+| Key            | Effect                                                                                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------- |
+| `step`         | Increment used by the input's stepper; the engine also validates values against it.                      |
+| `progress_bar` | Render the value as a progress bar instead of an editable input (for values a node reports, like 0–100). |
+
+For a bounded slider, use the `Slider` trait rather than writing `ui_options["slider"]` by hand — the trait also validates the range.
+
+### Image types
+
+| Key                      | Effect                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `clickable_file_browser` | Clicking the empty parameter opens a file picker; dropped/picked files are uploaded. |
+| `expander`               | Let the viewer expand/collapse.                                                      |
+| `crop` / `crop_image`    | Show the crop button that opens the crop editor.                                     |
+| `edit_mask`              | Show the mask button that opens the Paint Mask editor.                               |
+| `edit_excalidraw`        | Show the edit button that opens Image Bash.                                          |
+| `webcam_capture_image`   | Replace the thumbnail with a live webcam preview and capture button.                 |
+| `aspect_ratio`           | Fix the display area to an aspect ratio (e.g. `"16:9"`).                             |
+| `object_fit`             | How the image fills its frame (CSS object-fit values like `"contain"` / `"cover"`).  |
+| `hide_details`           | Hide the name/dimensions/file-size line under the thumbnail.                         |
+| `pulse_on_run`           | Pulse the viewer while the node is executing (also works on audio).                  |
+
+### Audio types
+
+| Key                        | Effect                                                  |
+| -------------------------- | ------------------------------------------------------- |
+| `clickable_file_browser`   | Click-to-browse upload, same as images.                 |
+| `microphone_capture_audio` | Show a record button that captures from the microphone. |
+| `pulse_on_run`             | Pulse the player while the node is executing.           |
+
+### `dict`
+
+| Key             | Effect                                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `compare`       | Render the dict (`{"input_image_1": ..., "input_image_2": ...}`) as the image comparison slider. Pair with `CompareImagesTrait` to validate the shape. |
+| `video_compare` | Render the dict as the side-by-side video comparison player.                                                                                           |
+
+### `json`
+
+| Key     | Effect                                             |
+| ------- | -------------------------------------------------- |
+| `modal` | Open the JSON editor in a modal instead of inline. |
+
+### `list`
+
+| Key         | Effect                                          |
+| ----------- | ----------------------------------------------- |
+| `collapsed` | Start the list collapsed.                       |
+| `columns`   | Lay items out in a grid with this many columns. |
+
+`ParameterList` sets the common list options for you — see [ParameterList Pattern](comprehensive_guide.md#parameterlist-pattern).
+
+## Traits
+
+Traits live in `griptape_nodes.traits` and are attached with `add_trait()` or `traits={...}` on the parameter. Each row lists what the trait renders and, where relevant, the `ui_options` keys it manages — set the trait rather than the keys.
+
+| Trait                | Typical types             | What it does                                                                                          | `ui_options` it writes                                   |
+| -------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `Options`            | `str`, any                | Dropdown constrained to fixed choices, with optional search.                                          | `simple_dropdown`, `show_search`, `search_filter`        |
+| `MultiOptions`       | `list`                    | Multi-select dropdown.                                                                                | `multi_options`                                          |
+| `Slider`             | `int`, `float`            | Slider between `min_val` and `max_val`; out-of-range values fail validation.                          | `slider`                                                 |
+| `Clamp`              | `int`, `float`, sequences | Clamps the value into range on assignment. No UI of its own.                                          | —                                                        |
+| `Button`             | `button`                  | Configures a button's label, variant, size, and click behavior.                                       | `button_label`, `variant`, `size`, `state`, `full_width` |
+| `ColorPicker`        | `str`                     | Color swatch that opens a color picker; validates the format (`"hex"`, etc.).                         | `color_picker`                                           |
+| `FileSystemPicker`   | `str`                     | Browse button that opens a file/directory picker with filtering options.                              | `fileSystemPicker`                                       |
+| `NumbersSelector`    | `dict`                    | Min/max/step numeric range selector.                                                                  | `numbers_selector`                                       |
+| `CompareImagesTrait` | `dict`                    | Validates the two-image dict shape used by the comparison slider (pair with `ui_options["compare"]`). | —                                                        |
+| `Widget`             | any                       | Replaces the built-in widget with a custom widget shipped by a library.                               | `widget`, `library`                                      |
+
+See the [Traits section of the Comprehensive Guide](comprehensive_guide.md#traits) for constructor signatures and examples.

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -1,0 +1,126 @@
+# Assets and Outputs
+
+When a node in your workflow generates an image, video, audio clip, or any
+other file, that file has to land somewhere on disk and be reachable by the
+editor so you can preview and download it. This page explains where those
+files go by default, how to change that, and how files get into a workflow
+in the first place (uploads, drag-and-drop).
+
+## Where generated files go
+
+Every workflow runs inside a **workspace** — the root folder Griptape Nodes
+resolves relative paths against. Nodes don't write to arbitrary locations;
+they save through a small set of named scenarios (the engine calls them
+**situations**) that each point at a directory under the workspace:
+
+- A node's rendered output (an image, a rendered video, generated audio)
+    goes into the `outputs` directory.
+- A file you drag into the editor or copy from outside the project goes
+    into the `inputs` directory.
+- Scratch files a node writes during processing and cleans up afterward go
+    into `temp`.
+- Thumbnails and preview images the editor generates for you go into
+    hidden `.griptape-nodes-previews` / `.griptape-nodes-thumbnails`
+    folders.
+
+You rarely need to think about this mapping directly — a node that says
+"save my output" just works — but if you're wondering "where did the file
+this node just made actually go," it's one of these directories, under
+your workspace. See [Directories](projects/directories.md) for the full
+list and how to point any of them somewhere else (a shared drive, a
+different subfolder, per-platform paths), and
+[Situations](projects/situations.md) for the exact save rule each kind of
+file follows, including what happens when a file with that name already
+exists.
+
+<!-- screenshot: the workspace folder in a file manager, with inputs/outputs/staticfiles visible -->
+
+## The static files directory
+
+Alongside `outputs` and `inputs` sits a `staticfiles` folder (the exact
+name is configurable — see below). This is where the engine puts files it
+needs to serve back to the editor over HTTP, rather than files a node
+saved for your own use. Node preview thumbnails in the UI, files a node's
+output parameter exposes for download, and other editor-facing artifacts
+generally flow through here.
+
+Concretely: when the engine needs to show you a file or let you download
+it, it doesn't hand the browser a raw filesystem path — it creates a URL.
+For files already living in `staticfiles`, that's usually a direct URL to
+the local static file server (`http://localhost:8124/workspace/...` by
+default). For anything else — an arbitrary path elsewhere in your
+workspace, a `file://` path, or a macro path like `{outputs}/render.png` —
+the engine mints a short-lived, presigned download URL on request. Either
+way, the mechanism is the same: the editor asks for a URL, the engine
+resolves it against wherever the file actually lives, and the browser uses
+that URL to fetch or download the file. You don't manage these URLs
+yourself; they're generated on demand and are not meant to be
+long-lived or shared outside your session.
+
+## Storage backends: local vs. Griptape Cloud
+
+Where the underlying bytes actually live is controlled by the
+`storage_backend` setting, which you set during `gtn init` or later in
+your configuration:
+
+- **`local`** (the default) — static files live on your local filesystem,
+    under `<workspace_directory>/staticfiles`, served by a small local web
+    server the engine starts alongside itself.
+- **`gtc`** — static files live in a Griptape Cloud bucket instead of on
+    your disk. Use this when you want assets to sync across machines, share
+    a workflow's generated files with collaborators, or avoid filling up
+    local disk with generated media. This requires a Griptape API key and a
+    bucket (either set up during `gtn init`, or created later — see the
+    [Griptape Cloud bucket configuration](../reference/command_line_interface.md#init)
+    prompts in `gtn init`).
+
+If you configure `gtc` but the bucket credentials aren't available when
+the engine starts, it logs a warning and falls back to local storage
+rather than failing outright — so a half-finished cloud setup won't
+silently swallow your outputs.
+
+Switching backends only changes where *new* static files are written; it
+doesn't move files you already generated under the other backend.
+
+See [Configuration Reference](../reference/configuration_reference.md#storage)
+for the exact `storage_backend`, `static_files_directory`, and
+`workspace_directory` settings, and
+[Command Line Interface](../reference/command_line_interface.md#init) for
+setting them from `gtn init`.
+
+## Uploading files into a workflow
+
+Getting an external file (a reference photo, a source video, an audio
+clip) into a workflow works the same way in reverse: you drag a file onto
+a node, or use a node's file picker, and the editor uploads it into the
+project. The upload lands in the `inputs` directory by default, named
+after the node and parameter that requested it so you can tell where it
+came from later.
+
+<!-- screenshot: dragging a file onto a node's file parameter, showing the drop target highlighted -->
+
+Under the hood this is a two-step handoff rather than the browser talking
+to your filesystem directly: the editor asks the engine for an upload URL,
+then PUTs the file's bytes to that URL. This works the same way regardless
+of storage backend — locally it's a PUT to the local static server;
+against `gtc` it's a PUT to a presigned Griptape Cloud URL — so switching
+backends doesn't change how uploading feels in the editor.
+
+## Related pages
+
+- [Directories](projects/directories.md) — the full list of named
+    directories (`inputs`, `outputs`, `temp`, and more) and how to
+    customize their paths.
+- [Situations](projects/situations.md) — the save rules (where a file
+    goes, what happens on a name collision) behind every kind of file a
+    node writes.
+- [Sequences](projects/sequences.md) — reading a directory of numbered
+    output files (`render.0001.exr`, `render.0002.exr`, …) back in as a
+    single ordered set.
+- [Macros](projects/macros.md) — the path-template syntax (`{outputs}/{file_name_base}.{file_extension}`)
+    that situations use to build file paths, if you want to customize where
+    something is saved.
+- [Configuration Reference](../reference/configuration_reference.md) — the
+    exact settings (`storage_backend`, `static_files_directory`,
+    `workspace_directory`, and friends) and their defaults and environment
+    variable overrides.

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -8,103 +8,74 @@ in the first place (uploads, drag-and-drop).
 
 ## Where generated files go
 
-Every workflow runs inside a **workspace** — the root folder Griptape Nodes
-resolves relative paths against. Nodes don't write to arbitrary locations;
-they save through a small set of named scenarios (the engine calls them
-**situations**) that each point at a directory under the workspace:
+Nodes don't write to hard-coded locations. Every save goes through your
+**project**: the project defines a set of named directories (`inputs`,
+`outputs`, `temp`, and more) and a set of named file-saving scenarios
+called **situations** that decide which directory a given kind of file
+lands in and what it gets called. With the default project, that works
+out to:
 
 - A node's rendered output (an image, a rendered video, generated audio)
-    goes into the `outputs` directory.
-- A file you drag into the editor or copy from outside the project goes
-    into the `inputs` directory.
+    is saved through the [`save_node_output`](projects/situations.md#save_node_output)
+    situation, into the project's `outputs` directory.
+- A file you drag into the editor or copy from outside the project is
+    saved through the [`copy_external_file`](projects/situations.md#copy_external_file)
+    situation, into the `inputs` directory.
 - Scratch files a node writes during processing and cleans up afterward go
     into `temp`.
 - Thumbnails and preview images the editor generates for you go into
     hidden `.griptape-nodes-previews` / `.griptape-nodes-thumbnails`
     folders.
 
-You rarely need to think about this mapping directly — a node that says
-"save my output" just works — but if you're wondering "where did the file
-this node just made actually go," it's one of these directories, under
-your workspace. See [Directories](projects/directories.md) for the full
-list and how to point any of them somewhere else (a shared drive, a
-different subfolder, per-platform paths), and
-[Situations](projects/situations.md) for the exact save rule each kind of
-file follows, including what happens when a file with that name already
-exists.
+None of these paths are baked into the engine — they come from the
+project, and a project file can point any of them somewhere else (a
+shared drive, a different subfolder, per-platform paths) or change what
+happens when a file with that name already exists. See
+[Directories](projects/directories.md) for the full list of named
+directories, [Situations](projects/situations.md) for the save rule each
+kind of file follows, and [Project](projects/index.md) for how to
+customize all of it.
 
-<!-- screenshot: the workspace folder in a file manager, with inputs/outputs/staticfiles visible -->
+<!-- screenshot: the default project's folder layout in a file manager, with inputs and outputs visible -->
 
-## The static files directory
+## How the editor previews and downloads files
 
-Alongside `outputs` and `inputs` sits a `staticfiles` folder (the exact
-name is configurable — see below). This is where the engine puts files it
-needs to serve back to the editor over HTTP, rather than files a node
-saved for your own use. Node preview thumbnails in the UI, files a node's
-output parameter exposes for download, and other editor-facing artifacts
-generally flow through here.
+When the engine needs to show you a file or let you download it, it
+doesn't hand the browser a raw filesystem path — it creates a URL. For
+files inside your workspace, that's usually a direct URL to the local
+static file server (`http://localhost:8124/workspace/...` by default).
+For anything else — a path outside the workspace, a `file://` path, or a
+macro path like `{outputs}/render.png` — the engine mints a short-lived,
+presigned download URL on request. Either way, the mechanism is the same:
+the editor asks for a URL, the engine resolves it against wherever the
+file actually lives, and the browser uses that URL to fetch or download
+the file. You don't manage these URLs yourself; they're generated on
+demand and are not meant to be long-lived or shared outside your session.
 
-Concretely: when the engine needs to show you a file or let you download
-it, it doesn't hand the browser a raw filesystem path — it creates a URL.
-For files already living in `staticfiles`, that's usually a direct URL to
-the local static file server (`http://localhost:8124/workspace/...` by
-default). For anything else — an arbitrary path elsewhere in your
-workspace, a `file://` path, or a macro path like `{outputs}/render.png` —
-the engine mints a short-lived, presigned download URL on request. Either
-way, the mechanism is the same: the editor asks for a URL, the engine
-resolves it against wherever the file actually lives, and the browser uses
-that URL to fetch or download the file. You don't manage these URLs
-yourself; they're generated on demand and are not meant to be
-long-lived or shared outside your session.
-
-## Storage backends: local vs. Griptape Cloud
-
-Where the underlying bytes actually live is controlled by the
-`storage_backend` setting, which you set during `gtn init` or later in
-your configuration:
-
-- **`local`** (the default) — static files live on your local filesystem,
-    under `<workspace_directory>/staticfiles`, served by a small local web
-    server the engine starts alongside itself.
-- **`gtc`** — static files live in a Griptape Cloud bucket instead of on
-    your disk. Use this when you want assets to sync across machines, share
-    a workflow's generated files with collaborators, or avoid filling up
-    local disk with generated media. This requires a Griptape API key and a
-    bucket (either set up during `gtn init`, or created later — see the
-    [Griptape Cloud bucket configuration](../reference/command_line_interface.md#init)
-    prompts in `gtn init`).
-
-If you configure `gtc` but the bucket credentials aren't available when
-the engine starts, it logs a warning and falls back to local storage
-rather than failing outright — so a half-finished cloud setup won't
-silently swallow your outputs.
-
-Switching backends only changes where *new* static files are written; it
-doesn't move files you already generated under the other backend.
-
-See [Configuration Reference](../reference/configuration_reference.md#storage)
-for the exact `storage_backend`, `static_files_directory`, and
-`workspace_directory` settings, and
-[Command Line Interface](../reference/command_line_interface.md#init) for
-setting them from `gtn init`.
+You may also see a `staticfiles` folder in your workspace (the exact name
+is set by the `static_files_directory` setting). It belongs to an older
+save path that most nodes no longer use — they save through the project
+system's directories described above instead — but files saved through
+the engine's static-file API still land there.
 
 ## Uploading files into a workflow
 
 Getting an external file (a reference photo, a source video, an audio
 clip) into a workflow works the same way in reverse: you drag a file onto
 a node, or use a node's file picker, and the editor uploads it into the
-project. The upload lands in the `inputs` directory by default, named
-after the node and parameter that requested it so you can tell where it
-came from later.
+project. Where it lands is decided by the project's
+[`copy_external_file`](projects/situations.md#copy_external_file)
+situation. With the default project, that's the `inputs` directory,
+grouped into a per-type subfolder (`images`, `videos`, `audio`, `text`)
+when the file's extension is recognized; if a file with the same name is
+already there, the new upload gets a numbered suffix (`photo_001.png`)
+instead of overwriting it.
 
 <!-- screenshot: dragging a file onto a node's file parameter, showing the drop target highlighted -->
 
 Under the hood this is a two-step handoff rather than the browser talking
 to your filesystem directly: the editor asks the engine for an upload URL,
-then PUTs the file's bytes to that URL. This works the same way regardless
-of storage backend — locally it's a PUT to the local static server;
-against `gtc` it's a PUT to a presigned Griptape Cloud URL — so switching
-backends doesn't change how uploading feels in the editor.
+then PUTs the file's bytes to that URL.
 
 ## Related pages
 
@@ -121,6 +92,5 @@ backends doesn't change how uploading feels in the editor.
     that situations use to build file paths, if you want to customize where
     something is saved.
 - [Configuration Reference](../reference/configuration_reference.md) — the
-    exact settings (`storage_backend`, `static_files_directory`,
-    `workspace_directory`, and friends) and their defaults and environment
-    variable overrides.
+    exact settings (`static_files_directory`, `workspace_directory`, and
+    friends) and their defaults and environment variable overrides.

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -36,7 +36,7 @@ directories, [Situations](projects/situations.md) for the save rule each
 kind of file follows, and [Project](projects/index.md) for how to
 customize all of it.
 
-<!-- screenshot: the default project's folder layout in a file manager, with inputs and outputs visible -->
+<!-- screenshot (#5166): the default project's folder layout in a file manager, with inputs and outputs visible -->
 
 ## How the editor previews and downloads files
 
@@ -71,7 +71,7 @@ when the file's extension is recognized; if a file with the same name is
 already there, the new upload gets a numbered suffix (`photo_001.png`)
 instead of overwriting it.
 
-<!-- screenshot: dragging a file onto a node's file parameter, showing the drop target highlighted -->
+<!-- screenshot (#5166): dragging a file onto a node's file parameter, showing the drop target highlighted -->
 
 Under the hood this is a two-step handoff rather than the browser talking
 to your filesystem directly: the editor asks the engine for an upload URL,

--- a/docs/guides/editor/index.md
+++ b/docs/guides/editor/index.md
@@ -12,7 +12,7 @@ task instead, the [Where to go next](#where-to-go-next) section links
 to focused guides for nodes, groups, running workflows, media editors,
 and library management.
 
-<!-- screenshot: full editor window with the canvas, header, left sidebar, and right sidebar all visible and labeled -->
+<!-- screenshot (#5166): full editor window with the canvas, header, left sidebar, and right sidebar all visible and labeled -->
 
 ## The canvas
 
@@ -44,7 +44,7 @@ you can do with a node once it's placed, and
 [Keyboard Shortcuts](keyboard_shortcuts.md) for the full list of
 canvas shortcuts.
 
-<!-- screenshot: canvas with a few connected nodes, the minimap visible in a corner, and the bottom-left controls cluster -->
+<!-- screenshot (#5166): canvas with a few connected nodes, the minimap visible in a corner, and the bottom-left controls cluster -->
 
 ## The header
 
@@ -76,7 +76,7 @@ On the **right**, an engine picker (for switching which running engine
 the editor talks to), an error history dropdown, and a **Publish
 Workflow** button that opens the publish dialog.
 
-<!-- screenshot: header close-up showing the workflow name with unsaved indicator, the run button cluster, and the right-side engine picker -->
+<!-- screenshot (#5166): header close-up showing the workflow name with unsaved indicator, the run button cluster, and the right-side engine picker -->
 
 ## The menu bar
 
@@ -126,7 +126,7 @@ Settings** (copies the settings file's path to your clipboard),
 **Show Settings Folder** (opens it in Finder/Explorer/your file
 manager), and **Reset Settings to Default**.
 
-<!-- screenshot: the menu bar with the File menu open, showing its items and shortcuts -->
+<!-- screenshot (#5166): the menu bar with the File menu open, showing its items and shortcuts -->
 
 ## The left sidebar
 
@@ -149,7 +149,7 @@ workflow. Click the sidebar-toggle button in the header (or its
 shortcut) to collapse the sidebar down to a narrow icon rail, or close
 it entirely.
 
-<!-- screenshot: left sidebar expanded, showing the Favorites section, search box, and the Nodes tab's category tree -->
+<!-- screenshot (#5166): left sidebar expanded, showing the Favorites section, search box, and the Nodes tab's category tree -->
 
 ## The right sidebar
 
@@ -176,7 +176,7 @@ The four panels:
 If the sidebar is closed, a floating button near the top-right corner
 of the canvas reopens it.
 
-<!-- screenshot: right sidebar showing the panel tabs (Chat, Code, Logs, Properties) with the panel-visibility dropdown open -->
+<!-- screenshot (#5166): right sidebar showing the panel tabs (Chat, Code, Logs, Properties) with the panel-visibility dropdown open -->
 
 ## Where to go next
 

--- a/docs/guides/editor/index.md
+++ b/docs/guides/editor/index.md
@@ -36,7 +36,7 @@ hidden) shows the whole graph at a glance and lets you jump around by
 clicking or dragging inside it. The controls cluster in the
 bottom-left gives you zoom in/out/fit-view buttons and a **Toggle
 Clean Mode** button that hides the decorative Griptape logo watermark
-— handy when you're taking a screenshot of your own workflow.
+— useful when you're taking a screenshot of your own workflow.
 
 Double-clicking empty canvas opens the **Add Node** menu at your
 cursor. See [Working with Nodes](working_with_nodes.md) for everything
@@ -156,9 +156,9 @@ it entirely.
 The right sidebar holds a set of tabbed panels, titled **Sidebar
 Panels**. A dropdown next to its close button (the icon with three
 dots) lets you show or hide any panel — each entry shows an eye icon
-so you can see at a glance which panels are currently visible. Hiding
-a panel here doesn't lose anything; it just gets a tab back the next
-time you re-enable it.
+so you can see which panels are currently visible. Hiding
+a panel here doesn't discard anything; its tab returns the next time
+you re-enable it.
 
 The four panels:
 
@@ -188,8 +188,8 @@ of the canvas reopens it.
     graph.
 - [Running Workflows](running_workflows.md) — the difference between
     running a workflow, running to a node, and running from a node.
-- [Media Editors](media_editors.md) — the built-in editors for images,
-    video, and other media parameters.
+- [Media Viewers and Editors](media_editors.md) — the built-in
+    viewers and editors for images, video, and other media parameters.
 - [Managing Models and Libraries](managing_models_and_libraries.md) —
     the Model Management and Library Management surfaces in more
     depth.

--- a/docs/guides/editor/index.md
+++ b/docs/guides/editor/index.md
@@ -1,0 +1,195 @@
+# The Editor
+
+The editor is the visual workspace where you build, run, and inspect
+Griptape Nodes workflows. It's a canvas: you drag nodes onto it, wire
+them together, and run the result. Everything else in the window —
+the header, the menu bar, the two sidebars — exists to support that
+canvas: naming and running your workflow, finding nodes to add, and
+inspecting what a node is doing once it runs.
+
+This page is a tour of each region. If you're looking for a specific
+task instead, the [Where to go next](#where-to-go-next) section links
+to focused guides for nodes, groups, running workflows, media editors,
+and library management.
+
+<!-- screenshot: full editor window with the canvas, header, left sidebar, and right sidebar all visible and labeled -->
+
+## The canvas
+
+The canvas is where your workflow lives. Nodes are boxes with inputs
+and outputs; connections between them are the lines you draw from one
+node's output to another's input. Everything you build ends up here.
+
+A few ways to move around:
+
+- **Pan**: hold `Space` and drag (this works even while your
+    cursor is over a node), or drag with the middle mouse button.
+- **Zoom**: scroll or pinch, use the zoom slider in the top-left
+    corner (if enabled in your settings), or hold `Z` and drag
+    left/right for a Photoshop-style scrubby zoom.
+- **Select**: drag on empty canvas to draw a selection box around
+    several nodes, or Shift-click individual nodes to add or remove
+    them from the current selection.
+
+A **minimap** in the corner (toggle it in your editor settings if it's
+hidden) shows the whole graph at a glance and lets you jump around by
+clicking or dragging inside it. The controls cluster in the
+bottom-left gives you zoom in/out/fit-view buttons and a **Toggle
+Clean Mode** button that hides the decorative Griptape logo watermark
+— handy when you're taking a screenshot of your own workflow.
+
+Double-clicking empty canvas opens the **Add Node** menu at your
+cursor. See [Working with Nodes](working_with_nodes.md) for everything
+you can do with a node once it's placed, and
+[Keyboard Shortcuts](keyboard_shortcuts.md) for the full list of
+canvas shortcuts.
+
+<!-- screenshot: canvas with a few connected nodes, the minimap visible in a corner, and the bottom-left controls cluster -->
+
+## The header
+
+The header runs across the top of the window and is split into three
+clusters.
+
+On the **left**, a sidebar-toggle button sits next to the
+[menu bar](#the-menu-bar), followed by your workflow's name. The name
+shows a trailing `*` whenever you have unsaved changes, and the file
+name (`<workflow>.py`) appears underneath once the workflow has been
+saved at least once. An unsaved, never-saved workflow shows just the
+in-progress name with no file name line.
+
+In the **center**, the run controls:
+
+| Button                | What it does                                                   |
+| --------------------- | -------------------------------------------------------------- |
+| **Run Workflow**      | Runs the entire workflow from its start.                       |
+| **Run To Selected**   | Runs up through the single selected node.                      |
+| **Run From Selected** | Starts execution at the single selected node and runs forward. |
+| **Cancel Run**        | Stops a workflow that's currently running.                     |
+
+**Run To Selected** and **Run From Selected** are only enabled when
+exactly one node is selected. See
+[Running Workflows](running_workflows.md) for what "runnable" means
+and how partial runs behave.
+
+On the **right**, an engine picker (for switching which running engine
+the editor talks to), an error history dropdown, and a **Publish
+Workflow** button that opens the publish dialog.
+
+<!-- screenshot: header close-up showing the workflow name with unsaved indicator, the run button cluster, and the right-side engine picker -->
+
+## The menu bar
+
+The menu bar sits in the header's left cluster, next to the sidebar
+toggle. It has three menus.
+
+### File
+
+Create, open, save, and manage the current workflow file:
+
+- **New** / **Open...** — start a new workflow or browse to an
+    existing one.
+- **Rename...** — rename the workflow (disabled for Griptape-provided
+    templates; use Save As to make an editable copy instead).
+- **Save** / **Save As...** / **Save As New Version** — Save As New
+    Version writes a new versioned file (`my_workflow_v002.py`, and so
+    on) instead of overwriting; it only appears once the workflow has
+    been saved at least once.
+- **AutoSave** — toggle automatic saving on or off, with a shortcut
+    into its settings.
+- **Refresh Libraries** — pick up library changes without restarting
+    the engine.
+- **Report Issue** — file a bug report.
+- **Exit** — leave the editor.
+- **Delete `<workflow name>`** — permanently delete the current
+    workflow file.
+
+### Manage
+
+Jumps to the management surfaces for the resources a workflow depends
+on:
+
+- **Model Management** — models available to nodes that need them.
+- **Library Management** — install, update, and configure node
+    libraries. See [Libraries](../libraries.md) for the full guide.
+- **Engine Management** — the engines the editor can connect to.
+- **Project Management** — the projects available to switch between.
+    See [Managing Projects in the GUI](../projects/gui_guide.md).
+
+### Settings
+
+Everything configurable, grouped under a **Settings** submenu (All
+Settings, Agent Settings, Editor Settings, Theme Settings, Engine
+Settings, File System, Libraries, Library Settings, MCP Servers, and
+API Keys & Secrets), plus three actions below it: **Copy Path to
+Settings** (copies the settings file's path to your clipboard),
+**Show Settings Folder** (opens it in Finder/Explorer/your file
+manager), and **Reset Settings to Default**.
+
+<!-- screenshot: the menu bar with the File menu open, showing its items and shortcuts -->
+
+## The left sidebar
+
+The left sidebar is where you find nodes and libraries to add to your
+workflow. A **Favorites** section sits above the tabs — star a node to
+pin it here so you don't have to hunt for it every time — followed by
+a search box that filters whichever tab is active.
+
+Two tabs live below the search box:
+
+- **Nodes** — every node available to you, organized by category, from
+    both built-in and installed libraries.
+- **Libraries** — the same nodes, organized by which library they come
+    from instead of by category. This is a browsing view; to install,
+    update, or remove a library itself, use **Manage → Library
+    Management** (see [Libraries](../libraries.md)).
+
+Drag a node from either tab onto the canvas to add it to your
+workflow. Click the sidebar-toggle button in the header (or its
+shortcut) to collapse the sidebar down to a narrow icon rail, or close
+it entirely.
+
+<!-- screenshot: left sidebar expanded, showing the Favorites section, search box, and the Nodes tab's category tree -->
+
+## The right sidebar
+
+The right sidebar holds a set of tabbed panels, titled **Sidebar
+Panels**. A dropdown next to its close button (the icon with three
+dots) lets you show or hide any panel — each entry shows an eye icon
+so you can see at a glance which panels are currently visible. Hiding
+a panel here doesn't lose anything; it just gets a tab back the next
+time you re-enable it.
+
+The four panels:
+
+- **Chat** — talk to an agent thread directly inside the editor, with
+    a picker for model/provider and any MCP servers you've wired up.
+- **Code** — the workflow's generated Python, in a syntax-highlighted
+    editor you can search and run from.
+- **Logs** — the execution log stream, filterable by severity (Debug,
+    Info, Warning, Error, Critical) and searchable.
+- **Properties** — the parameters of whichever node (or nodes) you
+    currently have selected on the canvas. This is usually where
+    you'll spend most of your time once a workflow is built, since
+    it's how you configure each node's inputs.
+
+If the sidebar is closed, a floating button near the top-right corner
+of the canvas reopens it.
+
+<!-- screenshot: right sidebar showing the panel tabs (Chat, Code, Logs, Properties) with the panel-visibility dropdown open -->
+
+## Where to go next
+
+- [Keyboard Shortcuts](keyboard_shortcuts.md) — every shortcut in the
+    editor, grouped by what you're trying to do.
+- [Working with Nodes](working_with_nodes.md) — adding, wiring,
+    renaming, locking, and duplicating nodes.
+- [Node Groups](node_groups.md) — grouping nodes and arranging your
+    graph.
+- [Running Workflows](running_workflows.md) — the difference between
+    running a workflow, running to a node, and running from a node.
+- [Media Editors](media_editors.md) — the built-in editors for images,
+    video, and other media parameters.
+- [Managing Models and Libraries](managing_models_and_libraries.md) —
+    the Model Management and Library Management surfaces in more
+    depth.

--- a/docs/guides/editor/keyboard_shortcuts.md
+++ b/docs/guides/editor/keyboard_shortcuts.md
@@ -1,0 +1,94 @@
+# Keyboard Shortcuts
+
+A reference for every shortcut in the editor, grouped by what you're
+trying to do. Where macOS and Windows/Linux use different modifier
+keys, both are listed; where a shortcut is the same key on every
+platform, it appears once.
+
+!!! note "Typing is never interrupted"
+
+    Most single-key canvas shortcuts (like `R` or `N`) are ignored
+    while you're typing in a text field, a node's parameter, or the
+    Code panel, so ordinary letters always go where you're typing
+    instead of triggering a shortcut.
+
+For a tour of the regions these shortcuts act on, see
+[The Editor](index.md).
+
+## Adding & editing nodes
+
+| Action                                                     | macOS               | Windows / Linux     |
+| ---------------------------------------------------------- | ------------------- | ------------------- |
+| Add a node at the cursor (canvas only)                     | Tab                 | Tab                 |
+| Add a node at the cursor, or select all if not over canvas | Shift+A             | Shift+A             |
+| Open the Add Node menu at the cursor                       | Double-click canvas | Double-click canvas |
+| Create a Note node at the cursor                           | N                   | N                   |
+| Rename the selected node(s)                                | R                   | R                   |
+| Duplicate the selected node(s)                             | Cmd+D               | Ctrl+D              |
+| Lock / unlock the selected node(s)                         | L                   | L                   |
+| Delete the selected node(s) or connection                  | Delete / Backspace  | Delete / Backspace  |
+
+## Selection
+
+| Action                                                | macOS                | Windows / Linux      |
+| ----------------------------------------------------- | -------------------- | -------------------- |
+| Select all nodes                                      | Cmd+A                | Ctrl+A               |
+| Clear the current selection                           | Escape               | Escape               |
+| Add or remove a node from the selection               | Shift-click a node   | Shift-click a node   |
+| Draw a selection box around several nodes             | Drag on empty canvas | Drag on empty canvas |
+| Move the selection to the nearest node in a direction | Arrow keys           | Arrow keys           |
+
+## Clipboard
+
+| Action                                                 | macOS | Windows / Linux |
+| ------------------------------------------------------ | ----- | --------------- |
+| Copy the selected node(s)                              | Cmd+C | Ctrl+C          |
+| Paste nodes, or an image/media file from the clipboard | Cmd+V | Ctrl+V          |
+
+## Navigation & view
+
+| Action                                                             | macOS               | Windows / Linux     |
+| ------------------------------------------------------------------ | ------------------- | ------------------- |
+| Frame the selected node(s), or the whole graph if nothing selected | F                   | F                   |
+| Fit a selected group to its nodes (otherwise frames the selection) | Shift+F             | Shift+F             |
+| Pan the canvas, even while over a node                             | Hold Space + drag   | Hold Space + drag   |
+| Pan the canvas                                                     | Middle-click + drag | Middle-click + drag |
+| Scrubby zoom — drag right to zoom in, left to zoom out             | Hold Z + drag       | Hold Z + drag       |
+| Zoom in                                                            | Cmd+=               | Alt+=               |
+| Zoom out                                                           | Cmd+-               | Alt+-               |
+| Zoom in / out                                                      | Scroll or pinch     | Scroll or pinch     |
+
+## Groups & layout
+
+| Action                                           | macOS       | Windows / Linux |
+| ------------------------------------------------ | ----------- | --------------- |
+| Create a group from the selection (default type) | Cmd+G       | Ctrl+G          |
+| Create a group, always choosing the type         | Shift+Cmd+G | Shift+Ctrl+G    |
+| Auto-arrange the graph                           | Shift+G     | Shift+G         |
+
+See [Node Groups](node_groups.md) for what the group types mean and
+how auto-arrange lays out your graph.
+
+## Connections
+
+| Action                                                         | macOS    | Windows / Linux |
+| -------------------------------------------------------------- | -------- | --------------- |
+| Toggle display of parameters that already have a connection    | Shift+H  | Shift+H         |
+| Insert a dot (reroute) node on the hovered/selected connection | I        | I               |
+| Show a connection's action buttons while hovering over it      | Hold Cmd | Hold Ctrl       |
+
+## Workflow / file
+
+| Action                            | macOS           | Windows / Linux  |
+| --------------------------------- | --------------- | ---------------- |
+| Save                              | Cmd+S           | Ctrl+S           |
+| Save As                           | Shift+Cmd+S     | Shift+Ctrl+S     |
+| Save As New Version               | Option+Shift+S  | Alt+Shift+S      |
+| Open Workflow                     | Cmd+O           | Ctrl+O           |
+| New Workflow                      | Shift+Cmd+O     | Shift+Ctrl+O     |
+| Run to the selected node          | Cmd+Enter       | Ctrl+Enter       |
+| Run the whole workflow            | Shift+Cmd+Enter | Shift+Ctrl+Enter |
+| Download the workflow as an image | Cmd+I           | Ctrl+I           |
+| Toggle the right sidebar          | Cmd+B           | Ctrl+B           |
+| Toggle the left sidebar           | Shift+Cmd+B     | Shift+Ctrl+B     |
+| Show this shortcuts reference     | Shift+?         | Shift+?          |

--- a/docs/guides/editor/keyboard_shortcuts.md
+++ b/docs/guides/editor/keyboard_shortcuts.md
@@ -1,9 +1,8 @@
 # Keyboard Shortcuts
 
 A reference for every shortcut in the editor, grouped by what you're
-trying to do. Where macOS and Windows/Linux use different modifier
-keys, both are listed; where a shortcut is the same key on every
-platform, it appears once.
+trying to do. macOS and Windows/Linux shortcuts are listed in separate
+columns where the modifier keys differ.
 
 !!! note "Typing is never interrupted"
 

--- a/docs/guides/editor/managing_models_and_libraries.md
+++ b/docs/guides/editor/managing_models_and_libraries.md
@@ -5,7 +5,7 @@ others come from a library you haven't installed yet. Both are managed from
 the editor's **Manage** menu, in the **Model Management** and **Library
 Management** windows. This page covers both.
 
-<!-- screenshot: the Manage menu open, showing Model Management and Library Management items -->
+<!-- screenshot (#5166): the Manage menu open, showing Model Management and Library Management items -->
 
 For the concepts behind libraries — how installs are isolated from each
 other, Shared vs. Isolated execution, and what to do when something goes
@@ -17,7 +17,7 @@ management windows themselves.
 Open **Manage → Model Management** to search for, download, and clean up
 models.
 
-<!-- screenshot: the Model Management window with the search box, filter chips, and a couple of installed models listed -->
+<!-- screenshot (#5166): the Model Management window with the search box, filter chips, and a couple of installed models listed -->
 
 ### Searching for a model
 
@@ -57,7 +57,7 @@ Click the trash icon on an entry that's still downloading to cancel it. A
 **Cancel Download** confirmation appears first — **Keep Downloading** backs
 out, **Cancel Download** stops it and removes the partial download record.
 
-<!-- screenshot: the Cancel Download confirmation dialog -->
+<!-- screenshot (#5166): the Cancel Download confirmation dialog -->
 
 ### Deleting a model
 
@@ -68,7 +68,7 @@ removes the files from local storage, and any workflow that depends on that
 model will fail until you either re-download it or point the workflow at a
 different one.
 
-<!-- screenshot: the Delete Model confirmation dialog -->
+<!-- screenshot (#5166): the Delete Model confirmation dialog -->
 
 ### Gated models need a token
 
@@ -90,7 +90,7 @@ gated model.
 Open **Manage → Library Management** to install, update, and remove
 libraries.
 
-<!-- screenshot: the Library Management window with the filter bar and a few installed libraries listed -->
+<!-- screenshot (#5166): the Library Management window with the filter bar and a few installed libraries listed -->
 
 The filter bar at the top lets you search installed libraries by name and
 narrow the list with the **All / Updates / Errors** chips — **Errors** is
@@ -108,7 +108,7 @@ Click **Add Library** to open the **Add Library** dialog. Paste a Git URL —
 for example a GitHub repository hosting a community library — and click
 **Install**.
 
-<!-- screenshot: the Add Library dialog with a Git URL entered and Advanced Options expanded -->
+<!-- screenshot (#5166): the Add Library dialog with a Git URL entered and Advanced Options expanded -->
 
 The editor first inspects the repository and shows you a confirmation with
 the library's name, description, version, and node count before actually

--- a/docs/guides/editor/managing_models_and_libraries.md
+++ b/docs/guides/editor/managing_models_and_libraries.md
@@ -1,30 +1,46 @@
 # Managing Models and Libraries
 
-Some nodes need a machine learning model on disk before they can run; others come from a library you haven't installed yet. Both are managed from the editor's **Manage** menu, in the **Model Management** and **Library Management** windows. This page covers both.
+Some nodes need a machine learning model on disk before they can run;
+others come from a library you haven't installed yet. Both are managed from
+the editor's **Manage** menu, in the **Model Management** and **Library
+Management** windows. This page covers both.
 
 <!-- screenshot: the Manage menu open, showing Model Management and Library Management items -->
 
-For the concepts behind libraries — how installs are isolated from each other, Shared vs. Isolated execution, and what to do when something goes wrong — see [Libraries](../libraries.md). This page is about the two management windows themselves.
+For the concepts behind libraries — how installs are isolated from each
+other, Shared vs. Isolated execution, and what to do when something goes
+wrong — see [Libraries](../libraries.md). This page is about the two
+management windows themselves.
 
 ## Model Management
 
-Open **Manage → Model Management** to search for, download, and clean up models.
+Open **Manage → Model Management** to search for, download, and clean up
+models.
 
 <!-- screenshot: the Model Management window with the search box, filter chips, and a couple of installed models listed -->
 
 ### Searching for a model
 
-Type into the search box to search Hugging Face for matching models as you type. Matching results appear in a dropdown below the box, showing each model's ID, description (if any), download count, likes, and a few of its tags; models you already have installed are marked **Installed**. Click a result to select it — the field then shows the model's size (once the engine has looked it up) and a link to open it on Hugging Face.
+Type into the search box to search Hugging Face for matching models as you
+type. Matching results appear in a dropdown below the box, showing each
+model's ID, description (if any), download count, likes, and a few of its
+tags; models you already have installed are marked **Installed**. Click a
+result to select it — the field then shows the model's size (once the
+engine has looked it up) and a link to open it on Hugging Face.
 
-If you already know the exact model ID, you can type it directly instead of searching and picking from the dropdown.
+If you already know the exact model ID, you can type it directly instead of
+searching and picking from the dropdown.
 
 ### Downloading a model
 
-With a model selected, click **Download**. The download starts in the background — you can keep working, close the window, or switch to Library Management, and the download keeps going.
+With a model selected, click **Download**. The download starts in the
+background — you can keep working, close the window, or switch to Library
+Management, and the download keeps going.
 
 ### Tracking progress
 
-The **Downloads** section lists every active and recently-finished download, each with a status badge:
+The **Downloads** section lists every active and recently finished
+download, each with a status badge:
 
 | Status          | Meaning                                                                                                                                                                                              |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -32,61 +48,113 @@ The **Downloads** section lists every active and recently-finished download, eac
 | **Completed**   | Finished; the bar fills green.                                                                                                                                                                       |
 | **Failed**      | The download didn't finish. The error message is shown below the entry (including any Hugging Face access-request link, if that's the cause — see [Gated models](#gated-models-need-a-token) below). |
 
-Use the **All / Downloads / Models** chips above the list to narrow it to just active downloads or just installed models.
+Use the **All / Downloads / Models** chips above the list to narrow it to
+just active downloads or just installed models.
 
 ### Cancelling a download
 
-Click the trash icon on an actively-downloading entry to cancel it. A **Cancel Download** confirmation appears first — **Keep Downloading** backs out, **Cancel Download** stops it and removes the partial download record.
+Click the trash icon on an entry that's still downloading to cancel it. A
+**Cancel Download** confirmation appears first — **Keep Downloading** backs
+out, **Cancel Download** stops it and removes the partial download record.
 
 <!-- screenshot: the Cancel Download confirmation dialog -->
 
 ### Deleting a model
 
-The **Installed Models** section lists everything you've already downloaded, with its local path and size. Click the trash icon to remove one. A **Delete Model** dialog confirms first — deleting is permanent, removes the files from local storage, and any workflow that depends on that model will fail until you either re-download it or point the workflow at a different one.
+The **Installed Models** section lists everything you've already
+downloaded, with its local path and size. Click the trash icon to remove
+one. A **Delete Model** dialog confirms first — deleting is permanent,
+removes the files from local storage, and any workflow that depends on that
+model will fail until you either re-download it or point the workflow at a
+different one.
 
 <!-- screenshot: the Delete Model confirmation dialog -->
 
 ### Gated models need a token
 
-Some models on Hugging Face are gated — you need to request access on the model's page, and you need a Hugging Face access token configured in Griptape Nodes before you can download them. If no token is configured, the Model Management window shows a banner at the top explaining how to fix that: create a token on Hugging Face, then add it as `HF_TOKEN` under **Settings → API Keys & Secrets**. The banner's link jumps you straight there.
+Some models on Hugging Face are gated — you need to request access on the
+model's page, and you need a Hugging Face access token configured in
+Griptape Nodes before you can download them. If no token is configured, the
+Model Management window shows a banner at the top explaining how to fix
+that: create a token on Hugging Face, then add it as `HF_TOKEN` under
+**Settings → API Keys & Secrets**. The banner's link jumps you straight
+there.
 
-See [Setup for Nodes that use Hugging Face](../integrations/hugging_face.md) for the full walkthrough, including how to request access to a specific gated model.
+See
+[Setup for Nodes that use Hugging Face](../integrations/hugging_face.md)
+for the full walkthrough, including how to request access to a specific
+gated model.
 
 ## Library Management
 
-Open **Manage → Library Management** to install, update, and remove libraries.
+Open **Manage → Library Management** to install, update, and remove
+libraries.
 
 <!-- screenshot: the Library Management window with the filter bar and a few installed libraries listed -->
 
-The filter bar at the top lets you search installed libraries by name and narrow the list with the **All / Updates / Errors** chips — **Errors** is the fastest way to find a library that failed to load. Two icon buttons next to the chips let you **check all libraries for updates** or just **refresh** the list.
+The filter bar at the top lets you search installed libraries by name and
+narrow the list with the **All / Updates / Errors** chips — **Errors** is
+the fastest way to find a library that failed to load. Two icon buttons
+next to the chips let you **check all libraries for updates** or just
+**refresh** the list.
 
-Click any library's row to expand it and see its description, its Git remote and ref (for Git-installed libraries), and any problems the engine reported loading it.
+Click any library's row to expand it and see its description, its Git
+remote and ref (for Git-installed libraries), and any problems the engine
+reported loading it.
 
 ### Installing a library
 
-Click **Add Library** to open the **Add Library** dialog. Paste a Git URL — for example a GitHub repository hosting a community library — and click **Install**.
+Click **Add Library** to open the **Add Library** dialog. Paste a Git URL —
+for example a GitHub repository hosting a community library — and click
+**Install**.
 
 <!-- screenshot: the Add Library dialog with a Git URL entered and Advanced Options expanded -->
 
-The editor first inspects the repository and shows you a confirmation with the library's name, description, version, and node count before actually cloning it, so you can back out if it's not what you expected.
+The editor first inspects the repository and shows you a confirmation with
+the library's name, description, version, and node count before actually
+cloning it, so you can back out if it's not what you expected.
 
 **Advanced Options** (the disclosure below the URL field) lets you set:
 
-- **Branch / Tag / Commit** — install a specific ref instead of the repository's default branch.
-- **Download Directory** — where the library gets cloned to, if you don't want the default libraries directory. Use the folder icon to browse for one.
+- **Branch / Tag / Commit** — install a specific ref instead of the
+    repository's default branch.
+- **Download Directory** — where the library gets cloned to, if you don't
+    want the default libraries directory. Use the folder icon to browse for
+    one.
 
-Not sure what to install? **Browse Community Libraries**, below the form, opens a curated directory of libraries you can copy a URL from and paste back into the field above.
+Not sure what to install? **Browse Community Libraries**, below the form,
+opens a curated directory of libraries you can copy a URL from and paste
+back into the field above.
 
-If the target directory already has something in it — a previous install of the same library, or unrelated files — you'll see a confirmation asking whether to overwrite it. Overwriting is destructive: it deletes what's there (including any uncommitted changes to a Git checkout) and replaces it with the new install. This is the same overwrite confirmation you'll see if you update a library that has local modifications.
+If the target directory already has something in it — a previous install of
+the same library, or unrelated files — you'll see a confirmation asking
+whether to overwrite it. Overwriting is destructive: it deletes what's
+there (including any uncommitted changes to a Git checkout) and replaces it
+with the new install. This is the same overwrite confirmation you'll see if
+you update a library that has local modifications.
 
 ### Updating a library
 
-Expand a library that has a Git remote and click **Check for Updates** to compare it against the remote. If an update is available, an **Update** button appears on its row (labeled with the target version when the engine knows it, e.g. **Update to 1.4.0**); click it to pull the update in. If the update is being held back — some updates are age-gated and only become available once the release has aged past a minimum, to avoid pulling in something too fresh — the row shows how long until it's eligible instead of an Update button.
+Expand a library that has a Git remote and click **Check for Updates** to
+compare it against the remote. If an update is available, an **Update**
+button appears on its row (labeled with the target version when the engine
+knows it, e.g. **Update to 1.4.0**); click it to pull the update in. If the
+update is being held back — releases only become eligible once they've aged
+past a minimum, so you don't pull in something published minutes ago — the
+row shows how long until it's eligible instead of an Update button.
 
-You can also switch a library to a different branch, tag, or commit directly from its expanded row: click the current ref to edit it in place, then confirm.
+You can also switch a library to a different branch, tag, or commit
+directly from its expanded row: click the current ref to edit it in place,
+then confirm.
 
-If a library's dependencies didn't install automatically, **Install Dependencies** on its expanded row retries just that step without re-cloning the library.
+If a library's dependencies didn't install automatically, **Install
+Dependencies** on its expanded row retries just that step without
+re-cloning the library.
 
 ### Removing a library
 
-The Library Management window itself doesn't delete a library's files from disk — for that, plus toggling a library off without removing it, or choosing whether it runs Shared or Isolated, see [Toggling and removing libraries](../libraries.md#toggling-and-removing-libraries) in the Libraries guide.
+The Library Management window itself doesn't delete a library's files from
+disk — for that, plus toggling a library off without removing it, or
+choosing whether it runs Shared or Isolated, see
+[Toggling and removing libraries](../libraries.md#toggling-and-removing-libraries)
+in the Libraries guide.

--- a/docs/guides/editor/managing_models_and_libraries.md
+++ b/docs/guides/editor/managing_models_and_libraries.md
@@ -1,7 +1,8 @@
 # Managing Models and Libraries
 
-Some nodes need a machine learning model on disk before they can run;
-others come from a library you haven't installed yet. Both are managed from
+Some nodes run AI models locally and need the model files on disk before
+they can run; others come from a library you haven't installed yet. Both
+are managed from
 the editor's **Manage** menu, in the **Model Management** and **Library
 Management** windows. This page covers both.
 
@@ -16,6 +17,10 @@ management windows themselves.
 
 Open **Manage → Model Management** to search for, download, and clean up
 models.
+
+Everything this window does is also available from the terminal via
+`gtn models` (search, download, list, delete, and download status) — see
+the [CLI reference](../../reference/command_line_interface.md#models).
 
 <!-- screenshot (#5166): the Model Management window with the search box, filter chips, and a couple of installed models listed -->
 
@@ -88,7 +93,9 @@ gated model.
 ## Library Management
 
 Open **Manage → Library Management** to install, update, and remove
-libraries.
+libraries. From the terminal, `gtn libraries download <git-url>` and
+`gtn libraries sync` cover installing and updating — see the
+[CLI reference](../../reference/command_line_interface.md#libraries).
 
 <!-- screenshot (#5166): the Library Management window with the filter bar and a few installed libraries listed -->
 

--- a/docs/guides/editor/managing_models_and_libraries.md
+++ b/docs/guides/editor/managing_models_and_libraries.md
@@ -1,0 +1,92 @@
+# Managing Models and Libraries
+
+Some nodes need a machine learning model on disk before they can run; others come from a library you haven't installed yet. Both are managed from the editor's **Manage** menu, in the **Model Management** and **Library Management** windows. This page covers both.
+
+<!-- screenshot: the Manage menu open, showing Model Management and Library Management items -->
+
+For the concepts behind libraries — how installs are isolated from each other, Shared vs. Isolated execution, and what to do when something goes wrong — see [Libraries](../libraries.md). This page is about the two management windows themselves.
+
+## Model Management
+
+Open **Manage → Model Management** to search for, download, and clean up models.
+
+<!-- screenshot: the Model Management window with the search box, filter chips, and a couple of installed models listed -->
+
+### Searching for a model
+
+Type into the search box to search Hugging Face for matching models as you type. Matching results appear in a dropdown below the box, showing each model's ID, description (if any), download count, likes, and a few of its tags; models you already have installed are marked **Installed**. Click a result to select it — the field then shows the model's size (once the engine has looked it up) and a link to open it on Hugging Face.
+
+If you already know the exact model ID, you can type it directly instead of searching and picking from the dropdown.
+
+### Downloading a model
+
+With a model selected, click **Download**. The download starts in the background — you can keep working, close the window, or switch to Library Management, and the download keeps going.
+
+### Tracking progress
+
+The **Downloads** section lists every active and recently-finished download, each with a status badge:
+
+| Status          | Meaning                                                                                                                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Downloading** | In progress. Shows a progress bar and how many GB are done out of the total, plus a percentage.                                                                                                      |
+| **Completed**   | Finished; the bar fills green.                                                                                                                                                                       |
+| **Failed**      | The download didn't finish. The error message is shown below the entry (including any Hugging Face access-request link, if that's the cause — see [Gated models](#gated-models-need-a-token) below). |
+
+Use the **All / Downloads / Models** chips above the list to narrow it to just active downloads or just installed models.
+
+### Cancelling a download
+
+Click the trash icon on an actively-downloading entry to cancel it. A **Cancel Download** confirmation appears first — **Keep Downloading** backs out, **Cancel Download** stops it and removes the partial download record.
+
+<!-- screenshot: the Cancel Download confirmation dialog -->
+
+### Deleting a model
+
+The **Installed Models** section lists everything you've already downloaded, with its local path and size. Click the trash icon to remove one. A **Delete Model** dialog confirms first — deleting is permanent, removes the files from local storage, and any workflow that depends on that model will fail until you either re-download it or point the workflow at a different one.
+
+<!-- screenshot: the Delete Model confirmation dialog -->
+
+### Gated models need a token
+
+Some models on Hugging Face are gated — you need to request access on the model's page, and you need a Hugging Face access token configured in Griptape Nodes before you can download them. If no token is configured, the Model Management window shows a banner at the top explaining how to fix that: create a token on Hugging Face, then add it as `HF_TOKEN` under **Settings → API Keys & Secrets**. The banner's link jumps you straight there.
+
+See [Setup for Nodes that use Hugging Face](../integrations/hugging_face.md) for the full walkthrough, including how to request access to a specific gated model.
+
+## Library Management
+
+Open **Manage → Library Management** to install, update, and remove libraries.
+
+<!-- screenshot: the Library Management window with the filter bar and a few installed libraries listed -->
+
+The filter bar at the top lets you search installed libraries by name and narrow the list with the **All / Updates / Errors** chips — **Errors** is the fastest way to find a library that failed to load. Two icon buttons next to the chips let you **check all libraries for updates** or just **refresh** the list.
+
+Click any library's row to expand it and see its description, its Git remote and ref (for Git-installed libraries), and any problems the engine reported loading it.
+
+### Installing a library
+
+Click **Add Library** to open the **Add Library** dialog. Paste a Git URL — for example a GitHub repository hosting a community library — and click **Install**.
+
+<!-- screenshot: the Add Library dialog with a Git URL entered and Advanced Options expanded -->
+
+The editor first inspects the repository and shows you a confirmation with the library's name, description, version, and node count before actually cloning it, so you can back out if it's not what you expected.
+
+**Advanced Options** (the disclosure below the URL field) lets you set:
+
+- **Branch / Tag / Commit** — install a specific ref instead of the repository's default branch.
+- **Download Directory** — where the library gets cloned to, if you don't want the default libraries directory. Use the folder icon to browse for one.
+
+Not sure what to install? **Browse Community Libraries**, below the form, opens a curated directory of libraries you can copy a URL from and paste back into the field above.
+
+If the target directory already has something in it — a previous install of the same library, or unrelated files — you'll see a confirmation asking whether to overwrite it. Overwriting is destructive: it deletes what's there (including any uncommitted changes to a Git checkout) and replaces it with the new install. This is the same overwrite confirmation you'll see if you update a library that has local modifications.
+
+### Updating a library
+
+Expand a library that has a Git remote and click **Check for Updates** to compare it against the remote. If an update is available, an **Update** button appears on its row (labeled with the target version when the engine knows it, e.g. **Update to 1.4.0**); click it to pull the update in. If the update is being held back — some updates are age-gated and only become available once the release has aged past a minimum, to avoid pulling in something too fresh — the row shows how long until it's eligible instead of an Update button.
+
+You can also switch a library to a different branch, tag, or commit directly from its expanded row: click the current ref to edit it in place, then confirm.
+
+If a library's dependencies didn't install automatically, **Install Dependencies** on its expanded row retries just that step without re-cloning the library.
+
+### Removing a library
+
+The Library Management window itself doesn't delete a library's files from disk — for that, plus toggling a library off without removing it, or choosing whether it runs Shared or Isolated, see [Toggling and removing libraries](../libraries.md#toggling-and-removing-libraries) in the Libraries guide.

--- a/docs/guides/editor/media_editors.md
+++ b/docs/guides/editor/media_editors.md
@@ -19,7 +19,9 @@ Which viewer you get is decided by the parameter's type:
 
 The comparison sliders (image and video) aren't separate types — a node
 opts a parameter into comparison display when it exposes two media
-values through one parameter.
+values through one parameter. (Node authors: the full type-to-widget
+mapping lives in the
+[Parameter UI Reference](../../development/custom_nodes/parameter_ui_reference.md).)
 
 Which of the extra buttons appear on top of a viewer
 (crop, mask, capture, and so on) depends on options a node author set on

--- a/docs/guides/editor/media_editors.md
+++ b/docs/guides/editor/media_editors.md
@@ -7,8 +7,23 @@ you can paint a mask, crop a frame, or composite layers without leaving
 the canvas. This page is a tour of each one: where it appears, how you
 open it, and what you can do once it's open.
 
-Which viewer you get, and which of the extra buttons appear on top of
-it, depends on options a node author set on that parameter. You don't
+Which viewer you get is decided by the parameter's type:
+
+| Parameter type                         | Viewer                                                        |
+| -------------------------------------- | ------------------------------------------------------------- |
+| `ImageArtifact` / `ImageUrlArtifact`   | [Image viewer](#viewing-an-image-and-its-right-click-actions) |
+| `VideoArtifact` / `VideoUrlArtifact`   | [Video player](#playing-and-comparing-video)                  |
+| `AudioArtifact` / `AudioUrlArtifact`   | [Audio player](#playing-audio)                                |
+| `ThreeDArtifact` / `ThreeDUrlArtifact` | [3D model viewer](#viewing-3d-models)                         |
+| `SplatArtifact` / `SplatUrlArtifact`   | [Gaussian splat viewer](#viewing-gaussian-splats)             |
+
+The comparison sliders (image and video) aren't separate types — a node
+opts a parameter into comparison display when it exposes two media
+values through one parameter.
+
+Which of the extra buttons appear on top of a viewer
+(crop, mask, capture, and so on) depends on options a node author set on
+that parameter. You don't
 configure this yourself — it's baked into the node — but it explains
 why the same image parameter might show a crop icon on one node and a
 mask icon on another.

--- a/docs/guides/editor/media_editors.md
+++ b/docs/guides/editor/media_editors.md
@@ -4,7 +4,7 @@ Whenever a parameter carries an image, video, audio clip, 3D model, or
 Gaussian splat, the editor swaps in a viewer built for that media type
 instead of a plain text field. Some of these viewers are also editors —
 you can paint a mask, crop a frame, or composite layers without leaving
-the canvas. This page is a tour of each one: what surfaces it, how you
+the canvas. This page is a tour of each one: where it appears, how you
 open it, and what you can do once it's open.
 
 Which viewer you get, and which of the extra buttons appear on top of
@@ -101,9 +101,9 @@ Image Bash is the editor's layered compositing tool. Some image
 parameters carry a pencil icon that opens it directly; it's also
 reachable from parameters that store their state as structured layer
 data, via an **Edit** button that opens the same tool. Griptape's own
-nodes that pass images through Image Bash (rather than editing a
-single image) use it for building up a shot from multiple source
-images and painted layers rather than editing one image in place.
+nodes that pass images through Image Bash use it to build up a shot
+from multiple source images and painted layers, rather than to edit
+one image in place.
 
 Inside, each layer is either an **image layer** (one of your source
 images, which you can move, scale, and rotate with the on-canvas

--- a/docs/guides/editor/media_editors.md
+++ b/docs/guides/editor/media_editors.md
@@ -202,7 +202,8 @@ exits.
 ## Loading a workflow from an image
 
 Griptape Nodes can embed a workflow's node graph inside the PNG it
-exports as a thumbnail. Drop one of those PNGs onto the canvas, and if
+exports as a thumbnail. Drop one of those PNG files onto the canvas, and
+if
 the editor detects embedded workflow metadata, it asks what you want
 to do with it instead of just adding an image node:
 
@@ -214,7 +215,7 @@ to do with it instead of just adding an image node:
     library, and dependency lists in the dialog to preview what will be
     added before you commit.
 
-Drop several PNGs at once and you get a batch version of the same
+Drop several PNG files at once and you get a batch version of the same
 dialog: it tells you how many of the dropped images carry workflow
 metadata and applies your choice (add as images, or add nodes from
 workflow) to all of them at once. Images without embedded metadata are

--- a/docs/guides/editor/media_editors.md
+++ b/docs/guides/editor/media_editors.md
@@ -1,0 +1,224 @@
+# Media Viewers and Editors
+
+Whenever a parameter carries an image, video, audio clip, 3D model, or
+Gaussian splat, the editor swaps in a viewer built for that media type
+instead of a plain text field. Some of these viewers are also editors —
+you can paint a mask, crop a frame, or composite layers without leaving
+the canvas. This page is a tour of each one: what surfaces it, how you
+open it, and what you can do once it's open.
+
+Which viewer you get, and which of the extra buttons appear on top of
+it, depends on options a node author set on that parameter. You don't
+configure this yourself — it's baked into the node — but it explains
+why the same image parameter might show a crop icon on one node and a
+mask icon on another.
+
+## Viewing an image and its right-click actions
+
+Image parameters display through the standard image viewer: a
+thumbnail with the image's name, dimensions, and file size underneath
+it. Hovering reveals an expand button that opens the image full-screen
+in a lightbox; press **Escape** or click outside it to close.
+
+Right-click any image — on its thumbnail in a node, or on the enlarged
+version in the lightbox — to get a context menu with:
+
+- **Copy image** — copies the full-resolution image to your system
+    clipboard as PNG (re-encoding it first if the source is a different
+    format).
+- **Copy image URL** — copies the image's URL as text.
+- **Save image** — downloads the full-resolution image to disk.
+- **Make thumbnail** — sets this image as the workflow's header
+    thumbnail, the one shown in the workflow browser. This updates the
+    workflow's saved metadata immediately.
+
+<!-- screenshot: right-click context menu open on an image node, showing Copy image / Copy image URL / Save image / Make thumbnail -->
+
+## Comparing two images with a slider
+
+When a node exposes a pair of images through a single comparison
+parameter, the editor renders them as one image with a draggable
+vertical divider: everything left of the divider is the first image,
+everything right of it is the second. Move your mouse across the
+comparison area to slide the divider.
+
+Hover to reveal an expand button that opens the same comparison
+full-screen, with each side labeled by its filename. Escape closes it.
+
+<!-- screenshot: image compare slider mid-drag, divider partway across the frame -->
+
+## Cropping an image
+
+Some image parameters carry a crop button (a crop icon over the
+thumbnail) that opens the crop editor. Inside, drag the handles on the
+overlay to resize the crop region, or use:
+
+- **Reset All** — resets the crop to the full image.
+- **Aspect ratio presets** — Square, 16:9, 3:2, 4:3, 9:16, 2:3, 3:4.
+- **Zoom** — 10–300%, previewed as a pulsing dashed overlay.
+- **Rotation** — -180° to 180°, with an arrow indicator showing the
+    up direction.
+- **Crop Details** — the current left/top/width/height in pixels.
+
+**Accept & Save** writes the crop as parameter values on the node
+(left, top, width, height, zoom, rotation) rather than baking it into
+a new image file — the node itself is responsible for applying the
+crop when it runs. **Cancel** discards your changes.
+
+<!-- screenshot: crop modal with drag handles on an image and the aspect-ratio preset buttons visible in the sidebar -->
+
+## Painting a mask
+
+Image parameters with mask editing enabled show a mask icon; clicking
+it opens the Paint Mask editor. You paint directly onto a canvas laid
+over the source image:
+
+- **Brush** paints white (reveal); **Erase** paints black (hide).
+- **Brush Size** and **Blur** sliders control stroke width and soft
+    edges. `[` and `]` also adjust brush size without touching the
+    sliders.
+- **Show Mask / Show Composite** toggles between the raw grayscale
+    mask and the image with the mask applied as transparency.
+- **Invert Mask** swaps black and white across the whole mask.
+- **Reset Mask** restores the mask to the image's original alpha
+    channel.
+- **Flood Fill** fills the entire mask with the current tool's color.
+- Hold **Alt** and drag to pan, or **Alt**+scroll to zoom; dedicated
+    zoom buttons and a reset-view button sit above the canvas.
+
+What **Apply** saves depends on what the parameter already holds: if
+it's a plain image, painting edits that image's alpha channel and
+saves a new image with transparency; if the parameter is already
+paired with a separate mask, painting edits that mask instead and
+saves it as its own grayscale file, keeping the source image
+untouched.
+
+<!-- screenshot: Paint Mask editor with a brush stroke mid-paint and the Invert/Reset/Flood Fill buttons visible in the sidebar -->
+
+## Image Bash: compositing images and paint layers
+
+Image Bash is the editor's layered compositing tool. Some image
+parameters carry a pencil icon that opens it directly; it's also
+reachable from parameters that store their state as structured layer
+data, via an **Edit** button that opens the same tool. Griptape's own
+nodes that pass images through Image Bash (rather than editing a
+single image) use it for building up a shot from multiple source
+images and painted layers rather than editing one image in place.
+
+Inside, each layer is either an **image layer** (one of your source
+images, which you can move, scale, and rotate with the on-canvas
+transform handles) or a **brush layer** (a paintable canvas you draw
+into). The sidebar lists every layer with a thumbnail, a visibility
+toggle, opacity, and drag-to-reorder handles; you can rename, delete,
+or duplicate any layer, and duplicate an image layer as a new
+paintable brush layer.
+
+Painting tools include four brush types — Pen, Soft, Crayon, and
+Spray — each with its own size, color, and opacity, plus extra
+controls for Crayon (fleck size, fleck density, spread, square ratio,
+density falloff) and Spray (spot size, spot density, spread radius).
+Undo/redo covers your last 50 brush strokes. You can also resize the
+canvas and change its background color from within the tool.
+
+Default brush and canvas settings live in the editor's Settings panel
+— search for "ImageBash" to find the card. Changing a default there
+only affects new sessions of the tool going forward.
+
+<!-- screenshot: Image Bash open with several image layers and a brush layer in the sidebar, transform handles visible on the selected layer -->
+
+## Playing and comparing video
+
+Video parameters use a frame-accurate player: step one frame at a
+time, play forward or backward, and jump between marked frames. Keys
+work the same as the on-screen controls: `←`/`→` step a frame,
+`j`/`k`/`l` play backward, pause, and play forward. If the node also
+exposes a frame-selection parameter, the timeline shows markers you
+can add (`.` adds the current frame), drag, or clear, and `n`/`m` jump
+to the previous/next marker.
+
+The bottom bar shows playback FPS (editable, with a button to snap
+back to the video's native rate), the current frame out of the total,
+mute, and volume. An expandable **Video Details** panel reports
+dimensions, file size, format, codec, aspect ratio, duration, and
+frame rate. **Enlarge** opens the player in a larger dialog; the
+**Fullscreen** button uses your browser's fullscreen mode.
+
+Video comparison parameters show two videos side by side with the
+same draggable divider as image comparison, kept in sync frame-for-frame,
+with a switch to choose which side's audio track plays.
+
+Right-click a video for **Copy video URL** and **Save video**.
+
+<!-- screenshot: video player with the frame timeline and markers visible, one marker being dragged -->
+
+## Playing audio
+
+Audio parameters render as a waveform with playback controls
+underneath: play/pause, elapsed/total time, mute, and a volume slider.
+Click and drag anywhere on the waveform to scrub to that position.
+
+## Capturing from a webcam or microphone
+
+Image parameters with webcam capture enabled show a live camera
+preview in place of the usual thumbnail once you grant camera access;
+a camera button captures a still and uploads it, replacing the
+preview with the captured image. A capture button lets you retake it.
+
+Audio parameters with microphone capture enabled show a record button
+next to the waveform. Click it to start recording — it turns into a
+running timer — and click again to stop; the recording is encoded and
+uploaded automatically. A trash icon clears a captured recording so
+you can record again.
+
+Both require you to grant the browser camera or microphone permission;
+if access is denied, the component shows an error message instead of
+the capture controls.
+
+## Viewing 3D models
+
+3D model parameters open in an interactive viewer: drag to orbit,
+scroll to zoom, and right-click drag to pan. Supported formats are
+glTF/GLB (including Draco-compressed meshes), OBJ, FBX, DAE, 3DS, STL,
+and PLY; USDZ files load only if they're the plain-text USDA variant —
+binary USDC files exported by tools like Rodin or Apple QuickLook
+won't preview, though the file itself is still saved and downloadable.
+Formats that don't carry their own materials (STL, PLY, plain OBJ) get
+a neutral default material so they still read as solid geometry.
+
+Hover the viewer and click the expand icon to open the same model
+full-screen, with slow auto-rotation while it's open. Escape or the
+close button exits.
+
+<!-- screenshot: 3D model viewer with an orbited glTF model and the expand icon visible on hover -->
+
+## Viewing Gaussian splats
+
+Splat parameters (`.splat` and `.ksplat` files) use the same
+orbit/zoom camera controls as the 3D model viewer, rendered through a
+Gaussian splatting renderer instead of a triangle mesh. Click the
+expand icon to open the splat full-screen; Escape or the close button
+exits.
+
+## Loading a workflow from an image
+
+Griptape Nodes can embed a workflow's node graph inside the PNG it
+exports as a thumbnail. Drop one of those PNGs onto the canvas, and if
+the editor detects embedded workflow metadata, it asks what you want
+to do with it instead of just adding an image node:
+
+- **Add Image** — treat it like any other image and create a regular
+    image-loading node from it.
+- **Add Nodes from Workflow** — add the nodes that generated the image
+    to your current workflow, importing the referenced libraries,
+    static files, and any workflows it depends on. Expand the node,
+    library, and dependency lists in the dialog to preview what will be
+    added before you commit.
+
+Drop several PNGs at once and you get a batch version of the same
+dialog: it tells you how many of the dropped images carry workflow
+metadata and applies your choice (add as images, or add nodes from
+workflow) to all of them at once. Images without embedded metadata are
+always added as plain image nodes, regardless of which option you
+pick.
+
+<!-- screenshot: the "Workflow found in image" dialog with "Add Nodes from Workflow" selected and the node/library lists expanded -->

--- a/docs/guides/editor/media_editors.md
+++ b/docs/guides/editor/media_editors.md
@@ -32,7 +32,7 @@ version in the lightbox — to get a context menu with:
     thumbnail, the one shown in the workflow browser. This updates the
     workflow's saved metadata immediately.
 
-<!-- screenshot: right-click context menu open on an image node, showing Copy image / Copy image URL / Save image / Make thumbnail -->
+<!-- screenshot (#5166): right-click context menu open on an image node, showing Copy image / Copy image URL / Save image / Make thumbnail -->
 
 ## Comparing two images with a slider
 
@@ -45,7 +45,7 @@ comparison area to slide the divider.
 Hover to reveal an expand button that opens the same comparison
 full-screen, with each side labeled by its filename. Escape closes it.
 
-<!-- screenshot: image compare slider mid-drag, divider partway across the frame -->
+<!-- screenshot (#5166): image compare slider mid-drag, divider partway across the frame -->
 
 ## Cropping an image
 
@@ -65,7 +65,7 @@ overlay to resize the crop region, or use:
 a new image file — the node itself is responsible for applying the
 crop when it runs. **Cancel** discards your changes.
 
-<!-- screenshot: crop modal with drag handles on an image and the aspect-ratio preset buttons visible in the sidebar -->
+<!-- screenshot (#5166): crop modal with drag handles on an image and the aspect-ratio preset buttons visible in the sidebar -->
 
 ## Painting a mask
 
@@ -93,7 +93,7 @@ paired with a separate mask, painting edits that mask instead and
 saves it as its own grayscale file, keeping the source image
 untouched.
 
-<!-- screenshot: Paint Mask editor with a brush stroke mid-paint and the Invert/Reset/Flood Fill buttons visible in the sidebar -->
+<!-- screenshot (#5166): Paint Mask editor with a brush stroke mid-paint and the Invert/Reset/Flood Fill buttons visible in the sidebar -->
 
 ## Image Bash: compositing images and paint layers
 
@@ -124,7 +124,7 @@ Default brush and canvas settings live in the editor's Settings panel
 — search for "ImageBash" to find the card. Changing a default there
 only affects new sessions of the tool going forward.
 
-<!-- screenshot: Image Bash open with several image layers and a brush layer in the sidebar, transform handles visible on the selected layer -->
+<!-- screenshot (#5166): Image Bash open with several image layers and a brush layer in the sidebar, transform handles visible on the selected layer -->
 
 ## Playing and comparing video
 
@@ -149,7 +149,7 @@ with a switch to choose which side's audio track plays.
 
 Right-click a video for **Copy video URL** and **Save video**.
 
-<!-- screenshot: video player with the frame timeline and markers visible, one marker being dragged -->
+<!-- screenshot (#5166): video player with the frame timeline and markers visible, one marker being dragged -->
 
 ## Playing audio
 
@@ -189,7 +189,7 @@ Hover the viewer and click the expand icon to open the same model
 full-screen, with slow auto-rotation while it's open. Escape or the
 close button exits.
 
-<!-- screenshot: 3D model viewer with an orbited glTF model and the expand icon visible on hover -->
+<!-- screenshot (#5166): 3D model viewer with an orbited glTF model and the expand icon visible on hover -->
 
 ## Viewing Gaussian splats
 
@@ -222,4 +222,4 @@ workflow) to all of them at once. Images without embedded metadata are
 always added as plain image nodes, regardless of which option you
 pick.
 
-<!-- screenshot: the "Workflow found in image" dialog with "Add Nodes from Workflow" selected and the node/library lists expanded -->
+<!-- screenshot (#5166): the "Workflow found in image" dialog with "Add Nodes from Workflow" selected and the node/library lists expanded -->

--- a/docs/guides/editor/node_groups.md
+++ b/docs/guides/editor/node_groups.md
@@ -22,7 +22,7 @@ default for `Cmd/Ctrl+G`** at the bottom before picking a type to skip the
 picker next time. Until you've set a default, `Cmd/Ctrl+G` opens the picker
 too.
 
-<!-- screenshot: the group type picker open, showing the built-in group types with the "make default" checkbox -->
+<!-- screenshot (#5166): the group type picker open, showing the built-in group types with the "make default" checkbox -->
 
 A new group is sized to wrap whatever was selected when you created it, with
 a bit of padding. Dropping a node onto an existing group's body adds it to
@@ -98,7 +98,7 @@ in) or right edge (things flowing out). You don't create these by hand: drag
 a connection from an inside node's handle to an outside node (or vice versa)
 and the wall parameter appears automatically, wired straight through.
 
-<!-- screenshot: an expanded subflow group showing wall parameters lined up on its left and right edges -->
+<!-- screenshot (#5166): an expanded subflow group showing wall parameters lined up on its left and right edges -->
 
 Behind the scenes each wall parameter is a proxy: the engine deletes the
 direct connection, adds a matching parameter on the group, and reconnects
@@ -153,7 +153,7 @@ when the group is selected), alongside the same collapse and duplicate
 controls every group has. Running a group resolves it — and, transitively,
 whatever it depends on upstream — the same way running any single node does.
 
-<!-- screenshot: a selected subflow group with its toolbar showing the Run Group button -->
+<!-- screenshot (#5166): a selected subflow group with its toolbar showing the Run Group button -->
 
 A subflow group also carries an **Execution Environment** setting (group
 settings popover), which chooses where its nodes actually run. It defaults

--- a/docs/guides/editor/node_groups.md
+++ b/docs/guides/editor/node_groups.md
@@ -1,0 +1,165 @@
+# Node Groups
+
+A **group** is a container node that holds other nodes. Every group visually
+organizes the nodes inside it, but some group types go further and take over
+how those nodes execute — running them together, or running them repeatedly.
+This page covers creating, configuring, and running groups. For working with
+ordinary nodes, see [Working with Nodes](working_with_nodes.md).
+
+## Creating a group
+
+Select the nodes you want to group (or select nothing, for an empty group you
+can drop nodes into later), then:
+
+- Press `Cmd/Ctrl+G` to create a group immediately, using whichever group
+    type you've marked as your default.
+- Press `Shift+Cmd/Ctrl+G`, or right-click and choose **Create Group**, to
+    open the **group type picker** first.
+
+The group type picker lists every group type available from your installed
+libraries, searchable the same way the Add Node menu is. Check **Make
+default for `Cmd/Ctrl+G`** at the bottom before picking a type to skip the
+picker next time. Until you've set a default, `Cmd/Ctrl+G` opens the picker
+too.
+
+<!-- screenshot: the group type picker open, showing the built-in group types with the "make default" checkbox -->
+
+A new group is sized to wrap whatever was selected when you created it, with
+a bit of padding. Dropping a node onto an existing group's body adds it to
+that group; dragging a child node out removes it.
+
+## Group types
+
+The group types that ship with the standard library fall into two families:
+
+| Type                   | Executes? | What it does                                                                                                                  |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Group**              | No        | Purely organizational. Bundles nodes visually with a description field; doesn't run them as a unit or affect execution order. |
+| **Subflow Node Group** | Yes       | Runs every node inside it together, as a single unit, in parallel.                                                            |
+| **ForEach Group**      | Yes       | Runs its contents once per item in an input list or dictionary.                                                               |
+| **For Loop Group**     | Yes       | Runs its contents once per value in a numeric range (start/end/step).                                                         |
+| **Retry Group**        | Yes       | Re-runs its contents on failure, up to a configurable number of attempts.                                                     |
+
+A plain **Group** never has a **Run Group** button — it's not executable, so
+there's nothing for the engine to run beyond the nodes inside it running on
+their own. Every other type in the table is a **subflow group**: it creates a
+dedicated subflow to hold its children, and the group node itself becomes a
+single executable unit in the outer flow's graph.
+
+### Subflow Node Group
+
+The baseline executable group. When the group runs, every node inside it runs
+together in its own subflow, and their outputs are collected back onto the
+group's own output parameters. Use it when you want to treat a cluster of
+nodes as one step in a larger flow — for readability, or because you want a
+single **Run Group** button instead of running each node individually.
+
+### ForEach Group
+
+Iterates over a list or dictionary. Wire a list (or dict) into its **items**
+input; the group runs its child nodes once per item, exposing that item on
+**current_item** and the item's position on **index** for the child nodes to
+consume. A **new_item_to_add** input on the far side collects a value from
+each iteration into the group's **results** output list.
+
+**Execution Mode** (in the group's settings) chooses between running
+iterations **one at a time** or **all at once**. Only sequential mode
+supports the **Skip to Next Iteration** and **Break Out of Loop** control
+inputs — they're hidden automatically when you switch to all-at-once, since
+there's no "next iteration" to skip to once every iteration is already
+running concurrently. A **Testing Mode** toggle in settings lets you run just
+one chosen index while you're wiring up the loop body, instead of the whole
+list.
+
+### For Loop Group
+
+Same shape as ForEach, but iterates over a numeric range instead of a list —
+**start**, **end**, **step**, and an **Include end value** toggle to control
+whether the range is inclusive. It shares the same **Execution Mode**,
+**results**, **skip**, and **break** machinery as ForEach.
+
+### Retry Group
+
+Re-executes its contents when they fail. Wire the success path from your
+child nodes to the group's **Succeeded** control input, and the failure path
+to **Failed**. If **Failed** fires and attempts remain (**Max Iterations**,
+default 3), the whole group re-runs; if **Succeeded** fires, or attempts run
+out, execution continues downstream with **was_successful** reporting which
+happened. A **Raise on failure** toggle turns an exhausted retry budget into
+a hard workflow error instead of a quiet `false`.
+
+## Wiring connections across the group boundary
+
+Every connection that crosses from outside a subflow group to a node inside
+it (or back out) is routed through a **wall parameter** — a parameter that
+lives on the group node itself, shown along its left edge (things flowing
+in) or right edge (things flowing out). You don't create these by hand: drag
+a connection from an inside node's handle to an outside node (or vice versa)
+and the wall parameter appears automatically, wired straight through.
+
+<!-- screenshot: an expanded subflow group showing wall parameters lined up on its left and right edges -->
+
+Behind the scenes each wall parameter is a proxy: the engine deletes the
+direct connection, adds a matching parameter on the group, and reconnects
+through it in two hops instead of one. If a node with wall connections gets
+dragged out of the group, those connections resolve back to a single direct
+connection and the now-unused wall parameter disappears; if two nodes inside
+the group each need to reach the same outside source, they share a single
+wall parameter rather than getting one each.
+
+A plain **Group** doesn't do any of this — it has no subflow to wall off, so
+connections just pass straight through its boundary.
+
+## Collapsing and rolling up
+
+Click the chevron in a group's header to **collapse** it. A collapsed group
+hides its children and shrinks down to just its wall parameters (or, if it
+has none, a single row that says "Group collapsed"). This is the fastest way
+to shrink a large group down to its inputs and outputs without losing the
+ability to rewire it.
+
+**Roll up** — double-click the group's header, or use the roll-up button
+next to the collapse button, when **Node Roll-Up** is enabled in settings —
+does something similar without discarding the layout: the group shrinks to
+its header height while keeping its current width and its child positions
+intact, so expanding it again snaps right back to how you left it.
+
+## Fit to nodes
+
+**Fit to nodes** (`Shift+F` with a single group selected, or the group's
+right-click menu / toolbar) resizes the group's box to snugly wrap whatever
+nodes are currently inside it, with a fixed padding on every side. Use it
+after adding or removing children by hand, when the group's box has drifted
+out of sync with what's actually inside it.
+
+## Ungrouping
+
+**Ungroup**, from the group's right-click menu or its toolbar, removes the
+group wrapper and leaves its child nodes exactly where they were, converted
+from group-relative to absolute canvas positions. For a subflow group, this
+also tears down its dedicated subflow and restores every wall connection as
+a direct connection between the original nodes — nothing about the
+underlying wiring is lost, only the grouping.
+
+Deleting a group node outright (rather than ungrouping it) does the same
+thing to its children: they're detached and left on the canvas rather than
+deleted along with the group.
+
+## Running a group
+
+Executable group types get a **Run Group** button in their toolbar (visible
+when the group is selected), alongside the same collapse and duplicate
+controls every group has. Running a group resolves it — and, transitively,
+whatever it depends on upstream — the same way running any single node does.
+
+<!-- screenshot: a selected subflow group with its toolbar showing the Run Group button -->
+
+A subflow group also carries an **Execution Environment** setting (group
+settings popover), which chooses where its nodes actually run. It defaults
+to **Local Execution** — inside the engine process, same as everything else
+on the canvas — with additional options appearing for any installed library
+that registers a way to publish and run workflows remotely.
+
+While a group is running, it shows the same **Running** / **Resolved** /
+**Unresolved** status pill in its header that ordinary nodes show. A plain
+**Group** never shows this pill, since it never runs as a unit.

--- a/docs/guides/editor/node_groups.md
+++ b/docs/guides/editor/node_groups.md
@@ -85,8 +85,9 @@ child nodes to the group's **Succeeded** control input, and the failure path
 to **Failed**. If **Failed** fires and attempts remain (**Max Iterations**,
 default 3), the whole group re-runs; if **Succeeded** fires, or attempts run
 out, execution continues downstream with **was_successful** reporting which
-happened. A **Raise on failure** toggle turns an exhausted retry budget into
-a hard workflow error instead of a quiet `false`.
+happened. A **Raise on failure** toggle stops the
+workflow with an error when the retry budget runs out, instead of
+continuing with **was_successful** set to `false`.
 
 ## Wiring connections across the group boundary
 

--- a/docs/guides/editor/running_workflows.md
+++ b/docs/guides/editor/running_workflows.md
@@ -1,10 +1,15 @@
 # Running Workflows
 
-This page covers everything that happens once your workflow is built and you want to actually run it: starting a run, stopping one, reading what's happening on the canvas while it runs, checking the logs and error history afterward, and saving your work.
+This page covers everything that happens once your workflow is built and
+you want to actually run it: starting a run, stopping one, reading what's
+happening on the canvas while it runs, checking the logs and error history
+afterward, and saving your work.
 
 ## Running the whole workflow
 
-The **Run Workflow** button, in the center of the header, runs every node in the current workflow from the start. It's disabled while a workflow is already running, and while no workflow is open.
+The **Run Workflow** button, in the center of the header, runs every node
+in the current workflow from the start. It's disabled while a workflow is
+already running, and while no workflow is open.
 
 <!-- screenshot: the header's run button group (Run Workflow, Run To Selected, Run From Selected, Cancel Run) -->
 
@@ -14,28 +19,43 @@ The **Run Workflow** button, in the center of the header, runs every node in the
 
 ## Running a single node
 
-Two more buttons next to Run Workflow let you run less than the whole graph. Both require exactly one node to be selected, and both are disabled while the workflow is already running.
+Two more buttons next to Run Workflow let you run less than the whole
+graph. The buttons require exactly one node to be selected, and both are
+disabled while the workflow is already running.
 
-- **Run To Selected** resolves the selected node — and everything upstream of it that isn't already resolved — without touching anything downstream. This is the one you reach for most often while iterating: change a parameter, run to the node you're looking at, check the result.
-- **Run From Selected** starts execution at the selected node and runs forward from there through the rest of the flow, the same way Run Workflow would, just starting partway through.
+- **Run To Selected** resolves the selected node — and everything upstream
+    of it that isn't already resolved — without touching anything
+    downstream. This is the usual way to iterate: change a parameter, run
+    to the node you're looking at, check the result.
+- **Run From Selected** starts execution at the selected node and runs
+    forward from there through the rest of the flow, the same way Run
+    Workflow would, just starting partway through.
 
 | Shortcut              | Action          |
 | --------------------- | --------------- |
 | `Cmd/Ctrl` + `Return` | Run To Selected |
 
-Run From Selected has no keyboard shortcut; use the button.
+Run From Selected has no keyboard shortcut; use the button. Unlike the
+buttons, the `Cmd/Ctrl` + `Return` shortcut also works with several nodes
+selected — it runs to each of them.
 
-Both single-node actions are also available from the node's right-click context menu, and from the multi-node toolbar when applicable.
+Both single-node actions are also available from the node's right-click
+context menu, and from the multi-node toolbar when applicable.
 
 ## Stopping a run
 
-While a workflow is running, the same button area shows **Cancel Run** in place of the run buttons. Click it to cancel the in-flight execution. The button shows **Cancelling…** while the cancellation request is in flight.
+While a workflow is running, the same button area shows **Cancel Run** in
+place of the run buttons. Click it to cancel the in-flight execution. The
+button shows **Cancelling…** while the cancellation request is in flight.
 
-Canceling a run is also how you get out of the **Cannot Save While Flow is Running** dialog (see [Saving](#saving) below) — that dialog offers a **Cancel Flow** button that does the same thing.
+Canceling a run is also how you get out of the **Cannot Save While Flow is
+Running** dialog (see [Saving](#saving) below) — that dialog offers a
+**Cancel Flow** button that does the same thing.
 
 ## Reading execution state on the canvas
 
-Every node shows a status pill in its header while it's involved in the current run:
+Every node shows a status pill in its header while it's involved in the
+current run:
 
 | Pill                           | Meaning                                                |
 | ------------------------------ | ------------------------------------------------------ |
@@ -44,61 +64,111 @@ Every node shows a status pill in its header while it's involved in the current 
 | **Error** (red)                | The node failed. Hover the pill for the error message. |
 | **Unresolved** (blue)          | The node hasn't run yet in this pass.                  |
 
-A small asterisk next to a node's name also marks it as unresolved, independent of whether it's part of the current run. After a run ends, a node that errored keeps its red **Error** pill so you can still find it and inspect the message without having to remember which node failed.
+A small asterisk next to a node's name also marks it as unresolved,
+independent of whether it's part of the current run. After a run ends, a
+node that errored keeps its red **Error** pill so you can still find it and
+inspect the message without having to remember which node failed.
 
 ## The Logs panel
 
-The **Execution Log** panel (right sidebar) collects everything the engine logs while your workflow runs — engine messages as well as anything a node itself logs, tagged with the node's name when available.
+The **Execution Log** panel (right sidebar) collects everything the engine
+logs while your workflow runs — engine messages as well as anything a node
+itself logs, tagged with the node's name when available.
 
 <!-- screenshot: the Execution Log panel showing a mix of INFO/WARNING/ERROR entries with node badges -->
 
 What you can do from the panel:
 
-- **Log Level Visibility** — a dropdown that sets the engine's logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). This changes what gets logged in the first place, not just what's displayed.
-- **Filter** — a row of level toggles (only the levels at or above the current verbosity are selectable) that lets you show or hide levels in the panel without changing the engine's verbosity.
-- **Download** (the download icon) — saves the currently filtered logs to a `.txt` file, one line per entry with a timestamp.
+- **Log Level Visibility** — a dropdown that sets the engine's logging
+    verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). This
+    changes what gets logged in the first place, not just what's displayed.
+- **Filter** — a row of level toggles (only the levels at or above the
+    current verbosity are selectable) that lets you show or hide levels in
+    the panel without changing the engine's verbosity.
+- **Download** (the download icon) — saves the currently filtered logs to a
+    `.txt` file, one line per entry with a timestamp.
 - **Clear** (the eraser icon) — clears the log list.
-- The settings (gear) icon opens **Log Settings**, where you can change the maximum number of log entries the panel keeps in memory.
+- The settings (gear) icon opens **Log Settings**, where you can change the
+    maximum number of log entries the panel keeps in memory.
 
-The panel auto-scrolls to the newest entry as logs arrive, so it stays pinned to the bottom of the run while you watch it progress.
+The panel auto-scrolls to the newest entry as logs arrive.
 
 ## Error History
 
-The header also carries an **Error History** button (the triangle/circle icon with a count badge) that's independent of any single run — it accumulates errors and permission denials across your whole session, not just the workflow that's currently executing.
+The header also carries an **Error History** button (the triangle/circle
+icon with a count badge) that's independent of any single run — it
+accumulates errors and permission denials across your whole session, not
+just the workflow that's currently executing.
 
-Click it to open a dropdown listing each error with a relative timestamp and its source. Click an entry to see the full error in a modal. **Clear All** empties the list; the small × next to an individual entry removes just that one.
+Click it to open a dropdown listing each error with a relative timestamp
+and its source. Click an entry to see the full error in a modal. **Clear
+All** empties the list; the small × next to an individual entry removes
+just that one.
 
 <!-- screenshot: the Error History dropdown open, showing a couple of recorded errors -->
 
 ## Saving
 
-The workflow name in the header shows an asterisk (`*`) whenever you have unsaved changes, whether that's from editing the graph or from a workflow that's never been saved to disk at all.
+The workflow name in the header shows an asterisk (`*`) whenever you have
+unsaved changes, whether that's from editing the graph or from a workflow
+that's never been saved to disk at all.
 
-- **Save** (`Cmd/Ctrl` + `S`) saves in place. For a workflow that's never been saved, this opens the **Save Workflow** dialog so you can confirm the name instead of guessing one for you.
-- **Save As** (`Cmd/Ctrl` + `Shift` + `S`) opens the **Save Workflow As…** dialog and writes a new, separate copy under the name you give it. Griptape-provided templates always go through Save As — you can't overwrite the template itself.
-- **Save As New Version** (`Option/Alt` + `Shift` + `S`, on engines that support versioned saves) writes the current state as a new versioned file (`my_workflow_v002.py`, and so on) and switches you to that new version, leaving the previous version untouched on disk.
+- **Save** (`Cmd/Ctrl` + `S`) saves in place. For a workflow that's never
+    been saved, this opens the **Save Workflow** dialog so you can choose a
+    name.
+- **Save As** (`Cmd/Ctrl` + `Shift` + `S`) opens the **Save Workflow As…**
+    dialog and writes a new, separate copy under the name you give it.
+    Griptape-provided templates always go through Save As — you can't
+    overwrite the template itself.
+- **Save As New Version** (`Option/Alt` + `Shift` + `S`, on engines that
+    support versioned saves) writes the current state as a new versioned
+    file (`my_workflow_v002.py`, and so on) and switches you to that new
+    version, leaving the previous version untouched on disk.
 
-While a workflow is running, all three save actions are blocked. Trying to save shows a **Cannot Save While Flow is Running** dialog explaining that you need to cancel or wait for the run to finish first, with a shortcut button to cancel the flow right from the dialog.
+While a workflow is running, all three save actions are blocked. Trying to
+save shows a **Cannot Save While Flow is Running** dialog explaining that
+you need to cancel or wait for the run to finish first, with a shortcut
+button to cancel the flow right from the dialog.
 
 <!-- screenshot: the Cannot Save While Flow is Running dialog -->
 
-A **Saving workflow…** overlay appears briefly at the bottom of the screen while a save is in progress.
+A **Saving workflow…** overlay appears briefly at the bottom of the screen
+while a save is in progress.
 
 ### Auto-save
 
-**Settings → Editor Settings → Auto-Save Settings** lets you turn on automatic saving so you don't have to remember to hit `Cmd/Ctrl+S`. Once enabled you can set:
+**Settings → Editor Settings → Auto-Save Settings** lets you turn on
+automatic saving so you don't have to remember to hit `Cmd/Ctrl+S`. Once
+enabled you can set:
 
-- **Auto-Save Interval (seconds)** — how often the editor attempts an auto-save.
+- **Auto-Save Interval (seconds)** — how often the editor attempts an
+    auto-save.
 - **Auto-Save Notifications** — whether a toast confirms each auto-save.
 
-Auto-save only fires when there's an open workflow with unsaved changes that already exists on disk, and it skips the attempt entirely while the workflow is running — the same running-workflow guard that blocks manual saves applies here too, just silently instead of via a dialog.
+Auto-save only fires when there's an open workflow with unsaved changes
+that already exists on disk, and it skips the attempt entirely while the
+workflow is running — the same running-workflow guard that blocks manual
+saves applies here too, just silently instead of via a dialog.
 
 ## Developer Mode
 
-**Settings → Editor Settings → Developer Mode** adds a couple of extras aimed at understanding *why* the engine is evaluating your workflow the way it is, rather than just *whether* a node succeeded.
+**Settings → Editor Settings → Developer Mode** adds a couple of extras for
+understanding *why* the engine is evaluating your workflow the way it is,
+rather than just *whether* a node succeeded.
 
 <!-- screenshot: a node with its Developer Mode panel expanded, showing upstream dependency chips -->
 
-With it enabled, every node gets a collapsible **Developer Mode** strip that lists its upstream data dependencies — the nodes actually feeding it data, not control-flow-only connections — each shown with its own resolution icon (✓ resolved, ↻ resolving, ✗ errored, ○ unresolved). Clicking a dependency chip pans the canvas to that node, which is handy for tracing a stale value back to its source in a large graph.
+With it enabled, every node gets a collapsible **Developer Mode** strip
+that lists its upstream data dependencies — the nodes actually feeding it
+data, not control-flow-only connections — each shown with its own
+resolution icon (✓ resolved, ↻ resolving, ✗ errored, ○ unresolved).
+Clicking a dependency chip pans the canvas to that node, which helps when
+you're tracing a stale value back to its source in a large graph.
 
-Developer Mode also adds a **Mark as unresolved** action to the node's right-click menu. Use it to force a node — and everything downstream of it — back to the unresolved state without changing anything about the node itself. That's the fastest way to make the engine re-run a node on the next Run Workflow or Run To Selected, even though none of its inputs actually changed (for example, after fixing something external the node depends on, like a file on disk).
+Developer Mode also adds a **Mark as unresolved** action to the node's
+right-click menu. Use it to force a node — and everything downstream of it
+— back to the unresolved state without changing anything about the node
+itself. That's the fastest way to make the engine re-run a node on the next
+Run Workflow or Run To Selected, even though none of its inputs actually
+changed (for example, after fixing something external the node depends on,
+like a file on disk).

--- a/docs/guides/editor/running_workflows.md
+++ b/docs/guides/editor/running_workflows.md
@@ -1,0 +1,104 @@
+# Running Workflows
+
+This page covers everything that happens once your workflow is built and you want to actually run it: starting a run, stopping one, reading what's happening on the canvas while it runs, checking the logs and error history afterward, and saving your work.
+
+## Running the whole workflow
+
+The **Run Workflow** button, in the center of the header, runs every node in the current workflow from the start. It's disabled while a workflow is already running, and while no workflow is open.
+
+<!-- screenshot: the header's run button group (Run Workflow, Run To Selected, Run From Selected, Cancel Run) -->
+
+| Shortcut                        | Action       |
+| ------------------------------- | ------------ |
+| `Shift` + `Cmd/Ctrl` + `Return` | Run Workflow |
+
+## Running a single node
+
+Two more buttons next to Run Workflow let you run less than the whole graph. Both require exactly one node to be selected, and both are disabled while the workflow is already running.
+
+- **Run To Selected** resolves the selected node — and everything upstream of it that isn't already resolved — without touching anything downstream. This is the one you reach for most often while iterating: change a parameter, run to the node you're looking at, check the result.
+- **Run From Selected** starts execution at the selected node and runs forward from there through the rest of the flow, the same way Run Workflow would, just starting partway through.
+
+| Shortcut              | Action          |
+| --------------------- | --------------- |
+| `Cmd/Ctrl` + `Return` | Run To Selected |
+
+Run From Selected has no keyboard shortcut; use the button.
+
+Both single-node actions are also available from the node's right-click context menu, and from the multi-node toolbar when applicable.
+
+## Stopping a run
+
+While a workflow is running, the same button area shows **Cancel Run** in place of the run buttons. Click it to cancel the in-flight execution. The button shows **Cancelling…** while the cancellation request is in flight.
+
+Canceling a run is also how you get out of the **Cannot Save While Flow is Running** dialog (see [Saving](#saving) below) — that dialog offers a **Cancel Flow** button that does the same thing.
+
+## Reading execution state on the canvas
+
+Every node shows a status pill in its header while it's involved in the current run:
+
+| Pill                           | Meaning                                                |
+| ------------------------------ | ------------------------------------------------------ |
+| **Running** (orange, spinning) | The node is actively resolving right now.              |
+| **Resolved** (green)           | The node finished successfully.                        |
+| **Error** (red)                | The node failed. Hover the pill for the error message. |
+| **Unresolved** (blue)          | The node hasn't run yet in this pass.                  |
+
+A small asterisk next to a node's name also marks it as unresolved, independent of whether it's part of the current run. After a run ends, a node that errored keeps its red **Error** pill so you can still find it and inspect the message without having to remember which node failed.
+
+## The Logs panel
+
+The **Execution Log** panel (right sidebar) collects everything the engine logs while your workflow runs — engine messages as well as anything a node itself logs, tagged with the node's name when available.
+
+<!-- screenshot: the Execution Log panel showing a mix of INFO/WARNING/ERROR entries with node badges -->
+
+What you can do from the panel:
+
+- **Log Level Visibility** — a dropdown that sets the engine's logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). This changes what gets logged in the first place, not just what's displayed.
+- **Filter** — a row of level toggles (only the levels at or above the current verbosity are selectable) that lets you show or hide levels in the panel without changing the engine's verbosity.
+- **Download** (the download icon) — saves the currently filtered logs to a `.txt` file, one line per entry with a timestamp.
+- **Clear** (the eraser icon) — clears the log list.
+- The settings (gear) icon opens **Log Settings**, where you can change the maximum number of log entries the panel keeps in memory.
+
+The panel auto-scrolls to the newest entry as logs arrive, so it stays pinned to the bottom of the run while you watch it progress.
+
+## Error History
+
+The header also carries an **Error History** button (the triangle/circle icon with a count badge) that's independent of any single run — it accumulates errors and permission denials across your whole session, not just the workflow that's currently executing.
+
+Click it to open a dropdown listing each error with a relative timestamp and its source. Click an entry to see the full error in a modal. **Clear All** empties the list; the small × next to an individual entry removes just that one.
+
+<!-- screenshot: the Error History dropdown open, showing a couple of recorded errors -->
+
+## Saving
+
+The workflow name in the header shows an asterisk (`*`) whenever you have unsaved changes, whether that's from editing the graph or from a workflow that's never been saved to disk at all.
+
+- **Save** (`Cmd/Ctrl` + `S`) saves in place. For a workflow that's never been saved, this opens the **Save Workflow** dialog so you can confirm the name instead of guessing one for you.
+- **Save As** (`Cmd/Ctrl` + `Shift` + `S`) opens the **Save Workflow As…** dialog and writes a new, separate copy under the name you give it. Griptape-provided templates always go through Save As — you can't overwrite the template itself.
+- **Save As New Version** (`Option/Alt` + `Shift` + `S`, on engines that support versioned saves) writes the current state as a new versioned file (`my_workflow_v002.py`, and so on) and switches you to that new version, leaving the previous version untouched on disk.
+
+While a workflow is running, all three save actions are blocked. Trying to save shows a **Cannot Save While Flow is Running** dialog explaining that you need to cancel or wait for the run to finish first, with a shortcut button to cancel the flow right from the dialog.
+
+<!-- screenshot: the Cannot Save While Flow is Running dialog -->
+
+A **Saving workflow…** overlay appears briefly at the bottom of the screen while a save is in progress.
+
+### Auto-save
+
+**Settings → Editor Settings → Auto-Save Settings** lets you turn on automatic saving so you don't have to remember to hit `Cmd/Ctrl+S`. Once enabled you can set:
+
+- **Auto-Save Interval (seconds)** — how often the editor attempts an auto-save.
+- **Auto-Save Notifications** — whether a toast confirms each auto-save.
+
+Auto-save only fires when there's an open workflow with unsaved changes that already exists on disk, and it skips the attempt entirely while the workflow is running — the same running-workflow guard that blocks manual saves applies here too, just silently instead of via a dialog.
+
+## Developer Mode
+
+**Settings → Editor Settings → Developer Mode** adds a couple of extras aimed at understanding *why* the engine is evaluating your workflow the way it is, rather than just *whether* a node succeeded.
+
+<!-- screenshot: a node with its Developer Mode panel expanded, showing upstream dependency chips -->
+
+With it enabled, every node gets a collapsible **Developer Mode** strip that lists its upstream data dependencies — the nodes actually feeding it data, not control-flow-only connections — each shown with its own resolution icon (✓ resolved, ↻ resolving, ✗ errored, ○ unresolved). Clicking a dependency chip pans the canvas to that node, which is handy for tracing a stale value back to its source in a large graph.
+
+Developer Mode also adds a **Mark as unresolved** action to the node's right-click menu. Use it to force a node — and everything downstream of it — back to the unresolved state without changing anything about the node itself. That's the fastest way to make the engine re-run a node on the next Run Workflow or Run To Selected, even though none of its inputs actually changed (for example, after fixing something external the node depends on, like a file on disk).

--- a/docs/guides/editor/running_workflows.md
+++ b/docs/guides/editor/running_workflows.md
@@ -11,7 +11,7 @@ The **Run Workflow** button, in the center of the header, runs every node
 in the current workflow from the start. It's disabled while a workflow is
 already running, and while no workflow is open.
 
-<!-- screenshot: the header's run button group (Run Workflow, Run To Selected, Run From Selected, Cancel Run) -->
+<!-- screenshot (#5166): the header's run button group (Run Workflow, Run To Selected, Run From Selected, Cancel Run) -->
 
 | Shortcut                        | Action       |
 | ------------------------------- | ------------ |
@@ -75,7 +75,7 @@ The **Execution Log** panel (right sidebar) collects everything the engine
 logs while your workflow runs — engine messages as well as anything a node
 itself logs, tagged with the node's name when available.
 
-<!-- screenshot: the Execution Log panel showing a mix of INFO/WARNING/ERROR entries with node badges -->
+<!-- screenshot (#5166): the Execution Log panel showing a mix of INFO/WARNING/ERROR entries with node badges -->
 
 What you can do from the panel:
 
@@ -105,7 +105,7 @@ and its source. Click an entry to see the full error in a modal. **Clear
 All** empties the list; the small × next to an individual entry removes
 just that one.
 
-<!-- screenshot: the Error History dropdown open, showing a couple of recorded errors -->
+<!-- screenshot (#5166): the Error History dropdown open, showing a couple of recorded errors -->
 
 ## Saving
 
@@ -130,7 +130,7 @@ save shows a **Cannot Save While Flow is Running** dialog explaining that
 you need to cancel or wait for the run to finish first, with a shortcut
 button to cancel the flow right from the dialog.
 
-<!-- screenshot: the Cannot Save While Flow is Running dialog -->
+<!-- screenshot (#5166): the Cannot Save While Flow is Running dialog -->
 
 A **Saving workflow…** overlay appears briefly at the bottom of the screen
 while a save is in progress.
@@ -156,7 +156,7 @@ saves applies here too, just silently instead of via a dialog.
 understanding *why* the engine is evaluating your workflow the way it is,
 rather than just *whether* a node succeeded.
 
-<!-- screenshot: a node with its Developer Mode panel expanded, showing upstream dependency chips -->
+<!-- screenshot (#5166): a node with its Developer Mode panel expanded, showing upstream dependency chips -->
 
 With it enabled, every node gets a collapsible **Developer Mode** strip
 that lists its upstream data dependencies — the nodes actually feeding it

--- a/docs/guides/editor/working_with_nodes.md
+++ b/docs/guides/editor/working_with_nodes.md
@@ -1,0 +1,209 @@
+# Working with Nodes
+
+This page covers the everyday mechanics of building a workflow on the canvas:
+adding nodes, selecting and moving them, renaming, duplicating, locking,
+deleting, wiring connections between them, and editing their parameters. For
+running a workflow once it's built, see
+[Running Workflows](running_workflows.md). For grouping nodes together, see
+[Node Groups](node_groups.md).
+
+## Adding nodes
+
+There are three ways to open the **Add Node** menu:
+
+- Press `Tab` while the cursor is over the canvas.
+- Press `Shift+A` while the cursor is over the canvas. (`Shift+A` with the
+    cursor off the canvas selects all nodes instead — see
+    [Selecting and moving](#selecting-and-moving).)
+- Right-click empty canvas and choose **Add Node**.
+
+The menu opens at your cursor and drops the new node there once you pick one.
+It's a searchable, categorized list — type to filter by name, description, or
+tag, or browse the category tree. A **Favorites** section (star a node to add
+it) and a **Recent** section (your last few added node types) sit above the
+category list when you have either.
+
+<!-- screenshot: the Add Node menu open at the cursor, showing search results and category tree -->
+
+You can also drag a node type from the **Nodes** tab in the left sidebar
+straight onto the canvas.
+
+## Selecting and moving
+
+Click a node to select it. `Cmd/Ctrl+A` selects every node in the flow;
+`Escape` clears the selection. Drag a box across empty canvas to select
+everything inside it.
+
+Shift-click (or Cmd/Ctrl-click) additional nodes to build a multi-selection.
+With more than one node selected, dragging any of them moves the whole
+selection together, and a floating toolbar appears above the selection with
+actions that apply to all of them at once — Copy, Duplicate, Lock, Reset,
+Delete, and Create Group, depending on what's configured in **Settings →
+Editor → Button Customization**.
+
+<!-- screenshot: two or more selected nodes with the floating multi-node toolbar visible above them -->
+
+The arrow keys move the selection to the nearest node in that direction,
+which is a fast way to step through a chain of connected nodes without
+touching the mouse. `F` frames the current selection (or the whole graph, if
+nothing is selected); `Shift+G` auto-arranges the graph into a tidy layout.
+
+## Renaming
+
+Every node's display name doubles as its unique identifier in the workflow,
+so renaming a node also updates every reference to it.
+
+To rename a single node, select it and press `R`, or click the small pencil
+icon that appears next to its name on hover, or choose **Rename** from its
+right-click menu. Type the new name and press `Enter` (or click away) to
+commit it, or `Escape` to cancel.
+
+To rename several nodes at once, select them and press `R`, or right-click
+one of them and choose **Rename**. This opens the **Rename nodes** dialog,
+which takes a single base name and applies it across the whole selection:
+the first node gets the base name exactly, and the rest get `Base_1`,
+`Base_2`, and so on.
+
+<!-- screenshot: the Rename nodes dialog with a base name typed in and the preview text showing Base, Base_1, Base_2 -->
+
+## Duplicating, copying, and pasting
+
+- **Duplicate** (`Cmd/Ctrl+D`, or the Duplicate action on the node or the
+    multi-node toolbar) creates an independent copy of the selected node(s)
+    right next to the originals, with no connections to anything.
+- **Copy** (`Cmd/Ctrl+C`) serializes the selected node(s) — including their
+    parameter values — to the system clipboard.
+- **Paste** (`Cmd/Ctrl+V`) creates new nodes from whatever you last copied,
+    dropped near your cursor.
+
+Copy/paste is also how you move nodes between two open workflow tabs: copy in
+one, switch tabs, paste in the other.
+
+## Locking
+
+Locking a node protects it from accidental changes: a locked node can't be
+run, deleted, have its parameters edited, or have parameters added to it
+until you unlock it again.
+
+Toggle a node's lock state with `L` (works on a multi-selection too), the
+lock icon in its header, or **Lock**/**Unlock** in its right-click menu. Note
+nodes can't be locked — the lock option doesn't apply to them.
+
+## Deleting
+
+Select one or more nodes and press `Delete` (or `Backspace` on some
+keyboards), or use **Delete Node** from the right-click menu or the toolbar.
+Deleting a node removes any connections it had; deleting a
+[dot node](#dot-and-reroute-nodes) that sits in the middle of a connection
+instead reconnects the two ends directly, so the rest of the wire survives.
+
+Deleting a group only removes the group wrapper — its child nodes stay on
+the canvas, ungrouped. See [Node Groups](node_groups.md#ungrouping) for
+more.
+
+## Connecting parameters
+
+Every parameter that can act as an input or output gets a small handle on
+the left (input) or right (output) edge of its row. Drag from one handle to
+another to create a connection; drag from empty canvas off a handle to open
+the Add Node menu pre-wired to that handle, which is a quick way to add the
+*next* node in a chain.
+
+The editor only lets you complete a connection between compatible types — as
+you drag, incompatible handles elsewhere on the canvas dim out so you can see
+at a glance where the connection can land. Most parameters accept more than
+one type (an image input that also accepts a URL string, for example), and
+the specific accepted types are baked into each parameter by its node.
+
+To remove a connection, click its wire to select it and press `Delete`, or
+hover the wire and use the connection button that appears on it (if **Show
+Connection Buttons on Hover** is enabled in **Settings → Editor → Node
+Settings**).
+
+## Dot and reroute nodes
+
+A **dot node** is a zero-logic pass-through you can drop in the middle of an
+existing connection to bend its path around other nodes, or just to tidy up
+a busy canvas. With a connection hovered or selected, press `I` to insert a
+dot node right at that spot — the original connection is split into two,
+routed through the new dot node, with no change to the data that flows
+through it.
+
+<!-- screenshot: a connection with a dot node inserted partway along its path -->
+
+Deleting a dot node reconnects its two neighbors directly, so removing one
+never breaks the flow.
+
+## Notes
+
+A **note** is a free-floating, non-executing block of text you drop on the
+canvas to leave yourself or a collaborator context — what a section of the
+graph is for, a TODO, a warning about an upstream dependency. Press `N` with
+the cursor over the canvas to drop one at your cursor.
+
+Notes can't be locked, and don't participate in execution or in the
+multi-node toolbar's Run/Reset actions.
+
+## The Properties panel
+
+Selecting a node opens its parameters in the **Properties** panel (right
+sidebar) alongside the parameter rows shown inline on the node itself — the
+same values, just in a dedicated, always-visible place that's easier to work
+in when a node has a lot of parameters or you've collapsed the node itself.
+Open it explicitly with `Cmd/Ctrl+B`, from the right-click menu's **Property
+Panel** entry, or from a node's header button if you've added it there.
+
+<!-- screenshot: the Properties panel showing a selected node's parameters -->
+
+Editing a value in the Properties panel and editing the same parameter's
+inline row on the node update the same underlying value — there's no
+distinction between the two beyond where you happen to be looking.
+
+### Adding a custom parameter
+
+Some nodes let you add parameters of your own on top of the ones the node
+ships with. If a node supports it, you'll see an **Add parameter** row at the
+bottom of its parameter list (on the node itself and in the Properties
+panel), or **Add parameter** in its right-click menu.
+
+Opening it shows the **Add New Parameter** dialog, where you set:
+
+| Field              | What it controls                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Name**           | The parameter's internal name. Must be unique on the node.                                                 |
+| **Display Name**   | The label shown in the UI, if you want it to read differently from the internal name.                      |
+| **Type**           | One of `Any`, `str`, `bool`, `int`, `float`, `dict`, `json`, or the media types `image`, `audio`, `video`. |
+| **Tooltip**        | Help text shown on hover.                                                                                  |
+| **Input / Output** | Whether the parameter can be wired as an incoming connection, an outgoing connection, or both.             |
+| **Default Value**  | The value the parameter starts with before you set or connect anything.                                    |
+
+Depending on the type you pick, more options appear — a multiline/Markdown
+toggle for text, a slider with min/max/step for numbers, or a fixed set of
+choices (with optional icons, subtitles, and a search box) for a dropdown.
+
+<!-- screenshot: the Add New Parameter dialog with the type dropdown open -->
+
+### Configuring an existing custom parameter
+
+Once a custom parameter exists, right-click it (or its equivalent row in the
+Properties panel) and choose **Configure parameter** to reopen the same
+dialog pre-filled with its current settings. This option only appears for
+parameters you added yourself — parameters that ship with the node's
+definition aren't editable this way.
+
+### Hiding connected parameters
+
+Turn on **Hide Connected Parameters** (`Shift+H`, or **Settings → Editor →
+Node Settings**) to collapse any parameter row whose input already has an
+incoming connection. It's a decluttering tool for busy workflows: once a
+value is coming from somewhere else on the canvas, you usually don't need to
+see its editable field taking up space too. Toggling it back off restores
+every row immediately.
+
+!!! tip "Keep specific parameters visible anyway"
+
+    **Ignore Hide Connected (Display Nodes)** and **Ignore Hide Connected
+    (Save Nodes)**, next to the main toggle in Node Settings, exempt any
+    parameter whose name contains "display" or "save" — handy for nodes
+    where you want to keep an eye on an output path or preview even while
+    its input is wired up.

--- a/docs/guides/editor/working_with_nodes.md
+++ b/docs/guides/editor/working_with_nodes.md
@@ -23,7 +23,7 @@ tag, or browse the category tree. A **Favorites** section (star a node to add
 it) and a **Recent** section (your last few added node types) sit above the
 category list when you have either.
 
-<!-- screenshot: the Add Node menu open at the cursor, showing search results and category tree -->
+<!-- screenshot (#5166): the Add Node menu open at the cursor, showing search results and category tree -->
 
 You can also drag a node type from the **Nodes** tab in the left sidebar
 straight onto the canvas.
@@ -41,7 +41,7 @@ actions that apply to all of them at once — Copy, Duplicate, Lock, Reset,
 Delete, and Create Group, depending on what's configured in **Settings →
 Editor → Button Customization**.
 
-<!-- screenshot: two or more selected nodes with the floating multi-node toolbar visible above them -->
+<!-- screenshot (#5166): two or more selected nodes with the floating multi-node toolbar visible above them -->
 
 The arrow keys move the selection to the nearest node in that direction,
 which is a fast way to step through a chain of connected nodes without
@@ -64,7 +64,7 @@ which takes a single base name and applies it across the whole selection:
 the first node gets the base name exactly, and the rest get `Base_1`,
 `Base_2`, and so on.
 
-<!-- screenshot: the Rename nodes dialog with a base name typed in and the preview text showing Base, Base_1, Base_2 -->
+<!-- screenshot (#5166): the Rename nodes dialog with a base name typed in and the preview text showing Base, Base_1, Base_2 -->
 
 ## Duplicating, copying, and pasting
 
@@ -129,7 +129,7 @@ dot node right at that spot — the original connection is split into two,
 routed through the new dot node, with no change to the data that flows
 through it.
 
-<!-- screenshot: a connection with a dot node inserted partway along its path -->
+<!-- screenshot (#5166): a connection with a dot node inserted partway along its path -->
 
 Deleting a dot node reconnects its two neighbors directly, so removing one
 never breaks the flow.
@@ -154,7 +154,7 @@ Open the right sidebar that hosts it with `Cmd/Ctrl+B`, from the
 right-click menu's **Property Panel** entry, or from a node's header button if
 you've added it there.
 
-<!-- screenshot: the Properties panel showing a selected node's parameters -->
+<!-- screenshot (#5166): the Properties panel showing a selected node's parameters -->
 
 Editing a value in the Properties panel and editing the same parameter's
 inline row on the node update the same underlying value.
@@ -181,7 +181,7 @@ Depending on the type you pick, more options appear — a multiline/Markdown
 toggle for text, a slider with min/max/step for numbers, or a fixed set of
 choices (with optional icons, subtitles, and a search box) for a dropdown.
 
-<!-- screenshot: the Add New Parameter dialog with the type dropdown open -->
+<!-- screenshot (#5166): the Add New Parameter dialog with the type dropdown open -->
 
 ### Configuring an existing custom parameter
 

--- a/docs/guides/editor/working_with_nodes.md
+++ b/docs/guides/editor/working_with_nodes.md
@@ -111,7 +111,7 @@ the Add Node menu pre-wired to that handle, which is a quick way to add the
 
 The editor only lets you complete a connection between compatible types — as
 you drag, incompatible handles elsewhere on the canvas dim out so you can see
-at a glance where the connection can land. Most parameters accept more than
+where the connection can land. Most parameters accept more than
 one type (an image input that also accepts a URL string, for example), and
 the specific accepted types are baked into each parameter by its node.
 
@@ -150,14 +150,14 @@ Selecting a node opens its parameters in the **Properties** panel (right
 sidebar) alongside the parameter rows shown inline on the node itself — the
 same values, just in a dedicated, always-visible place that's easier to work
 in when a node has a lot of parameters or you've collapsed the node itself.
-Open it explicitly with `Cmd/Ctrl+B`, from the right-click menu's **Property
-Panel** entry, or from a node's header button if you've added it there.
+Open the right sidebar that hosts it with `Cmd/Ctrl+B`, from the
+right-click menu's **Property Panel** entry, or from a node's header button if
+you've added it there.
 
 <!-- screenshot: the Properties panel showing a selected node's parameters -->
 
 Editing a value in the Properties panel and editing the same parameter's
-inline row on the node update the same underlying value — there's no
-distinction between the two beyond where you happen to be looking.
+inline row on the node update the same underlying value.
 
 ### Adding a custom parameter
 
@@ -204,6 +204,6 @@ every row immediately.
 
     **Ignore Hide Connected (Display Nodes)** and **Ignore Hide Connected
     (Save Nodes)**, next to the main toggle in Node Settings, exempt any
-    parameter whose name contains "display" or "save" — handy for nodes
+    parameter whose name contains "display" or "save" — useful for nodes
     where you want to keep an eye on an output path or preview even while
     its input is wired up.

--- a/docs/guides/projects/macros.md
+++ b/docs/guides/projects/macros.md
@@ -2,6 +2,10 @@
 
 A macro is a template string that generates a file path by substituting named variables. Macros are used in situation templates and directory definitions.
 
+!!! note
+
+    This page is about **file-path macros** used by the project system. For named values you create and read inside a workflow — including `{name}` substitution in text parameters — see [Workflow Variables](../variables.md).
+
 Before diving into the full syntax, here are two examples that show what macros look like in practice:
 
 ```

--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -35,7 +35,7 @@ new value the next time it runs.
 The **Variables** category in the node library has a small family of nodes
 for creating and managing variables:
 
-<!-- screenshot: the Variables category in the node library panel, showing Create Variable, Set Variable, Get Variable, Has Variable, Set Variables from Data, and Set Variable Substitution -->
+<!-- screenshot (#5166): the Variables category in the node library panel, showing Create Variable, Set Variable, Get Variable, Has Variable, Set Variables from Data, and Set Variable Substitution -->
 
 - **Create Variable** — creates a variable with a name, type, and initial
     value, or updates it if a variable with that name already exists in the
@@ -56,7 +56,7 @@ for creating and managing variables:
 - **Has Variable** — checks whether a variable exists, so you can branch on
     it (for example, only create a variable the first time a flow runs).
 
-<!-- screenshot: a Create Variable node configured with variable_name "project_name" and a text value wired into its value input -->
+<!-- screenshot (#5166): a Create Variable node configured with variable_name "project_name" and a text value wired into its value input -->
 
 **Create Variable** and **Set Variable** always create the variable in the
 node's own flow (flow-scoped, described below) — there's currently no node
@@ -138,7 +138,7 @@ Type `{` inside any text parameter that supports it and the editor pops up
 a variable picker listing every variable and project macro currently in
 scope, grouped by source:
 
-<!-- screenshot: a text parameter field with the { picker open, showing grouped variables and project macros -->
+<!-- screenshot (#5166): a text parameter field with the { picker open, showing grouped variables and project macros -->
 
 Pick one, or just type the name and close the brace yourself —
 `{project_name}` — and its value is substituted in at execution time. If
@@ -219,7 +219,7 @@ several prompt fields.
     you typed), with the second one rendering `autumn-campaign` where the
     slug spec applies.
 
-<!-- screenshot: the finished flow with a Create Variable node feeding project_name into two prompt fields that show the resolved {project_name} text -->
+<!-- screenshot (#5166): the finished flow with a Create Variable node feeding project_name into two prompt fields that show the resolved {project_name} text -->
 
 To change the project for a new run, edit the value on the **Create
 Variable** node (or wire a different source into it) — every field

--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -19,13 +19,13 @@ to show up — including inline inside text fields, using `{variable_name}`.
 
 ## When to use a variable
 
-Say three prompt fields across your workflow all need the same client name,
-or a batch of image nodes should all write to the same subject name. Wiring
+Say three prompt fields across your workflow all need the same client name.
+Wiring
 a connection from one source node to every field that needs it works, but
 it clutters the canvas and breaks if you ever want to type the value
 directly into a field instead of dragging a wire.
 
-A variable solves this without a single connection: set it once, then
+A variable solves this without any connections: set it once, then
 reference `{project_name}` inside as many text parameters as you like.
 Change the variable's value and every field that references it picks up the
 new value the next time it runs.
@@ -93,9 +93,8 @@ in the top-level flow, and every sub-flow nested inside it can read
 everything inside it — the parent's value is untouched and reappears once
 you leave the nested flow.
 
-A shorter way to think about it: a variable defined closer to where you're
-reading it always wins over one defined farther away, and flow-scoped
-variables always win over global ones.
+A shorter way to think about it: the definition closest to where you're
+reading wins, and flow-scoped variables win over global ones.
 
 ## Variable types
 
@@ -145,7 +144,7 @@ Pick one, or just type the name and close the brace yourself —
 `{project_name}` — and its value is substituted in at execution time. If
 the name doesn't resolve to anything in scope, the token is left in the
 text untouched (or, for an optional token, silently dropped — see below),
-so a typo doesn't manufacture a confusing value out of nowhere.
+so a typo doesn't silently produce a wrong value.
 
 You can turn this behavior off per workflow with the **Set Variable
 Substitution** node if you specifically want `{literal text like this}` to
@@ -196,8 +195,8 @@ above cover the common cases.
 
 ## Worked example: a project name across several prompts
 
-Say a workflow generates concept art and needs the same project name
-sprinkled through several prompt fields.
+Say a workflow generates concept art and needs the same project name in
+several prompt fields.
 
 1. Drop a **Create Variable** node near the top of the flow. Set
     `variable_name` to `project_name`, type `Autumn Campaign` directly into
@@ -225,4 +224,4 @@ sprinkled through several prompt fields.
 To change the project for a new run, edit the value on the **Create
 Variable** node (or wire a different source into it) — every field
 referencing `{project_name}` updates the next time the flow executes,
-without touching a single connection.
+without rewiring anything.

--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -1,0 +1,228 @@
+# Workflow Variables
+
+A **variable** is a named value that lives on a flow instead of on any one
+node. Create it once, then read or write it from anywhere that value needs
+to show up — including inline inside text fields, using `{variable_name}`.
+
+!!! info "Not the same as macro path variables"
+
+    [Macros](projects/macros.md) are the template syntax the project system
+    uses to build **file paths** (`{outputs}/{file_name_base}.{file_extension}`).
+    Workflow variables are user-created values you store and reuse across a
+    workflow's node parameters. The two systems share the same `{name}` /
+    `{name:spec}` syntax and format specs under the hood, and project macros
+    (like `workspace_dir` and `workflow_name`) even show up alongside your
+    own variables when you type `{` in a text field — but a macro path
+    template describes how to build a filename, while a workflow variable is
+    a value you define and change during a run. If you're building a save
+    path, read [Macros](projects/macros.md) instead.
+
+## When to use a variable
+
+Say three prompt fields across your workflow all need the same client name,
+or a batch of image nodes should all write to the same subject name. Wiring
+a connection from one source node to every field that needs it works, but
+it clutters the canvas and breaks if you ever want to type the value
+directly into a field instead of dragging a wire.
+
+A variable solves this without a single connection: set it once, then
+reference `{project_name}` inside as many text parameters as you like.
+Change the variable's value and every field that references it picks up the
+new value the next time it runs.
+
+## Creating a variable
+
+The **Variables** category in the node library has a small family of nodes
+for creating and managing variables:
+
+<!-- screenshot: the Variables category in the node library panel, showing Create Variable, Set Variable, Get Variable, Has Variable, Set Variables from Data, and Set Variable Substitution -->
+
+- **Create Variable** — creates a variable with a name, type, and initial
+    value, or updates it if a variable with that name already exists in the
+    current flow. Connect any output into its `value` input and the
+    variable's type is inferred automatically from that connection.
+- **Set Variable** — sets a variable's value, creating the variable first
+    if it doesn't exist yet. Its `variable_name` field is a dropdown of
+    variables already in scope, plus a **Create new variable** option that
+    reveals a name field when picked.
+- **Set Variables from Data** — turns a dict, a JSON/YAML string, or a list
+    of key-value pairs into several variables in one step. Useful when you
+    already have a JSON blob (parsed config, an API response) and want each
+    key to become its own variable instead of wiring up one **Set Variable**
+    node per key.
+- **Get Variable** — reads a variable's current value out as a normal
+    output, for wiring into a node that doesn't support inline `{name}`
+    substitution.
+- **Has Variable** — checks whether a variable exists, so you can branch on
+    it (for example, only create a variable the first time a flow runs).
+
+<!-- screenshot: a Create Variable node configured with variable_name "project_name" and a text value wired into its value input -->
+
+**Create Variable** and **Set Variable** always create the variable in the
+node's own flow (flow-scoped, described below) — there's currently no node
+that creates a global variable directly. The **scope** setting on these
+nodes (under **Advanced**) controls where they *look* for an existing
+variable, not where a new one is created.
+
+These nodes treat the variable they touch as live state rather than a
+resolved-once value. **Create Variable** forces itself back to unresolved
+every time the workflow or the node runs, so it always re-applies its
+current `value`. **Get Variable**, **Set Variable**, and **Has Variable**
+check the variable's actual current value each time they're asked for their
+resolution state, and mark themselves unresolved if it no longer matches
+what they last read or wrote — so they pick up a change made elsewhere
+(another **Set Variable** node, a different flow) without needing a manual
+run.
+
+## Scopes
+
+Every variable request — create, get, set, list — takes a **scope**, which
+controls where the lookup searches:
+
+| Scope                    | Behavior                                                                                                                      |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `hierarchical` (default) | Search the current flow, then each ancestor flow up to the root, then global variables. The first match wins.                 |
+| `current_flow_only`      | Only the exact flow the node is in. Ignores parent flows and globals entirely.                                                |
+| `global_only`            | Only global variables — variables not owned by any flow.                                                                      |
+| `all`                    | Every variable from every flow, primarily for enumeration (populating a picker or list) rather than resolving a single value. |
+
+`hierarchical` is what you want almost always: define `project_name` once
+in the top-level flow, and every sub-flow nested inside it can read
+`{project_name}` without redeclaring it. If a nested flow defines its own
+`project_name`, that nested definition **shadows** the parent's for
+everything inside it — the parent's value is untouched and reappears once
+you leave the nested flow.
+
+A shorter way to think about it: a variable defined closer to where you're
+reading it always wins over one defined farther away, and flow-scoped
+variables always win over global ones.
+
+## Variable types
+
+A variable's `type` is the same type label you'd see on any node
+parameter — `str`, `int`, `float`, `bool`, `json`, an image type, and so on.
+**Create Variable** and **Set Variable** infer the type automatically from
+whatever you connect to their `value` input; you don't need to set it by
+hand unless you're leaving `value` unconnected and typing a literal
+directly into the node.
+
+Only variables holding a `str` or `int` value (not `bool`) can be
+substituted inline into a `{name}` token in a text field — see
+[Inline substitution](#inline-substitution-in-text-fields) below. Variables
+holding other types (JSON, images, lists) still work fine with **Get
+Variable** / **Set Variable**; they just can't be dropped into a text field
+as a bare token, since there's no sensible way to render an image inline as
+text.
+
+## Setting and reading values during a run
+
+Outside of nodes, if you're scripting against the engine's request API
+directly, the relevant requests are `CreateVariableRequest`,
+`GetVariableValueRequest`, and `SetVariableValueRequest` — each takes a
+`name` and a `lookup_scope`. `SetVariableValueRequest` unresolves any
+already-resolved node downstream that references the variable, so changing
+a variable mid-editing correctly invalidates anything that was computed
+from its old value.
+
+For inline substitution, one more layer sits on top of the plain variable
+lookup: when a node runs, the engine resolves every `{name}` token in its
+parameter values against a merged set of **your workflow variables plus the
+project's read-only macro values** (`workspace_dir`, `workflow_name`, and
+any project template directories) — your own variables take priority if a
+name collides with one of those. That merge is what lets a text field
+reference `{workflow_name}` and `{project_name}` side by side even though
+one comes from the project and the other from a variable you created.
+
+## Inline substitution in text fields
+
+Type `{` inside any text parameter that supports it and the editor pops up
+a variable picker listing every variable and project macro currently in
+scope, grouped by source:
+
+<!-- screenshot: a text parameter field with the { picker open, showing grouped variables and project macros -->
+
+Pick one, or just type the name and close the brace yourself —
+`{project_name}` — and its value is substituted in at execution time. If
+the name doesn't resolve to anything in scope, the token is left in the
+text untouched (or, for an optional token, silently dropped — see below),
+so a typo doesn't manufacture a confusing value out of nowhere.
+
+You can turn this behavior off per workflow with the **Set Variable
+Substitution** node if you specifically want `{literal text like this}` to
+pass through untouched instead of being treated as a token.
+
+### Format specs
+
+A token can carry format specs after a `:`, applied left to right, using
+the same syntax and the same underlying spec list documented in full in
+[Macros → String transformations](projects/macros.md#string-transformations):
+
+| Spec               | Result                            |
+| ------------------ | --------------------------------- |
+| `:lower`           | all lowercase                     |
+| `:upper`           | ALL UPPERCASE                     |
+| `:title`           | Title Case                        |
+| `:snake`           | snake_case                        |
+| `:pascal`          | PascalCase                        |
+| `:camel`           | camelCase                         |
+| `:screaming_snake` | SCREAMING_SNAKE_CASE              |
+| `:slug`            | url-safe-slug                     |
+| `:dot`             | dot.case                          |
+| `:abbrev`          | first letter of each word         |
+| `:trim`            | strip leading/trailing whitespace |
+
+```
+{project_name}            → "Autumn Campaign"
+{project_name:lower}      → "autumn campaign"
+{project_name:slug}       → "autumn-campaign"
+{project_name:snake:upper} → "AUTUMN_CAMPAIGN"
+```
+
+Two more pieces of syntax carry over from macros and work the same way here:
+
+- **Optional marker `?`** — `{project_name?}` renders as an empty string
+    instead of leaving the literal token behind when the variable isn't
+    found, so you can build sentences that gracefully drop a clause when a
+    variable is unset.
+- **Default value `|default`** — `{project_name|untitled}` substitutes
+    `untitled` if `project_name` isn't in scope.
+
+Numeric padding (`:03`), sequence slots (`{###}`), and leading separators
+(`:^prefix`) are also parsed by the same engine and technically valid inside
+a text field, but they exist for building filenames with auto-incrementing
+counters — see [Macros](projects/macros.md) if you need that behavior. For
+ordinary text substitution, the transformations and optional/default specs
+above cover the common cases.
+
+## Worked example: a project name across several prompts
+
+Say a workflow generates concept art and needs the same project name
+sprinkled through several prompt fields.
+
+1. Drop a **Create Variable** node near the top of the flow. Set
+    `variable_name` to `project_name`, type `Autumn Campaign` directly into
+    `value` (no connection needed for a literal), and let `variable_type`
+    stay as the inferred `str`.
+
+1. In your prompt-building node's text field, type:
+
+    ```
+    A cinematic key art poster for {project_name}, dramatic lighting, wide shot
+    ```
+
+1. In a second prompt field elsewhere in the flow:
+
+    ```
+    Concept sketch, {project_name:slug} style guide, muted palette
+    ```
+
+1. Run the flow once. Both prompts pick up "Autumn Campaign" (or whatever
+    you typed), with the second one rendering `autumn-campaign` where the
+    slug spec applies.
+
+<!-- screenshot: the finished flow with a Create Variable node feeding project_name into two prompt fields that show the resolved {project_name} text -->
+
+To change the project for a new run, edit the value on the **Create
+Variable** node (or wire a different source into it) — every field
+referencing `{project_name}` updates the next time the flow executes,
+without touching a single connection.

--- a/docs/guides/workflow_versions.md
+++ b/docs/guides/workflow_versions.md
@@ -1,0 +1,50 @@
+# Workflow Versions
+
+**File → Save As New Version** (`Option/Alt` + `Shift` + `S`) writes the
+current state of your workflow to a new file instead of overwriting the one
+you have open, and switches you over to editing that new file. Save it again
+and you get another new file — each save produces the next one in the
+sequence, leaving every earlier version untouched on disk.
+
+## What it produces
+
+Versioned saves add a padded `_v<number>` suffix to the workflow's file
+name: saving `my_workflow.py` this way produces `my_workflow_v001.py`, then
+`my_workflow_v002.py`, and so on. The version number always advances; it
+never overwrites an existing version file.
+
+<!-- screenshot: the File menu open with Save As New Version highlighted -->
+
+## When to use it
+
+Reach for Save As New Version when you want a checkpoint you can go back to
+without losing your current progress — before a risky restructuring, before
+handing a workflow off, or just to keep a trail of snapshots as you iterate.
+Because each version is its own file, opening an older version and opening
+the newest one are both just "open a file"; nothing about picking a version
+is special.
+
+## How it differs from Save and Save As
+
+- **Save** overwrites the file you currently have open. No new file is
+    created.
+- **Save As** writes a new, separate file under a name *you* choose, and
+    switches you to editing it. It's a one-time fork with an arbitrary name.
+- **Save As New Version** writes a new file too, but the name is chosen for
+    you (the next number in the sequence) and it's meant to be repeated —
+    each subsequent save from that file keeps incrementing the same
+    sequence.
+
+Autosave, when enabled, behaves like **Save**: it silently overwrites the
+currently open file on an interval, and never creates a versioned file on
+its own. See [Auto-save](editor/running_workflows.md#auto-save) for how to
+configure it.
+
+!!! note "Not the same as engine or library version pinning"
+
+    Workflow versions are just numbered copies of a workflow *file* — they
+    have nothing to do with which engine or library *versions* a project
+    requires to run correctly. If you're looking to pin a project to a
+    known-good engine version or a known-good set of library versions, see
+    [Pinning engine and library versions](projects/version_pinning.md)
+    instead.

--- a/docs/guides/workflow_versions.md
+++ b/docs/guides/workflow_versions.md
@@ -13,7 +13,7 @@ name: saving `my_workflow.py` this way produces `my_workflow_v001.py`, then
 `my_workflow_v002.py`, and so on. The version number always advances; it
 never overwrites an existing version file.
 
-<!-- screenshot: the File menu open with Save As New Version highlighted -->
+<!-- screenshot (#5166): the File menu open with Save As New Version highlighted -->
 
 ## When to use it
 

--- a/docs/guides/workflow_versions.md
+++ b/docs/guides/workflow_versions.md
@@ -17,19 +17,18 @@ never overwrites an existing version file.
 
 ## When to use it
 
-Reach for Save As New Version when you want a checkpoint you can go back to
+Use Save As New Version when you want a checkpoint you can go back to
 without losing your current progress — before a risky restructuring, before
 handing a workflow off, or just to keep a trail of snapshots as you iterate.
-Because each version is its own file, opening an older version and opening
-the newest one are both just "open a file"; nothing about picking a version
-is special.
+Because each version is its own file, going back to an older version is
+just a matter of opening that file.
 
 ## How it differs from Save and Save As
 
 - **Save** overwrites the file you currently have open. No new file is
     created.
 - **Save As** writes a new, separate file under a name *you* choose, and
-    switches you to editing it. It's a one-time fork with an arbitrary name.
+    switches you to editing it: a one-time copy.
 - **Save As New Version** writes a new file too, but the name is chosen for
     you (the next number in the sequence) and it's meant to be repeated —
     each subsequent save from that file keeps incrementing the same

--- a/docs/reference/command_line_interface.md
+++ b/docs/reference/command_line_interface.md
@@ -26,7 +26,9 @@ This will start the Griptape Nodes engine and open the web interface at https://
 
 ### `init`
 
-Initialize a new workspace for Griptape Nodes.
+Initialize a new workspace for Griptape Nodes: sets your API key, workspace
+directory, storage backend, and (optionally) extra libraries. Running it
+again re-runs the same prompts so you can change any of these later.
 
 ```
 griptape-nodes init [options]
@@ -36,6 +38,14 @@ Options:
 
 - `--api-key` - Directly specify your Griptape API key without being prompted
 - `--workspace-directory` - Directly specify your workspace directory without being prompted
+- `--storage-backend` - Set the storage backend (`local` or `gtc`) without being prompted
+- `--bucket-name` - Name for the bucket (existing or new) to use when `--storage-backend gtc` is set
+- `--register-diffusers-library` / `--no-register-diffusers-library` - Install (or skip) the Griptape Nodes Diffusers Library
+- `--register-griptape-cloud-library` / `--no-register-griptape-cloud-library` - Install (or skip) the Griptape Cloud Library
+- `--no-interactive` - Run init without any prompts, using only the flags and defaults provided
+- `--hf-token` - Set the Hugging Face token used for downloading gated models
+- `--config key=value` - Set an arbitrary configuration value; repeat the flag to set several (e.g. `--config log_level=DEBUG --config workspace_directory=/tmp`)
+- `--secret key=value` - Set an arbitrary secret value; repeat the flag to set several (e.g. `--secret MY_API_KEY=abc123`)
 
 ### `config`
 
@@ -47,9 +57,12 @@ griptape-nodes config SUBCOMMAND
 
 Subcommands:
 
-- `show` - Show the current configuration settings
-- `list` - List all configuration files in order of precedence
+- `show [config_path]` - Show the current configuration. With no argument, prints the whole merged configuration as JSON; with a dotted path (e.g. `workspace_directory`), prints just that value
+- `list` - List all configuration files that contribute to your configuration, in order of precedence
 - `reset` - Reset your configuration to default values
+
+For the full list of settings you can read or set this way, see the
+[Configuration Reference](configuration_reference.md).
 
 ### `self`
 
@@ -61,8 +74,9 @@ griptape-nodes self SUBCOMMAND
 
 Subcommands:
 
-- `uninstall` - Uninstall the CLI, removing configuration and data directories
+- `uninstall` - Uninstall the CLI, removing its configuration and data directories and the installed executable
 - `version` - Display the current version of the CLI
+- `info` - Print a system information report for debugging: engine version and install source, platform and Python details, configuration paths, the full merged configuration, and every registered library with its version. Useful to paste into a bug report
 
 ### `libraries`
 
@@ -76,7 +90,48 @@ griptape-nodes libraries SUBCOMMAND
 Subcommands:
 
 - `sync` - Update every registered library to its latest version
+    - `--overwrite` - Discard any uncommitted local changes in a library's clone before updating it
 - `download <git_url>` - Clone a library from Git and register it
+    - `--branch` - Branch, tag, or commit to check out
+    - `--target-dir` - Name of the directory to clone into
+    - `--download-dir` - Parent directory the library is cloned under
+    - `--overwrite` - Overwrite the library's directory if it already exists
+
+### `models`
+
+Manage AI models downloaded from the Hugging Face Hub — the same models
+nodes like local diffusion or LLM nodes pull from when you run a workflow.
+
+```
+griptape-nodes models SUBCOMMAND
+```
+
+Subcommands:
+
+- `download <model_id>` - Download a model from the Hugging Face Hub (e.g. `microsoft/DialoGPT-medium`)
+    - `--local-dir` - Local directory to download the model into
+    - `--revision` - Git revision to download (defaults to `main`)
+- `list` - List all model files currently in your local cache, with their size on disk
+- `delete <model_id>` - Delete a model's files from your local cache
+- `search [query]` - Search for models on the Hugging Face Hub
+    - `--task` - Filter results by task type (e.g. `text-generation`)
+    - `--limit` - Maximum number of results to return (defaults to 20, capped at 100)
+    - `--sort` - Field to sort results by (defaults to `downloads`)
+    - `--direction` - Sort direction (defaults to `desc`)
+- `downloads status [model_id]` - Show download progress/status for one model, or for every tracked model if none is given
+- `downloads list` - List every tracked model download and its status
+- `downloads delete <model_id>` - Delete the download-status tracking record for a model (does not delete the model's files; use `models delete` for that)
+
+### `doctor`
+
+Run health checks against your Griptape Nodes installation and print a
+pass/fail table (for example, whether the engine's WebSocket connection is
+reachable). Exits with a nonzero status if any check fails, so it's safe to
+use in scripts.
+
+```
+griptape-nodes doctor
+```
 
 ## Configuration
 

--- a/docs/reference/command_line_interface.md
+++ b/docs/reference/command_line_interface.md
@@ -1,6 +1,6 @@
 # Griptape Nodes Command Line Interface (CLI)
 
-If you're new to command-line interfaces (CLIs), a CLI is a text-based way to interact with software by typing commands instead of clicking buttons in a UI. Griptape Nodes provides a CLI with the the `griptape-nodes` (or `gtn`) command. This enables you to interact with Griptape Nodes in the terminal.
+If you're new to command-line interfaces (CLIs), a CLI is a text-based way to interact with software by typing commands instead of clicking buttons in a UI. Griptape Nodes provides a CLI with the `griptape-nodes` (or `gtn`) command. This enables you to interact with Griptape Nodes in the terminal.
 
 `griptape-nodes` (or its shorthand alias `gtn`) is a command-line tool specifically designed to launch and manage the Griptape Nodes Engine installation on your computer. This tool handles tasks like initializing your workspace, managing configuration settings, and starting the engine that powers the web-based Griptape Nodes editor. The actual creation and editing of workflows happens in the web interface that opens when you run the engine.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ plugins:
           - development/custom_nodes/index.md: Developing custom nodes overview
           - development/custom_nodes/getting_started.md: Beginner-friendly intro to node development
           - development/custom_nodes/comprehensive_guide.md: Exhaustive node development reference
+          - development/custom_nodes/parameter_ui_reference.md: Parameter type to widget mapping, supported ui_options keys, and traits
           - development/custom_nodes/node_isolation_with_workers.md: Running a library isolated in a worker subprocess for dependency isolation
           - development/custom_nodes/strict_mode.md: Strict-mode rules that identify isolation incompatibilities
         Reference:
@@ -523,6 +524,7 @@ nav:
           - Overview: development/custom_nodes/index.md
           - Getting Started: development/custom_nodes/getting_started.md
           - Comprehensive Guide: development/custom_nodes/comprehensive_guide.md
+          - Parameter UI Reference: development/custom_nodes/parameter_ui_reference.md
           - Node Isolation with Workers: development/custom_nodes/node_isolation_with_workers.md
           - Strict Mode Reference: development/custom_nodes/strict_mode.md
           - Example Control Node: development/custom_nodes/example_control_node.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,10 @@ plugins:
           - guides/projects/sequences.md: Numbered file sequences (patterns and policies)
           - guides/projects/version_pinning.md: Pinning engine and library versions
           - guides/projects/customization.md: Customization guide
+        Workflows:
+          - guides/variables.md: Workflow variables — scopes, variable nodes, and inline {name} substitution
+          - guides/assets.md: Where generated files go, storage backends, and uploads
+          - guides/workflow_versions.md: Save As New Version and versioned workflow files
         Publishing:
           - guides/publishing.md: Publishing a workflow — lifecycle, dependency bundling, and static-file workarounds
         MCP integration:
@@ -292,7 +296,11 @@ nav:
           - Sequences: guides/projects/sequences.md
           - Version Pinning: guides/projects/version_pinning.md
           - Customization Guide: guides/projects/customization.md
-      - Publishing Workflows: guides/publishing.md
+      - Workflows:
+          - Variables: guides/variables.md
+          - Assets & Outputs: guides/assets.md
+          - Workflow Versions: guides/workflow_versions.md
+          - Publishing: guides/publishing.md
       - MCP:
           - Overview: guides/mcp/index.md
           - Getting Started: guides/mcp/getting_started.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,14 @@ plugins:
           - tutorials/02_coordinating_agents/index.md
           - tutorials/03_compare_prompts/index.md
           - tutorials/04_photography_team/index.md
+        Editor:
+          - guides/editor/index.md: Orientation tour of the visual editor (canvas, header, menus, sidebars)
+          - guides/editor/keyboard_shortcuts.md: Complete keyboard shortcut reference
+          - guides/editor/working_with_nodes.md: Adding, selecting, wiring, and editing nodes on the canvas
+          - guides/editor/node_groups.md: Groups, subflows, and iterative group types (ForEach, For Loop, Retry)
+          - guides/editor/running_workflows.md: Running, stopping, logs, error history, and saving
+          - guides/editor/media_editors.md: Built-in viewers and editors for images, video, audio, 3D, and splats
+          - guides/editor/managing_models_and_libraries.md: Model Management and Library Management windows
         Agent:
           - guides/agent/index.md: Built-in AI assistant with direct workflow access via the Griptape MCP server
           - guides/agent/threads.md: Conversation threads and local storage locations
@@ -245,6 +253,14 @@ nav:
       - FAQ: faq.md
       - Glossary: glossary.md
   - Guides:
+      - Editor:
+          - Overview: guides/editor/index.md
+          - Keyboard Shortcuts: guides/editor/keyboard_shortcuts.md
+          - Working with Nodes: guides/editor/working_with_nodes.md
+          - Node Groups: guides/editor/node_groups.md
+          - Running Workflows: guides/editor/running_workflows.md
+          - Media Viewers & Editors: guides/editor/media_editors.md
+          - Managing Models & Libraries: guides/editor/managing_models_and_libraries.md
       - Agent:
           - Overview: guides/agent/index.md
           - Threads: guides/agent/threads.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,9 +136,8 @@ plugins:
           - guides/projects/customization.md: Customization guide
         Workflows:
           - guides/variables.md: Workflow variables — scopes, variable nodes, and inline {name} substitution
-          - guides/assets.md: Where generated files go, storage backends, and uploads
+          - guides/assets.md: Where generated files go, previews and downloads, and uploads
           - guides/workflow_versions.md: Save As New Version and versioned workflow files
-        Publishing:
           - guides/publishing.md: Publishing a workflow — lifecycle, dependency bundling, and static-file workarounds
         MCP integration:
           - guides/mcp/index.md: MCP integration overview
@@ -263,8 +262,8 @@ nav:
           - Working with Nodes: guides/editor/working_with_nodes.md
           - Node Groups: guides/editor/node_groups.md
           - Running Workflows: guides/editor/running_workflows.md
-          - Media Viewers & Editors: guides/editor/media_editors.md
-          - Managing Models & Libraries: guides/editor/managing_models_and_libraries.md
+          - Media Viewers and Editors: guides/editor/media_editors.md
+          - Managing Models and Libraries: guides/editor/managing_models_and_libraries.md
       - Agent:
           - Overview: guides/agent/index.md
           - Threads: guides/agent/threads.md


### PR DESCRIPTION
Added a bunch of new docs.

New Editor guide section

- Overview — a tour of the editor's regions: canvas, header, menu bar, and both sidebars
- Keyboard Shortcuts — complete shortcut reference, grouped by task, with macOS vs Windows/Linux columns (verified against the GUI source)
- Working with Nodes — adding, selecting, renaming, duplicating, locking, deleting, wiring connections, dot/reroute nodes, notes, the Properties panel, and custom parameters
- Node Groups — plain groups vs executable subflow groups (Subflow, ForEach, For Loop, Retry), wall parameters, collapsing/roll-up, ungrouping, and running groups
- Running Workflows — full runs vs Run To/From Selected, canceling, status pills, the Logs panel, Error History, saving/auto-save, and Developer Mode
- Media Viewers & Editors — the built-in viewers/editors for images (crop, mask painting, Image Bash compositing), video, audio, webcam/mic capture, 3D models, Gaussian splats, and loading workflows from PNG metadata
- Managing Models & Libraries — the Model Management (Hugging Face search/download/delete, gated-model tokens) and Library Management windows, with pointers to the equivalent CLI commands

New Workflows guides

- Variables — workflow variables: the variable node family, scopes (hierarchical/flow/global), inline {name} substitution with format specs, and how they differ from path macros
- Assets & Outputs — where generated files go, framed around the project system (directories + situations like save_node_output and copy_external_file), how the editor mints preview/download URLs, and uploads
- Workflow Versions — Save As New Version (my_workflow_v001.py sequence) and how it differs from Save/Save As

New developer reference

- Parameter UI Reference — parameter type → widget mapping, the supported ui_options keys per type, and the full traits table (including the previously undocumented ones)

CLI reference completion

- Documented the previously missing models and doctor commands, all init flags, libraries subcommand flags, config show [path], and self info

Misc

- Screenshots are stubbed as placeholders in the pages and tracked in #5166
- Added documentation guidance to CLAUDE.md
- Follow-up to split the comprehensive node development guide: #5167

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5165.org.readthedocs.build/en/5165/

<!-- readthedocs-preview griptape-nodes end -->
