### PR TITLE
feat(libraries): lazy node loading with on-demand stable-namespace imports

### DIFF
--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -513,6 +513,46 @@ class LibraryRegistry(metaclass=SingletonMeta):
         return schemas
 
 
+class NodeTypeEntry:
+    """A node type registered in a Library, resolved to its class on demand.
+
+    Holds the node's class name plus either an already-imported class (eager
+    registration) or a zero-argument loader that imports the class on first
+    ``resolve()`` (lazy registration). Either way the resolved class is cached,
+    so a node's module is imported at most once. When registered lazily, the
+    module is imported the first time the class is actually needed (node
+    creation, execution, or introspection) rather than at library load time, so
+    startup never pays the import cost of node modules that are never used, and
+    an import failure surfaces to whichever caller first resolves the entry.
+    """
+
+    def __init__(
+        self,
+        class_name: str,
+        *,
+        node_class: type[BaseNode] | None = None,
+        loader: Callable[[], type[BaseNode]] | None = None,
+    ) -> None:
+        self.class_name = class_name
+        self._resolved = node_class
+        self._loader = loader
+
+    def resolve(self) -> type[BaseNode]:
+        """Return the node class, importing its module on first use for a lazy entry.
+
+        Not thread-safe: assumes resolution happens on a single thread (the event loop).
+        Concurrent callers could each run the loader (a double import). This holds today
+        because lazy entries are only resolved on the event loop -- workers force eager
+        loading, so their entries are already resolved before any threaded access.
+        """
+        if self._resolved is None:
+            if self._loader is None:
+                msg = f"Node type '{self.class_name}' has neither a resolved class nor a loader."
+                raise RuntimeError(msg)
+            self._resolved = self._loader()
+        return self._resolved
+
+
 class Library:
     """A collection of nodes curated by library author.
 
@@ -521,8 +561,9 @@ class Library:
 
     _library_data: LibrarySchema
     _is_default_library: bool
-    # Maintain fast lookups for node class name to class and to its metadata.
-    _node_types: dict[str, type[BaseNode]]
+    # Fast lookup from node class name to its registration entry (which resolves
+    # the class on demand -- see NodeTypeEntry) and to its metadata.
+    _node_types: dict[str, NodeTypeEntry]
     _node_metadata: dict[str, NodeMetadata]
     _advanced_library: AdvancedNodeLibrary | None
     # Tracks handlers registered on behalf of this library so they can be
@@ -583,8 +624,27 @@ class Library:
             library=self, node_class_name=node_class_as_str
         )
 
-        self._node_types[node_class_as_str] = node_class
+        self._node_types[node_class_as_str] = NodeTypeEntry(node_class_as_str, node_class=node_class)
         self._node_metadata[node_class_as_str] = metadata
+        return library_problem
+
+    def register_lazy_node_type(
+        self, node_class_name: str, metadata: NodeMetadata, loader: Callable[[], type[BaseNode]]
+    ) -> LibraryProblem | None:
+        """Register a node type without importing its module yet.
+
+        The class is imported on first use via ``loader`` (see ``NodeTypeEntry``),
+        so an import failure surfaces when the node is first created rather than
+        at library load time. The registry key is the caller-supplied
+        ``node_class_name`` (the library JSON's declared class name), since the
+        class is not imported here to read its ``__name__``. Returns a
+        LibraryProblem if registration fails (e.g. a cross-library name
+        collision), or None if all clear.
+        """
+        library_problem = LibraryRegistry.register_node_type_from_library(library=self, node_class_name=node_class_name)
+
+        self._node_types[node_class_name] = NodeTypeEntry(class_name=node_class_name, loader=loader)
+        self._node_metadata[node_class_name] = metadata
         return library_problem
 
     def unregister_node_type(self, node_class_name: str) -> None:
@@ -634,10 +694,13 @@ class Library:
         metadata: dict[Any, Any] | None = None,
     ) -> BaseNode:
         """Create a new node instance of the specified type."""
-        node_class = self._node_types.get(node_type)
-        if not node_class:
+        if not self.has_node_type(node_type):
             msg = f"Node type '{node_type}' not found in library '{self._library_data.name}'"
             raise KeyError(msg)
+        # Resolve the class, importing its module now if it was registered lazily.
+        # An import failure propagates to the caller (e.g. the CreateNode handler,
+        # which substitutes an Error Proxy node carrying the failure reason).
+        node_class = self._node_types[node_type].resolve()
         # Inject the metadata ABOUT the node from the Library
         # into the node's metadata blob.
         if metadata is None:
@@ -676,10 +739,13 @@ class Library:
         For callers that need the class itself, e.g. classmethod checks like
         `allow_outgoing_connection_by_class`, rather than an instance produced
         by `create_node`.
+
+        Imports the node's module now if it was registered lazily; the import
+        failure propagates to the caller.
         """
         if node_type not in self._node_types:
             raise KeyError(self._library_data.name, node_type)
-        return self._node_types[node_type]
+        return self._node_types[node_type].resolve()
 
     def get_categories(self) -> list[dict[str, CategoryDefinition]]:
         return self._library_data.categories
@@ -701,6 +767,11 @@ class Library:
     def get_nodes_by_base_type(self, base_type: type) -> list[str]:
         """Get all node types in this library that are subclasses of the specified base type.
 
+        Resolving a lazily-registered node type imports its module, so the first call on a
+        lazily-loaded library imports every node module in it (to test each against
+        ``base_type``); a node whose module fails to import is skipped rather than aborting
+        the scan. Callers on the event loop should be aware this can block on those imports.
+
         Args:
             base_type: The base class to filter by (e.g., StartNode, ControlNode)
 
@@ -708,7 +779,18 @@ class Library:
             List of node type names that extend the base type
         """
         matching_nodes = []
-        for node_type, node_class in self._node_types.items():
+        for node_type, entry in self._node_types.items():
+            try:
+                node_class = entry.resolve()
+            except (ImportError, AttributeError, TypeError):
+                logger.debug(
+                    "Skipping node type '%s' in library '%s' while scanning for base type '%s': module failed to import.",
+                    node_type,
+                    self._library_data.name,
+                    base_type.__name__,
+                    exc_info=True,
+                )
+                continue
             if issubclass(node_class, base_type):
                 matching_nodes.append(node_type)
         return matching_nodes

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -232,6 +232,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
+    LIBRARY_LAZY_NODE_LOADING_KEY,
     LIBRARY_MINIMUM_RELEASE_AGE_KEY,
     REQUIRES_ENGINE_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
@@ -1774,7 +1775,32 @@ class LibraryManager:
         # In that case we still return a success payload with the library-level metadata and a
         # WARNING entry in result_details, so callers can present the node at all instead of
         # getting an opaque failure for every such node type.
-        node_class = library.get_node_class(request.node_type)
+        # Resolving the class imports the node's module (lazy registration defers this to
+        # first use). A broken module raises here; return the library-level metadata with a
+        # WARNING rather than an opaque failure, matching the probe-failure path below.
+        try:
+            node_class = library.get_node_class(request.node_type)
+        except (ImportError, AttributeError, TypeError) as err:
+            import_error = f"{type(err).__name__}: {err}"
+            return DescribeNodeTypeResultSuccess(
+                library=library_name,
+                node_type=request.node_type,
+                metadata=node_metadata,
+                parameters=[],
+                result_details=ResultDetails(
+                    ResultDetail(
+                        level=logging.INFO,
+                        message=(
+                            f"Described node type '{request.node_type}' in Library '{library_name}' "
+                            "with library metadata only."
+                        ),
+                    ),
+                    ResultDetail(
+                        level=logging.WARNING,
+                        message=f"Node module failed to import: {import_error}",
+                    ),
+                ),
+            )
         probe_name = f"__describe_node_type_probe__{request.node_type}"
         try:
             # Wrap in ``LibraryRegistry.constructing_node()`` so the
@@ -2319,13 +2345,14 @@ class LibraryManager:
                             library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
                             self._library_file_path_to_info[file_path] = library_info
                         else:
-                            # Attempt to load nodes from the library (modifies library_info in place)
+                            # Attempt to load nodes from the library (modifies library_info in place).
                             await asyncio.to_thread(
                                 self._attempt_load_nodes_from_library,
                                 library_data=library_data,
                                 library=library,
                                 base_dir=base_dir,
                                 library_info=library_info,
+                                lazy_loading=self._should_lazy_load_nodes(),
                             )
                             self._library_file_path_to_info[file_path] = library_info
 
@@ -3229,41 +3256,72 @@ class LibraryManager:
 
         return module
 
-    def _load_class_from_file(self, file_path: Path | str, class_name: str, library_name: str) -> type[BaseNode]:
-        """Dynamically load a class from a Python file with support for hot reloading.
-
-        Args:
-            file_path: Path to the Python file
-            class_name: Name of the class to load
-            library_name: Name of the library
-
-        Returns:
-            The loaded class
+    @staticmethod
+    def _get_node_class_from_module(module: ModuleType, class_name: str, file_path: Path | str) -> type[BaseNode]:
+        """Extract and validate a BaseNode subclass from an already-imported module.
 
         Raises:
-            ImportError: If the module cannot be imported
             AttributeError: If the class doesn't exist in the module
-            TypeError: If the loaded class isn't a BaseNode-derived class
+            TypeError: If the named object isn't a BaseNode-derived class
         """
-        try:
-            module = self._load_module_from_file(file_path, library_name)
-        except ImportError as err:
-            msg = f"Attempted to load class '{class_name}'. Error: {err}"
-            raise ImportError(msg) from err
-
-        # Get the class
         try:
             node_class = getattr(module, class_name)
         except AttributeError as err:
             msg = f"Class '{class_name}' not found in module '{file_path}'"
             raise AttributeError(msg) from err
 
-        # Verify it's a BaseNode subclass
         if not issubclass(node_class, BaseNode):
             msg = f"'{class_name}' must inherit from BaseNode"
             raise TypeError(msg)
 
         return node_class
+
+    def _make_memoized_module_loader(self, node_file_path: Path, library_name: str) -> Callable[[], ModuleType]:
+        """Return a loader that imports a file's module at most once, caching the result.
+
+        ``_load_module_from_file`` re-executes a module that is already in ``sys.modules`` (its
+        hot-reload path). Without memoization, resolving several node classes that share one file
+        would re-run that file's top-level code once per class and bind the classes to different
+        module objects. Memoizing per file makes the module import (and its top-level side
+        effects) happen exactly once per library load, whether its classes are resolved eagerly in
+        a burst or lazily at scattered points in the session. A fresh cache is created per
+        ``_attempt_load_nodes_from_library`` call, so a reload still re-imports the file once.
+        """
+        cache: dict[str, ModuleType] = {}
+
+        def load_module() -> ModuleType:
+            module = cache.get("module")
+            if module is None:
+                module = self._load_module_from_file(node_file_path, library_name)
+                cache["module"] = module
+            return module
+
+        return load_module
+
+    def _make_node_class_loader(
+        self,
+        node_file_path: Path,
+        class_name: str,
+        library_name: str,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> Callable[[], type[BaseNode]]:
+        """Return a zero-argument loader that imports and returns a node class on demand.
+
+        Node classes that share a file reuse a single memoized module loader from
+        ``module_loaders`` (keyed by resolved file path), so the file's module is imported once
+        even when its classes are resolved at different times. Binds its arguments as method
+        parameters (not loop variables), so the closure is safe to build inside a per-node loop.
+        """
+        module_loader = module_loaders.get(node_file_path)
+        if module_loader is None:
+            module_loader = self._make_memoized_module_loader(node_file_path, library_name)
+            module_loaders[node_file_path] = module_loader
+
+        def load() -> type[BaseNode]:
+            module = module_loader()
+            return self._get_node_class_from_module(module, class_name, node_file_path)
+
+        return load
 
     async def _load_and_track_library(self, lib_path: str, index: int, total: int) -> None:
         """Load a single library and emit the corresponding progress event."""
@@ -4229,12 +4287,110 @@ class LibraryManager:
 
         return advanced_library_instance
 
+    def _should_lazy_load_nodes(self) -> bool:
+        """Return whether node modules should be imported lazily for this process.
+
+        Lazy loading is the default (fast startup); set ``library.lazy_node_loading`` to False
+        to load eagerly so node import errors surface at startup while authoring. A worker always
+        loads eagerly regardless of the setting: it imports every node anyway to serialize schemas
+        back to the orchestrator, and eager load lets it report import problems.
+        """
+        if self._is_worker:
+            return False
+        return bool(GriptapeNodes.ConfigManager().get_config_value(LIBRARY_LAZY_NODE_LOADING_KEY, default=True))
+
+    def _register_node_eager(
+        self,
+        node_definition: NodeDefinition,
+        node_file_path: Path,
+        library: Library,
+        library_info: LibraryInfo,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> bool:
+        """Import a node's module now and register its class, recording any load problem.
+
+        Returns True if the node type was registered, False if its module failed to import
+        (a problem is appended to ``library_info`` in that case).
+        """
+        library_name = library.get_library_data().name
+        try:
+            node_class = self._make_node_class_loader(
+                node_file_path, node_definition.class_name, library_name, module_loaders
+            )()
+        except ImportError as err:
+            root_cause = self._get_root_cause_from_exception(err)
+            library_info.problems.append(
+                NodeModuleImportProblem(
+                    class_name=node_definition.class_name,
+                    file_path=str(node_file_path),
+                    error_message=str(err),
+                    root_cause=str(root_cause),
+                )
+            )
+            logger.error(
+                "Attempted to load node '%s' from '%s'. Failed because module could not be imported: %s",
+                node_definition.class_name,
+                node_file_path,
+                err,
+            )
+            return False
+        except AttributeError:
+            library_info.problems.append(
+                NodeClassNotFoundProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
+            )
+            logger.error(
+                "Attempted to load node '%s' from '%s'. Failed because class not found in module",
+                node_definition.class_name,
+                node_file_path,
+            )
+            return False
+        except TypeError:
+            library_info.problems.append(
+                NodeClassNotBaseNodeProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
+            )
+            logger.error(
+                "Attempted to load node '%s' from '%s'. Failed because class doesn't inherit from BaseNode",
+                node_definition.class_name,
+                node_file_path,
+            )
+            return False
+
+        library_problem = library.register_new_node_type(node_class, metadata=node_definition.metadata)
+        if library_problem is not None:
+            library_info.problems.append(library_problem)
+        return True
+
+    def _register_node_lazy(
+        self,
+        node_definition: NodeDefinition,
+        node_file_path: Path,
+        library: Library,
+        library_info: LibraryInfo,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> bool:
+        """Register a node type with a deferred loader; its module imports on first use.
+
+        Always returns True: registration itself does not import the module, so an import
+        error cannot be detected here (it surfaces when the node is first used).
+        """
+        loader = self._make_node_class_loader(
+            node_file_path, node_definition.class_name, library.get_library_data().name, module_loaders
+        )
+        library_problem = library.register_lazy_node_type(
+            node_definition.class_name, metadata=node_definition.metadata, loader=loader
+        )
+        if library_problem is not None:
+            library_info.problems.append(library_problem)
+        return True
+
     def _attempt_load_nodes_from_library(  # noqa: PLR0912, PLR0915, C901
         self,
         library_data: LibrarySchema,
         library: Library,
         base_dir: Path,
         library_info: LibraryInfo,
+        *,
+        lazy_loading: bool = False,
     ) -> None:
         """Load nodes from library and update library_info in place.
 
@@ -4243,6 +4399,9 @@ class LibraryManager:
             library: Library instance to register nodes with
             base_dir: Base directory for resolving relative paths
             library_info: LibraryInfo to update with problems and fitness
+            lazy_loading: When False (default), each node's module is imported now so import
+                errors surface here as library problems. When True, node types are registered
+                with a deferred loader and their modules are imported on first use instead.
         """
         any_nodes_loaded_successfully = False
 
@@ -4279,49 +4438,31 @@ class LibraryManager:
                 )
                 logger.error(details)
 
-        # Process each node in the metadata
+        # Process each node in the metadata. Lazy loading (the default) registers each type with
+        # a deferred loader and imports the module on first use, keeping startup from paying the
+        # import cost (often heavy deps like torch/diffusers) of node modules that are never used;
+        # the tradeoff is that an import error is not reported until the node is first used (the
+        # CreateNode handler then substitutes an Error Proxy). Eager loading (library.lazy_node_loading
+        # = False, and always for the sandbox library) instead imports each node's module now so a
+        # broken node surfaces as a library problem at startup, before it is placed on a canvas.
+        # module_loaders memoizes each file's module import so classes sharing a file (whether
+        # resolved eagerly here or lazily later) import it once rather than re-executing per class.
+        module_loaders: dict[Path, Callable[[], ModuleType]] = {}
         for node_definition in library_data.nodes:
             # Resolve relative path to absolute path
             node_file_path = resolve_workspace_path(Path(node_definition.file_path), base_dir)
 
-            try:
-                # Dynamically load the module containing the node class
-                node_class = self._load_class_from_file(node_file_path, node_definition.class_name, library_data.name)
-            except ImportError as err:
-                root_cause = self._get_root_cause_from_exception(err)
-                library_info.problems.append(
-                    NodeModuleImportProblem(
-                        class_name=node_definition.class_name,
-                        file_path=str(node_file_path),
-                        error_message=str(err),
-                        root_cause=str(root_cause),
-                    )
+            if lazy_loading:
+                node_registered = self._register_node_lazy(
+                    node_definition, node_file_path, library, library_info, module_loaders
                 )
-                details = f"Attempted to load node '{node_definition.class_name}' from '{node_file_path}'. Failed because module could not be imported: {err}"
-                logger.error(details)
-                continue  # SKIP IT
-            except AttributeError:
-                library_info.problems.append(
-                    NodeClassNotFoundProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
+            else:
+                node_registered = self._register_node_eager(
+                    node_definition, node_file_path, library, library_info, module_loaders
                 )
-                details = f"Attempted to load node '{node_definition.class_name}' from '{node_file_path}'. Failed because class not found in module"
-                logger.error(details)
-                continue  # SKIP IT
-            except TypeError:
-                library_info.problems.append(
-                    NodeClassNotBaseNodeProblem(class_name=node_definition.class_name, file_path=str(node_file_path))
-                )
-                details = f"Attempted to load node '{node_definition.class_name}' from '{node_file_path}'. Failed because class doesn't inherit from BaseNode"
-                logger.error(details)
-                continue  # SKIP IT
 
-            # Register the node type with the library
-            library_problem = library.register_new_node_type(node_class, metadata=node_definition.metadata)
-            if library_problem is not None:
-                library_info.problems.append(library_problem)
-
-            # If we got here, at least one node came in.
-            any_nodes_loaded_successfully = True
+            if node_registered:
+                any_nodes_loaded_successfully = True
 
         # Register widgets and check for duplicates
         if library_data.widgets:
@@ -4655,13 +4796,16 @@ class LibraryManager:
         library_info.problems.extend(problems)
 
         # Load nodes into the library (modifies library_info in place)
-        # Note: library_info is passed as parameter from lifecycle handler
+        # Note: library_info is passed as parameter from lifecycle handler.
+        # Sandbox nodes always load eagerly (not gated on library.lazy_node_loading): they are
+        # being actively authored, so import errors should surface immediately, not on first use.
         await asyncio.to_thread(
             self._attempt_load_nodes_from_library,
             library_data=library_data,
             library=library,
             base_dir=sandbox_library_dir,
             library_info=library_info,
+            lazy_loading=False,
         )
 
     def _find_files_in_dir(self, directory: Path, extension: str) -> list[Path]:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib.abc
+import importlib.machinery
 import importlib.util
 import json
 import logging
@@ -280,7 +282,7 @@ from griptape_nodes.utils.version_utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Sequence
     from types import ModuleType
 
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
@@ -294,6 +296,58 @@ logger = logging.getLogger("griptape_nodes")
 EXCLUDED_SCAN_DIRECTORIES = frozenset({"venv", "__pycache__"})
 
 TRegisteredEventData = TypeVar("TRegisteredEventData")
+
+
+class StableNamespaceImportFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Imports lazily registered library node modules on demand via their stable namespace.
+
+    Saved workflows reference node-file classes through their stable namespace
+    (``griptape_nodes.node_libraries.<lib>.<file>``), both as ``from`` imports emitted into the
+    generated Python and inside pickled parameter values. With eager node loading those modules
+    are already aliased into ``sys.modules`` when the library registers, so the imports resolve.
+    With lazy loading nothing is imported until a node class is first resolved, so opening a
+    workflow before then would fail with ``No module named 'griptape_nodes.node_libraries'``.
+
+    This finder fills that gap: importing a stable namespace triggers the same memoized module
+    load that the deferred node-class loaders use, and the synthetic parent packages
+    (``griptape_nodes.node_libraries`` and ``griptape_nodes.node_libraries.<lib>``, which do not
+    exist on disk) are materialized as empty namespace packages so the dotted import chain
+    resolves.
+    """
+
+    def __init__(self, library_manager: LibraryManager) -> None:
+        self._library_manager = library_manager
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None = None,  # noqa: ARG002 (MetaPathFinder protocol)
+        target: ModuleType | None = None,  # noqa: ARG002 (MetaPathFinder protocol)
+    ) -> importlib.machinery.ModuleSpec | None:
+        package_root = LibraryManager.STABLE_NAMESPACE_PREFIX.rstrip(".")
+        if fullname != package_root and not fullname.startswith(LibraryManager.STABLE_NAMESPACE_PREFIX):
+            return None
+
+        pending_loaders = self._library_manager._pending_stable_module_loaders
+        if fullname in pending_loaders:
+            return importlib.util.spec_from_loader(fullname, self)
+
+        # Synthesize the namespace-package parents of any known stable namespace so the import
+        # machinery can walk the dotted chain down to the leaf loader above. Known namespaces
+        # cover both pending (lazy, not yet imported) and already-loaded library modules.
+        child_prefix = f"{fullname}."
+        known_namespaces = (*pending_loaders, *self._library_manager._stable_to_dynamic_module_mapping)
+        if fullname == package_root or any(namespace.startswith(child_prefix) for namespace in known_namespaces):
+            return importlib.machinery.ModuleSpec(fullname, None, is_package=True)
+
+        return None
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
+        module_loader = self._library_manager._pending_stable_module_loaders[spec.name]
+        return module_loader()
+
+    def exec_module(self, module: ModuleType) -> None:
+        """No-op: the module was fully executed by the memoized loader in create_module."""
 
 
 class LibraryGitOperationContext(NamedTuple):
@@ -359,6 +413,10 @@ class LibraryVenvInitResult(NamedTuple):
 
 class LibraryManager:
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
+    # Prefix for the stable, deterministic module namespaces that library node files are
+    # importable under. Anything under this prefix is a dynamically loaded library module
+    # whose import path only exists in-process once its library has been registered.
+    STABLE_NAMESPACE_PREFIX = "griptape_nodes.node_libraries."
     LIBRARY_CONFIG_FILENAME = "griptape_nodes_library.json"
     LIBRARY_CONFIG_GLOB_PATTERN = "griptape[_-]nodes[_-]library.json"
 
@@ -504,6 +562,15 @@ class LibraryManager:
     _dynamic_to_stable_module_mapping: dict[str, str]  # dynamic_module_name -> stable_namespace
     _stable_to_dynamic_module_mapping: dict[str, str]  # stable_namespace -> dynamic_module_name
     _library_to_stable_modules: dict[str, set[str]]  # library_name -> set of stable_namespaces
+    # Deferred module loaders for lazily registered node files, keyed by stable namespace.
+    # Populated at (lazy) library registration time and consumed by StableNamespaceImportFinder
+    # so a saved workflow can import `griptape_nodes.node_libraries.<lib>.<file>` before any
+    # node class from that file has been resolved. An entry is dropped as soon as its module
+    # actually loads (sys.modules satisfies imports from then on) or when its library unloads.
+    _pending_stable_module_loaders: dict[str, Callable[[], ModuleType]]  # stable_namespace -> module loader
+    _library_to_pending_stable_namespaces: dict[str, set[str]]  # library_name -> pending stable_namespaces
+    # Meta-path finder that resolves stable namespaces for pending (lazy) node modules.
+    _stable_namespace_finder: StableNamespaceImportFinder
     # Callbacks invoked immediately before all libraries are reloaded.
     _pre_reload_callbacks: list[Callable[[], Awaitable[None]]]
 
@@ -512,6 +579,9 @@ class LibraryManager:
         self._dynamic_to_stable_module_mapping = {}
         self._stable_to_dynamic_module_mapping = {}
         self._library_to_stable_modules = {}
+        self._pending_stable_module_loaders = {}
+        self._library_to_pending_stable_namespaces = {}
+        self._install_stable_namespace_finder()
         # Two separate handler registration systems exist in this manager:
         #
         # 1. EventManager.assign_manager_to_request_type() — singleton (one handler per
@@ -3008,7 +3078,45 @@ class LibraryManager:
         # Convert file path to safe module name
         safe_file_name = file_path.stem.replace("-", "_")
 
-        return f"griptape_nodes.node_libraries.{safe_library_name}.{safe_file_name}"
+        return f"{self.STABLE_NAMESPACE_PREFIX}{safe_library_name}.{safe_file_name}"
+
+    def _install_stable_namespace_finder(self) -> None:
+        """Install the meta-path finder that resolves stable namespaces for lazy node modules.
+
+        Any finder left behind by a previously constructed LibraryManager (tests construct
+        several per process) is removed first so exactly one finder, backed by this manager's
+        state, is consulted.
+        """
+        sys.meta_path[:] = [finder for finder in sys.meta_path if not isinstance(finder, StableNamespaceImportFinder)]
+        self._stable_namespace_finder = StableNamespaceImportFinder(self)
+        sys.meta_path.append(self._stable_namespace_finder)
+
+    def _register_pending_stable_module_loader(
+        self, stable_namespace: str, library_name: str, module_loader: Callable[[], ModuleType]
+    ) -> None:
+        """Make a lazily registered node file importable via its stable namespace.
+
+        The loader is the same memoized per-file loader the node-class loaders share, so an
+        import through StableNamespaceImportFinder and a later class resolution reuse one
+        module object (and the file's top-level code runs once).
+
+        Args:
+            stable_namespace: Stable namespace the file will be importable under
+            library_name: Name of the owning library (for cleanup on unload)
+            module_loader: Memoized zero-argument loader that imports the file's module
+        """
+        self._pending_stable_module_loaders[stable_namespace] = module_loader
+        self._library_to_pending_stable_namespaces.setdefault(library_name, set()).add(stable_namespace)
+
+    def _unregister_pending_stable_module_loaders_for_library(self, library_name: str) -> None:
+        """Drop pending (never-imported) stable module loaders for a library on unload.
+
+        Args:
+            library_name: Name of the library to clean up
+        """
+        pending_namespaces = self._library_to_pending_stable_namespaces.pop(library_name, set())
+        for stable_namespace in pending_namespaces:
+            self._pending_stable_module_loaders.pop(stable_namespace, None)
 
     def _register_stable_module_alias(
         self, dynamic_module_name: str, stable_namespace: str, module: ModuleType, library_name: str
@@ -3033,6 +3141,11 @@ class LibraryManager:
 
         # Register the stable alias in sys.modules
         sys.modules[stable_namespace] = module
+
+        # The module is importable through sys.modules now; retire its pending loader so the
+        # meta-path finder can never serve a stale module object after this one is unloaded.
+        self._pending_stable_module_loaders.pop(stable_namespace, None)
+        self._library_to_pending_stable_namespaces.get(library_key, set()).discard(stable_namespace)
 
         details = f"Registered stable alias: {stable_namespace} -> {dynamic_module_name} (library: {library_key})"
         logger.debug(details)
@@ -3067,6 +3180,8 @@ class LibraryManager:
         Args:
             library_name: Name of the library to clean up
         """
+        self._unregister_pending_stable_module_loaders_for_library(library_name)
+
         library_key = library_name
         if library_key not in self._library_to_stable_modules:
             return
@@ -3298,6 +3413,24 @@ class LibraryManager:
 
         return load_module
 
+    def _get_or_create_module_loader(
+        self,
+        node_file_path: Path,
+        library_name: str,
+        module_loaders: dict[Path, Callable[[], ModuleType]],
+    ) -> Callable[[], ModuleType]:
+        """Get the memoized module loader for a node file, creating and caching one if needed.
+
+        All consumers of a file's module (node-class loaders and the stable-namespace import
+        finder) must share one memoized loader so the file is imported exactly once per
+        library load.
+        """
+        module_loader = module_loaders.get(node_file_path)
+        if module_loader is None:
+            module_loader = self._make_memoized_module_loader(node_file_path, library_name)
+            module_loaders[node_file_path] = module_loader
+        return module_loader
+
     def _make_node_class_loader(
         self,
         node_file_path: Path,
@@ -3312,10 +3445,7 @@ class LibraryManager:
         even when its classes are resolved at different times. Binds its arguments as method
         parameters (not loop variables), so the closure is safe to build inside a per-node loop.
         """
-        module_loader = module_loaders.get(node_file_path)
-        if module_loader is None:
-            module_loader = self._make_memoized_module_loader(node_file_path, library_name)
-            module_loaders[node_file_path] = module_loader
+        module_loader = self._get_or_create_module_loader(node_file_path, library_name, module_loaders)
 
         def load() -> type[BaseNode]:
             module = module_loader()
@@ -4373,9 +4503,15 @@ class LibraryManager:
         Always returns True: registration itself does not import the module, so an import
         error cannot be detected here (it surfaces when the node is first used).
         """
-        loader = self._make_node_class_loader(
-            node_file_path, node_definition.class_name, library.get_library_data().name, module_loaders
-        )
+        library_name = library.get_library_data().name
+        loader = self._make_node_class_loader(node_file_path, node_definition.class_name, library_name, module_loaders)
+        # Saved workflows import (and unpickle) classes from this file via its stable namespace
+        # (`griptape_nodes.node_libraries.<lib>.<file>`). With eager loading that namespace is in
+        # sys.modules by now; with lazy loading it is not, so register a pending loader that the
+        # StableNamespaceImportFinder resolves on first import of the namespace.
+        stable_namespace = self._create_stable_namespace(library_name, node_file_path)
+        module_loader = self._get_or_create_module_loader(node_file_path, library_name, module_loaders)
+        self._register_pending_stable_module_loader(stable_namespace, library_name, module_loader)
         library_problem = library.register_lazy_node_type(
             node_definition.class_name, metadata=node_definition.metadata, loader=loader
         )

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -23,6 +23,7 @@ WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
+LIBRARY_LAZY_NODE_LOADING_KEY = "library.lazy_node_loading"
 
 
 class Category(BaseModel):
@@ -296,6 +297,19 @@ class LibrarySettings(BaseModel):
             "Controls automatic installation of library dependencies declared in library manifests. "
             "'always' downloads and installs them on registration. "
             "'never' skips installation and marks the library as degraded if required dependencies are missing."
+        ),
+    )
+    lazy_node_loading: bool = Field(
+        default=True,
+        description=(
+            "When True (the default), a node's Python module is imported lazily the first time a node "
+            "of that type is created (or the type is otherwise resolved, such as when introspected) "
+            "rather than at startup, which speeds up engine startup for libraries with many or heavy "
+            "nodes. The tradeoff is that a broken node's import error is not reported until that type is "
+            "first created. When False, the engine imports every node's Python module at startup, so an "
+            "import error surfaces immediately as a library problem, before the node is placed on a "
+            "canvas; set this while authoring nodes if you want that check. Nodes in the sandbox library "
+            "are always loaded eagerly regardless of this setting."
         ),
     )
     minimum_release_age: float = Field(

--- a/tests/e2e/fixtures/lazy_payload_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/lazy_payload_library/griptape_nodes_library.json
@@ -1,0 +1,35 @@
+{
+  "name": "Lazy Payload Library",
+  "library_schema_version": "0.7.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library used by lazy-loading stable-namespace e2e tests",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "LazyPayloadNode",
+      "file_path": "lazy_payload_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Holds a LazyPayload object in its `payload` parameter",
+        "display_name": "Lazy Payload"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/lazy_payload_library/lazy_payload_node.py
+++ b/tests/e2e/fixtures/lazy_payload_library/lazy_payload_node.py
@@ -1,0 +1,42 @@
+"""Fixture nodes for the lazy-loading stable-namespace e2e tests.
+
+LazyPayload is a plain picklable class defined inside a dynamically loaded library module.
+When a workflow holding a LazyPayload parameter value is saved, the generated Python embeds
+a ``from griptape_nodes.node_libraries.lazy_payload_library.lazy_payload_node import
+LazyPayload`` statement plus pickled bytes referencing that stable namespace. Loading that
+workflow therefore requires the stable namespace to be importable, which is exactly what the
+lazy-node-loading regression broke (`No module named 'griptape_nodes.node_libraries'`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class LazyPayload:
+    """Picklable value class whose only home is this dynamically loaded module."""
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+
+class LazyPayloadNode(DataNode):
+    """Holds a LazyPayload object in its `payload` parameter."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="payload",
+                type="LazyPayload",
+                default_value=None,
+                tooltip="Payload object defined in this library module",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["payload"] = self.get_parameter_value("payload")

--- a/tests/e2e/test_lazy_loading_stable_namespace.py
+++ b/tests/e2e/test_lazy_loading_stable_namespace.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -38,6 +39,8 @@ from griptape_nodes.retained_mode.events.flow_events import (
 from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultSuccess,
+    UnloadLibraryFromRegistryRequest,
+    UnloadLibraryFromRegistryResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
@@ -60,21 +63,43 @@ STABLE_NAMESPACE = "griptape_nodes.node_libraries.lazy_payload_library.lazy_payl
 PAYLOAD_TAG = "round-trip"
 
 
-def _materialize_library(target_dir: Path) -> Path:
+def _materialize_library(target_dir: Path, *, library_name: str | None = None) -> Path:
     """Copy the on-disk fixture into ``target_dir`` and stamp the current engine version.
 
     Rewrites the fixture's ``engine_version`` field to the engine's running version so
     ``IncompatibleEngineVersionCheck`` never marks the library UNUSABLE on a version bump.
+    ``library_name`` overrides the schema's name so tests that manage their own library
+    lifecycle don't collide with other tests' registrations in the shared engine singleton.
     """
     from griptape_nodes.utils.version_utils import engine_version
 
     target_dir.mkdir(parents=True, exist_ok=True)
     schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
     schema["metadata"]["engine_version"] = engine_version
+    if library_name is not None:
+        schema["name"] = library_name
     library_json = target_dir / "griptape_nodes_library.json"
     library_json.write_text(json.dumps(schema, indent=2))
     (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
     return library_json
+
+
+def _purge_stable_namespace_modules() -> None:
+    """Drop all stable-namespace modules from sys.modules.
+
+    Tests in this module share the engine singleton (and therefore sys.modules), so each
+    scenario purges before relying on "the namespace has not been imported yet".
+    """
+    for module_name in list(sys.modules):
+        if module_name == "griptape_nodes.node_libraries" or module_name.startswith("griptape_nodes.node_libraries."):
+            del sys.modules[module_name]
+
+
+def _unload_library_if_registered(library_name: str) -> None:
+    """Unload a library from the shared engine singleton, tolerating it not being registered."""
+    GriptapeNodes.handle_request(
+        UnloadLibraryFromRegistryRequest(library_name=library_name, failure_log_level=logging.DEBUG)
+    )
 
 
 def _write_isolated_config(config_root: Path, *, workspace: Path, library_path: Path) -> None:
@@ -107,25 +132,28 @@ def _import_stable_namespace() -> ModuleType:
     return importlib.import_module(STABLE_NAMESPACE)
 
 
-def _generate_payload_workflow_source(library_json: Path) -> str:
+def _generate_payload_workflow_source(library_json: Path, *, lazy_save: bool) -> str:
     """Build a flow holding a LazyPayload parameter value and serialize it to a Python module.
 
-    Mirrors the engine's save path: register the library (lazily, per this process's config
-    default), create a flow, drop a node into it, set its ``payload`` parameter to an object
-    defined by the library module, serialize, and generate the workflow file content.
+    Mirrors the engine's save path: register the library, create a flow, drop a node into it,
+    set its ``payload`` parameter to an object defined by the library module, serialize, and
+    generate the workflow file content. ``lazy_save`` pins whether the saving engine loads
+    nodes lazily or eagerly, so both save-time worlds can be round-tripped into a lazy loader.
     """
     GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    _unload_library_if_registered(LIBRARY_NAME)
+    _purge_stable_namespace_modules()
 
-    # Pin lazy loading on for this registration regardless of the developer's ambient config,
-    # so the in-process stable-namespace import below always goes through the deferred path.
-    with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=True):
+    # Pin the loading mode for this registration regardless of the developer's ambient config.
+    with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=lazy_save):
         register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    # The library registered lazily, so no node module has loaded yet. Importing the stable
-    # namespace here must work regardless (it is what saved workflows execute), and it is the
+    # Under a lazy save no node module has loaded yet, so importing the stable namespace here
+    # must go through the deferred path (it is what saved workflows execute), and it is the
     # only way to get at LazyPayload without resolving a node class first.
-    assert STABLE_NAMESPACE not in sys.modules, "Sanity: lazy registration must not import the node module"
+    if lazy_save:
+        assert STABLE_NAMESPACE not in sys.modules, "Sanity: lazy registration must not import the node module"
     module = _import_stable_namespace()
     payload = module.LazyPayload(PAYLOAD_TAG)
 
@@ -220,12 +248,21 @@ if __name__ == "__main__":
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Lazy Payload Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
-def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "lazy_save",
+    [
+        pytest.param(True, id="saved-by-lazy-engine"),
+        pytest.param(False, id="saved-by-eager-engine"),
+    ],
+)
+def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path, *, lazy_save: bool) -> None:
     """A saved workflow carrying a library-defined value must open with lazy loading enabled.
 
     Regression test for the lazy-node-loading rollback: opening any workflow failed with
     ``No module named 'griptape_nodes.node_libraries'`` because the stable namespaces its
     imports and pickles reference were only present in ``sys.modules`` after an eager load.
+    The eager-save case is the literal field failure: workflows saved by earlier (eager)
+    engines must open after updating to an engine that loads nodes lazily.
     """
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -233,7 +270,7 @@ def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path) -> None:
     library_json = _materialize_library(tmp_path / "library")
     _write_isolated_config(config_root, workspace=workspace, library_path=library_json)
 
-    workflow_source = _generate_payload_workflow_source(library_json)
+    workflow_source = _generate_payload_workflow_source(library_json, lazy_save=lazy_save)
     runnable_source = _wrap_with_runtime_assertions(workflow_source)
     assert f"from {STABLE_NAMESPACE} import LazyPayload" in workflow_source, (
         "The generator must emit the deferred stable-namespace import for the pickled payload;"
@@ -266,3 +303,57 @@ def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path) -> None:
     assert "type=LazyPayloadNode" in result.stdout, diagnostic
     assert "type=ErrorProxyNode" not in result.stdout, diagnostic
     assert f"PAYLOAD type=LazyPayload tag={PAYLOAD_TAG}" in result.stdout, diagnostic
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Lazy Payload Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+def test_stable_namespace_import_tracks_library_lifecycle(tmp_path: Path) -> None:
+    """Stable-namespace importability must follow the library's register/unload/re-register lifecycle.
+
+    Drives the public request surface only, so it pins the behavioral contract that must
+    survive internal reworks of module loading (e.g. executing node files directly under
+    their stable namespace): under lazy loading, registering a library makes its namespaces
+    importable, unloading revokes them, and re-registering after a source edit serves the
+    fresh code rather than a stale cached module.
+    """
+    library_name = "Lazy Lifecycle Library"
+    stable_namespace = "griptape_nodes.node_libraries.lazy_lifecycle_library.lazy_payload_node"
+    library_json = _materialize_library(tmp_path / "library", library_name=library_name)
+    node_file = library_json.parent / FIXTURE_NODE_FILE.name
+
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    _unload_library_if_registered(library_name)
+    _purge_stable_namespace_modules()
+
+    node_file.write_text(FIXTURE_NODE_FILE.read_text() + '\nLIFECYCLE_MARKER = "initial"\n')
+
+    # Register: the namespace becomes importable without any node class having resolved.
+    with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=True):
+        register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    assert stable_namespace not in sys.modules, "Sanity: lazy registration must not import the node module"
+
+    module = importlib.import_module(stable_namespace)
+    assert module.LIFECYCLE_MARKER == "initial"
+
+    # Unload: the namespace must stop resolving, both from sys.modules and via fresh import.
+    unload_result = GriptapeNodes.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name))
+    assert isinstance(unload_result, UnloadLibraryFromRegistryResultSuccess), unload_result
+    assert stable_namespace not in sys.modules, "Unload must remove the stable namespace from sys.modules"
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module(stable_namespace)
+
+    # Re-register after a source edit: the import must serve the fresh code, not a stale module.
+    node_file.write_text(FIXTURE_NODE_FILE.read_text() + '\nLIFECYCLE_MARKER = "reloaded"\n')
+    with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=True):
+        reregister_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(reregister_result, RegisterLibraryFromFileResultSuccess), reregister_result
+
+    reloaded_module = importlib.import_module(stable_namespace)
+    assert reloaded_module.LIFECYCLE_MARKER == "reloaded"
+
+    # Leave the shared singleton the way we found it.
+    _unload_library_if_registered(library_name)
+    _purge_stable_namespace_modules()

--- a/tests/e2e/test_lazy_loading_stable_namespace.py
+++ b/tests/e2e/test_lazy_loading_stable_namespace.py
@@ -1,0 +1,268 @@
+"""End-to-end coverage for opening workflows while nodes are lazily loaded.
+
+With lazy node loading (``library.lazy_node_loading``, the default), registering a library
+imports nothing: each node's module loads on first use. But saved workflows reference library
+classes through their stable namespace (``griptape_nodes.node_libraries.<lib>.<file>``), both as
+``from`` imports emitted into the generated Python and inside pickled parameter values. Before
+the ``StableNamespaceImportFinder`` meta-path hook, those imports only resolved if the module
+happened to be in ``sys.modules`` already, so opening any workflow that carried a
+library-defined value failed with ``No module named 'griptape_nodes.node_libraries'`` the moment
+lazy loading shipped.
+
+This suite drives the full regression path: build a workflow whose parameter value is an object
+defined in a fixture library, save it through the real generator, then execute the generated
+``.py`` in a fresh subprocess whose config has lazy loading enabled. The subprocess must import
+the stable namespace and unpickle the value without ever having resolved a node class first.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    SetParameterValueRequest,
+    SetParameterValueResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "lazy_payload_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "lazy_payload_node.py"
+
+LIBRARY_NAME = "Lazy Payload Library"
+STABLE_NAMESPACE = "griptape_nodes.node_libraries.lazy_payload_library.lazy_payload_node"
+PAYLOAD_TAG = "round-trip"
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    """Copy the on-disk fixture into ``target_dir`` and stamp the current engine version.
+
+    Rewrites the fixture's ``engine_version`` field to the engine's running version so
+    ``IncompatibleEngineVersionCheck`` never marks the library UNUSABLE on a version bump.
+    """
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / FIXTURE_NODE_FILE.name).write_text(FIXTURE_NODE_FILE.read_text())
+    return library_json
+
+
+def _write_isolated_config(config_root: Path, *, workspace: Path, library_path: Path) -> None:
+    """Write an XDG-style config that registers the fixture library with lazy loading pinned on.
+
+    ``lazy_node_loading`` is the default, but the subprocess pins it explicitly so this
+    regression test keeps meaning the same thing if the default ever flips.
+    """
+    config_dir = config_root / "griptape_nodes"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "griptape_nodes_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "workspace_directory": str(workspace),
+                "log_level": "WARNING",
+                "library": {"lazy_node_loading": True},
+                "app_events": {
+                    "on_app_initialization_complete": {
+                        "libraries_to_register": [str(library_path)],
+                    },
+                },
+            }
+        )
+    )
+
+
+def _import_stable_namespace() -> ModuleType:
+    """Import the fixture's stable namespace, the exact operation the regression broke."""
+    return importlib.import_module(STABLE_NAMESPACE)
+
+
+def _generate_payload_workflow_source(library_json: Path) -> str:
+    """Build a flow holding a LazyPayload parameter value and serialize it to a Python module.
+
+    Mirrors the engine's save path: register the library (lazily, per this process's config
+    default), create a flow, drop a node into it, set its ``payload`` parameter to an object
+    defined by the library module, serialize, and generate the workflow file content.
+    """
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    # Pin lazy loading on for this registration regardless of the developer's ambient config,
+    # so the in-process stable-namespace import below always goes through the deferred path.
+    with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=True):
+        register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    # The library registered lazily, so no node module has loaded yet. Importing the stable
+    # namespace here must work regardless (it is what saved workflows execute), and it is the
+    # only way to get at LazyPayload without resolving a node class first.
+    assert STABLE_NAMESPACE not in sys.modules, "Sanity: lazy registration must not import the node module"
+    module = _import_stable_namespace()
+    payload = module.LazyPayload(PAYLOAD_TAG)
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="lazy_payload_e2e_workflow")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+
+    node_result = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LazyPayloadNode",
+            specific_library_name=LIBRARY_NAME,
+            node_name="LazyPayload_1",
+            override_parent_flow_name=flow_result.flow_name,
+        )
+    )
+    assert isinstance(node_result, CreateNodeResultSuccess), node_result
+    assert node_result.node_type == "LazyPayloadNode", (
+        f"Sanity: in-process registration must yield real node, got {node_result.node_type!r}"
+    )
+
+    set_value_result = GriptapeNodes.handle_request(
+        SetParameterValueRequest(parameter_name="payload", value=payload, node_name="LazyPayload_1")
+    )
+    assert isinstance(set_value_result, SetParameterValueResultSuccess), set_value_result
+
+    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_result.flow_name))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+
+    metadata = WorkflowMetadata(
+        name="lazy_payload_e2e_workflow",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
+        # Skip the executable wrapper; we only need build_workflow to run end-to-end.
+        workflow_shape=None,
+    )
+    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        workflow_metadata=metadata,
+    )
+
+
+def _wrap_with_runtime_assertions(workflow_source: str) -> str:
+    """Append a ``__main__`` block that runs build_workflow and prints the round-tripped payload.
+
+    The subprocess this runs in has lazy node loading enabled and never resolves a node class
+    before build_workflow executes, so the deferred stable-namespace import and the pickled
+    parameter value inside the generated source are what exercise the import path under test.
+    """
+    runtime_block = """
+
+import asyncio as _e2e_asyncio
+import logging as _e2e_logging
+
+from griptape_nodes.retained_mode.events.flow_events import (
+    GetTopLevelFlowRequest as _E2EGetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess as _E2EGetTopLevelFlowResultSuccess,
+    ListNodesInFlowRequest as _E2EListNodesInFlowRequest,
+    ListNodesInFlowResultSuccess as _E2EListNodesInFlowResultSuccess,
+)
+
+
+async def _e2e_run() -> None:
+    await build_workflow()  # noqa: F821 - defined by exec'd workflow source above
+    top_level = await GriptapeNodes.ahandle_request(_E2EGetTopLevelFlowRequest())  # noqa: F821
+    if not isinstance(top_level, _E2EGetTopLevelFlowResultSuccess) or top_level.flow_name is None:
+        raise RuntimeError(f"E2E_FAIL: no top-level flow after build_workflow: {top_level}")
+    list_nodes = await GriptapeNodes.ahandle_request(  # noqa: F821
+        _E2EListNodesInFlowRequest(flow_name=top_level.flow_name)
+    )
+    if not isinstance(list_nodes, _E2EListNodesInFlowResultSuccess):
+        raise RuntimeError(f"E2E_FAIL: could not list nodes: {list_nodes}")
+    node_manager = GriptapeNodes.NodeManager()  # noqa: F821
+    for node_name in list_nodes.node_names:
+        node = node_manager.get_node_by_name(node_name)
+        print(f"NODE_TYPE name={node_name} type={type(node).__name__}", flush=True)
+        payload = node.get_parameter_value("payload")
+        print(f"PAYLOAD type={type(payload).__name__} tag={getattr(payload, 'tag', None)}", flush=True)
+
+
+if __name__ == "__main__":
+    _e2e_logging.basicConfig(level=_e2e_logging.WARNING)
+    _e2e_asyncio.run(_e2e_run())
+"""
+    return workflow_source + runtime_block
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Lazy Payload Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path) -> None:
+    """A saved workflow carrying a library-defined value must open with lazy loading enabled.
+
+    Regression test for the lazy-node-loading rollback: opening any workflow failed with
+    ``No module named 'griptape_nodes.node_libraries'`` because the stable namespaces its
+    imports and pickles reference were only present in ``sys.modules`` after an eager load.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_root = tmp_path / "xdg_config"
+    library_json = _materialize_library(tmp_path / "library")
+    _write_isolated_config(config_root, workspace=workspace, library_path=library_json)
+
+    workflow_source = _generate_payload_workflow_source(library_json)
+    runnable_source = _wrap_with_runtime_assertions(workflow_source)
+    assert f"from {STABLE_NAMESPACE} import LazyPayload" in workflow_source, (
+        "The generator must emit the deferred stable-namespace import for the pickled payload;"
+        " without it this test would not exercise the lazy import path."
+    )
+
+    workflow_path = tmp_path / "lazy_payload_workflow.py"
+    workflow_path.write_text(runnable_source)
+
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = str(config_root)
+    # Engine bootstrap requires GT_CLOUD_API_KEY to be set; the value never leaves the
+    # subprocess so a placeholder is fine.
+    env.setdefault("GT_CLOUD_API_KEY", "fake-test-key-for-bootstrap")
+
+    result = subprocess.run(  # noqa: S603 - subprocess input is constructed inside the test
+        [sys.executable, str(workflow_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    diagnostic = (
+        f"workflow exit code: {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, diagnostic
+    assert "No module named 'griptape_nodes.node_libraries'" not in result.stderr, diagnostic
+    assert "type=LazyPayloadNode" in result.stdout, diagnostic
+    assert "type=ErrorProxyNode" not in result.stdout, diagnostic
+    assert f"PAYLOAD type=LazyPayload tag={PAYLOAD_TAG}" in result.stdout, diagnostic

--- a/tests/unit/node_library/test_lazy_node_loading.py
+++ b/tests/unit/node_library/test_lazy_node_loading.py
@@ -1,0 +1,177 @@
+"""Tests for lazy node-type registration on Library.
+
+A node type registered via ``register_lazy_node_type`` records its metadata and a
+loader but does not import the node's Python module until the real class is first
+needed (creation, execution, or introspection). Import failures surface to that
+first caller rather than at library-load time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode
+from griptape_nodes.node_library.library_registry import Library, LibrarySchema, NodeMetadata
+
+
+class _LazyMockNode(BaseNode):
+    def __init__(self, name: str = "mock", **kwargs: Any) -> None:
+        super().__init__(name=name, **kwargs)
+
+    def process(self) -> AsyncResult | None:
+        return None
+
+
+class _AlphaNode(_LazyMockNode):
+    pass
+
+
+class _BetaNode(_LazyMockNode):
+    pass
+
+
+def _make_library(name: str = "TestLib") -> Library:
+    schema = MagicMock(spec=LibrarySchema)
+    schema.is_default_library = False
+    schema.name = name
+    return Library(library_data=schema)
+
+
+def _metadata(display_name: str = "Node") -> NodeMetadata:
+    return NodeMetadata(category="test", description="desc", display_name=display_name)
+
+
+class TestLazyRegistration:
+    def test_register_lazy_does_not_invoke_loader(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=loader)
+
+        loader.assert_not_called()
+        assert lib.has_node_type("_LazyMockNode")
+        assert "_LazyMockNode" in lib.get_registered_nodes()
+
+    def test_metadata_available_without_resolution(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+        metadata = _metadata(display_name="Fancy Node")
+
+        lib.register_lazy_node_type("_LazyMockNode", metadata=metadata, loader=loader)
+
+        assert lib.get_node_metadata("_LazyMockNode") is metadata
+        loader.assert_not_called()
+
+
+class TestLazyResolution:
+    def test_create_node_resolves_loader_once(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=loader)
+
+        first = lib.create_node(node_type="_LazyMockNode", name="a")
+        second = lib.create_node(node_type="_LazyMockNode", name="b")
+
+        assert isinstance(first, _LazyMockNode)
+        assert isinstance(second, _LazyMockNode)
+        # Loader runs once; the resolved class is promoted and reused thereafter.
+        loader.assert_called_once()
+
+    def test_get_node_class_resolves_and_caches(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_LazyMockNode)
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=loader)
+
+        assert lib.get_node_class("_LazyMockNode") is _LazyMockNode
+        assert lib.get_node_class("_LazyMockNode") is _LazyMockNode
+        # The module is imported at most once; the resolved class is cached.
+        loader.assert_called_once()
+
+    def test_get_node_class_unknown_type_raises_keyerror(self) -> None:
+        lib = _make_library()
+        with pytest.raises(KeyError):
+            lib.get_node_class("DoesNotExist")
+
+    def test_create_node_unknown_type_raises_keyerror(self) -> None:
+        lib = _make_library()
+        with pytest.raises(KeyError):
+            lib.create_node(node_type="DoesNotExist", name="a")
+
+
+class TestImportFailureSurfacesOnFirstUse:
+    def test_create_node_propagates_import_error(self) -> None:
+        lib = _make_library()
+
+        def boom() -> type[BaseNode]:
+            msg = "module import blew up"
+            raise ImportError(msg)
+
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=boom)
+
+        # Registration and metadata lookups succeed; the failure is deferred to first use.
+        assert lib.has_node_type("_LazyMockNode")
+        assert lib.get_node_metadata("_LazyMockNode").display_name == "Node"
+
+        with pytest.raises(ImportError, match="module import blew up"):
+            lib.create_node(node_type="_LazyMockNode", name="a")
+
+
+class TestGetNodesByBaseType:
+    def test_resolves_lazy_types(self) -> None:
+        lib = _make_library()
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=lambda: _AlphaNode)
+        lib.register_lazy_node_type("_BetaNode", metadata=_metadata(), loader=lambda: _BetaNode)
+
+        assert lib.get_nodes_by_base_type(_AlphaNode) == ["_AlphaNode"]
+
+    def test_skips_types_whose_module_fails_to_import(self) -> None:
+        lib = _make_library()
+
+        def boom() -> type[BaseNode]:
+            raise ImportError
+
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=lambda: _AlphaNode)
+        lib.register_lazy_node_type("_Broken", metadata=_metadata(), loader=boom)
+
+        # The broken type is skipped; the scan still finds the importable one.
+        assert lib.get_nodes_by_base_type(_LazyMockNode) == ["_AlphaNode"]
+
+
+class TestSupersedeSemantics:
+    def test_eager_registration_supersedes_lazy(self) -> None:
+        lib = _make_library()
+        loader = MagicMock(return_value=_AlphaNode)
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=loader)
+
+        lib.register_new_node_type(_AlphaNode, metadata=_metadata())
+
+        assert lib.get_node_class("_AlphaNode") is _AlphaNode
+        loader.assert_not_called()
+
+    def test_lazy_registration_supersedes_eager(self) -> None:
+        lib = _make_library()
+        lib.register_new_node_type(_AlphaNode, metadata=_metadata())
+
+        loader = MagicMock(return_value=_BetaNode)
+        lib.register_lazy_node_type("_AlphaNode", metadata=_metadata(), loader=loader)
+
+        assert lib.get_node_class("_AlphaNode") is _BetaNode
+        loader.assert_called_once()
+
+
+class TestUnregister:
+    def test_unregister_removes_lazy_type(self) -> None:
+        lib = _make_library()
+        lib.register_lazy_node_type("_LazyMockNode", metadata=_metadata(), loader=lambda: _LazyMockNode)
+
+        lib.unregister_node_type("_LazyMockNode")
+
+        assert not lib.has_node_type("_LazyMockNode")
+
+    def test_unregister_unknown_type_raises_keyerror(self) -> None:
+        lib = _make_library()
+        with pytest.raises(KeyError):
+            lib.unregister_node_type("DoesNotExist")

--- a/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
@@ -1,0 +1,268 @@
+"""Tests for the opt-in lazy node-loading flag in LibraryManager.
+
+Eager loading (the default) imports each node's module at load time, so a broken node
+surfaces as a library problem immediately. Lazy loading registers node types with a
+deferred loader and imports on first use, so a broken node is not reported until used.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import (
+    CategoryDefinition,
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+    NodeDefinition,
+    NodeMetadata,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    DescribeNodeTypeRequest,
+    DescribeNodeTypeResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.node_module_import_problem import (
+    NodeModuleImportProblem,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.retained_mode.managers.settings import LibrarySettings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+_GOOD_NODE_SOURCE = """
+from griptape_nodes.exe_types.node_types import BaseNode
+
+
+class GoodNode(BaseNode):
+    def process(self):
+        return None
+"""
+
+_BROKEN_NODE_SOURCE = """
+import definitely_not_a_real_module_zzz  # noqa: F401
+
+from griptape_nodes.exe_types.node_types import BaseNode
+
+
+class BrokenNode(BaseNode):
+    def process(self):
+        return None
+"""
+
+# Two node classes in one file, plus a top-level side effect that appends to a marker file on
+# every module execution. Used to prove the module is imported exactly once even when its two
+# classes are resolved separately.
+_SIBLINGS_SOURCE = """
+from pathlib import Path
+
+from griptape_nodes.exe_types.node_types import BaseNode
+
+Path({marker!r}).open("a").write("x")
+
+
+class SiblingA(BaseNode):
+    def process(self):
+        return None
+
+
+class SiblingB(BaseNode):
+    def process(self):
+        return None
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Iterator[None]:
+    # LibraryRegistry._libraries is a ClassVar, so it survives the conftest singleton reset.
+    # Clear it around each test so re-registering the same library name does not collide.
+    LibraryRegistry._clear()
+    yield
+    LibraryRegistry._clear()
+
+
+def _node_metadata(display_name: str) -> NodeMetadata:
+    return NodeMetadata(category="Test", description="test node", display_name=display_name)
+
+
+def _write_library(tmp_path: Path) -> LibrarySchema:
+    (tmp_path / "good_node.py").write_text(_GOOD_NODE_SOURCE)
+    (tmp_path / "broken_node.py").write_text(_BROKEN_NODE_SOURCE)
+    return LibrarySchema(
+        name="Lazy Flag Test Library",
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test",
+            description="test",
+            library_version="1.0.0",
+            engine_version="1.0.0",
+            tags=[],
+        ),
+        categories=[{"Test": CategoryDefinition(title="Test", description="test", color="#000", icon="Folder")}],
+        nodes=[
+            NodeDefinition(class_name="GoodNode", file_path="good_node.py", metadata=_node_metadata("Good")),
+            NodeDefinition(class_name="BrokenNode", file_path="broken_node.py", metadata=_node_metadata("Broken")),
+        ],
+    )
+
+
+def _library_info(schema: LibrarySchema, tmp_path: Path) -> LibraryManager.LibraryInfo:
+    return LibraryManager.LibraryInfo(
+        lifecycle_state=LibraryManager.LibraryLifecycleState.METADATA_LOADED,
+        library_path=str(tmp_path / "griptape_nodes_library.json"),
+        is_sandbox=False,
+        library_name=schema.name,
+        library_version="1.0.0",
+        fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
+        problems=[],
+    )
+
+
+def _schema(name: str, nodes: list[NodeDefinition]) -> LibrarySchema:
+    return LibrarySchema(
+        name=name,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test", description="test", library_version="1.0.0", engine_version="1.0.0", tags=[]
+        ),
+        categories=[{"Test": CategoryDefinition(title="Test", description="test", color="#000", icon="Folder")}],
+        nodes=nodes,
+    )
+
+
+class TestLazyNodeLoadingDefault:
+    def test_setting_defaults_to_lazy(self) -> None:
+        assert LibrarySettings().lazy_node_loading is True
+
+
+class TestEagerLoading:
+    def test_broken_node_is_reported_at_load(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=False
+        )
+
+        # The importable node registers; the broken one does not, and its failure is a problem now.
+        assert library.has_node_type("GoodNode")
+        assert not library.has_node_type("BrokenNode")
+        assert any(isinstance(p, NodeModuleImportProblem) for p in info.problems)
+        # Some nodes loaded, but with problems -> FLAWED.
+        assert info.fitness is LibraryManager.LibraryFitness.FLAWED
+
+
+class TestLazyLoading:
+    def test_broken_node_is_not_reported_until_used(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        # Both types register without importing; no import problem is recorded at load.
+        assert library.has_node_type("GoodNode")
+        assert library.has_node_type("BrokenNode")
+        assert not any(isinstance(p, NodeModuleImportProblem) for p in info.problems)
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+        # The good node imports on first use; the broken one raises only when first used.
+        assert library.create_node(node_type="GoodNode", name="g") is not None
+        with pytest.raises(ImportError):
+            library.get_node_class("BrokenNode")
+
+
+class TestShouldLazyLoadNodes:
+    def test_worker_always_eager(self, griptape_nodes: GriptapeNodes) -> None:
+        manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        # Even with the setting on, a worker loads eagerly.
+        with (
+            patch.object(manager, "_is_worker", True),
+            patch.object(config_mgr, "get_config_value", return_value=True),
+        ):
+            assert manager._should_lazy_load_nodes() is False
+
+    def test_orchestrator_honors_setting_enabled(self, griptape_nodes: GriptapeNodes) -> None:
+        manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        with (
+            patch.object(manager, "_is_worker", False),
+            patch.object(config_mgr, "get_config_value", return_value=True),
+        ):
+            assert manager._should_lazy_load_nodes() is True
+
+    def test_orchestrator_honors_setting_disabled(self, griptape_nodes: GriptapeNodes) -> None:
+        manager = griptape_nodes.LibraryManager()
+        config_mgr = griptape_nodes.ConfigManager()
+        with (
+            patch.object(manager, "_is_worker", False),
+            patch.object(config_mgr, "get_config_value", return_value=False),
+        ):
+            assert manager._should_lazy_load_nodes() is False
+
+
+class TestMultipleNodesPerFile:
+    def test_sibling_classes_share_a_single_module_import(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager = griptape_nodes.LibraryManager()
+        marker = tmp_path / "import_count.txt"
+        (tmp_path / "siblings.py").write_text(_SIBLINGS_SOURCE.format(marker=str(marker)))
+        schema = _schema(
+            "Siblings Library",
+            [
+                NodeDefinition(class_name="SiblingA", file_path="siblings.py", metadata=_node_metadata("A")),
+                NodeDefinition(class_name="SiblingB", file_path="siblings.py", metadata=_node_metadata("B")),
+            ],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        # Registration imports nothing.
+        assert not marker.exists()
+
+        node_a = library.get_node_class("SiblingA")
+        node_b = library.get_node_class("SiblingB")
+
+        # The shared file's module is imported exactly once (its top-level code ran once),
+        # even though the two classes resolved separately.
+        assert marker.read_text() == "x"
+        # Both classes come from the same module object, so identity/side effects stay consistent.
+        assert sys.modules[node_a.__module__] is sys.modules[node_b.__module__]
+        assert sys.modules[node_a.__module__].SiblingA is node_a
+
+
+class TestDescribeNodeTypeWithLazyImportFailure:
+    def test_describe_returns_metadata_only_when_lazy_import_fails(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        result = manager.describe_node_type_request(
+            DescribeNodeTypeRequest(node_type="BrokenNode", library=schema.name)
+        )
+
+        # A broken lazy import yields a usable (metadata-only) description rather than a failure.
+        assert isinstance(result, DescribeNodeTypeResultSuccess)
+        assert result.parameters == []

--- a/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
@@ -7,6 +7,8 @@ deferred loader and imports on first use, so a broken node is not reported until
 
 from __future__ import annotations
 
+import importlib
+import pickle
 import sys
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -266,3 +268,120 @@ class TestDescribeNodeTypeWithLazyImportFailure:
         # A broken lazy import yields a usable (metadata-only) description rather than a failure.
         assert isinstance(result, DescribeNodeTypeResultSuccess)
         assert result.parameters == []
+
+
+class TestStableNamespaceImportUnderLazyLoading:
+    """Lazily registered node files must be importable via their stable namespace.
+
+    Saved workflows reference library classes through
+    ``griptape_nodes.node_libraries.<lib>.<file>`` imports and pickled values. With lazy
+    loading nothing is in ``sys.modules`` at registration time, so these imports resolve
+    through the StableNamespaceImportFinder meta-path hook instead.
+    """
+
+    GOOD_STABLE_NAMESPACE = "griptape_nodes.node_libraries.lazy_flag_test_library.good_node"
+    BROKEN_STABLE_NAMESPACE = "griptape_nodes.node_libraries.lazy_flag_test_library.broken_node"
+
+    @pytest.fixture(autouse=True)
+    def _clean_stable_modules(self) -> Iterator[None]:
+        # Purge before as well as after: earlier tests in this file load modules under the
+        # same library name (and therefore the same stable namespace) without cleaning up.
+        self._purge_stable_namespace_modules()
+        yield
+        self._purge_stable_namespace_modules()
+
+    @staticmethod
+    def _purge_stable_namespace_modules() -> None:
+        for module_name in list(sys.modules):
+            if module_name == "griptape_nodes.node_libraries" or module_name.startswith(
+                "griptape_nodes.node_libraries."
+            ):
+                del sys.modules[module_name]
+
+    def _register_lazy_library(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> tuple[LibraryManager, LibrarySchema]:
+        manager = griptape_nodes.LibraryManager()
+        schema = _write_library(tmp_path)
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+        return manager, schema
+
+    def test_stable_namespace_imports_before_any_class_resolution(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        self._register_lazy_library(griptape_nodes, tmp_path)
+        assert self.GOOD_STABLE_NAMESPACE not in sys.modules
+
+        module = importlib.import_module(self.GOOD_STABLE_NAMESPACE)
+
+        assert module.GoodNode is not None
+        # A later node-class resolution reuses the module the import loaded (shared memoized
+        # loader), so class identity is consistent between imports and node creation.
+        library = LibraryRegistry.get_library("Lazy Flag Test Library")
+        assert library.get_node_class("GoodNode") is module.GoodNode
+
+    def test_unpickle_resolves_stable_namespace_reference(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        self._register_lazy_library(griptape_nodes, tmp_path)
+        assert self.GOOD_STABLE_NAMESPACE not in sys.modules
+
+        # A GLOBAL-opcode pickle referencing the stable namespace, as found inside saved
+        # workflow parameter values. Unpickling must import the module on demand.
+        payload = f"c{self.GOOD_STABLE_NAMESPACE}\nGoodNode\n.".encode()
+        node_class = pickle.loads(payload)  # noqa: S301 - crafted in-test payload
+
+        assert node_class.__name__ == "GoodNode"
+
+    def test_parent_packages_resolve_as_namespace_packages(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        self._register_lazy_library(griptape_nodes, tmp_path)
+
+        root_package = importlib.import_module("griptape_nodes.node_libraries")
+        library_package = importlib.import_module("griptape_nodes.node_libraries.lazy_flag_test_library")
+
+        assert root_package.__path__ is not None
+        assert library_package.__path__ is not None
+
+    def test_broken_module_import_raises_import_error(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        self._register_lazy_library(griptape_nodes, tmp_path)
+
+        with pytest.raises(ImportError):
+            importlib.import_module(self.BROKEN_STABLE_NAMESPACE)
+
+    def test_unregistered_library_is_no_longer_importable(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        manager, schema = self._register_lazy_library(griptape_nodes, tmp_path)
+
+        manager._unregister_all_stable_module_aliases_for_library(schema.name)
+
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(self.GOOD_STABLE_NAMESPACE)
+
+    def test_loaded_module_import_is_not_reexecuted_by_class_resolution(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        manager = griptape_nodes.LibraryManager()
+        marker = tmp_path / "import_count.txt"
+        (tmp_path / "siblings.py").write_text(_SIBLINGS_SOURCE.format(marker=str(marker)))
+        schema = _schema(
+            "Siblings Import Library",
+            [
+                NodeDefinition(class_name="SiblingA", file_path="siblings.py", metadata=_node_metadata("A")),
+                NodeDefinition(class_name="SiblingB", file_path="siblings.py", metadata=_node_metadata("B")),
+            ],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        info = _library_info(schema, tmp_path)
+        manager._attempt_load_nodes_from_library(
+            library_data=schema, library=library, base_dir=tmp_path, library_info=info, lazy_loading=True
+        )
+
+        module = importlib.import_module("griptape_nodes.node_libraries.siblings_import_library.siblings")
+        node_a = library.get_node_class("SiblingA")
+        node_b = library.get_node_class("SiblingB")
+
+        # The import and both class resolutions share one module execution.
+        assert marker.read_text() == "x"
+        assert module.SiblingA is node_a
+        assert module.SiblingB is node_b


### PR DESCRIPTION
Closes #5221

Re-application of https://github.com/griptape-ai/griptape-nodes-engine/pull/5114 that was reverted in 54b3db76fe06bece0004bbfbd1482169319e4476 because of an error raised internally:
```
Error: RunWorkflowFromRegistry Failed
Description: Failed to run workflow on path '/Volumes/griptape/foo.py'. Exception: No module named 'griptape_nodes.node_libraries'
Timestamp: 7/14/2026, 12:45:06 PM
```

This has been fixed in 60e17b3bac592c12ef9c35cdc161036f8910c58a on this PR. PR is otherwise identical to the reverted one.