### PR TITLE
Implement resolve_cloud_credential

### DIFF
--- a/src/griptape_nodes/agents/pydantic_ai/model.py
+++ b/src/griptape_nodes/agents/pydantic_ai/model.py
@@ -17,6 +17,7 @@ import os
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
+from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.cloud_models import (
     LM_STUDIO_DEFAULT_BASE_URL,
     OLLAMA_DEFAULT_BASE_URL,
@@ -38,18 +39,19 @@ def build_griptape_cloud_model(
     Args:
         model_name: The Griptape Cloud model id (e.g. ``"gpt-4o"``). Cloud picks
             the underlying provider from this name server-side.
-        api_key: Griptape Cloud API key. Falls back to the ``GT_CLOUD_API_KEY``
-            environment variable. Sent as ``Authorization: Bearer <key>``.
+        api_key: Griptape Cloud credential. Falls back to the Griptape Nodes
+            License, then the ``GT_CLOUD_API_KEY`` environment variable, per
+            :func:`resolve_cloud_credential`. Sent as ``Authorization: Bearer <key>``.
         base_url: Griptape Cloud root URL (no ``/api/v1`` suffix). Falls back to
             the ``GT_CLOUD_BASE_URL`` environment variable, then to
             :data:`GRIPTAPE_CLOUD_BASE_URL`.
 
     Raises:
-        ValueError: If no API key is available.
+        ValueError: If neither a license nor an API key is available.
     """
-    resolved_key = api_key or os.environ.get("GT_CLOUD_API_KEY")
+    resolved_key = api_key or resolve_cloud_credential()
     if not resolved_key:
-        msg = "Griptape Cloud API key is required. Pass `api_key=` or set the GT_CLOUD_API_KEY environment variable."
+        msg = f"Attempted to reach Griptape Cloud. Failed because {MISSING_CREDENTIAL_MESSAGE}"
         raise ValueError(msg)
 
     cloud_root = (base_url or os.environ.get("GT_CLOUD_BASE_URL", GRIPTAPE_CLOUD_BASE_URL)).rstrip("/")
@@ -73,9 +75,9 @@ def build_model(
         provider: One of ``"griptape_cloud"``, ``"ollama"``, ``"lmstudio"``,
             or ``"custom"``.
         api_key: API key for the target endpoint. Required for
-            ``"griptape_cloud"`` (falls back to ``GT_CLOUD_API_KEY``) and
-            ``"custom"``. Ignored for ``"ollama"`` and ``"lmstudio"``
-            (no auth needed).
+            ``"griptape_cloud"`` (falls back to the license, then
+            ``GT_CLOUD_API_KEY``) and ``"custom"``. Ignored for ``"ollama"``
+            and ``"lmstudio"`` (no auth needed).
         base_url: Base URL of the endpoint. For ``"griptape_cloud"`` the
             ``/api/v1`` suffix is appended automatically. For ``"ollama"``
             defaults to :data:`OLLAMA_DEFAULT_BASE_URL`. For ``"lmstudio"``

--- a/src/griptape_nodes/cli/commands/init.py
+++ b/src/griptape_nodes/cli/commands/init.py
@@ -19,6 +19,7 @@ from griptape_nodes.cli.shared import (
     InitConfig,
     console,
 )
+from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -356,12 +357,12 @@ def _get_griptape_cloud_buckets_and_display_table() -> tuple[list[str], dict[str
     Returns:
         tuple: (bucket_names, name_to_id_mapping, display_table)
     """
-    api_key = secrets_manager.get_secret("GT_CLOUD_API_KEY")
+    api_key = resolve_cloud_credential(secrets_manager)
     bucket_names: list[str] = []
     name_to_id: dict[str, str] = {}
 
     if api_key is None:
-        msg = "Griptape Cloud API Key not found."
+        msg = f"Attempted to list Griptape Cloud buckets. Failed because {MISSING_CREDENTIAL_MESSAGE}"
         raise RuntimeError(msg)
 
     table = Table(show_header=True, box=HEAVY_EDGE, show_lines=True, expand=True)
@@ -595,9 +596,9 @@ def _create_new_bucket(bucket_name: str) -> str:
     Returns:
         The bucket ID of the created bucket.
     """
-    api_key = secrets_manager.get_secret("GT_CLOUD_API_KEY")
+    api_key = resolve_cloud_credential(secrets_manager)
     if api_key is None:
-        msg = "GT_CLOUD_API_KEY secret is required to create a bucket."
+        msg = f"Attempted to create a Griptape Cloud bucket. Failed because {MISSING_CREDENTIAL_MESSAGE}"
         raise ValueError(msg)
 
     try:

--- a/src/griptape_nodes/drivers/cloud_credentials.py
+++ b/src/griptape_nodes/drivers/cloud_credentials.py
@@ -1,0 +1,144 @@
+"""Resolve the credential used to authenticate against Griptape Cloud.
+
+Griptape Cloud accepts two kinds of bearer credential: a Griptape Cloud API key
+(``GT_CLOUD_API_KEY``, a ``gt-`` prefixed key) and a Griptape Nodes License
+(``GRIPTAPE_NODES_LICENSE``, a JWT the desktop app writes into the engine's
+global ``.env``). A license-only user has no API key at all, so any code path
+that reads ``GT_CLOUD_API_KEY`` directly is unreachable for them.
+
+Endpoints that accept a License, via the control plane's ``LicenseAuthMixin``:
+
+- ``POST /api/v1/chat/completions`` (the sidebar agent's chat model)
+- ``POST /api/images/generations`` (the agent's image-generation tool)
+- ``/api/buckets*`` and ``/api/assets*`` (cloud storage and static files)
+- ``GET /api/organizations``
+- the model proxy (``/api/proxy/*``), which the standard library already handles
+  in its own ``resolve_proxy_api_key``
+
+Two endpoints must keep using the API key and must NOT be routed through here:
+
+- ``GET /api/users`` has no ``LicenseAuthMixin``, so it answers a License with
+  HTTP 401. Were one added, an unassigned license authenticates as the org's
+  synthetic service principal, so "who is the current user" would answer with a
+  service account rather than the human.
+- ``wss://api.nodes.griptape.ai/ws/engines/events`` is served by a different
+  service that accepts only ``gt-`` keys or Auth0-signed JWTs. A License is
+  signed by the license key, so it fails signing-key lookup there.
+
+Authenticating with a License is necessary but not always sufficient: the
+control plane also evaluates an entitlement policy per request, so a License
+that authenticates can still be refused with HTTP 403. See
+:data:`POLICY_DENIED_HINT`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, Protocol, overload
+
+
+class SecretsReader(Protocol):
+    """The slice of ``SecretsManager`` this module needs.
+
+    Structural so that callers can pass any secret source (and tests a stub)
+    without importing the manager, which would invert the dependency between
+    ``drivers`` and ``retained_mode``. The overloads mirror ``SecretsManager``'s
+    so the real manager satisfies this protocol.
+    """
+
+    @overload
+    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[True] = True) -> str: ...
+
+    @overload
+    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[False]) -> str | None: ...
+
+
+LICENSE_SECRET_NAME = "GRIPTAPE_NODES_LICENSE"  # noqa: S105  # a secret's name, not a secret
+"""Secret holding the Griptape Nodes License JWT. Written by the desktop app."""
+
+API_KEY_SECRET_NAME = "GT_CLOUD_API_KEY"  # noqa: S105  # a secret's name, not a secret
+"""Secret holding the Griptape Cloud API key."""
+
+MISSING_CREDENTIAL_MESSAGE = (
+    "no Griptape Cloud credential was found. Sign in with your Griptape license, "
+    f"or set the {API_KEY_SECRET_NAME} secret in Settings."
+)
+"""User-facing reason to append to a "failed because" message.
+
+Starts lowercase because every call site reads "Failed because ...".
+
+Names both credentials, because telling a license-only user to set an API key
+sends them after the wrong knob.
+"""
+
+_JWT_SEGMENT_COUNT = 3
+"""A License is a JWT: header, payload, signature."""
+
+POLICY_DENIED_HINT = (
+    "your Griptape license or organization is not entitled to this action. "
+    "Contact your Griptape administrator to request access."
+)
+"""User-facing reason for an HTTP 403 from Griptape Cloud."""
+
+
+def resolve_cloud_credential(
+    secrets_manager: SecretsReader | None = None,
+    *,
+    secret_name: str = API_KEY_SECRET_NAME,
+) -> str | None:
+    """Return the bearer credential for Griptape Cloud, or None if there is none.
+
+    Resolution order, first non-empty wins:
+
+    1. The Griptape Nodes License. Preferred over the API key so that a user who
+       has both authenticates as their license, matching the standard library's
+       ``resolve_proxy_api_key``.
+    2. The Griptape Cloud API key (``secret_name``).
+
+    Deliberately does NOT honor ``GT_CLOUD_PROXY_API_KEY``, even though the
+    library's proxy resolver checks it first. That variable is scoped to the
+    model proxy specifically ("without affecting other engine systems that use
+    GT_CLOUD_API_KEY"), and the engine does not read its ``GT_CLOUD_PROXY_BASE_URL``
+    companion. Honoring it here would send a proxy-only credential (e.g. the
+    ``local`` value used against local proxy infra) to production Cloud for
+    storage, sync, and bucket calls.
+
+    Args:
+        secrets_manager: Used to read secrets so that workspace and global
+            ``.env`` files are searched, not just the environment. When omitted,
+            only environment variables are consulted. Note that this is a
+            boot-time snapshot: ``SecretsManager.__init__`` hydrates ``os.environ``
+            from the ``.env`` files once, and the desktop app rewrites the license
+            in that file without notifying the engine, so an env-only caller can
+            hold a stale license until the process restarts.
+        secret_name: Secret to fall back to for the API key.
+
+    Returns:
+        The credential, or None when neither a license nor an API key is set.
+        Callers decide whether that is fatal; see
+        :data:`MISSING_CREDENTIAL_MESSAGE` for the user-facing wording.
+    """
+    if secrets_manager is None:
+        return os.getenv(LICENSE_SECRET_NAME) or os.getenv(secret_name)
+
+    license_token = secrets_manager.get_secret(LICENSE_SECRET_NAME, should_error_on_not_found=False)
+    if license_token:
+        return license_token
+
+    return secrets_manager.get_secret(secret_name, should_error_on_not_found=False)
+
+
+def is_license_credential(credential: str | None) -> bool:
+    """Return whether a credential is a License rather than a Griptape Cloud API key.
+
+    Tests positively for a JWT's three dot-separated segments rather than merely
+    "does not start with ``gt-``". Callers use this to attribute an HTTP 403 to a
+    licensing decision, so a negative test would blame licensing for any
+    unrecognized credential (a truncated paste, a future key format) and send the
+    user to their administrator for an entitlement they already have.
+    """
+    if not credential:
+        return False
+    if credential.startswith("gt-"):
+        return False
+    return len(credential.split(".")) == _JWT_SEGMENT_COUNT

--- a/src/griptape_nodes/drivers/cloud_credentials.py
+++ b/src/griptape_nodes/drivers/cloud_credentials.py
@@ -34,24 +34,10 @@ that authenticates can still be refused with HTTP 403. See
 from __future__ import annotations
 
 import os
-from typing import Literal, Protocol, overload
+from typing import TYPE_CHECKING
 
-
-class SecretsReader(Protocol):
-    """The slice of ``SecretsManager`` this module needs.
-
-    Structural so that callers can pass any secret source (and tests a stub)
-    without importing the manager, which would invert the dependency between
-    ``drivers`` and ``retained_mode``. The overloads mirror ``SecretsManager``'s
-    so the real manager satisfies this protocol.
-    """
-
-    @overload
-    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[True] = True) -> str: ...
-
-    @overload
-    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[False]) -> str | None: ...
-
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 
 LICENSE_SECRET_NAME = "GRIPTAPE_NODES_LICENSE"  # noqa: S105  # a secret's name, not a secret
 """Secret holding the Griptape Nodes License JWT. Written by the desktop app."""
@@ -82,7 +68,7 @@ POLICY_DENIED_HINT = (
 
 
 def resolve_cloud_credential(
-    secrets_manager: SecretsReader | None = None,
+    secrets_manager: SecretsManager | None = None,
     *,
     secret_name: str = API_KEY_SECRET_NAME,
 ) -> str | None:

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
+from griptape_nodes.drivers.cloud_credentials import resolve_cloud_credential
 from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
 from griptape_nodes.files.path_utils import get_workspace_relative_path
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
@@ -33,14 +34,14 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
         Args:
             workspace_directory: The base workspace directory path.
             bucket_id: The ID of the bucket to use. Required.
-            api_key: The API key for authentication. If not provided, it will be retrieved from the environment variable "GT_CLOUD_API_KEY".
+            api_key: The credential for authentication. If not provided, it is resolved from the Griptape Nodes License, then "GT_CLOUD_API_KEY".
             static_files_directory: The directory path prefix for static files. If provided, file names will be prefixed with this path.
             **kwargs: Additional keyword arguments including base_url and headers.
         """
         super().__init__(workspace_directory)
 
         self.base_url = kwargs.get("base_url") or os.environ.get("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
-        self.api_key = api_key if api_key is not None else os.environ.get("GT_CLOUD_API_KEY")
+        self.api_key = api_key if api_key is not None else resolve_cloud_credential()
         self.headers = kwargs.get("headers") or {"Authorization": f"Bearer {self.api_key}"}
         self.request_timeout = kwargs.get("request_timeout")
         self.bucket_id = bucket_id
@@ -652,7 +653,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
         Args:
             asset_url: Cloud asset URL to convert
             bucket_id: Bucket ID. If None, reads from GT_CLOUD_BUCKET_ID env var.
-            api_key: API key. If None, reads from GT_CLOUD_API_KEY env var.
+            api_key: Credential. If None, resolves the license, then GT_CLOUD_API_KEY.
             base_url: Cloud base URL. If None, reads from GT_CLOUD_BASE_URL env var.
             httpx_request_func: The httpx request function to use (original, not patched)
 
@@ -663,7 +664,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
         if bucket_id is None:
             bucket_id = os.environ.get("GT_CLOUD_BUCKET_ID")
         if api_key is None:
-            api_key = os.environ.get("GT_CLOUD_API_KEY")
+            api_key = resolve_cloud_credential()
         if base_url is None:
             base_url = os.environ.get("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
 
@@ -673,7 +674,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
             return None
 
         if not api_key:
-            logger.debug("GT_CLOUD_API_KEY not set, skipping cloud URL conversion: %s", asset_url)
+            logger.debug("No Griptape Cloud credential set, skipping cloud URL conversion: %s", asset_url)
             return None
 
         # Extract workspace-relative path

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -11,6 +11,7 @@ from griptape.artifacts.url_artifact import UrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 
 from griptape_nodes.common.parameter_hydration import hydrate_value
+from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
@@ -51,7 +52,14 @@ class PublicArtifactUrlParameter:
             )
             raise ValueError(msg)
 
-        api_key = str(self._get_secret_value(self.API_KEY_NAME))
+        api_key = resolve_cloud_credential(GriptapeNodes.SecretsManager(), secret_name=self.API_KEY_NAME)
+        if not api_key:
+            msg = (
+                f"Attempted to make '{artifact_url_parameter.name}' publicly accessible. "
+                f"Failed because {MISSING_CREDENTIAL_MESSAGE}"
+            )
+            raise ValueError(msg)
+
         base = os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
         self._storage_driver = GriptapeCloudStorageDriver(
             workspace_directory=GriptapeNodes.ConfigManager().workspace_path,

--- a/src/griptape_nodes/files/drivers/griptape_cloud_file_driver.py
+++ b/src/griptape_nodes/files/drivers/griptape_cloud_file_driver.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
+from griptape_nodes.drivers.cloud_credentials import resolve_cloud_credential
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.files.base_file_driver import BaseFileDriver
 
@@ -45,14 +46,15 @@ class GriptapeCloudFileDriver(BaseFileDriver):
     def create_from_env(cls) -> "GriptapeCloudFileDriver | None":
         """Create driver from environment variables if available.
 
-        Checks for GT_CLOUD_BUCKET_ID and GT_CLOUD_API_KEY environment variables.
-        If both are present, creates and returns a driver instance.
+        Checks for a GT_CLOUD_BUCKET_ID and a Griptape Cloud credential (the
+        license, else GT_CLOUD_API_KEY). If both are present, creates and returns
+        a driver instance.
 
         Returns:
             GriptapeCloudFileDriver instance if credentials available, None otherwise
         """
         bucket_id = os.environ.get("GT_CLOUD_BUCKET_ID")
-        api_key = os.environ.get("GT_CLOUD_API_KEY")
+        api_key = resolve_cloud_credential()
         base_url = os.environ.get("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
 
         if bucket_id and api_key:

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -26,11 +26,13 @@ import os
 import textwrap
 import threading
 from dataclasses import dataclass, replace
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 import httpx
+from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.messages import BinaryContent, ImageUrl, ModelMessagesTypeAdapter, ModelRequest, UserPromptPart
 from pydantic_ai.usage import UsageLimits
 from xdg_base_dirs import xdg_data_home
@@ -45,6 +47,12 @@ from griptape_nodes.agents.pydantic_ai.runner import (
     ThinkingDelta,
     ToolCall,
     ToolResult,
+)
+from griptape_nodes.drivers.cloud_credentials import (
+    MISSING_CREDENTIAL_MESSAGE,
+    POLICY_DENIED_HINT,
+    is_license_credential,
+    resolve_cloud_credential,
 )
 from griptape_nodes.drivers.cloud_models import (
     DEPRECATED_MODELS,
@@ -182,6 +190,35 @@ _IMAGE_TOOL_INSTRUCTION = (
 def _build_agent_instructions(*, include_image_tool: bool) -> str:
     image_tool_line = _IMAGE_TOOL_INSTRUCTION if include_image_tool else ""
     return _AGENT_INSTRUCTIONS_BASE.format(image_tool_line=image_tool_line)
+
+
+def _cloud_http_status_of(exc: BaseException, cloud_host: str) -> int | None:
+    """Return the HTTP status of a Griptape Cloud failure, or None if it isn't one.
+
+    Two unrelated shapes reach this code: Pydantic AI's ``ModelHTTPError`` carries
+    ``status_code`` directly (the chat path), while ``httpx.HTTPStatusError`` keeps
+    it on ``response`` (the image path). The image toolset also wraps its failure in
+    ``ModelRetry`` with ``raise ... from exc``, so follow the cause chain.
+
+    Only errors from ``cloud_host`` count. An agent turn also talks to remote MCP
+    servers, which raise the same ``httpx.HTTPStatusError``; attributing their 403
+    to Griptape licensing would send the user to their Griptape administrator over
+    an expired token on their own MCP server.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, httpx.HTTPStatusError):
+            if current.request.url.host == cloud_host:
+                return current.response.status_code
+            return None
+        # ModelHTTPError has no URL, but the model is the Cloud provider whenever
+        # the caller has already confirmed the active provider is Griptape Cloud.
+        if isinstance(current, ModelHTTPError):
+            return current.status_code
+        current = current.__cause__
+    return None
 
 
 def _friendly_list_models_error(exc: Exception, base_url: str | None) -> str | None:
@@ -399,9 +436,28 @@ class AgentManager:
         try:
             return await self._run_agent(request)
         except Exception as e:
-            err_msg = f"Error running agent: {e}"
+            message = self._explain_agent_run_error(e, request.provider_name)
+            err_msg = f"Error running agent: {message}"
             logger.exception(err_msg)
-            return RunAgentResultFailure(error={"message": str(e)}, result_details=err_msg)
+            return RunAgentResultFailure(error={"message": message}, result_details=err_msg)
+
+    def _explain_agent_run_error(self, exc: Exception, provider_name: str | None) -> str:
+        """Return the user-facing text for a failed agent run.
+
+        A Griptape Cloud request authenticated with a License can authenticate
+        successfully and still be refused: Cloud evaluates an entitlement policy
+        per request and answers HTTP 403. On its own that surfaces as a bare
+        "Forbidden", which reads like a bug rather than a licensing decision, so
+        name the cause. Every other error keeps its original text.
+        """
+        if self._get_provider(provider_name).type != _PROTECTED_PROVIDER_NAME:
+            return str(exc)
+        cloud_host = urlsplit(os.environ.get("GT_CLOUD_BASE_URL") or GRIPTAPE_CLOUD_BASE_URL).hostname or ""
+        if _cloud_http_status_of(exc, cloud_host) != HTTPStatus.FORBIDDEN:
+            return str(exc)
+        if not is_license_credential(resolve_cloud_credential(secrets_manager, secret_name=API_KEY_ENV_VAR)):
+            return str(exc)
+        return f"Griptape Cloud refused the request because {POLICY_DENIED_HINT} ({exc})"
 
     async def _run_agent(self, request: RunAgentRequest) -> ResultPayload:
         thread_id = self._validate_thread_for_run(request.thread_id)
@@ -742,9 +798,9 @@ class AgentManager:
         base_url = provider.base_url or ""
 
         if provider_type == _PROTECTED_PROVIDER_NAME:
-            api_key = secrets_manager.get_secret(API_KEY_ENV_VAR)
+            api_key = resolve_cloud_credential(secrets_manager, secret_name=API_KEY_ENV_VAR)
             if not api_key:
-                msg = f"Secret '{API_KEY_ENV_VAR}' not found"
+                msg = f"Attempted to start the agent. Failed because {MISSING_CREDENTIAL_MESSAGE}"
                 raise ValueError(msg)
             # Match build_griptape_cloud_model's `or` semantics: a set-but-empty
             # GT_CLOUD_BASE_URL falls back to the default rather than yielding a

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -9,6 +9,7 @@ from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
 from griptape_nodes.common.project_templates.situation import BuiltInSituation, SituationFilePolicy
+from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
@@ -110,9 +111,20 @@ class StaticFilesManager:
             case StorageBackend.GTC:
                 bucket_id = secrets_manager.get_secret("GT_CLOUD_BUCKET_ID", should_error_on_not_found=False)
 
+                cloud_credential = resolve_cloud_credential(secrets_manager)
+
                 if not bucket_id:
                     logger.warning(
                         "GT_CLOUD_BUCKET_ID secret is not available, falling back to local storage. Run `gtn init` to set it up."
+                    )
+                    self.storage_driver = LocalStorageDriver(workspace_directory, base_url=base_url)
+                elif not cloud_credential:
+                    # Without this the driver would send "Bearer None" and every
+                    # upload would fail with an opaque 401 instead of naming the
+                    # missing credential at boot.
+                    logger.warning(
+                        "Falling back to local storage because %s",
+                        MISSING_CREDENTIAL_MESSAGE,
                     )
                     self.storage_driver = LocalStorageDriver(workspace_directory, base_url=base_url)
                 else:
@@ -122,7 +134,7 @@ class StaticFilesManager:
                     self.storage_driver = GriptapeCloudStorageDriver(
                         workspace_directory,
                         bucket_id=bucket_id,
-                        api_key=secrets_manager.get_secret("GT_CLOUD_API_KEY"),
+                        api_key=cloud_credential,
                         static_files_directory=static_files_directory,
                     )
             case StorageBackend.LOCAL:
@@ -295,9 +307,9 @@ class StaticFilesManager:
             bucket_id: The bucket ID to use
 
         Returns:
-            GriptapeCloudStorageDriver instance if API key is available, None otherwise
+            GriptapeCloudStorageDriver instance if a credential is available, None otherwise
         """
-        api_key = self.secrets_manager.get_secret("GT_CLOUD_API_KEY", should_error_on_not_found=False)
+        api_key = resolve_cloud_credential(self.secrets_manager)
 
         if not api_key:
             return None
@@ -372,7 +384,7 @@ class StaticFilesManager:
         if bucket_id is not None:
             driver = self._create_cloud_storage_driver(bucket_id)
             if driver is None:
-                msg = f"Attempted to create download URL for Griptape Cloud file. Failed with file_path='{file_path}' because GT_CLOUD_API_KEY secret is not available."
+                msg = f"Attempted to create download URL for Griptape Cloud file. Failed with file_path='{file_path}' because {MISSING_CREDENTIAL_MESSAGE}"
                 return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
             # For cloud URLs, pass the full URL to the driver

--- a/src/griptape_nodes/retained_mode/managers/sync_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/sync_manager.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from watchfiles import Change, PythonFilter, watch
 
+from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.files.path_utils import canonicalize_for_identity
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
@@ -213,13 +214,13 @@ class SyncManager:
         # Get cloud storage configuration from secrets
         bucket_id = secrets_manager.get_secret("GT_CLOUD_BUCKET_ID", should_error_on_not_found=False)
         base_url = secrets_manager.get_secret("GT_CLOUD_BASE_URL", should_error_on_not_found=False)
-        api_key = secrets_manager.get_secret("GT_CLOUD_API_KEY")
+        api_key = resolve_cloud_credential(secrets_manager)
 
         if not bucket_id:
             msg = "Cloud storage bucket_id not configured. Set GT_CLOUD_BUCKET_ID secret."
             raise RuntimeError(msg)
         if not api_key:
-            msg = "Cloud storage api_key not configured. Set GT_CLOUD_API_KEY secret."
+            msg = f"Attempted to reach cloud storage. Failed because {MISSING_CREDENTIAL_MESSAGE}"
             raise RuntimeError(msg)
 
         workspace_directory = self._config_manager.workspace_path

--- a/src/griptape_nodes/retained_mode/managers/user_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/user_manager.py
@@ -9,10 +9,16 @@ from __future__ import annotations
 import logging
 import os
 from functools import cached_property
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 import httpx
 
+from griptape_nodes.drivers.cloud_credentials import (
+    POLICY_DENIED_HINT,
+    is_license_credential,
+    resolve_cloud_credential,
+)
 from griptape_nodes.retained_mode.events.app_events import OrganizationInfo, UserInfo
 
 if TYPE_CHECKING:
@@ -42,6 +48,12 @@ class UserManager:
             UserInfo | None: The user information or None if not available/not logged in.
         """
         try:
+            # Deliberately not license-aware: /api/users has no license
+            # authenticator, so a license is rejected before it identifies anyone.
+            # Were one added, a license assigned to a user would correctly answer
+            # as that human, but an unassigned one authenticates as the org's
+            # service principal and would answer "who am I" with a synthetic
+            # "License Service Principal" row.
             api_key = self._secrets_manager.get_secret("GT_CLOUD_API_KEY")
             if not api_key:
                 logger.debug("No GT_CLOUD_API_KEY found, skipping user fetch")
@@ -85,10 +97,13 @@ class UserManager:
         Returns:
             OrganizationInfo | None: The organization information or None if not available/not logged in.
         """
+        # Bound before the try so the 403 handler below can always read it; this
+        # property never raises, it logs and returns None.
+        api_key: str | None = None
         try:
-            api_key = self._secrets_manager.get_secret("GT_CLOUD_API_KEY")
+            api_key = resolve_cloud_credential(self._secrets_manager)
             if not api_key:
-                logger.debug("No GT_CLOUD_API_KEY found, skipping user organization fetch")
+                logger.debug("No Griptape Cloud credential found, skipping user organization fetch")
                 return None
 
             base_url = os.environ.get("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
@@ -111,7 +126,10 @@ class UserManager:
             logger.debug("No organizations found in API response")
 
         except httpx.HTTPStatusError as e:
-            logger.warning("Failed to fetch user organization (HTTP %s): %s", e.response.status_code, e)
+            if e.response.status_code == HTTPStatus.FORBIDDEN and is_license_credential(api_key):
+                logger.warning("Failed to fetch user organization because %s", POLICY_DENIED_HINT)
+            else:
+                logger.warning("Failed to fetch user organization (HTTP %s): %s", e.response.status_code, e)
         except httpx.RequestError as e:
             logger.warning("Failed to fetch user organization (request error): %s", e)
         except Exception as e:

--- a/tests/unit/drivers/test_cloud_credentials.py
+++ b/tests/unit/drivers/test_cloud_credentials.py
@@ -1,0 +1,127 @@
+"""Griptape Cloud credential resolution: license first, then the API key."""
+
+from __future__ import annotations
+
+from typing import Literal, overload
+
+import pytest
+
+from griptape_nodes.drivers.cloud_credentials import (
+    API_KEY_SECRET_NAME,
+    LICENSE_SECRET_NAME,
+    is_license_credential,
+    resolve_cloud_credential,
+)
+
+_OTHER_SECRET_NAME = "OTHER_KEY"  # noqa: S105  # a secret's name, not a secret
+_PROXY_API_KEY_ENV_VAR = "GT_CLOUD_PROXY_API_KEY"  # a secret's name, not a secret
+_LICENSE = "eyJhbGciOiJFZERTQSJ9.eyJvcmdfaWQiOiJvIn0.sig"
+
+
+class _FakeSecretsManager:
+    """Stands in for SecretsManager, which reads .env files off disk.
+
+    Mirrors the real manager's overloads so it satisfies `SecretsReader`.
+    """
+
+    def __init__(self, secrets: dict[str, str | None]) -> None:
+        self._secrets = secrets
+
+    @overload
+    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[True] = True) -> str: ...
+
+    @overload
+    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[False]) -> str | None: ...
+
+    def get_secret(self, secret_name: str, *, should_error_on_not_found: bool = True) -> str | None:  # noqa: ARG002
+        return self._secrets.get(secret_name)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate from the developer's own Griptape Cloud credentials."""
+    for var in (_PROXY_API_KEY_ENV_VAR, LICENSE_SECRET_NAME, API_KEY_SECRET_NAME):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestResolveCloudCredential:
+    """Resolution order and the missing-credential case."""
+
+    def test_resolves_license_when_api_key_absent(self) -> None:
+        """The reported case: an Enterprise license, no GT_CLOUD_API_KEY."""
+        secrets = _FakeSecretsManager({LICENSE_SECRET_NAME: _LICENSE})
+
+        assert resolve_cloud_credential(secrets) == _LICENSE
+
+    def test_prefers_license_over_api_key(self) -> None:
+        """With both configured the license wins, matching the standard library."""
+        secrets = _FakeSecretsManager({LICENSE_SECRET_NAME: _LICENSE, API_KEY_SECRET_NAME: "gt-the-api-key"})
+
+        assert resolve_cloud_credential(secrets) == _LICENSE
+
+    def test_falls_back_to_api_key(self) -> None:
+        """Today's normal setup keeps working."""
+        secrets = _FakeSecretsManager({API_KEY_SECRET_NAME: "gt-the-api-key"})
+
+        assert resolve_cloud_credential(secrets) == "gt-the-api-key"
+
+    def test_ignores_proxy_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GT_CLOUD_PROXY_API_KEY is proxy-scoped and must not hijack engine calls.
+
+        A proxy developer points that var at local infra (e.g. "local"). Honoring
+        it here would send that credential to production Cloud for storage, sync,
+        and bucket calls, which is a regression for an API-key-only user.
+        """
+        monkeypatch.setenv(_PROXY_API_KEY_ENV_VAR, "local")
+        secrets = _FakeSecretsManager({API_KEY_SECRET_NAME: "gt-the-api-key"})
+
+        assert resolve_cloud_credential(secrets) == "gt-the-api-key"
+
+    def test_returns_none_when_nothing_configured(self) -> None:
+        """Callers decide whether a missing credential is fatal."""
+        assert resolve_cloud_credential(_FakeSecretsManager({})) is None
+
+    def test_honors_custom_secret_name(self) -> None:
+        """A caller with its own API-key secret name still gets the license first."""
+        secrets = _FakeSecretsManager({_OTHER_SECRET_NAME: "gt-other"})
+
+        assert resolve_cloud_credential(secrets, secret_name=_OTHER_SECRET_NAME) == "gt-other"
+
+    def test_without_secrets_manager_reads_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drivers built straight from the environment are license-aware too."""
+        monkeypatch.setenv(LICENSE_SECRET_NAME, _LICENSE)
+        monkeypatch.setenv(API_KEY_SECRET_NAME, "gt-env-key")
+
+        assert resolve_cloud_credential() == _LICENSE
+
+    def test_without_secrets_manager_falls_back_to_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Environment-only resolution still honors the API key."""
+        monkeypatch.setenv(API_KEY_SECRET_NAME, "gt-env-key")
+
+        assert resolve_cloud_credential() == "gt-env-key"
+
+
+class TestIsLicenseCredential:
+    """Telling a license apart from anything else, to attribute an HTTP 403.
+
+    Only a real JWT counts. A negative "not `gt-`" test would blame licensing for
+    a malformed or future-format credential and send the user to their
+    administrator for an entitlement they already have.
+    """
+
+    @pytest.mark.parametrize(
+        ("credential", "expected"),
+        [
+            ("eyJhbGciOiJSUzI1NiJ9.payload.sig", True),
+            ("gt-abc123", False),
+            (None, False),
+            ("", False),
+            # Not a license: must not be reported as an entitlement denial.
+            ("local", False),
+            ("eyJhbGciOiJSUzI1NiJ9.truncated", False),
+            ("has.four.dot.segments", False),
+        ],
+    )
+    def test_classifies_credential(self, credential: str | None, expected: bool) -> None:  # noqa: FBT001
+        """Only a three-segment JWT counts as a license."""
+        assert is_license_credential(credential) is expected

--- a/tests/unit/drivers/test_cloud_credentials.py
+++ b/tests/unit/drivers/test_cloud_credentials.py
@@ -66,6 +66,12 @@ class TestResolveCloudCredential:
 
         assert resolve_cloud_credential(secrets) == "gt-the-api-key"  # type: ignore[arg-type]
 
+    def test_blank_license_falls_through_to_api_key(self) -> None:
+        """First non-empty wins: a hand-edited empty license must not shadow the key."""
+        secrets = _FakeSecretsManager({LICENSE_SECRET_NAME: "", API_KEY_SECRET_NAME: "gt-the-api-key"})
+
+        assert resolve_cloud_credential(secrets) == "gt-the-api-key"  # type: ignore[arg-type]
+
     def test_returns_none_when_nothing_configured(self) -> None:
         """Callers decide whether a missing credential is fatal."""
         assert resolve_cloud_credential(_FakeSecretsManager({})) is None  # type: ignore[arg-type]

--- a/tests/unit/drivers/test_cloud_credentials.py
+++ b/tests/unit/drivers/test_cloud_credentials.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Literal, overload
-
 import pytest
 
 from griptape_nodes.drivers.cloud_credentials import (
@@ -19,19 +17,10 @@ _LICENSE = "eyJhbGciOiJFZERTQSJ9.eyJvcmdfaWQiOiJvIn0.sig"
 
 
 class _FakeSecretsManager:
-    """Stands in for SecretsManager, which reads .env files off disk.
-
-    Mirrors the real manager's overloads so it satisfies `SecretsReader`.
-    """
+    """Stands in for SecretsManager, which reads .env files off disk."""
 
     def __init__(self, secrets: dict[str, str | None]) -> None:
         self._secrets = secrets
-
-    @overload
-    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[True] = True) -> str: ...
-
-    @overload
-    def get_secret(self, secret_name: str, *, should_error_on_not_found: Literal[False]) -> str | None: ...
 
     def get_secret(self, secret_name: str, *, should_error_on_not_found: bool = True) -> str | None:  # noqa: ARG002
         return self._secrets.get(secret_name)
@@ -51,19 +40,19 @@ class TestResolveCloudCredential:
         """The reported case: an Enterprise license, no GT_CLOUD_API_KEY."""
         secrets = _FakeSecretsManager({LICENSE_SECRET_NAME: _LICENSE})
 
-        assert resolve_cloud_credential(secrets) == _LICENSE
+        assert resolve_cloud_credential(secrets) == _LICENSE  # type: ignore[arg-type]
 
     def test_prefers_license_over_api_key(self) -> None:
         """With both configured the license wins, matching the standard library."""
         secrets = _FakeSecretsManager({LICENSE_SECRET_NAME: _LICENSE, API_KEY_SECRET_NAME: "gt-the-api-key"})
 
-        assert resolve_cloud_credential(secrets) == _LICENSE
+        assert resolve_cloud_credential(secrets) == _LICENSE  # type: ignore[arg-type]
 
     def test_falls_back_to_api_key(self) -> None:
         """Today's normal setup keeps working."""
         secrets = _FakeSecretsManager({API_KEY_SECRET_NAME: "gt-the-api-key"})
 
-        assert resolve_cloud_credential(secrets) == "gt-the-api-key"
+        assert resolve_cloud_credential(secrets) == "gt-the-api-key"  # type: ignore[arg-type]
 
     def test_ignores_proxy_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """GT_CLOUD_PROXY_API_KEY is proxy-scoped and must not hijack engine calls.
@@ -75,17 +64,17 @@ class TestResolveCloudCredential:
         monkeypatch.setenv(_PROXY_API_KEY_ENV_VAR, "local")
         secrets = _FakeSecretsManager({API_KEY_SECRET_NAME: "gt-the-api-key"})
 
-        assert resolve_cloud_credential(secrets) == "gt-the-api-key"
+        assert resolve_cloud_credential(secrets) == "gt-the-api-key"  # type: ignore[arg-type]
 
     def test_returns_none_when_nothing_configured(self) -> None:
         """Callers decide whether a missing credential is fatal."""
-        assert resolve_cloud_credential(_FakeSecretsManager({})) is None
+        assert resolve_cloud_credential(_FakeSecretsManager({})) is None  # type: ignore[arg-type]
 
     def test_honors_custom_secret_name(self) -> None:
         """A caller with its own API-key secret name still gets the license first."""
         secrets = _FakeSecretsManager({_OTHER_SECRET_NAME: "gt-other"})
 
-        assert resolve_cloud_credential(secrets, secret_name=_OTHER_SECRET_NAME) == "gt-other"
+        assert resolve_cloud_credential(secrets, secret_name=_OTHER_SECRET_NAME) == "gt-other"  # type: ignore[arg-type]
 
     def test_without_secrets_manager_reads_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Drivers built straight from the environment are license-aware too."""

--- a/tests/unit/files/drivers/test_griptape_cloud_file_driver.py
+++ b/tests/unit/files/drivers/test_griptape_cloud_file_driver.py
@@ -36,9 +36,13 @@ class TestGriptapeCloudFileDriver:
 
     def test_create_from_env_with_credentials(self) -> None:
         """Test creating driver from environment variables."""
+        # clear=True so a Griptape license in the developer's own environment (or
+        # hydrated from their .env by SecretsManager) can't win credential
+        # resolution and fail this test on behavior it isn't covering.
         with patch.dict(
             os.environ,
             {"GT_CLOUD_BUCKET_ID": "env-bucket", "GT_CLOUD_API_KEY": "env-key", "GT_CLOUD_BASE_URL": "https://test.ai"},
+            clear=True,
         ):
             driver = GriptapeCloudFileDriver.create_from_env()
             assert driver is not None
@@ -54,7 +58,7 @@ class TestGriptapeCloudFileDriver:
 
     def test_create_from_env_default_base_url(self) -> None:
         """Test creating driver uses default base URL when not provided."""
-        with patch.dict(os.environ, {"GT_CLOUD_BUCKET_ID": "bucket", "GT_CLOUD_API_KEY": "key"}):
+        with patch.dict(os.environ, {"GT_CLOUD_BUCKET_ID": "bucket", "GT_CLOUD_API_KEY": "key"}, clear=True):
             driver = GriptapeCloudFileDriver.create_from_env()
             assert driver is not None
             assert driver.base_url == "https://cloud.griptape.ai"

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -9,12 +9,15 @@ the real config system.
 import asyncio
 import json
 from dataclasses import dataclass, field
+from http import HTTPStatus
 from pathlib import Path
 
 import httpx
 import pytest
+from pydantic_ai.exceptions import ModelHTTPError, ModelRetry
 from pydantic_ai.messages import BinaryContent, ImageUrl, ModelMessage, ModelRequest, UserPromptPart
 
+import griptape_nodes.retained_mode.managers.agent_manager as agent_manager_module
 from griptape_nodes.drivers.cloud_models import (
     DEPRECATED_MODELS,
     IMAGE_DEPRECATED_MODELS,
@@ -62,6 +65,7 @@ from griptape_nodes.retained_mode.managers.agent_manager import (
     AgentManager,
     ComposedPrompt,
     _ActiveRun,
+    _cloud_http_status_of,
     _compose_prompt,
     _friendly_list_models_error,
     _message_has_image_url,
@@ -1047,3 +1051,128 @@ class TestConfigureAgentActiveProvider:
         assert isinstance(result, ConfigureAgentResultSuccess)
         gc = next(p for p in providers_manager._providers if p.name == "griptape_cloud")
         assert gc.model == "gpt-5"
+
+
+class TestBuildRunnerCredential:
+    """The Griptape Cloud runner accepts a license, not just `GT_CLOUD_API_KEY`."""
+
+    def test_license_only_config_builds_runner(
+        self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The reported bug: an Enterprise license with no GT_CLOUD_API_KEY raised
+        # "Secret 'GT_CLOUD_API_KEY' not found" instead of running the agent.
+        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "the-license")
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            agent_manager_module,
+            "PydanticAgentRunner",
+            lambda **kwargs: captured.update(kwargs) or object(),
+        )
+        monkeypatch.setattr(providers_manager, "_ensure_skills_directory", lambda _root: None)
+        providers_manager._mcp_server_port = 1234
+        # The runner is stubbed out, so these only need to exist, not be real.
+        providers_manager._system_prompt_extra = ""
+        providers_manager._thread_storage = object()  # type: ignore[assignment]
+        providers_manager.static_files_manager = None  # type: ignore[assignment]
+
+        providers_manager._build_runner([], provider_name="griptape_cloud")
+
+        assert captured["api_key"] == "the-license"
+
+    def test_missing_both_credentials_names_both(
+        self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: None)
+
+        with pytest.raises(ValueError, match="Sign in with your Griptape license") as excinfo:
+            providers_manager._build_runner([], provider_name="griptape_cloud")
+
+        assert "GT_CLOUD_API_KEY" in str(excinfo.value)
+
+
+class TestExplainAgentRunError:
+    """A 403 on a license-authenticated Cloud request is an entitlement denial."""
+
+    def test_forbidden_with_license_explains_entitlement(
+        self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "a.license.jwt")
+        exc = ModelHTTPError(status_code=403, model_name="gpt-4o", body="Forbidden")
+
+        message = providers_manager._explain_agent_run_error(exc, "griptape_cloud")
+
+        assert "not entitled" in message
+
+    def test_forbidden_with_api_key_keeps_original_message(
+        self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An API key can't be refused by license policy, so don't blame licensing.
+        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "gt-abc")
+        exc = ModelHTTPError(status_code=403, model_name="gpt-4o", body="Forbidden")
+
+        message = providers_manager._explain_agent_run_error(exc, "griptape_cloud")
+
+        assert "not entitled" not in message
+
+    def test_non_forbidden_error_keeps_original_message(self, providers_manager: AgentManager) -> None:
+        message = providers_manager._explain_agent_run_error(ValueError("boom"), "griptape_cloud")
+
+        assert message == "boom"
+
+    def test_forbidden_on_other_provider_keeps_original_message(
+        self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "a.license.jwt")
+        exc = ModelHTTPError(status_code=403, model_name="llama3.2", body="Forbidden")
+
+        message = providers_manager._explain_agent_run_error(exc, "my-ollama")
+
+        assert "not entitled" not in message
+
+
+_CLOUD_HOST = "cloud.griptape.ai"
+
+
+def _httpx_403(url: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", url)
+    response = httpx.Response(403, request=request)
+    return httpx.HTTPStatusError("Forbidden", request=request, response=response)
+
+
+class TestCloudHttpStatusOf:
+    """`_cloud_http_status_of` spans two error shapes but only for Griptape Cloud."""
+
+    def test_reads_model_http_error(self) -> None:
+        """The chat path raises pydantic-ai's ModelHTTPError, which has status_code."""
+        exc = ModelHTTPError(status_code=403, model_name="gpt-4o")
+
+        assert _cloud_http_status_of(exc, _CLOUD_HOST) == HTTPStatus.FORBIDDEN
+
+    def test_reads_httpx_status_error(self) -> None:
+        """The image path raises an httpx error, which keeps status on .response."""
+        exc = _httpx_403("https://cloud.griptape.ai/api/images/generations")
+
+        assert _cloud_http_status_of(exc, _CLOUD_HOST) == HTTPStatus.FORBIDDEN
+
+    def test_follows_cause_chain(self) -> None:
+        """The image toolset wraps its failure in ModelRetry via `raise ... from exc`."""
+        wrapped = ModelRetry("image generation failed")
+        wrapped.__cause__ = _httpx_403("https://cloud.griptape.ai/api/images/generations")
+
+        assert _cloud_http_status_of(wrapped, _CLOUD_HOST) == HTTPStatus.FORBIDDEN
+
+    def test_ignores_403_from_another_host(self) -> None:
+        """A remote MCP server's expired token must not be blamed on Griptape licensing."""
+        exc = _httpx_403("https://mcp.example.com/mcp/")
+
+        assert _cloud_http_status_of(exc, _CLOUD_HOST) is None
+
+    def test_honors_custom_cloud_host(self) -> None:
+        """A self-hosted GT_CLOUD_BASE_URL is still recognized as Cloud."""
+        exc = _httpx_403("https://cloud.internal.example/api/images/generations")
+
+        assert _cloud_http_status_of(exc, "cloud.internal.example") == HTTPStatus.FORBIDDEN
+
+    def test_returns_none_for_non_http_error(self) -> None:
+        """A plain error has no status, so the caller keeps the original message."""
+        assert _cloud_http_status_of(ValueError("boom"), _CLOUD_HOST) is None

--- a/tests/unit/retained_mode/managers/test_agent_manager.py
+++ b/tests/unit/retained_mode/managers/test_agent_manager.py
@@ -17,7 +17,6 @@ import pytest
 from pydantic_ai.exceptions import ModelHTTPError, ModelRetry
 from pydantic_ai.messages import BinaryContent, ImageUrl, ModelMessage, ModelRequest, UserPromptPart
 
-import griptape_nodes.retained_mode.managers.agent_manager as agent_manager_module
 from griptape_nodes.drivers.cloud_models import (
     DEPRECATED_MODELS,
     IMAGE_DEPRECATED_MODELS,
@@ -71,6 +70,8 @@ from griptape_nodes.retained_mode.managers.agent_manager import (
     _message_has_image_url,
     _rehydrate_history,
 )
+
+_AGENT_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.agent_manager"
 
 
 @pytest.fixture
@@ -1061,11 +1062,10 @@ class TestBuildRunnerCredential:
     ) -> None:
         # The reported bug: an Enterprise license with no GT_CLOUD_API_KEY raised
         # "Secret 'GT_CLOUD_API_KEY' not found" instead of running the agent.
-        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "the-license")
+        monkeypatch.setattr(_AGENT_MANAGER_MODULE + ".resolve_cloud_credential", lambda *_a, **_k: "the-license")
         captured: dict[str, object] = {}
         monkeypatch.setattr(
-            agent_manager_module,
-            "PydanticAgentRunner",
+            _AGENT_MANAGER_MODULE + ".PydanticAgentRunner",
             lambda **kwargs: captured.update(kwargs) or object(),
         )
         monkeypatch.setattr(providers_manager, "_ensure_skills_directory", lambda _root: None)
@@ -1082,7 +1082,7 @@ class TestBuildRunnerCredential:
     def test_missing_both_credentials_names_both(
         self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: None)
+        monkeypatch.setattr(_AGENT_MANAGER_MODULE + ".resolve_cloud_credential", lambda *_a, **_k: None)
 
         with pytest.raises(ValueError, match="Sign in with your Griptape license") as excinfo:
             providers_manager._build_runner([], provider_name="griptape_cloud")
@@ -1096,7 +1096,7 @@ class TestExplainAgentRunError:
     def test_forbidden_with_license_explains_entitlement(
         self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "a.license.jwt")
+        monkeypatch.setattr(_AGENT_MANAGER_MODULE + ".resolve_cloud_credential", lambda *_a, **_k: "a.license.jwt")
         exc = ModelHTTPError(status_code=403, model_name="gpt-4o", body="Forbidden")
 
         message = providers_manager._explain_agent_run_error(exc, "griptape_cloud")
@@ -1107,7 +1107,7 @@ class TestExplainAgentRunError:
         self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # An API key can't be refused by license policy, so don't blame licensing.
-        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "gt-abc")
+        monkeypatch.setattr(_AGENT_MANAGER_MODULE + ".resolve_cloud_credential", lambda *_a, **_k: "gt-abc")
         exc = ModelHTTPError(status_code=403, model_name="gpt-4o", body="Forbidden")
 
         message = providers_manager._explain_agent_run_error(exc, "griptape_cloud")
@@ -1122,7 +1122,7 @@ class TestExplainAgentRunError:
     def test_forbidden_on_other_provider_keeps_original_message(
         self, providers_manager: AgentManager, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(agent_manager_module, "resolve_cloud_credential", lambda *_a, **_k: "a.license.jwt")
+        monkeypatch.setattr(_AGENT_MANAGER_MODULE + ".resolve_cloud_credential", lambda *_a, **_k: "a.license.jwt")
         exc = ModelHTTPError(status_code=403, model_name="llama3.2", body="Forbidden")
 
         message = providers_manager._explain_agent_run_error(exc, "my-ollama")

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -5,6 +5,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from griptape_nodes.drivers.storage import StorageBackend
+from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
+from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.managers.static_files_manager import ResolvedStaticFilePath, StaticFilesManager
 
@@ -1036,3 +1039,89 @@ class TestStaticFilesManagerOnAppInitializationComplete:
 
         with pytest.raises(RuntimeError, match="static_server_base_url accessed before"):
             _ = manager.static_server_base_url
+
+
+class TestStaticFilesManagerCloudCredential:
+    """The `StorageBackend.GTC` arm takes a license, and refuses a missing credential.
+
+    Without these, reverting the credential resolution (or dropping the
+    no-credential guard) leaves the suite green while either breaking
+    license-only users or sending `Bearer None` to Cloud on every upload.
+    """
+
+    _BUCKET_ID = "bucket-123"
+    _LICENSE = "eyJhbGciOiJFZERTQSJ9.eyJvcmdfaWQiOiJvIn0.sig"
+
+    @pytest.fixture
+    def gtc_config_manager(self) -> Mock:
+        """A ConfigManager configured for the Griptape Cloud storage backend."""
+        mock_config = Mock()
+        mock_config.workspace_path = Path("/mock/workspace")
+        mock_config.get_config_value.side_effect = lambda key, default=None: {
+            "storage_backend": StorageBackend.GTC,
+            "static_files_directory": "staticfiles",
+            "static_server_base_url": None,
+        }.get(key, default)
+        return mock_config
+
+    def _secrets(self, secrets: dict[str, str | None]) -> Mock:
+        manager = Mock()
+        manager.get_secret.side_effect = lambda name, **_kwargs: secrets.get(name)
+        return manager
+
+    def _build(self, config_manager: Mock, secrets: dict[str, str | None]) -> StaticFilesManager:
+        return StaticFilesManager(
+            config_manager=config_manager,
+            secrets_manager=self._secrets(secrets),
+            event_manager=None,
+        )
+
+    def test_license_only_builds_cloud_driver(self, gtc_config_manager: Mock) -> None:
+        """The reported bug: a license with no GT_CLOUD_API_KEY must still reach Cloud."""
+        manager = self._build(
+            gtc_config_manager,
+            {"GT_CLOUD_BUCKET_ID": self._BUCKET_ID, "GRIPTAPE_NODES_LICENSE": self._LICENSE},
+        )
+
+        assert isinstance(manager.storage_driver, GriptapeCloudStorageDriver)
+        assert manager.storage_driver.api_key == self._LICENSE
+
+    def test_api_key_only_builds_cloud_driver(self, gtc_config_manager: Mock) -> None:
+        """Today's common setup is unchanged."""
+        manager = self._build(
+            gtc_config_manager,
+            {"GT_CLOUD_BUCKET_ID": self._BUCKET_ID, "GT_CLOUD_API_KEY": "gt-the-key"},
+        )
+
+        assert isinstance(manager.storage_driver, GriptapeCloudStorageDriver)
+        assert manager.storage_driver.api_key == "gt-the-key"
+
+    def test_no_credential_falls_back_to_local_storage(self, gtc_config_manager: Mock) -> None:
+        """A bucket but no credential must not yield a driver that sends "Bearer None"."""
+        manager = self._build(gtc_config_manager, {"GT_CLOUD_BUCKET_ID": self._BUCKET_ID})
+
+        assert isinstance(manager.storage_driver, LocalStorageDriver)
+
+    def test_no_bucket_falls_back_to_local_storage(self, gtc_config_manager: Mock) -> None:
+        """Pre-existing behavior: no bucket means local storage regardless of credential."""
+        manager = self._build(gtc_config_manager, {"GRIPTAPE_NODES_LICENSE": self._LICENSE})
+
+        assert isinstance(manager.storage_driver, LocalStorageDriver)
+
+    def test_download_url_driver_accepts_a_license(self, gtc_config_manager: Mock) -> None:
+        """`_create_cloud_storage_driver` backs the download-URL path for cloud assets."""
+        manager = self._build(
+            gtc_config_manager,
+            {"GT_CLOUD_BUCKET_ID": self._BUCKET_ID, "GRIPTAPE_NODES_LICENSE": self._LICENSE},
+        )
+
+        driver = manager._create_cloud_storage_driver(self._BUCKET_ID)
+
+        assert driver is not None
+        assert driver.api_key == self._LICENSE
+
+    def test_download_url_driver_is_none_without_a_credential(self, gtc_config_manager: Mock) -> None:
+        """No credential yields no driver, so the caller reports the missing credential."""
+        manager = self._build(gtc_config_manager, {"GT_CLOUD_BUCKET_ID": self._BUCKET_ID})
+
+        assert manager._create_cloud_storage_driver(self._BUCKET_ID) is None

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -471,7 +471,9 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
             )
 
             assert isinstance(result, CreateStaticFileDownloadUrlResultFailure)
-            assert "GT_CLOUD_API_KEY secret is not available" in result.error
+            # Names both credentials: a license-only user has no API key to set.
+            assert "no Griptape Cloud credential was found" in result.error
+            assert "GT_CLOUD_API_KEY" in result.error
 
     @pytest.mark.asyncio
     async def test_create_download_url_from_path_non_cloud_url(

--- a/tests/unit/retained_mode/managers/test_user_manager.py
+++ b/tests/unit/retained_mode/managers/test_user_manager.py
@@ -294,7 +294,8 @@ class TestUserManager:
             assert isinstance(org_info, OrganizationInfo)
             assert org_info.id == "test-org-uuid"
             assert org_info.name == "Test Organization"
-            mock_secrets_manager.get_secret.assert_called_once_with("GT_CLOUD_API_KEY")
+            # /api/organizations accepts a license, so the license is tried first.
+            mock_secrets_manager.get_secret.assert_any_call("GRIPTAPE_NODES_LICENSE", should_error_on_not_found=False)
 
     def test_user_organization_cached_property(self) -> None:
         """Test that user_organization property is cached and httpx.get is only called once."""
@@ -536,3 +537,24 @@ class TestUserManager:
             assert isinstance(org_info, OrganizationInfo)
             assert org_info.id == "org-1"
             assert org_info.name == "First Organization"
+
+
+class TestUserManagerCredentialScope:
+    """`user` identity stays on the API key; only `user_organization` is license-aware."""
+
+    def test_user_does_not_resolve_license(self) -> None:
+        # /api/users has no license authenticator, and an unassigned license
+        # authenticates as the org service principal, so a license here would
+        # answer "who am I" with a service account.
+        mock_secrets_manager = Mock()
+        mock_secrets_manager.get_secret.return_value = "test-api-key"
+
+        mock_response = Mock()
+        mock_response.json.return_value = {"users": [{"user_id": "u", "email": "e@example.com", "name": "N"}]}
+
+        with patch("griptape_nodes.retained_mode.managers.user_manager.httpx.get", return_value=mock_response):
+            UserManager(mock_secrets_manager).user  # noqa: B018
+
+        requested = [call.args[0] for call in mock_secrets_manager.get_secret.call_args_list]
+        assert "GRIPTAPE_NODES_LICENSE" not in requested
+        assert requested == ["GT_CLOUD_API_KEY"]


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-app/issues/194

Re-usable method to get the relevant auth mechanism for cloud (License or API Key)