### PR TITLE
test: stub clock in thread-storage sort test to fix Windows flake

### DIFF
--- a/tests/unit/drivers/test_local_thread_storage_driver.py
+++ b/tests/unit/drivers/test_local_thread_storage_driver.py
@@ -7,7 +7,10 @@ operations (rename, archive, delete, list).
 
 from __future__ import annotations
 
+import itertools
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from pydantic_ai.messages import ImageUrl, ModelMessage, ModelRequest, ModelResponse, TextPart, UserPromptPart
@@ -67,20 +70,36 @@ def test_image_url_in_user_prompt_round_trips(storage: LocalThreadStorageDriver)
 
 
 def test_list_threads_returns_message_counts_and_sorts(storage: LocalThreadStorageDriver) -> None:
-    """list_threads reports per-thread message counts and orders by recency."""
-    older_id, _ = storage.create_thread(title="older")
-    newer_id, _ = storage.create_thread(title="newer")
+    """list_threads reports per-thread message counts and orders by recency.
 
-    storage.save_history(older_id, [ModelRequest(parts=[UserPromptPart(content="Hi")])])
-    storage.save_history(
-        newer_id,
-        [
-            ModelRequest(parts=[UserPromptPart(content="Q1")]),
-            ModelResponse(parts=[TextPart(content="A1")]),
-        ],
-    )
+    The clock is stubbed so successive writes get strictly increasing timestamps.
+    This keeps the recency assertion deterministic on platforms with coarse
+    wall-clock resolution (e.g. Windows), where two real back-to-back writes can
+    otherwise land on the same tick and sort arbitrarily.
+    """
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    tick = itertools.count()
 
-    threads = storage.list_threads()
+    def increasing_now(_tz: object = None) -> datetime:
+        return base + timedelta(seconds=next(tick))
+
+    with patch("griptape_nodes.drivers.thread_storage.local_thread_storage_driver.datetime") as mock_datetime:
+        mock_datetime.now.side_effect = increasing_now
+
+        older_id, _ = storage.create_thread(title="older")
+        newer_id, _ = storage.create_thread(title="newer")
+
+        storage.save_history(older_id, [ModelRequest(parts=[UserPromptPart(content="Hi")])])
+        storage.save_history(
+            newer_id,
+            [
+                ModelRequest(parts=[UserPromptPart(content="Q1")]),
+                ModelResponse(parts=[TextPart(content="A1")]),
+            ],
+        )
+
+        threads = storage.list_threads()
+
     by_id = {t.thread_id: t for t in threads}
     assert by_id[older_id].message_count == 1
     assert by_id[newer_id].message_count == 2  # noqa: PLR2004


### PR DESCRIPTION
## Problem

`test_list_threads_returns_message_counts_and_sorts` fails intermittently on the Windows CI job (`unit-test-windows`). It surfaced as an unrelated failure on an in-flight PR (#5183), which touches only `test_project_manager.py`.

## Root cause

`list_threads()` sorts purely by the `updated_at` ISO timestamp:

`src/griptape_nodes/drivers/thread_storage/local_thread_storage_driver.py:100`
```python
threads.sort(key=lambda t: t.updated_at, reverse=True)
```

The test creates two threads and calls `save_history` on each back-to-back. On platforms with coarse wall-clock resolution (Windows, ~15ms), both `save_history` calls can land in the same tick and write identical `updated_at` timestamps, so the order between them is arbitrary and `threads[0]` isn't guaranteed to be the newer thread. Linux jobs pass because their clock granularity is fine enough to distinguish the two writes.

This is a test-only concern — for real usage, the ordering of two threads updated within the same millisecond doesn't matter.

## Fix

Stub the driver's `datetime.now` inside the test so successive writes get strictly increasing timestamps. The recency assertion is now deterministic regardless of platform clock granularity, and no `sleep` is introduced.

## Testing

- `uv run pytest tests/unit/drivers/test_local_thread_storage_driver.py` → 8 passed
- `make check` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)