### PR TITLE
docs: add deployment architecture page with diagrams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,13 +62,38 @@ Model calls do not have to involve Griptape Cloud at all. You can point nodes at
 The editor and the application are separate programs, so events between them need a transport:
 
 - **Direct WebSocket.** The application listens locally and the editor connects straight to it. Events never leave the machine. This is what Griptape Nodes Desktop uses when you activate with a license.
-- **Nodes API WebSocket.** Both sides connect out to Griptape Cloud, which relays events between them. This is what lets an editor in a browser drive an application on a different machine.
+- **Nodes API WebSocket.** The editor and the application each open their own outbound connection to Griptape Cloud, which relays events between them. This is what lets an editor in a browser drive an application on a different machine.
 
-The distinction matters for privacy, because editor traffic carries workflow content: node graphs, parameter values, and previews of generated assets. On the direct WebSocket, none of it is exposed to the network.
+The relay is worth drawing, because it is the one arrangement where editor traffic crosses the internet:
+
+```mermaid
+flowchart TB
+    subgraph browser["Your browser, on any machine"]
+        editor["Editor"]
+    end
+
+    subgraph machine["The machine running your workflows"]
+        direction TB
+        app["Griptape Nodes application"]
+        workspace[("Workspace<br/>workflows, assets, secrets")]
+        app --- workspace
+    end
+
+    subgraph cloud["Griptape Cloud"]
+        wsapi["Nodes API WebSocket<br/>relays events between the two"]
+    end
+
+    editor <-.->|"outbound connection"| wsapi
+    app <-.->|"outbound connection"| wsapi
+```
+
+Neither side accepts an inbound connection. Both dial out to Griptape Cloud and exchange events over a pair of topics scoped to their session, which is why this works without opening a port or knowing the other machine's address.
+
+The distinction matters for privacy, because editor traffic carries workflow content: node graphs, parameter values, and previews of generated assets. On the direct WebSocket none of it is exposed to the network, and your workspace stays on the machine that runs the workflows in either case.
 
 ## SaaS configuration
 
-The default. Your machine reaches Griptape Cloud directly, so nothing needs to be deployed on your side.
+The default. Your machine reaches Griptape Cloud directly, so nothing needs to be deployed on your side. This diagram shows the editor on the same machine, connected over the direct WebSocket; swap in the relay above if your editor runs elsewhere.
 
 ```mermaid
 flowchart TB
@@ -86,7 +111,6 @@ flowchart TB
     subgraph cloud["Griptape Cloud"]
         direction TB
         control["Licensing and sessions<br/>Entitlements"]
-        wsapi["Nodes API WebSocket"]
         modelproxy["Model proxy"]
         buckets["Buckets and Assets"]
     end
@@ -94,8 +118,6 @@ flowchart TB
     providers["Third-party model providers"]
 
     app ==>|"license + session<br/>(required)"| control
-    editor <-.->|"if editor is remote"| wsapi
-    wsapi <-.-> app
     app -.->|"HTTPS: model calls"| modelproxy
     app -.->|"optional sync"| buckets
     modelproxy --> providers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,78 +1,85 @@
 # Architecture
 
-Griptape Nodes runs the same way everywhere. You build workflows in an editor, and an application on a machine you control executes them. A license is what unlocks that application, and Griptape Cloud is what validates the license.
+Griptape Nodes is two programs: an **editor** where you build workflows, and an **application** that executes them on a machine you control. The application does the work, holds the data, and calls out to Griptape Cloud for the few things it cannot do itself.
 
-That is the whole shape of it. The two configurations on this page differ in exactly one thing: **how the application's licensing checks reach Griptape Cloud.**
+That shape does not change between deployments. What changes is the network path from your machines to Griptape Cloud:
 
-- **[SaaS configuration](#saas-configuration)** is the default. The application talks to Griptape Cloud directly.
+- **[SaaS configuration](#saas-configuration)** is the default. Your machine reaches Griptape Cloud directly.
 - **[On-premises configuration](#on-premises-configuration)** keeps your machines off the public internet. They reach Griptape Cloud only through a single [Admin Server](enterprise/admin_server.md) you run.
 
-Both run identical software, licensed the same way. Moving between them changes a route, not a product.
+Both run identical software. Moving between them changes a route, not a product.
 
 ## The pieces
 
-Two things sit between you and a running workflow.
+| Component       | What it is                                                                                                                                                                                                                                                             | Where it runs                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Editor**      | The visual canvas where you build workflows.                                                                                                                                                                                                                           | In your browser, or bundled inside Griptape Nodes Desktop. |
+| **Application** | The program that runs your workflows, distributed as [`griptape-nodes`](https://pypi.org/project/griptape-nodes/). It executes the graph, manages your workspace, and enforces the permissions your license grants.                                                    | On your machine.                                           |
+| **Engine**      | The open source workflow runtime, distributed as [`griptape-nodes-engine`](https://pypi.org/project/griptape-nodes-engine/) with source at [griptape-nodes-engine](https://github.com/griptape-ai/griptape-nodes-engine). Loads node libraries and executes the graph. | Inside the application.                                    |
 
-| Component       | What it is                                                                                                                                                                                                              | Where it runs                                              |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Editor**      | The visual canvas where you build workflows.                                                                                                                                                                            | In your browser, or bundled inside Griptape Nodes Desktop. |
-| **Application** | The licensed program that runs your workflows, distributed as [`griptape-nodes`](https://pypi.org/project/griptape-nodes/). It validates your license, enforces the permissions attached to it, and executes the graph. | On your machine.                                           |
+The engine is where workflow execution actually happens, and it is fully open source, so anything you want to verify about how a workflow runs or where it writes files is auditable. It is not a separate deployment target: an editor connects to the application, never to the engine directly.
 
-Inside the application is the open source [`griptape-nodes-engine`](https://pypi.org/project/griptape-nodes-engine/), which loads node libraries and does the actual execution. It is worth knowing about because it is public and auditable, but it is not a separate thing you deploy or connect to. An editor always connects to the application, never to the engine directly.
+[Griptape Nodes Desktop](installation.md#griptape-nodes-desktop-recommended) bundles the editor and ships the application with a pinned Python interpreter, so there is nothing to install separately.
 
-[Griptape Nodes Desktop](installation.md#griptape-nodes-desktop-recommended) is the easiest way to get both: it bundles the editor and ships the application with a pinned Python interpreter, so there is nothing to install separately.
+## Where your data lives
 
-Griptape Cloud provides the services the application cannot provide for itself:
+Everything you create is stored on the machine running the application, in a directory you choose called the **workspace**. Nothing in this table is sent anywhere by default.
 
-| Capability                 | What it does                                                                                                                              |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Licensing and sessions** | Validates licenses, allocates and renews the session that permits an application to run, then releases it when you are done.              |
-| **Entitlements**           | Resolves the permissions attached to your license, which the application then enforces locally.                                           |
-| **Nodes API WebSocket**    | Carries events between an editor and an application that are not on the same machine.                                                     |
-| **Model proxy**            | Routes model calls to many providers under one Griptape credential, so you need no account with each provider.                            |
-| **Buckets and Assets**     | Optional cloud storage for syncing workflows and assets across machines.                                                                  |
-| **Admin Dashboard**        | Backs the interface where owners issue license keys and build permission templates. See [Admin Dashboard](enterprise/admin_dashboard.md). |
+| What                                   | Where it lives                                                                                      | Leaves your machine?                                        |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Workflows and project files            | Your workspace directory                                                                            | No                                                          |
+| Generated assets: images, video, audio | Your workspace directory                                                                            | No, unless you switch the storage backend to Griptape Cloud |
+| Secrets and API keys                   | Environment variables, then a `.env` file in your workspace, then one in your user config directory | No                                                          |
+| Conversation history                   | Your workspace directory                                                                            | No                                                          |
+| Node libraries                         | Installed locally, each in its own virtual environment                                              | No                                                          |
 
-Model calls can also bypass Griptape Cloud entirely. You can point nodes at a third party provider with your own API key, or at a local model runner such as Ollama or LM Studio. See [AI Providers](guides/agent/providers/index.md).
+Two settings can change this, both off by default and both documented in [Configuration](guides/configuration.md):
 
-## How a license unlocks the application
+- **Storage backend.** Defaults to `local`, which writes assets to your workspace. Set it to `gtc` and generated assets go to a Griptape Cloud bucket instead.
+- **Synced workflows.** Opt in to sync workflows through a Griptape Cloud bucket to share them across machines.
 
-A license is issued to you by your organization and authenticates **the application itself**, not you as a person. Activating one is the same in both configurations described below:
+Beyond those, data leaves your machine only where a workflow sends it: a node that calls a model provider sends that node's inputs to that provider. Which is the next section.
 
-1. You paste your license key into the application.
-1. The application validates the key's signature locally, then asks Griptape Cloud to allocate a **session**, which is the permission slip that lets it run.
-1. Griptape Cloud returns the **entitlements** attached to your license: which node libraries you may load, which models you may call.
-1. The application enforces those entitlements locally for as long as it runs, renewing the session periodically.
+## What talks to Griptape Cloud
 
-Step 2 is the only step whose network path differs between the two configurations. Everything else is identical.
+The application depends on Griptape Cloud for a small number of things. This is the complete list.
 
-See [Using the Admin Server](enterprise/using_the_admin_server.md) for the activation walkthrough.
+| Capability                 | Required?                                         | What crosses the boundary                                                                                    |
+| -------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Licensing and sessions** | **Yes.** The application will not run without it. | Your license, and session allocate, renew, and release calls. No workflow content.                           |
+| **Entitlements**           | Yes, resolved with the session                    | The permissions your license grants, returned to the application, which enforces them locally                |
+| **Model proxy**            | No                                                | The prompts and inputs of nodes you point at it, forwarded to the model provider                             |
+| **Buckets and Assets**     | No, opt in                                        | Assets and workflows you choose to sync                                                                      |
+| **Nodes API WebSocket**    | No                                                | Editor and application events, when the two are not on the same machine                                      |
+| **Admin Dashboard**        | No, administrators only                           | License and permission administration, from a browser. See [Admin Dashboard](enterprise/admin_dashboard.md). |
 
-!!! info "If you signed in with a Griptape account instead"
+**Licensing is the only hard dependency.** A license is what permits the application to run: the application validates it, asks Griptape Cloud to allocate a session, receives the permissions attached to it, and enforces those locally while it runs. Workflow content is never part of that exchange. See [Using the Admin Server](enterprise/using_the_admin_server.md) for activation.
 
-    Individual users can also sign in with a Griptape Cloud account, which provisions credentials for you rather than using a license key. This is the older mechanism and it still works. Licenses are the direction the product is heading, and they are what organizations deploying Griptape Nodes should use, so this page describes the licensed path.
+Model calls do not have to involve Griptape Cloud at all. You can point nodes at a third party provider with your own API key, or at a model running locally under Ollama or LM Studio, in which case prompts never leave the machine. See [AI Providers](guides/agent/providers/index.md).
 
 ### How the editor reaches the application
 
-The editor and the application are separate programs, so events between them need a transport. Two exist:
+The editor and the application are separate programs, so events between them need a transport:
 
-- **Direct WebSocket.** The application listens on your machine and the editor connects straight to it. Events never leave the machine. **This is what license activation uses.**
-- **Nodes API WebSocket.** Both sides connect out to Griptape Cloud, which relays events between them. This is what lets you open an editor on a laptop and drive an application running on a different machine. It is tied to the account sign-in path above.
+- **Direct WebSocket.** The application listens locally and the editor connects straight to it. Events never leave the machine. This is what Griptape Nodes Desktop uses when you activate with a license.
+- **Nodes API WebSocket.** Both sides connect out to Griptape Cloud, which relays events between them. This is what lets an editor in a browser drive an application on a different machine.
 
-So on a licensed application, your workflow events are local by construction, in either configuration. Griptape Nodes Desktop wires this up for you: activate with a license and it configures the direct WebSocket.
+The distinction matters for privacy, because editor traffic carries workflow content: node graphs, parameter values, and previews of generated assets. On the direct WebSocket, none of it is exposed to the network.
 
 ## SaaS configuration
 
-The default. Your machine reaches Griptape Cloud directly, so licensing works with no infrastructure of your own.
+The default. Your machine reaches Griptape Cloud directly, so nothing needs to be deployed on your side.
 
 ```mermaid
 flowchart TB
     subgraph machine["Your machine"]
         direction TB
         editor["Editor"]
-        app["Griptape Nodes application<br/>license enforcement<br/>+ workflow execution"]
+        app["Griptape Nodes application<br/>engine + policy enforcement"]
+        workspace[("Workspace<br/>workflows, assets, secrets")]
         local["Local models<br/>Ollama, LM Studio"]
         editor <-->|"direct WebSocket"| app
+        app --- workspace
         app -.-> local
     end
 
@@ -86,34 +93,32 @@ flowchart TB
 
     providers["Third-party model providers"]
 
-    app -->|"HTTPS: license, session, entitlements"| control
-    editor <-.->|"account sign-in only"| wsapi
+    app ==>|"license + session<br/>(required)"| control
+    editor <-.->|"if editor is remote"| wsapi
     wsapi <-.-> app
-    app -->|"HTTPS: model calls"| modelproxy
+    app -.->|"HTTPS: model calls"| modelproxy
     app -.->|"optional sync"| buckets
     modelproxy --> providers
     app -.->|"direct, your own API key"| providers
 ```
 
-Two things are worth noticing.
-
-**Your workflows and assets stay on your machine.** The application reads and writes your local workspace. Nothing is copied to Griptape Cloud unless you opt into Buckets and Assets, or a node you placed sends data somewhere.
-
-**Only licensing has to go to Griptape Cloud.** The dotted paths are all optional. Model calls can go direct to a provider or to a local runner, asset sync is opt in, and the Nodes API WebSocket is only involved on the account sign-in path.
+Solid lines are required, dotted lines are optional. The only traffic Griptape Nodes cannot run without is licensing.
 
 ## On-premises configuration
 
-Same licensing flow, different route. Your machines have no path to the public internet, so they reach Griptape Cloud through an [Admin Server](enterprise/admin_server.md) you run inside your network. You allow one host through your firewall instead of one per machine.
+Your machines have no route to the public internet. They reach Griptape Cloud through an [Admin Server](enterprise/admin_server.md) you run inside your network, so you allow one host through your firewall instead of one per machine.
 
 ```mermaid
 flowchart TB
     subgraph network["Your network"]
         direction TB
         editor["Editor<br/>bundled with Desktop"]
-        app["Griptape Nodes application<br/>license enforcement<br/>+ workflow execution"]
+        app["Griptape Nodes application<br/>engine + policy enforcement"]
+        workspace[("Workspace<br/>workflows, assets, secrets")]
         local["Local models<br/>Ollama, LM Studio"]
         admin["Admin Server<br/>single egress point<br/>optional path filtering"]
         editor <-->|"direct WebSocket<br/>never leaves your network"| app
+        app --- workspace
         app -.-> local
         app -->|"HTTPS, in-network"| admin
         %% Invisible link: keeps the Admin Server on its own rank below the
@@ -131,17 +136,13 @@ flowchart TB
     admin -.->|"permitted only if you allow it"| modelproxy
 ```
 
-Three differences carry the whole configuration.
+Three properties carry the configuration.
 
-**Everything about the editor is local.** Griptape Nodes Desktop bundles the editor, so no browser fetches it over the internet, and license activation puts it on the direct WebSocket. Workflow events never leave your network.
+**Nothing about building or running a workflow crosses the perimeter.** Griptape Nodes Desktop bundles the editor, so no browser fetches it over the internet, and it connects to the application over the direct WebSocket. Workflows, assets, and secrets sit in a workspace on the machine. Combined with a local model runner, a workflow can execute start to finish with no packet leaving your network.
 
-**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`. You get one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths may leave, so you might keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
+**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`, giving you one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths are permitted, so you can keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
 
-**Local models never egress at all.** A model running under Ollama or LM Studio on the same machine is reached without passing through the Admin Server.
-
-### What has to leave your network
-
-Even fully locked down, an application needs a small set of Cloud routes to license itself. The Admin Server refuses to start if your configuration would block them:
+**What must egress is a fixed, inspectable list.** Licensing needs the routes below, and nothing else is required. The Admin Server refuses to start if your configuration would block them:
 
 | Route                  | Why it is needed                                                     |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -151,8 +152,6 @@ Even fully locked down, an application needs a small set of Cloud routes to lice
 | `/api/users`           | Identify the license holder at startup and on each heartbeat.        |
 | `/api/organizations`   | Resolve the owning organization at startup and on each heartbeat.    |
 
-Everything else is your choice. Model calls can go through the Cloud model proxy, direct to a third party provider, or to a local model runner that never leaves your network.
-
 !!! note "Griptape Cloud is still required"
 
     On premises means your machines, workflows, and assets stay inside your network. It does not mean Griptape Nodes runs disconnected. Sessions are allocated by Griptape Cloud, so the Admin Server needs a route to it. If that route is unavailable, the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
@@ -161,19 +160,19 @@ Everything else is your choice. Model calls can go through the Cloud model proxy
 
 If you are reviewing Griptape Nodes for a security assessment, these are the load bearing details.
 
-**License enforcement happens on your machine, not in the network.** The application validates its license and enforces the attached policy locally, in compiled code, before a request reaches the engine. Policy comes only from the signed license, so it cannot be loosened by editing engine code. The permissions themselves are resolved from Griptape Cloud when a session is allocated.
+**Policy is enforced on your machine, not in the network.** The application enforces the permissions attached to your license locally, in compiled code, before a request reaches the engine. Those permissions come only from the signed license, so they cannot be loosened by editing engine code. They are resolved from Griptape Cloud when a session is allocated.
 
 **The Admin Server forwards; it does not decide.** It validates no licenses, allocates no sessions, resolves no entitlements, and caches nothing. It does not authenticate callers either: each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. Because it holds no state, it is not an offline fallback. With no route upstream, it returns an error.
 
-**Griptape Cloud remains the authority on licensing and entitlement.** Session allocation and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path that traffic takes to get there.
+**Griptape Cloud is the authority on licensing and entitlement.** Session allocation and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path traffic takes to get there.
 
-**The engine is open source and unlicensed.** Enforcement lives in the application, not the engine. A workflow saved as a Python file can be run directly against the open source engine with no license, which also places it outside the policy boundary described above. That is deliberate: it is what keeps the engine open source.
+**The execution runtime is open source and auditable.** The engine that runs your workflows is public, so its file handling, network calls, and node execution can be inspected rather than taken on trust. Enforcement lives in the application layer above it, which means a workflow saved as a Python file can also be run directly against the engine with no license, outside the policy boundary described above. That is deliberate: it is what keeps the engine open source.
 
 ## Related pages
 
 - [Installation](installation.md) covers installing Desktop or the application by hand.
+- [Configuration](guides/configuration.md) covers the workspace, storage backend, and static server settings.
+- [Assets and Outputs](guides/assets.md) explains where generated files go and how the editor previews them.
 - [Using the Admin Server](enterprise/using_the_admin_server.md) walks through activating with a license key.
 - [Admin Server](enterprise/admin_server.md) covers deploying and configuring the on-premises proxy.
 - [Admin Dashboard](enterprise/admin_dashboard.md) covers issuing license keys and building permission templates.
-- [Assets and Outputs](guides/assets.md) explains where generated files go and how the editor previews them.
-- [Configuration](guides/configuration.md) covers workspace, storage backend, and static server settings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,77 +1,92 @@
 # Architecture
 
-Griptape Nodes runs the same way everywhere: you build workflows in an editor, and an engine on a machine you control executes them. What changes between deployments is where that machine sits and how it reaches Griptape Cloud.
+Griptape Nodes runs the same way everywhere. You build workflows in an editor, and an engine on a machine you control executes them. What changes between setups is how you sign in, how the editor reaches the engine, and whether your machines talk to Griptape Cloud directly or through a server you operate.
 
-This page shows the two deployment models available today:
+This page covers the two configurations available today:
 
-- **[Griptape Cloud](#griptape-cloud-deployment)** — the default. Your engine talks to Griptape Cloud directly.
-- **[On-premises](#on-premises-deployment)** — your engines run inside your network with no direct internet access, reaching Griptape Cloud through a single [Admin Server](enterprise/admin_server.md) you operate.
+- **[SaaS configuration](#saas-configuration)** is the default. Your machines talk to Griptape Cloud directly.
+- **[On-premises configuration](#on-premises-configuration)** keeps your machines off the public internet. They reach Griptape Cloud only through a single [Admin Server](enterprise/admin_server.md) you run.
 
-Both models run identical software. Moving between them is configuration, not a different product.
+Both configurations run identical software. Moving between them is a matter of configuration, not a different product.
 
 ## The pieces
 
-Three things sit between you and a running workflow, and it helps to know which is which before reading the diagrams.
+Three things sit between you and a running workflow.
 
-| Component       | What it is                                                                                                                              | Where it runs                                              |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Editor**      | The visual canvas where you build workflows.                                                                                            | In your browser, or bundled inside Griptape Nodes Desktop. |
-| **Application** | The licensed program you launch. It wraps the engine and enforces your license: what libraries you may load, which models you may call. | On your machine.                                           |
-| **Engine**      | The open-source workflow executor. Loads node libraries, runs workflows, writes results to your workspace.                              | Inside the application, on your machine.                   |
+| Component       | What it is                                                                                                                                                                                                            | Where it runs                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Editor**      | The visual canvas where you build workflows.                                                                                                                                                                          | In your browser, or bundled inside Griptape Nodes Desktop. |
+| **Application** | The licensed program you launch, distributed as [`griptape-nodes`](https://pypi.org/project/griptape-nodes/). It wraps the engine and enforces your license: which libraries you may load, which models you may call. | On your machine.                                           |
+| **Engine**      | The open source workflow executor, distributed as [`griptape-nodes-engine`](https://pypi.org/project/griptape-nodes-engine/). Loads node libraries, runs workflows, writes results to your workspace.                 | Inside the application, on your machine.                   |
 
-Alongside the engine, two local services do supporting work:
-
-- A **static file server** hands generated media (images, video, audio) to the editor for preview and download. See [Assets and Outputs](guides/assets.md).
-- Your **workspace** on local disk holds your projects, workflow files, secrets, and generated assets.
+[Griptape Nodes Desktop](installation.md#griptape-nodes-desktop-recommended) is the easiest way to get all three: it bundles the editor and ships the application with a pinned Python interpreter, so there is nothing to install separately.
 
 Griptape Cloud provides the services the application cannot provide for itself:
 
 | Capability                 | What it does                                                                                                                              |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | **Authentication**         | Signs you in and identifies your organization.                                                                                            |
-| **Licensing and sessions** | Issues licenses, allocates and renews the session that permits an application to run, and releases it when you are done.                  |
-| **Entitlements**           | Resolves the permissions attached to your license — the policy the application enforces locally.                                          |
-| **Model proxy**            | Routes model calls to many providers under one Griptape credential, so you need no per-provider accounts.                                 |
+| **Licensing and sessions** | Issues licenses, allocates and renews the session that permits an application to run, then releases it when you are done.                 |
+| **Entitlements**           | Resolves the permissions attached to your license, which the application then enforces locally.                                           |
+| **Nodes API WebSocket**    | Carries events between an editor and an application that are not on the same machine.                                                     |
+| **Model proxy**            | Routes model calls to many providers under one Griptape credential, so you need no per provider accounts.                                 |
 | **Buckets and Assets**     | Optional cloud storage for syncing workflows and assets across machines.                                                                  |
-| **Event relay**            | Carries events between editor and engine when they are not on the same machine.                                                           |
 | **Admin Dashboard**        | Backs the interface where owners issue license keys and build permission templates. See [Admin Dashboard](enterprise/admin_dashboard.md). |
 
-Model calls can also bypass Griptape Cloud: you can point nodes at a third-party provider with your own API key, or at a local model runner such as Ollama or LM Studio. See [AI Providers](guides/agent/providers/index.md).
+Model calls can also bypass Griptape Cloud entirely. You can point nodes at a third party provider with your own API key, or at a local model runner such as Ollama or LM Studio. See [AI Providers](guides/agent/providers/index.md).
 
-## Griptape Cloud deployment
+## Two choices that shape your setup
 
-This is what you get by default, whether you installed Griptape Nodes Desktop or the engine by hand.
+Before the diagrams, two settings are worth separating, because they are independent and each is often mistaken for the other.
+
+### How you sign in
+
+There are two ways to authenticate, and both work in either configuration:
+
+- **Griptape Cloud account.** You sign in through Griptape Cloud, and your account identifies you.
+- **License key.** You paste a license key issued by your organization and point the application at a server endpoint. No cloud account is involved. See [Using the Admin Server](enterprise/using_the_admin_server.md).
+
+License keys are what on-premises deployments normally use, but nothing stops you from activating with a license against Griptape Cloud directly.
+
+### How the editor reaches the application
+
+The editor and the application are separate programs, so events between them need a transport. Two are available:
+
+- **Direct WebSocket.** The application listens on your machine and the editor connects straight to it. Events never leave the machine.
+- **Nodes API WebSocket.** Both sides connect out to Griptape Cloud, which passes events between them. This is what lets you open an editor on a laptop and drive an application running somewhere else.
+
+**The transport follows how you signed in.** Griptape Nodes Desktop configures the direct WebSocket when you activate with a license key, and the Nodes API WebSocket when you sign in with a Griptape Cloud account. So the choice in the previous section decides this one.
+
+## SaaS configuration
+
+This is the default setup, whether you installed Griptape Nodes Desktop or the engine by hand. Your machine talks to Griptape Cloud directly.
 
 ```mermaid
-flowchart LR
+flowchart TB
     subgraph machine["Your machine"]
         direction TB
-        editor["Editor<br/>Desktop or browser"]
+        editor["Editor"]
         app["Application<br/>license + policy enforcement"]
         engine["Engine<br/>workflow execution"]
-        static["Static file server"]
-        workspace[("Workspace<br/>projects, assets, secrets")]
         local["Local models<br/>Ollama, LM Studio"]
+        editor <-->|"direct WebSocket<br/>(license sign-in)"| app
         app --- engine
-        engine --- workspace
-        engine --- static
-        editor -.->|"media preview"| static
         engine -.-> local
     end
 
     subgraph cloud["Griptape Cloud"]
         direction TB
         control["Authentication<br/>Licensing and sessions<br/>Entitlements"]
-        relay["Event relay"]
+        wsapi["Nodes API WebSocket"]
         modelproxy["Model proxy"]
         buckets["Buckets and Assets"]
     end
 
-    providers["Third-party<br/>model providers"]
+    providers["Third-party model providers"]
 
-    app -->|"HTTPS: sign-in,<br/>license, session"| control
-    app <-->|"WSS: workflow events"| relay
-    editor <-->|"HTTPS / WSS"| relay
+    app -->|"HTTPS: sign-in, license, session"| control
+    editor <-.->|"or via cloud<br/>(account sign-in)"| wsapi
+    wsapi <-.-> app
     engine -->|"HTTPS: model calls"| modelproxy
     engine -.->|"optional sync"| buckets
     modelproxy --> providers
@@ -82,30 +97,28 @@ Two things are worth noticing.
 
 **Your workflows and assets stay on your machine.** The engine reads and writes your local workspace. Nothing is copied to Griptape Cloud unless you opt into Buckets and Assets, or a node you placed sends data somewhere.
 
-**Editor and engine reach each other through the event relay.** They are separate programs, so events between them travel over Griptape Cloud by default. That is what lets you open the editor on a laptop and drive an engine running elsewhere. Media is the exception: the editor fetches previews straight from the local static file server, so large files never make the round trip.
+**Either transport is available here.** The dotted path through the Nodes API WebSocket is what you get with an account sign-in. Activate with a license key instead and the editor connects straight to the application, exactly as it does on premises.
 
-## On-premises deployment
+## On-premises configuration
 
-In this model your engines have no route to the public internet. They reach Griptape Cloud only through an [Admin Server](enterprise/admin_server.md) you run inside your network — one host through your firewall instead of one per instance.
+In this setup your machines have no route to the public internet. They reach Griptape Cloud only through an [Admin Server](enterprise/admin_server.md) you run inside your network, so you allow one host through your firewall instead of one per machine.
 
 ```mermaid
-flowchart LR
+flowchart TB
     subgraph network["Your network"]
         direction TB
         editor["Editor<br/>bundled with Desktop"]
         app["Application<br/>license + policy enforcement"]
         engine["Engine<br/>workflow execution"]
-        static["Static file server"]
-        workspace[("Workspace<br/>projects, assets, secrets")]
-        localmodels["Local models<br/>Ollama, LM Studio"]
-        admin["Admin Server<br/>single egress point<br/>+ optional path filtering"]
-        editor <-->|"local WebSocket,<br/>no cloud round trip"| app
+        local["Local models<br/>Ollama, LM Studio"]
+        admin["Admin Server<br/>single egress point<br/>optional path filtering"]
+        editor <-->|"direct WebSocket<br/>never leaves your network"| app
         app --- engine
-        engine --- workspace
-        engine --- static
-        editor -.->|"media preview"| static
-        engine -.-> localmodels
+        engine -.-> local
         app -->|"HTTPS, in-network"| admin
+        %% Invisible link: keeps the Admin Server on its own rank below the
+        %% local models, so the egress edge does not pass behind them.
+        local ~~~ admin
     end
 
     subgraph cloud["Griptape Cloud"]
@@ -115,16 +128,16 @@ flowchart LR
     end
 
     admin ==>|"HTTPS: the only traffic<br/>leaving your network"| control
-    admin -.->|"permitted only<br/>if you allow it"| modelproxy
+    admin -.->|"permitted only if you allow it"| modelproxy
 ```
 
-Three differences from the cloud deployment carry the whole model.
+Three differences carry the whole configuration.
 
-**The editor is local, and so is its connection to the engine.** Griptape Nodes Desktop bundles the editor, so no browser needs to load it over the internet. Editor and application sit on the same workstation and talk over a local WebSocket. The cloud event relay is not used, so your workflow events never leave the building.
+**Everything about the editor is local.** Griptape Nodes Desktop bundles the editor, so no browser fetches it over the internet. Users activate with a license key, which puts the editor on the direct WebSocket, so workflow events never leave your network.
 
-**One host egresses, and you choose what it may carry.** Every application instance points at the Admin Server instead of `cloud.griptape.ai`. You get one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict *which* Cloud paths may leave — for example, keeping the model proxy in-network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
+**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`. You get one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths may leave. You might keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
 
-**Users activate with a license instead of signing in.** Rather than a Griptape Cloud login, each user pastes a license key and points the application at your Admin Server. See [Using the Admin Server](enterprise/using_the_admin_server.md).
+**Local models never egress at all.** A model running under Ollama or LM Studio on the same machine is reached without passing through the Admin Server.
 
 ### What has to leave your network
 
@@ -138,29 +151,29 @@ Even fully locked down, an application needs a small set of Cloud routes to run.
 | `/api/users`           | Identify the license holder at startup and on each heartbeat.        |
 | `/api/organizations`   | Resolve the owning organization at startup and on each heartbeat.    |
 
-Everything else is your choice. Model calls can go through the Cloud model proxy, direct to a third-party provider, or to a local model runner that never leaves your network.
+Everything else is your choice. Model calls can go through the Cloud model proxy, direct to a third party provider, or to a local model runner that never leaves your network.
 
 !!! note "Griptape Cloud is still required"
 
-    On-premises means your engines, workflows, and assets stay inside your network — not that Griptape Nodes runs disconnected. Sessions are allocated by Griptape Cloud, so the Admin Server needs a route to it. If that route is unavailable the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
+    On premises means your machines, workflows, and assets stay inside your network. It does not mean Griptape Nodes runs disconnected. Sessions are allocated by Griptape Cloud, so the Admin Server needs a route to it. If that route is unavailable, the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
 
 ## Where the boundaries are
 
-If you are reviewing Griptape Nodes for a security assessment, these are the load-bearing details.
+If you are reviewing Griptape Nodes for a security assessment, these are the load bearing details.
 
 **License enforcement happens on your machine, not in the network.** The application validates its license and enforces the attached policy locally, in compiled code, before a request reaches the engine. Policy comes only from the signed license, so it cannot be loosened by editing engine code. The permissions themselves are resolved from Griptape Cloud when a session is allocated.
 
-**The Admin Server is a forwarder, not a decision-maker.** It does not validate licenses, allocate sessions, resolve entitlements, or cache anything, and it does not authenticate callers — each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. Because it holds no state, it is not an offline fallback: with no route upstream, it returns an error.
+**The Admin Server forwards; it does not decide.** It validates no licenses, allocates no sessions, resolves no entitlements, and caches nothing. It does not authenticate callers either: each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. Because it holds no state, it is not an offline fallback. With no route upstream, it returns an error.
 
-**Griptape Cloud remains the authority on identity and entitlement.** Authentication, session allocation, and entitlement resolution are Cloud decisions in both deployment models. The difference on-premises is only the path traffic takes to get there.
+**Griptape Cloud remains the authority on identity and entitlement.** Authentication, session allocation, and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path that traffic takes to get there.
 
-**The engine is open source and unlicensed.** Enforcement lives in the application wrapper, not the engine. A workflow saved as a Python file can be run directly against the open-source engine with no license — which also means it is outside the policy boundary described above.
+**The engine is open source and unlicensed.** Enforcement lives in the application, not the engine. A workflow saved as a Python file can be run directly against the open source engine with no license, which also places it outside the policy boundary described above.
 
 ## Related pages
 
-- [Installation](installation.md) — install Desktop or the engine by hand.
-- [Admin Server](enterprise/admin_server.md) — deploy and configure the on-premises proxy.
-- [Using the Admin Server](enterprise/using_the_admin_server.md) — activate a workstation with a license.
-- [Admin Dashboard](enterprise/admin_dashboard.md) — issue license keys and build permission templates.
-- [Assets and Outputs](guides/assets.md) — where generated files go and how the editor previews them.
-- [Configuration](guides/configuration.md) — workspace, storage backend, and static server settings.
+- [Installation](installation.md) covers installing Desktop or the engine by hand.
+- [Admin Server](enterprise/admin_server.md) covers deploying and configuring the on-premises proxy.
+- [Using the Admin Server](enterprise/using_the_admin_server.md) walks through activating with a license key.
+- [Admin Dashboard](enterprise/admin_dashboard.md) covers issuing license keys and building permission templates.
+- [Assets and Outputs](guides/assets.md) explains where generated files go and how the editor previews them.
+- [Configuration](guides/configuration.md) covers workspace, storage backend, and static server settings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,82 +1,84 @@
 # Architecture
 
-Griptape Nodes runs the same way everywhere. You build workflows in an editor, and an engine on a machine you control executes them. What changes between setups is how you sign in, how the editor reaches the engine, and whether your machines talk to Griptape Cloud directly or through a server you operate.
+Griptape Nodes runs the same way everywhere. You build workflows in an editor, and an application on a machine you control executes them. A license is what unlocks that application, and Griptape Cloud is what validates the license.
 
-This page covers the two configurations available today:
+That is the whole shape of it. The two configurations on this page differ in exactly one thing: **how the application's licensing checks reach Griptape Cloud.**
 
-- **[SaaS configuration](#saas-configuration)** is the default. Your machines talk to Griptape Cloud directly.
+- **[SaaS configuration](#saas-configuration)** is the default. The application talks to Griptape Cloud directly.
 - **[On-premises configuration](#on-premises-configuration)** keeps your machines off the public internet. They reach Griptape Cloud only through a single [Admin Server](enterprise/admin_server.md) you run.
 
-Both configurations run identical software. Moving between them is a matter of configuration, not a different product.
+Both run identical software, licensed the same way. Moving between them changes a route, not a product.
 
 ## The pieces
 
-Three things sit between you and a running workflow.
+Two things sit between you and a running workflow.
 
-| Component       | What it is                                                                                                                                                                                                            | Where it runs                                              |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Editor**      | The visual canvas where you build workflows.                                                                                                                                                                          | In your browser, or bundled inside Griptape Nodes Desktop. |
-| **Application** | The licensed program you launch, distributed as [`griptape-nodes`](https://pypi.org/project/griptape-nodes/). It wraps the engine and enforces your license: which libraries you may load, which models you may call. | On your machine.                                           |
-| **Engine**      | The open source workflow executor, distributed as [`griptape-nodes-engine`](https://pypi.org/project/griptape-nodes-engine/). Loads node libraries, runs workflows, writes results to your workspace.                 | Inside the application, on your machine.                   |
+| Component       | What it is                                                                                                                                                                                                              | Where it runs                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Editor**      | The visual canvas where you build workflows.                                                                                                                                                                            | In your browser, or bundled inside Griptape Nodes Desktop. |
+| **Application** | The licensed program that runs your workflows, distributed as [`griptape-nodes`](https://pypi.org/project/griptape-nodes/). It validates your license, enforces the permissions attached to it, and executes the graph. | On your machine.                                           |
 
-[Griptape Nodes Desktop](installation.md#griptape-nodes-desktop-recommended) is the easiest way to get all three: it bundles the editor and ships the application with a pinned Python interpreter, so there is nothing to install separately.
+Inside the application is the open source [`griptape-nodes-engine`](https://pypi.org/project/griptape-nodes-engine/), which loads node libraries and does the actual execution. It is worth knowing about because it is public and auditable, but it is not a separate thing you deploy or connect to. An editor always connects to the application, never to the engine directly.
+
+[Griptape Nodes Desktop](installation.md#griptape-nodes-desktop-recommended) is the easiest way to get both: it bundles the editor and ships the application with a pinned Python interpreter, so there is nothing to install separately.
 
 Griptape Cloud provides the services the application cannot provide for itself:
 
 | Capability                 | What it does                                                                                                                              |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Authentication**         | Signs you in and identifies your organization.                                                                                            |
-| **Licensing and sessions** | Issues licenses, allocates and renews the session that permits an application to run, then releases it when you are done.                 |
+| **Licensing and sessions** | Validates licenses, allocates and renews the session that permits an application to run, then releases it when you are done.              |
 | **Entitlements**           | Resolves the permissions attached to your license, which the application then enforces locally.                                           |
 | **Nodes API WebSocket**    | Carries events between an editor and an application that are not on the same machine.                                                     |
-| **Model proxy**            | Routes model calls to many providers under one Griptape credential, so you need no per provider accounts.                                 |
+| **Model proxy**            | Routes model calls to many providers under one Griptape credential, so you need no account with each provider.                            |
 | **Buckets and Assets**     | Optional cloud storage for syncing workflows and assets across machines.                                                                  |
 | **Admin Dashboard**        | Backs the interface where owners issue license keys and build permission templates. See [Admin Dashboard](enterprise/admin_dashboard.md). |
 
 Model calls can also bypass Griptape Cloud entirely. You can point nodes at a third party provider with your own API key, or at a local model runner such as Ollama or LM Studio. See [AI Providers](guides/agent/providers/index.md).
 
-## Two choices that shape your setup
+## How a license unlocks the application
 
-Before the diagrams, two settings are worth separating, because they are independent and each is often mistaken for the other.
+A license is issued to you by your organization and authenticates **the application itself**, not you as a person. Activating one is the same in both configurations described below:
 
-### How you sign in
+1. You paste your license key into the application.
+1. The application validates the key's signature locally, then asks Griptape Cloud to allocate a **session**, which is the permission slip that lets it run.
+1. Griptape Cloud returns the **entitlements** attached to your license: which node libraries you may load, which models you may call.
+1. The application enforces those entitlements locally for as long as it runs, renewing the session periodically.
 
-There are two ways to authenticate, and both work in either configuration:
+Step 2 is the only step whose network path differs between the two configurations. Everything else is identical.
 
-- **Griptape Cloud account.** You sign in through Griptape Cloud, and your account identifies you.
-- **License key.** You paste a license key issued by your organization and point the application at a server endpoint. No cloud account is involved. See [Using the Admin Server](enterprise/using_the_admin_server.md).
+See [Using the Admin Server](enterprise/using_the_admin_server.md) for the activation walkthrough.
 
-License keys are what on-premises deployments normally use, but nothing stops you from activating with a license against Griptape Cloud directly.
+!!! info "If you signed in with a Griptape account instead"
+
+    Individual users can also sign in with a Griptape Cloud account, which provisions credentials for you rather than using a license key. This is the older mechanism and it still works. Licenses are the direction the product is heading, and they are what organizations deploying Griptape Nodes should use, so this page describes the licensed path.
 
 ### How the editor reaches the application
 
-The editor and the application are separate programs, so events between them need a transport. Two are available:
+The editor and the application are separate programs, so events between them need a transport. Two exist:
 
-- **Direct WebSocket.** The application listens on your machine and the editor connects straight to it. Events never leave the machine.
-- **Nodes API WebSocket.** Both sides connect out to Griptape Cloud, which passes events between them. This is what lets you open an editor on a laptop and drive an application running somewhere else.
+- **Direct WebSocket.** The application listens on your machine and the editor connects straight to it. Events never leave the machine. **This is what license activation uses.**
+- **Nodes API WebSocket.** Both sides connect out to Griptape Cloud, which relays events between them. This is what lets you open an editor on a laptop and drive an application running on a different machine. It is tied to the account sign-in path above.
 
-**The transport follows how you signed in.** Griptape Nodes Desktop configures the direct WebSocket when you activate with a license key, and the Nodes API WebSocket when you sign in with a Griptape Cloud account. So the choice in the previous section decides this one.
+So on a licensed application, your workflow events are local by construction, in either configuration. Griptape Nodes Desktop wires this up for you: activate with a license and it configures the direct WebSocket.
 
 ## SaaS configuration
 
-This is the default setup, whether you installed Griptape Nodes Desktop or the engine by hand. Your machine talks to Griptape Cloud directly.
+The default. Your machine reaches Griptape Cloud directly, so licensing works with no infrastructure of your own.
 
 ```mermaid
 flowchart TB
     subgraph machine["Your machine"]
         direction TB
         editor["Editor"]
-        app["Application<br/>license + policy enforcement"]
-        engine["Engine<br/>workflow execution"]
+        app["Griptape Nodes application<br/>license enforcement<br/>+ workflow execution"]
         local["Local models<br/>Ollama, LM Studio"]
-        editor <-->|"direct WebSocket<br/>(license sign-in)"| app
-        app --- engine
-        engine -.-> local
+        editor <-->|"direct WebSocket"| app
+        app -.-> local
     end
 
     subgraph cloud["Griptape Cloud"]
         direction TB
-        control["Authentication<br/>Licensing and sessions<br/>Entitlements"]
+        control["Licensing and sessions<br/>Entitlements"]
         wsapi["Nodes API WebSocket"]
         modelproxy["Model proxy"]
         buckets["Buckets and Assets"]
@@ -84,37 +86,35 @@ flowchart TB
 
     providers["Third-party model providers"]
 
-    app -->|"HTTPS: sign-in, license, session"| control
-    editor <-.->|"or via cloud<br/>(account sign-in)"| wsapi
+    app -->|"HTTPS: license, session, entitlements"| control
+    editor <-.->|"account sign-in only"| wsapi
     wsapi <-.-> app
-    engine -->|"HTTPS: model calls"| modelproxy
-    engine -.->|"optional sync"| buckets
+    app -->|"HTTPS: model calls"| modelproxy
+    app -.->|"optional sync"| buckets
     modelproxy --> providers
-    engine -.->|"direct, your own API key"| providers
+    app -.->|"direct, your own API key"| providers
 ```
 
 Two things are worth noticing.
 
-**Your workflows and assets stay on your machine.** The engine reads and writes your local workspace. Nothing is copied to Griptape Cloud unless you opt into Buckets and Assets, or a node you placed sends data somewhere.
+**Your workflows and assets stay on your machine.** The application reads and writes your local workspace. Nothing is copied to Griptape Cloud unless you opt into Buckets and Assets, or a node you placed sends data somewhere.
 
-**Either transport is available here.** The dotted path through the Nodes API WebSocket is what you get with an account sign-in. Activate with a license key instead and the editor connects straight to the application, exactly as it does on premises.
+**Only licensing has to go to Griptape Cloud.** The dotted paths are all optional. Model calls can go direct to a provider or to a local runner, asset sync is opt in, and the Nodes API WebSocket is only involved on the account sign-in path.
 
 ## On-premises configuration
 
-In this setup your machines have no route to the public internet. They reach Griptape Cloud only through an [Admin Server](enterprise/admin_server.md) you run inside your network, so you allow one host through your firewall instead of one per machine.
+Same licensing flow, different route. Your machines have no path to the public internet, so they reach Griptape Cloud through an [Admin Server](enterprise/admin_server.md) you run inside your network. You allow one host through your firewall instead of one per machine.
 
 ```mermaid
 flowchart TB
     subgraph network["Your network"]
         direction TB
         editor["Editor<br/>bundled with Desktop"]
-        app["Application<br/>license + policy enforcement"]
-        engine["Engine<br/>workflow execution"]
+        app["Griptape Nodes application<br/>license enforcement<br/>+ workflow execution"]
         local["Local models<br/>Ollama, LM Studio"]
         admin["Admin Server<br/>single egress point<br/>optional path filtering"]
         editor <-->|"direct WebSocket<br/>never leaves your network"| app
-        app --- engine
-        engine -.-> local
+        app -.-> local
         app -->|"HTTPS, in-network"| admin
         %% Invisible link: keeps the Admin Server on its own rank below the
         %% local models, so the egress edge does not pass behind them.
@@ -123,7 +123,7 @@ flowchart TB
 
     subgraph cloud["Griptape Cloud"]
         direction TB
-        control["Authentication<br/>Licensing and sessions<br/>Entitlements"]
+        control["Licensing and sessions<br/>Entitlements"]
         modelproxy["Model proxy"]
     end
 
@@ -133,15 +133,15 @@ flowchart TB
 
 Three differences carry the whole configuration.
 
-**Everything about the editor is local.** Griptape Nodes Desktop bundles the editor, so no browser fetches it over the internet. Users activate with a license key, which puts the editor on the direct WebSocket, so workflow events never leave your network.
+**Everything about the editor is local.** Griptape Nodes Desktop bundles the editor, so no browser fetches it over the internet, and license activation puts it on the direct WebSocket. Workflow events never leave your network.
 
-**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`. You get one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths may leave. You might keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
+**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`. You get one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths may leave, so you might keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
 
 **Local models never egress at all.** A model running under Ollama or LM Studio on the same machine is reached without passing through the Admin Server.
 
 ### What has to leave your network
 
-Even fully locked down, an application needs a small set of Cloud routes to run. These are the licensing and session routes, and the Admin Server refuses to start if your configuration would block them:
+Even fully locked down, an application needs a small set of Cloud routes to license itself. The Admin Server refuses to start if your configuration would block them:
 
 | Route                  | Why it is needed                                                     |
 | ---------------------- | -------------------------------------------------------------------- |
@@ -165,15 +165,15 @@ If you are reviewing Griptape Nodes for a security assessment, these are the loa
 
 **The Admin Server forwards; it does not decide.** It validates no licenses, allocates no sessions, resolves no entitlements, and caches nothing. It does not authenticate callers either: each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. Because it holds no state, it is not an offline fallback. With no route upstream, it returns an error.
 
-**Griptape Cloud remains the authority on identity and entitlement.** Authentication, session allocation, and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path that traffic takes to get there.
+**Griptape Cloud remains the authority on licensing and entitlement.** Session allocation and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path that traffic takes to get there.
 
-**The engine is open source and unlicensed.** Enforcement lives in the application, not the engine. A workflow saved as a Python file can be run directly against the open source engine with no license, which also places it outside the policy boundary described above.
+**The engine is open source and unlicensed.** Enforcement lives in the application, not the engine. A workflow saved as a Python file can be run directly against the open source engine with no license, which also places it outside the policy boundary described above. That is deliberate: it is what keeps the engine open source.
 
 ## Related pages
 
-- [Installation](installation.md) covers installing Desktop or the engine by hand.
-- [Admin Server](enterprise/admin_server.md) covers deploying and configuring the on-premises proxy.
+- [Installation](installation.md) covers installing Desktop or the application by hand.
 - [Using the Admin Server](enterprise/using_the_admin_server.md) walks through activating with a license key.
+- [Admin Server](enterprise/admin_server.md) covers deploying and configuring the on-premises proxy.
 - [Admin Dashboard](enterprise/admin_dashboard.md) covers issuing license keys and building permission templates.
 - [Assets and Outputs](guides/assets.md) explains where generated files go and how the editor previews them.
 - [Configuration](guides/configuration.md) covers workspace, storage backend, and static server settings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,7 +185,7 @@ Three properties carry the configuration.
 
 **Nothing about building or running a workflow crosses the perimeter.** Griptape Nodes Desktop bundles the editor, so no browser fetches it over the internet, and it connects to the application over the direct WebSocket. Workflows, assets, and secrets sit in a workspace on the machine. Combined with a local model runner, a workflow can execute start to finish with no packet leaving your network.
 
-**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`, giving you one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths are permitted, so you can keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
+**One host egresses, and you decide what it may carry.** Every application points at the Admin Server instead of `cloud.griptape.ai`, giving you one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict which Cloud paths are permitted, so you can keep model calls in network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding). It forwards rather than decides: it validates no licenses, allocates no sessions, and caches nothing, and each application's own credential passes through untouched for Griptape Cloud to accept or reject.
 
 **What must egress is a fixed, inspectable list.** Licensing needs the routes below, and nothing else is required. The Admin Server refuses to start if your configuration would block them:
 
@@ -202,18 +202,6 @@ Three properties carry the configuration.
     That connection does more than allocate a session. It is also how an application picks up the current contents of its license, so when an administrator changes what a license permits, running deployments get the new permissions on their next session rather than waiting for a reissue or a redeploy. Managing entitlements centrally and having them take effect immediately is the practical benefit of keeping the route open.
 
     It does mean on premises is not a disconnected mode. On premises means your machines, workflows, and assets stay inside your network; it does not mean Griptape Nodes runs with no route out. Sessions are allocated by Griptape Cloud, so the Admin Server needs to reach it. If that route is unavailable, the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
-
-## Where the boundaries are
-
-If you are reviewing Griptape Nodes for a security assessment, these are the details that matter most.
-
-**The Admin Server forwards; it does not decide.** It validates no licenses, allocates no sessions, resolves no entitlements, and caches nothing. It does not authenticate callers either: each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. It holds no state, so it is not an offline fallback. With no route upstream, it returns an error.
-
-**Policy is enforced on your machine, not in the network.** The application enforces the permissions attached to your license locally, before a request reaches the engine. Those permissions come from the signed license and are resolved from Griptape Cloud when a session is allocated, so no network appliance or firewall rule is involved in deciding what a workflow may do.
-
-**Griptape Cloud is the authority on licensing and entitlement.** Session allocation and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path traffic takes to get there.
-
-**The execution runtime is open source and auditable.** The engine that runs your workflows is public, so its file handling, network calls, and node execution can be inspected rather than taken on trust. Enforcement lives in the application layer above it.
 
 ## Related pages
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,36 +64,17 @@ The editor and the application are separate programs, so events between them nee
 - **Direct WebSocket.** The application listens locally and the editor connects straight to it. Events never leave the machine. This is what Griptape Nodes Desktop uses when you activate with a license.
 - **Nodes API WebSocket.** The editor and the application each open their own outbound connection to Griptape Cloud, which relays events between them. This is what lets an editor in a browser drive an application on a different machine.
 
-The relay is worth drawing, because it is the one arrangement where editor traffic crosses the internet:
-
-```mermaid
-flowchart TB
-    subgraph browser["Your browser, on any machine"]
-        editor["Editor"]
-    end
-
-    subgraph machine["The machine running your workflows"]
-        direction TB
-        app["Griptape Nodes application"]
-        workspace[("Workspace<br/>workflows, assets, secrets")]
-        app --- workspace
-    end
-
-    subgraph cloud["Griptape Cloud"]
-        wsapi["Nodes API WebSocket<br/>relays events between the two"]
-    end
-
-    editor <-.->|"outbound connection"| wsapi
-    app <-.->|"outbound connection"| wsapi
-```
-
-Neither side accepts an inbound connection. Both dial out to Griptape Cloud and exchange events over a pair of topics scoped to their session, which is why this works without opening a port or knowing the other machine's address.
-
-The distinction matters for privacy, because editor traffic carries workflow content: node graphs, parameter values, and previews of generated assets. On the direct WebSocket none of it is exposed to the network, and your workspace stays on the machine that runs the workflows in either case.
+The distinction matters for privacy, because editor traffic carries workflow content: node graphs, parameter values, and previews of generated assets. On the direct WebSocket none of it is exposed to the network. Either way your workspace stays on the machine that runs the workflows. The [SaaS configuration](#saas-configuration) section below draws both arrangements.
 
 ## SaaS configuration
 
-The default. Your machine reaches Griptape Cloud directly, so nothing needs to be deployed on your side. This diagram shows the editor on the same machine, connected over the direct WebSocket; swap in the relay above if your editor runs elsewhere.
+The default. Your machine reaches Griptape Cloud directly, so nothing needs to be deployed on your side. This configuration comes in two variations, which differ only in how the editor reaches the application.
+
+In both, solid lines are required and dotted lines are optional. The only traffic Griptape Nodes cannot run without is licensing.
+
+### Editor on the same machine
+
+The arrangement you get from Griptape Nodes Desktop. The editor connects straight to the application, so no workflow content touches the network.
 
 ```mermaid
 flowchart TB
@@ -124,7 +105,47 @@ flowchart TB
     app -.->|"direct, your own API key"| providers
 ```
 
-Solid lines are required, dotted lines are optional. The only traffic Griptape Nodes cannot run without is licensing.
+### Editor on a different machine
+
+Use this when you want the application on a bigger box than the one you are sitting at, or the editor in a browser on a laptop. The editor and the application each open an **outbound** connection to the Nodes API WebSocket, which relays events between them.
+
+```mermaid
+flowchart TB
+    subgraph remote["Any other machine"]
+        editor["Editor<br/>in a browser"]
+    end
+
+    subgraph machine["Your machine"]
+        direction TB
+        app["Griptape Nodes application<br/>engine + policy enforcement"]
+        workspace[("Workspace<br/>workflows, assets, secrets")]
+        local["Local models<br/>Ollama, LM Studio"]
+        app --- workspace
+        app -.-> local
+    end
+
+    subgraph cloud["Griptape Cloud"]
+        direction TB
+        wsapi["Nodes API<br/>WebSocket"]
+        control["Licensing,<br/>sessions,<br/>entitlements"]
+        modelproxy["Model<br/>proxy"]
+        buckets["Buckets<br/>and Assets"]
+    end
+
+    providers["Third-party model providers"]
+
+    editor <-.->|"outbound"| wsapi
+    app <-.->|"outbound"| wsapi
+    app ==>|"license + session<br/>(required)"| control
+    app -.->|"model calls"| modelproxy
+    app -.->|"optional sync"| buckets
+    modelproxy --> providers
+    app -.->|"your own API key"| providers
+```
+
+Because both sides dial out, this needs no open inbound port and neither machine needs to know the other's address. The trade is that editor traffic now crosses the internet: node graphs, parameter values, and asset previews pass through Griptape Cloud. Your workspace does not move, and the workflow still runs entirely on your machine.
+
+**Neither variation applies on premises.** The Nodes API WebSocket is a Griptape Cloud service, so an on-premises deployment uses the direct connection, which is what keeps workflow events inside your network.
 
 ## On-premises configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,166 @@
+# Architecture
+
+Griptape Nodes runs the same way everywhere: you build workflows in an editor, and an engine on a machine you control executes them. What changes between deployments is where that machine sits and how it reaches Griptape Cloud.
+
+This page shows the two deployment models available today:
+
+- **[Griptape Cloud](#griptape-cloud-deployment)** — the default. Your engine talks to Griptape Cloud directly.
+- **[On-premises](#on-premises-deployment)** — your engines run inside your network with no direct internet access, reaching Griptape Cloud through a single [Admin Server](enterprise/admin_server.md) you operate.
+
+Both models run identical software. Moving between them is configuration, not a different product.
+
+## The pieces
+
+Three things sit between you and a running workflow, and it helps to know which is which before reading the diagrams.
+
+| Component       | What it is                                                                                                                              | Where it runs                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Editor**      | The visual canvas where you build workflows.                                                                                            | In your browser, or bundled inside Griptape Nodes Desktop. |
+| **Application** | The licensed program you launch. It wraps the engine and enforces your license: what libraries you may load, which models you may call. | On your machine.                                           |
+| **Engine**      | The open-source workflow executor. Loads node libraries, runs workflows, writes results to your workspace.                              | Inside the application, on your machine.                   |
+
+Alongside the engine, two local services do supporting work:
+
+- A **static file server** hands generated media (images, video, audio) to the editor for preview and download. See [Assets and Outputs](guides/assets.md).
+- Your **workspace** on local disk holds your projects, workflow files, secrets, and generated assets.
+
+Griptape Cloud provides the services the application cannot provide for itself:
+
+| Capability                 | What it does                                                                                                                              |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Authentication**         | Signs you in and identifies your organization.                                                                                            |
+| **Licensing and sessions** | Issues licenses, allocates and renews the session that permits an application to run, and releases it when you are done.                  |
+| **Entitlements**           | Resolves the permissions attached to your license — the policy the application enforces locally.                                          |
+| **Model proxy**            | Routes model calls to many providers under one Griptape credential, so you need no per-provider accounts.                                 |
+| **Buckets and Assets**     | Optional cloud storage for syncing workflows and assets across machines.                                                                  |
+| **Event relay**            | Carries events between editor and engine when they are not on the same machine.                                                           |
+| **Admin Dashboard**        | Backs the interface where owners issue license keys and build permission templates. See [Admin Dashboard](enterprise/admin_dashboard.md). |
+
+Model calls can also bypass Griptape Cloud: you can point nodes at a third-party provider with your own API key, or at a local model runner such as Ollama or LM Studio. See [AI Providers](guides/agent/providers/index.md).
+
+## Griptape Cloud deployment
+
+This is what you get by default, whether you installed Griptape Nodes Desktop or the engine by hand.
+
+```mermaid
+flowchart LR
+    subgraph machine["Your machine"]
+        direction TB
+        editor["Editor<br/>Desktop or browser"]
+        app["Application<br/>license + policy enforcement"]
+        engine["Engine<br/>workflow execution"]
+        static["Static file server"]
+        workspace[("Workspace<br/>projects, assets, secrets")]
+        local["Local models<br/>Ollama, LM Studio"]
+        app --- engine
+        engine --- workspace
+        engine --- static
+        editor -.->|"media preview"| static
+        engine -.-> local
+    end
+
+    subgraph cloud["Griptape Cloud"]
+        direction TB
+        control["Authentication<br/>Licensing and sessions<br/>Entitlements"]
+        relay["Event relay"]
+        modelproxy["Model proxy"]
+        buckets["Buckets and Assets"]
+    end
+
+    providers["Third-party<br/>model providers"]
+
+    app -->|"HTTPS: sign-in,<br/>license, session"| control
+    app <-->|"WSS: workflow events"| relay
+    editor <-->|"HTTPS / WSS"| relay
+    engine -->|"HTTPS: model calls"| modelproxy
+    engine -.->|"optional sync"| buckets
+    modelproxy --> providers
+    engine -.->|"direct, your own API key"| providers
+```
+
+Two things are worth noticing.
+
+**Your workflows and assets stay on your machine.** The engine reads and writes your local workspace. Nothing is copied to Griptape Cloud unless you opt into Buckets and Assets, or a node you placed sends data somewhere.
+
+**Editor and engine reach each other through the event relay.** They are separate programs, so events between them travel over Griptape Cloud by default. That is what lets you open the editor on a laptop and drive an engine running elsewhere. Media is the exception: the editor fetches previews straight from the local static file server, so large files never make the round trip.
+
+## On-premises deployment
+
+In this model your engines have no route to the public internet. They reach Griptape Cloud only through an [Admin Server](enterprise/admin_server.md) you run inside your network — one host through your firewall instead of one per instance.
+
+```mermaid
+flowchart LR
+    subgraph network["Your network"]
+        direction TB
+        editor["Editor<br/>bundled with Desktop"]
+        app["Application<br/>license + policy enforcement"]
+        engine["Engine<br/>workflow execution"]
+        static["Static file server"]
+        workspace[("Workspace<br/>projects, assets, secrets")]
+        localmodels["Local models<br/>Ollama, LM Studio"]
+        admin["Admin Server<br/>single egress point<br/>+ optional path filtering"]
+        editor <-->|"local WebSocket,<br/>no cloud round trip"| app
+        app --- engine
+        engine --- workspace
+        engine --- static
+        editor -.->|"media preview"| static
+        engine -.-> localmodels
+        app -->|"HTTPS, in-network"| admin
+    end
+
+    subgraph cloud["Griptape Cloud"]
+        direction TB
+        control["Authentication<br/>Licensing and sessions<br/>Entitlements"]
+        modelproxy["Model proxy"]
+    end
+
+    admin ==>|"HTTPS: the only traffic<br/>leaving your network"| control
+    admin -.->|"permitted only<br/>if you allow it"| modelproxy
+```
+
+Three differences from the cloud deployment carry the whole model.
+
+**The editor is local, and so is its connection to the engine.** Griptape Nodes Desktop bundles the editor, so no browser needs to load it over the internet. Editor and application sit on the same workstation and talk over a local WebSocket. The cloud event relay is not used, so your workflow events never leave the building.
+
+**One host egresses, and you choose what it may carry.** Every application instance points at the Admin Server instead of `cloud.griptape.ai`. You get one firewall rule and one place to audit outbound traffic. The Admin Server can also restrict *which* Cloud paths may leave — for example, keeping the model proxy in-network while still permitting licensing. See [forwarding rules](enterprise/admin_server.md#forwarding).
+
+**Users activate with a license instead of signing in.** Rather than a Griptape Cloud login, each user pastes a license key and points the application at your Admin Server. See [Using the Admin Server](enterprise/using_the_admin_server.md).
+
+### What has to leave your network
+
+Even fully locked down, an application needs a small set of Cloud routes to run. These are the licensing and session routes, and the Admin Server refuses to start if your configuration would block them:
+
+| Route                  | Why it is needed                                                     |
+| ---------------------- | -------------------------------------------------------------------- |
+| `/api/sessions/*`      | Allocate and manage the session that permits the application to run. |
+| `/api/session-renew`   | Keep that session alive.                                             |
+| `/api/session-release` | End the session cleanly and free the seat.                           |
+| `/api/users`           | Identify the license holder at startup and on each heartbeat.        |
+| `/api/organizations`   | Resolve the owning organization at startup and on each heartbeat.    |
+
+Everything else is your choice. Model calls can go through the Cloud model proxy, direct to a third-party provider, or to a local model runner that never leaves your network.
+
+!!! note "Griptape Cloud is still required"
+
+    On-premises means your engines, workflows, and assets stay inside your network — not that Griptape Nodes runs disconnected. Sessions are allocated by Griptape Cloud, so the Admin Server needs a route to it. If that route is unavailable the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
+
+## Where the boundaries are
+
+If you are reviewing Griptape Nodes for a security assessment, these are the load-bearing details.
+
+**License enforcement happens on your machine, not in the network.** The application validates its license and enforces the attached policy locally, in compiled code, before a request reaches the engine. Policy comes only from the signed license, so it cannot be loosened by editing engine code. The permissions themselves are resolved from Griptape Cloud when a session is allocated.
+
+**The Admin Server is a forwarder, not a decision-maker.** It does not validate licenses, allocate sessions, resolve entitlements, or cache anything, and it does not authenticate callers — each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. Because it holds no state, it is not an offline fallback: with no route upstream, it returns an error.
+
+**Griptape Cloud remains the authority on identity and entitlement.** Authentication, session allocation, and entitlement resolution are Cloud decisions in both deployment models. The difference on-premises is only the path traffic takes to get there.
+
+**The engine is open source and unlicensed.** Enforcement lives in the application wrapper, not the engine. A workflow saved as a Python file can be run directly against the open-source engine with no license — which also means it is outside the policy boundary described above.
+
+## Related pages
+
+- [Installation](installation.md) — install Desktop or the engine by hand.
+- [Admin Server](enterprise/admin_server.md) — deploy and configure the on-premises proxy.
+- [Using the Admin Server](enterprise/using_the_admin_server.md) — activate a workstation with a license.
+- [Admin Dashboard](enterprise/admin_dashboard.md) — issue license keys and build permission templates.
+- [Assets and Outputs](guides/assets.md) — where generated files go and how the editor previews them.
+- [Configuration](guides/configuration.md) — workspace, storage backend, and static server settings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,22 +23,24 @@ The engine is where workflow execution actually happens, and it is fully open so
 
 ## Where your data lives
 
-Everything you create is stored on the machine running the application, in a directory you choose called the **workspace**. Nothing in this table is sent anywhere by default.
+Almost everything you create is written to your **workspace**: a single root directory that the application reads and writes, and from which relative paths are resolved. Its location is yours to choose. It defaults to a folder beside the application, but you can point it anywhere the machine can reach, including network attached storage such as a NAS mount or LucidLink, which is a common arrangement for studios that keep project data on shared infrastructure. See [Workspace](guides/projects/workspace.md).
 
-| What                                   | Where it lives                                                                                      | Leaves your machine?                                        |
+That makes the workspace the thing to look at when you are asking where data goes. The application writes to the path you configured, and nothing in this table is sent to Griptape Cloud by default.
+
+| What                                   | Where it lives                                                                                      | Sent to Griptape Cloud?                                     |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| Workflows and project files            | Your workspace directory                                                                            | No                                                          |
-| Generated assets: images, video, audio | Your workspace directory                                                                            | No, unless you switch the storage backend to Griptape Cloud |
+| Workflows and project files            | Your workspace                                                                                      | No                                                          |
+| Generated assets: images, video, audio | Your workspace                                                                                      | No, unless you switch the storage backend to Griptape Cloud |
 | Secrets and API keys                   | Environment variables, then a `.env` file in your workspace, then one in your user config directory | No                                                          |
-| Conversation history                   | Your workspace directory                                                                            | No                                                          |
-| Node libraries                         | Installed locally, each in its own virtual environment                                              | No                                                          |
+| Conversation history                   | Your workspace                                                                                      | No                                                          |
+| Node libraries                         | Installed on the machine running the application, each in its own virtual environment               | No                                                          |
 
 Two settings can change this, both off by default and both documented in [Configuration](guides/configuration.md):
 
 - **Storage backend.** Defaults to `local`, which writes assets to your workspace. Set it to `gtc` and generated assets go to a Griptape Cloud bucket instead.
 - **Synced workflows.** Opt in to sync workflows through a Griptape Cloud bucket to share them across machines.
 
-Beyond those, data leaves your machine only where a workflow sends it: a node that calls a model provider sends that node's inputs to that provider. Which is the next section.
+Beyond those, data leaves the workspace only where a workflow sends it: a node that calls a model provider sends that node's inputs to that provider. Which is the next section.
 
 ## What talks to Griptape Cloud
 
@@ -70,11 +72,11 @@ The distinction matters for privacy, because editor traffic carries workflow con
 
 The default. Your machine reaches Griptape Cloud directly, so nothing needs to be deployed on your side. This configuration comes in two variations, which differ only in how the editor reaches the application.
 
-In both, solid lines are required and dotted lines are optional. The only traffic Griptape Nodes cannot run without is licensing.
+In all three diagrams on this page, solid lines are required and dotted lines are optional, and a double headed arrow means data comes back along the same path. The only traffic Griptape Nodes cannot run without is licensing.
 
-### Editor on the same machine
+### Editor and engine on the same machine
 
-The arrangement you get from Griptape Nodes Desktop. The editor connects straight to the application, so no workflow content touches the network.
+The arrangement you get from Griptape Nodes Desktop. The editor connects straight to the application that hosts the engine, so no workflow content touches the network.
 
 ```mermaid
 flowchart TB
@@ -85,8 +87,8 @@ flowchart TB
         workspace[("Workspace<br/>workflows, assets, secrets")]
         local["Local models<br/>Ollama, LM Studio"]
         editor <-->|"direct WebSocket"| app
-        app --- workspace
-        app -.-> local
+        app <--> workspace
+        app <-.-> local
     end
 
     subgraph cloud["Griptape Cloud"]
@@ -98,16 +100,16 @@ flowchart TB
 
     providers["Third-party model providers"]
 
-    app ==>|"license + session<br/>(required)"| control
-    app -.->|"HTTPS: model calls"| modelproxy
-    app -.->|"optional sync"| buckets
-    modelproxy --> providers
-    app -.->|"direct, your own API key"| providers
+    app <==>|"license + session out<br/>entitlements back"| control
+    app <-.->|"prompts out<br/>completions back"| modelproxy
+    app <-.->|"optional sync"| buckets
+    modelproxy <--> providers
+    app <-.->|"your own API key"| providers
 ```
 
-### Editor on a different machine
+### Editor and engine on different machines
 
-Use this when you want the application on a bigger box than the one you are sitting at, or the editor in a browser on a laptop. The editor and the application each open an **outbound** connection to the Nodes API WebSocket, which relays events between them.
+Use this when you want the engine on a bigger box than the one you are sitting at, or the editor in a browser on a laptop. The editor and the application each open an **outbound** connection to the Nodes API WebSocket, which relays events between them.
 
 ```mermaid
 flowchart TB
@@ -120,8 +122,8 @@ flowchart TB
         app["Griptape Nodes application<br/>engine + policy enforcement"]
         workspace[("Workspace<br/>workflows, assets, secrets")]
         local["Local models<br/>Ollama, LM Studio"]
-        app --- workspace
-        app -.-> local
+        app <--> workspace
+        app <-.-> local
     end
 
     subgraph cloud["Griptape Cloud"]
@@ -136,14 +138,14 @@ flowchart TB
 
     editor <-.->|"outbound"| wsapi
     app <-.->|"outbound"| wsapi
-    app ==>|"license + session<br/>(required)"| control
-    app -.->|"model calls"| modelproxy
-    app -.->|"optional sync"| buckets
-    modelproxy --> providers
-    app -.->|"your own API key"| providers
+    app <==>|"license out<br/>entitlements back"| control
+    app <-.->|"model calls"| modelproxy
+    app <-.->|"optional sync"| buckets
+    modelproxy <--> providers
+    app <-.->|"your own API key"| providers
 ```
 
-Because both sides dial out, this needs no open inbound port and neither machine needs to know the other's address. The trade is that editor traffic now crosses the internet: node graphs, parameter values, and asset previews pass through Griptape Cloud. Your workspace does not move, and the workflow still runs entirely on your machine.
+Both sides dial out, so this arrangement needs no open inbound port, and neither machine needs to know the other's address. The trade is that editor traffic now crosses the internet: node graphs, parameter values, and asset previews pass through Griptape Cloud. Your workspace does not move, and the workflow still runs on the machine hosting the engine.
 
 **Neither variation applies on premises.** The Nodes API WebSocket is a Griptape Cloud service, so an on-premises deployment uses the direct connection, which is what keeps workflow events inside your network.
 
@@ -161,9 +163,9 @@ flowchart TB
         local["Local models<br/>Ollama, LM Studio"]
         admin["Admin Server<br/>single egress point<br/>optional path filtering"]
         editor <-->|"direct WebSocket<br/>never leaves your network"| app
-        app --- workspace
-        app -.-> local
-        app -->|"HTTPS, in-network"| admin
+        app <--> workspace
+        app <-.-> local
+        app <-->|"HTTPS, in-network"| admin
         %% Invisible link: keeps the Admin Server on its own rank below the
         %% local models, so the egress edge does not pass behind them.
         local ~~~ admin
@@ -175,8 +177,8 @@ flowchart TB
         modelproxy["Model proxy"]
     end
 
-    admin ==>|"HTTPS: the only traffic<br/>leaving your network"| control
-    admin -.->|"permitted only if you allow it"| modelproxy
+    admin <==>|"HTTPS: the only traffic<br/>leaving your network"| control
+    admin <-.->|"permitted only if you allow it"| modelproxy
 ```
 
 Three properties carry the configuration.
@@ -195,21 +197,23 @@ Three properties carry the configuration.
 | `/api/users`           | Identify the license holder at startup and on each heartbeat.        |
 | `/api/organizations`   | Resolve the owning organization at startup and on each heartbeat.    |
 
-!!! note "Griptape Cloud is still required"
+!!! note "Why the Cloud connection is worth having"
 
-    On premises means your machines, workflows, and assets stay inside your network. It does not mean Griptape Nodes runs disconnected. Sessions are allocated by Griptape Cloud, so the Admin Server needs a route to it. If that route is unavailable, the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
+    That connection does more than allocate a session. It is also how an application picks up the current contents of its license, so when an administrator changes what a license permits, running deployments get the new permissions on their next session rather than waiting for a reissue or a redeploy. Managing entitlements centrally and having them take effect immediately is the practical benefit of keeping the route open.
+
+    It does mean on premises is not a disconnected mode. On premises means your machines, workflows, and assets stay inside your network; it does not mean Griptape Nodes runs with no route out. Sessions are allocated by Griptape Cloud, so the Admin Server needs to reach it. If that route is unavailable, the Admin Server returns an error rather than serving stale approvals, and applications cannot start new sessions.
 
 ## Where the boundaries are
 
-If you are reviewing Griptape Nodes for a security assessment, these are the load bearing details.
+If you are reviewing Griptape Nodes for a security assessment, these are the details that matter most.
 
-**Policy is enforced on your machine, not in the network.** The application enforces the permissions attached to your license locally, in compiled code, before a request reaches the engine. Those permissions come only from the signed license, so they cannot be loosened by editing engine code. They are resolved from Griptape Cloud when a session is allocated.
+**The Admin Server forwards; it does not decide.** It validates no licenses, allocates no sessions, resolves no entitlements, and caches nothing. It does not authenticate callers either: each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. It holds no state, so it is not an offline fallback. With no route upstream, it returns an error.
 
-**The Admin Server forwards; it does not decide.** It validates no licenses, allocates no sessions, resolves no entitlements, and caches nothing. It does not authenticate callers either: each application's own credential is forwarded untouched for Griptape Cloud to accept or reject. Its jobs are egress consolidation and, if you configure it, egress filtering. Because it holds no state, it is not an offline fallback. With no route upstream, it returns an error.
+**Policy is enforced on your machine, not in the network.** The application enforces the permissions attached to your license locally, before a request reaches the engine. Those permissions come from the signed license and are resolved from Griptape Cloud when a session is allocated, so no network appliance or firewall rule is involved in deciding what a workflow may do.
 
 **Griptape Cloud is the authority on licensing and entitlement.** Session allocation and entitlement resolution are Cloud decisions in both configurations. On premises changes only the path traffic takes to get there.
 
-**The execution runtime is open source and auditable.** The engine that runs your workflows is public, so its file handling, network calls, and node execution can be inspected rather than taken on trust. Enforcement lives in the application layer above it, which means a workflow saved as a Python file can also be run directly against the engine with no license, outside the policy boundary described above. That is deliberate: it is what keeps the engine open source.
+**The execution runtime is open source and auditable.** The engine that runs your workflows is public, so its file handling, network calls, and node execution can be inspected rather than taken on trust. Enforcement lives in the application layer above it.
 
 ## Related pages
 

--- a/docs/enterprise/admin_server.md
+++ b/docs/enterprise/admin_server.md
@@ -12,7 +12,7 @@ A studio that deploys Griptape Nodes on-premises usually does not want every app
 
 If your application instances can already reach `cloud.griptape.ai` directly and that is acceptable for your environment, you do not need the Admin Server.
 
-For a diagram of where the Admin Server sits and what traffic flows through it, see [Architecture](../architecture.md#on-premises-deployment).
+For a diagram of where the Admin Server sits and what traffic flows through it, see [Architecture](../architecture.md#on-premises-configuration).
 
 ## Getting the Admin Server
 

--- a/docs/enterprise/admin_server.md
+++ b/docs/enterprise/admin_server.md
@@ -12,6 +12,8 @@ A studio that deploys Griptape Nodes on-premises usually does not want every app
 
 If your application instances can already reach `cloud.griptape.ai` directly and that is acceptable for your environment, you do not need the Admin Server.
 
+For a diagram of where the Admin Server sits and what traffic flows through it, see [Architecture](../architecture.md#on-premises-deployment).
+
 ## Getting the Admin Server
 
 The Admin Server is provided to enterprise customers. [Contact Foundry](https://www.foundry.com/products/griptape/request-demo) to obtain it for your deployment.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,7 +129,7 @@ Organizations can run Griptape Nodes on license keys instead of individual Gript
 
 If your organization runs an on-premises [Admin Server](enterprise/admin_server.md), you'll also point the application at it during activation. See [Using the Admin Server](enterprise/using_the_admin_server.md) for the full walkthrough of the license activation flow.
 
-Organization admins looking to issue and manage license keys should start with the [Admin Dashboard](enterprise/admin_dashboard.md) guide.
+Organization admins looking to issue and manage license keys should start with the [Admin Dashboard](enterprise/admin_dashboard.md) guide. For a diagram of how the pieces fit together in either deployment model, see [Architecture](architecture.md).
 
 ## Next Steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ plugins:
         Get started:
           - index.md: Top-level introduction to Griptape Nodes
           - installation.md: Install Griptape Nodes via the Desktop app (recommended), a manual engine install, or license activation
+          - architecture.md: Deployment architecture for the Griptape Cloud and on-premises models — components, trust boundaries, and what leaves your network
           - faq.md: Frequently asked questions
           - troubleshooting.md: Fixes for commonly encountered issues and states
           - glossary.md: Terms and definitions used throughout the docs
@@ -255,6 +256,7 @@ nav:
   - Get Started:
       - Overview: index.md
       - Installation: installation.md
+      - Architecture: architecture.md
       - Tutorials:
           - Overview: tutorials/index.md
           - 1. A Tour of the Editor: tutorials/00_tour/index.md


### PR DESCRIPTION
Adds `docs/architecture.md`, a canonical page for how Griptape Nodes is deployed and interconnected, with a Mermaid diagram per configuration.

Closes griptape-ai/internal#184

Builds on #5210, which moved Mermaid rendering to mkdocs-material so diagrams follow the light/dark palette.

## What's on the page

- **The pieces** — Editor / Application / Engine, naming the `griptape-nodes` and `griptape-nodes-engine` PyPI distributions and linking the open source engine repo. Stated once so no diagram re-explains it.
- **Where your data lives** — leads with the workspace as a configurable root directory (defaults beside the application, but can point at network attached storage such as a NAS mount or LucidLink), then a per-artifact table of where each thing is written and whether it is sent to Griptape Cloud.
- **What talks to Griptape Cloud** — the complete list of Cloud capabilities with a Required? column, so the one hard dependency (licensing and sessions) is distinguishable from everything optional. Includes how the editor reaches the application, direct WebSocket vs the Nodes API WebSocket.
- **SaaS configuration** — the default, in two variations: editor and engine on the same machine (direct WebSocket, no workflow content on the network), and on different machines (both sides dial out to the Nodes API WebSocket).
- **On-premises configuration** — machines inside the customer network reaching Cloud only through the Admin Server, on the direct WebSocket so workflow events never egress. Covers the five licensing and session routes the Admin Server refuses to start without, and why keeping the Cloud route open is a feature: it is how a license picks up permission changes without a reissue or redeploy.

## Scope: two configurations, not three

The issue asks for on-prem, SaaS, and hybrid. What ships doesn't split that way, so the page documents the two real configurations instead.

Today's on-prem configuration *is* the hybrid one: workloads and data on-prem, control plane in Cloud. A fully self-hosted deployment isn't covered because it doesn't exist yet. Sessions are allocated by Griptape Cloud, and per its own `ARCHITECTURE.md` the Admin Server validates no licenses, holds no state, and returns an error rather than serving stale approvals. The page says that plainly in a callout.

Flagging for reviewers, since it's the likely question from an evaluating client: That gap is tracked as the missing licensed headless application. I'd rather the diagram be accurate than reassuring.

## Verification

- `make docs` (`--clean --strict`) and `make check` both pass. Page is wired into **both** `nav` and the `llmstxt` sections per CLAUDE.md, and appears in the generated `llms.txt`.
- All three diagrams were rendered through `@mermaid-js/mermaid-cli` and visually inspected, since the strict build does not validate Mermaid and a broken or illegible diagram would otherwise ship silently. Each is portrait so it fills the ~750px content column rather than scaling down to unreadable text; the first landscape drafts scaled to ~176px tall.
- Re-validated rendering after `mdformat`, and diffed the committed diagram source against the exact variants that were rendered and inspected.
- The transport claim is verified in code: `gtn-service.ts` `applyDirectModeIpcDrivers()` enables `websocket_direct` on license/direct mode and `websocket_api` on Cloud sign-in.
- The bundled-editor claim is verified in code: `@griptape-ai/nodes-editor-dist` is an npm dependency shipped as an Electron `extraResource` and served over the privileged `gtn-editor://editor` protocol. Desktop also bundles a pinned Python with `griptape-nodes` preinstalled, so first launch needs no PyPI access.

## Review asks

1. **The Cloud capability table** — drawn as one boundary with named capabilities rather than separate services, since internal topology isn't verifiable from client-side repos. Please flag anything mis-named or missing.
2. **Transport naming.** The page calls the cloud path the "Nodes API WebSocket". The code calls the driver `websocket_api` and describes it as a cloud relay; user-facing Desktop strings say "Griptape Server Endpoint" and "Direct Engine WebSocket URL". Worth settling on one term if there's an established preference.
3. **Palette check** on the RTD preview, in both light and dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
