### PR TITLE
feat: resolve ffmpeg from config and PATH before static-ffmpeg download

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -250,3 +250,34 @@ Now when workflows generate media:
 - Local access: Works via the tunnel URL
 - External services: Can fetch media via the ngrok URL
 - CORS: Automatically configured for the tunnel URL
+
+## FFmpeg Configuration
+
+Video nodes use **ffmpeg** and **ffprobe** to read video files (dimensions, codec, duration) and to generate the browser-playable previews you see in the editor. The engine finds these two binaries automatically, in this order:
+
+1. **The `ffmpeg_path` and `ffprobe_path` settings**, if you set them to a specific executable.
+1. **Your system `PATH`** — an ffmpeg installed with Homebrew, apt, or a manual install is used as-is.
+1. **A bundled build**, downloaded from GitHub on first use if the first two turn up nothing.
+
+Because a binary already on your `PATH` is preferred over the download, installing ffmpeg yourself (for example `brew install ffmpeg` on macOS or `sudo apt install ffmpeg` on Linux) means the engine never has to fetch one over the network.
+
+### When to Set These Settings
+
+Leave `ffmpeg_path` and `ffprobe_path` empty for most setups — auto-detection handles them. Set them when you want to:
+
+- **Run without network access**: on an air-gapped or firewalled machine that cannot reach GitHub to download the bundled build, point the settings at a locally installed ffmpeg so no download is attempted.
+- **Pin a specific build**: force the engine to use one exact ffmpeg/ffprobe rather than whichever one happens to be first on `PATH`.
+
+If you set a path that does not point at a runnable executable, the video node fails with a message naming the setting, so a typo is easy to spot.
+
+### How to Configure
+
+Open the Configuration Editor (**Settings → All Settings**), search for "ffmpeg", and set `ffmpeg_path` and `ffprobe_path` to the full paths of the executables. Both are top-level settings, so you can also set them from the environment when running headless:
+
+```bash
+GTN_CONFIG_FFMPEG_PATH=/opt/homebrew/bin/ffmpeg GTN_CONFIG_FFPROBE_PATH=/opt/homebrew/bin/ffprobe gtn
+```
+
+Restart the engine after changing either setting for it to take effect.
+
+If a video node fails while trying to download ffmpeg, see [A video node fails to download ffmpeg](../troubleshooting.md#a-video-node-fails-to-download-ffmpeg).

--- a/docs/reference/configuration_reference.md
+++ b/docs/reference/configuration_reference.md
@@ -81,6 +81,15 @@ Settings for artifact providers and preview generation
 | ----------- | ------ | ------- | ------------------------------ | ------------------------------------------------------------------- |
 | `artifacts` | object | `{}`    | n/a (nested; edit config file) | Control how previews are generated for images and other media files |
 
+## FFmpeg
+
+Locations of the ffmpeg and ffprobe binaries used for video processing
+
+| Setting        | Type   | Default | Environment variable      | Description                                                                                                                                                                                                                                                                                                              |
+| -------------- | ------ | ------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ffmpeg_path`  | string | `null`  | `GTN_CONFIG_FFMPEG_PATH`  | Absolute path to an ffmpeg executable to use for video processing. When unset, the engine uses an ffmpeg found on the system PATH, and otherwise downloads a bundled build via static-ffmpeg on first use. Set this to force a specific binary, for example on a machine with no network access to download one.         |
+| `ffprobe_path` | string | `null`  | `GTN_CONFIG_FFPROBE_PATH` | Absolute path to an ffprobe executable to use for reading video metadata. When unset, the engine uses an ffprobe found on the system PATH, and otherwise downloads a bundled build via static-ffmpeg on first use. Set this to force a specific binary, for example on a machine with no network access to download one. |
+
 ## Projects
 
 Project template configurations and registrations

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -166,6 +166,46 @@ If the logs don't show enough detail, raise the engine's log level: open the Con
 GTN_CONFIG_LOG_LEVEL=DEBUG gtn
 ```
 
+## A video node fails to download ffmpeg
+
+**Symptoms**
+
+- A video node (for example an image-to-video generation node, or any node that reads or previews a video) fails, and the engine logs an error like:
+
+    ```
+    Attempted to get ffprobe binary via static-ffmpeg for '.../temp/....mp4'.
+    Failed to fetch platform executables: 404 Client Error: Not Found for url:
+    https://media.githubusercontent.com/media/.../darwin_arm64.zip
+    ```
+
+- The download URL looks valid, and retrying sometimes works.
+
+**Cause**
+
+When the engine can't find ffmpeg and ffprobe another way, it downloads a bundled build from GitHub the first time a video node runs. That download host occasionally returns a `404` or times out under rate limiting, a network blip, or a corporate VPN, firewall, or DNS filter that blocks it. When the download can't complete, the video node fails.
+
+**Fix**
+
+1. **Run the node again.** These download failures are usually transient and clear on a second attempt.
+
+1. **Install ffmpeg yourself and let the engine use it.** The engine prefers an ffmpeg/ffprobe already on your system `PATH` over downloading one, so a normal install removes the download entirely:
+
+    - **macOS**: `brew install ffmpeg`
+    - **Linux (Debian/Ubuntu)**: `sudo apt install ffmpeg`
+    - **Windows**: install from [ffmpeg.org](https://ffmpeg.org/download.html) and add it to your `PATH`.
+
+    Restart the engine after installing so the new `PATH` is picked up.
+
+1. **Point the engine at a specific binary.** If ffmpeg isn't on your `PATH` (or you want to pin an exact build), set the `ffmpeg_path` and `ffprobe_path` settings to the full paths of the executables. Open the Configuration Editor (**Settings → All Settings**), search for "ffmpeg", and fill them in. When running headless, set them through the environment instead:
+
+    ```bash
+    GTN_CONFIG_FFMPEG_PATH=/opt/homebrew/bin/ffmpeg GTN_CONFIG_FFPROBE_PATH=/opt/homebrew/bin/ffprobe gtn
+    ```
+
+!!! note "On a locked-down network?"
+
+    If the machine can't reach `media.githubusercontent.com` at all, installing ffmpeg locally (steps 2 or 3) is the reliable fix. It skips the download completely.
+
 ## Related error-specific entries
 
 A few specific error messages are documented in the FAQ:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -173,8 +173,9 @@ GTN_CONFIG_LOG_LEVEL=DEBUG gtn
 - A video node (for example an image-to-video generation node, or any node that reads or previews a video) fails, and the engine logs an error like:
 
     ```
-    Attempted to get ffprobe binary via static-ffmpeg for '.../temp/....mp4'.
-    Failed to fetch platform executables: 404 Client Error: Not Found for url:
+    Could not locate an ffprobe binary to read video metadata for '.../temp/....mp4':
+    Attempted to download ffmpeg via static-ffmpeg because no ffmpeg/ffprobe was found
+    on PATH or in settings. Failed because: 404 Client Error: Not Found for url:
     https://media.githubusercontent.com/media/.../darwin_arm64.zip
     ```
 

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/video/preview_generators/ffmpeg_preview_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/video/preview_generators/ffmpeg_preview_generator.py
@@ -105,14 +105,11 @@ class FFmpegPreviewGenerator(BaseArtifactPreviewGenerator):
             FileNotFoundError: If ffmpeg is not installed or source file not found
             OSError: If preview generation fails
         """
-        # FAILURE CASE: ffmpeg not available
+        # FAILURE CASE: ffmpeg not available.
         # Run in a thread because the first call may download and extract the ffmpeg binary,
         # which would otherwise block the event loop long enough to disconnect WebSocket clients.
-        try:
-            ffmpeg_path = (await to_thread(resolve_ffmpeg_binaries)).ffmpeg
-        except Exception as e:
-            msg = f"Attempted to locate the ffmpeg binary. Failed because: {e}"
-            raise FileNotFoundError(msg) from e
+        # resolve_ffmpeg_binaries raises FileNotFoundError with an actionable, self-contained message.
+        ffmpeg_path = (await to_thread(resolve_ffmpeg_binaries)).ffmpeg
 
         # FAILURE CASE: source file does not exist
         source_path = anyio.Path(self.source_file_location)

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/video/preview_generators/ffmpeg_preview_generator.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/video/preview_generators/ffmpeg_preview_generator.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import anyio
 from pydantic import PositiveInt  # noqa: TC002 - Runtime validation, not type-only
-from static_ffmpeg import run as static_ffmpeg_run
 
 from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_preview_generator import (
     BaseArtifactPreviewGenerator,
@@ -18,6 +17,7 @@ from griptape_nodes.retained_mode.managers.artifact_providers.base_generator_par
     Field,
 )
 from griptape_nodes.utils.async_utils import subprocess_run, to_thread
+from griptape_nodes.utils.ffmpeg_utils import resolve_ffmpeg_binaries
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -106,12 +106,12 @@ class FFmpegPreviewGenerator(BaseArtifactPreviewGenerator):
             OSError: If preview generation fails
         """
         # FAILURE CASE: ffmpeg not available
-        # Run in a thread because the first call downloads and extracts the ffmpeg binary,
+        # Run in a thread because the first call may download and extract the ffmpeg binary,
         # which would otherwise block the event loop long enough to disconnect WebSocket clients.
         try:
-            ffmpeg_path, _ffprobe_path = await to_thread(static_ffmpeg_run.get_or_fetch_platform_executables_else_raise)
+            ffmpeg_path = (await to_thread(resolve_ffmpeg_binaries)).ffmpeg
         except Exception as e:
-            msg = f"Attempted to get ffmpeg binary via static-ffmpeg. Failed because: {e}"
+            msg = f"Attempted to locate the ffmpeg binary. Failed because: {e}"
             raise FileNotFoundError(msg) from e
 
         # FAILURE CASE: source file does not exist

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/video/video_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/video/video_artifact_provider.py
@@ -8,8 +8,6 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
-from static_ffmpeg import run as static_ffmpeg_run
-
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import (
     BaseArtifactMetadata,
@@ -24,6 +22,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointFailure,
     CheckpointSubjectType,
 )
+from griptape_nodes.utils.ffmpeg_utils import resolve_ffmpeg_binaries
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_preview_generator import (
@@ -49,7 +48,9 @@ class VideoArtifactProvider(BaseArtifactProvider):
     """Provider for video artifacts.
 
     Uses ffmpeg/ffprobe for metadata extraction and preview generation.
-    ffmpeg must be available on the system PATH.
+    Binaries are resolved via griptape_nodes.utils.ffmpeg_utils: an explicit
+    ffmpeg_path/ffprobe_path setting, then the system PATH, then a static-ffmpeg
+    download as a last resort.
     """
 
     # Minimum bytes needed for the magic-byte sniffer below. ISO BMFF brand
@@ -284,10 +285,10 @@ class VideoArtifactProvider(BaseArtifactProvider):
         to ERROR+.
         """
         try:
-            _ffmpeg_path, ffprobe_path = static_ffmpeg_run.get_or_fetch_platform_executables_else_raise()
+            ffprobe_path = resolve_ffmpeg_binaries().ffprobe
         except Exception as exc:
             logger.error(
-                "Attempted to get ffprobe binary via static-ffmpeg for '%s'. Failed to fetch platform executables: %s",
+                "Attempted to locate the ffprobe binary for '%s'. Failed because: %s",
                 source_path,
                 exc,
             )

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/video/video_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/video/video_artifact_provider.py
@@ -288,7 +288,7 @@ class VideoArtifactProvider(BaseArtifactProvider):
             ffprobe_path = resolve_ffmpeg_binaries().ffprobe
         except Exception as exc:
             logger.error(
-                "Attempted to locate the ffprobe binary for '%s'. Failed because: %s",
+                "Could not locate an ffprobe binary to read video metadata for '%s': %s",
                 source_path,
                 exc,
             )

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -23,6 +23,8 @@ WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
+FFMPEG_PATH_KEY = "ffmpeg_path"
+FFPROBE_PATH_KEY = "ffprobe_path"
 
 
 class Category(BaseModel):
@@ -48,6 +50,7 @@ STATIC_SERVER = Category(name="Static Server", description="Static file server c
 ARTIFACTS = Category(name="Artifacts", description="Settings for artifact providers and preview generation")
 AGENT = Category(name="Agent", description="Agent behavior and system prompt")
 LIBRARIES = Category(name="Libraries", description="Settings for library management and dependency installation")
+FFMPEG = Category(name="FFmpeg", description="Locations of the ffmpeg and ffprobe binaries used for video processing")
 
 
 def Field(category: str | Category = "General", **kwargs) -> Any:
@@ -480,6 +483,26 @@ class Settings(BaseModel):
         category=ARTIFACTS,
         default_factory=dict,
         description="Control how previews are generated for images and other media files",
+    )
+    ffmpeg_path: str | None = Field(
+        category=FFMPEG,
+        default=None,
+        description=(
+            "Absolute path to an ffmpeg executable to use for video processing. When unset, the engine uses an "
+            "ffmpeg found on the system PATH, and otherwise downloads a bundled build via static-ffmpeg on first "
+            "use. Set this to force a specific binary, for example on a machine with no network access to "
+            "download one."
+        ),
+    )
+    ffprobe_path: str | None = Field(
+        category=FFMPEG,
+        default=None,
+        description=(
+            "Absolute path to an ffprobe executable to use for reading video metadata. When unset, the engine "
+            "uses an ffprobe found on the system PATH, and otherwise downloads a bundled build via static-ffmpeg "
+            "on first use. Set this to force a specific binary, for example on a machine with no network access "
+            "to download one."
+        ),
     )
     project_file: str | None = Field(
         category=PROJECTS,

--- a/src/griptape_nodes/utils/ffmpeg_utils.py
+++ b/src/griptape_nodes/utils/ffmpeg_utils.py
@@ -1,0 +1,129 @@
+"""Locate the ffmpeg and ffprobe binaries used for video processing.
+
+Each binary is resolved independently, in this order:
+
+1. An explicit path from settings (``ffmpeg_path`` / ``ffprobe_path``).
+2. The system ``PATH`` (a Homebrew, apt, or manual install).
+3. ``static-ffmpeg``, which downloads a bundled build from GitHub on first use.
+
+A system binary is preferred over the ``static-ffmpeg`` download so an install
+that already has ffmpeg never depends on fetching binaries over the network, and
+so a transient download failure does not break video nodes when a usable ffmpeg
+is already present.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass
+from functools import cache
+
+from static_ffmpeg import run as static_ffmpeg_run
+
+logger = logging.getLogger("griptape_nodes")
+
+
+@dataclass(frozen=True)
+class FFmpegBinaries:
+    """Absolute paths to the resolved ffmpeg and ffprobe executables."""
+
+    ffmpeg: str
+    ffprobe: str
+
+
+def resolve_ffmpeg_binaries() -> FFmpegBinaries:
+    """Resolve ffmpeg/ffprobe, preferring configured paths, then PATH, then static-ffmpeg.
+
+    Reads the ``ffmpeg_path`` and ``ffprobe_path`` settings and delegates to the
+    cached resolver so repeated calls do not re-scan PATH or re-trigger a
+    static-ffmpeg download.
+
+    Raises:
+        FileNotFoundError: If a configured path is not an executable, or if no
+            binary is found and the static-ffmpeg download fails.
+    """
+    # Lazy import: ffmpeg_utils is a leaf util imported by the artifact providers,
+    # so reaching GriptapeNodes/ConfigManager or the settings keys at module
+    # top-level would create a cycle (ffmpeg_utils <- artifact providers <-
+    # settings <- ffmpeg_utils). file_utils.py breaks the same cycle the same way.
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.managers.settings import FFMPEG_PATH_KEY, FFPROBE_PATH_KEY
+
+    config_manager = GriptapeNodes.ConfigManager()
+    configured_ffmpeg = config_manager.get_config_value(FFMPEG_PATH_KEY)
+    configured_ffprobe = config_manager.get_config_value(FFPROBE_PATH_KEY)
+    return _resolve_ffmpeg_binaries(configured_ffmpeg, configured_ffprobe, FFMPEG_PATH_KEY, FFPROBE_PATH_KEY)
+
+
+@cache
+def _resolve_ffmpeg_binaries(
+    configured_ffmpeg: str | None,
+    configured_ffprobe: str | None,
+    ffmpeg_key: str,
+    ffprobe_key: str,
+) -> FFmpegBinaries:
+    """Resolve both binaries from the given configured paths, PATH, then static-ffmpeg.
+
+    The setting-key names are passed in rather than imported so this function
+    stays free of the settings import that would re-introduce a circular import,
+    and so it is trivially testable without engine state.
+
+    Cached on its arguments so a successful resolution is reused for the life of
+    the process. Exceptions are not cached, so a transient static-ffmpeg download
+    failure can be retried on the next call.
+
+    Raises:
+        FileNotFoundError: If a configured path is not an executable, or if no
+            binary is found and the static-ffmpeg download fails.
+    """
+    # FAILURE CASE: a configured path is set but does not point at an executable.
+    ffmpeg = _resolve_configured_binary(configured_ffmpeg, ffmpeg_key)
+    ffprobe = _resolve_configured_binary(configured_ffprobe, ffprobe_key)
+
+    # Prefer a system binary on PATH for anything not pinned in settings.
+    if ffmpeg is None:
+        ffmpeg = shutil.which("ffmpeg")
+    if ffprobe is None:
+        ffprobe = shutil.which("ffprobe")
+
+    # FAILURE CASE: still missing a binary, so fall back to the static-ffmpeg download.
+    if ffmpeg is None or ffprobe is None:
+        try:
+            static_ffmpeg_path, static_ffprobe_path = static_ffmpeg_run.get_or_fetch_platform_executables_else_raise()
+        except Exception as e:
+            msg = (
+                "Attempted to download ffmpeg via static-ffmpeg because no ffmpeg/ffprobe was found on PATH "
+                f"or in settings. Failed because: {e}. Install ffmpeg (for example 'brew install ffmpeg') and "
+                f"make sure it is on your PATH, or set the '{ffmpeg_key}' and '{ffprobe_key}' settings."
+            )
+            raise FileNotFoundError(msg) from e
+        if ffmpeg is None:
+            ffmpeg = static_ffmpeg_path
+        if ffprobe is None:
+            ffprobe = static_ffprobe_path
+
+    logger.debug("Resolved ffmpeg=%s ffprobe=%s", ffmpeg, ffprobe)
+    return FFmpegBinaries(ffmpeg=ffmpeg, ffprobe=ffprobe)
+
+
+def _resolve_configured_binary(configured_path: str | None, config_key: str) -> str | None:
+    """Return the executable for an explicitly configured path, or None if unset.
+
+    Raises:
+        FileNotFoundError: If a path is configured but does not resolve to an
+            executable file.
+    """
+    if not configured_path:
+        return None
+
+    resolved = shutil.which(configured_path)
+    # FAILURE CASE: configured but not an executable file.
+    if resolved is None:
+        msg = (
+            f"Attempted to locate an ffmpeg binary at the configured path '{configured_path}' "
+            f"(setting '{config_key}'). Failed because it is not an executable file. Point the setting at a "
+            "valid executable, or clear it to auto-detect one on PATH."
+        )
+        raise FileNotFoundError(msg)
+    return resolved

--- a/src/griptape_nodes/utils/ffmpeg_utils.py
+++ b/src/griptape_nodes/utils/ffmpeg_utils.py
@@ -78,8 +78,8 @@ def _resolve_ffmpeg_binaries(
             binary is found and the static-ffmpeg download fails.
     """
     # FAILURE CASE: a configured path is set but does not point at an executable.
-    ffmpeg = _resolve_configured_binary(configured_ffmpeg, ffmpeg_key)
-    ffprobe = _resolve_configured_binary(configured_ffprobe, ffprobe_key)
+    ffmpeg = _resolve_configured_binary(configured_ffmpeg, "ffmpeg", ffmpeg_key)
+    ffprobe = _resolve_configured_binary(configured_ffprobe, "ffprobe", ffprobe_key)
 
     # Prefer a system binary on PATH for anything not pinned in settings.
     if ffmpeg is None:
@@ -107,7 +107,7 @@ def _resolve_ffmpeg_binaries(
     return FFmpegBinaries(ffmpeg=ffmpeg, ffprobe=ffprobe)
 
 
-def _resolve_configured_binary(configured_path: str | None, config_key: str) -> str | None:
+def _resolve_configured_binary(configured_path: str | None, binary_name: str, config_key: str) -> str | None:
     """Return the executable for an explicitly configured path, or None if unset.
 
     Raises:
@@ -121,7 +121,7 @@ def _resolve_configured_binary(configured_path: str | None, config_key: str) -> 
     # FAILURE CASE: configured but not an executable file.
     if resolved is None:
         msg = (
-            f"Attempted to locate an ffmpeg binary at the configured path '{configured_path}' "
+            f"Attempted to locate the {binary_name} binary at the configured path '{configured_path}' "
             f"(setting '{config_key}'). Failed because it is not an executable file. Point the setting at a "
             "valid executable, or clear it to auto-detect one on PATH."
         )

--- a/tests/unit/retained_mode/managers/artifact_providers/video/preview_generators/test_ffmpeg_preview_generator.py
+++ b/tests/unit/retained_mode/managers/artifact_providers/video/preview_generators/test_ffmpeg_preview_generator.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -200,6 +201,31 @@ class TestFFmpegPreviewGeneratorClassMethods:
         # Verify defaults
         assert model_fields["max_width"].default == 1024  # noqa: PLR2004
         assert model_fields["max_height"].default == 1024  # noqa: PLR2004
+
+
+class TestFFmpegPreviewGeneratorBinaryResolution:
+    """Binary-resolution failures surface from preview generation."""
+
+    @pytest.mark.asyncio
+    async def test_resolver_failure_propagates_unwrapped(self, dummy_source_path: str, temp_output_dir: str) -> None:
+        """A resolver FileNotFoundError propagates verbatim, not re-wrapped in a second message."""
+        generator = FFmpegPreviewGenerator(
+            source_file_location=dummy_source_path,
+            preview_format="mp4",
+            destination_preview_directory=temp_output_dir,
+            destination_preview_file_name="output.mp4",
+            params={"max_width": 100, "max_height": 100},
+        )
+
+        target = (
+            "griptape_nodes.retained_mode.managers.artifact_providers.video.preview_generators"
+            ".ffmpeg_preview_generator.resolve_ffmpeg_binaries"
+        )
+        with (
+            patch(target, side_effect=FileNotFoundError("boom")),
+            pytest.raises(FileNotFoundError, match=r"^boom$"),
+        ):
+            await generator.attempt_generate_preview()
 
 
 @pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")

--- a/tests/unit/retained_mode/managers/artifact_providers/video/test_video_artifact_provider_ffprobe.py
+++ b/tests/unit/retained_mode/managers/artifact_providers/video/test_video_artifact_provider_ffprobe.py
@@ -1,0 +1,36 @@
+"""Coverage for VideoArtifactProvider._run_ffprobe binary resolution.
+
+The codec-vetting path calls ``_run_ffprobe`` synchronously. When no ffprobe
+binary can be resolved, it must fail closed (return ``None``) and log an error
+whose text matches what the troubleshooting docs tell users to look for.
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.retained_mode.managers.artifact_providers.video.video_artifact_provider import (
+    VideoArtifactProvider,
+)
+
+_RESOLVE_TARGET = (
+    "griptape_nodes.retained_mode.managers.artifact_providers.video.video_artifact_provider.resolve_ffmpeg_binaries"
+)
+
+
+class TestRunFfprobeBinaryResolution:
+    """``_run_ffprobe`` fails closed and logs when no ffprobe can be resolved."""
+
+    def test_returns_none_and_logs_when_resolver_fails(self, caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+        source_path = str(tmp_path / "example.mp4")
+
+        with (
+            patch(_RESOLVE_TARGET, side_effect=FileNotFoundError("no ffprobe found")),
+            caplog.at_level(logging.ERROR, logger="griptape_nodes"),
+        ):
+            result = VideoArtifactProvider._run_ffprobe(source_path)
+
+        assert result is None
+        assert "Could not locate an ffprobe binary to read video metadata for" in caplog.text

--- a/tests/unit/utils/test_ffmpeg_utils.py
+++ b/tests/unit/utils/test_ffmpeg_utils.py
@@ -165,6 +165,13 @@ class TestResolveFromConfig:
         with pytest.raises(FileNotFoundError, match="ffmpeg_path"):
             _resolve("/nope/ffmpeg", None)
 
+    def test_invalid_configured_ffprobe_path_names_ffprobe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bad ffprobe path names ffprobe (not ffmpeg) in the error, from the shared validator."""
+        monkeypatch.setattr(ffmpeg_utils.shutil, "which", _fake_which({}))
+
+        with pytest.raises(FileNotFoundError, match=r"ffprobe binary.*ffprobe_path"):
+            _resolve(None, "/nope/ffprobe")
+
 
 class TestResolvePublicApi:
     """The public entry point reads settings and delegates to the resolver."""

--- a/tests/unit/utils/test_ffmpeg_utils.py
+++ b/tests/unit/utils/test_ffmpeg_utils.py
@@ -1,0 +1,183 @@
+"""Tests for ffmpeg/ffprobe binary resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.utils import ffmpeg_utils
+from griptape_nodes.utils.ffmpeg_utils import (
+    FFmpegBinaries,
+    _resolve_ffmpeg_binaries,
+    resolve_ffmpeg_binaries,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+FFMPEG_KEY = "ffmpeg_path"
+FFPROBE_KEY = "ffprobe_path"
+
+
+@pytest.fixture(autouse=True)
+def clear_resolver_cache() -> Generator[None, None, None]:
+    """The resolver is cached on its arguments; clear it around every test."""
+    _resolve_ffmpeg_binaries.cache_clear()
+    yield
+    _resolve_ffmpeg_binaries.cache_clear()
+
+
+def _resolve(configured_ffmpeg: str | None = None, configured_ffprobe: str | None = None) -> FFmpegBinaries:
+    """Call the cached resolver with the standard setting-key names."""
+    return _resolve_ffmpeg_binaries(configured_ffmpeg, configured_ffprobe, FFMPEG_KEY, FFPROBE_KEY)
+
+
+def _fake_which(mapping: dict[str, str]) -> object:
+    """Build a shutil.which stand-in that returns paths from a name/path mapping."""
+
+    def which(cmd: str) -> str | None:
+        return mapping.get(cmd)
+
+    return which
+
+
+class TestResolveFromPath:
+    """Resolution from the system PATH."""
+
+    def test_prefers_path_binaries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When both binaries are on PATH, they are used and static-ffmpeg is not called."""
+        monkeypatch.setattr(
+            ffmpeg_utils.shutil,
+            "which",
+            _fake_which({"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": "/usr/bin/ffprobe"}),
+        )
+
+        def fail_fetch() -> tuple[str, str]:
+            pytest.fail("static-ffmpeg should not be called when PATH binaries exist")
+
+        monkeypatch.setattr(ffmpeg_utils.static_ffmpeg_run, "get_or_fetch_platform_executables_else_raise", fail_fetch)
+
+        result = _resolve()
+
+        assert result == FFmpegBinaries(ffmpeg="/usr/bin/ffmpeg", ffprobe="/usr/bin/ffprobe")
+
+    def test_missing_binary_falls_back_to_static(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ffmpeg on PATH but ffprobe missing pulls only ffprobe from static-ffmpeg."""
+        monkeypatch.setattr(
+            ffmpeg_utils.shutil,
+            "which",
+            _fake_which({"ffmpeg": "/usr/bin/ffmpeg"}),
+        )
+        monkeypatch.setattr(
+            ffmpeg_utils.static_ffmpeg_run,
+            "get_or_fetch_platform_executables_else_raise",
+            lambda: ("/static/ffmpeg", "/static/ffprobe"),
+        )
+
+        result = _resolve()
+
+        assert result == FFmpegBinaries(ffmpeg="/usr/bin/ffmpeg", ffprobe="/static/ffprobe")
+
+
+class TestResolveFromStatic:
+    """Fallback to the static-ffmpeg download."""
+
+    def test_no_binaries_uses_static(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With nothing on PATH, both binaries come from static-ffmpeg."""
+        monkeypatch.setattr(ffmpeg_utils.shutil, "which", _fake_which({}))
+        monkeypatch.setattr(
+            ffmpeg_utils.static_ffmpeg_run,
+            "get_or_fetch_platform_executables_else_raise",
+            lambda: ("/static/ffmpeg", "/static/ffprobe"),
+        )
+
+        result = _resolve()
+
+        assert result == FFmpegBinaries(ffmpeg="/static/ffmpeg", ffprobe="/static/ffprobe")
+
+    def test_static_download_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A static-ffmpeg download failure surfaces as FileNotFoundError."""
+        monkeypatch.setattr(ffmpeg_utils.shutil, "which", _fake_which({}))
+
+        def raise_fetch() -> tuple[str, str]:
+            msg = "404 Client Error"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(ffmpeg_utils.static_ffmpeg_run, "get_or_fetch_platform_executables_else_raise", raise_fetch)
+
+        with pytest.raises(FileNotFoundError, match="static-ffmpeg"):
+            _resolve()
+
+    def test_download_failure_is_not_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A transient download failure can be retried; only success is cached."""
+        monkeypatch.setattr(ffmpeg_utils.shutil, "which", _fake_which({}))
+
+        calls = {"count": 0}
+
+        def flaky_fetch() -> tuple[str, str]:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                msg = "transient network error"
+                raise RuntimeError(msg)
+            return ("/static/ffmpeg", "/static/ffprobe")
+
+        monkeypatch.setattr(ffmpeg_utils.static_ffmpeg_run, "get_or_fetch_platform_executables_else_raise", flaky_fetch)
+
+        with pytest.raises(FileNotFoundError):
+            _resolve()
+
+        result = _resolve()
+        assert result == FFmpegBinaries(ffmpeg="/static/ffmpeg", ffprobe="/static/ffprobe")
+
+
+class TestResolveFromConfig:
+    """Resolution from explicitly configured paths."""
+
+    def test_configured_paths_take_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Configured paths win over PATH, and static-ffmpeg is not called."""
+        monkeypatch.setattr(
+            ffmpeg_utils.shutil,
+            "which",
+            _fake_which(
+                {
+                    "ffmpeg": "/usr/bin/ffmpeg",
+                    "ffprobe": "/usr/bin/ffprobe",
+                    "/opt/ffmpeg": "/opt/ffmpeg",
+                    "/opt/ffprobe": "/opt/ffprobe",
+                }
+            ),
+        )
+
+        def fail_fetch() -> tuple[str, str]:
+            pytest.fail("static-ffmpeg should not be called when configured paths resolve")
+
+        monkeypatch.setattr(ffmpeg_utils.static_ffmpeg_run, "get_or_fetch_platform_executables_else_raise", fail_fetch)
+
+        result = _resolve("/opt/ffmpeg", "/opt/ffprobe")
+
+        assert result == FFmpegBinaries(ffmpeg="/opt/ffmpeg", ffprobe="/opt/ffprobe")
+
+    def test_invalid_configured_path_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A configured path that is not executable raises a clear error."""
+        monkeypatch.setattr(ffmpeg_utils.shutil, "which", _fake_which({}))
+
+        with pytest.raises(FileNotFoundError, match="ffmpeg_path"):
+            _resolve("/nope/ffmpeg", None)
+
+
+class TestResolvePublicApi:
+    """The public entry point reads settings and delegates to the resolver."""
+
+    @pytest.mark.usefixtures("griptape_nodes")
+    def test_reads_settings_and_resolves_from_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no configured paths, the public API resolves from PATH."""
+        monkeypatch.setattr(
+            ffmpeg_utils.shutil,
+            "which",
+            _fake_which({"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": "/usr/bin/ffprobe"}),
+        )
+
+        result = resolve_ffmpeg_binaries()
+
+        assert result == FFmpegBinaries(ffmpeg="/usr/bin/ffmpeg", ffprobe="/usr/bin/ffprobe")


### PR DESCRIPTION
We pull down ffmpeg from `static-ffmpeg`. If a user has a ffmpeg in their path, we should use that instead.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5181.org.readthedocs.build/en/5181/

<!-- readthedocs-preview griptape-nodes end -->