### PR TITLE
fix(resolution): prevent livelock hang when two tasks finish together

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ test = [
   "pytest-mock>=3.14.0",
   "pytest-xdist>=3.6.1",
   "pytest-cov>=6.0.0",
+  "pytest-timeout>=2.4.0",
   "coverage>=7.0.0",
 ]
 
@@ -109,10 +110,10 @@ ignore = [
   "ANN003",  # Intentional
   "ANN401",  # Intentional
   "COM812",  # Intentional
-  "E501",    # TODO: https://github.com/griptape-ai/griptape-nodes-engine/issues/834 
-  "D100",    # TODO: https://github.com/griptape-ai/griptape-nodes-engine/issues/835 
+  "E501",    # TODO: https://github.com/griptape-ai/griptape-nodes-engine/issues/834
+  "D100",    # TODO: https://github.com/griptape-ai/griptape-nodes-engine/issues/835
   "BLE001",  # TODO: https://github.com/griptape-ai/griptape-nodes-engine/issues/839
-  "SLF001",  # TODO :https://github.com/griptape-ai/griptape-nodes-engine/issues/838 
+  "SLF001",  # TODO :https://github.com/griptape-ai/griptape-nodes-engine/issues/838
   "SIM108",  # Intentional
   "SIM110",  # Intentional
   "D105",    # Intentional

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -614,11 +614,6 @@ class ExecuteDagState(State):
                         context.node_priority_queue.add_node(end_node_reference)
                         node_reference = end_node_reference
 
-            def on_task_done(task: asyncio.Task) -> None:
-                if task in context.task_to_node:
-                    node = context.task_to_node[task]
-                    node.node_state = NodeState.DONE
-
             # Execute the node asynchronously
             logger.debug(
                 "CREATING EXECUTION TASK for node '%s' - this should only happen once per node!",
@@ -629,10 +624,8 @@ class ExecuteDagState(State):
             node_reference.node_reference.state = NodeResolutionState.RESOLVING
 
             node_task = asyncio.create_task(ExecuteDagState.execute_node(node_reference))
-            # Add a callback to set node to done when task has finished.
             context.task_to_node[node_task] = node_reference
             node_reference.task_reference = node_task
-            node_task.add_done_callback(on_task_done)
 
             # Send an event that this is a current data node:
 
@@ -648,19 +641,19 @@ class ExecuteDagState(State):
             context.running_tasks_count -= len(done)
             # New node has finished - priorities are stale
             context.node_priority_queue.mark_priorities_stale()
-            # Check for task exceptions and handle them properly
+            # Check for task exceptions and handle them properly.
             for task in done:
+                dag_node = context.task_to_node.pop(task)
                 if task.cancelled():
                     # Task was cancelled - this is expected during flow cancellation
-                    context.task_to_node.pop(task)
+                    dag_node.node_state = NodeState.CANCELED
                     logger.info("Task execution was cancelled.")
                     return ErrorState
-                if task.exception():
-                    exc = task.exception()
-                    dag_node = context.task_to_node.get(task)
-                    node_name = dag_node.node_reference.name if dag_node else "Unknown"
+                if (exc := task.exception()) is not None:
+                    node_name = dag_node.node_reference.name
+                    dag_node.node_state = NodeState.ERRORED
 
-                    logger.exception("Error processing node '%s'", node_name)
+                    logger.exception("Error processing node '%s'", node_name, exc_info=exc)
                     msg = f"Node '{node_name}' encountered a problem: {exc}"
 
                     await GriptapeNodes.EventManager().aput_event(
@@ -673,11 +666,11 @@ class ExecuteDagState(State):
                             )
                         )
                     )
-                    context.task_to_node.pop(task)
                     context.error_message = msg
                     context.workflow_state = WorkflowState.ERRORED
                     return ErrorState
-                context.task_to_node.pop(task)
+
+                dag_node.node_state = NodeState.DONE
 
         # Once a task has finished, loop back to the top.
         await ExecuteDagState.pop_done_states(context)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,174 @@
+"""Shared configuration and helpers for the end-to-end suite."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.utils.metaclasses import SingletonMeta
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+
+@pytest.fixture(autouse=True)
+def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Boot each test against empty temp config/secrets and a clean registry.
+
+    ``SecretsManager`` installs ``ENV_VAR_PATH``'s contents into ``os.environ`` at init;
+    without this isolation a subprocess spawned via ``os.environ.copy()`` inherits the
+    developer's real ``GT_CLOUD_BUCKET_ID`` and runs in Griptape Cloud mode, whose
+    background threads segfault the child at interpreter shutdown.
+
+    Clearing ``SingletonMeta._instances`` forces the managers to re-initialize against the
+    patched paths and gives each test a fresh object registry. ``LibraryRegistry`` keeps its
+    state in ``ClassVar`` dicts that ``SingletonMeta`` clearing does not touch, so it is
+    reset explicitly.
+    """
+    SingletonMeta._instances.clear()
+    LibraryRegistry._clear()
+
+    for key in list(os.environ):
+        if key.startswith(("GT_CLOUD_", "GTN_CONFIG_")):
+            monkeypatch.delenv(key, raising=False)
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_config_path = Path(temp_dir) / "griptape_nodes_config.json"
+            temp_config_path.write_text(json.dumps({}, indent=2))
+            temp_env_path = Path(temp_dir) / ".env"
+            temp_env_path.write_text("")
+            with (
+                patch.object(config_manager_module, "USER_CONFIG_PATH", temp_config_path),
+                patch.object(secrets_manager_module, "ENV_VAR_PATH", temp_env_path),
+            ):
+                yield
+    finally:
+        SingletonMeta._instances.clear()
+        LibraryRegistry._clear()
+
+
+@pytest.fixture
+def engine_subprocess_env() -> Callable[..., dict[str, str]]:
+    """Return a factory that builds the env for an engine workflow subprocess.
+
+    With ``_isolated_engine_env`` active ``os.environ`` carries no real secrets, so a plain
+    copy is already hermetic. The factory just supplies the ``GT_CLOUD_API_KEY`` placeholder
+    the bootstrap requires and applies any overrides (e.g. ``XDG_CONFIG_HOME``).
+    """
+
+    def _build(**overrides: str) -> dict[str, str]:
+        env = os.environ.copy()
+        # Engine bootstrap requires GT_CLOUD_API_KEY to be set; the value never leaves the
+        # subprocess so a placeholder is fine.
+        env.setdefault("GT_CLOUD_API_KEY", "fake-test-key-for-bootstrap")
+        env.update(overrides)
+        return env
+
+    return _build
+
+
+@pytest.fixture
+def materialize_library() -> Callable[..., Path]:
+    """Return a factory that copies a fixture library into a temp dir for registration.
+
+    Rewrites the fixture JSON's ``engine_version`` to the running engine version so
+    ``IncompatibleEngineVersionCheck`` never marks the library UNUSABLE on a version bump,
+    optionally overrides the library ``name`` (needed when two tests register the same
+    fixture under distinct names), copies the node file, and returns the written
+    ``griptape_nodes_library.json`` path.
+    """
+
+    def _materialize(target_dir: Path, *, template: Path, node_file: Path, name: str | None = None) -> Path:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        schema = json.loads(template.read_text())
+        if name is not None:
+            schema["name"] = name
+        schema["metadata"]["engine_version"] = engine_version
+        library_json = target_dir / "griptape_nodes_library.json"
+        library_json.write_text(json.dumps(schema, indent=2))
+        (target_dir / node_file.name).write_text(node_file.read_text())
+        return library_json
+
+    return _materialize
+
+
+@pytest.fixture
+def write_isolated_config() -> Callable[..., None]:
+    """Return a factory that writes an XDG-style engine config registering the fixture library.
+
+    Used by subprocess tests to point the child engine at an isolated workspace and have it
+    auto-register the materialized library on initialization.
+    """
+
+    def _write(config_root: Path, *, workspace: Path, library_path: Path) -> None:
+        config_dir = config_root / "griptape_nodes"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_path = config_dir / "griptape_nodes_config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "workspace_directory": str(workspace),
+                    "log_level": "WARNING",
+                    "app_events": {
+                        "on_app_initialization_complete": {
+                            "libraries_to_register": [str(library_path)],
+                        },
+                    },
+                }
+            )
+        )
+
+    return _write
+
+
+@pytest.fixture
+def create_node() -> Callable[..., str]:
+    """Return a helper that creates a node from the given library and asserts success."""
+
+    def _create(node_type: str, node_name: str, flow_name: str, *, library_name: str) -> str:
+        result = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type=node_type,
+                specific_library_name=library_name,
+                node_name=node_name,
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess), result
+        return result.node_name
+
+    return _create
+
+
+@pytest.fixture
+def connect() -> Callable[..., None]:
+    """Return a helper that connects two node parameters and asserts success."""
+
+    def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
+        result = GriptapeNodes.handle_request(
+            CreateConnectionRequest(
+                source_node_name=source_node,
+                source_parameter_name=source_param,
+                target_node_name=target_node,
+                target_parameter_name=target_param,
+            )
+        )
+        assert isinstance(result, CreateConnectionResultSuccess), result
+
+    return _connect

--- a/tests/e2e/test_nonserializable_resolution_state.py
+++ b/tests/e2e/test_nonserializable_resolution_state.py
@@ -17,19 +17,12 @@ as RESOLVED, because its output value was not persisted.
 
 from __future__ import annotations
 
-import contextlib
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
-from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.retained_mode.events.connection_events import (
-    CreateConnectionRequest,
-    CreateConnectionResultSuccess,
-)
 from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
@@ -43,15 +36,14 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultSuccess,
 )
-from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
-from griptape_nodes.retained_mode.events.object_events import (
-    ClearAllObjectStateRequest,
-    ClearAllObjectStateResultSuccess,
-)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "nonserializable_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -59,63 +51,17 @@ FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "nonserializable_nodes.py"
 LIBRARY_NAME = "NonSerializable Library"
 
 
-def _materialize_library(target_dir: Path) -> Path:
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
-    return library_json
-
-
-def _create_node(node_type: str, node_name: str, flow_name: str) -> str:
-    result = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type=node_type,
-            specific_library_name=LIBRARY_NAME,
-            node_name=node_name,
-            override_parent_flow_name=flow_name,
-        )
-    )
-    assert isinstance(result, CreateNodeResultSuccess), result
-    return result.node_name
-
-
-def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
-    result = GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name=source_param,
-            target_node_name=target_node,
-            target_parameter_name=target_param,
-        )
-    )
-    assert isinstance(result, CreateConnectionResultSuccess), result
-
-
-@pytest.fixture
-def _clean_engine_state() -> Iterator[None]:
-    """Keep the shared engine singleton clean despite running in-process."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    try:
-        yield
-    finally:
-        clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
-        with contextlib.suppress(KeyError):
-            LibraryRegistry.unregister_library(LIBRARY_NAME)
-
-
 @pytest.mark.skipif(
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"NonSerializable Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_clean_engine_state")
-async def test_serializable_false_output_reresolved_on_load(tmp_path: Path) -> None:
+async def test_serializable_false_output_reresolved_on_load(
+    tmp_path: Path,
+    materialize_library: Callable[..., Path],
+    create_node: Callable[..., str],
+    connect: Callable[..., None],
+) -> None:
     """A node with serializable=False output must not be re-resolved after save/load.
 
     Steps:
@@ -125,7 +71,9 @@ async def test_serializable_false_output_reresolved_on_load(tmp_path: Path) -> N
         4. Clear state, create a fresh flow, deserialize (load).
         5. Run the loaded flow — the consumer must get a recomputed Session, not None.
     """
-    library_json = _materialize_library(tmp_path / "library")
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
+    )
     register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
@@ -137,9 +85,9 @@ async def test_serializable_false_output_reresolved_on_load(tmp_path: Path) -> N
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
     flow_name = flow_result.flow_name
 
-    _create_node("ProducerNode", "Producer", flow_name)
-    _create_node("ConsumerNode", "Consumer", flow_name)
-    _connect("Producer", "session", "Consumer", "session")
+    create_node("ProducerNode", "Producer", flow_name, library_name=LIBRARY_NAME)
+    create_node("ConsumerNode", "Consumer", flow_name, library_name=LIBRARY_NAME)
+    connect("Producer", "session", "Consumer", "session")
 
     # --- Step 2: Run the flow so both nodes become RESOLVED ---
     run_result = await GriptapeNodes.ahandle_request(

--- a/tests/e2e/test_standalone_workflow_execution.py
+++ b/tests/e2e/test_standalone_workflow_execution.py
@@ -15,11 +15,10 @@ test fails.
 
 from __future__ import annotations
 
-import json
-import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -38,55 +37,15 @@ from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, C
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "echo_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
 FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "echo_node.py"
-
-
-def _materialize_library(target_dir: Path) -> Path:
-    """Copy the on-disk fixture into ``target_dir`` and stamp the current engine version.
-
-    Rewrites the fixture's ``engine_version`` field to the engine's running version so
-    ``IncompatibleEngineVersionCheck`` never marks the library UNUSABLE on a version
-    bump. The on-disk copy of the JSON keeps a placeholder version that is never read
-    by anything except this materializer.
-    """
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
-    return library_json
-
-
-def _write_isolated_config(config_root: Path, *, workspace: Path, library_path: Path) -> None:
-    """Write an XDG-style config file that registers the fixture library.
-
-    ``RegisterLibraryFromFileRequest(perform_discovery_if_not_found=True)`` resolves
-    library names through the engine's normal discovery path, which reads from
-    ``app_events.on_app_initialization_complete.libraries_to_register`` in the user
-    config. Pointing that at the materialized fixture is enough to let the standalone
-    workflow find ``Echo Library`` without touching the user's real config.
-    """
-    config_dir = config_root / "griptape_nodes"
-    config_dir.mkdir(parents=True, exist_ok=True)
-    config_path = config_dir / "griptape_nodes_config.json"
-    config_path.write_text(
-        json.dumps(
-            {
-                "workspace_directory": str(workspace),
-                "log_level": "WARNING",
-                "app_events": {
-                    "on_app_initialization_complete": {
-                        "libraries_to_register": [str(library_path)],
-                    },
-                },
-            }
-        )
-    )
 
 
 def _generate_echo_workflow_source(library_json: Path) -> str:
@@ -204,7 +163,12 @@ if __name__ == "__main__":
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Echo Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
-def test_standalone_workflow_registers_declared_libraries(tmp_path: Path) -> None:
+def test_standalone_workflow_registers_declared_libraries(
+    tmp_path: Path,
+    engine_subprocess_env: Callable[..., dict[str, str]],
+    materialize_library: Callable[..., Path],
+    write_isolated_config: Callable[..., None],
+) -> None:
     """A generated workflow run via subprocess must produce real nodes, not proxies.
 
     Drives the real generator (no hand-crafted source) so a regression that drops
@@ -215,8 +179,10 @@ def test_standalone_workflow_registers_declared_libraries(tmp_path: Path) -> Non
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     config_root = tmp_path / "xdg_config"
-    library_json = _materialize_library(tmp_path / "library")
-    _write_isolated_config(config_root, workspace=workspace, library_path=library_json)
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
+    )
+    write_isolated_config(config_root, workspace=workspace, library_path=library_json)
 
     # Generator runs in the test process where Echo Library can be registered locally,
     # so SerializeFlowToCommandsRequest can build a faithful command list.
@@ -230,11 +196,10 @@ def test_standalone_workflow_registers_declared_libraries(tmp_path: Path) -> Non
     workflow_path = tmp_path / "echo_workflow.py"
     workflow_path.write_text(runnable_source)
 
-    env = os.environ.copy()
-    env["XDG_CONFIG_HOME"] = str(config_root)
-    # Engine bootstrap requires GT_CLOUD_API_KEY to be set; the value never leaves the
-    # subprocess so a placeholder is fine.
-    env.setdefault("GT_CLOUD_API_KEY", "fake-test-key-for-bootstrap")
+    # Isolated config dir + the GT_CLOUD_API_KEY placeholder the bootstrap needs. The child
+    # runs hermetically in LOCAL storage because conftest.py's _isolated_engine_env keeps real
+    # cloud secrets out of os.environ.
+    env = engine_subprocess_env(XDG_CONFIG_HOME=str(config_root))
 
     result = subprocess.run(  # noqa: S603 - subprocess input is constructed inside the test
         [sys.executable, str(workflow_path)],

--- a/tests/e2e/test_subflow_dataflow_execution.py
+++ b/tests/e2e/test_subflow_dataflow_execution.py
@@ -17,35 +17,26 @@ here.
 
 from __future__ import annotations
 
-import contextlib
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
-from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.retained_mode.events.connection_events import (
-    CreateConnectionRequest,
-    CreateConnectionResultSuccess,
-)
 from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultSuccess,
 )
-from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
-from griptape_nodes.retained_mode.events.object_events import (
-    ClearAllObjectStateRequest,
-    ClearAllObjectStateResultSuccess,
-)
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_dataflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -54,76 +45,21 @@ LIBRARY_NAME = "Subflow Dataflow Library"
 _EXPECTED = "value-through-data-only-subflow"
 
 
-def _materialize_library(target_dir: Path) -> Path:
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
-    return library_json
-
-
-def _create_node(node_type: str, node_name: str, flow_name: str) -> str:
-    result = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type=node_type,
-            specific_library_name=LIBRARY_NAME,
-            node_name=node_name,
-            override_parent_flow_name=flow_name,
-        )
-    )
-    assert isinstance(result, CreateNodeResultSuccess), result
-    return result.node_name
-
-
-def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
-    result = GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name=source_param,
-            target_node_name=target_node,
-            target_parameter_name=target_param,
-        )
-    )
-    assert isinstance(result, CreateConnectionResultSuccess), result
-
-
-@pytest.fixture
-def _clean_engine_state() -> Iterator[None]:
-    """Keep the shared engine singleton clean despite running in-process.
-
-    This test mutates global GriptapeNodes state (the object registry and the workflow context
-    stack) directly instead of in a subprocess, so it clears object state before running and
-    tears down object state plus the registered fixture library afterwards. Without this
-    teardown the registered objects/library would leak into sibling tests sharing the same
-    pytest-xdist worker.
-    """
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    yield
-    # ClearAllObjectStateRequest drains the workflow context stack and deletes its flows/nodes in
-    # one step; popping the workflow first would leave has_current_workflow() False and skip that
-    # deletion, so the clear must run against the still-active context.
-    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
-    # ClearAllObjectStateRequest does not touch the LibraryRegistry, so drop the fixture library
-    # explicitly to avoid a dangling entry pointing at a deleted tmp_path directory. The library
-    # is absent if the test failed before registering it.
-    with contextlib.suppress(KeyError):
-        LibraryRegistry.unregister_library(LIBRARY_NAME)
-
-
 @pytest.mark.skipif(
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Subflow Dataflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_clean_engine_state")
-async def test_isolated_subflow_runs_data_only_graph(tmp_path: Path) -> None:
+async def test_isolated_subflow_runs_data_only_graph(
+    tmp_path: Path,
+    materialize_library: Callable[..., Path],
+    create_node: Callable[..., str],
+    connect: Callable[..., None],
+) -> None:
     """A data-only referenced subflow must resolve its downstream/leaf nodes and return outputs."""
-    library_json = _materialize_library(tmp_path / "library")
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
+    )
     register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
@@ -143,16 +79,16 @@ async def test_isolated_subflow_runs_data_only_graph(tmp_path: Path) -> None:
     subflow = subflow_result.flow_name
 
     # Subflow: Start -> Pass -> End wired with DATA connections ONLY (no exec_out -> exec_in).
-    _create_node("DataStartNode", "Start", subflow)
-    _create_node("DataPassNode", "Pass", subflow)
-    _create_node("DataEndNode", "End", subflow)
-    _connect("Start", "value", "Pass", "value")
-    _connect("Pass", "value", "End", "value")
+    create_node("DataStartNode", "Start", subflow, library_name=LIBRARY_NAME)
+    create_node("DataPassNode", "Pass", subflow, library_name=LIBRARY_NAME)
+    create_node("DataEndNode", "End", subflow, library_name=LIBRARY_NAME)
+    connect("Start", "value", "Pass", "value")
+    connect("Pass", "value", "End", "value")
 
     GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="value", node_name="Start", value=_EXPECTED))
 
     # Driver runs the subflow the way SubflowWorkflowNode does.
-    _create_node("RunSubflowNode", "Driver", parent_flow)
+    create_node("RunSubflowNode", "Driver", parent_flow, library_name=LIBRARY_NAME)
     driver = GriptapeNodes.NodeManager().get_node_by_name("Driver")
     driver.metadata["subflow_name"] = subflow
     driver.metadata["end_node_name"] = "End"

--- a/tests/e2e/test_subflow_execution.py
+++ b/tests/e2e/test_subflow_execution.py
@@ -14,11 +14,10 @@ WebSocket relay that the Private Execution (SubprocessWorkflowExecutor) path nee
 
 from __future__ import annotations
 
-import json
-import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -38,42 +37,16 @@ from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStat
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
 
 _EXPECTED_TEXT = "hello from subflow"
-
-
-def _materialize_library(target_dir: Path) -> Path:
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    node_file = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
-    (target_dir / node_file.name).write_text(node_file.read_text())
-    return library_json
-
-
-def _write_isolated_config(config_root: Path, *, workspace: Path, library_path: Path) -> None:
-    config_dir = config_root / "griptape_nodes"
-    config_dir.mkdir(parents=True, exist_ok=True)
-    config_path = config_dir / "griptape_nodes_config.json"
-    config_path.write_text(
-        json.dumps(
-            {
-                "workspace_directory": str(workspace),
-                "log_level": "WARNING",
-                "app_events": {
-                    "on_app_initialization_complete": {
-                        "libraries_to_register": [str(library_path)],
-                    },
-                },
-            }
-        )
-    )
 
 
 def _generate_subflow_workflow_source(library_json: Path) -> str:
@@ -203,7 +176,12 @@ if __name__ == "__main__":
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
-def test_subflow_node_group_propagates_output_values(tmp_path: Path) -> None:
+def test_subflow_node_group_propagates_output_values(
+    tmp_path: Path,
+    engine_subprocess_env: Callable[..., dict[str, str]],
+    materialize_library: Callable[..., Path],
+    write_isolated_config: Callable[..., None],
+) -> None:
     """A SubflowNodeGroup must propagate child node outputs back to the parent flow.
 
     Drives the real serializer + LocalWorkflowExecutor so a regression in
@@ -213,8 +191,12 @@ def test_subflow_node_group_propagates_output_values(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     config_root = tmp_path / "xdg_config"
-    library_json = _materialize_library(tmp_path / "library")
-    _write_isolated_config(config_root, workspace=workspace, library_path=library_json)
+    library_json = materialize_library(
+        tmp_path / "library",
+        template=FIXTURE_LIBRARY_JSON_TEMPLATE,
+        node_file=FIXTURE_LIBRARY_DIR / "subflow_echo_node.py",
+    )
+    write_isolated_config(config_root, workspace=workspace, library_path=library_json)
 
     workflow_source = _generate_subflow_workflow_source(library_json)
     runnable_source = _wrap_with_runtime_assertions(workflow_source)
@@ -222,9 +204,10 @@ def test_subflow_node_group_propagates_output_values(tmp_path: Path) -> None:
     workflow_path = tmp_path / "subflow_workflow.py"
     workflow_path.write_text(runnable_source)
 
-    env = os.environ.copy()
-    env["XDG_CONFIG_HOME"] = str(config_root)
-    env.setdefault("GT_CLOUD_API_KEY", "fake-test-key-for-bootstrap")
+    # Isolated config dir + the GT_CLOUD_API_KEY placeholder the bootstrap needs. The child
+    # runs hermetically in LOCAL storage because conftest.py's _isolated_engine_env keeps real
+    # cloud secrets out of os.environ.
+    env = engine_subprocess_env(XDG_CONFIG_HOME=str(config_root))
 
     result = subprocess.run(  # noqa: S603
         [sys.executable, str(workflow_path)],

--- a/tests/e2e/test_subflow_group_name_collision.py
+++ b/tests/e2e/test_subflow_group_name_collision.py
@@ -19,15 +19,12 @@ raises because it has no valid input.
 
 from __future__ import annotations
 
-import contextlib
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
-from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import (
@@ -36,8 +33,6 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 from griptape_nodes.retained_mode.events.object_events import (
-    ClearAllObjectStateRequest,
-    ClearAllObjectStateResultSuccess,
     RenameObjectRequest,
     RenameObjectResultSuccess,
 )
@@ -45,7 +40,10 @@ from griptape_nodes.retained_mode.events.parameter_events import SetParameterVal
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -55,37 +53,14 @@ FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
 LIBRARY_NAME = "Subflow Group Metadata Collision Library"
 
 
-def _materialize_library(target_dir: Path) -> Path:
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["name"] = LIBRARY_NAME
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
-    return library_json
-
-
-@pytest.fixture
-def _clean_engine_state() -> Iterator[None]:
-    """Keep the shared engine singleton clean despite running in-process."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    yield
-    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
-    with contextlib.suppress(KeyError):
-        LibraryRegistry.unregister_library(LIBRARY_NAME)
-
-
 @pytest.mark.skipif(
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_clean_engine_state")
-async def test_running_first_group_does_not_execute_second_groups_member(tmp_path: Path) -> None:
+async def test_running_first_group_does_not_execute_second_groups_member(
+    tmp_path: Path, materialize_library: Callable[..., Path]
+) -> None:
     """Running the first group must execute ONLY its own member, not the second group's.
 
     Builds the collision trigger (group, rename, group-reusing-the-freed-name), where the
@@ -94,7 +69,9 @@ async def test_running_first_group_does_not_execute_second_groups_member(tmp_pat
     group's member, which raises ``Echo node must have text input``. After the fix each
     group owns its own subflow and running the first group succeeds.
     """
-    library_json = _materialize_library(tmp_path / "library")
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE, name=LIBRARY_NAME
+    )
     register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 

--- a/tests/e2e/test_subflow_group_parallel_execution.py
+++ b/tests/e2e/test_subflow_group_parallel_execution.py
@@ -13,15 +13,12 @@ top-level workflow run.
 
 from __future__ import annotations
 
-import contextlib
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from griptape_nodes.exe_types.node_types import NodeResolutionState
-from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import (
@@ -29,15 +26,14 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
-from griptape_nodes.retained_mode.events.object_events import (
-    ClearAllObjectStateRequest,
-    ClearAllObjectStateResultSuccess,
-)
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -50,39 +46,18 @@ _NODE_COUNT = 3
 _DELAY_SECONDS = 0.4
 
 
-def _materialize_library(target_dir: Path) -> Path:
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["name"] = LIBRARY_NAME
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
-    return library_json
-
-
-@pytest.fixture
-def _clean_engine_state() -> Iterator[None]:
-    """Keep the shared engine singleton clean despite running in-process."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    yield
-    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
-    with contextlib.suppress(KeyError):
-        LibraryRegistry.unregister_library(LIBRARY_NAME)
-
-
 @pytest.mark.skipif(
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_clean_engine_state")
-async def test_group_runs_independent_nodes_in_parallel(tmp_path: Path) -> None:
+async def test_group_runs_independent_nodes_in_parallel(
+    tmp_path: Path, materialize_library: Callable[..., Path]
+) -> None:
     """Every independent child of a group resolves, and they overlap in time under PARALLEL mode."""
-    library_json = _materialize_library(tmp_path / "library")
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE, name=LIBRARY_NAME
+    )
     register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 

--- a/tests/e2e/test_subflow_import_flow_selection.py
+++ b/tests/e2e/test_subflow_import_flow_selection.py
@@ -9,14 +9,11 @@ records as its ``subflow_name`` and routes I/O through.
 
 from __future__ import annotations
 
-import contextlib
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
-from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
 from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
@@ -29,10 +26,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
-from griptape_nodes.retained_mode.events.object_events import (
-    ClearAllObjectStateRequest,
-    ClearAllObjectStateResultSuccess,
-)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
@@ -42,7 +36,10 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -50,30 +47,6 @@ FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
 # Distinct name so the LibraryManager's LOADED bookkeeping doesn't collide with the other
 # in-process subflow tests sharing a worker.
 LIBRARY_NAME = "Subflow Import Flow Selection Library"
-
-
-def _materialize_library(target_dir: Path) -> Path:
-    from griptape_nodes.utils.version_utils import engine_version
-
-    target_dir.mkdir(parents=True, exist_ok=True)
-    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
-    schema["name"] = LIBRARY_NAME
-    schema["metadata"]["engine_version"] = engine_version
-    library_json = target_dir / "griptape_nodes_library.json"
-    library_json.write_text(json.dumps(schema, indent=2))
-    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
-    return library_json
-
-
-@pytest.fixture
-def _clean_engine_state() -> Iterator[None]:
-    """Keep the shared engine singleton clean despite running in-process."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    yield
-    clear_result = GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    assert isinstance(clear_result, ClearAllObjectStateResultSuccess), clear_result
-    with contextlib.suppress(KeyError):
-        LibraryRegistry.unregister_library(LIBRARY_NAME)
 
 
 def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> None:
@@ -141,10 +114,13 @@ def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> Non
     reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
 @pytest.mark.asyncio
-@pytest.mark.usefixtures("_clean_engine_state")
-async def test_import_binds_to_top_level_flow_not_group_body(tmp_path: Path) -> None:
+async def test_import_binds_to_top_level_flow_not_group_body(
+    tmp_path: Path, materialize_library: Callable[..., Path]
+) -> None:
     """Importing a group-containing workflow must return the top-level imported flow."""
-    library_json = _materialize_library(tmp_path / "library")
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE, name=LIBRARY_NAME
+    )
     workflow_path = tmp_path / "grouped_inner_workflow.py"
     _write_grouped_workflow_file(library_json, workflow_path)
 

--- a/tests/unit/machines/test_parallel_flow_execution.py
+++ b/tests/unit/machines/test_parallel_flow_execution.py
@@ -2,15 +2,23 @@
 
 # ruff: noqa: PLR2004
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from griptape_nodes.common.directed_graph import DirectedGraph
 from griptape_nodes.exe_types.connections import Direction
-from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
 from griptape_nodes.machines.control_flow import ControlFlowMachine
-from griptape_nodes.machines.dag_builder import DagBuilder
-from griptape_nodes.machines.parallel_resolution import ExecuteDagState, ParallelResolutionMachine
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, NodeState
+from griptape_nodes.machines.fsm import WorkflowState
+from griptape_nodes.machines.parallel_resolution import (
+    ErrorState,
+    ExecuteDagState,
+    ParallelResolutionContext,
+    ParallelResolutionMachine,
+)
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.settings import WorkflowExecutionMode
 
@@ -467,3 +475,104 @@ class TestCollectValuesFromUpstreamNodes:
             assert request.node_name == "target_node"
             assert request.parameter_name == "prompt"
             assert request.value == "hello"
+
+
+class TestParallelResolutionNodeDoneWhenTaskCompletes:
+    """Reaping a finished task must set the node's terminal state in ``on_update`` itself.
+
+    The done-callback that used to do this could fire after the task was popped from
+    ``task_to_node`` (``asyncio.wait`` reports a task in ``done`` before its callback has run),
+    silently leaving the node ``PROCESSING`` and livelocking ``on_update``. The reap loop now
+    sets the terminal state for every outcome: ``DONE``, ``CANCELED``, or ``ERRORED``.
+    """
+
+    @staticmethod
+    def _context_with_processing_node() -> ParallelResolutionContext:
+        """A context with one PROCESSING leaf node, not in the priority queue - ready to be reaped."""
+        node = MagicMock(spec=BaseNode)
+        node.name = "n"
+        node.lock = False
+        node.state = NodeResolutionState.RESOLVING
+
+        graph = DirectedGraph()
+        graph.add_node("n")
+
+        dag_builder = DagBuilder()
+        dag_builder.graphs["n"] = graph
+        dag_builder.node_to_reference["n"] = DagNode(node_reference=node, node_state=NodeState.PROCESSING)
+
+        return ParallelResolutionContext("flow", max_nodes_in_parallel=5, dag_builder=dag_builder)
+
+    @pytest.mark.asyncio
+    async def test_reaping_a_completed_task_marks_node_done(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A completed task's node must reach DONE via the reap, not a (possibly-late) callback."""
+        context = self._context_with_processing_node()
+        dag_node = context.node_to_reference["n"]
+
+        async def _finished() -> None:
+            return None
+
+        task = asyncio.ensure_future(_finished())
+        await asyncio.sleep(0)  # let the task run to completion
+        assert task.done()
+        context.task_to_node[task] = dag_node
+        context.running_tasks_count = 1
+
+        # handle_done_nodes touches the full engine (events, connections, library registry); stub it
+        # so this stays a focused scheduler unit test. It runs after the reap has set node_state.
+        monkeypatch.setattr(ExecuteDagState, "handle_done_nodes", AsyncMock())
+
+        await ExecuteDagState.on_update(context)
+
+        assert task not in context.task_to_node, "on_update did not reap the completed task"
+        assert dag_node.node_state == NodeState.DONE
+
+    @pytest.mark.asyncio
+    async def test_reaping_a_cancelled_task_marks_node_canceled(self) -> None:
+        """A cancelled task's node must be reaped as CANCELED and drive the flow to ErrorState."""
+        context = self._context_with_processing_node()
+        dag_node = context.node_to_reference["n"]
+
+        task = asyncio.ensure_future(asyncio.sleep(3600))
+        task.cancel()
+        await asyncio.sleep(0)  # let the cancellation propagate to completion
+        assert task.cancelled()
+        context.task_to_node[task] = dag_node
+        context.running_tasks_count = 1
+
+        state = await ExecuteDagState.on_update(context)
+
+        assert state is ErrorState
+        assert task not in context.task_to_node
+        assert dag_node.node_state == NodeState.CANCELED
+
+    @pytest.mark.asyncio
+    async def test_reaping_an_errored_task_marks_node_errored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A task that raised must be reaped as ERRORED, set the error state, and go to ErrorState."""
+        context = self._context_with_processing_node()
+        dag_node = context.node_to_reference["n"]
+
+        async def _boom() -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        task = asyncio.ensure_future(_boom())
+        await asyncio.sleep(0)  # run the task to completion; it raises internally
+        assert isinstance(task.exception(), RuntimeError)
+        context.task_to_node[task] = dag_node
+        context.running_tasks_count = 1
+
+        # The error branch emits a NodeErrorEvent; stub the event manager so no engine is needed.
+        event_manager = MagicMock()
+        event_manager.aput_event = AsyncMock()
+        monkeypatch.setattr(
+            "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.EventManager", lambda: event_manager
+        )
+
+        state = await ExecuteDagState.on_update(context)
+
+        assert state is ErrorState
+        assert task not in context.task_to_node
+        assert dag_node.node_state == NodeState.ERRORED
+        assert context.workflow_state == WorkflowState.ERRORED
+        assert context.error_message is not None

--- a/uv.lock
+++ b/uv.lock
@@ -658,6 +658,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
 
@@ -727,6 +728,7 @@ test = [
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
 ]
 
@@ -1987,6 +1989,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #5201.

This PR includes some test fixes/conveniences that then lead to fixing the actual bug that has been sporadically hanging e2e tests on CI (e.g. [here](https://github.com/griptape-ai/griptape-nodes-engine/actions/runs/30238357823/job/89890376886)).

### Bug

If two tasks finish at nearly the same time, then we can get something like:
- First task completes
- First task done callback is scheduled.
- Waking of `asyncio.wait(..., return_when=asyncio.FIRST_COMPLETED)` is  scheduled.
- Second task completes
- Second task done callback is scheduled.

So now we have second task's done callback scheduled _after_ the `asyncio.wait` wakes up.

We relied on a task being in `task_to_node` in order to set the `node_state` in the task's done callback. But if the task had already been reaped from the `task_to_node` map before the done callback fired, then the node would never
become `DONE`, causing an infinite `on_update` loop. This can happen in the case illustrated above.

So eschew usage of a done callback, and set the `node_state` in response to `asyncio.wait` alone.

#### Reproducing

To help repro the hang fixed above, the `test_group_runs_independent_nodes_in_parallel` test has been adapted to obey a `--parallel-repro-iterations=N` flag (see commit message).  This commit can be dropped, pending review.

E.g. on Ubuntu:

* In one terminal max out your CPUs `stress-ng --cpu $(( $(nproc) * 4 ))`
* In another terminal `uv run pytest -s --parallel-repro-iterations=100 tests/e2e/test_subflow_group_parallel_execution.py::test_group_runs_independent_nodes_in_parallel`

### e2e test improvements

On dev boxes with a local Griptape Nodes config, the local config can leak into tests causing unexpected behaviour. In particular, `GT_CLOUD_BUCKET_ID` and `GTN_CONFIG_ENABLE_WORKSPACE_FILE_WATCHING` cause background threads to spawn that cause segfaults on subprocess test teardown, causing false positives. This affected `test_subflow_node_group_propagates_output_values` and `test_standalone_workflow_registers_declared_libraries`.

So add a conftest.py with shared fixtures to ensure a clean Griptape Nodes config across all tests.

Debugging the hang above was particularly tricky, since CI is empty, with no logs helping isolate the issue (and initially it seemed not to reproduce locally).

So add pytest-timeout plugin and use in all (and only) e2e tests. On timeout, the plugin will dump a thread trace, which should help us debug.

Move a few other common helpers into the conftest.py file too.

