### PR TITLE
fix(events): strip large blobs from events

### DIFF
--- a/docs/reference/configuration_reference.md
+++ b/docs/reference/configuration_reference.md
@@ -77,9 +77,10 @@ Static file server configuration for serving media assets
 
 Settings for artifact providers and preview generation
 
-| Setting     | Type   | Default | Environment variable           | Description                                                         |
-| ----------- | ------ | ------- | ------------------------------ | ------------------------------------------------------------------- |
-| `artifacts` | object | `{}`    | n/a (nested; edit config file) | Control how previews are generated for images and other media files |
+| Setting                       | Type    | Default  | Environment variable                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------- | ------- | -------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `artifacts`                   | object  | `{}`     | n/a (nested; edit config file)           | Control how previews are generated for images and other media files                                                                                                                                                                                                                                                                                                                                                                |
+| `max_blob_artifact_b64_bytes` | integer | `262144` | `GTN_CONFIG_MAX_BLOB_ARTIFACT_B64_BYTES` | Size threshold for blob-backed artifact values (ImageArtifact, AudioArtifact, BlobArtifact) emitted to connected clients such as the editor. Compared against the base64-encoded value length. Values above the threshold are blanked (replaced with null) in everything broadcast over the wire. This does NOT affect values returned to in-engine callers, the saved workflow file, or the value stored in engine/runtime state. |
 
 ## Projects
 

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field, is_dataclass
 from dataclasses import fields as dataclass_fields
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
+from griptape.artifacts import BlobArtifact
 from pydantic import BaseModel, ConfigDict, Field
 
 from griptape_nodes.retained_mode.events.event_converter import (
@@ -26,10 +27,6 @@ logger = logging.getLogger(__name__)
 # ExecutionEvent.dict) walks *only* tagged fields when blanking oversized blobs, i.e.
 # ``field(metadata={BLOB_FIELD_METADATA_KEY: True})``.
 BLOB_FIELD_METADATA_KEY = "may_contain_blob"
-
-# Serialized "type" strings of blob-backed griptape artifacts whose `.value` is
-# base64-encoded bytes. URL artifacts carry a small URL string and are never stripped.
-_BLOB_ARTIFACT_TYPE_NAMES = frozenset({"ImageArtifact", "AudioArtifact", "BlobArtifact"})
 
 
 def _resolve_payload_type(event_data: dict[str, Any], type_key: str) -> type:
@@ -668,10 +665,11 @@ def _blank_oversized_tagged_blob_fields(payload: Payload, serialized: dict[str, 
     if not tagged:
         return
     max_b64_bytes = _max_blob_artifact_b64_bytes()
+    type_names = _blob_artifact_type_names()
     blanked: list[tuple[str, int]] = []
     for field_name in tagged:
         if field_name in serialized:
-            blanked.extend(_blank_oversized_blobs(serialized[field_name], max_b64_bytes))
+            blanked.extend(_blank_oversized_blobs(serialized[field_name], max_b64_bytes, type_names))
     if blanked:
         # Best-effort node context: only payloads that carry a top-level ``node_name``
         # others log without it -- acceptable given the volume.
@@ -694,12 +692,37 @@ def _max_blob_artifact_b64_bytes() -> int:
     )
 
 
-def _blank_oversized_blobs(obj: dict | list, max_b64_bytes: int) -> list[tuple[str, int]]:
+def _blob_artifact_type_names() -> frozenset[str]:
+    """Names of BlobArtifact and every currently-loaded subclass.
+
+    Computed from the live class tree (rather than a maintained static list) so a
+    bytes-backed artifact type from any library -- first- or third-party, loaded
+    before or after this module -- is covered automatically. Matches by class name
+    because the serialized artifact dict (``obj.to_dict()``, see SerializableMixin)
+    carries only ``type``, not the class itself. Callers should compute this once per
+    top-level walk and thread it through, not call it per node (see _blank_oversized_blobs).
+    """
+    names = {BlobArtifact.__name__}
+    stack = [BlobArtifact]
+    while stack:
+        cls = stack.pop()
+        for sub in cls.__subclasses__():
+            if sub.__name__ not in names:
+                names.add(sub.__name__)
+                stack.append(sub)
+    return frozenset(names)
+
+
+def _blank_oversized_blobs(obj: dict | list, max_b64_bytes: int, type_names: frozenset[str]) -> list[tuple[str, int]]:
     """Blank oversized serialized blob-artifact values, in place.
 
      A serialized artifact is a dict ``{"type": "ImageArtifact"|"AudioArtifact"|
-     "BlobArtifact", "value": <b64 str>}``; over the limit its ``value`` becomes None
-     (wrapper kept so clients render a placeholder rather than a broken artifact).
+     "BlobArtifact"|..., "value": <b64 str>}`` where ``type`` names BlobArtifact or
+     one of its subclasses; over the limit its ``value`` becomes None.
+
+    ``type_names`` (from ``_blob_artifact_type_names()``) is resolved once by the
+    top-level caller and threaded through the recursion, so the class-tree walk runs
+    once per payload rather than once per node.
 
     Return (type, b64_len) per blank
     """
@@ -707,14 +730,14 @@ def _blank_oversized_blobs(obj: dict | list, max_b64_bytes: int) -> list[tuple[s
     if isinstance(obj, dict):
         value = obj.get("value")
         type_name = obj.get("type")
-        if type_name in _BLOB_ARTIFACT_TYPE_NAMES and isinstance(value, str) and len(value) > max_b64_bytes:
+        if type_name in type_names and isinstance(value, str) and len(value) > max_b64_bytes:
             obj["value"] = None
             return [(type_name, len(value))]
         for item in obj.values():
-            blanked.extend(_blank_oversized_blobs(item, max_b64_bytes))
+            blanked.extend(_blank_oversized_blobs(item, max_b64_bytes, type_names))
     elif isinstance(obj, list):
         for item in obj:
-            blanked.extend(_blank_oversized_blobs(item, max_b64_bytes))
+            blanked.extend(_blank_oversized_blobs(item, max_b64_bytes, type_names))
     return blanked
 
 

--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, is_dataclass
 from dataclasses import fields as dataclass_fields
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
     import builtins
 
 logger = logging.getLogger(__name__)
+
+# Dataclass-field metadata key marking a payload field that may carry a large
+# blob-backed artifact value (raw bytes -> base64). Serialization (EventResult.dict /
+# ExecutionEvent.dict) walks *only* tagged fields when blanking oversized blobs, i.e.
+# ``field(metadata={BLOB_FIELD_METADATA_KEY: True})``.
+BLOB_FIELD_METADATA_KEY = "may_contain_blob"
+
+# Serialized "type" strings of blob-backed griptape artifacts whose `.value` is
+# base64-encoded bytes. URL artifacts carry a small URL string and are never stripped.
+_BLOB_ARTIFACT_TYPE_NAMES = frozenset({"ImageArtifact", "AudioArtifact", "BlobArtifact"})
 
 
 def _resolve_payload_type(event_data: dict[str, Any], type_key: str) -> type:
@@ -465,7 +475,6 @@ class EventResult[P: RequestPayload, R: ResultPayload](BaseEvent, ABC):
     def dict(self, *args, **kwargs) -> dict[str, Any]:
         """Override dict to handle payload serialization."""
         result = super().dict(*args, **kwargs)
-        result["request"] = safe_unstructure(self.request)
         result_dict = safe_unstructure(self.result)
         if self.request.fields is not None and self.result.succeeded():
             tree = build_path_tree(self.request.fields)
@@ -477,6 +486,12 @@ class EventResult[P: RequestPayload, R: ResultPayload](BaseEvent, ABC):
                 if fw_field in result_dict:
                     filtered.setdefault(fw_field, result_dict[fw_field])
             result_dict = filtered
+
+        # Blank oversized blob-artifact values before this result goes over the wire.
+        request_dict = safe_unstructure(self.request)
+        _blank_oversized_tagged_blob_fields(self.request, request_dict)
+        result["request"] = request_dict
+        _blank_oversized_tagged_blob_fields(self.result, result_dict)
         result["result"] = result_dict
         if self.retained_mode:
             result["retained_mode"] = self.retained_mode
@@ -557,7 +572,11 @@ class ExecutionEvent[E: ExecutionPayload](BaseEvent):
     def dict(self, *args, **kwargs) -> dict[str, Any]:
         """Override dict to handle payload serialization."""
         result = super().dict(*args, **kwargs)
-        result["payload"] = safe_unstructure(self.payload)
+        payload_dict = safe_unstructure(self.payload)
+        # Blank oversized blob-artifact values before this event goes over the wire (see
+        # EventResult.dict).
+        _blank_oversized_tagged_blob_fields(self.payload, payload_dict)
+        result["payload"] = payload_dict
         return result
 
     def get_request(self) -> E:
@@ -634,6 +653,91 @@ class ProgressEvent:
     value: Any = field()
     node_name: str = field()
     parameter_name: str = field()
+
+
+def _blank_oversized_tagged_blob_fields(payload: Payload, serialized: dict[str, Any]) -> None:
+    """Blank oversized BlobArtifacts in payload fields.
+
+    ``serialized`` is the safe_unstructure output of ``payload``. Only fields tagged
+    with ``field(metadata={BLOB_FIELD_METADATA_KEY: True})`` are walked, so nothing else
+    is touched; the threshold is read fresh so a runtime config change takes effect.
+    """
+    if not is_dataclass(payload) or isinstance(payload, type):
+        return
+    tagged = [f.name for f in dataclass_fields(payload) if f.metadata.get(BLOB_FIELD_METADATA_KEY)]
+    if not tagged:
+        return
+    max_b64_bytes = _max_blob_artifact_b64_bytes()
+    blanked: list[tuple[str, int]] = []
+    for field_name in tagged:
+        if field_name in serialized:
+            blanked.extend(_blank_oversized_blobs(serialized[field_name], max_b64_bytes))
+    if blanked:
+        # Best-effort node context: only payloads that carry a top-level ``node_name``
+        # others log without it -- acceptable given the volume.
+        node_name = getattr(payload, "node_name", None)
+        _warn_blanked(type(payload).__name__, node_name, blanked, max_b64_bytes)
+
+
+def _max_blob_artifact_b64_bytes() -> int:
+    """Configured max base64 length for blob-artifact values sent to clients."""
+    # Lazy imports: these modules import (transitively) this one, so top-level imports would cycle.
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.managers.settings import (
+        DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES,
+        MAX_BLOB_ARTIFACT_B64_BYTES_KEY,
+    )
+
+    # cast_type=int: env-var overrides (GTN_CONFIG_MAX_BLOB_ARTIFACT_B64_BYTES) arrive as strings.
+    return GriptapeNodes.ConfigManager().get_config_value(
+        MAX_BLOB_ARTIFACT_B64_BYTES_KEY, default=DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES, cast_type=int
+    )
+
+
+def _blank_oversized_blobs(obj: dict | list, max_b64_bytes: int) -> list[tuple[str, int]]:
+    """Blank oversized serialized blob-artifact values, in place.
+
+     A serialized artifact is a dict ``{"type": "ImageArtifact"|"AudioArtifact"|
+     "BlobArtifact", "value": <b64 str>}``; over the limit its ``value`` becomes None
+     (wrapper kept so clients render a placeholder rather than a broken artifact).
+
+    Return (type, b64_len) per blank
+    """
+    blanked: list[tuple[str, int]] = []
+    if isinstance(obj, dict):
+        value = obj.get("value")
+        type_name = obj.get("type")
+        if type_name in _BLOB_ARTIFACT_TYPE_NAMES and isinstance(value, str) and len(value) > max_b64_bytes:
+            obj["value"] = None
+            return [(type_name, len(value))]
+        for item in obj.values():
+            blanked.extend(_blank_oversized_blobs(item, max_b64_bytes))
+    elif isinstance(obj, list):
+        for item in obj:
+            blanked.extend(_blank_oversized_blobs(item, max_b64_bytes))
+    return blanked
+
+
+def _warn_blanked(
+    payload_type_name: str, node_name: str | None, blanked: list[tuple[str, int]], max_b64_bytes: int
+) -> None:
+    """Log that blob artifact(s) have been stripped from a payload.
+
+    ``node_name`` names the offending node when the payload exposes it (best-effort); when it is None
+    only the payload type is reported.
+    """
+    type_names = ", ".join(sorted({type_name for type_name, _ in blanked}))
+    largest_b64_bytes = max(b64_len for _, b64_len in blanked)
+    location = f"node '{node_name}' ({payload_type_name})" if node_name else payload_type_name
+    logger.warning(
+        "Stripped %d oversized blob artifacts (%s) on %s before transmission (largest %d base64 bytes > %d limit)."
+        " See max_blob_artifact_b64_bytes setting",
+        len(blanked),
+        type_names,
+        location,
+        largest_b64_bytes,
+        max_b64_bytes,
+    )
 
 
 # Register ResultDetail subclasses (e.g. StrictModeViolationDetail) with the

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, Required, TypedDict
 
 from griptape_nodes.retained_mode.events.base_events import (
+    BLOB_FIELD_METADATA_KEY,
     ExecutionPayload,
     RequestPayload,
     ResultDetails,
@@ -390,7 +391,7 @@ class ParameterSpotlightEvent(ExecutionPayload):
 @PayloadRegistry.register
 class ControlFlowResolvedEvent(ExecutionPayload):
     end_node_name: str
-    parameter_output_values: dict
+    parameter_output_values: dict = field(metadata={BLOB_FIELD_METADATA_KEY: True})
     # Optional field for pickled parameter values - when present, parameter_output_values contains UUID references
     unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, bytes] | None = field(
         default=None
@@ -408,7 +409,7 @@ class ControlFlowCancelledEvent(ExecutionPayload):
 @PayloadRegistry.register
 class NodeResolvedEvent(ExecutionPayload):
     node_name: str
-    parameter_output_values: dict
+    parameter_output_values: dict = field(metadata={BLOB_FIELD_METADATA_KEY: True})
     node_type: str
     specific_library_name: str | None = None
 
@@ -419,7 +420,7 @@ class ParameterValueUpdateEvent(ExecutionPayload):
     node_name: str
     parameter_name: str
     data_type: str
-    value: Any
+    value: Any = field(metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 @dataclass
@@ -465,7 +466,7 @@ class GriptapeEvent(ExecutionPayload):
     node_name: str
     parameter_name: str
     type: str
-    value: Any
+    value: Any = field(metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 class NodeMetadata(TypedDict, total=False):
@@ -512,7 +513,7 @@ class ExecuteNodeRequest(RequestPayload):
     """
 
     node_name: str
-    parameter_values: dict[str, Any] = field(default_factory=dict)
+    parameter_values: dict[str, Any] = field(default_factory=dict, metadata={BLOB_FIELD_METADATA_KEY: True})
     node_metadata: NodeMetadata | None = None
     variables: dict[str, str | int] = field(default_factory=dict)
 
@@ -526,7 +527,7 @@ class ExecuteNodeResultSuccess(ResultPayloadSuccess):
         parameter_output_values: Output parameter values from the node.
     """
 
-    parameter_output_values: dict[str, Any] = field(default_factory=dict)
+    parameter_output_values: dict[str, Any] = field(default_factory=dict, metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/node_events.py
+++ b/src/griptape_nodes/retained_mode/events/node_events.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from griptape_nodes.exe_types.core_types import NodeMessagePayload
 from griptape_nodes.exe_types.node_types import NodeDependencies, NodeResolutionState
 from griptape_nodes.retained_mode.events.base_events import (
+    BLOB_FIELD_METADATA_KEY,
     RequestPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
@@ -392,7 +393,7 @@ class GetAllNodeInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess)
     node_resolution_state: str
     locked: bool
     connections: ListConnectionsForNodeResultSuccess
-    element_id_to_value: dict[str, ParameterInfoValue]
+    element_id_to_value: dict[str, ParameterInfoValue] = field(metadata={BLOB_FIELD_METADATA_KEY: True})
     root_node_element: dict[str, Any]
 
 

--- a/src/griptape_nodes/retained_mode/events/parameter_events.py
+++ b/src/griptape_nodes/retained_mode/events/parameter_events.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.retained_mode.events.base_events import (
+    BLOB_FIELD_METADATA_KEY,
     ExecutionPayload,
     RequestPayload,
     ResultPayloadFailure,
@@ -244,7 +245,7 @@ class SetParameterValueRequest(RequestPayload):
     """
 
     parameter_name: str
-    value: str | int | float | bool | dict | list | None
+    value: str | int | float | bool | dict | list | None = field(metadata={BLOB_FIELD_METADATA_KEY: True})
     # If node name is None, use the Current Context
     node_name: str | None = None
     data_type: str | None = None
@@ -268,7 +269,7 @@ class SetParameterValueResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess)
         data_type: The determined data type of the value
     """
 
-    finalized_value: Any
+    finalized_value: Any = field(metadata={BLOB_FIELD_METADATA_KEY: True})
     data_type: str
 
 
@@ -484,7 +485,7 @@ class GetParameterValueResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucce
     input_types: list[str]
     type: str
     output_type: str
-    value: Any
+    value: Any = field(metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 @dataclass
@@ -499,7 +500,7 @@ class OnParameterValueChanged(WorkflowAlteredMixin, ResultPayloadSuccess):
     node_name: str
     parameter_name: str
     data_type: str
-    value: Any
+    value: Any = field(metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 @dataclass
@@ -570,7 +571,7 @@ class GetNodeElementDetailsRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class GetNodeElementDetailsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
-    element_details: dict[str, Any]
+    element_details: dict[str, Any] = field(metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 @dataclass
@@ -583,7 +584,7 @@ class GetNodeElementDetailsResultFailure(WorkflowNotAlteredMixin, ResultPayloadF
 @dataclass
 @PayloadRegistry.register
 class AlterElementEvent(ExecutionPayload):
-    element_details: dict[str, Any]
+    element_details: dict[str, Any] = field(metadata={BLOB_FIELD_METADATA_KEY: True})
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -21,6 +21,8 @@ WORKER_HEARTBEAT_INTERVAL_KEY = "worker.heartbeat_interval_s"
 WORKER_HEARTBEAT_TIMEOUT_KEY = "worker.heartbeat_timeout_s"
 WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
+MAX_BLOB_ARTIFACT_B64_BYTES_KEY = "max_blob_artifact_b64_bytes"
+DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES = 262_144
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
 
@@ -480,6 +482,17 @@ class Settings(BaseModel):
         category=ARTIFACTS,
         default_factory=dict,
         description="Control how previews are generated for images and other media files",
+    )
+    max_blob_artifact_b64_bytes: int = Field(
+        category=ARTIFACTS,
+        default=DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES,
+        description=(
+            "Size threshold for blob-backed artifact values (ImageArtifact, AudioArtifact, BlobArtifact) emitted to"
+            " connected clients such as the editor. Compared against the base64-encoded value length. Values above the"
+            " threshold are blanked (replaced with null) in everything broadcast over the wire."
+            " This does NOT affect values returned to in-engine callers, the saved workflow file, or the value stored"
+            " in engine/runtime state."
+        ),
     )
     project_file: str | None = Field(
         category=PROJECTS,

--- a/tests/e2e/fixtures/media_bloat_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/media_bloat_library/griptape_nodes_library.json
@@ -1,0 +1,36 @@
+{
+  "name": "Media Bloat Library",
+  "library_schema_version": "0.7.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library for the workflow-bloat regression tests (issue #5177): nodes that emit large inline binary parameter values.",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "InlineBytesImageNode",
+      "file_path": "media_bloat_nodes.py",
+      "metadata": {"category": "test", "description": "emits an ImageArtifact with an inline byte payload", "display_name": "Inline Bytes Image"}
+    },
+    {
+      "class_name": "InlineBytesAudioNode",
+      "file_path": "media_bloat_nodes.py",
+      "metadata": {"category": "test", "description": "emits an AudioArtifact with an inline byte payload", "display_name": "Inline Bytes Audio"}
+    }
+  ]
+}

--- a/tests/e2e/fixtures/media_bloat_library/media_bloat_nodes.py
+++ b/tests/e2e/fixtures/media_bloat_library/media_bloat_nodes.py
@@ -1,0 +1,101 @@
+"""Fixture nodes for the workflow-bloat regression tests (issue #5177).
+
+These nodes deliberately emit *blob-backed artifacts* (`ImageArtifact`,
+`AudioArtifact`) whose `.value` holds raw bytes -- the way a user-authored media
+node might, instead of saving to storage and emitting a small URL artifact. When
+such a value is emitted to the editor (via `GetAllNodeInfo` results and the
+`NodeResolvedEvent`/`ParameterValueUpdateEvent` execution events), it is
+base64-encoded inline, producing a multi-megabyte websocket message that the cloud
+transport drops -- leaving the canvas empty. The engine's blob-size gate should
+blank such values before they are emitted.
+
+Each node's payload size is configurable via a `payload_size` property (settable
+with `SetParameterValueRequest`) so a test can bracket the configured threshold. The
+payload is prefixed with the node name so two instances produce distinct values.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape.artifacts import AudioArtifact, ImageArtifact
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+# Default raw payload (~1.5 MB), matching the oversized artifacts in the real ~9 MB
+# support-case workflow. Tests override this per node via `payload_size`.
+DEFAULT_PAYLOAD_SIZE_BYTES = 1_500_000
+
+
+def _payload(node_name: str, size_bytes: int) -> bytes:
+    """Build a distinct byte payload of ``size_bytes``, prefixed with the node name."""
+    prefix = node_name.encode()
+    filler = max(0, size_bytes - len(prefix))
+    return prefix + b"\x00" * filler
+
+
+class InlineBytesImageNode(DataNode):
+    """Emits an ImageArtifact whose ``.value`` holds raw bytes of a configurable size."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="payload_size",
+                type="int",
+                default_value=DEFAULT_PAYLOAD_SIZE_BYTES,
+                tooltip="Raw byte size of the emitted image payload",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="output_image",
+                type="ImageArtifact",
+                default_value=None,
+                tooltip="Image with an inline byte payload",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        size_bytes = self.get_parameter_value("payload_size")
+        self.parameter_output_values["output_image"] = ImageArtifact(
+            value=_payload(self.name, size_bytes),
+            format="png",
+            width=64,
+            height=64,
+        )
+
+
+class InlineBytesAudioNode(DataNode):
+    """Emits an AudioArtifact with an inline byte payload -- proves the gate is type-agnostic."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="payload_size",
+                type="int",
+                default_value=DEFAULT_PAYLOAD_SIZE_BYTES,
+                tooltip="Raw byte size of the emitted audio payload",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="output_audio",
+                type="AudioArtifact",
+                default_value=None,
+                tooltip="Audio with an inline byte payload",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        size_bytes = self.get_parameter_value("payload_size")
+        self.parameter_output_values["output_audio"] = AudioArtifact(
+            value=_payload(self.name, size_bytes),
+            format="wav",
+        )

--- a/tests/e2e/test_workflow_serialization_bloat.py
+++ b/tests/e2e/test_workflow_serialization_bloat.py
@@ -1,0 +1,529 @@
+"""Test oversized blob-artifact values are blanked on the engine→UI emit path."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.base_events import EventResult, ExecutionEvent
+from griptape_nodes.retained_mode.events.event_converter import safe_unstructure
+from griptape_nodes.retained_mode.events.execution_events import (
+    NodeResolvedEvent,
+    ParameterValueUpdateEvent,
+    StartFlowRequest,
+    StartFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    GetAllNodeInfoRequest,
+    GetAllNodeInfoResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AlterElementEvent,
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+    SetParameterValueRequest,
+    SetParameterValueResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.settings import (
+    DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES,
+    MAX_BLOB_ARTIFACT_B64_BYTES_KEY,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "media_bloat_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "media_bloat_nodes.py"
+LIBRARY_NAME = "Media Bloat Library"
+
+# Raw payload sizes chosen so their base64 length (~1.33x raw) brackets the default
+# threshold: `small` lands ~0.8x the default (under), `large` ~1.6x (over).
+DEFAULT = DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES
+SMALL_RAW = int(DEFAULT * 0.6)
+LARGE_RAW = int(DEFAULT * 1.2)
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+        reason=f"Media Bloat Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+    ),
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures("_media_bloat_library", "_clean_flow_state"),
+]
+
+
+async def test_no_oversized_blob_escapes_any_carrier() -> None:
+    """Carrier-agnostic invariant: no over-threshold blob escapes on ANY event or result.
+
+    Exercises the full lifecycle a real editor session hits — run (NodeResolvedEvent,
+    ParameterValueUpdateEvent, AlterElementEvent), set/echo the stored output back
+    (SetParameterValueResultSuccess, as workflow-load does), and hydrate the canvas
+    (GetAllNodeInfo) — then asserts nothing over the threshold reached the wire.
+
+    This is the primary RED gate and the guard against forgotten carriers: it fails until
+    every value-bearing carrier is gated, and will fail again if a new one is ever added.
+    """
+    flow_name = _create_flow("bloat_backstop_wf")
+    _create_node("InlineBytesImageNode", "ImageLarge", flow_name)
+    _set_payload_size("ImageLarge", LARGE_RAW)
+
+    with _capture_emitted() as captured:
+        await _run_node(flow_name, "ImageLarge")
+
+        # Full-resolution fetch (the escape hatch) — used only to obtain the stored value to set back.
+        full = GriptapeNodes.handle_request(
+            GetParameterValueRequest(node_name="ImageLarge", parameter_name="output_image")
+        )
+        assert isinstance(full, GetParameterValueResultSuccess), full
+
+        # Set the stored output value back, as loading a saved workflow does — echoes finalized_value.
+        set_result = GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                node_name="ImageLarge", parameter_name="output_image", value=full.value, is_output=True
+            )
+        )
+        assert isinstance(set_result, SetParameterValueResultSuccess), set_result
+
+        # Hydrate the canvas, as opening the workflow does.
+        GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageLarge"))
+
+    _assert_no_oversized_emitted(captured, DEFAULT)
+
+
+async def test_default_threshold_blanks_large_preserves_small() -> None:
+    """At the default threshold: an over-threshold image is blanked, an under-threshold one preserved.
+
+    Asserted across the live-run event carriers (NodeResolvedEvent, ParameterValueUpdateEvent,
+    AlterElementEvent) and canvas hydration (GetAllNodeInfo).
+    """
+    flow_name = _create_flow("bloat_default_wf")
+    _create_node("InlineBytesImageNode", "ImageSmall", flow_name)
+    _create_node("InlineBytesImageNode", "ImageLarge", flow_name)
+    _set_payload_size("ImageSmall", SMALL_RAW)
+    _set_payload_size("ImageLarge", LARGE_RAW)
+
+    with _capture_emitted() as captured:
+        await _run_node(flow_name, "ImageSmall")
+        await _run_node(flow_name, "ImageLarge")
+        GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageSmall"))
+        GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageLarge"))
+
+    small_resolved = _latest_event(captured, NodeResolvedEvent, node_name="ImageSmall")
+    small_update = _latest_event(
+        captured, ParameterValueUpdateEvent, node_name="ImageSmall", parameter_name="output_image"
+    )
+    small_alter = _latest_event(captured, AlterElementEvent, node_name="ImageSmall")
+    _assert_preserved(_blob_value(small_resolved, "ImageArtifact"), "small NodeResolvedEvent")
+    _assert_preserved(_blob_value(small_update, "ImageArtifact"), "small ParameterValueUpdateEvent")
+    _assert_preserved(_blob_value(small_alter, "ImageArtifact"), "small AlterElementEvent")
+    _assert_preserved(_node_info_value(captured, "ImageSmall", "ImageArtifact"), "small GetAllNodeInfo")
+
+    large_resolved = _latest_event(captured, NodeResolvedEvent, node_name="ImageLarge")
+    large_update = _latest_event(
+        captured, ParameterValueUpdateEvent, node_name="ImageLarge", parameter_name="output_image"
+    )
+    large_alter = _latest_event(captured, AlterElementEvent, node_name="ImageLarge")
+    _assert_blanked(_blob_value(large_resolved, "ImageArtifact"), "large NodeResolvedEvent")
+    _assert_blanked(_blob_value(large_update, "ImageArtifact"), "large ParameterValueUpdateEvent")
+    _assert_blanked(_blob_value(large_alter, "ImageArtifact"), "large AlterElementEvent")
+    _assert_blanked(_node_info_value(captured, "ImageLarge", "ImageArtifact"), "large GetAllNodeInfo")
+
+
+async def test_low_threshold_blanks_both() -> None:
+    """A threshold below both payloads blanks both images across the run carriers and GetAllNodeInfo."""
+    flow_name = _create_flow("bloat_low_wf")
+    _create_node("InlineBytesImageNode", "ImageSmall", flow_name)
+    _create_node("InlineBytesImageNode", "ImageLarge", flow_name)
+    _set_payload_size("ImageSmall", SMALL_RAW)
+    _set_payload_size("ImageLarge", LARGE_RAW)
+
+    # Stripping reads the threshold at serialization time (.dict()), and the wire helpers call .dict()
+    # in the assertions -- so the assertions must run while the override is still active.
+    with _threshold_override(int(DEFAULT * 0.5)):
+        with _capture_emitted() as captured:
+            await _run_node(flow_name, "ImageSmall")
+            await _run_node(flow_name, "ImageLarge")
+            GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageSmall"))
+            GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageLarge"))
+
+        _assert_blanked(
+            _blob_value(_latest_event(captured, AlterElementEvent, node_name="ImageSmall"), "ImageArtifact"),
+            "small AlterElementEvent",
+        )
+        _assert_blanked(_node_info_value(captured, "ImageSmall", "ImageArtifact"), "small GetAllNodeInfo")
+        _assert_blanked(
+            _blob_value(_latest_event(captured, AlterElementEvent, node_name="ImageLarge"), "ImageArtifact"),
+            "large AlterElementEvent",
+        )
+        _assert_blanked(_node_info_value(captured, "ImageLarge", "ImageArtifact"), "large GetAllNodeInfo")
+
+
+async def test_high_threshold_preserves_both() -> None:
+    """A threshold above both payloads preserves both images across the run carriers and GetAllNodeInfo."""
+    flow_name = _create_flow("bloat_high_wf")
+    _create_node("InlineBytesImageNode", "ImageSmall", flow_name)
+    _create_node("InlineBytesImageNode", "ImageLarge", flow_name)
+    _set_payload_size("ImageSmall", SMALL_RAW)
+    _set_payload_size("ImageLarge", LARGE_RAW)
+
+    # The wire helpers call .dict() (where stripping reads the threshold) in the assertions, so keep
+    # them inside the override.
+    with _threshold_override(DEFAULT * 2):
+        with _capture_emitted() as captured:
+            await _run_node(flow_name, "ImageSmall")
+            await _run_node(flow_name, "ImageLarge")
+            GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageSmall"))
+            GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="ImageLarge"))
+
+        _assert_preserved(
+            _blob_value(_latest_event(captured, AlterElementEvent, node_name="ImageSmall"), "ImageArtifact"),
+            "small AlterElementEvent",
+        )
+        _assert_preserved(_node_info_value(captured, "ImageSmall", "ImageArtifact"), "small GetAllNodeInfo")
+        _assert_preserved(
+            _blob_value(_latest_event(captured, AlterElementEvent, node_name="ImageLarge"), "ImageArtifact"),
+            "large AlterElementEvent",
+        )
+        _assert_preserved(_node_info_value(captured, "ImageLarge", "ImageArtifact"), "large GetAllNodeInfo")
+
+
+async def test_get_parameter_value_returns_full_to_caller_but_blanked_on_wire() -> None:
+    """GetParameterValue is NOT exempt: its broadcast copy is blanked like any other wire response.
+
+    The object returned in-process keeps the full value (engine/library code that calls it directly
+    relies on that), but the copy that goes over the wire is blanked -- a large response would
+    overwhelm the transport regardless of which request produced it.
+    """
+    flow_name = _create_flow("bloat_get_param_wf")
+    _create_node("InlineBytesImageNode", "ImageLarge", flow_name)
+    _set_payload_size("ImageLarge", LARGE_RAW)
+    await _run_node(flow_name, "ImageLarge")
+
+    with _capture_emitted() as captured:
+        result = GriptapeNodes.handle_request(
+            GetParameterValueRequest(node_name="ImageLarge", parameter_name="output_image")
+        )
+    assert isinstance(result, GetParameterValueResultSuccess), result
+
+    # The in-process return value keeps the full value...
+    _assert_preserved(_blob_value(safe_unstructure(result), "ImageArtifact"), "returned GetParameterValue")
+    # ...but the broadcast copy on the wire is blanked.
+    broadcast = _latest_broadcast_result(
+        captured, GetParameterValueResultSuccess, node_name="ImageLarge", parameter_name="output_image"
+    )
+    _assert_blanked(_blob_value(broadcast, "ImageArtifact"), "broadcast GetParameterValue")
+
+
+async def test_audio_artifact_also_blanked() -> None:
+    """The gate is type-agnostic: an over-threshold AudioArtifact is blanked too, not just images."""
+    flow_name = _create_flow("bloat_audio_wf")
+    _create_node("InlineBytesAudioNode", "AudioLarge", flow_name)
+    _set_payload_size("AudioLarge", LARGE_RAW)
+
+    with _capture_emitted() as captured:
+        await _run_node(flow_name, "AudioLarge")
+        GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name="AudioLarge"))
+
+    _assert_blanked(
+        _blob_value(_latest_event(captured, AlterElementEvent, node_name="AudioLarge"), "AudioArtifact"),
+        "audio AlterElementEvent",
+    )
+    _assert_blanked(_node_info_value(captured, "AudioLarge", "AudioArtifact"), "audio GetAllNodeInfo")
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+def _create_node(node_type: str, node_name: str, flow_name: str) -> str:
+    result = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY_NAME,
+            node_name=node_name,
+            override_parent_flow_name=flow_name,
+        )
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _set_payload_size(node_name: str, size_bytes: int) -> None:
+    result = GriptapeNodes.handle_request(
+        SetParameterValueRequest(parameter_name="payload_size", node_name=node_name, value=size_bytes)
+    )
+    assert isinstance(result, SetParameterValueResultSuccess), result
+
+
+async def _run_node(flow_name: str, node_name: str) -> None:
+    result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=flow_name,
+            flow_node_name=node_name,
+            wait_for_completion=True,
+            completion_timeout_ms=30_000,
+        )
+    )
+    assert isinstance(result, StartFlowResultSuccess), result
+
+
+@pytest.fixture(scope="module")
+def _media_bloat_library(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Register the fixture library once for the module (ClearAllObjectState leaves libraries intact)."""
+    library_json = _materialize_library(tmp_path_factory.mktemp("media_bloat_library"))
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    try:
+        yield
+    finally:
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        with contextlib.suppress(KeyError):
+            LibraryRegistry.unregister_library(LIBRARY_NAME)
+
+
+@pytest.fixture
+def _clean_flow_state() -> Iterator[None]:
+    """Clear flows/nodes before and after each test, leaving the library registered."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    try:
+        yield
+    finally:
+        clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
+
+
+def _create_flow(workflow_name: str) -> str:
+    GriptapeNodes.ContextManager().push_workflow(workflow_name=workflow_name)
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="TestFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    return flow_result.flow_name
+
+
+@dataclass
+class _Captured:
+    """The wrapped events the engine put on the broadcast queue during a scenario.
+
+    We keep the wrapped ExecutionEvent / EventResult objects and serialize them via their real
+    ``.dict()`` -- which is where blob stripping now happens -- to inspect exactly what goes over the
+    wire. We do NOT inspect the objects returned from handle_request: those keep their full values,
+    because stripping runs only on the disposable serialized dict.
+    """
+
+    execution_events: list[ExecutionEvent] = field(default_factory=list)
+    result_events: list[EventResult] = field(default_factory=list)
+
+
+@contextlib.contextmanager
+def _capture_emitted() -> Iterator[_Captured]:
+    """Capture everything the engine broadcasts by draining the EventManager queue.
+
+    put_event/aput_event early-return (skipping dispatch) when the queue is None, so we install a
+    fresh queue for the duration and drain it afterwards. Any request whose result should be
+    inspected must be issued INSIDE this block so its broadcast lands on the queue.
+    """
+    event_manager = GriptapeNodes.EventManager()
+    # Snapshot/restore the queue so we don't leave a live queue installed on the singleton, which
+    # would defeat the None-queue broadcast suppression other tests rely on. There's no public
+    # restore: initialize_queue(None) *creates* a fresh queue rather than clearing it.
+    previous_queue = event_manager._event_queue
+    queue: asyncio.Queue = asyncio.Queue()
+    event_manager.initialize_queue(queue)
+    captured = _Captured()
+    try:
+        yield captured
+    finally:
+        event_manager._event_queue = previous_queue
+        while not queue.empty():
+            wrapped = getattr(queue.get_nowait(), "wrapped_event", None)
+            if isinstance(wrapped, ExecutionEvent):
+                captured.execution_events.append(wrapped)
+            elif isinstance(wrapped, EventResult):
+                captured.result_events.append(wrapped)
+
+
+def _wire_payload(execution_event: ExecutionEvent) -> Any:
+    """The serialized payload as it goes over the wire -- blob stripping runs inside ExecutionEvent.dict()."""
+    return execution_event.dict()["payload"]
+
+
+def _wire_result(result_event: EventResult) -> Any:
+    """The serialized result as it goes over the wire -- blob stripping runs inside EventResult.dict()."""
+    return result_event.dict()["result"]
+
+
+@contextlib.contextmanager
+def _threshold_override(value: int) -> Iterator[None]:
+    """Temporarily set max_blob_artifact_b64_bytes, restoring the previous value afterward."""
+    config_manager = GriptapeNodes.ConfigManager()
+    original = config_manager.get_config_value(MAX_BLOB_ARTIFACT_B64_BYTES_KEY, default=DEFAULT)
+    config_manager.set_config_value(MAX_BLOB_ARTIFACT_B64_BYTES_KEY, value)
+    try:
+        yield
+    finally:
+        config_manager.set_config_value(MAX_BLOB_ARTIFACT_B64_BYTES_KEY, original)
+
+
+def _wire_frame_size(event: Any) -> int:
+    """Byte length of the full serialized wire frame for an event -- what the transport actually sends."""
+    return len(json.dumps(event.dict(), default=str))
+
+
+def _wire_label(event: Any) -> str:
+    """A short label identifying an event by its inner payload/result type, for failure messages."""
+    inner = getattr(event, "result", None)
+    if inner is None:
+        inner = getattr(event, "payload", None)
+    return f"{type(event).__name__}[{type(inner).__name__}]" if inner is not None else type(event).__name__
+
+
+def _assert_no_oversized_emitted(captured: _Captured, max_frame_bytes: int) -> None:
+    """The invariant: no emitted event serializes to a wire frame larger than the threshold.
+
+    Measures the size of the *entire* serialized event (the real ``.dict()`` -> JSON, exactly what the
+    transport sends), not specific artifact fields -- so it catches any oversized content regardless
+    of where or how it is nested, and can't be fooled by a blob the field walker doesn't recognize.
+    A frame whose blobs were all stripped is a few KB; an unstripped oversized blob pushes the frame
+    past the threshold.
+    """
+    offenders = [
+        f"{_wire_label(event)}: {size} bytes > {max_frame_bytes}"
+        for event in (*captured.execution_events, *captured.result_events)
+        if (size := _wire_frame_size(event)) > max_frame_bytes
+    ]
+    assert not offenders, "oversized wire frame(s) escaped the engine:\n  " + "\n  ".join(offenders)
+
+
+def _event_node_name(payload: Any) -> Any:
+    """The owning node name for an event, whether a top-level attr or nested in element_details."""
+    name = getattr(payload, "node_name", None)
+    if name is not None:
+        return name
+    details = getattr(payload, "element_details", None)
+    if isinstance(details, dict):
+        return details.get("node_name")
+    return None
+
+
+def _latest_event(captured: _Captured, event_type: type, **match: Any) -> Any:
+    """Return the wire-serialized payload of the most recent captured execution event matching attrs.
+
+    ``node_name`` is matched via ``_event_node_name`` so it works for AlterElementEvent (which
+    carries the node name inside ``element_details``); other keys match top-level attributes.
+    """
+    wanted_node = match.pop("node_name", None)
+    for execution_event in reversed(captured.execution_events):
+        payload = execution_event.payload
+        if not isinstance(payload, event_type):
+            continue
+        if wanted_node is not None and _event_node_name(payload) != wanted_node:
+            continue
+        if all(getattr(payload, k, None) == v for k, v in match.items()):
+            return _wire_payload(execution_event)
+    msg = f"No {event_type.__name__} captured matching node_name={wanted_node}, {match}"
+    raise AssertionError(msg)
+
+
+def _latest_broadcast_result(captured: _Captured, result_type: type, **request_match: Any) -> Any:
+    """Return the wire-serialized result of the most recent broadcast result event of a type.
+
+    Matches on the originating request's attributes (e.g. node_name), so the caller must have
+    issued the request INSIDE the _capture_emitted block.
+    """
+    for result_event in reversed(captured.result_events):
+        if not isinstance(result_event.result, result_type):
+            continue
+        request = result_event.request
+        if all(getattr(request, key, None) == value for key, value in request_match.items()):
+            return _wire_result(result_event)
+    msg = f"No {result_type.__name__} broadcast captured matching {request_match}"
+    raise AssertionError(msg)
+
+
+def _node_info_value(captured: _Captured, node_name: str, artifact_type: str) -> Any:
+    """The blob value (or None if blanked) the broadcast GetAllNodeInfo carried for a node's artifact.
+
+    GetAllNodeInfoRequest must have been issued inside the _capture_emitted block.
+    """
+    serialized = _latest_broadcast_result(captured, GetAllNodeInfoResultSuccess, node_name=node_name)
+    return _blob_value(serialized, artifact_type)
+
+
+_MISSING = object()
+
+
+def _search_artifact_value(serialized: Any, artifact_type: str) -> Any:
+    """Return the first blob-artifact *leaf* value of the given type, or _MISSING.
+
+    Matches an artifact dict only when its ``value`` is a leaf (base64 str, or None when
+    blanked) — not a nested dict/list. This avoids colliding with payloads that carry their
+    own ``type`` field (e.g. GetParameterValueResultSuccess.type == "ImageArtifact", whose
+    ``value`` holds the artifact dict). Returns None (not _MISSING) when the artifact is
+    present but blanked, so callers can distinguish "blanked" from "absent".
+    """
+    if isinstance(serialized, dict):
+        value = serialized.get("value")
+        if serialized.get("type") == artifact_type and not isinstance(value, (dict, list)):
+            return value
+        for child in serialized.values():
+            found = _search_artifact_value(child, artifact_type)
+            if found is not _MISSING:
+                return found
+    elif isinstance(serialized, list):
+        for child in serialized:
+            found = _search_artifact_value(child, artifact_type)
+            if found is not _MISSING:
+                return found
+    return _MISSING
+
+
+def _blob_value(serialized: Any, artifact_type: str) -> Any:
+    """The base64 value (or None if blanked) of the first blob artifact of the given type; raises if absent."""
+    found = _search_artifact_value(serialized, artifact_type)
+    if found is _MISSING:
+        msg = f"no {artifact_type} artifact found in serialized structure"
+        raise AssertionError(msg)
+    return found
+
+
+def _assert_blanked(value: Any, where: str) -> None:
+    assert value is None, f"{where}: value not blanked (len={len(value) if isinstance(value, str) else value!r})"
+
+
+def _assert_preserved(value: Any, where: str) -> None:
+    assert isinstance(value, str), f"{where}: value not preserved (got {type(value)})"
+    assert value, f"{where}: value unexpectedly empty"

--- a/tests/unit/retained_mode/events/test_base_events.py
+++ b/tests/unit/retained_mode/events/test_base_events.py
@@ -1,24 +1,63 @@
 """Tests for RequestPayload base class broadcast_result behavior."""
 
+import importlib
 import logging
+import pkgutil
+from collections.abc import Callable
+from dataclasses import dataclass, field, fields, is_dataclass
+from typing import Any
+from unittest.mock import Mock
 
 import pytest
+from griptape.artifacts import AudioArtifact, BlobArtifact, ImageArtifact
 
 from griptape_nodes.retained_mode.events.base_events import (
+    _BLOB_ARTIFACT_TYPE_NAMES,
+    BLOB_FIELD_METADATA_KEY,
     EventResultFailure,
     EventResultSuccess,
+    ExecutionEvent,
     RequestPayload,
     ResultDetail,
     ResultDetails,
+    ResultPayloadSuccess,
     StrictModeViolationDetail,
+    _blank_oversized_blobs,
+    _blank_oversized_tagged_blob_fields,
+    _max_blob_artifact_b64_bytes,
+    _warn_blanked,
 )
-from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.connection_events import ListConnectionsForNodeResultSuccess
+from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
+from griptape_nodes.retained_mode.events.execution_events import (
+    ControlFlowResolvedEvent,
+    ExecuteNodeRequest,
+    ExecuteNodeResultSuccess,
+    GriptapeEvent,
+    NodeResolvedEvent,
+    ParameterValueUpdateEvent,
+)
+from griptape_nodes.retained_mode.events.node_events import GetAllNodeInfoResultSuccess
 from griptape_nodes.retained_mode.events.os_events import ReadFileRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AlterElementEvent,
+    GetNodeElementDetailsResultSuccess,
+    GetParameterValueResultSuccess,
+    OnParameterValueChanged,
+    SetParameterValueRequest,
+    SetParameterValueResultSuccess,
+)
 from griptape_nodes.retained_mode.events.path_filter import apply_path_tree, build_path_tree
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
     GetAllSituationsForProjectRequest,
     GetAllSituationsForProjectResultFailure,
     GetAllSituationsForProjectResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+from griptape_nodes.retained_mode.managers.settings import (
+    DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES,
+    MAX_BLOB_ARTIFACT_B64_BYTES_KEY,
 )
 
 
@@ -256,3 +295,406 @@ class TestEventResultDictFiltering:
         with caplog.at_level(logging.WARNING):
             self._success(fields=["situatons"])  # typo
         assert any("situatons" in r.message and "not found" in r.message for r in caplog.records)
+
+
+# Single source of truth for blob-carrying payloads. Each entry maps a payload type to:
+#   - a factory that builds an instance with the given blob artifact in its tagged field, and
+#   - the key-path from the serialized payload down to that artifact's base64 ``value``.
+_BLOB_CASE_BUILDERS: dict[type, tuple[Callable[[Any], Any], tuple[str, ...]]] = {
+    NodeResolvedEvent: (
+        lambda a: NodeResolvedEvent(node_name="n", parameter_output_values={"out": a}, node_type="T"),
+        ("parameter_output_values", "out", "value"),
+    ),
+    ParameterValueUpdateEvent: (
+        lambda a: ParameterValueUpdateEvent(node_name="n", parameter_name="p", data_type="ImageArtifact", value=a),
+        ("value", "value"),
+    ),
+    ControlFlowResolvedEvent: (
+        lambda a: ControlFlowResolvedEvent(end_node_name="n", parameter_output_values={"out": a}),
+        ("parameter_output_values", "out", "value"),
+    ),
+    GriptapeEvent: (
+        lambda a: GriptapeEvent(node_name="n", parameter_name="p", type="event", value=a),
+        ("value", "value"),
+    ),
+    AlterElementEvent: (
+        lambda a: AlterElementEvent(element_details={"node_name": "n", "value": a}),
+        ("element_details", "value", "value"),
+    ),
+    SetParameterValueResultSuccess: (
+        lambda a: SetParameterValueResultSuccess(finalized_value=a, data_type="ImageArtifact", result_details="ok"),
+        ("finalized_value", "value"),
+    ),
+    GetParameterValueResultSuccess: (
+        lambda a: GetParameterValueResultSuccess(
+            input_types=["ImageArtifact"],
+            type="ImageArtifact",
+            output_type="ImageArtifact",
+            value=a,
+            result_details="ok",
+        ),
+        ("value", "value"),
+    ),
+    GetNodeElementDetailsResultSuccess: (
+        lambda a: GetNodeElementDetailsResultSuccess(element_details={"value": a}, result_details="ok"),
+        ("element_details", "value", "value"),
+    ),
+    GetAllNodeInfoResultSuccess: (
+        lambda a: GetAllNodeInfoResultSuccess(
+            metadata={},
+            node_resolution_state="",
+            locked=False,
+            connections=ListConnectionsForNodeResultSuccess(
+                incoming_connections=[], outgoing_connections=[], result_details="ok"
+            ),
+            element_id_to_value={"e1": a},
+            root_node_element={},
+            result_details="ok",
+        ),
+        ("element_id_to_value", "e1", "value"),
+    ),
+    ExecuteNodeResultSuccess: (
+        lambda a: ExecuteNodeResultSuccess(parameter_output_values={"out": a}, result_details="ok"),
+        ("parameter_output_values", "out", "value"),
+    ),
+    OnParameterValueChanged: (
+        lambda a: OnParameterValueChanged(
+            node_name="n", parameter_name="p", data_type="ImageArtifact", value=a, result_details="ok"
+        ),
+        ("value", "value"),
+    ),
+    # Requests carry blobs too: the result echoes the request back to clients, so its value-bearing
+    # fields are tagged and stripped in EventResult.dict() (not EventRequest.dict()).
+    SetParameterValueRequest: (
+        lambda a: SetParameterValueRequest(parameter_name="p", value=a, node_name="n"),
+        ("value", "value"),
+    ),
+    ExecuteNodeRequest: (
+        lambda a: ExecuteNodeRequest(node_name="n", parameter_values={"p": a}),
+        ("parameter_values", "p", "value"),
+    ),
+}
+# Per-case parametrize ids (payload type names, in dict order).
+_BLOB_TAGGED_FIELD_IDS = [payload_type.__name__ for payload_type in _BLOB_CASE_BUILDERS]
+
+
+@dataclass(kw_only=True)
+class _TaggedResult(ResultPayloadSuccess):
+    """A result with one blob-tagged field and one untagged field, for _strip_tagged_blob_fields tests."""
+
+    tagged: Any = field(default=None, metadata={BLOB_FIELD_METADATA_KEY: True})
+    untagged: Any = None
+
+
+@dataclass(kw_only=True)
+class _UntaggedResult(ResultPayloadSuccess):
+    """A result with no blob-tagged fields (nothing to strip)."""
+
+    plain: Any = None
+
+
+class TestBlankOversizedBlobs:
+    """The in-place walker over a freshly-serialized structure."""
+
+    def test_over_threshold_blanked_in_place(self) -> None:
+        for type_name in _BLOB_ARTIFACT_TYPE_NAMES:
+            artifact = {"type": type_name, "value": "A" * 200, "format": "png"}
+            blanked = _blank_oversized_blobs(artifact, max_b64_bytes=100)
+            assert blanked == [(type_name, 200)]
+            assert artifact["value"] is None
+            assert artifact["type"] == type_name  # wrapper + metadata kept
+            assert artifact["format"] == "png"
+
+    def test_under_threshold_preserved(self) -> None:
+        artifact = _blob_artifact(50)
+        assert _blank_oversized_blobs(artifact, max_b64_bytes=100) == []
+        assert artifact["value"] == "A" * 50
+
+    def test_non_blob_and_plain_string_untouched(self) -> None:
+        url = {"type": "ImageUrlArtifact", "value": "http://x/" + "a" * 500}
+        text = {"type": "TextArtifact", "value": "z" * 500}
+        plain = {"some_field": "x" * 1000}
+        for obj in (url, text, plain):
+            assert _blank_oversized_blobs(obj, max_b64_bytes=100) == []
+        assert url["value"].startswith("http://")
+        assert text["value"] == "z" * 500
+
+    def test_nested_dicts_and_lists_walked(self) -> None:
+        payload = {"e1": _blob_artifact(300), "e2": _blob_artifact(10), "nested": {"deep": [_blob_artifact(300)]}}
+        blanked = _blank_oversized_blobs(payload, max_b64_bytes=100)
+        assert sorted(blanked) == [("ImageArtifact", 300), ("ImageArtifact", 300)]
+        assert payload["e1"]["value"] is None
+        assert payload["e2"]["value"] == "A" * 10
+        assert payload["nested"]["deep"][0]["value"] is None
+
+    def test_non_string_value_ignored(self) -> None:
+        artifact = {"type": "ImageArtifact", "value": None}
+        assert _blank_oversized_blobs(artifact, max_b64_bytes=100) == []
+
+
+class TestStripTaggedBlobFields:
+    """Only fields carrying the blob tag are walked."""
+
+    def test_only_tagged_fields_are_walked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = _TaggedResult(tagged=None, untagged=None, result_details="ok")
+        serialized = {"tagged": _blob_artifact(300), "untagged": _blob_artifact(300)}
+        _mock_blob_threshold(monkeypatch, 100)
+
+        _blank_oversized_tagged_blob_fields(payload, serialized)
+
+        assert serialized["tagged"]["value"] is None
+        assert serialized["untagged"]["value"] == "A" * 300  # untagged field never inspected
+
+    def test_payload_without_tagged_fields_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No blob-tagged fields -> return before even reading the threshold.
+        threshold = Mock()
+        monkeypatch.setattr("griptape_nodes.retained_mode.events.base_events._max_blob_artifact_b64_bytes", threshold)
+        _blank_oversized_tagged_blob_fields(_UntaggedResult(plain="x", result_details="ok"), {"plain": "A" * 500})
+        threshold.assert_not_called()
+
+    def test_non_dataclass_payload_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Defensive guard: a non-dataclass, or a dataclass *class* rather than an instance,
+        # must be ignored (no field introspection, no mutation) rather than crash serialization.
+        threshold = Mock()
+        monkeypatch.setattr("griptape_nodes.retained_mode.events.base_events._max_blob_artifact_b64_bytes", threshold)
+        serialized = {"tagged": _blob_artifact(500)}
+
+        not_a_dataclass: Any = object()
+        _blank_oversized_tagged_blob_fields(not_a_dataclass, serialized)
+
+        dataclass_type: Any = _TaggedResult  # the class object, not an instance
+        _blank_oversized_tagged_blob_fields(dataclass_type, serialized)
+
+        assert serialized["tagged"]["value"] == "A" * 500  # untouched
+        threshold.assert_not_called()
+
+    def test_warning_names_the_node_when_payload_exposes_it(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # payload.node_name (best-effort) flows into the warning to point users at the offending node.
+        _mock_blob_threshold(monkeypatch, 100)
+        payload = NodeResolvedEvent(node_name="MyNode", parameter_output_values={}, node_type="T")
+        with caplog.at_level(logging.WARNING):
+            _blank_oversized_tagged_blob_fields(payload, {"parameter_output_values": {"out": _blob_artifact(300)}})
+        assert "MyNode" in caplog.records[-1].getMessage()
+
+
+class TestMaxBlobArtifactB64Bytes:
+    def test_reads_setting_with_documented_key_default_and_cast(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config_manager = _mock_blob_threshold(monkeypatch, 4242)
+        assert _max_blob_artifact_b64_bytes() == 4242  # noqa: PLR2004
+        config_manager.get_config_value.assert_called_once_with(
+            MAX_BLOB_ARTIFACT_B64_BYTES_KEY, default=DEFAULT_MAX_BLOB_ARTIFACT_B64_BYTES, cast_type=int
+        )
+
+
+class TestWarnBlanked:
+    """A WARNING is logged for every blanking (not deduped); the node name appears when known."""
+
+    def test_warns_each_call_with_node_and_details(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            _warn_blanked("SetParameterValueResultSuccess", "GenerateImage", [("ImageArtifact", 500)], 100)
+            _warn_blanked("NodeResolvedEvent", "LoadAudio", [("AudioArtifact", 900)], 100)
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warns) == 2  # noqa: PLR2004 -- one per blanking, not deduped
+        first = warns[0].getMessage()
+        assert "GenerateImage" in first
+        assert "ImageArtifact" in first
+        assert "500" in first
+        assert "max_blob_artifact_b64_bytes" in first
+        assert "LoadAudio" in warns[1].getMessage()
+
+    def test_omits_node_clause_when_unknown(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            _warn_blanked("GetAllNodeInfoResultSuccess", None, [("ImageArtifact", 500)], 100)
+        message = caplog.records[-1].getMessage()
+        assert "node '" not in message  # no node clause when node_name is None
+        assert "GetAllNodeInfoResultSuccess" in message
+
+
+class TestSerializationBlanksBlobs:
+    """The integration: .dict() blanks oversized blob-tagged fields on the wire form only."""
+
+    def test_event_result_dict_blanks_but_leaves_in_memory_result_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_blob_threshold(monkeypatch, 100)
+        image = ImageArtifact(value=b"\x00" * 300, format="png", width=1, height=1)
+        result = SetParameterValueResultSuccess(finalized_value=image, data_type="ImageArtifact", result_details="ok")
+        event = EventResultSuccess(
+            request=SetParameterValueRequest(parameter_name="p", node_name="n", value=None), result=result
+        )
+
+        wire = event.dict()
+
+        assert wire["result"]["finalized_value"]["value"] is None  # blanked on the wire
+        assert result.finalized_value is image  # in-memory object untouched
+        assert image.value == b"\x00" * 300
+
+    def test_event_result_dict_preserves_under_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_blob_threshold(monkeypatch, 10_000)
+        image = ImageArtifact(value=b"\x00" * 30, format="png", width=1, height=1)
+        result = SetParameterValueResultSuccess(finalized_value=image, data_type="ImageArtifact", result_details="ok")
+        event = EventResultSuccess(
+            request=SetParameterValueRequest(parameter_name="p", node_name="n", value=None), result=result
+        )
+
+        assert event.dict()["result"]["finalized_value"]["value"] is not None
+
+    def test_execution_event_dict_blanks_tagged_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_blob_threshold(monkeypatch, 100)
+        image = ImageArtifact(value=b"\x00" * 300, format="png", width=1, height=1)
+        payload = NodeResolvedEvent(node_name="n", parameter_output_values={"out": image}, node_type="T")
+        event = ExecutionEvent(payload=payload)
+
+        wire = event.dict()
+
+        assert wire["payload"]["parameter_output_values"]["out"]["value"] is None
+
+    def test_event_result_dict_blanks_the_echoed_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The result echoes the request back to clients; a request carrying a blob (e.g. workflow-load
+        # SetParameterValue) must be blanked in that echo too.
+        _mock_blob_threshold(monkeypatch, 100)
+        request = SetParameterValueRequest(parameter_name="p", node_name="n", value=_blob_artifact(300))
+        result = SetParameterValueResultSuccess(finalized_value=None, data_type="ImageArtifact", result_details="ok")
+
+        wire = EventResultSuccess(request=request, result=result).dict()
+
+        assert wire["request"]["value"]["value"] is None
+
+
+class TestEveryTaggedFieldBlanksWhenSerialized:
+    """Serialize each tagged carrier with a real blob artifact, then run the real tag-driven strip.
+
+    This is the authoritative end-to-end check: it uses the real ``safe_unstructure`` serialization of
+    each payload and drives ``_strip_tagged_blob_fields`` (which reads the field tag, exactly as
+    production's EventResult.dict()/ExecutionEvent.dict() do). So it catches both a tagged field whose
+    real shape (direct value / dict-of-values / list / nested) the walker mishandles, AND a field that
+    lost (or moved) its blob tag.
+    """
+
+    @pytest.mark.parametrize("payload_type", list(_BLOB_CASE_BUILDERS), ids=_BLOB_TAGGED_FIELD_IDS)
+    def test_tagged_field_blanks(self, payload_type: type, monkeypatch: pytest.MonkeyPatch) -> None:
+        factory, path = _BLOB_CASE_BUILDERS[payload_type]
+        payload = factory(_tiny_image_artifact())
+        serialized = safe_unstructure(payload)
+
+        # Positive control: the blob really is at the expected path as a base64 string before stripping.
+        assert isinstance(_navigate(serialized, path), str), (
+            f"{payload_type.__name__}: no base64 blob at {path} (serialized shape changed?)"
+        )
+
+        _mock_blob_threshold(monkeypatch, 4)
+        _blank_oversized_tagged_blob_fields(payload, serialized)  # tag-driven, exactly as production serialization does
+
+        assert _navigate(serialized, path) is None, (
+            f"{payload_type.__name__}: blob at {path} not blanked (field lost its tag, or shape unhandled?)"
+        )
+        assert _surviving_blob_str_values(serialized[path[0]]) == [], (
+            f"{payload_type.__name__}.{path[0]}: a blob value survived blanking"
+        )
+
+    def test_builders_cover_exactly_the_tagged_payloads(self) -> None:
+        # Ground truth = payloads that actually carry a blob tag. _BLOB_CASE_BUILDERS must match it, so a
+        # newly-tagged (or newly-untagged) carrier fails here until the builders dict is updated.
+        tagged = _blob_tagged_payload_types()
+        missing = {cls.__name__ for cls in tagged - set(_BLOB_CASE_BUILDERS)}
+        extra = {cls.__name__ for cls in set(_BLOB_CASE_BUILDERS) - tagged}
+        assert not missing, f"Tagged payloads with no blob-case builder: {sorted(missing)}"
+        assert not extra, f"Blob-case builders for payloads that are not tagged: {sorted(extra)}"
+
+    @pytest.mark.parametrize(
+        "artifact",
+        [
+            ImageArtifact(value=b"blob" * 8, format="png", width=1, height=1),
+            AudioArtifact(value=b"blob" * 8, format="wav"),
+            BlobArtifact(value=b"blob" * 8),
+        ],
+        ids=["ImageArtifact", "AudioArtifact", "BlobArtifact"],
+    )
+    def test_real_artifact_type_blanks(self, artifact: Any) -> None:
+        # All three blob-backed artifact types serialize to the {type, value: <b64>} shape the walker blanks.
+        serialized = safe_unstructure(artifact)
+
+        blanked = _blank_oversized_blobs(serialized, max_b64_bytes=4)
+
+        assert blanked
+        assert serialized["value"] is None
+
+    def test_list_valued_field_blanks(self) -> None:
+        # A tagged Any field can hold a list of artifacts (e.g. a node emitting list[ImageArtifact]).
+        payload = ParameterValueUpdateEvent(
+            node_name="n", parameter_name="p", data_type="list", value=[_tiny_image_artifact(), _tiny_image_artifact()]
+        )
+        serialized = safe_unstructure(payload)
+
+        blanked = _blank_oversized_blobs(serialized["value"], max_b64_bytes=4)
+
+        assert len(blanked) == 2  # noqa: PLR2004
+        assert _surviving_blob_str_values(serialized["value"]) == []
+
+
+def _blob_artifact(size: int) -> dict:
+    """A serialized blob-artifact dict with a base64 ``value`` of ``size`` characters."""
+    return {"type": "ImageArtifact", "value": "A" * size, "format": "png"}
+
+
+def _mock_blob_threshold(monkeypatch: pytest.MonkeyPatch, value: int) -> Mock:
+    """Force the blob-size threshold via a spec'd ConfigManager mock (base_events reads it lazily)."""
+    config_manager = Mock(spec=ConfigManager)
+    config_manager.get_config_value.return_value = value
+    monkeypatch.setattr(
+        "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.ConfigManager",
+        lambda: config_manager,
+    )
+    return config_manager
+
+
+def _navigate(serialized: Any, path: tuple[str, ...]) -> Any:
+    """Follow a key-path into a serialized structure (raises KeyError if the expected shape is gone)."""
+    for key in path:
+        serialized = serialized[key]
+    return serialized
+
+
+# Event-package modules that are NOT payload definitions and must not be imported for discovery.
+# generate_request_payload_schemas is a script: at import it builds pydantic models for every registered
+# payload and writes request_payload_schemas.json (and trips on an unresolved forward ref).
+_NON_PAYLOAD_EVENT_MODULES = frozenset({"generate_request_payload_schemas"})
+
+
+def _all_registered_payload_types() -> set[type]:
+    """Every registered Payload subclass -- importing all event modules first so the registry is complete."""
+    import griptape_nodes.retained_mode.events as events_pkg
+
+    for module_info in pkgutil.iter_modules(events_pkg.__path__, f"{events_pkg.__name__}."):
+        if module_info.name.rsplit(".", 1)[-1] in _NON_PAYLOAD_EVENT_MODULES:
+            continue
+        importlib.import_module(module_info.name)
+    return set(PayloadRegistry.get_registry().values())
+
+
+def _blob_tagged_payload_types() -> set[type]:
+    """Payload types that actually carry a blob-tagged field (the ground truth _BLOB_CASE_BUILDERS must match)."""
+    return {
+        cls
+        for cls in _all_registered_payload_types()
+        if is_dataclass(cls) and any(f.metadata.get(BLOB_FIELD_METADATA_KEY) for f in fields(cls))
+    }
+
+
+def _surviving_blob_str_values(serialized: Any) -> list[str]:
+    """All base64 string values still present under a blob-artifact dict (should be empty after blanking)."""
+    found: list[str] = []
+    if isinstance(serialized, dict):
+        if serialized.get("type") in _BLOB_ARTIFACT_TYPE_NAMES and isinstance(serialized.get("value"), str):
+            found.append(serialized["value"])
+        for child in serialized.values():
+            found.extend(_surviving_blob_str_values(child))
+    elif isinstance(serialized, list):
+        for child in serialized:
+            found.extend(_surviving_blob_str_values(child))
+    return found
+
+
+def _tiny_image_artifact() -> ImageArtifact:
+    """A real ImageArtifact whose base64 value (~44 chars) comfortably exceeds a 4-byte threshold."""
+    return ImageArtifact(value=b"blob" * 8, format="png", width=1, height=1)

--- a/tests/unit/retained_mode/events/test_base_events.py
+++ b/tests/unit/retained_mode/events/test_base_events.py
@@ -12,7 +12,6 @@ import pytest
 from griptape.artifacts import AudioArtifact, BlobArtifact, ImageArtifact
 
 from griptape_nodes.retained_mode.events.base_events import (
-    _BLOB_ARTIFACT_TYPE_NAMES,
     BLOB_FIELD_METADATA_KEY,
     EventResultFailure,
     EventResultSuccess,
@@ -24,6 +23,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     StrictModeViolationDetail,
     _blank_oversized_blobs,
     _blank_oversized_tagged_blob_fields,
+    _blob_artifact_type_names,
     _max_blob_artifact_b64_bytes,
     _warn_blanked,
 )
@@ -397,9 +397,9 @@ class TestBlankOversizedBlobs:
     """The in-place walker over a freshly-serialized structure."""
 
     def test_over_threshold_blanked_in_place(self) -> None:
-        for type_name in _BLOB_ARTIFACT_TYPE_NAMES:
+        for type_name in _blob_artifact_type_names():
             artifact = {"type": type_name, "value": "A" * 200, "format": "png"}
-            blanked = _blank_oversized_blobs(artifact, max_b64_bytes=100)
+            blanked = _blank_oversized_blobs(artifact, max_b64_bytes=100, type_names=_blob_artifact_type_names())
             assert blanked == [(type_name, 200)]
             assert artifact["value"] is None
             assert artifact["type"] == type_name  # wrapper + metadata kept
@@ -407,21 +407,49 @@ class TestBlankOversizedBlobs:
 
     def test_under_threshold_preserved(self) -> None:
         artifact = _blob_artifact(50)
-        assert _blank_oversized_blobs(artifact, max_b64_bytes=100) == []
+        assert _blank_oversized_blobs(artifact, max_b64_bytes=100, type_names=_blob_artifact_type_names()) == []
         assert artifact["value"] == "A" * 50
+
+    def test_future_blob_artifact_subclass_is_covered(self) -> None:
+        """A brand-new BlobArtifact subclass (e.g. from a third-party library) is caught automatically."""
+
+        class _FutureArtifact(BlobArtifact):
+            pass
+
+        assert _FutureArtifact.__name__ in _blob_artifact_type_names()
+
+        artifact = {"type": "_FutureArtifact", "value": "A" * 200}
+        blanked = _blank_oversized_blobs(artifact, max_b64_bytes=100, type_names=_blob_artifact_type_names())
+
+        assert blanked == [("_FutureArtifact", 200)]
+        assert artifact["value"] is None
+
+    def test_blob_artifact_grandchild_subclass_is_covered(self) -> None:
+        """A grandchild of BlobArtifact is caught automatically."""
+
+        class _GrandchildArtifact(ImageArtifact):
+            pass
+
+        assert _GrandchildArtifact.__name__ in _blob_artifact_type_names()
+
+        artifact = {"type": "_GrandchildArtifact", "value": "A" * 200}
+        blanked = _blank_oversized_blobs(artifact, max_b64_bytes=100, type_names=_blob_artifact_type_names())
+
+        assert blanked == [("_GrandchildArtifact", 200)]
+        assert artifact["value"] is None
 
     def test_non_blob_and_plain_string_untouched(self) -> None:
         url = {"type": "ImageUrlArtifact", "value": "http://x/" + "a" * 500}
         text = {"type": "TextArtifact", "value": "z" * 500}
         plain = {"some_field": "x" * 1000}
         for obj in (url, text, plain):
-            assert _blank_oversized_blobs(obj, max_b64_bytes=100) == []
+            assert _blank_oversized_blobs(obj, max_b64_bytes=100, type_names=_blob_artifact_type_names()) == []
         assert url["value"].startswith("http://")
         assert text["value"] == "z" * 500
 
     def test_nested_dicts_and_lists_walked(self) -> None:
         payload = {"e1": _blob_artifact(300), "e2": _blob_artifact(10), "nested": {"deep": [_blob_artifact(300)]}}
-        blanked = _blank_oversized_blobs(payload, max_b64_bytes=100)
+        blanked = _blank_oversized_blobs(payload, max_b64_bytes=100, type_names=_blob_artifact_type_names())
         assert sorted(blanked) == [("ImageArtifact", 300), ("ImageArtifact", 300)]
         assert payload["e1"]["value"] is None
         assert payload["e2"]["value"] == "A" * 10
@@ -429,7 +457,7 @@ class TestBlankOversizedBlobs:
 
     def test_non_string_value_ignored(self) -> None:
         artifact = {"type": "ImageArtifact", "value": None}
-        assert _blank_oversized_blobs(artifact, max_b64_bytes=100) == []
+        assert _blank_oversized_blobs(artifact, max_b64_bytes=100, type_names=_blob_artifact_type_names()) == []
 
 
 class TestStripTaggedBlobFields:
@@ -614,7 +642,7 @@ class TestEveryTaggedFieldBlanksWhenSerialized:
         # All three blob-backed artifact types serialize to the {type, value: <b64>} shape the walker blanks.
         serialized = safe_unstructure(artifact)
 
-        blanked = _blank_oversized_blobs(serialized, max_b64_bytes=4)
+        blanked = _blank_oversized_blobs(serialized, max_b64_bytes=4, type_names=_blob_artifact_type_names())
 
         assert blanked
         assert serialized["value"] is None
@@ -626,7 +654,7 @@ class TestEveryTaggedFieldBlanksWhenSerialized:
         )
         serialized = safe_unstructure(payload)
 
-        blanked = _blank_oversized_blobs(serialized["value"], max_b64_bytes=4)
+        blanked = _blank_oversized_blobs(serialized["value"], max_b64_bytes=4, type_names=_blob_artifact_type_names())
 
         assert len(blanked) == 2  # noqa: PLR2004
         assert _surviving_blob_str_values(serialized["value"]) == []
@@ -685,7 +713,7 @@ def _surviving_blob_str_values(serialized: Any) -> list[str]:
     """All base64 string values still present under a blob-artifact dict (should be empty after blanking)."""
     found: list[str] = []
     if isinstance(serialized, dict):
-        if serialized.get("type") in _BLOB_ARTIFACT_TYPE_NAMES and isinstance(serialized.get("value"), str):
+        if serialized.get("type") in _blob_artifact_type_names() and isinstance(serialized.get("value"), str):
             found.append(serialized["value"])
         for child in serialized.values():
             found.extend(_surviving_blob_str_values(child))


### PR DESCRIPTION
Closes #5177. Partially addresses #4124.

When a node makes use of an BlobArtifact (i.e. ImageArtifact or AudioArtifact) as a parameter type, the raw bytes of that artifact are persisted in the workflow and sent over the wire as part of the payload in various events and responses.

If the payload is too large then it can overwhelm the websocket connection and cause the editor UI to claim lost connection, or even fail and come up blank.

So strip large BlobArtifact values when serializing to send over the wire. This affects clients including the UI and MCP server.

Don't strip otherwise, including when serializing to a workflow file. Tackling overly-large workflow files is left for future work.

Tag all event `dataclass` fields that may contain a blob value with metadata, to aid in knowing which fields to strip.

Add a configuration key "max_blob_artifact_b64_bytes" to allow users to control what the cutoff is, with a default of 256k.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5189.org.readthedocs.build/en/5189/

<!-- readthedocs-preview griptape-nodes end -->