### PR TITLE
fix: enrich InvokeModel checkpoint with resolved provider and family

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -17,7 +17,9 @@ from huggingface_hub import model_info as hf_model_info
 from huggingface_hub.utils.tqdm import tqdm
 from xdg_base_dirs import xdg_data_home
 
+from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.file import File, FileWriteError
+from griptape_nodes.node_library.library_registry import get_declared_models
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
@@ -59,6 +61,7 @@ from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD_KE
 from griptape_nodes.utils.async_utils import cancel_subprocess
 
 if TYPE_CHECKING:
+    from griptape_nodes.node_library.library_declarations import ResolvedModel
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -734,11 +737,44 @@ class ModelManager:
     def _model_checkpoint_attributes(request: DeclareModelInvocationRequest) -> dict[str, Any]:
         """Resolve the facts a hook may gate a model invocation on.
 
-        `id` is the stable catalog key the node declared. The app owns the model
-        catalog and resolves the provider, family, and key support from that key,
-        mapping it onto the `Model in ModelProvider` hierarchy a policy walks via `in`.
+        `id` is the stable catalog key the node declared -- always present, so a
+        policy can gate on the bare key alone. When the declaration names its node,
+        the key is resolved against that node's declared catalog models into the
+        `provider_id` and `model_families` facts the `OfferModel` (dropdown) and
+        `InstantiateNode` checkpoints already carry, so a provider- or
+        family-scoped rule gates an invocation exactly as it gates the picker that
+        offered the model -- not only a bare-id rule. Resolution is best-effort: a
+        declaration with no node, an unregistered node, or a key absent from the
+        node's declared models falls back to the bare id.
         """
-        return {CheckpointAttribute.ID: request.model_id}
+        attributes: dict[str, Any] = {CheckpointAttribute.ID: request.model_id}
+        resolved = ModelManager._resolve_invocation_model(request)
+        if resolved is not None:
+            attributes[CheckpointAttribute.PROVIDER_ID] = resolved.provider_id
+            if resolved.model.family:
+                attributes[CheckpointAttribute.MODEL_FAMILIES] = [resolved.model.family]
+        return attributes
+
+    @staticmethod
+    def _resolve_invocation_model(request: DeclareModelInvocationRequest) -> ResolvedModel | None:
+        """Resolve a declared invocation's stable catalog key to its catalog entry.
+
+        The declaring node names itself, so the key resolves against that node's
+        declared catalog models -- the same set the node's model dropdown is built
+        from -- keeping the invocation gate consistent with the picker that offered
+        the model. Returns None when the declaration carries no node, the node is
+        not registered, or the key is not one of the node's declared models,
+        leaving the invocation gated on the bare id.
+        """
+        if request.node_name is None:
+            return None
+        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(request.node_name, BaseNode)
+        if node is None:
+            return None
+        return next(
+            (resolved for resolved in get_declared_models(node) if resolved.model_id == request.model_id),
+            None,
+        )
 
     def on_handle_declare_model_invocation_request(self, request: DeclareModelInvocationRequest) -> ResultPayload:
         """Acknowledge a node's declaration that it is about to invoke a model.
@@ -757,9 +793,11 @@ class ModelManager:
             ResultPayload: Success, meaning the node is cleared to proceed
         """
         # License-policy checkpoint: gate the declared invocation on the stable
-        # catalog key. The node already opted in by declaring; a denial returns a
-        # failure so the node does not invoke the model. Provider/family hierarchy
-        # is resolved app-side from the declared model_id.
+        # catalog key, enriched with the provider and family the key resolves to
+        # (see _model_checkpoint_attributes) so a provider- or family-scoped rule
+        # gates the invocation, not just a bare-id rule. The node already opted in
+        # by declaring; a denial returns a failure so the node does not invoke the
+        # model.
         denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.INVOKE_MODEL,

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -430,9 +430,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
 
         def deny(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
             if "GPT Image" in (checkpoint.attributes.get("model_families") or []):
-                return CheckpointDenial(
-                    failures=(CheckpointFailure(detail="GPT Image family is not in your plan."),)
-                )
+                return CheckpointDenial(failures=(CheckpointFailure(detail="GPT Image family is not in your plan."),))
             return None
 
         griptape_nodes.EventManager().add_authorization_hook(deny)

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
@@ -26,6 +27,7 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultFailure,
     SearchModelsResultSuccess,
 )
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, ModelManager
 
@@ -287,6 +289,208 @@ class TestOnHandleDeclareModelInvocationRequest:
         )
         assert isinstance(denied, DeclareModelInvocationResultFailure)
         assert "Denied by the license policy." in str(denied.result_details)
+
+
+_CATALOG_LIBRARY_NAME = "model-manager-invocation-test-library"
+
+
+class _ProbeModelNode(BaseNode):
+    """Concrete node whose declared catalog models drive invocation enrichment."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+
+
+class TestDeclareModelInvocationCatalogEnrichment:
+    """`_model_checkpoint_attributes` enriches the InvokeModel checkpoint.
+
+    The declared stable catalog key resolves against the declaring node's catalog
+    models into the same `provider_id` / `model_families` facts the OfferModel
+    (dropdown) and InstantiateNode checkpoints carry, so a provider- or
+    family-scoped policy gates an invocation the way it gates the picker.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):  # noqa: ANN202
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    @staticmethod
+    def _catalog():  # noqa: ANN205
+        from griptape_nodes.node_library.library_declarations import (
+            KeySupport,
+            Model,
+            ModelCatalogLibraryProperty,
+            ModelProvider,
+        )
+
+        return ModelCatalogLibraryProperty(
+            providers={
+                "openai": ModelProvider(
+                    display_name="OpenAI",
+                    models={
+                        "gtc_gpt_image_1_mini": Model(
+                            display_name="GPT Image 1 Mini",
+                            family="GPT Image",
+                            provider_model_id="gpt-image-1-mini",
+                            key_support=KeySupport.SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY,
+                        ),
+                    },
+                )
+            }
+        )
+
+    def _register_node(self, node_name: str) -> None:
+        """Register a library + probe node type, then a node instance the handler can resolve."""
+        from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=_CATALOG_LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t",
+                description="d",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+                declarations=[self._catalog()],
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(
+            _ProbeModelNode,
+            NodeMetadata(
+                category="t",
+                description="d",
+                display_name="Probe",
+                declarations=[ModelUsageNodeProperty(model_ids=["gtc_gpt_image_1_mini"])],
+            ),
+        )
+        node = _ProbeModelNode(
+            name=node_name,
+            metadata={"library": _CATALOG_LIBRARY_NAME, "node_type": _ProbeModelNode.__name__},
+        )
+        GriptapeNodes.ObjectManager().add_object_by_name(node_name, node)
+
+    def test_checkpoint_carries_family_and_provider_for_declared_model(
+        self,
+        griptape_nodes: GriptapeNodes,
+    ) -> None:
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+        )
+
+        self._register_node("Probe_1")
+        seen: dict[str, object] = {}
+
+        def capture(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            seen["attributes"] = dict(checkpoint.attributes)
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(capture)
+        manager = ModelManager.__new__(ModelManager)
+
+        result = manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model_id="gtc_gpt_image_1_mini", node_name="Probe_1")
+        )
+
+        assert isinstance(result, DeclareModelInvocationResultSuccess)
+        # The InvokeModel checkpoint now carries the provider and family the
+        # declared catalog key resolves to, not just the bare id.
+        assert seen["attributes"] == {
+            "id": "gtc_gpt_image_1_mini",
+            "provider_id": "openai",
+            "model_families": ["GPT Image"],
+        }
+
+    def test_family_scoped_hook_blocks_the_invocation(self, griptape_nodes: GriptapeNodes) -> None:
+        # Mirrors a license policy that forbids a family via the attribute form
+        # `resource.model_families.contains(...)`: with the family now on the
+        # InvokeModel checkpoint, that forbid fires at invocation time, not only
+        # on the dropdown query.
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+            CheckpointFailure,
+        )
+
+        self._register_node("Probe_1")
+
+        def deny(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            if "GPT Image" in (checkpoint.attributes.get("model_families") or []):
+                return CheckpointDenial(
+                    failures=(CheckpointFailure(detail="GPT Image family is not in your plan."),)
+                )
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny)
+        manager = ModelManager.__new__(ModelManager)
+
+        result = manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model_id="gtc_gpt_image_1_mini", node_name="Probe_1")
+        )
+
+        assert isinstance(result, DeclareModelInvocationResultFailure)
+        assert "GPT Image family is not in your plan." in str(result.result_details)
+
+    def test_key_absent_from_node_models_falls_back_to_bare_id(self, griptape_nodes: GriptapeNodes) -> None:
+        # A key the node does not declare cannot be enriched; the checkpoint
+        # carries only the bare id, so a family/provider rule cannot match but a
+        # bare-id rule still can.
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+        )
+
+        self._register_node("Probe_1")
+        seen: dict[str, object] = {}
+
+        def capture(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            seen["attributes"] = dict(checkpoint.attributes)
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(capture)
+        manager = ModelManager.__new__(ModelManager)
+
+        manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model_id="gtc_not_declared", node_name="Probe_1")
+        )
+
+        assert seen["attributes"] == {"id": "gtc_not_declared"}
+
+    def test_missing_node_name_falls_back_to_bare_id(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+            AuthorizationCheckpoint,
+            CheckpointDenial,
+        )
+
+        seen: dict[str, object] = {}
+
+        def capture(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            seen["attributes"] = dict(checkpoint.attributes)
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(capture)
+        manager = ModelManager.__new__(ModelManager)
+
+        manager.on_handle_declare_model_invocation_request(
+            DeclareModelInvocationRequest(model_id="gtc_gpt_image_1_mini")
+        )
+
+        # No node to resolve against -- only the bare id, as before.
+        assert seen["attributes"] == {"id": "gtc_gpt_image_1_mini"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The `InvokeModel` checkpoint was missing provider and family information meaning family/provider policies would not be enforced. This got removed in #4917 thinking it would be added by consumers of the engine. Don't know why I had this thought.