### PR TITLE
test: prevent walking entire filesystem in project manager test

### DIFF
--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -2520,6 +2520,7 @@ situations:
         parent-chain-aware loader, so inheritance resolves on boot.
         """
         from griptape_nodes.retained_mode.managers.project_manager import WORKSPACE_PROJECT_FILE
+        from griptape_nodes.retained_mode.managers.settings import PROJECTS_TO_REGISTER_KEY
 
         self._setup_system_defaults(pm, str(tmp_path))
 
@@ -2554,9 +2555,11 @@ situations:
             "  SHOW: child\n"
         )
 
-        def get_config_value_side_effect(key: str, **_: object) -> str | dict | None:
+        def get_config_value_side_effect(key: str, **_: object) -> object:
             if key == "project_file":
                 return None
+            if key == PROJECTS_TO_REGISTER_KEY:
+                return []
             if "project_workspaces" in key:
                 return {}
             return str(tmp_path)


### PR DESCRIPTION
Unlike sibling tests, the config value for `PROJECTS_TO_REGISTER_KEY` was not mocked in `test_seed_child_inherits_parent_situations_and_directories`. This meant that `tmp_path` was returned direct, rather than a list. Since a string is iterable, and the first element in `tmp_path` is `/`, the test would cause `find_files_recursive("/")"` in `_load_projects_from_directory`.

On CI this is probably tractable, given runners are sparsely populated. But on a dev machine this manifests as an apparently hung unit test.

So fix the `get_config_value` mock to return an empty list when encountering `PROJECTS_TO_REGISTER_KEY`, rather than returning a string.