### PR TITLE
build(docs): render Mermaid via mkdocs-material instead of mermaid2

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,6 @@ site_url: https://docs.griptapenodes.com/
 
 plugins:
   - search
-  - mermaid2
   - mkdocstrings:
       handlers:
         python:
@@ -246,7 +245,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:mermaid2.fence_mermaid_custom
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - tables
   - md_in_html
   - toc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ docs = [
   "mkdocs-material>=9.6.9",
   "mkdocs>=1.5.2",
   "mkdocstrings[python]>=0.29.1",
-  "mkdocs-mermaid2-plugin>=1.2.2",
   "mkdocs-llmstxt>=0.5.0",
   "mkdocs-redirects>=1.2.2,<1.2.4",
   "pymdown-extensions>=10.17",

--- a/uv.lock
+++ b/uv.lock
@@ -403,15 +403,6 @@ wheels = [
 ]
 
 [[package]]
-name = "editorconfig"
-version = "0.17.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
-]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -672,7 +663,6 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
-    { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocs-redirects" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
@@ -742,7 +732,6 @@ docs = [
     { name = "mkdocs", specifier = ">=1.5.2" },
     { name = "mkdocs-llmstxt", specifier = ">=0.5.0" },
     { name = "mkdocs-material", specifier = ">=9.6.9" },
-    { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.2" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2,<1.2.4" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
     { name = "pymdown-extensions", specifier = ">=10.17" },
@@ -1011,19 +1000,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/ac/d4fd5b30f82900eac60d765f179f0ba005825ac462cc8ced6e13ec685ab3/joserfc-1.6.8.tar.gz", hash = "sha256:878620c553a6ebdd76ccdc356782fee3f735f21a356d079a546b42a4670ace5f", size = 232930, upload-time = "2026-05-27T03:22:37.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/8c/5cdce2cf3ce8155849baf9a5e2ce77e89dc87ec3bdb38259e5d85fbc45bd/joserfc-1.6.8-py3-none-any.whl", hash = "sha256:22fb31a69094a5e6f44632002a9df2c30c941fc6c8ce1b037e92c03de954cf9f", size = 70927, upload-time = "2026-05-27T03:22:35.796Z" },
-]
-
-[[package]]
-name = "jsbeautifier"
-version = "1.15.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "editorconfig" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
 ]
 
 [[package]]
@@ -1437,23 +1413,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
-]
-
-[[package]]
-name = "mkdocs-mermaid2-plugin"
-version = "1.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "jsbeautifier" },
-    { name = "mkdocs" },
-    { name = "pymdown-extensions" },
-    { name = "requests" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
 ]
 
 [[package]]
@@ -2406,15 +2365,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Drops `mkdocs-mermaid2-plugin` in favor of the Mermaid support built into `mkdocs-material` (9.7.6, already a dependency), by pointing the superfences custom fence at `pymdownx.superfences.fence_code_format`.

Three files, 1 insertion / 53 deletions:

- `mkdocs.yml` — remove the `mermaid2` plugin; switch the fence `format`. The `name: mermaid` / `class: mermaid` lines stay, since that's what Material's integration keys on.
- `pyproject.toml` — drop `mkdocs-mermaid2-plugin` from the `docs` group.
- `uv.lock` — `uv lock` also removed three transitive deps it was pulling in (`jsbeautifier`, `editorconfig`, `setuptools`).

## Why

Material renders diagrams through its own bundle, so they inherit the active color scheme, the palette toggle, and the theme fonts. `mermaid2` instead pins Mermaid 10.4.0 and injects a fixed `mermaid.initialize()` from a CDN, leaving diagrams on a single hardcoded theme regardless of whether the reader is in light or dark mode — this repo has a light/dark toggle and no Mermaid theming in `docs/assets/css/extra.css`.

Groundwork for the deployment architecture diagrams in griptape-ai/internal#184, which will add substantially more diagram content than the four pages we have today. Worth getting the rendering path right first.

## Compatibility

The four existing diagram pages use only plain `flowchart`/`graph` and `subgraph` syntax with no `mermaid2`-specific features (no pyjs callbacks, no custom JS), so nothing depended on the plugin.

## Verification

- `make docs` (`--clean --strict`) exits 0; `make check` passes.
- All four diagram pages emit `<pre class="mermaid"><code>` and Material's bundle contains the Mermaid loader. No CDN `<script>` anywhere in `site/`.
- Diagram source is byte-preserved, including the `subgraph Security ["🔒 Everything Stays Local"]` label in `advanced_local_models.md`.
- Repo-wide grep for `mermaid2` outside `site/` and `.venv/` returns nothing.
- `.readthedocs.yml` builds with `uv sync --group docs` and `fail_on_warning: true`, so I simulated it: a `--frozen` sync plus strict build also exits 0 with all four diagrams intact. The hosted build won't break on the lockfile change.

## Not verified — needs a reviewer with a browser

Everything above is build-level. The actual payoff is diagrams following the light/dark palette toggle, and confirming that needs a browser. Please run `make docs/serve` and check these four pages in **both** color schemes:

- `guides/publishing`
- `guides/mcp/getting_started`
- `guides/mcp/advanced_local_models`
- `guides/mcp/mcp_task_agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)