### PR TITLE
refactor: inject an Engine instead of reaching through the GriptapeNodes singleton

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,12 @@ Instance methods come first because they can call anything. Class methods come n
 
 ## Architecture
 
-**Singleton managers** - `GriptapeNodes` is a singleton holding 25+ managers (e.g., `FlowManager`, `NodeManager`), each accessed via `GriptapeNodes.ManagerName()` classmethods.
+**Engine owns the managers** - `Engine` (`retained_mode/engine.py`) holds ~28 managers (e.g. `FlowManager`, `NodeManager`) and injects itself into each one. Managers extend `EngineScoped` and reach peers via `self.engine.flow_manager`, not through process-wide state. `Engine` is a plain class, so tests and embedders can construct as many as they need.
+
+**One global, at the edge** - `GriptapeNodes` (`retained_mode/griptape_nodes.py`) is a thin facade whose classmethods delegate to `current_engine()`. It is the only intentionally global entry point, and it exists for callers that cannot be handed a reference: saved workflow `.py` files (generated code carrying a `schema_version`), separately-versioned node libraries, and process entry points like the CLI. Engine-internal code must not use it; a `TID251` ban in `pyproject.toml` enforces this, with an allowlist that separates legitimate facade users from code not yet migrated.
 
 **Event-driven operations** - All operations flow through request/response event dataclasses defined in `retained_mode/events/`, routed by `GriptapeNodes.handle_request()`.
 
-**Library registration flow** - Libraries are defined by `griptape_nodes_library.json` files and registered via the `LibraryRegistry` singleton. Node creation flows through `LibraryRegistry.create_node()` -> `Library.create_node()`.
+**Library registration flow** - Libraries are defined by `griptape_nodes_library.json` files and registered via the `LibraryRegistry`. Node creation flows through `LibraryRegistry.create_node()` -> `Library.create_node()`. `LibraryRegistry` is deliberately process-global: it hands out node classes imported into `sys.modules`, so per-engine copies would advertise isolation the module system does not provide. `WorkflowRegistry` is still process-global too, but less defensibly: which workflows exist depends on the engine's workspace config, so it should become engine-owned.
 
 **Custom nodes** - Extend `BaseNode` from `exe_types/node_types.py`. Parameters, flows, and connections are defined in `exe_types/core_types.py` and `exe_types/node_types.py`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,34 @@
+# Unreleased
+
+## Test isolation for node library test suites
+
+`GriptapeNodes` is no longer built by `SingletonMeta`. Its managers now live on an `Engine`
+that is resolved per context, so clearing the metaclass cache no longer resets engine state.
+
+If your library's test suite copied this repo's old isolation pattern:
+
+```python
+from griptape_nodes.utils.metaclasses import SingletonMeta
+
+SingletonMeta._instances.clear()
+```
+
+replace it with:
+
+```python
+from griptape_nodes.retained_mode.engine import reset_root_engine
+
+reset_root_engine()
+```
+
+This matters even though the old call still imports and runs: it silently stops resetting the
+engine, so a patched `USER_CONFIG_PATH` or `ENV_VAR_PATH` set up per test no longer takes
+effect after the first test touches the engine. Tests keep passing while reading config from a
+previous test's temporary directory.
+
+A test that needs an engine it can hold, rather than a reset between cases, can use
+`engine_scope()` from the same module.
+
 # v0.64.0
 
 This guide documents the removal of deprecated nodes from Griptape Nodes libraries in version 0.64.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,11 +130,40 @@ ignore = [
 "libraries.griptape_nodes_library".msg = "Import from griptape_nodes_library instead of libraries.griptape_nodes_library"
 "libraries.griptape_nodes_advanced_media_library".msg = "Import from griptape_nodes_advanced_media_library instead of libraries.griptape_nodes_advanced_media_library"
 "libraries.griptape_cloud".msg = "Import from griptape_cloud instead of libraries.griptape_cloud"
+"griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes".msg = "Engine-internal code should take an injected Engine (see griptape_nodes.retained_mode.engine) and reach peers via self.engine, not the process-wide GriptapeNodes facade. The facade exists for saved workflow files, node libraries, and process entry points; those are allowlisted in per-file-ignores."
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "D104"]
+"tests/*" = ["S101", "D104", "TID251"]
 "libraries/**/tests/**" = ["S101", "D104", "INP001"]
 "src/griptape_nodes/retained_mode/events/*" = ["TC001"]
+
+# TID251 allowlist for the GriptapeNodes facade. Two groups, and the difference matters.
+#
+# Group 1 -- legitimate facade users. These are process entry points or the public
+# surface that separately-versioned callers bind to, so they have no Engine to be handed.
+"src/griptape_nodes/retained_mode/griptape_nodes.py" = ["TID251"]
+"src/griptape_nodes/retained_mode/retained_mode.py" = ["TID251"]
+"src/griptape_nodes/cli/**" = ["TID251"]
+"src/griptape_nodes/api_client/**" = ["TID251"]
+"src/griptape_nodes/servers/**" = ["TID251"]
+"src/griptape_nodes/bootstrap/**" = ["TID251"]
+"src/griptape_nodes/app/**" = ["TID251"]
+#
+# Group 2 -- not yet migrated. Each of these should eventually receive an Engine instead.
+# Deleting an entry from this list is the definition of done; do not add new entries.
+"src/griptape_nodes/common/**" = ["TID251"]
+"src/griptape_nodes/drivers/**" = ["TID251"]
+"src/griptape_nodes/exe_types/**" = ["TID251"]
+"src/griptape_nodes/files/**" = ["TID251"]
+"src/griptape_nodes/machines/**" = ["TID251"]
+# WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
+# Making it engine-owned is its own change, since it alters what node libraries import.
+"src/griptape_nodes/node_library/workflow_registry.py" = ["TID251"]
+"src/griptape_nodes/utils/**" = ["TID251"]
+"src/griptape_nodes/version_compatibility/**" = ["TID251"]
+"src/griptape_nodes/retained_mode/file_metadata/**" = ["TID251"]
+"src/griptape_nodes/retained_mode/publishing/**" = ["TID251"]
+"src/griptape_nodes/retained_mode/managers/artifact_providers/**" = ["TID251"]
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -271,19 +271,17 @@ def schedule_broadcast(broadcast_type: type[RequestPayload]) -> None:
     Use this from a manager's request handler (orchestrator-side) to fire the
     matching broadcast after a successful local mutation -- e.g. ``ConfigManager``
     calls ``schedule_broadcast(ReloadConfigRequest)`` after persisting a config
-    write. No-op when the GriptapeNodes singleton has not been instantiated yet
-    (isolated unit tests that construct managers on their own) or when no
-    workers are registered.
+    write. No-op when no engine has been built yet (isolated unit tests that construct
+    managers on their own) or when no workers are registered.
 
-    Imports the singleton lazily because this module is loaded during engine
-    boot, before the GriptapeNodes accessor is ready.
+    Imports the engine lazily because this module is loaded during engine boot,
+    before the accessor is ready.
     """
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-    from griptape_nodes.utils.metaclasses import SingletonMeta
+    from griptape_nodes.retained_mode.engine import current_engine, has_current_engine
 
-    if GriptapeNodes not in SingletonMeta._instances:
+    if not has_current_engine():
         return
-    GriptapeNodes.WorkerManager().schedule_broadcast(broadcast_type)
+    current_engine().worker_manager.schedule_broadcast(broadcast_type)
 
 
 def register_remote_handlers(event_manager: EventManager) -> None:

--- a/src/griptape_nodes/drivers/image_metadata/image_metadata_driver_registry.py
+++ b/src/griptape_nodes/drivers/image_metadata/image_metadata_driver_registry.py
@@ -3,14 +3,13 @@
 from typing import ClassVar
 
 from griptape_nodes.drivers.image_metadata.base_image_metadata_driver import BaseImageMetadataDriver
-from griptape_nodes.utils.metaclasses import SingletonMeta
 
 
-class ImageMetadataDriverRegistry(metaclass=SingletonMeta):
+class ImageMetadataDriverRegistry:
     """Registry for image metadata injection drivers.
 
     Provides centralized registration and lookup of metadata injection drivers
-    based on image format. Follows singleton pattern to ensure single registry instance.
+    based on image format.
     """
 
     _drivers: ClassVar[list[BaseImageMetadataDriver]] = []
@@ -22,8 +21,7 @@ class ImageMetadataDriverRegistry(metaclass=SingletonMeta):
         Args:
             driver: Driver instance to register
         """
-        instance = cls()
-        instance._drivers.append(driver)
+        cls._drivers.append(driver)
 
     @classmethod
     def get_driver_for_format(cls, format_str: str) -> BaseImageMetadataDriver | None:
@@ -35,8 +33,7 @@ class ImageMetadataDriverRegistry(metaclass=SingletonMeta):
         Returns:
             Driver instance or None if no driver supports format
         """
-        instance = cls()
-        for driver in instance._drivers:
+        for driver in cls._drivers:
             if format_str in driver.get_supported_formats():
                 return driver
         return None
@@ -48,8 +45,7 @@ class ImageMetadataDriverRegistry(metaclass=SingletonMeta):
         Returns:
             Set of format strings supported by any registered driver
         """
-        instance = cls()
         formats = set()
-        for driver in instance._drivers:
+        for driver in cls._drivers:
             formats.update(driver.get_supported_formats())
         return formats

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -142,7 +142,9 @@ class CompleteState(State):
             # Use pickle-based serialization for complex parameter output values
 
             parameter_output_values, unique_uuid_to_values = NodeManager.serialize_parameter_output_values(
-                current_node, use_pickling=context.pickle_control_flow_result
+                current_node,
+                workflow_manager=GriptapeNodes.WorkflowManager(),
+                use_pickling=context.pickle_control_flow_result,
             )
             GriptapeNodes.EventManager().put_event(
                 ExecutionGriptapeNodeEvent(

--- a/src/griptape_nodes/node_library/advanced_node_library.py
+++ b/src/griptape_nodes/node_library/advanced_node_library.py
@@ -108,10 +108,10 @@ class AdvancedNodeLibrary:
         discover which request types it registered and inspect their field schemas
         using standard Python APIs::
 
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+            from griptape_nodes.node_library.library_registry import LibraryRegistry
             import dataclasses, typing
 
-            library = GriptapeNodes.LibraryRegistry().get_library("My Library Name")
+            library = LibraryRegistry.get_library("My Library Name")
             for request_type in library.get_registered_request_handler_types():
                 hints = typing.get_type_hints(request_type)
                 fields = dataclasses.fields(request_type)

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -27,7 +27,6 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries.duplicate_
 from griptape_nodes.retained_mode.managers.resource_components.resource_instance import (
     Requirements,
 )
-from griptape_nodes.utils.metaclasses import SingletonMeta
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
     from griptape_nodes.node_library.library_declarations import ResolvedModel
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
 
 logger = logging.getLogger("griptape_nodes")
@@ -239,8 +239,13 @@ class LibrarySchema(BaseModel):
     widgets: list[WidgetDefinition] | None = None
 
 
-class LibraryRegistry(metaclass=SingletonMeta):
-    """Singleton registry to manage many libraries."""
+class LibraryRegistry:
+    """Process-global registry of libraries and the node classes they contain.
+
+    Registration imports library modules into `sys.modules` and hands out the resulting
+    `type[BaseNode]` classes, so this state is inherently process-wide: every engine in
+    the process shares the same imported modules and must share the same registry.
+    """
 
     _libraries: ClassVar[dict[str, Library]] = {}
     _node_aliases: ClassVar[dict[str, Library]] = {}
@@ -252,9 +257,10 @@ class LibraryRegistry(metaclass=SingletonMeta):
     def _clear(cls) -> None:
         """Drop every registered library and its tracking state.
 
-        Used by tests to reset the singleton between cases. Centralizes the store
-        list here so renaming a `ClassVar` updates this one method rather than
-        silently degrading callers that would otherwise clear stores by name.
+        This is the deliberate reset for this process-global registry: `tests/e2e/conftest.py`
+        calls it between cases. Centralizes the store list here so renaming a `ClassVar`
+        updates this one method rather than silently degrading callers that would otherwise
+        clear stores by name.
         """
         cls._libraries.clear()
         cls._node_aliases.clear()
@@ -269,26 +275,22 @@ class LibraryRegistry(metaclass=SingletonMeta):
         mark_as_default_library: bool = False,
         advanced_library: AdvancedNodeLibrary | None = None,
     ) -> Library:
-        instance = cls()
-
-        if library_data.name in instance._libraries:
+        if library_data.name in cls._libraries:
             msg = f"Library '{library_data.name}' already registered."
             raise KeyError(msg)
         library = Library(
             library_data=library_data, is_default_library=mark_as_default_library, advanced_library=advanced_library
         )
-        instance._libraries[library_data.name] = library
+        cls._libraries[library_data.name] = library
         return library
 
     @classmethod
-    def unregister_library(cls, library_name: str) -> None:
-        instance = cls()
-
-        if library_name not in instance._libraries:
+    def unregister_library(cls, library_name: str, *, event_manager: EventManager) -> None:
+        if library_name not in cls._libraries:
             msg = f"Library '{library_name}' was requested to be unregistered, but it wasn't registered in the first place."
             raise KeyError(msg)
 
-        library = instance._libraries[library_name]
+        library = cls._libraries[library_name]
         advanced_library = library.get_advanced_library()
 
         # Teardown hook — called before any deregistration.
@@ -303,15 +305,7 @@ class LibraryRegistry(metaclass=SingletonMeta):
                 )
                 # Continue — a failing teardown must not prevent unregistration.
 
-        # Deregister tracked handlers. Lazy import required: library_registry is part of the
-        # import chain griptape_nodes → workflow_registry → library_registry, so a top-level
-        # import of GriptapeNodes here would create a circular dependency.
-        from griptape_nodes.retained_mode.griptape_nodes import (
-            GriptapeNodes,
-        )  # circular: griptape_nodes → workflow_registry → library_registry
-
-        event_manager = GriptapeNodes.EventManager()
-
+        # Deregister tracked handlers.
         if library._registered_app_event_listeners:
             for event_type, listener in library._registered_app_event_listeners:
                 event_manager.remove_listener_for_app_event(event_type, listener)
@@ -331,23 +325,20 @@ class LibraryRegistry(metaclass=SingletonMeta):
         cls.unregister_widgets_for_library(library_name)
 
         # Now delete the library from the registry.
-        del instance._libraries[library_name]
+        del cls._libraries[library_name]
 
     @classmethod
     def get_library(cls, name: str) -> Library:
-        instance = cls()
-        if name not in instance._libraries:
+        if name not in cls._libraries:
             msg = f"Library '{name}' not found"
             raise KeyError(msg)
-        return instance._libraries[name]
+        return cls._libraries[name]
 
     @classmethod
     def list_libraries(cls) -> list[str]:
-        instance = cls()
-
         # Put the default libraries first.
-        default_libraries = [k for k, v in instance._libraries.items() if v.is_default_library()]
-        other_libraries = [k for k, v in instance._libraries.items() if not v.is_default_library()]
+        default_libraries = [k for k, v in cls._libraries.items() if v.is_default_library()]
+        other_libraries = [k for k, v in cls._libraries.items() if not v.is_default_library()]
         sorted_list = default_libraries + other_libraries
         return sorted_list
 
@@ -373,14 +364,12 @@ class LibraryRegistry(metaclass=SingletonMeta):
         cls, library_name: str, widget_name: str
     ) -> DuplicateWidgetRegistrationProblem | None:
         """Register a widget from a library. Returns a LibraryProblem if registration fails."""
-        instance = cls()
-
         # Initialize the set for this library if needed
-        if library_name not in instance._registered_widgets:
-            instance._registered_widgets[library_name] = set()
+        if library_name not in cls._registered_widgets:
+            cls._registered_widgets[library_name] = set()
 
         # Check if widget is already registered for this library
-        if widget_name in instance._registered_widgets[library_name]:
+        if widget_name in cls._registered_widgets[library_name]:
             logger.error(
                 "Attempted to register widget '%s' from library '%s', but a widget with that name from that library was already registered",
                 widget_name,
@@ -389,35 +378,31 @@ class LibraryRegistry(metaclass=SingletonMeta):
             return DuplicateWidgetRegistrationProblem(widget_name=widget_name, library_name=library_name)
 
         # Register the widget
-        instance._registered_widgets[library_name].add(widget_name)
+        cls._registered_widgets[library_name].add(widget_name)
         return None
 
     @classmethod
     def unregister_widgets_for_library(cls, library_name: str) -> None:
         """Unregister all widgets for a library (used during library unload)."""
-        instance = cls()
-        if library_name in instance._registered_widgets:
-            del instance._registered_widgets[library_name]
+        if library_name in cls._registered_widgets:
+            del cls._registered_widgets[library_name]
 
     @classmethod
     def get_libraries_with_node_type(cls, node_type: str) -> list[str]:
-        instance = cls()
         libraries = []
-        for library_name, library in instance._libraries.items():
+        for library_name, library in cls._libraries.items():
             if library.has_node_type(node_type):
                 libraries.append(library_name)
         return libraries
 
     @classmethod
     def get_library_for_node_type(cls, node_type: str, specific_library_name: str | None = None) -> Library:
-        instance = cls()
-
         if specific_library_name is None:
             # Find its library.
             libraries_with_node_type = LibraryRegistry.get_libraries_with_node_type(node_type)
             if len(libraries_with_node_type) == 1:
                 specific_library_name = libraries_with_node_type[0]
-                dest_library = instance.get_library(specific_library_name)
+                dest_library = cls.get_library(specific_library_name)
             elif len(libraries_with_node_type) > 1:
                 msg = f"Attempted to create a node of type '{node_type}' with no library name specified. The following libraries have nodes in them with the same name: {libraries_with_node_type}. In order to disambiguate, specify the library this node should come from."
                 raise KeyError(msg)
@@ -426,7 +411,7 @@ class LibraryRegistry(metaclass=SingletonMeta):
                 raise KeyError(msg)
         else:
             # See if the library exists.
-            dest_library = instance.get_library(specific_library_name)
+            dest_library = cls.get_library(specific_library_name)
 
         return dest_library
 
@@ -438,11 +423,7 @@ class LibraryRegistry(metaclass=SingletonMeta):
         metadata: dict[Any, Any] | None = None,
         specific_library_name: str | None = None,
     ) -> BaseNode:
-        instance = cls()
-
-        dest_library = instance.get_library_for_node_type(
-            node_type=node_type, specific_library_name=specific_library_name
-        )
+        dest_library = cls.get_library_for_node_type(node_type=node_type, specific_library_name=specific_library_name)
 
         with cls.constructing_node():
             return dest_library.create_node(node_type=node_type, name=name, metadata=metadata)
@@ -489,11 +470,10 @@ class LibraryRegistry(metaclass=SingletonMeta):
         Returns:
             Dictionary mapping category names to their JSON Schema dicts
         """
-        instance = cls()
         schemas = {}
 
         # Get explicit schemas from loaded libraries
-        for library in instance._libraries.values():
+        for library in cls._libraries.values():
             library_data = library.get_library_data()
             if library_data.settings:
                 for setting in library_data.settings:

--- a/src/griptape_nodes/retained_mode/engine.py
+++ b/src/griptape_nodes/retained_mode/engine.py
@@ -1,0 +1,739 @@
+"""The Engine: the object graph that owns every manager.
+
+``Engine`` is a plain class. Construct as many as you like -- each one owns its own
+``EventManager``, ``FlowManager``, ``ObjectManager``, and so on, with no shared state
+between instances. This is what makes isolated tests and multiple in-process engines
+possible.
+
+Exactly one piece of global state lives here: the process-wide root engine, resolved by
+``current_engine()``. The ``GriptapeNodes`` facade in ``griptape_nodes.py`` is the only
+thing that should read it. Everything else receives its dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import semver
+
+from griptape_nodes.exe_types.flow import ControlFlow
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.app_events import (
+    EngineHeartbeatRequest,
+    EngineHeartbeatResultFailure,
+    EngineHeartbeatResultSuccess,
+    GetEngineVersionRequest,
+    GetEngineVersionResultFailure,
+    GetEngineVersionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.base_events import (
+    GriptapeNodeEvent,
+    ResultPayloadFailure,
+)
+from griptape_nodes.retained_mode.events.execution_events import (
+    CancelFlowRequest,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    DeleteFlowRequest,
+)
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from griptape_nodes.retained_mode.events.base_events import (
+        AppPayload,
+        RequestPayload,
+        ResultPayload,
+    )
+    from griptape_nodes.retained_mode.managers.access_manager import AccessManager
+    from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
+    from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
+        ArbitraryCodeExecManager,
+    )
+    from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager
+    from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+    from griptape_nodes.retained_mode.managers.context_manager import ContextManager
+    from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
+    from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+    from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
+    from griptape_nodes.retained_mode.managers.mcp_manager import MCPManager
+    from griptape_nodes.retained_mode.managers.model_manager import ModelManager
+    from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+    from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
+    from griptape_nodes.retained_mode.managers.operation_manager import (
+        OperationDepthManager,
+    )
+    from griptape_nodes.retained_mode.managers.os_manager import OSManager
+    from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
+    from griptape_nodes.retained_mode.managers.resource_manager import ResourceManager
+    from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
+    from griptape_nodes.retained_mode.managers.session_manager import SessionManager
+    from griptape_nodes.retained_mode.managers.static_files_manager import (
+        StaticFilesManager,
+    )
+    from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+    from griptape_nodes.retained_mode.managers.user_manager import UserManager
+    from griptape_nodes.retained_mode.managers.variable_manager import (
+        VariablesManager,
+    )
+    from griptape_nodes.retained_mode.managers.version_compatibility_manager import (
+        VersionCompatibilityManager,
+    )
+    from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
+    from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
+
+
+logger = logging.getLogger("griptape_nodes")
+
+# Scoped override of the root engine. Set by `engine_scope`; `None` means "use the
+# process root". A ContextVar rather than a plain global so a test (or an embedder
+# running two engines) can rebind for a block and have asyncio tasks created inside
+# that block inherit the binding.
+_scoped_engine: ContextVar[Engine | None] = ContextVar("griptape_nodes_scoped_engine", default=None)
+
+# The process root engine, created on first `current_engine()` call. Deliberately not a
+# ContextVar: lazy creation can happen inside an arbitrary task, and a ContextVar set
+# there would evaporate when that task finished.
+_root_engine: Engine | None = None
+
+# Serializes the lazy build so two threads racing the first `current_engine()` cannot each
+# construct an engine and leave one of them orphaned mid-use. Reentrant so a nested call on
+# the building thread reaches the guard in `current_engine` instead of deadlocking.
+_root_engine_lock = threading.RLock()
+_root_engine_building = False
+
+
+class EngineScoped:
+    """Base for objects that belong to a single `Engine`.
+
+    Managers reach their peers through `self.engine` rather than through process-wide
+    state, so an engine's object graph is self-contained.
+
+    `engine` is optional only so a unit test can build a manager on its own without
+    standing up a whole engine. `Engine` always injects itself, so the fallback to
+    `current_engine()` never runs in production. It is the one implicit global read left
+    outside the `GriptapeNodes` facade; make `engine` required once no test constructs a
+    manager bare.
+    """
+
+    def __init__(self, engine: Engine | None = None) -> None:
+        self._engine = engine
+
+    @property
+    def engine(self) -> Engine:
+        if self._engine is None:
+            return current_engine()
+        return self._engine
+
+
+class Engine:
+    """Owns one complete set of managers.
+
+    Managers are created here and hold a reference back to this engine, so they resolve
+    peers through `self._engine` rather than reaching for process-wide state.
+    """
+
+    _event_manager: EventManager
+    _os_manager: OSManager
+    _config_manager: ConfigManager
+    _secrets_manager: SecretsManager
+    _object_manager: ObjectManager
+    _node_manager: NodeManager
+    _flow_manager: FlowManager
+    _context_manager: ContextManager
+    _library_manager: LibraryManager
+    _model_manager: ModelManager
+    _access_manager: AccessManager
+    _workflow_manager: WorkflowManager
+    _workflow_variables_manager: VariablesManager
+    _arbitrary_code_exec_manager: ArbitraryCodeExecManager
+    _operation_depth_manager: OperationDepthManager
+    _static_files_manager: StaticFilesManager
+    _agent_manager: AgentManager
+    _version_compatibility_manager: VersionCompatibilityManager
+    _session_manager: SessionManager
+    _engine_identity_manager: EngineIdentityManager
+    _mcp_manager: MCPManager
+    _resource_manager: ResourceManager
+    _sync_manager: SyncManager
+    _user_manager: UserManager
+    _project_manager: ProjectManager
+    _artifact_manager: ArtifactManager
+    _manifest_manager: ManifestManager
+    _worker_manager: WorkerManager
+
+    def __init__(self) -> None:  # noqa: PLR0915
+        from griptape_nodes.retained_mode.managers.access_manager import AccessManager
+        from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
+        from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
+            ArbitraryCodeExecManager,
+        )
+        from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager
+        from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+        from griptape_nodes.retained_mode.managers.context_manager import ContextManager
+        from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
+        from griptape_nodes.retained_mode.managers.event_manager import EventManager
+        from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
+        from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+        from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
+        from griptape_nodes.retained_mode.managers.mcp_manager import MCPManager
+        from griptape_nodes.retained_mode.managers.model_manager import ModelManager
+        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
+        from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
+        from griptape_nodes.retained_mode.managers.operation_manager import (
+            OperationDepthManager,
+        )
+        from griptape_nodes.retained_mode.managers.os_manager import OSManager
+        from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
+        from griptape_nodes.retained_mode.managers.resource_manager import ResourceManager
+        from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
+        from griptape_nodes.retained_mode.managers.session_manager import SessionManager
+        from griptape_nodes.retained_mode.managers.static_files_manager import (
+            StaticFilesManager,
+        )
+        from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+        from griptape_nodes.retained_mode.managers.user_manager import UserManager
+        from griptape_nodes.retained_mode.managers.variable_manager import (
+            VariablesManager,
+        )
+        from griptape_nodes.retained_mode.managers.version_compatibility_manager import (
+            VersionCompatibilityManager,
+        )
+        from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
+        from griptape_nodes.retained_mode.managers.workflow_manager import (
+            WorkflowManager,
+        )
+
+        self._event_manager = EventManager(engine=self)
+        self._resource_manager = ResourceManager(self._event_manager)
+        self._config_manager = ConfigManager(self._event_manager, engine=self)
+        self._os_manager = OSManager(self._event_manager, engine=self)
+        self._secrets_manager = SecretsManager(self._config_manager, self._event_manager)
+        self._object_manager = ObjectManager(self._event_manager, engine=self)
+        self._node_manager = NodeManager(self._event_manager, engine=self)
+        self._flow_manager = FlowManager(self._event_manager, engine=self)
+        self._context_manager = ContextManager(self._event_manager, engine=self)
+        self._worker_manager = WorkerManager(engine=self, event_manager=self._event_manager)
+        self._library_manager = LibraryManager(self._event_manager, worker_manager=self._worker_manager, engine=self)
+        self._model_manager = ModelManager(self._event_manager, engine=self)
+        self._access_manager = AccessManager(self._event_manager, engine=self)
+        self._workflow_manager = WorkflowManager(self._event_manager, engine=self)
+        self._workflow_variables_manager = VariablesManager(self._event_manager, engine=self)
+        self._arbitrary_code_exec_manager = ArbitraryCodeExecManager(self._event_manager)
+        self._operation_depth_manager = OperationDepthManager(self._config_manager)
+        self._static_files_manager = StaticFilesManager(
+            self._config_manager, self._secrets_manager, self._event_manager, engine=self
+        )
+        self._agent_manager = AgentManager(self._static_files_manager, self._event_manager, engine=self)
+        self._version_compatibility_manager = VersionCompatibilityManager(self._event_manager, engine=self)
+        self._engine_identity_manager = EngineIdentityManager(self._event_manager)
+        self._session_manager = SessionManager(self._engine_identity_manager, self._event_manager)
+        self._mcp_manager = MCPManager(self._event_manager, self._config_manager)
+        self._sync_manager = SyncManager(self._event_manager, self._config_manager, engine=self)
+        self._user_manager = UserManager(self._secrets_manager)
+        self._project_manager = ProjectManager(
+            self._event_manager, self._config_manager, self._secrets_manager, engine=self
+        )
+        self._artifact_manager = ArtifactManager(self._event_manager, engine=self)
+        self._manifest_manager = ManifestManager(self._event_manager, engine=self)
+
+        # Assign handlers now that these are created.
+        self._event_manager.assign_manager_to_request_type(GetEngineVersionRequest, self.handle_engine_version_request)
+        self._event_manager.assign_manager_to_request_type(EngineHeartbeatRequest, self.handle_engine_heartbeat_request)
+
+    @property
+    def event_manager(self) -> EventManager:
+        return self._event_manager
+
+    @property
+    def os_manager(self) -> OSManager:
+        return self._os_manager
+
+    @property
+    def config_manager(self) -> ConfigManager:
+        return self._config_manager
+
+    @property
+    def secrets_manager(self) -> SecretsManager:
+        return self._secrets_manager
+
+    @property
+    def object_manager(self) -> ObjectManager:
+        return self._object_manager
+
+    @property
+    def node_manager(self) -> NodeManager:
+        return self._node_manager
+
+    @property
+    def flow_manager(self) -> FlowManager:
+        return self._flow_manager
+
+    @property
+    def context_manager(self) -> ContextManager:
+        return self._context_manager
+
+    @property
+    def library_manager(self) -> LibraryManager:
+        return self._library_manager
+
+    @property
+    def model_manager(self) -> ModelManager:
+        return self._model_manager
+
+    @property
+    def access_manager(self) -> AccessManager:
+        return self._access_manager
+
+    @property
+    def workflow_manager(self) -> WorkflowManager:
+        return self._workflow_manager
+
+    @property
+    def variables_manager(self) -> VariablesManager:
+        return self._workflow_variables_manager
+
+    @property
+    def arbitrary_code_exec_manager(self) -> ArbitraryCodeExecManager:
+        return self._arbitrary_code_exec_manager
+
+    @property
+    def operation_depth_manager(self) -> OperationDepthManager:
+        return self._operation_depth_manager
+
+    @property
+    def static_files_manager(self) -> StaticFilesManager:
+        return self._static_files_manager
+
+    @property
+    def agent_manager(self) -> AgentManager:
+        return self._agent_manager
+
+    @property
+    def version_compatibility_manager(self) -> VersionCompatibilityManager:
+        return self._version_compatibility_manager
+
+    @property
+    def session_manager(self) -> SessionManager:
+        return self._session_manager
+
+    @property
+    def engine_identity_manager(self) -> EngineIdentityManager:
+        return self._engine_identity_manager
+
+    @property
+    def mcp_manager(self) -> MCPManager:
+        return self._mcp_manager
+
+    @property
+    def resource_manager(self) -> ResourceManager:
+        return self._resource_manager
+
+    @property
+    def sync_manager(self) -> SyncManager:
+        return self._sync_manager
+
+    @property
+    def user_manager(self) -> UserManager:
+        return self._user_manager
+
+    @property
+    def project_manager(self) -> ProjectManager:
+        return self._project_manager
+
+    @property
+    def artifact_manager(self) -> ArtifactManager:
+        return self._artifact_manager
+
+    @property
+    def manifest_manager(self) -> ManifestManager:
+        return self._manifest_manager
+
+    @property
+    def worker_manager(self) -> WorkerManager:
+        return self._worker_manager
+
+    # Node libraries and saved workflows do `app = GriptapeNodes()` and then call these
+    # PascalCase accessors on the result. `GriptapeNodes()` hands back an `Engine`, so
+    # the compat surface has to live here. Engine-internal code uses the snake_case
+    # properties above; nothing in this repo should call these.
+
+    def EventManager(self) -> EventManager:
+        return self._event_manager
+
+    def LibraryManager(self) -> LibraryManager:
+        return self._library_manager
+
+    def ModelManager(self) -> ModelManager:
+        return self._model_manager
+
+    def AccessManager(self) -> AccessManager:
+        return self._access_manager
+
+    def ObjectManager(self) -> ObjectManager:
+        return self._object_manager
+
+    def FlowManager(self) -> FlowManager:
+        return self._flow_manager
+
+    def NodeManager(self) -> NodeManager:
+        return self._node_manager
+
+    def ContextManager(self) -> ContextManager:
+        return self._context_manager
+
+    def WorkflowManager(self) -> WorkflowManager:
+        return self._workflow_manager
+
+    def ArbitraryCodeExecManager(self) -> ArbitraryCodeExecManager:
+        return self._arbitrary_code_exec_manager
+
+    def ConfigManager(self) -> ConfigManager:
+        return self._config_manager
+
+    def OSManager(self) -> OSManager:
+        return self._os_manager
+
+    def SecretsManager(self) -> SecretsManager:
+        return self._secrets_manager
+
+    def OperationDepthManager(self) -> OperationDepthManager:
+        return self._operation_depth_manager
+
+    def StaticFilesManager(self) -> StaticFilesManager:
+        return self._static_files_manager
+
+    def AgentManager(self) -> AgentManager:
+        return self._agent_manager
+
+    def VersionCompatibilityManager(self) -> VersionCompatibilityManager:
+        return self._version_compatibility_manager
+
+    def SessionManager(self) -> SessionManager:
+        return self._session_manager
+
+    def MCPManager(self) -> MCPManager:
+        return self._mcp_manager
+
+    def EngineIdentityManager(self) -> EngineIdentityManager:
+        return self._engine_identity_manager
+
+    def ResourceManager(self) -> ResourceManager:
+        return self._resource_manager
+
+    def SyncManager(self) -> SyncManager:
+        return self._sync_manager
+
+    def VariablesManager(self) -> VariablesManager:
+        return self._workflow_variables_manager
+
+    def UserManager(self) -> UserManager:
+        return self._user_manager
+
+    def ProjectManager(self) -> ProjectManager:
+        return self._project_manager
+
+    def ArtifactManager(self) -> ArtifactManager:
+        return self._artifact_manager
+
+    def ManifestManager(self) -> ManifestManager:
+        return self._manifest_manager
+
+    def WorkerManager(self) -> WorkerManager:
+        return self._worker_manager
+
+    def get_instance(self) -> Engine:
+        """Back-compat for callers that reach for the instance through an instance."""
+        return self
+
+    def handle_request(self, request: RequestPayload) -> ResultPayload:
+        """Synchronous request handler."""
+        event_mgr = self._event_manager
+
+        try:
+            result_event = event_mgr.handle_request(request=request)
+            # Only queue result event if broadcasting is enabled and not suppressed
+            if request.broadcast_result and not event_mgr.should_suppress_event(result_event):
+                event_mgr.put_event(GriptapeNodeEvent(wrapped_event=result_event))
+        except Exception as e:
+            logger.exception(
+                "Unhandled exception while processing request of type %s. "
+                "Consider saving your work and restarting the engine if issues persist."
+                "Request: %s",
+                type(request).__name__,
+                request,
+            )
+            return ResultPayloadFailure(
+                exception=e, result_details=f"Unhandled exception while processing {type(request).__name__}: {e}"
+            )
+        else:
+            return result_event.result
+
+    async def ahandle_request(self, request: RequestPayload) -> ResultPayload:
+        """Asynchronous request handler.
+
+        Args:
+            request: The request payload to handle.
+        """
+        event_mgr = self._event_manager
+
+        try:
+            result_event = await event_mgr.ahandle_request(request=request)
+            # Only queue result event if broadcasting is enabled and not suppressed
+            if request.broadcast_result and not event_mgr.should_suppress_event(result_event):
+                await event_mgr.aput_event(GriptapeNodeEvent(wrapped_event=result_event))
+        except Exception as e:
+            logger.exception(
+                "Unhandled exception while processing async request of type %s. "
+                "Consider saving your work and restarting the engine if issues persist."
+                "Request: %s",
+                type(request).__name__,
+                request,
+            )
+            return ResultPayloadFailure(
+                exception=e, result_details=f"Unhandled exception while processing async {type(request).__name__}: {e}"
+            )
+        else:
+            return result_event.result
+
+    def broadcast_app_event(self, app_event: AppPayload) -> None:
+        self._event_manager.broadcast_app_event(app_event)
+
+    async def abroadcast_app_event(self, app_event: AppPayload) -> None:
+        await self._event_manager.abroadcast_app_event(app_event)
+
+    def get_session_id(self) -> str | None:
+        return self._session_manager.active_session_id
+
+    def get_engine_id(self) -> str | None:
+        return self._engine_identity_manager.active_engine_id
+
+    def clear_current_workflow_data(self) -> None:  # noqa: C901
+        """Tear down the active workflow: cancel running flows, delete its orphan flows, then pop it.
+
+        Requires an active workflow on the ContextManager stack. Order matters:
+        `on_delete_flow_request` pushes a flow context via `ContextManager().flow(...)`,
+        which raises `NoActiveWorkflowError` if the workflow has already been popped.
+        So we delete flows first and pop the workflow last.
+        """
+        context_manager = self._context_manager
+        if not context_manager.has_current_workflow():
+            msg = "Cannot clear current workflow data without an active workflow context."
+            raise RuntimeError(msg)
+
+        # Cancel any running flow so the delete path doesn't race with execution.
+        flow_manager = self._flow_manager
+        for flow_name in self._object_manager.get_filtered_subset(type=ControlFlow):
+            if flow_manager.check_for_existing_running_flow():
+                self.handle_request(CancelFlowRequest(flow_name=flow_name))
+
+        # Delete all orphan (top-level) flows. We can't rely on
+        # `ListFlowsInCurrentContextRequest` here because the caller may only have a
+        # workflow on the context stack (no child flow), and that request requires a
+        # current flow. Instead, repeatedly find a flow with no parent and delete it;
+        # `on_delete_flow_request` cascades into its children and nodes.
+        more_flows = True
+        while more_flows:
+            flows = self._object_manager.get_filtered_subset(type=ControlFlow)
+            found_orphan = False
+            for flow_name in flows:
+                parent = flow_manager.get_parent_flow(flow_name)
+                if not parent:
+                    self.handle_request(DeleteFlowRequest(flow_name=flow_name))
+                    found_orphan = True
+                    break
+            if not flows or not found_orphan:
+                more_flows = False
+
+        # Drain this workflow's context substack before popping the workflow itself.
+        while context_manager.has_current_flow():
+            while context_manager.has_current_node():
+                while context_manager.has_current_element():
+                    context_manager.pop_element()
+                context_manager.pop_node()
+            context_manager.pop_flow()
+        context_manager.pop_workflow()
+
+    def handle_engine_version_request(self, request: GetEngineVersionRequest) -> ResultPayload:  # noqa: ARG002
+        try:
+            engine_ver = semver.VersionInfo.parse(engine_version)
+            return GetEngineVersionResultSuccess(
+                major=engine_ver.major,
+                minor=engine_ver.minor,
+                patch=engine_ver.patch,
+                result_details="Engine version retrieved successfully.",
+            )
+        except Exception as err:
+            details = f"Attempted to get engine version. Failed due to '{err}'."
+            logger.error(details)
+            return GetEngineVersionResultFailure(result_details=details)
+
+    def handle_engine_heartbeat_request(self, request: EngineHeartbeatRequest) -> ResultPayload:
+        """Handle engine heartbeat requests.
+
+        Returns engine status information including version, session state, and system metrics.
+        """
+        try:
+            # Get instance information based on environment variables
+            instance_info = self._get_instance_info()
+
+            # Get current workflow information
+            workflow_info = self._get_current_workflow_info()
+
+            # Get engine name
+            engine_name = self._engine_identity_manager.engine_name
+
+            # Get user and organization
+            user = self._user_manager.user
+            user_organization = self._user_manager.user_organization
+
+            return EngineHeartbeatResultSuccess(
+                heartbeat_id=request.heartbeat_id,
+                engine_version=engine_version,
+                engine_name=engine_name,
+                engine_id=self._engine_identity_manager.active_engine_id,
+                session_id=self._session_manager.active_session_id,
+                timestamp=datetime.now(tz=UTC).isoformat(),
+                user=user,
+                user_organization=user_organization,
+                is_initializing=self._library_manager.is_initializing(),
+                # Set on worker processes (injected at spawn by WorkerManager), unset on the
+                # orchestrator. Lets a discovery client tell workers apart and nest them.
+                orchestrator_engine_id=os.getenv("GTN_ORCHESTRATOR_ENGINE_ID"),
+                result_details="Engine heartbeat successful",
+                **instance_info,
+                **workflow_info,
+            )
+        except Exception as err:
+            details = f"Failed to handle engine heartbeat: {err}"
+            logger.error(details)
+            return EngineHeartbeatResultFailure(heartbeat_id=request.heartbeat_id, result_details=details)
+
+    def _get_instance_info(self) -> dict[str, str | None]:
+        """Get instance information from environment variables.
+
+        Returns instance type, region, provider, and public IP information if available.
+        """
+        instance_info: dict[str, str | None] = {
+            "instance_type": os.getenv("GTN_INSTANCE_TYPE"),
+            "instance_region": os.getenv("GTN_INSTANCE_REGION"),
+            "instance_provider": os.getenv("GTN_INSTANCE_PROVIDER"),
+        }
+
+        # Determine deployment type based on presence of instance environment variables
+        instance_info["deployment_type"] = "griptape_hosted" if any(instance_info.values()) else "local"
+
+        return instance_info
+
+    def _get_current_workflow_info(self) -> dict[str, Any]:
+        """Get information about the currently loaded workflow.
+
+        Returns workflow name, file path, and status information if available.
+        """
+        workflow_info = {
+            "current_workflow": None,
+            "workflow_file_path": None,
+            "has_active_flow": False,
+        }
+
+        try:
+            context_manager = self._context_manager
+
+            # Check if there's an active workflow
+            if context_manager.has_current_workflow():
+                workflow_name = context_manager.get_current_workflow_name()
+                workflow_info["current_workflow"] = workflow_name
+                workflow_info["has_active_flow"] = context_manager.has_current_flow()
+
+                # Get workflow file path from registry (None for unsaved workflows).
+                if WorkflowRegistry.has_workflow_with_name(workflow_name):
+                    workflow = WorkflowRegistry.get_workflow_by_name(workflow_name)
+                    if workflow.file_path is not None:
+                        absolute_path = WorkflowRegistry.get_complete_file_path(workflow.file_path)
+                        workflow_info["workflow_file_path"] = absolute_path
+
+        except Exception as err:
+            logger.warning("Failed to get current workflow info: %s", err)
+
+        return workflow_info
+
+
+def current_engine() -> Engine:
+    """Return the engine bound to this context, creating the process root on first use.
+
+    Prefer an injected `Engine` reference. Reach for this only where no reference can be
+    threaded through -- the `GriptapeNodes` facade, saved workflow files, and node
+    libraries.
+    """
+    global _root_engine, _root_engine_building  # noqa: PLW0603
+
+    scoped = _scoped_engine.get()
+    if scoped is not None:
+        return scoped
+    if _root_engine is not None:
+        return _root_engine
+
+    with _root_engine_lock:
+        # Another thread may have finished the build while this one waited for the lock.
+        if _root_engine is not None:
+            return _root_engine
+        if _root_engine_building:
+            msg = (
+                "Something asked for the current engine while that engine was still being built. "
+                "A manager's constructor is reaching for the engine instead of using the one "
+                "passed to it."
+            )
+            raise RuntimeError(msg)
+        _root_engine_building = True
+        try:
+            _root_engine = Engine()
+        finally:
+            _root_engine_building = False
+        return _root_engine
+
+
+def has_current_engine() -> bool:
+    """Whether an engine exists yet, without creating one.
+
+    Lets boot-time and broadcast code skip work when no engine has been built, which is
+    the normal state in unit tests that construct managers on their own.
+    """
+    return _scoped_engine.get() is not None or _root_engine is not None
+
+
+@contextmanager
+def engine_scope(engine: Engine | None = None) -> Iterator[Engine]:
+    """Bind `engine` (or a fresh one) as the current engine for the duration of the block.
+
+    Tests use this to get a clean object graph without mutating process-wide state.
+    asyncio tasks created inside the block inherit the binding.
+    """
+    if engine is None:
+        engine = Engine()
+    token = _scoped_engine.set(engine)
+    try:
+        yield engine
+    finally:
+        _scoped_engine.reset(token)
+
+
+def reset_root_engine() -> None:
+    """Drop the process root engine so the next `current_engine()` builds a fresh one.
+
+    Test-only. Lets a test suite hand each test a clean object graph without paying to
+    construct an engine the test may never touch. Prefer `engine_scope` when a test wants
+    an engine it can hold.
+    """
+    global _root_engine  # noqa: PLW0603
+
+    with _root_engine_lock:
+        _root_engine = None

--- a/src/griptape_nodes/retained_mode/events/payload_registry.py
+++ b/src/griptape_nodes/retained_mode/events/payload_registry.py
@@ -3,12 +3,11 @@ from typing import ClassVar
 from typing_extensions import TypeVar
 
 from griptape_nodes.retained_mode.events.base_events import Payload
-from griptape_nodes.utils.metaclasses import SingletonMeta
 
 T = TypeVar("T", bound=Payload, default=Payload)
 
 
-class PayloadRegistry(metaclass=SingletonMeta):
+class PayloadRegistry:
     """Registry for payload types."""
 
     _registry: ClassVar[dict[str, type[Payload]]] = {}
@@ -23,9 +22,7 @@ class PayloadRegistry(metaclass=SingletonMeta):
         Returns:
             The registered class (for decorator use)
         """
-        # Ensure we have an instance
-        instance = cls()
-        instance._registry[payload_class.__name__] = payload_class
+        cls._registry[payload_class.__name__] = payload_class
         return payload_class
 
     @classmethod
@@ -38,9 +35,7 @@ class PayloadRegistry(metaclass=SingletonMeta):
         Returns:
             The payload class or None if not found
         """
-        # Ensure we have an instance
-        instance = cls()
-        return instance._registry.get(type_name)
+        return cls._registry.get(type_name)
 
     @classmethod
     def get_registry(cls) -> dict:
@@ -49,9 +44,7 @@ class PayloadRegistry(metaclass=SingletonMeta):
         Returns:
             Dictionary of payload type name to payload class
         """
-        # Ensure we have an instance
-        instance = cls()
-        return instance._registry.copy()
+        return cls._registry.copy()
 
     # Register decorator as a classmethod
     @classmethod

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -1,34 +1,22 @@
+"""Process-wide facade over the current `Engine`.
+
+`GriptapeNodes` is the one intentionally global entry point into the engine. It exists
+for callers that cannot be handed a reference:
+
+- saved workflow `.py` files, which are generated code carrying a `schema_version`
+- node libraries, which are versioned and distributed separately from the engine
+- CLI commands and servers, at the point where they first reach into the engine
+
+Engine-internal code should not use it. Managers receive an `Engine` and resolve peers
+through it; see `griptape_nodes.retained_mode.engine`.
+"""
+
 from __future__ import annotations
 
 import logging
-import os
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import semver
-
-from griptape_nodes.exe_types.flow import ControlFlow
-from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
-from griptape_nodes.retained_mode.events.app_events import (
-    EngineHeartbeatRequest,
-    EngineHeartbeatResultFailure,
-    EngineHeartbeatResultSuccess,
-    GetEngineVersionRequest,
-    GetEngineVersionResultFailure,
-    GetEngineVersionResultSuccess,
-)
-from griptape_nodes.retained_mode.events.base_events import (
-    GriptapeNodeEvent,
-    ResultPayloadFailure,
-)
-from griptape_nodes.retained_mode.events.execution_events import (
-    CancelFlowRequest,
-)
-from griptape_nodes.retained_mode.events.flow_events import (
-    DeleteFlowRequest,
-)
-from griptape_nodes.utils.metaclasses import SingletonMeta
-from griptape_nodes.utils.version_utils import engine_version
+from griptape_nodes.retained_mode.engine import Engine, current_engine
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import (
@@ -79,458 +67,162 @@ if TYPE_CHECKING:
 logger = logging.getLogger("griptape_nodes")
 
 
-class GriptapeNodes(metaclass=SingletonMeta):
-    _event_manager: EventManager
-    _os_manager: OSManager
-    _config_manager: ConfigManager
-    _secrets_manager: SecretsManager
-    _object_manager: ObjectManager
-    _node_manager: NodeManager
-    _flow_manager: FlowManager
-    _context_manager: ContextManager
-    _library_manager: LibraryManager
-    _model_manager: ModelManager
-    _access_manager: AccessManager
-    _workflow_manager: WorkflowManager
-    _workflow_variables_manager: VariablesManager
-    _arbitrary_code_exec_manager: ArbitraryCodeExecManager
-    _operation_depth_manager: OperationDepthManager
-    _static_files_manager: StaticFilesManager
-    _agent_manager: AgentManager
-    _version_compatibility_manager: VersionCompatibilityManager
-    _session_manager: SessionManager
-    _engine_identity_manager: EngineIdentityManager
-    _mcp_manager: MCPManager
-    _resource_manager: ResourceManager
-    _sync_manager: SyncManager
-    _user_manager: UserManager
-    _project_manager: ProjectManager
-    _artifact_manager: ArtifactManager
-    _manifest_manager: ManifestManager
-    _worker_manager: WorkerManager
+class _EngineRootMeta(type):
+    """Makes `GriptapeNodes()` resolve the current engine instead of building a facade.
 
-    def __init__(self) -> None:  # noqa: PLR0915
-        from griptape_nodes.retained_mode.managers.access_manager import AccessManager
-        from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
-        from griptape_nodes.retained_mode.managers.arbitrary_code_exec_manager import (
-            ArbitraryCodeExecManager,
-        )
-        from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager
-        from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
-        from griptape_nodes.retained_mode.managers.context_manager import ContextManager
-        from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
-        from griptape_nodes.retained_mode.managers.event_manager import EventManager
-        from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
-        from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
-        from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
-        from griptape_nodes.retained_mode.managers.mcp_manager import MCPManager
-        from griptape_nodes.retained_mode.managers.model_manager import ModelManager
-        from griptape_nodes.retained_mode.managers.node_manager import NodeManager
-        from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
-        from griptape_nodes.retained_mode.managers.operation_manager import (
-            OperationDepthManager,
-        )
-        from griptape_nodes.retained_mode.managers.os_manager import OSManager
-        from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
-        from griptape_nodes.retained_mode.managers.resource_manager import ResourceManager
-        from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
-        from griptape_nodes.retained_mode.managers.session_manager import SessionManager
-        from griptape_nodes.retained_mode.managers.static_files_manager import (
-            StaticFilesManager,
-        )
-        from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
-        from griptape_nodes.retained_mode.managers.user_manager import UserManager
-        from griptape_nodes.retained_mode.managers.variable_manager import (
-            VariablesManager,
-        )
-        from griptape_nodes.retained_mode.managers.version_compatibility_manager import (
-            VersionCompatibilityManager,
-        )
-        from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
-        from griptape_nodes.retained_mode.managers.workflow_manager import (
-            WorkflowManager,
-        )
+    Saved workflows and node libraries call `GriptapeNodes()` and then use the result as
+    the engine (`app = GriptapeNodes(); app.MCPManager()`), so instantiating the facade
+    has to hand back the real object.
+    """
 
-        # Initialize only if our managers haven't been created yet
-        if not hasattr(self, "_event_manager"):
-            self._event_manager = EventManager()
-            self._resource_manager = ResourceManager(self._event_manager)
-            self._config_manager = ConfigManager(self._event_manager)
-            self._os_manager = OSManager(self._event_manager)
-            self._secrets_manager = SecretsManager(self._config_manager, self._event_manager)
-            self._object_manager = ObjectManager(self._event_manager)
-            self._node_manager = NodeManager(self._event_manager)
-            self._flow_manager = FlowManager(self._event_manager)
-            self._context_manager = ContextManager(self._event_manager)
-            self._worker_manager = WorkerManager(griptape_nodes=self, event_manager=self._event_manager)
-            self._library_manager = LibraryManager(self._event_manager, worker_manager=self._worker_manager)
-            self._model_manager = ModelManager(self._event_manager)
-            self._access_manager = AccessManager(self._event_manager)
-            self._workflow_manager = WorkflowManager(self._event_manager)
-            self._workflow_variables_manager = VariablesManager(self._event_manager)
-            self._arbitrary_code_exec_manager = ArbitraryCodeExecManager(self._event_manager)
-            self._operation_depth_manager = OperationDepthManager(self._config_manager)
-            self._static_files_manager = StaticFilesManager(
-                self._config_manager, self._secrets_manager, self._event_manager
-            )
-            self._agent_manager = AgentManager(self._static_files_manager, self._event_manager)
-            self._version_compatibility_manager = VersionCompatibilityManager(self._event_manager)
-            self._engine_identity_manager = EngineIdentityManager(self._event_manager)
-            self._session_manager = SessionManager(self._engine_identity_manager, self._event_manager)
-            self._mcp_manager = MCPManager(self._event_manager, self._config_manager)
-            self._sync_manager = SyncManager(self._event_manager, self._config_manager)
-            self._user_manager = UserManager(self._secrets_manager)
-            self._project_manager = ProjectManager(self._event_manager, self._config_manager, self._secrets_manager)
-            self._artifact_manager = ArtifactManager(self._event_manager)
-            self._manifest_manager = ManifestManager(self._event_manager)
+    def __call__(cls) -> Engine:
+        return current_engine()
 
-            # Assign handlers now that these are created.
-            self._event_manager.assign_manager_to_request_type(
-                GetEngineVersionRequest, self.handle_engine_version_request
-            )
-            self._event_manager.assign_manager_to_request_type(
-                EngineHeartbeatRequest, self.handle_engine_heartbeat_request
-            )
+
+class GriptapeNodes(metaclass=_EngineRootMeta):
+    """Static accessors for the current engine's managers and request handlers."""
 
     @classmethod
-    def get_instance(cls) -> GriptapeNodes:
-        """Helper method to get the singleton instance."""
-        return cls()
+    def get_instance(cls) -> Engine:
+        """Return the current engine."""
+        return current_engine()
 
     @classmethod
-    def handle_request(
-        cls,
-        request: RequestPayload,
-    ) -> ResultPayload:
-        """Synchronous request handler."""
-        event_mgr = GriptapeNodes.EventManager()
-
-        try:
-            result_event = event_mgr.handle_request(request=request)
-            # Only queue result event if broadcasting is enabled and not suppressed
-            if request.broadcast_result and not event_mgr.should_suppress_event(result_event):
-                event_mgr.put_event(GriptapeNodeEvent(wrapped_event=result_event))
-        except Exception as e:
-            logger.exception(
-                "Unhandled exception while processing request of type %s. "
-                "Consider saving your work and restarting the engine if issues persist."
-                "Request: %s",
-                type(request).__name__,
-                request,
-            )
-            return ResultPayloadFailure(
-                exception=e, result_details=f"Unhandled exception while processing {type(request).__name__}: {e}"
-            )
-        else:
-            return result_event.result
+    def handle_request(cls, request: RequestPayload) -> ResultPayload:
+        return current_engine().handle_request(request)
 
     @classmethod
-    async def ahandle_request(
-        cls,
-        request: RequestPayload,
-    ) -> ResultPayload:
-        """Asynchronous request handler.
-
-        Args:
-            request: The request payload to handle.
-        """
-        event_mgr = GriptapeNodes.EventManager()
-
-        try:
-            result_event = await event_mgr.ahandle_request(request=request)
-            # Only queue result event if broadcasting is enabled and not suppressed
-            if request.broadcast_result and not event_mgr.should_suppress_event(result_event):
-                await event_mgr.aput_event(GriptapeNodeEvent(wrapped_event=result_event))
-        except Exception as e:
-            logger.exception(
-                "Unhandled exception while processing async request of type %s. "
-                "Consider saving your work and restarting the engine if issues persist."
-                "Request: %s",
-                type(request).__name__,
-                request,
-            )
-            return ResultPayloadFailure(
-                exception=e, result_details=f"Unhandled exception while processing async {type(request).__name__}: {e}"
-            )
-        else:
-            return result_event.result
+    async def ahandle_request(cls, request: RequestPayload) -> ResultPayload:
+        return await current_engine().ahandle_request(request)
 
     @classmethod
     def broadcast_app_event(cls, app_event: AppPayload) -> None:
-        event_mgr = GriptapeNodes.get_instance()._event_manager
-        event_mgr.broadcast_app_event(app_event)
+        current_engine().broadcast_app_event(app_event)
 
     @classmethod
     async def abroadcast_app_event(cls, app_event: AppPayload) -> None:
-        event_mgr = GriptapeNodes.get_instance()._event_manager
-        await event_mgr.abroadcast_app_event(app_event)
+        await current_engine().abroadcast_app_event(app_event)
 
     @classmethod
     def get_session_id(cls) -> str | None:
-        return GriptapeNodes.SessionManager().active_session_id
+        return current_engine().get_session_id()
 
     @classmethod
     def get_engine_id(cls) -> str | None:
-        return GriptapeNodes.EngineIdentityManager().active_engine_id
+        return current_engine().get_engine_id()
+
+    @classmethod
+    def clear_current_workflow_data(cls) -> None:
+        current_engine().clear_current_workflow_data()
 
     @classmethod
     def EventManager(cls) -> EventManager:
-        return GriptapeNodes.get_instance()._event_manager
+        return current_engine().event_manager
 
     @classmethod
     def LibraryManager(cls) -> LibraryManager:
-        return GriptapeNodes.get_instance()._library_manager
+        return current_engine().library_manager
 
     @classmethod
     def ModelManager(cls) -> ModelManager:
-        return GriptapeNodes.get_instance()._model_manager
+        return current_engine().model_manager
 
     @classmethod
     def AccessManager(cls) -> AccessManager:
-        return GriptapeNodes.get_instance()._access_manager
+        return current_engine().access_manager
 
     @classmethod
     def ObjectManager(cls) -> ObjectManager:
-        return GriptapeNodes.get_instance()._object_manager
+        return current_engine().object_manager
 
     @classmethod
     def FlowManager(cls) -> FlowManager:
-        return GriptapeNodes.get_instance()._flow_manager
+        return current_engine().flow_manager
 
     @classmethod
     def NodeManager(cls) -> NodeManager:
-        return GriptapeNodes.get_instance()._node_manager
+        return current_engine().node_manager
 
     @classmethod
     def ContextManager(cls) -> ContextManager:
-        return GriptapeNodes.get_instance()._context_manager
+        return current_engine().context_manager
 
     @classmethod
     def WorkflowManager(cls) -> WorkflowManager:
-        return GriptapeNodes.get_instance()._workflow_manager
+        return current_engine().workflow_manager
 
     @classmethod
     def ArbitraryCodeExecManager(cls) -> ArbitraryCodeExecManager:
-        return GriptapeNodes.get_instance()._arbitrary_code_exec_manager
+        return current_engine().arbitrary_code_exec_manager
 
     @classmethod
     def ConfigManager(cls) -> ConfigManager:
-        return GriptapeNodes.get_instance()._config_manager
+        return current_engine().config_manager
 
     @classmethod
     def OSManager(cls) -> OSManager:
-        return GriptapeNodes.get_instance()._os_manager
+        return current_engine().os_manager
 
     @classmethod
     def SecretsManager(cls) -> SecretsManager:
-        return GriptapeNodes.get_instance()._secrets_manager
+        return current_engine().secrets_manager
 
     @classmethod
     def OperationDepthManager(cls) -> OperationDepthManager:
-        return GriptapeNodes.get_instance()._operation_depth_manager
+        return current_engine().operation_depth_manager
 
     @classmethod
     def StaticFilesManager(cls) -> StaticFilesManager:
-        return GriptapeNodes.get_instance()._static_files_manager
+        return current_engine().static_files_manager
 
     @classmethod
     def AgentManager(cls) -> AgentManager:
-        return GriptapeNodes.get_instance()._agent_manager
+        return current_engine().agent_manager
 
     @classmethod
     def VersionCompatibilityManager(cls) -> VersionCompatibilityManager:
-        return GriptapeNodes.get_instance()._version_compatibility_manager
+        return current_engine().version_compatibility_manager
 
     @classmethod
     def SessionManager(cls) -> SessionManager:
-        return GriptapeNodes.get_instance()._session_manager
+        return current_engine().session_manager
 
     @classmethod
     def MCPManager(cls) -> MCPManager:
-        return GriptapeNodes.get_instance()._mcp_manager
+        return current_engine().mcp_manager
 
     @classmethod
     def EngineIdentityManager(cls) -> EngineIdentityManager:
-        return GriptapeNodes.get_instance()._engine_identity_manager
+        return current_engine().engine_identity_manager
 
     @classmethod
     def ResourceManager(cls) -> ResourceManager:
-        return GriptapeNodes.get_instance()._resource_manager
+        return current_engine().resource_manager
 
     @classmethod
     def SyncManager(cls) -> SyncManager:
-        return GriptapeNodes.get_instance()._sync_manager
+        return current_engine().sync_manager
 
     @classmethod
     def VariablesManager(cls) -> VariablesManager:
-        return GriptapeNodes.get_instance()._workflow_variables_manager
+        return current_engine().variables_manager
 
     @classmethod
     def UserManager(cls) -> UserManager:
-        return GriptapeNodes.get_instance()._user_manager
+        return current_engine().user_manager
 
     @classmethod
     def ProjectManager(cls) -> ProjectManager:
-        return GriptapeNodes.get_instance()._project_manager
+        return current_engine().project_manager
 
     @classmethod
     def ArtifactManager(cls) -> ArtifactManager:
-        return GriptapeNodes.get_instance()._artifact_manager
+        return current_engine().artifact_manager
 
     @classmethod
     def ManifestManager(cls) -> ManifestManager:
-        return GriptapeNodes.get_instance()._manifest_manager
+        return current_engine().manifest_manager
 
     @classmethod
     def WorkerManager(cls) -> WorkerManager:
-        return GriptapeNodes.get_instance()._worker_manager
-
-    @classmethod
-    def clear_current_workflow_data(cls) -> None:  # noqa: C901
-        """Tear down the active workflow: cancel running flows, delete its orphan flows, then pop it.
-
-        Requires an active workflow on the ContextManager stack. Order matters:
-        `on_delete_flow_request` pushes a flow context via `ContextManager().flow(...)`,
-        which raises `NoActiveWorkflowError` if the workflow has already been popped.
-        So we delete flows first and pop the workflow last.
-        """
-        context_manager = GriptapeNodes.ContextManager()
-        if not context_manager.has_current_workflow():
-            msg = "Cannot clear current workflow data without an active workflow context."
-            raise RuntimeError(msg)
-
-        # Cancel any running flow so the delete path doesn't race with execution.
-        flow_manager = GriptapeNodes.FlowManager()
-        for flow_name in GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow):
-            if flow_manager.check_for_existing_running_flow():
-                GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow_name))
-
-        # Delete all orphan (top-level) flows. We can't rely on
-        # `ListFlowsInCurrentContextRequest` here because the caller may only have a
-        # workflow on the context stack (no child flow), and that request requires a
-        # current flow. Instead, repeatedly find a flow with no parent and delete it;
-        # `on_delete_flow_request` cascades into its children and nodes.
-        more_flows = True
-        while more_flows:
-            flows = GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow)
-            found_orphan = False
-            for flow_name in flows:
-                parent = flow_manager.get_parent_flow(flow_name)
-                if not parent:
-                    GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=flow_name))
-                    found_orphan = True
-                    break
-            if not flows or not found_orphan:
-                more_flows = False
-
-        # Drain this workflow's context substack before popping the workflow itself.
-        while context_manager.has_current_flow():
-            while context_manager.has_current_node():
-                while context_manager.has_current_element():
-                    context_manager.pop_element()
-                context_manager.pop_node()
-            context_manager.pop_flow()
-        context_manager.pop_workflow()
-
-    def handle_engine_version_request(self, request: GetEngineVersionRequest) -> ResultPayload:  # noqa: ARG002
-        try:
-            engine_ver = semver.VersionInfo.parse(engine_version)
-            return GetEngineVersionResultSuccess(
-                major=engine_ver.major,
-                minor=engine_ver.minor,
-                patch=engine_ver.patch,
-                result_details="Engine version retrieved successfully.",
-            )
-        except Exception as err:
-            details = f"Attempted to get engine version. Failed due to '{err}'."
-            logger.error(details)
-            return GetEngineVersionResultFailure(result_details=details)
-
-    def handle_engine_heartbeat_request(self, request: EngineHeartbeatRequest) -> ResultPayload:
-        """Handle engine heartbeat requests.
-
-        Returns engine status information including version, session state, and system metrics.
-        """
-        try:
-            # Get instance information based on environment variables
-            instance_info = self._get_instance_info()
-
-            # Get current workflow information
-            workflow_info = self._get_current_workflow_info()
-
-            # Get engine name
-            engine_name = GriptapeNodes.EngineIdentityManager().engine_name
-
-            # Get user and organization
-            user = GriptapeNodes.UserManager().user
-            user_organization = GriptapeNodes.UserManager().user_organization
-
-            return EngineHeartbeatResultSuccess(
-                heartbeat_id=request.heartbeat_id,
-                engine_version=engine_version,
-                engine_name=engine_name,
-                engine_id=GriptapeNodes.EngineIdentityManager().active_engine_id,
-                session_id=GriptapeNodes.SessionManager().active_session_id,
-                timestamp=datetime.now(tz=UTC).isoformat(),
-                user=user,
-                user_organization=user_organization,
-                is_initializing=GriptapeNodes.LibraryManager().is_initializing(),
-                # Set on worker processes (injected at spawn by WorkerManager), unset on the
-                # orchestrator. Lets a discovery client tell workers apart and nest them.
-                orchestrator_engine_id=os.getenv("GTN_ORCHESTRATOR_ENGINE_ID"),
-                result_details="Engine heartbeat successful",
-                **instance_info,
-                **workflow_info,
-            )
-        except Exception as err:
-            details = f"Failed to handle engine heartbeat: {err}"
-            logger.error(details)
-            return EngineHeartbeatResultFailure(heartbeat_id=request.heartbeat_id, result_details=details)
-
-    def _get_instance_info(self) -> dict[str, str | None]:
-        """Get instance information from environment variables.
-
-        Returns instance type, region, provider, and public IP information if available.
-        """
-        instance_info: dict[str, str | None] = {
-            "instance_type": os.getenv("GTN_INSTANCE_TYPE"),
-            "instance_region": os.getenv("GTN_INSTANCE_REGION"),
-            "instance_provider": os.getenv("GTN_INSTANCE_PROVIDER"),
-        }
-
-        # Determine deployment type based on presence of instance environment variables
-        instance_info["deployment_type"] = "griptape_hosted" if any(instance_info.values()) else "local"
-
-        return instance_info
-
-    def _get_current_workflow_info(self) -> dict[str, Any]:
-        """Get information about the currently loaded workflow.
-
-        Returns workflow name, file path, and status information if available.
-        """
-        workflow_info = {
-            "current_workflow": None,
-            "workflow_file_path": None,
-            "has_active_flow": False,
-        }
-
-        try:
-            context_manager = self._context_manager
-
-            # Check if there's an active workflow
-            if context_manager.has_current_workflow():
-                workflow_name = context_manager.get_current_workflow_name()
-                workflow_info["current_workflow"] = workflow_name
-                workflow_info["has_active_flow"] = context_manager.has_current_flow()
-
-                # Get workflow file path from registry (None for unsaved workflows).
-                if WorkflowRegistry.has_workflow_with_name(workflow_name):
-                    workflow = WorkflowRegistry.get_workflow_by_name(workflow_name)
-                    if workflow.file_path is not None:
-                        absolute_path = WorkflowRegistry.get_complete_file_path(workflow.file_path)
-                        workflow_info["workflow_file_path"] = absolute_path
-
-        except Exception as err:
-            logger.warning("Failed to get current workflow info: %s", err)
-
-        return workflow_info
+        return current_engine().worker_manager

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -52,6 +52,7 @@ from griptape_nodes.node_library.library_declarations import (
     resolve_node_models,
 )
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.access_events import (
     CodecAccessDirection,
     CodecAccessVerdict,
@@ -67,7 +68,6 @@ from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessRequest,
     QueryModelAccessResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     AuthorizationCheckpoint,
     CheckpointAction,
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from griptape_nodes.node_library.library_declarations import ModelCatalogLibraryProperty, NodeDeclaration
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -105,10 +106,11 @@ class _NodeResolution:
     resolved_by_id: dict[str, ResolvedModel]
 
 
-class AccessManager:
+class AccessManager(EngineScoped):
     """Answers per-candidate authorization queries via the `OFFER_MODEL` checkpoint."""
 
-    def __init__(self, event_manager: EventManager | None = None) -> None:
+    def __init__(self, event_manager: EventManager | None = None, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(QueryModelAccessRequest, self.on_query_model_access_request)
             event_manager.assign_manager_to_request_type(
@@ -125,6 +127,7 @@ class AccessManager:
             candidate_model_ids=request.candidate_model_ids,
             node_type=None,
             resolved_by_id={},
+            event_manager=self.engine.event_manager,
         )
         return QueryModelAccessResultSuccess(
             verdicts=verdicts,
@@ -150,6 +153,7 @@ class AccessManager:
             candidate_model_ids=candidates,
             node_type=request.node_type,
             resolved_by_id=resolution.resolved_by_id,
+            event_manager=self.engine.event_manager,
         )
         return QueryModelAccessForNodeResultSuccess(
             verdicts=verdicts,
@@ -178,7 +182,7 @@ class AccessManager:
                 )
                 return QueryCodecAccessResultFailure(result_details=msg)
 
-        event_manager = GriptapeNodes.EventManager()
+        event_manager = self.engine.event_manager
         verdicts: list[CodecAccessVerdict] = []
         for codec in request.candidate_codecs:
             attributes: dict[str, Any] = {CheckpointAttribute.ID: codec}
@@ -216,6 +220,7 @@ class AccessManager:
             candidate_model_ids=request.candidate_model_ids,
             node_type=None,
             resolved_by_id=resolved_by_id,
+            event_manager=self.engine.event_manager,
         )
         return QueryModelAccessForCatalogResultSuccess(
             verdicts=verdicts,
@@ -312,6 +317,7 @@ class AccessManager:
         candidate_model_ids: Sequence[str],
         node_type: str | None,
         resolved_by_id: dict[str, ResolvedModel],
+        event_manager: EventManager,
     ) -> list[ModelAccessVerdict]:
         """Ask the authorization hook chain once per candidate; collect one verdict each.
 
@@ -329,7 +335,6 @@ class AccessManager:
         iterations; the guard only short-circuits when a hook itself re-enters a
         guarded engine operation, not when one handler loops over candidates.
         """
-        event_manager = GriptapeNodes.EventManager()
         verdicts: list[ModelAccessVerdict] = []
         for model_id in candidate_model_ids:
             attributes: dict[str, Any] = {CheckpointAttribute.ID: model_id}

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -65,6 +65,7 @@ from griptape_nodes.drivers.cloud_models import (
     provider_catalog_entries,
 )
 from griptape_nodes.drivers.thread_storage.local_thread_storage_driver import LocalThreadStorageDriver
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.agent_events import (
     AgentStreamEvent,
     AgentThinkingEvent,
@@ -128,7 +129,6 @@ from griptape_nodes.retained_mode.events.mcp_events import (
     GetEnabledMCPServersRequest,
     GetEnabledMCPServersResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from griptape_nodes.servers import bind_free_socket
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
     from pydantic_ai.messages import ModelMessage, UserContent
     from pydantic_ai.toolsets import AbstractToolset
 
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.static_files_manager import StaticFilesManager
 
@@ -335,10 +336,17 @@ class _RehydratedMessage:
     succeeded: int
 
 
-class AgentManager:
+class AgentManager(EngineScoped):
     """Owns the chat-sidebar agent runner and the engine-bundled MCP server."""
 
-    def __init__(self, static_files_manager: StaticFilesManager, event_manager: EventManager | None = None) -> None:
+    def __init__(
+        self,
+        static_files_manager: StaticFilesManager,
+        event_manager: EventManager | None = None,
+        *,
+        engine: Engine | None = None,
+    ) -> None:
+        super().__init__(engine)
         self.static_files_manager = static_files_manager
         self._mcp_server_port = GTN_MCP_SERVER_PORT
 
@@ -470,7 +478,7 @@ class AgentManager:
         )
         composed = await _compose_prompt(request.input, request.url_artifacts)
 
-        event_manager = GriptapeNodes.EventManager()
+        event_manager = self.engine.event_manager
 
         def emit(event: RunEvent) -> None:
             payload = _run_event_to_payload(event)
@@ -1055,11 +1063,10 @@ class AgentManager:
         parts.extend(server_rules)
         return "\n\n".join(parts)
 
-    @staticmethod
-    def _lookup_mcp_configs(server_names: list[str]) -> list[dict[str, Any]]:
+    def _lookup_mcp_configs(self, server_names: list[str]) -> list[dict[str, Any]]:
         if not server_names:
             return []
-        result = GriptapeNodes.handle_request(GetEnabledMCPServersRequest())
+        result = self.engine.handle_request(GetEnabledMCPServersRequest())
         if not isinstance(result, GetEnabledMCPServersResultSuccess):
             logger.warning("Could not load enabled MCP servers; agent will run without extras.")
             return []

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ValidationError
 from griptape_nodes.common.macro_parser import MacroVariables, ParsedMacro
 from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.files.path_utils import decompose_source_path
+from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.artifact_events import (
     CheckArtifactReadPermissionRequest,
@@ -81,7 +82,6 @@ from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import (
     SituationMetadata,
     SituationPolicy,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.artifact_providers import (
     AudioArtifactProvider,
     BaseArtifactPreviewGenerator,
@@ -165,19 +165,21 @@ class PreviewSettings(BaseModel):
     generator_params: BaseGeneratorParameters  # Will be a specific BaseGeneratorParameters subclass
 
 
-class ArtifactManager:
+class ArtifactManager(EngineScoped):
     """Manages artifact operations including preview generation.
 
     Coordinates artifact type providers to handle different media formats.
     Providers are looked up by file extension for efficient routing.
     """
 
-    def __init__(self, event_manager: EventManager | None = None) -> None:
+    def __init__(self, event_manager: EventManager | None = None, *, engine: Engine | None = None) -> None:
         """Initialize the ArtifactManager.
 
         Args:
             event_manager: Optional event manager for handling artifact events
+            engine: The owning Engine, used to resolve peer managers.
         """
+        super().__init__(engine)
         # Provider registry for managing artifact providers
         self._registry = ProviderRegistry()
 
@@ -400,7 +402,7 @@ class ArtifactManager:
         """
         # FAILURE CASE: Resolve source path from MacroPath
         resolve_request = ResolveMacroPathRequest(macro_path=request.macro_path)
-        resolve_result = GriptapeNodes.handle_request(resolve_request)
+        resolve_result = self.engine.handle_request(resolve_request)
 
         if not isinstance(resolve_result, ResolveMacroPathResultSuccess):
             return GeneratePreviewResultFailure(
@@ -411,7 +413,7 @@ class ArtifactManager:
 
         # FAILURE CASE: Verify file exists
         file_info_request = GetFileInfoRequest(path=source_path, workspace_only=False)
-        file_info_result = GriptapeNodes.handle_request(file_info_request)
+        file_info_result = self.engine.handle_request(file_info_request)
 
         if not isinstance(file_info_result, GetFileInfoResultSuccess):
             return GeneratePreviewResultFailure(
@@ -509,7 +511,7 @@ class ArtifactManager:
                 if isinstance(preview_file_names, str):
                     preview_path = str(destination_dir / preview_file_names)
                     delete_request = DeleteFileRequest(path=preview_path, workspace_only=False)
-                    delete_result = GriptapeNodes.handle_request(delete_request)
+                    delete_result = self.engine.handle_request(delete_request)
 
                     if delete_result.failed():
                         error_details += (
@@ -520,7 +522,7 @@ class ArtifactManager:
                     for filename in preview_file_names.values():
                         preview_path = str(destination_dir / filename)
                         delete_request = DeleteFileRequest(path=preview_path, workspace_only=False)
-                        delete_result = GriptapeNodes.handle_request(delete_request)
+                        delete_result = self.engine.handle_request(delete_request)
 
                         if delete_result.failed():
                             error_details += f". Additionally, failed to delete preview file {filename}: {delete_result.result_details}"
@@ -560,7 +562,7 @@ class ArtifactManager:
                 existing_file_policy=ExistingFilePolicy.OVERWRITE,
                 file_metadata=None,
             )
-            metadata_write_result = GriptapeNodes.handle_request(metadata_write_request)
+            metadata_write_result = self.engine.handle_request(metadata_write_request)
 
             if not isinstance(metadata_write_result, WriteFileResultSuccess):
                 return fail_with_cleanup(
@@ -651,7 +653,7 @@ class ArtifactManager:
         """
         # FAILURE CASE: Resolve source path from MacroPath
         resolve_request = ResolveMacroPathRequest(macro_path=request.macro_path)
-        resolve_result = GriptapeNodes.handle_request(resolve_request)
+        resolve_result = self.engine.handle_request(resolve_request)
 
         if not isinstance(resolve_result, ResolveMacroPathResultSuccess):
             return GetPreviewForArtifactResultFailure(
@@ -662,7 +664,7 @@ class ArtifactManager:
 
         # FAILURE CASE: Verify source file exists and get its metadata
         file_info_request = GetFileInfoRequest(path=source_path, workspace_only=False)
-        file_info_result = GriptapeNodes.handle_request(file_info_request)
+        file_info_result = self.engine.handle_request(file_info_request)
 
         if not isinstance(file_info_result, GetFileInfoResultSuccess):
             return GetPreviewForArtifactResultFailure(
@@ -702,7 +704,7 @@ class ArtifactManager:
 
         # Check if metadata file exists
         metadata_info_request = GetFileInfoRequest(path=metadata_path, workspace_only=False)
-        metadata_info_result = GriptapeNodes.handle_request(metadata_info_request)
+        metadata_info_result = self.engine.handle_request(metadata_info_request)
 
         metadata_exists = (
             isinstance(metadata_info_result, GetFileInfoResultSuccess) and metadata_info_result.file_entry is not None
@@ -748,7 +750,7 @@ class ArtifactManager:
             workspace_only=False,
             should_transform_image_content_to_thumbnail=False,
         )
-        read_metadata_result = await GriptapeNodes.ahandle_request(read_metadata_request)
+        read_metadata_result = await self.engine.ahandle_request(read_metadata_request)
 
         if not isinstance(read_metadata_result, ReadFileResultSuccess):
             return GetPreviewForArtifactResultFailure(
@@ -791,7 +793,7 @@ class ArtifactManager:
             # Single file case
             preview_file_path = str(destination_dir / metadata.preview_file_names)
             preview_info_request = GetFileInfoRequest(path=preview_file_path, workspace_only=False)
-            preview_info_result = GriptapeNodes.handle_request(preview_info_request)
+            preview_info_result = self.engine.handle_request(preview_info_request)
 
             if not isinstance(preview_info_result, GetFileInfoResultSuccess) or preview_info_result.file_entry is None:
                 preview_files_missing = True
@@ -800,7 +802,7 @@ class ArtifactManager:
             for filename in metadata.preview_file_names.values():
                 file_path = str(destination_dir / filename)
                 preview_file_check_request = GetFileInfoRequest(path=file_path, workspace_only=False)
-                preview_file_check_result = GriptapeNodes.handle_request(preview_file_check_request)
+                preview_file_check_result = self.engine.handle_request(preview_file_check_request)
 
                 if (
                     not isinstance(preview_file_check_result, GetFileInfoResultSuccess)
@@ -1260,7 +1262,7 @@ class ArtifactManager:
         key_prefix = generator_class.get_config_key_prefix(provider_class.get_friendly_name())
 
         request = GetConfigCategoryRequest(category=key_prefix, failure_log_level=logging.DEBUG)
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
 
         # Config category doesn't exist - no settings written yet
         if not isinstance(result, GetConfigCategoryResultSuccess):
@@ -1288,7 +1290,7 @@ class ArtifactManager:
 
         # Single batched write for all parameters
         request = SetConfigCategoryRequest(category=key_prefix, contents=params)
-        GriptapeNodes.handle_request(request)
+        self.engine.handle_request(request)
 
     def _write_provider_default_settings(self, provider_class: type[BaseArtifactProvider]) -> None:
         """Write provider-level default settings (format and generator name) in one batch.
@@ -1304,7 +1306,7 @@ class ArtifactManager:
 
         category = provider_class.get_config_key_prefix()
         request = SetConfigCategoryRequest(category=category, contents=settings)
-        GriptapeNodes.handle_request(request)
+        self.engine.handle_request(request)
 
     def _validate_and_register_generator_settings(
         self, provider_class: type[BaseArtifactProvider], generator_class: type[BaseArtifactPreviewGenerator]
@@ -1382,7 +1384,7 @@ class ArtifactManager:
         generator_key = provider_class.get_preview_generator_config_key()
 
         # Check format validity
-        format_result = GriptapeNodes.handle_request(
+        format_result = self.engine.handle_request(
             GetConfigValueRequest(category_and_key=format_key, failure_log_level=logging.DEBUG)
         )
         format_valid = (
@@ -1391,7 +1393,7 @@ class ArtifactManager:
         )
 
         # Check generator validity
-        generator_result = GriptapeNodes.handle_request(
+        generator_result = self.engine.handle_request(
             GetConfigValueRequest(category_and_key=generator_key, failure_log_level=logging.DEBUG)
         )
         registered_generators = self._registry.get_preview_generators_for_provider(provider_class)
@@ -1437,7 +1439,7 @@ class ArtifactManager:
         # Step 1: Read format from config (or use default if missing)
         format_config_key = provider_class.get_preview_format_config_key()
         format_request = GetConfigValueRequest(category_and_key=format_config_key, failure_log_level=logging.DEBUG)
-        format_result = GriptapeNodes.handle_request(format_request)
+        format_result = self.engine.handle_request(format_request)
 
         if isinstance(format_result, GetConfigValueResultSuccess):
             # Config exists - use it (provider will validate later)
@@ -1451,7 +1453,7 @@ class ArtifactManager:
         generator_request = GetConfigValueRequest(
             category_and_key=generator_config_key, failure_log_level=logging.DEBUG
         )
-        generator_result = GriptapeNodes.handle_request(generator_request)
+        generator_result = self.engine.handle_request(generator_request)
 
         registered_generators = self._registry.get_preview_generators_for_provider(provider_class)
         registered_generator_names = [gen.get_friendly_name() for gen in registered_generators]
@@ -1493,7 +1495,7 @@ class ArtifactManager:
                 f"{provider_class.get_config_key_prefix()}.preview_generator_configurations.{generator_key}"
             )
             params_request = GetConfigValueRequest(category_and_key=params_config_key, failure_log_level=logging.DEBUG)
-            params_result = GriptapeNodes.handle_request(params_request)
+            params_result = self.engine.handle_request(params_request)
 
             if isinstance(params_result, GetConfigValueResultSuccess):
                 # Params exist in config - validate them through Pydantic
@@ -1593,7 +1595,7 @@ class ArtifactManager:
         """
         # Get current project
         get_project_request = GetCurrentProjectRequest()
-        project_result = GriptapeNodes.handle_request(get_project_request)
+        project_result = self.engine.handle_request(get_project_request)
 
         if not isinstance(project_result, GetCurrentProjectResultSuccess):
             msg = "No current project loaded"
@@ -1607,7 +1609,7 @@ class ArtifactManager:
 
         # Get save_griptape_nodes_preview situation template
         get_situation_request = GetSituationRequest(situation_name=BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW)
-        get_situation_result = GriptapeNodes.handle_request(get_situation_request)
+        get_situation_result = self.engine.handle_request(get_situation_request)
 
         if not isinstance(get_situation_result, GetSituationResultSuccess):
             msg = f"{BuiltInSituation.SAVE_GRIPTAPE_NODES_PREVIEW} situation not found in project template"
@@ -1630,7 +1632,7 @@ class ArtifactManager:
             parsed_macro=parsed_macro,
             variables=variables,
         )
-        path_result = GriptapeNodes.handle_request(path_request)
+        path_result = self.engine.handle_request(path_request)
 
         if not isinstance(path_result, GetPathForMacroResultSuccess):
             msg = f"Failed to resolve preview path macro: {path_result.result_details}"

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -10,6 +10,7 @@ from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.files.path_utils import resolve_workspace_path
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.events.artifact_events import (
     GetArtifactSchemasRequest,
@@ -59,7 +60,7 @@ logger = logging.getLogger("griptape_nodes")
 USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config.json"
 
 
-class ConfigManager:
+class ConfigManager(EngineScoped):
     """A class to manage application configuration and file pathing.
 
     This class handles loading and saving configuration from multiple sources with the following precedence:
@@ -84,12 +85,14 @@ class ConfigManager:
         merged_config (dict): The merged configuration, combining all sources in precedence order.
     """
 
-    def __init__(self, event_manager: EventManager | None = None) -> None:
+    def __init__(self, event_manager: EventManager | None = None, *, engine: Engine | None = None) -> None:
         """Initialize the ConfigManager.
 
         Args:
             event_manager: The EventManager instance to use for event handling.
+            engine: The Engine this manager belongs to.
         """
+        super().__init__(engine)
         self._project_config_path: Path | None = None
         self._workspace_config_path: Path | None = None
         self._workspace_dir_override: str | None = None
@@ -570,9 +573,7 @@ class ConfigManager:
             return None
 
         if should_load_env_var_if_detected and isinstance(value, str) and value.startswith("$"):
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-            value = GriptapeNodes.SecretsManager().get_secret(value[1:])
+            value = self.engine.secrets_manager.get_secret(value[1:])
 
         if cast_type is not None:
             value = self._coerce_to_type(value, cast_type)
@@ -643,9 +644,7 @@ class ConfigManager:
         write_succeeded = self._write_user_config_delta(delta)
 
         if should_set_env_var_if_detected and isinstance(value, str) and value.startswith("$"):
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-            value = GriptapeNodes.SecretsManager().set_secret(value[1:], "")
+            value = self.engine.secrets_manager.set_secret(value[1:], "")
 
         # We need to fully reload the user config because we need to regenerate the merged config.
         # Also eventually need to reload registered workflows.
@@ -766,8 +765,6 @@ class ConfigManager:
         libraries without schemas get simple object types.
         """
         try:
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
             # Get base settings schema and current values
             base_schema = Settings.model_json_schema()
             current_values = self.merged_config.copy()
@@ -777,7 +774,7 @@ class ConfigManager:
 
             # Get artifact schemas (dynamically generated from registered providers/generators)
             schemas_request = GetArtifactSchemasRequest()
-            schemas_result = GriptapeNodes.handle_request(schemas_request)
+            schemas_result = self.engine.handle_request(schemas_request)
 
             if not isinstance(schemas_result, GetArtifactSchemasResultSuccess):
                 result_details = f"Failed to retrieve artifact schemas: {schemas_result.result_details}"
@@ -915,10 +912,7 @@ class ConfigManager:
             worker fan-out on this so workers don't reload from a file that
             wasn't actually updated.
         """
-        # Lazy import to avoid circular dependency during initialization
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        os_manager = GriptapeNodes.OSManager()
+        os_manager = self.engine.os_manager
         config_path_str = str(USER_CONFIG_PATH)
 
         # Step 1: Check if config file exists

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.files.path_utils import canonicalize_for_identity, derive_registry_key
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.context_events import (
     EnsureWorkflowAndFlowRequest,
     EnsureWorkflowAndFlowResultFailure,
@@ -23,13 +24,14 @@ if TYPE_CHECKING:
 
     from griptape_nodes.exe_types.core_types import BaseNodeElement
     from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 logger = logging.getLogger("griptape_nodes")
 
 
-class ContextManager:
+class ContextManager(EngineScoped):
     """Context manager for Workflow, Flow, Node, and Element contexts.
 
     Workflows own Flows, Flows own Nodes, and Nodes own Elements.
@@ -245,8 +247,9 @@ class ContextManager:
         ) -> None:
             self._manager.pop_element()
 
-    def __init__(self, event_manager: EventManager) -> None:
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
         """Initialize the context manager with empty workflow and flow stacks."""
+        super().__init__(engine)
         self._workflow_stack = []
         event_manager.assign_manager_to_request_type(
             request_type=SetWorkflowContextRequest, callback=self.on_set_workflow_context_request
@@ -313,13 +316,12 @@ class ContextManager:
             CreateFlowRequest,
             CreateFlowResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         created_workflow = False
         if self.has_current_workflow():
             workflow_name = self.get_current_workflow_name()
         else:
-            set_workflow_result = GriptapeNodes.handle_request(
+            set_workflow_result = self.engine.handle_request(
                 SetWorkflowContextRequest(
                     workflow_name=request.workflow_name,
                     display_name=request.display_name,
@@ -339,7 +341,7 @@ class ContextManager:
         if self.has_current_flow():
             flow_name = self.get_current_flow().name
         else:
-            create_flow_result = GriptapeNodes.handle_request(
+            create_flow_result = self.engine.handle_request(
                 CreateFlowRequest(
                     parent_flow_name=None,
                     flow_name=request.flow_name,
@@ -382,8 +384,6 @@ class ContextManager:
         return self.WorkflowContext(self, workflow_name)
 
     def flow(self, flow: ControlFlow | str) -> ContextManager.FlowContext:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         """Create a context manager for a Flow context.
 
         Args:
@@ -394,7 +394,7 @@ class ContextManager:
         """
         if isinstance(flow, str):
             try:
-                control_flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow, ControlFlow)
+                control_flow = self.engine.object_manager.attempt_get_object_by_name_as_type(flow, ControlFlow)
                 if control_flow is None:
                     msg = f"Flow '{flow}' not found in current workflow."
                     logger.error(msg)
@@ -587,11 +587,8 @@ class ContextManager:
         if workflow_name is not None:
             resolved_name = workflow_name
         elif file_path is not None:
-            # Lazy import required: context_manager is imported by griptape_nodes, creating a circular dependency.
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
             resolved = canonicalize_for_identity(file_path)
-            workspace_path = canonicalize_for_identity(GriptapeNodes.ConfigManager().workspace_path)
+            workspace_path = canonicalize_for_identity(self.engine.config_manager.workspace_path)
             if resolved.is_relative_to(workspace_path):
                 path_for_key = str(resolved.relative_to(workspace_path))
             else:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -17,6 +17,7 @@ from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
     BaseEvent,
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
 
     from griptape_nodes.api_client.request_client import RequestClient
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 RP = TypeVar("RP", bound=RequestPayload, default=RequestPayload)
@@ -89,8 +91,9 @@ class ResultContext(TypedDict, total=False):
     request_id: str | None
 
 
-class EventManager:
-    def __init__(self) -> None:
+class EventManager(EngineScoped):
+    def __init__(self, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         # Dictionary to store the SPECIFIC manager for each request type
         self._request_type_to_manager: dict[type[RequestPayload], Callable] = defaultdict(list)  # pyright: ignore[reportAttributeAccessIssue]
         # Dictionary to store ALL SUBSCRIBERS to app events.
@@ -646,10 +649,8 @@ class EventManager:
         context: ResultContext,
     ) -> EventResultSuccess | EventResultFailure:
         """Core logic for handling requests, shared between sync and async methods."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        operation_depth_mgr = GriptapeNodes.OperationDepthManager()
-        workflow_mgr = GriptapeNodes.WorkflowManager()
+        operation_depth_mgr = self.engine.operation_depth_manager
+        workflow_mgr = self.engine.workflow_manager
 
         with operation_depth_mgr as depth_manager:
             # Now see if the WorkflowManager was asking us to squelch altered_workflow_state commands
@@ -705,9 +706,7 @@ class EventManager:
             request: The request to handle
             result_context: The result context containing response_topic and request_id
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        operation_depth_mgr = GriptapeNodes.OperationDepthManager()
+        operation_depth_mgr = self.engine.operation_depth_manager
         if result_context is None:
             result_context = ResultContext()
 
@@ -761,9 +760,7 @@ class EventManager:
             request: The request to handle
             result_context: The result context containing response_topic and request_id
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        operation_depth_mgr = GriptapeNodes.OperationDepthManager()
+        operation_depth_mgr = self.engine.operation_depth_manager
         if result_context is None:
             result_context = ResultContext()
 
@@ -985,9 +982,7 @@ class EventManager:
                     tg.create_task(call_function(listener_callback, app_event))
 
     def _flush_tracked_parameter_changes(self) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        obj_manager = GriptapeNodes.ObjectManager()
+        obj_manager = self.engine.object_manager
         # Get all flows and their nodes
         nodes = obj_manager.get_filtered_subset(type=BaseNode)
         for node in nodes.values():

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -39,6 +39,7 @@ from griptape_nodes.machines.control_flow import CompleteState, ControlFlowMachi
 from griptape_nodes.machines.dag_builder import DagBuilder, DagNodeCategories
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import LibraryNameAndNodeType
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.base_events import (
     ExecutionEvent,
     ExecutionGriptapeNodeEvent,
@@ -173,11 +174,11 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowResultSuccess,
 )
 from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.settings import WorkflowExecutionMode
 from griptape_nodes.retained_mode.variable_types import VariableScope
 
 if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowShapeNodes
@@ -252,7 +253,7 @@ class MultiNodeEndNodeResult(NamedTuple):
     end_node_name: str
 
 
-class FlowManager:
+class FlowManager(EngineScoped):
     _name_to_parent_name: dict[str, str | None]
     _flow_to_referenced_workflow_name: dict[ControlFlow, str]
     _connections: Connections
@@ -264,7 +265,8 @@ class FlowManager:
     _global_dag_builder: DagBuilder
     _node_executor: NodeExecutor
 
-    def __init__(self, event_manager: EventManager) -> None:
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         event_manager.assign_manager_to_request_type(CreateFlowRequest, self.on_create_flow_request)
         event_manager.assign_manager_to_request_type(DeleteFlowRequest, self.on_delete_flow_request)
         event_manager.assign_manager_to_request_type(ListNodesInFlowRequest, self.on_list_nodes_in_flow_request)
@@ -347,10 +349,10 @@ class FlowManager:
             pushed_flow_context: Whether we pushed this flow to the context
         """
         if pushed_flow_context:
-            GriptapeNodes.ContextManager().pop_flow()
+            self.engine.context_manager.pop_flow()
 
         delete_flow_request = DeleteFlowRequest(flow_name=flow_name)
-        delete_result = GriptapeNodes.handle_request(delete_flow_request)
+        delete_result = self.engine.handle_request(delete_flow_request)
         if delete_result.failed():
             logger.warning(
                 "Failed to clean up flow '%s' after deserialization failure: %s",
@@ -406,7 +408,7 @@ class FlowManager:
         # connections here would fail the whole save with a "node not found in UUID map" error.
         all_node_names = set(flow.nodes.keys())
         for child_flow_name in child_flow_names:
-            child_flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
+            child_flow = self.engine.object_manager.attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
             if child_flow is None:
                 continue
             if self.is_referenced_workflow(child_flow) or child_flow.metadata.get(TRANSIENT_KEY):
@@ -461,13 +463,13 @@ class FlowManager:
 
         if flow_name is None:
             # We want to get details for whatever is at the top of the Current Context.
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = "Attempted to get Flow details from the Current Context. Failed because the Current Context was empty."
                 return GetFlowDetailsResultFailure(result_details=details)
-            flow = GriptapeNodes.ContextManager().get_current_flow()
+            flow = self.engine.context_manager.get_current_flow()
             flow_name = flow.name
         else:
-            flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+            flow = self.engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
             if flow is None:
                 details = (
                     f"Attempted to get Flow details for '{flow_name}'. Failed because no Flow with that name exists."
@@ -499,16 +501,16 @@ class FlowManager:
         flow = None
         if flow_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = "Attempted to get metadata for a Flow from the Current Context. Failed because the Current Context is empty."
                 return GetFlowMetadataResultFailure(result_details=details)
 
-            flow = GriptapeNodes.ContextManager().get_current_flow()
+            flow = self.engine.context_manager.get_current_flow()
             flow_name = flow.name
 
         # Does this flow exist?
         if flow is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
             if flow is None:
                 details = f"Attempted to get metadata for a Flow '{flow_name}', but no such Flow was found."
@@ -524,16 +526,16 @@ class FlowManager:
         flow = None
         if flow_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = "Attempted to set metadata for a Flow from the Current Context. Failed because the Current Context is empty."
                 return SetFlowMetadataResultFailure(result_details=details)
 
-            flow = GriptapeNodes.ContextManager().get_current_flow()
+            flow = self.engine.context_manager.get_current_flow()
             flow_name = flow.name
 
         # Does this flow exist?
         if flow is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
             if flow is None:
                 details = f"Attempted to set metadata for a Flow '{flow_name}', but no such Flow was found."
@@ -561,15 +563,15 @@ class FlowManager:
         # We'll explore #1 first by seeing if the Context Manager already has a current flow,
         # which would mean the canvas is already established:
         parent = None
-        if (parent_name is None) and (GriptapeNodes.ContextManager().has_current_flow()):
+        if (parent_name is None) and (self.engine.context_manager.has_current_flow()):
             # Aha! Just use that.
-            parent = GriptapeNodes.ContextManager().get_current_flow()
+            parent = self.engine.context_manager.get_current_flow()
             parent_name = parent.name
 
         # TODO: FIX THIS LOGIC MESS https://github.com/griptape-ai/griptape-nodes/issues/616
 
         if parent_name is not None and parent is None:
-            parent = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(parent_name, ControlFlow)
+            parent = self.engine.object_manager.attempt_get_object_by_name_as_type(parent_name, ControlFlow)
         if parent_name is None:
             if self.does_canvas_exist():
                 # We're trying to create the canvas. Ensure that parent does NOT already exist.
@@ -585,20 +587,20 @@ class FlowManager:
             return result
 
         # We need to have a current workflow context to proceed.
-        if not GriptapeNodes.ContextManager().has_current_workflow():
+        if not self.engine.context_manager.has_current_workflow():
             details = "Attempted to create a Flow, but no Workflow was active in the Current Context."
             return CreateFlowResultFailure(result_details=details)
 
         # Create it.
-        final_flow_name = GriptapeNodes.ObjectManager().generate_name_for_object(
+        final_flow_name = self.engine.object_manager.generate_name_for_object(
             type_name="ControlFlow", requested_name=request.flow_name
         )
         # Check if we're creating this flow within a referenced workflow context
         # This will inform the engine to maintain a reference to the workflow
         # when serializing it. It may inform the editor to render it differently.
-        workflow_manager = GriptapeNodes.WorkflowManager()
+        workflow_manager = self.engine.workflow_manager
         flow = ControlFlow(name=final_flow_name, metadata=request.metadata)
-        GriptapeNodes.ObjectManager().add_object_by_name(name=final_flow_name, obj=flow)
+        self.engine.object_manager.add_object_by_name(name=final_flow_name, obj=flow)
         self._name_to_parent_name[final_flow_name] = parent_name
 
         # Track referenced workflow if this flow was created within a referenced workflow context
@@ -608,7 +610,7 @@ class FlowManager:
 
         # See if we need to push it as the current context.
         if request.set_as_new_context:
-            GriptapeNodes.ContextManager().push_flow(flow)
+            self.engine.context_manager.push_flow(flow)
 
         # Success
         details = f"Successfully created Flow '{final_flow_name}'."
@@ -628,18 +630,18 @@ class FlowManager:
         flow = None
         if flow_name is None:
             # We want to delete whatever is at the top of the Current Context.
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = (
                     "Attempted to delete a Flow from the Current Context. Failed because the Current Context was empty."
                 )
                 result = DeleteFlowResultFailure(result_details=details)
                 return result
             # We pop it off here, but we'll re-add it using context in a moment.
-            flow = GriptapeNodes.ContextManager().pop_flow()
+            flow = self.engine.context_manager.pop_flow()
 
         # Does this Flow even exist?
         if flow is None and flow_name is not None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             details = f"Attempted to delete Flow '{flow_name}', but no Flow with that name could be found."
@@ -654,25 +656,25 @@ class FlowManager:
             and self._global_control_flow_machine is not None
             and self._global_control_flow_machine.context.flow_name == flow.name
         ):
-            result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=flow.name))
+            result = self.engine.handle_request(CancelFlowRequest(flow_name=flow.name))
             if result.failed():
                 details = f"Attempted to delete flow '{flow_name}'. Failed because running flow could not cancel."
                 return DeleteFlowResultFailure(result_details=details)
 
         # Let this Flow assume the Current Context while we delete everything within it.
-        with GriptapeNodes.ContextManager().flow(flow=flow):
+        with self.engine.context_manager.flow(flow=flow):
             # Delete all child Flows of this Flow.
             # Note: We use ListFlowsInCurrentContextRequest here instead of ListFlowsInFlowRequest(parent_flow_name=None)
             # because None in ListFlowsInFlowRequest means "get canvas/top-level flows". We want the flows in the
             # current context, which is the flow we're deleting.
             list_flows_request = ListFlowsInCurrentContextRequest()
-            list_flows_result = GriptapeNodes.handle_request(list_flows_request)
+            list_flows_result = self.engine.handle_request(list_flows_request)
             if not isinstance(list_flows_result, ListFlowsInCurrentContextResultSuccess):
                 details = f"Attempted to delete Flow '{flow_name}', but failed while attempting to get the list of Flows owned by this Flow."
                 result = DeleteFlowResultFailure(result_details=details)
                 return result
             flow_names = list_flows_result.flow_names
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             for child_flow_name in flow_names:
                 child_flow = obj_mgr.attempt_get_object_by_name_as_type(child_flow_name, ControlFlow)
                 if child_flow is None:
@@ -681,17 +683,17 @@ class FlowManager:
                     )
                     result = DeleteFlowResultFailure(result_details=details)
                     return result
-                with GriptapeNodes.ContextManager().flow(flow=child_flow):
+                with self.engine.context_manager.flow(flow=child_flow):
                     # Delete them.
                     delete_flow_request = DeleteFlowRequest(flow_name=child_flow_name)
-                    delete_flow_result = GriptapeNodes.handle_request(delete_flow_request)
+                    delete_flow_result = self.engine.handle_request(delete_flow_request)
                     if isinstance(delete_flow_result, DeleteFlowResultFailure):
                         details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to delete child Flow '{child_flow.name}'."
                         result = DeleteFlowResultFailure(result_details=details)
                         return result
             # Delete all child nodes in this Flow.
             list_nodes_request = ListNodesInFlowRequest()
-            list_nodes_result = GriptapeNodes.handle_request(list_nodes_request)
+            list_nodes_result = self.engine.handle_request(list_nodes_request)
             if not isinstance(list_nodes_result, ListNodesInFlowResultSuccess):
                 details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to get the list of Nodes owned by this Flow."
                 result = DeleteFlowResultFailure(result_details=details)
@@ -699,7 +701,7 @@ class FlowManager:
             node_names = list_nodes_result.node_names
             for node_name in node_names:
                 delete_node_request = DeleteNodeRequest(node_name=node_name)
-                delete_node_result = GriptapeNodes.handle_request(delete_node_request)
+                delete_node_result = self.engine.handle_request(delete_node_request)
                 if isinstance(delete_node_result, DeleteNodeResultFailure):
                     details = f"Attempted to delete Flow '{flow.name}', but failed while attempting to delete child Node '{node_name}'."
                     result = DeleteFlowResultFailure(result_details=details)
@@ -728,7 +730,7 @@ class FlowManager:
         return result
 
     def on_get_is_flow_running_request(self, request: GetIsFlowRunningRequest) -> ResultPayload:
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
         if request.flow_name is None:
             details = "Attempted to get Flow, but no flow name was provided."
             return GetIsFlowRunningResultFailure(result_details=details)
@@ -752,16 +754,16 @@ class FlowManager:
         flow = None
         if flow_name is None:
             # First check if we have a current flow
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = "Attempted to list Nodes in a Flow in the Current Context. Failed because the Current Context was empty."
                 result = ListNodesInFlowResultFailure(result_details=details)
                 return result
             # Get the current flow from context
-            flow = GriptapeNodes.ContextManager().get_current_flow()
+            flow = self.engine.context_manager.get_current_flow()
             flow_name = flow.name
         # Does this Flow even exist?
         if flow is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             details = (
@@ -783,7 +785,7 @@ class FlowManager:
     def on_list_flows_in_flow_request(self, request: ListFlowsInFlowRequest) -> ResultPayload:
         if request.parent_flow_name is not None:
             # Does this Flow even exist?
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             flow = obj_mgr.attempt_get_object_by_name_as_type(request.parent_flow_name, ControlFlow)
             if flow is None:
                 details = f"Attempted to list Flows that are children of Flow '{request.parent_flow_name}', but no Flow with that name could be found."
@@ -802,7 +804,7 @@ class FlowManager:
         return result
 
     def get_flow_by_name(self, flow_name: str) -> ControlFlow:
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
         flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if flow is None:
             msg = f"Flow with name {flow_name} doesn't exist"
@@ -832,7 +834,7 @@ class FlowManager:
                 self._name_to_parent_name[flow_name] = new_name
 
         # Let the Node Manager know about the change, too.
-        GriptapeNodes.NodeManager().handle_flow_rename(old_name=old_name, new_name=new_name)
+        self.engine.node_manager.handle_flow_rename(old_name=old_name, new_name=new_name)
 
     def on_create_connection_request(self, request: CreateConnectionRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, PLR0915, C901
         # Vet the two nodes first.
@@ -840,16 +842,16 @@ class FlowManager:
         source_node = None
         if source_node_name is None:
             # First check if we have a current node
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to create a Connection with a source node from the Current Context. Failed because the Current Context was empty."
                 return CreateConnectionResultFailure(result_details=details)
 
             # Get the current node from context
-            source_node = GriptapeNodes.ContextManager().get_current_node()
+            source_node = self.engine.context_manager.get_current_node()
             source_node_name = source_node.name
         if source_node is None:
             try:
-                source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
+                source_node = self.engine.node_manager.get_node_by_name(source_node_name)
             except ValueError as err:
                 details = f'Connection failed: "{source_node_name}" does not exist. Error: {err}.'
 
@@ -859,16 +861,16 @@ class FlowManager:
         target_node = None
         if target_node_name is None:
             # First check if we have a current node
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to create a Connection with the target node from the Current Context. Failed because the Current Context was empty."
                 return CreateConnectionResultFailure(result_details=details)
 
             # Get the current node from context
-            target_node = GriptapeNodes.ContextManager().get_current_node()
+            target_node = self.engine.context_manager.get_current_node()
             target_node_name = target_node.name
         if target_node is None:
             try:
-                target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
+                target_node = self.engine.node_manager.get_node_by_name(target_node_name)
             except ValueError as err:
                 details = f'Connection failed: "{target_node_name}" does not exist. Error: {err}.'
                 return CreateConnectionResultFailure(result_details=details)
@@ -877,7 +879,7 @@ class FlowManager:
         # Get the parent flows.
         source_flow_name = None
         try:
-            source_flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(source_node_name)
+            source_flow_name = self.engine.node_manager.get_node_parent_flow_by_name(source_node_name)
             self.get_flow_by_name(flow_name=source_flow_name)
         except KeyError as err:
             details = f'Connection "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}" failed: {err}.'
@@ -885,7 +887,7 @@ class FlowManager:
 
         target_flow_name = None
         try:
-            target_flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(target_node_name)
+            target_flow_name = self.engine.node_manager.get_node_parent_flow_by_name(target_node_name)
             self.get_flow_by_name(flow_name=target_flow_name)
         except KeyError as err:
             details = f'Connection "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}" failed: {err}.'
@@ -989,7 +991,7 @@ class FlowManager:
                 target_node_name=old_target_node_name,
                 target_parameter_name=old_target_param_name,
             )
-            delete_old_result = GriptapeNodes.handle_request(delete_old_request)
+            delete_old_result = self.engine.handle_request(delete_old_request)
             if delete_old_result.failed():
                 details = f"Attempted to connect '{source_node_name}.{request.source_parameter_name}'. Failed because there was a previous connection from '{old_source_node_name}.{old_source_param_name}' to '{old_target_node_name}.{old_target_param_name}' that could not be deleted."
                 return CreateConnectionResultFailure(result_details=details)
@@ -1031,7 +1033,7 @@ class FlowManager:
                     target_parameter_name=old_target_param_name,
                     initial_setup=request.initial_setup,
                 )
-                create_old_connection_result = GriptapeNodes.handle_request(create_old_connection_request)
+                create_old_connection_result = self.engine.handle_request(create_old_connection_request)
                 if create_old_connection_result.failed():
                     details = "Failed attempting to restore the old Connection after failing the replacement. A thousand pardons."
             return CreateConnectionResultFailure(result_details=details)
@@ -1114,7 +1116,7 @@ class FlowManager:
             # When creating a connection, pass the initial value from source to target parameter
             # Set incoming_connection_source fields to identify this as legitimate connection value passing
             # (not manual property setting) so it bypasses the INPUT+PROPERTY connection blocking logic
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 SetParameterValueRequest(
                     parameter_name=target_param.name,
                     node_name=target_node.name,
@@ -1155,16 +1157,16 @@ class FlowManager:
         target_node = None
         if source_node_name is None:
             # First check if we have a current node
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to delete a Connection with a source node from the Current Context. Failed because the Current Context was empty."
                 return DeleteConnectionResultFailure(result_details=details)
 
             # Get the current node from context
-            source_node = GriptapeNodes.ContextManager().get_current_node()
+            source_node = self.engine.context_manager.get_current_node()
             source_node_name = source_node.name
         if source_node is None:
             try:
-                source_node = GriptapeNodes.NodeManager().get_node_by_name(source_node_name)
+                source_node = self.engine.node_manager.get_node_by_name(source_node_name)
             except ValueError as err:
                 details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
 
@@ -1173,16 +1175,16 @@ class FlowManager:
         target_node_name = request.target_node_name
         if target_node_name is None:
             # First check if we have a current node
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to delete a Connection with a target node from the Current Context. Failed because the Current Context was empty."
                 return DeleteConnectionResultFailure(result_details=details)
 
             # Get the current node from context
-            target_node = GriptapeNodes.ContextManager().get_current_node()
+            target_node = self.engine.context_manager.get_current_node()
             target_node_name = target_node.name
         if target_node is None:
             try:
-                target_node = GriptapeNodes.NodeManager().get_node_by_name(target_node_name)
+                target_node = self.engine.node_manager.get_node_by_name(target_node_name)
             except ValueError as err:
                 details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
 
@@ -1192,7 +1194,7 @@ class FlowManager:
         # Get the parent flows.
         source_flow_name = None
         try:
-            source_flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(source_node_name)
+            source_flow_name = self.engine.node_manager.get_node_parent_flow_by_name(source_node_name)
             self.get_flow_by_name(flow_name=source_flow_name)
         except KeyError as err:
             details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
@@ -1201,7 +1203,7 @@ class FlowManager:
 
         target_flow_name = None
         try:
-            target_flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(target_node_name)
+            target_flow_name = self.engine.node_manager.get_node_parent_flow_by_name(target_node_name)
             self.get_flow_by_name(flow_name=target_flow_name)
         except KeyError as err:
             details = f'Connection not deleted "{source_node_name}.{request.source_parameter_name}" to "{target_node_name}.{request.target_parameter_name}". Error: {err}'
@@ -1345,7 +1347,7 @@ class FlowManager:
         # Get the actual node objects for processing
         nodes_to_package = []
         for node_name in request.node_names:
-            node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
+            node = self.engine.node_manager.get_node_by_name(node_name)
             nodes_to_package.append(node)
 
         # Step 4: Initialize tracking variables and mappings (moved up so package node serialization can use them)
@@ -1386,7 +1388,7 @@ class FlowManager:
         node_group_node: SubflowNodeGroup | None = None
         if request.node_group_name:
             try:
-                node = GriptapeNodes.NodeManager().get_node_by_name(request.node_group_name)
+                node = self.engine.node_manager.get_node_by_name(request.node_group_name)
                 if isinstance(node, SubflowNodeGroup):
                     node_group_node = node
             except Exception as e:
@@ -1451,7 +1453,7 @@ class FlowManager:
         )
 
         # Build WorkflowShape from collected parameter shape data
-        workflow_shape = GriptapeNodes.WorkflowManager().build_workflow_shape_from_parameter_info(
+        workflow_shape = self.engine.workflow_manager.build_workflow_shape_from_parameter_info(
             input_node_params=start_node_result.input_shape_data,
             output_node_params=end_node_packaging_result.output_shape_data,
         )
@@ -1556,7 +1558,7 @@ class FlowManager:
         missing_nodes = []
         for node_name in request.node_names:
             try:
-                GriptapeNodes.NodeManager().get_node_by_name(node_name)
+                self.engine.node_manager.get_node_by_name(node_name)
             except Exception:
                 missing_nodes.append(node_name)
 
@@ -1615,7 +1617,7 @@ class FlowManager:
                 serialized_parameter_value_tracker=serialized_parameter_value_tracker,
                 include_existing_subflow_in_group=True,
             )
-            serialize_result = GriptapeNodes.NodeManager().on_serialize_node_to_commands(serialize_request)
+            serialize_result = self.engine.node_manager.on_serialize_node_to_commands(serialize_request)
 
             if not isinstance(serialize_result, SerializeNodeToCommandsResultSuccess):
                 return PackageNodesAsSerializedFlowResultFailure(
@@ -1696,7 +1698,7 @@ class FlowManager:
         # Query connections from connection manager
         for node in nodes_to_package:
             list_connections_request = ListConnectionsForNodeRequest(node_name=node.name)
-            list_connections_result = GriptapeNodes.NodeManager().on_list_connections_for_node_request(
+            list_connections_result = self.engine.node_manager.on_list_connections_for_node_request(
                 list_connections_request
             )
 
@@ -1826,7 +1828,7 @@ class FlowManager:
         # Get incoming and outgoing connections for this node
         # Get connection details using the standard approach
         list_connections_request = ListConnectionsForNodeRequest(node_name=node_name)
-        list_connections_result = GriptapeNodes.NodeManager().on_list_connections_for_node_request(
+        list_connections_result = self.engine.node_manager.on_list_connections_for_node_request(
             list_connections_request
         )
 
@@ -2139,7 +2141,7 @@ class FlowManager:
         )
 
         # Extract parameter shape info for workflow shape (outputs to external consumers)
-        param_shape_info = GriptapeNodes.WorkflowManager().extract_parameter_shape_info(
+        param_shape_info = self.engine.workflow_manager.extract_parameter_shape_info(
             parameter, include_control_params=True
         )
         if param_shape_info is not None:
@@ -2425,7 +2427,7 @@ class FlowManager:
 
             # Get the source node to determine parameter type (from the external connection)
             try:
-                source_node = GriptapeNodes.NodeManager().get_node_by_name(connection.source_node_name)
+                source_node = self.engine.node_manager.get_node_by_name(connection.source_node_name)
             except ValueError as err:
                 details = f"Attempted to package nodes as serialized flow. Failed because source node '{connection.source_node_name}' from incoming connection could not be found. Error: {err}."
                 return PackageNodesAsSerializedFlowResultFailure(result_details=details)
@@ -2437,7 +2439,7 @@ class FlowManager:
                 return PackageNodesAsSerializedFlowResultFailure(result_details=details)
 
             # Extract parameter shape info for workflow shape (inputs from external sources)
-            param_shape_info = GriptapeNodes.WorkflowManager().extract_parameter_shape_info(
+            param_shape_info = self.engine.workflow_manager.extract_parameter_shape_info(
                 source_param, include_control_params=True
             )
             if param_shape_info is not None:
@@ -2446,12 +2448,13 @@ class FlowManager:
                 input_shape_data[start_node_name][param_name] = param_shape_info
 
             # Extract parameter value from source node to set on start node
-            param_value_commands = GriptapeNodes.NodeManager().handle_parameter_value_saving(
+            param_value_commands = self.engine.node_manager.handle_parameter_value_saving(
                 parameter=source_param,
                 node=source_node,
                 unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
                 serialized_parameter_value_tracker=serialized_parameter_value_tracker,
                 create_node_request=start_create_node_command,
+                workflow_manager=self.engine.workflow_manager,
             )
             if param_value_commands is not None:
                 # Modify each command to target the start node parameter instead
@@ -2516,7 +2519,7 @@ class FlowManager:
         # Connect start node to specified entry control node (if specified)
         if request.entry_control_node_name:
             # Get the entry node (already validated to exist)
-            entry_node = GriptapeNodes.NodeManager().get_node_by_name(request.entry_control_node_name)
+            entry_node = self.engine.node_manager.get_node_by_name(request.entry_control_node_name)
             entry_node_uuid = node_name_to_uuid[request.entry_control_node_name]
 
             # Connect start node to specified entry control node
@@ -2635,8 +2638,8 @@ class FlowManager:
             # Fall back to the current-context flow so callers do not have to echo the name
             # EnsureWorkflowAndFlowRequest / CreateFlowRequest just returned. If nothing is in
             # context either, preserve the original "you must provide one" error.
-            if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow().name
+            if self.engine.context_manager.has_current_flow():
+                flow_name = self.engine.context_manager.get_current_flow().name
             else:
                 details = (
                     "Must provide flow_name, or set a flow in the Current Context "
@@ -2656,7 +2659,7 @@ class FlowManager:
         # A node has been provided to either start or to run up to.
         if request.flow_node_name:
             flow_node_name = request.flow_node_name
-            flow_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_node_name, BaseNode)
+            flow_node = self.engine.object_manager.attempt_get_object_by_name_as_type(flow_node_name, BaseNode)
             if not flow_node:
                 details = f"Provided node with name {flow_node_name} does not exist"
                 return StartFlowResultFailure(validation_exceptions=[], result_details=details)
@@ -2750,12 +2753,12 @@ class FlowManager:
         # from the node's parent flow so callers do not have to keep them in sync.
         node_name = request.node_name
         if node_name is None:
-            if GriptapeNodes.ContextManager().has_current_node():
-                node_name = GriptapeNodes.ContextManager().get_current_node().name
+            if self.engine.context_manager.has_current_node():
+                node_name = self.engine.context_manager.get_current_node().name
             else:
                 details = "Must provide node_name, or set a node in the Current Context first."
                 return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
-        start_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        start_node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if not start_node:
             details = f"Provided node with name {node_name} does not exist"
             return StartFlowFromNodeResultFailure(validation_exceptions=[], result_details=details)
@@ -2763,7 +2766,7 @@ class FlowManager:
         flow_name = request.flow_name
         if not flow_name:
             try:
-                flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+                flow_name = self.engine.node_manager.get_node_parent_flow_by_name(node_name)
             except KeyError as err:
                 details = f"Could not derive parent flow for node '{node_name}': {err}"
                 return StartFlowFromNodeResultFailure(validation_exceptions=[err], result_details=details)
@@ -2937,7 +2940,7 @@ class FlowManager:
             return start_nodes[0]
 
         try:
-            return GriptapeNodes.NodeManager().get_node_by_name(start_node_name)
+            return self.engine.node_manager.get_node_by_name(start_node_name)
         except ValueError as err:
             details = f"Cannot start subflow '{flow_name}'. Start node '{start_node_name}' not found: {err}"
             return StartLocalSubflowResultFailure(result_details=details)
@@ -3160,7 +3163,7 @@ class FlowManager:
             return ValidateFlowDependenciesResultFailure(result_details=details)
         if request.flow_node_name:
             flow_node_name = request.flow_node_name
-            flow_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_node_name, BaseNode)
+            flow_node = self.engine.object_manager.attempt_get_object_by_name_as_type(flow_node_name, BaseNode)
             if not flow_node:
                 details = f"Provided node with name {flow_node_name} does not exist"
                 return ValidateFlowDependenciesResultFailure(result_details=details)
@@ -3181,11 +3184,11 @@ class FlowManager:
         )
 
     def on_list_flows_in_current_context_request(self, request: ListFlowsInCurrentContextRequest) -> ResultPayload:  # noqa: ARG002 (request isn't actually used)
-        if not GriptapeNodes.ContextManager().has_current_flow():
+        if not self.engine.context_manager.has_current_flow():
             details = "Attempted to list Flows in the Current Context. Failed because the Current Context was empty."
             return ListFlowsInCurrentContextResultFailure(result_details=details)
 
-        parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+        parent_flow = self.engine.context_manager.get_current_flow()
         parent_flow_name = parent_flow.name
 
         # Create a list of all child flow names that point DIRECTLY to us.
@@ -3213,8 +3216,8 @@ class FlowManager:
         """
         flow_name = request.flow_name
         if not flow_name:
-            if GriptapeNodes.ContextManager().has_current_flow():
-                flow_name = GriptapeNodes.ContextManager().get_current_flow().name
+            if self.engine.context_manager.has_current_flow():
+                flow_name = self.engine.context_manager.get_current_flow().name
             else:
                 details = (
                     "Attempted to auto-layout a flow. Failed because no flow_name was provided "
@@ -3280,12 +3283,12 @@ class FlowManager:
             for row_idx, name in enumerate(sorted(layers[layer_idx])):
                 x = request.origin_x + layer_idx * request.layer_spacing
                 y = request.origin_y + row_idx * request.row_spacing
-                # Dispatch the position update through GriptapeNodes.ahandle_request so the
+                # Dispatch the position update through self.engine.ahandle_request so the
                 # per-node SetNodeMetadataResultSuccess event is broadcast to subscribers.
                 # The editor listens on that event to move nodes on the canvas live; mutating
                 # node.metadata directly here would update the engine state but leave the UI
                 # stale until a reload.
-                set_metadata_result = await GriptapeNodes.ahandle_request(
+                set_metadata_result = await self.engine.ahandle_request(
                     SetNodeMetadataRequest(node_name=name, metadata={"position": {"x": x, "y": y}})
                 )
                 if not isinstance(set_metadata_result, SetNodeMetadataResultSuccess):
@@ -3438,7 +3441,7 @@ class FlowManager:
         if not declared_names_for_this_flow:
             return []
 
-        flow_list_result = GriptapeNodes.handle_request(
+        flow_list_result = self.engine.handle_request(
             ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY)
         )
         if not isinstance(flow_list_result, ListVariablesResultSuccess):
@@ -3511,7 +3514,7 @@ class FlowManager:
 
     def _variable_is_owned_by(self, name: str, flow_name: str) -> bool:
         """Return True if a flow-scoped variable with ``name`` exists directly in ``flow_name``."""
-        list_result = GriptapeNodes.handle_request(
+        list_result = self.engine.handle_request(
             ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY)
         )
         if not isinstance(list_result, ListVariablesResultSuccess):
@@ -3526,7 +3529,7 @@ class FlowManager:
 
     def _hierarchical_owning_flow_for(self, name: str, starting_flow: str) -> str | None:
         """Return the owning flow name of a variable found by hierarchical lookup, or None if not found."""
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             GetVariableRequest(name=name, lookup_scope=VariableScope.HIERARCHICAL, starting_flow=starting_flow)
         )
         if not isinstance(result, GetVariableResultSuccess):
@@ -3611,15 +3614,15 @@ class FlowManager:
         flow_name = request.flow_name
         flow = None
         if flow_name is None:
-            if GriptapeNodes.ContextManager().has_current_flow():
-                flow = GriptapeNodes.ContextManager().get_current_flow()
+            if self.engine.context_manager.has_current_flow():
+                flow = self.engine.context_manager.get_current_flow()
                 flow_name = flow.name
             else:
                 details = "Attempted to serialize a Flow to commands from the Current Context. Failed because the Current Context was empty."
                 return SerializeFlowToCommandsResultFailure(result_details=details)
         if flow is None:
             # Does this flow exist?
-            flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+            flow = self.engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
             if flow is None:
                 details = (
                     f"Attempted to serialize Flow '{flow_name}' to commands, but no Flow with that name could be found."
@@ -3631,7 +3634,7 @@ class FlowManager:
         # And track how values map into that map.
         serialized_parameter_value_tracker = SerializedParameterValueTracker()
 
-        with GriptapeNodes.ContextManager().flow(flow):
+        with self.engine.context_manager.flow(flow):
             # The base flow creation, if desired.
             if request.include_create_flow_command:
                 # Check if this flow is a referenced workflow
@@ -3663,7 +3666,7 @@ class FlowManager:
             # Now each of the child nodes in the flow.
             node_name_to_uuid = {}
             nodes_in_flow_request = ListNodesInFlowRequest()
-            nodes_in_flow_result = GriptapeNodes().handle_request(nodes_in_flow_request)
+            nodes_in_flow_result = self.engine.handle_request(nodes_in_flow_request)
             if not isinstance(nodes_in_flow_result, ListNodesInFlowResultSuccess):
                 details = (
                     f"Attempted to serialize Flow '{flow_name}'. Failed while attempting to list Nodes in the Flow."
@@ -3672,12 +3675,12 @@ class FlowManager:
 
             # Serialize each node
             for node_name in nodes_in_flow_result.node_names:
-                node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+                node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
                 if node is None:
                     details = f"Attempted to serialize Flow '{flow_name}'. Failed while attempting to serialize Node '{node_name}' within the Flow."
                     return SerializeFlowToCommandsResultFailure(result_details=details)
 
-                with GriptapeNodes.ContextManager().node(node):
+                with self.engine.context_manager.node(node):
                     # Note: the parameter value stuff is pass-by-reference, and we expect the values to be modified in place.
                     # This might be dangerous if done over the wire.
 
@@ -3687,7 +3690,7 @@ class FlowManager:
                         serialized_parameter_value_tracker=serialized_parameter_value_tracker,  # Mapping values to UUIDs,
                         include_existing_subflow_in_group=True,
                     )
-                    serialize_node_result = GriptapeNodes.handle_request(serialize_node_request)
+                    serialize_node_result = self.engine.handle_request(serialize_node_request)
                     if not isinstance(serialize_node_result, SerializeNodeToCommandsResultSuccess):
                         details = f"Attempted to serialize Flow '{flow_name}'. Failed while attempting to serialize Node '{node_name}' within the Flow."
                         return SerializeFlowToCommandsResultFailure(result_details=details)
@@ -3714,19 +3717,17 @@ class FlowManager:
 
             # Serialize sub-flows first, before creating connections.
             # We need the complete UUID map from all flows to handle cross-flow connections.
-            parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+            parent_flow = self.engine.context_manager.get_current_flow()
             parent_flow_name = parent_flow.name
             flows_in_flow_request = ListFlowsInFlowRequest(parent_flow_name=parent_flow_name)
-            flows_in_flow_result = GriptapeNodes().handle_request(flows_in_flow_request)
+            flows_in_flow_result = self.engine.handle_request(flows_in_flow_request)
             if not isinstance(flows_in_flow_result, ListFlowsInFlowResultSuccess):
                 details = f"Attempted to serialize Flow '{flow_name}'. Failed while attempting to list child Flows in the Flow."
                 return SerializeFlowToCommandsResultFailure(result_details=details)
 
             sub_flow_commands = []
             for child_flow in flows_in_flow_result.flow_names:
-                child_flow_obj = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(
-                    child_flow, ControlFlow
-                )
+                child_flow_obj = self.engine.object_manager.attempt_get_object_by_name_as_type(child_flow, ControlFlow)
                 if child_flow_obj is None:
                     details = f"Attempted to serialize Flow '{flow_name}', but no Flow with that name could be found."
                     return SerializeFlowToCommandsResultFailure(result_details=details)
@@ -3765,9 +3766,9 @@ class FlowManager:
                     sub_flow_commands.append(serialized_flow)
                 else:
                     # For standalone sub-flows, use the existing recursive serialization.
-                    with GriptapeNodes.ContextManager().flow(flow=child_flow_obj):
+                    with self.engine.context_manager.flow(flow=child_flow_obj):
                         child_flow_request = SerializeFlowToCommandsRequest()
-                        child_flow_result = GriptapeNodes().handle_request(child_flow_request)
+                        child_flow_result = self.engine.handle_request(child_flow_request)
                         if not isinstance(child_flow_result, SerializeFlowToCommandsResultSuccess):
                             details = f"Attempted to serialize parent flow '{flow_name}'. Failed while serializing child flow '{child_flow}'."
                             return SerializeFlowToCommandsResultFailure(result_details=details)
@@ -3885,8 +3886,8 @@ class FlowManager:
     def on_deserialize_flow_from_commands(self, request: DeserializeFlowFromCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915 (I am big and complicated and have a lot of negative edge-cases)
         # Do we want to create a NEW Flow to deserialize into, or use the one in the Current Context?
         if request.serialized_flow_commands.flow_initialization_command is None:
-            if GriptapeNodes.ContextManager().has_current_flow():
-                flow = GriptapeNodes.ContextManager().get_current_flow()
+            if self.engine.context_manager.has_current_flow():
+                flow = self.engine.context_manager.get_current_flow()
                 flow_name = flow.name
                 pushed_flow_context = False
                 created_new_flow = False
@@ -3896,7 +3897,7 @@ class FlowManager:
         else:
             # Issue the creation command first.
             flow_initialization_command = request.serialized_flow_commands.flow_initialization_command
-            flow_initialization_result = GriptapeNodes.handle_request(flow_initialization_command)
+            flow_initialization_result = self.engine.handle_request(flow_initialization_command)
 
             # Handle different types of creation commands
             match flow_initialization_command:
@@ -3915,11 +3916,11 @@ class FlowManager:
                     return DeserializeFlowFromCommandsResultFailure(result_details=details)
 
             # Adopt the newly-created flow as our current context.
-            flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+            flow = self.engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
             if flow is None:
                 details = f"Attempted to deserialize a serialized set of Flow Creation commands. Failed to find created flow '{flow_name}'."
                 return DeserializeFlowFromCommandsResultFailure(result_details=details)
-            GriptapeNodes.ContextManager().push_flow(flow=flow)
+            self.engine.context_manager.push_flow(flow=flow)
             pushed_flow_context = True  # Mark that we pushed this flow
             created_new_flow = True  # Mark that we created this flow
 
@@ -3971,7 +3972,7 @@ class FlowManager:
             deserialize_node_request = DeserializeNodeFromCommandsRequest(
                 serialized_node_commands=serialized_node_for_deserialization
             )
-            deserialized_node_result = GriptapeNodes.handle_request(deserialize_node_request)
+            deserialized_node_result = self.engine.handle_request(deserialize_node_request)
             if not isinstance(deserialized_node_result, DeserializeNodeFromCommandsResultSuccess):
                 details = (
                     f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a node within the flow."
@@ -4011,7 +4012,7 @@ class FlowManager:
                 target_node_name=target_node_name,
                 target_parameter_name=indirect_connection.target_parameter_name,
             )
-            create_connection_result = GriptapeNodes.handle_request(create_connection_request)
+            create_connection_result = self.engine.handle_request(create_connection_request)
             if create_connection_result.failed():
                 details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a Connection from '{source_node_name}.{indirect_connection.source_parameter_name}' to '{target_node_name}.{indirect_connection.target_parameter_name}' within the flow."
                 if created_new_flow:
@@ -4026,13 +4027,13 @@ class FlowManager:
         for node_uuid, set_value_command_list in request.serialized_flow_commands.set_parameter_value_commands.items():
             node_name = node_uuid_to_deserialized_node_result[node_uuid].node_name
             # Make this node the current context.
-            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a value assignment for node '{node_name}'."
                 if created_new_flow:
                     self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
                 return DeserializeFlowFromCommandsResultFailure(result_details=details)
-            with GriptapeNodes.ContextManager().node(node=node):
+            with self.engine.context_manager.node(node=node):
                 # Iterate through each set value command in the list for this node.
                 for indirect_set_value_command in set_value_command_list:
                     parameter_name = indirect_set_value_command.set_parameter_value_command.parameter_name
@@ -4051,7 +4052,7 @@ class FlowManager:
                     indirect_set_value_command.set_parameter_value_command.value = value
                     # Update the parameter value command to have the correct name.
                     indirect_set_value_command.set_parameter_value_command.node_name = node.name
-                    set_parameter_value_result = GriptapeNodes.handle_request(
+                    set_parameter_value_result = self.engine.handle_request(
                         indirect_set_value_command.set_parameter_value_command
                     )
                     if set_parameter_value_result.failed():
@@ -4068,7 +4069,7 @@ class FlowManager:
                 serialized_flow_commands=sub_flow_command,
                 pop_flow_context_after=True,  # Clean up child flows
             )
-            sub_flow_result = GriptapeNodes.handle_request(sub_flow_request)
+            sub_flow_result = self.engine.handle_request(sub_flow_request)
             if sub_flow_result.failed():
                 details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a sub-flow within the Flow."
                 if created_new_flow:
@@ -4077,7 +4078,7 @@ class FlowManager:
 
         # Pop flow context if requested and we pushed it
         if request.pop_flow_context_after and pushed_flow_context:
-            GriptapeNodes.ContextManager().pop_flow()
+            self.engine.context_manager.pop_flow()
 
         details = f"Successfully deserialized Flow '{flow_name}'."
         return DeserializeFlowFromCommandsResultSuccess(
@@ -4117,7 +4118,7 @@ class FlowManager:
             if self.check_for_existing_running_flow():
                 await self.cancel_flow_run()
             raise
-        GriptapeNodes.EventManager().put_event(
+        self.engine.event_manager.put_event(
             ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=[])))
         )
 
@@ -4217,7 +4218,7 @@ class FlowManager:
         if request.deserialize:
             # Deserialize the flow
             deserialize_request = DeserializeFlowFromCommandsRequest(serialized_flow_commands=serialized_flow_commands)
-            deserialize_result = GriptapeNodes.handle_request(deserialize_request)
+            deserialize_result = self.engine.handle_request(deserialize_request)
 
             # Validation: Check if deserialization succeeded
             if not isinstance(deserialize_result, DeserializeFlowFromCommandsResultSuccess):
@@ -4293,10 +4294,10 @@ class FlowManager:
         self._global_dag_builder.clear()
         logger.debug("Cancelling flow run")
 
-        GriptapeNodes.EventManager().put_event(
+        self.engine.event_manager.put_event(
             ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=[])))
         )
-        GriptapeNodes.EventManager().put_event(
+        self.engine.event_manager.put_event(
             ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=ControlFlowCancelledEvent()))
         )
 
@@ -4383,7 +4384,7 @@ class FlowManager:
             self._global_dag_builder.add_node_with_dependencies(node, node.name)
             # Emit involved nodes update after adding node to DAG
             involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))
                 )
@@ -4402,7 +4403,7 @@ class FlowManager:
             resolution_machine.context.dag_builder = self._global_dag_builder
 
             # In SEQUENTIAL mode, show all flow nodes as involved. In PARALLEL mode, show only DAG nodes.
-            execution_type = GriptapeNodes.ConfigManager().get_config_value(
+            execution_type = self.engine.config_manager.get_config_value(
                 "workflow_execution_mode", default=WorkflowExecutionMode.SEQUENTIAL
             )
             if execution_type == WorkflowExecutionMode.SEQUENTIAL:
@@ -4411,7 +4412,7 @@ class FlowManager:
                 involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
             # Send a InvolvedNodesRequest
 
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=involved_nodes))
                 )
@@ -4431,7 +4432,7 @@ class FlowManager:
                 logger.error("Node '%s' failed: %s", node.name, error_message)
                 self._global_single_node_resolution = False
                 self._global_control_flow_machine.context.current_nodes = []
-                GriptapeNodes.EventManager().put_event(
+                self.engine.event_manager.put_event(
                     ExecutionGriptapeNodeEvent(
                         wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=[]))
                     )
@@ -4442,7 +4443,7 @@ class FlowManager:
             if resolution_machine.is_complete():
                 self._global_single_node_resolution = False
                 self._global_control_flow_machine.context.current_nodes = []
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=InvolvedNodesEvent(involved_nodes=[])))
             )
 
@@ -4562,7 +4563,7 @@ class FlowManager:
         # the classifier stays scope-agnostic and is shared with isolated subflow execution.
         self._global_flow_queue.queue.clear()
 
-        all_flows = GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow)
+        all_flows = self.engine.object_manager.get_filtered_subset(type=ControlFlow)
         scope_nodes: list[BaseNode] = []
         for current_flow in all_flows.values():
             if self.is_referenced_workflow(current_flow):

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -61,6 +61,7 @@ from griptape_nodes.node_library.library_validation import (
     detect_retired_node_declarations,
     validate_library_declarations,
 )
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
     AppInitializationComplete,
     AppSessionStartedEvent,
@@ -194,7 +195,6 @@ from griptape_nodes.retained_mode.events.resource_events import (
     ListCompatibleResourceInstancesResultSuccess,
 )
 from griptape_nodes.retained_mode.events.worker_events import StartWorkerRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     AuthorizationCheckpoint,
     CheckpointAction,
@@ -286,6 +286,7 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import Payload, RequestPayload, ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
@@ -411,7 +412,7 @@ class LibraryVenvInitResult(NamedTuple):
     reused: bool
 
 
-class LibraryManager:
+class LibraryManager(EngineScoped):
     SANDBOX_LIBRARY_NAME = "Sandbox Library"
     # Prefix for the stable, deterministic module namespaces that library node files are
     # importable under. Anything under this prefix is a dynamically loaded library module
@@ -574,7 +575,11 @@ class LibraryManager:
     # Callbacks invoked immediately before all libraries are reloaded.
     _pre_reload_callbacks: list[Callable[[], Awaitable[None]]]
 
-    def __init__(self, event_manager: EventManager, *, worker_manager: WorkerManager) -> None:
+    def __init__(
+        self, event_manager: EventManager, *, worker_manager: WorkerManager, engine: Engine | None = None
+    ) -> None:
+        super().__init__(engine)
+        self._worker_manager = worker_manager
         self._library_file_path_to_info = {}
         self._dynamic_to_stable_module_mapping = {}
         self._stable_to_dynamic_module_mapping = {}
@@ -759,7 +764,7 @@ class LibraryManager:
         if library_name:
             library_info = self.get_library_info_by_library_name(library_name)
             if library_info and library_info.requires_worker:
-                wm = GriptapeNodes.WorkerManager()
+                wm = self._worker_manager
                 if wm:
                     worker = wm.get_worker_for_key(library_name)
                     if worker:
@@ -788,7 +793,7 @@ class LibraryManager:
                 library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
                 # Create (or reset) the worker_ready event for this spawn.
                 library_info.worker_ready = asyncio.Event()
-                await GriptapeNodes.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
+                await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
         """Called when a worker is evicted by the orchestrator heartbeat monitor.
@@ -1436,7 +1441,7 @@ class LibraryManager:
                 icon="Folder",
             )
 
-            engine_version = GriptapeNodes().handle_engine_version_request(request=GetEngineVersionRequest())
+            engine_version = self.engine.handle_engine_version_request(request=GetEngineVersionRequest())
             if not isinstance(engine_version, GetEngineVersionResultSuccess):
                 details = "Could not get engine version for sandbox library generation."
                 return LoadLibraryMetadataFromFileResultFailure(
@@ -1609,7 +1614,7 @@ class LibraryManager:
         Returns:
             Path to sandbox directory if configured and exists, None otherwise.
         """
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         sandbox_library_subdir = config_mgr.get_config_value("sandbox_library_directory")
         if not sandbox_library_subdir:
             return None
@@ -2256,7 +2261,7 @@ class LibraryManager:
 
                         # Download and install any griptape libraries this library depends on.
                         if griptape_library_deps:
-                            config_mgr = GriptapeNodes.ConfigManager()
+                            config_mgr = self.engine.config_manager
                             install_behavior = config_mgr.get_config_value(
                                 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
                                 default=LibraryDependencyInstallBehavior.ALWAYS,
@@ -2436,7 +2441,7 @@ class LibraryManager:
                             and library_info.library_name
                         ):
                             node_schemas = await self._serialize_library_node_schemas(library_info.library_name)
-                            await GriptapeNodes.abroadcast_app_event(
+                            await self.engine.abroadcast_app_event(
                                 LibraryLoadedNotification(
                                     library_name=library_info.library_name,
                                     fitness=library_info.fitness,
@@ -2524,19 +2529,19 @@ class LibraryManager:
             return []
 
         problems: list[LibraryProblem] = []
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         for library_data_setting in library_data.settings:
             get_category_request = GetConfigCategoryRequest(
                 category=library_data_setting.category,
                 failure_log_level=logging.DEBUG,
             )
-            get_category_result = GriptapeNodes.handle_request(get_category_request)
+            get_category_result = self.engine.handle_request(get_category_request)
             if not isinstance(get_category_result, GetConfigCategoryResultSuccess):
                 # Create new category
                 create_new_category_request = SetConfigCategoryRequest(
                     category=library_data_setting.category, contents=library_data_setting.contents
                 )
-                create_new_category_result = GriptapeNodes.handle_request(create_new_category_request)
+                create_new_category_result = self.engine.handle_request(create_new_category_request)
                 if not isinstance(create_new_category_result, SetConfigCategoryResultSuccess):
                     problems.append(CreateConfigCategoryProblem(category_name=library_data_setting.category))
                     details = f"Failed attempting to create new config category '{library_data_setting.category}' for library '{library_data.name}'."
@@ -2570,7 +2575,7 @@ class LibraryManager:
             set_category_request = SetConfigCategoryRequest(
                 category=library_data_setting.category, contents=existing_category_contents
             )
-            set_category_result = GriptapeNodes.handle_request(set_category_request)
+            set_category_result = self.engine.handle_request(set_category_request)
             if not isinstance(set_category_result, SetConfigCategoryResultSuccess):
                 problems.append(UpdateConfigCategoryProblem(category_name=library_data_setting.category))
                 details = f"Failed attempting to update config category '{library_data_setting.category}' for library '{library_data.name}'."
@@ -2603,7 +2608,7 @@ class LibraryManager:
                 )
             elif self._can_write_to_venv_location(library_python_venv_path):
                 # Check disk space before installing dependencies
-                config_manager = GriptapeNodes.ConfigManager()
+                config_manager = self.engine.config_manager
                 min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
                 if not OSManager.check_available_disk_space(Path(venv_path), min_space_gb):
                     error_msg = OSManager.format_disk_space_error(Path(venv_path))
@@ -2642,7 +2647,7 @@ class LibraryManager:
 
         library_path = str(files(package_name).joinpath(request.library_config_name))
 
-        register_result = await GriptapeNodes.ahandle_request(RegisterLibraryFromFileRequest(file_path=library_path))
+        register_result = await self.engine.ahandle_request(RegisterLibraryFromFileRequest(file_path=library_path))
         if isinstance(register_result, RegisterLibraryFromFileResultFailure):
             details = f"Attempted to install library '{request.requirement_specifier}'. Failed due to {register_result}"
             return RegisterLibraryFromRequirementSpecifierResultFailure(result_details=details)
@@ -2686,7 +2691,7 @@ class LibraryManager:
                 raise RuntimeError(msg) from e
 
         # Check disk space before creating virtual environment
-        config_manager = GriptapeNodes.ConfigManager()
+        config_manager = self.engine.config_manager
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
         if not OSManager.check_available_disk_space(library_venv_path.parent, min_space_gb):
             error_msg = OSManager.format_disk_space_error(library_venv_path.parent)
@@ -2739,7 +2744,7 @@ class LibraryManager:
                 requirements=os_requirements,
                 include_locked=True,
             )
-            result = GriptapeNodes.handle_request(list_request)
+            result = self.engine.handle_request(list_request)
 
             if isinstance(result, ListCompatibleResourceInstancesResultSuccess) and not result.instance_ids:
                 system_capabilities = self._get_system_capabilities()
@@ -2760,7 +2765,7 @@ class LibraryManager:
                 requirements=compute_requirements,
                 include_locked=True,
             )
-            result = GriptapeNodes.handle_request(list_request)
+            result = self.engine.handle_request(list_request)
 
             if isinstance(result, ListCompatibleResourceInstancesResultSuccess) and not result.instance_ids:
                 system_capabilities = self._get_system_capabilities()
@@ -2790,11 +2795,11 @@ class LibraryManager:
             requirements=None,
             include_locked=True,
         )
-        os_result = GriptapeNodes.handle_request(os_list_request)
+        os_result = self.engine.handle_request(os_list_request)
 
         if isinstance(os_result, ListCompatibleResourceInstancesResultSuccess) and os_result.instance_ids:
             status_request = GetResourceInstanceStatusRequest(instance_id=os_result.instance_ids[0])
-            status_result = GriptapeNodes.handle_request(status_request)
+            status_result = self.engine.handle_request(status_request)
             if isinstance(status_result, GetResourceInstanceStatusResultSuccess):
                 capabilities.update(status_result.status.capabilities)
 
@@ -2803,11 +2808,11 @@ class LibraryManager:
             requirements=None,
             include_locked=True,
         )
-        compute_result = GriptapeNodes.handle_request(compute_list_request)
+        compute_result = self.engine.handle_request(compute_list_request)
 
         if isinstance(compute_result, ListCompatibleResourceInstancesResultSuccess) and compute_result.instance_ids:
             status_request = GetResourceInstanceStatusRequest(instance_id=compute_result.instance_ids[0])
-            status_result = GriptapeNodes.handle_request(status_request)
+            status_result = self.engine.handle_request(status_request)
             if isinstance(status_result, GetResourceInstanceStatusResultSuccess):
                 capabilities.update(status_result.status.capabilities)
 
@@ -2889,7 +2894,9 @@ class LibraryManager:
 
     def unload_library_from_registry_request(self, request: UnloadLibraryFromRegistryRequest) -> ResultPayload:
         try:
-            LibraryRegistry.unregister_library(library_name=request.library_name)
+            LibraryRegistry.unregister_library(
+                library_name=request.library_name, event_manager=self.engine.event_manager
+            )
         except Exception as e:
             details = f"Attempted to unload library '{request.library_name}'. Failed due to {e}"
             return UnloadLibraryFromRegistryResultFailure(result_details=details)
@@ -3018,7 +3025,7 @@ class LibraryManager:
                 len(library_data.widgets),
             )
             # Get the static server base URL for constructing absolute bundle URLs
-            static_server_base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+            static_server_base_url = self.engine.static_files_manager.static_server_base_url
             # Get the library directory so we can hash each bundle file
             library_info_for_path = self.get_library_info_by_library_name(request.library)
             library_dir = Path(library_info_for_path.library_path).parent if library_info_for_path is not None else None
@@ -3257,8 +3264,7 @@ class LibraryManager:
             current = current.__cause__
         return current
 
-    @staticmethod
-    def _check_engine_version_compatibility(required_engine_version: str) -> tuple[bool, str]:
+    def _check_engine_version_compatibility(self, required_engine_version: str) -> tuple[bool, str]:
         """Check if a required engine version is compatible with the current engine.
 
         Args:
@@ -3269,7 +3275,7 @@ class LibraryManager:
             is_compatible is True if required_engine_version <= current_engine_version.
             If version comparison fails, returns (True, current_engine_version) to allow the operation.
         """
-        engine_version_result = GriptapeNodes.handle_request(GetEngineVersionRequest())
+        engine_version_result = self.engine.handle_request(GetEngineVersionRequest())
         if not isinstance(engine_version_result, GetEngineVersionResultSuccess):
             logger.warning("Failed to get engine version for compatibility check, allowing operation to proceed")
             return True, ""
@@ -3465,7 +3471,7 @@ class LibraryManager:
             if pre_register_info and pre_register_info.library_name
             else Path(lib_path).stem
         )
-        GriptapeNodes.EventManager().put_event(
+        self.engine.event_manager.put_event(
             AppEvent(
                 payload=EngineInitializationProgress(
                     phase=InitializationPhase.LIBRARIES,
@@ -3492,7 +3498,7 @@ class LibraryManager:
                 if isinstance(load_result.result_details, ResultDetails)
                 else str(load_result.result_details)
             )
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 AppEvent(
                     payload=EngineInitializationProgress(
                         phase=InitializationPhase.LIBRARIES,
@@ -3506,7 +3512,7 @@ class LibraryManager:
                 )
             )
         elif isinstance(load_result, RegisterLibraryFromFileResultSuccess):
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 AppEvent(
                     payload=EngineInitializationProgress(
                         phase=InitializationPhase.LIBRARIES,
@@ -3603,7 +3609,7 @@ class LibraryManager:
         library pin or engine_version, so it gets the same plan + gate. A non-loaded
         file-backed project (or one with no adjacent config dir) is a Failure.
         """
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
 
         # System defaults is a synthetic id, not a path, so match it verbatim before
         # any canonicalization (mirroring on_set_current_project_request). Its activation
@@ -3612,7 +3618,7 @@ class LibraryManager:
         if request.project_id == SYSTEM_DEFAULTS_KEY:
             merged = config_mgr.compute_system_defaults_provisioning_config()
         else:
-            dirs = await GriptapeNodes.ProjectManager().resolve_provisioning_config_dirs(request.project_id)
+            dirs = await self.engine.project_manager.resolve_provisioning_config_dirs(request.project_id)
             if dirs is None:
                 return PreviewProjectProvisioningResultFailure(
                     result_details=f"Attempted to preview provisioning for project '{request.project_id}'. "
@@ -3637,9 +3643,7 @@ class LibraryManager:
         # (a layer may re-point it); only the base dir is the shared global workspace.
         libraries_root = None
         if request.project_id != SYSTEM_DEFAULTS_KEY:
-            libraries_root = await GriptapeNodes.ProjectManager().resolve_libraries_root_for_project_id(
-                request.project_id
-            )
+            libraries_root = await self.engine.project_manager.resolve_libraries_root_for_project_id(request.project_id)
         if libraries_root is not None:
             libraries_path = libraries_root
         else:
@@ -3679,7 +3683,7 @@ class LibraryManager:
         if engine_version_failure is not None:
             return [engine_version_failure]
 
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         raw_libraries = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
         downloads = normalize_library_downloads(raw_libraries)
 
@@ -3697,7 +3701,7 @@ class LibraryManager:
         Reads the merged `requires_engine` config key and delegates the PEP 440
         compare to `engine_version_failure_detail`. No key means no constraint.
         """
-        spec_string = GriptapeNodes.ConfigManager().get_config_value(REQUIRES_ENGINE_KEY, default=None)
+        spec_string = self.engine.config_manager.get_config_value(REQUIRES_ENGINE_KEY, default=None)
         return engine_version_failure_detail(spec_string)
 
     async def _plan_one_library_provisioning(
@@ -3716,7 +3720,7 @@ class LibraryManager:
         The preview passes it so the installed-version probe reads the workspace
         the switch would land in, not the currently-active one; activation runs
         after the config layers switch, so its reconcile leaves this None and
-        resolves from the (now-target) live config.
+        resolves from this engine's (now-target) live config.
 
         `destructive` is True ONLY for a git OVERWRITE, matching the
         `overwrite_existing = installed_version is not None` decision in
@@ -3728,6 +3732,9 @@ class LibraryManager:
         handler lands it, so a `version` pin is enforced without requiring `name`.
         The action's `library_name` falls back to the repo name for display.
         """
+        if libraries_path is None:
+            libraries_path = self.engine.config_manager.resolved_libraries_root()
+
         library_name = download.name if download.name is not None else extract_repo_name_from_url(download.git_url)
         installed_version = await self._installed_download_version(download, libraries_path)
         parsed = parse_git_url_with_ref(download.git_url)
@@ -3808,7 +3815,9 @@ class LibraryManager:
         download_directory: str | None = None
         target_directory_name: str | None = None
         if overwrite_existing and download.name is not None:
-            manifest_path = await self._installed_library_manifest_path(download.name)
+            manifest_path = await self._installed_library_manifest_path(
+                download.name, self.engine.config_manager.resolved_libraries_root()
+            )
             if manifest_path is not None:
                 download_directory = str(manifest_path.parent.parent)
                 target_directory_name = manifest_path.parent.name
@@ -3822,14 +3831,14 @@ class LibraryManager:
             download_directory=download_directory,
             target_directory_name=target_directory_name,
         )
-        download_result = await GriptapeNodes.ahandle_request(download_request)
+        download_result = await self.engine.ahandle_request(download_request)
         if not isinstance(download_result, DownloadLibraryResultSuccess):
             library_label = download.name if download.name is not None else extract_repo_name_from_url(git_url)
             return f"Failed to provision library '{library_label}' from '{git_url}': {download_result.result_details}"
         return None
 
     @staticmethod
-    async def _installed_library_manifest_path(library_name: str, libraries_path: Path | None = None) -> Path | None:
+    async def _installed_library_manifest_path(library_name: str, libraries_path: Path) -> Path | None:
         """Return the on-disk manifest path for a provisioned library by name, or None.
 
         Scans the manifests under `libraries_directory` (where reconcile clones
@@ -3841,9 +3850,9 @@ class LibraryManager:
         manifest matches.
 
         `libraries_path` lets the provisioning preview probe the TARGET project's
-        libraries directory rather than the live one. When None it resolves from
-        the live config, which is correct for the real reconcile (it runs after
-        activation has switched the config layers to the target).
+        libraries directory rather than the live one; the real reconcile passes
+        the live config's resolved libraries root (it runs after activation has
+        switched the config layers to the target).
 
         This is the single source of truth for the provisioning planner
         (`_installed_library_version`, which decides SKIP/INSTALL/OVERWRITE) and
@@ -3851,9 +3860,6 @@ class LibraryManager:
         directory before re-cloning), guaranteeing the file the planner reasoned
         about is exactly the file overwrite targets.
         """
-        if libraries_path is None:
-            libraries_path = GriptapeNodes.ConfigManager().resolved_libraries_root()
-
         for manifest_path in await find_files_recursive(libraries_path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN):
             try:
                 content = manifest_path.read_text(encoding="utf-8")
@@ -3866,20 +3872,18 @@ class LibraryManager:
         return None
 
     @staticmethod
-    async def _installed_library_version(library_name: str) -> str | None:
+    async def _installed_library_version(library_name: str, libraries_path: Path) -> str | None:
         """Return the on-disk version of a library by manifest name, or None when absent.
 
         Locates the provisioned manifest via `_installed_library_manifest_path`
         (the shared resolver), then reads `metadata.library_version`. None when no
         manifest matches or the version is absent/unreadable.
         """
-        manifest_path = await LibraryManager._installed_library_manifest_path(library_name)
+        manifest_path = await LibraryManager._installed_library_manifest_path(library_name, libraries_path)
         return LibraryManager._library_version_from_manifest(manifest_path)
 
     @staticmethod
-    async def _installed_manifest_path_for_download(
-        download: LibraryDownload, libraries_path: Path | None = None
-    ) -> Path | None:
+    async def _installed_manifest_path_for_download(download: LibraryDownload, libraries_path: Path) -> Path | None:
         """Return the on-disk manifest path for a download entry, or None when absent.
 
         Locates the installed copy the same way the download handler lands it:
@@ -3891,27 +3895,25 @@ class LibraryManager:
         the directory is unconfigured/missing or no manifest is found.
 
         `libraries_path` lets the provisioning preview probe the TARGET project's
-        libraries directory; when None it resolves from the live config (correct
-        for the real reconcile, which runs post-activation).
+        libraries directory; the real reconcile passes the live config's resolved
+        libraries root (correct post-activation).
         """
         if download.name is not None:
             return await LibraryManager._installed_library_manifest_path(download.name, libraries_path)
-
-        if libraries_path is None:
-            libraries_path = GriptapeNodes.ConfigManager().resolved_libraries_root()
 
         repo_name = extract_repo_name_from_url(download.git_url)
         repo_directory = libraries_path / repo_name
         return find_file_in_directory(repo_directory, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN)
 
     @staticmethod
-    async def _installed_download_version(download: LibraryDownload, libraries_path: Path | None = None) -> str | None:
+    async def _installed_download_version(download: LibraryDownload, libraries_path: Path) -> str | None:
         """Return the on-disk version for a download entry, or None when absent.
 
         Resolves the installed manifest via `_installed_manifest_path_for_download`
         (repo-name directory, or `name` override), then reads
         `metadata.library_version`. `libraries_path` threads the TARGET project's
-        libraries directory through for the preview; None resolves from live config.
+        libraries directory through for the preview, or the live config's
+        resolved root for the real reconcile.
         """
         manifest_path = await LibraryManager._installed_manifest_path_for_download(download, libraries_path)
         return LibraryManager._library_version_from_manifest(manifest_path)
@@ -3964,7 +3966,7 @@ class LibraryManager:
         Supports URL format with @ref suffix (e.g., "https://github.com/user/repo@stable").
         Libraries are registered later by load_all_libraries_from_config().
         """
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         raw_downloads = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
         git_urls = [download.git_url for download in normalize_library_downloads(raw_downloads)]
 
@@ -4016,7 +4018,7 @@ class LibraryManager:
                 }
             }
         """
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         libraries_path = config_mgr.resolved_libraries_root()
 
         async def download_one(git_url_with_ref: str) -> tuple[str, dict[str, Any]]:
@@ -4037,7 +4039,7 @@ class LibraryManager:
                 }
 
             logger.info("Downloading library from '%s'", git_url_with_ref)
-            download_result = await GriptapeNodes.ahandle_request(
+            download_result = await self.engine.ahandle_request(
                 DownloadLibraryRequest(
                     git_url=git_url,
                     branch_tag_commit=ref,
@@ -4081,11 +4083,11 @@ class LibraryManager:
     async def _run_app_initialization(self, payload: AppInitializationComplete) -> None:
         if payload.skip_library_loading:
             # Register all secrets even in headless mode
-            GriptapeNodes.SecretsManager().register_all_secrets()
+            self.engine.secrets_manager.register_all_secrets()
 
             # Still need to tell WorkflowManager to register workflows
             # Pass the specific workflows if provided, otherwise it will scan workspace
-            await GriptapeNodes.WorkflowManager().refresh_workflow_registry(
+            await self.engine.workflow_manager.refresh_workflow_registry(
                 workflows_to_register=payload.workflows_to_register
             )
             return
@@ -4121,20 +4123,20 @@ class LibraryManager:
         # when AppStartSessionRequest arrives and will finish before the user can open a
         # workflow. Awaiting here on fresh boot would wait the full worker-startup grace
         # period for workers that haven't started yet.
-        if GriptapeNodes.get_session_id():
+        if self.engine.get_session_id():
             await self._await_pending_workers()
 
         # Register all secrets now that libraries are loaded and settings are merged
-        GriptapeNodes.SecretsManager().register_all_secrets()
+        self.engine.secrets_manager.register_all_secrets()
 
         # We have to load all libraries before we attempt to load workflows.
 
         # This will (attempts to) load all workflows specified by LIBRARIES. User workflows are loaded later.
         library_workflow_files_to_register = await self._collect_library_workflow_files()
-        await GriptapeNodes.WorkflowManager().register_list_of_workflows(library_workflow_files_to_register)
+        await self.engine.workflow_manager.register_list_of_workflows(library_workflow_files_to_register)
 
         # Go tell the Workflow Manager that it's turn is now.
-        await GriptapeNodes.WorkflowManager().refresh_workflow_registry()
+        await self.engine.workflow_manager.refresh_workflow_registry()
 
         # Signal readiness so the application layer can render its library status
         # table and "engine ready" banner, and other consumers (the GUI, the
@@ -4143,7 +4145,7 @@ class LibraryManager:
         # owned by the app, not the engine. The library statuses reflect real
         # fitness because workers have already reported back above.
         if not self._is_worker:
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 AppEvent(
                     payload=EngineReadyEvent(
                         libraries=self._collect_library_load_statuses(),
@@ -4159,7 +4161,7 @@ class LibraryManager:
         to sys.path so relative imports work when the workflow is loaded.
         """
         workflow_files: list[str] = []
-        library_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
+        library_result = await self.engine.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
         if not isinstance(library_result, ListRegisteredLibrariesResultSuccess):
             return workflow_files
         for library_name in library_result.libraries:
@@ -4204,9 +4206,9 @@ class LibraryManager:
         not send that request, so this method handles the case at the end of library
         initialization.
         """
-        if self._is_worker or not GriptapeNodes.get_session_id():
+        if self._is_worker or not self.engine.get_session_id():
             return
-        worker_manager = GriptapeNodes.WorkerManager()
+        worker_manager = self._worker_manager
         if worker_manager is not None:
             worker_manager.set_session_ready()
             await self._start_workers()
@@ -4231,7 +4233,7 @@ class LibraryManager:
             return
 
         if wait_seconds is None:
-            config_mgr = GriptapeNodes.ConfigManager()
+            config_mgr = self.engine.config_manager
             wait_seconds = config_mgr.get_config_value(
                 WORKER_HEARTBEAT_STARTUP_GRACE_KEY, default=600.0, cast_type=float
             )
@@ -4427,7 +4429,7 @@ class LibraryManager:
         """
         if self._is_worker:
             return False
-        return bool(GriptapeNodes.ConfigManager().get_config_value(LIBRARY_LAZY_NODE_LOADING_KEY, default=True))
+        return bool(self.engine.config_manager.get_config_value(LIBRARY_LAZY_NODE_LOADING_KEY, default=True))
 
     def _register_node_eager(
         self,
@@ -4640,7 +4642,7 @@ class LibraryManager:
                         len(handlers),
                     )
                 for request_type, handler in handlers:
-                    event_manager = GriptapeNodes.EventManager()
+                    event_manager = self.engine.event_manager
                     event_manager.assign_manager_to_request_type(request_type, handler)
                     library._registered_request_handler_types.append(request_type)
                 if handlers:
@@ -4973,7 +4975,7 @@ class LibraryManager:
             content=library_schema.model_dump_json(indent=2),
             encoding="utf-8",
         )
-        write_result = GriptapeNodes.handle_request(write_request)
+        write_result = self.engine.handle_request(write_request)
 
         if write_result.failed():
             logger.error("Failed to write library schema to '%s': %s", json_path, write_result.result_details)
@@ -5004,7 +5006,7 @@ class LibraryManager:
         if is_incompatible or not registered_path:
             return manifest_default
 
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         raw_entries = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY) or []
         target_path_lower = registered_path.lower()
         for entry in raw_entries:
@@ -5033,7 +5035,7 @@ class LibraryManager:
 
     def _remove_missing_libraries_from_config(self, config_category: str) -> None:
         # Now remove all libraries that were missing from the user's config.
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         libraries_to_register_category = config_mgr.get_config_value(config_category)
 
         paths_to_remove = set()
@@ -5059,7 +5061,7 @@ class LibraryManager:
         the libraries are re-downloaded. This migration happens automatically on app startup,
         so users don't need to run gtn init.
         """
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
 
         # Get both config lists
         register_key = LIBRARIES_TO_REGISTER_KEY
@@ -5156,14 +5158,14 @@ class LibraryManager:
     async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
         # Start with a clean slate.
         clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
-        clear_all_result = await GriptapeNodes.ahandle_request(clear_all_request)
+        clear_all_result = await self.engine.ahandle_request(clear_all_request)
         if not clear_all_result.succeeded():
             details = "Failed to clear the existing object state when preparing to reload all libraries."
             return ReloadAllLibrariesResultFailure(result_details=details)
 
         # Unload all libraries now.
         all_libraries_request = ListRegisteredLibrariesRequest(broadcast_result=False)
-        all_libraries_result = await GriptapeNodes.ahandle_request(all_libraries_request)
+        all_libraries_result = await self.engine.ahandle_request(all_libraries_request)
         if not isinstance(all_libraries_result, ListRegisteredLibrariesResultSuccess):
             details = "When preparing to reload all libraries, failed to get registered libraries."
             logger.error(details)
@@ -5171,7 +5173,7 @@ class LibraryManager:
 
         for library_name in all_libraries_result.libraries:
             unload_library_request = UnloadLibraryFromRegistryRequest(library_name=library_name)
-            unload_library_result = GriptapeNodes.handle_request(unload_library_request)
+            unload_library_result = self.engine.handle_request(unload_library_request)
             if not unload_library_result.succeeded():
                 details = f"When preparing to reload all libraries, failed to unload library '{library_name}'."
                 logger.error(details)
@@ -5201,7 +5203,7 @@ class LibraryManager:
         # fitness now that workers have reported back. is_initial_start=False so the app
         # refreshes the table without re-showing the startup banner. Orchestrator only.
         if not self._is_worker:
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 AppEvent(
                     payload=EngineReadyEvent(
                         libraries=self._collect_library_load_statuses(),
@@ -5382,7 +5384,7 @@ class LibraryManager:
         problems: list[LibraryProblem] = []
 
         # Check for version-based compatibility issues
-        version_issues = GriptapeNodes.VersionCompatibilityManager().check_library_version_compatibility(schema)
+        version_issues = self.engine.version_compatibility_manager.check_library_version_compatibility(schema)
         has_disqualifying_issues = False
 
         for issue in version_issues:
@@ -5402,7 +5404,7 @@ class LibraryManager:
         # stage. A denial is rendered as a fitness problem and marks the library
         # UNUSABLE, so it is not registered and the GUI shows every missing
         # permission on the failure icon. With no hook installed this allows.
-        denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+        denial = self.engine.event_manager.evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.LOAD_LIBRARY,
                 subject_type=CheckpointSubjectType.LIBRARY,
@@ -5425,7 +5427,9 @@ class LibraryManager:
         # without blocking the library, which stays usable for its permitted nodes.
         # Instantiating a denied node later substitutes an Error Proxy via the same
         # checkpoint. Runs on the schema, so no library module is imported here.
-        node_denials = GriptapeNodes.NodeManager().evaluate_schema_node_instantiation_denials(schema)
+        node_denials = self.engine.node_manager.evaluate_schema_node_instantiation_denials(
+            schema, event_manager=self.engine.event_manager
+        )
         for node_type, node_denial in node_denials.items():
             problems.append(NodePermissionDeniedProblem(node_type=node_type, messages=node_denial.messages()))
 
@@ -5505,7 +5509,7 @@ class LibraryManager:
                 if pre_register_info and pre_register_info.library_name
                 else Path(lib_path).stem
             )
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 AppEvent(
                     payload=EngineInitializationProgress(
                         phase=InitializationPhase.LIBRARIES,
@@ -5541,7 +5545,7 @@ class LibraryManager:
                 loaded_count += 1
 
                 # Emit success event
-                GriptapeNodes.EventManager().put_event(
+                self.engine.event_manager.put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
                             phase=InitializationPhase.LIBRARIES,
@@ -5563,7 +5567,7 @@ class LibraryManager:
                     if isinstance(load_result.result_details, ResultDetails)
                     else str(load_result.result_details)
                 )
-                GriptapeNodes.EventManager().put_event(
+                self.engine.event_manager.put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
                             phase=InitializationPhase.LIBRARIES,
@@ -5597,7 +5601,7 @@ class LibraryManager:
             workspace resolution). Directory entries expand to one entry per discovered
             library file; every child inherits the parent's `registered_path`.
         """
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         user_libraries_section = LIBRARIES_TO_REGISTER_KEY
 
         discovered_entries: list[LibraryManager.DiscoveredLibraryEntry] = []
@@ -5641,7 +5645,9 @@ class LibraryManager:
         # libraries_to_register config (which would leak it into every project).
         download_libraries = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
         for download in normalize_library_downloads(download_libraries):
-            manifest_path = await self._installed_manifest_path_for_download(download)
+            manifest_path = await self._installed_manifest_path_for_download(
+                download, config_mgr.resolved_libraries_root()
+            )
             if manifest_path is not None:
                 await process_path(manifest_path, enabled=True, registered_path=str(manifest_path))
 
@@ -5666,7 +5672,7 @@ class LibraryManager:
 
     def _read_minimum_release_age_config(self) -> MinimumReleaseAgeConfig:
         """Read the minimum-release-age setting once. Centralizes the key literal and default handling."""
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         # get_config_value returns None for an explicit `null` override (it bypasses both cast_type
         # and the default in that case), so coalesce None back to the default here to keep the gate
         # fail-open rather than raising when float(None) is attempted.
@@ -5996,7 +6002,7 @@ class LibraryManager:
             On failure: ResultPayloadFailure instance
         """
         # Unload the library
-        unload_result = GriptapeNodes.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name))
+        unload_result = self.engine.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name))
         if not unload_result.succeeded():
             details = f"Failed to unload Library '{library_name}' after git operation."
             return failure_result_class(result_details=details)
@@ -6042,7 +6048,7 @@ class LibraryManager:
         self._library_file_path_to_info[actual_library_file_path] = lib_info
 
         # Reload the library from file
-        reload_result = await GriptapeNodes.ahandle_request(
+        reload_result = await self.engine.ahandle_request(
             RegisterLibraryFromFileRequest(file_path=actual_library_file_path)
         )
         if not isinstance(reload_result, RegisterLibraryFromFileResultSuccess):
@@ -6236,7 +6242,7 @@ class LibraryManager:
         download_directory = request.download_directory
 
         # Determine the parent directory for the download
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
 
         if download_directory is not None:
             # Use custom download directory if provided
@@ -6264,7 +6270,7 @@ class LibraryManager:
             if request.overwrite_existing:
                 # Delete existing directory before cloning
                 delete_request = DeleteFileRequest(path=str(target_path), workspace_only=False)
-                delete_result = await GriptapeNodes.ahandle_request(delete_request)
+                delete_result = await self.engine.ahandle_request(delete_request)
 
                 if isinstance(delete_result, DeleteFileResultFailure):
                     details = f"Cannot delete existing directory at {target_path}: {delete_result.result_details}"
@@ -6333,7 +6339,7 @@ class LibraryManager:
             self._library_file_path_to_info[str(library_json_path)] = lib_info
 
             register_request = RegisterLibraryFromFileRequest(file_path=str(library_json_path))
-            register_result = await GriptapeNodes.ahandle_request(register_request)
+            register_result = await self.engine.ahandle_request(register_request)
             if not register_result.succeeded():
                 return DownloadLibraryResultFailure(
                     result_details=f"Library '{library_name}' downloaded but failed to register: {register_result.result_details}"
@@ -6414,7 +6420,7 @@ class LibraryManager:
             return InstallLibraryDependenciesResultFailure(result_details=details)
 
         # Check disk space
-        config_manager = GriptapeNodes.ConfigManager()
+        config_manager = self.engine.config_manager
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
         if not OSManager.check_available_disk_space(Path(venv_path), min_space_gb):
             error_msg = OSManager.format_disk_space_error(Path(venv_path))
@@ -6563,7 +6569,7 @@ class LibraryManager:
     async def sync_libraries_request(self, request: SyncLibrariesRequest) -> ResultPayload:  # noqa: C901, PLR0912, PLR0915
         """Sync all libraries to latest versions and ensure dependencies are installed."""
         # Phase 1: Download missing libraries from both config keys
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
 
         # Collect git URLs from both config keys
         download_config = config_mgr.get_config_value(LIBRARIES_TO_DOWNLOAD_KEY, default=[])
@@ -6600,7 +6606,7 @@ class LibraryManager:
         # Phase 2: Load libraries to ensure newly downloaded ones are registered
         logger.info("Loading libraries to register newly downloaded ones")
         load_request = LoadLibrariesRequest()
-        load_result = await GriptapeNodes.ahandle_request(load_request)
+        load_result = await self.engine.ahandle_request(load_request)
 
         if not isinstance(load_result, LoadLibrariesResultSuccess):
             logger.warning("Failed to load libraries after download: %s", load_result.result_details)
@@ -6608,7 +6614,7 @@ class LibraryManager:
 
         # Phase 3: Check and update all registered libraries
         # Get all registered libraries
-        list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
+        list_result = await self.engine.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
         if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
             details = "Failed to list registered libraries for sync"
             return SyncLibrariesResultFailure(result_details=details)
@@ -6621,7 +6627,7 @@ class LibraryManager:
         async def check_library_for_update(library_name: str) -> tuple[str, ResultPayload]:
             """Check a single library for updates."""
             logger.info("Checking library '%s' for updates", library_name)
-            check_result = await GriptapeNodes.ahandle_request(
+            check_result = await self.engine.ahandle_request(
                 CheckLibraryUpdateRequest(library_name=library_name, failure_log_level=logging.DEBUG)
             )
             return library_name, check_result
@@ -6688,7 +6694,7 @@ class LibraryManager:
         async def update_library(library_name: str, old_version: str, new_version: str) -> LibraryUpdateResult:
             """Update a single library."""
             logger.info("Updating library '%s' from %s to %s", library_name, old_version, new_version)
-            update_result = await GriptapeNodes.ahandle_request(
+            update_result = await self.engine.ahandle_request(
                 UpdateLibraryRequest(
                     library_name=library_name,
                     overwrite_existing=request.overwrite_existing,

--- a/src/griptape_nodes/retained_mode/managers/manifest_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/manifest_manager.py
@@ -14,6 +14,7 @@ from griptape_nodes.common.manifests.manifest import (
     ProjectTemplateManifestEntry,
 )
 from griptape_nodes.node_library.library_declarations import ModelCatalogLibraryProperty
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
@@ -35,28 +36,30 @@ from griptape_nodes.retained_mode.events.project_events import (
     ListProjectTemplatesRequest,
     ListProjectTemplatesResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.project_events import ProjectTemplateInfo
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 logger = logging.getLogger("griptape_nodes")
 
 
-class ManifestManager:
+class ManifestManager(EngineScoped):
     """Builds manifests describing the engine's registered libraries and project templates.
 
     The manager owns no persistent state. It assembles a manifest on demand by
     querying the existing library and project registries through their events.
     """
 
-    def __init__(self, event_manager: EventManager) -> None:
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
         """Initialize the ManifestManager.
 
         Args:
             event_manager: The EventManager instance to use for event handling.
+            engine: The owning Engine, used to resolve peer managers.
         """
+        super().__init__(engine)
         event_manager.assign_manager_to_request_type(GenerateManifestRequest, self.on_generate_manifest_request)
 
     async def on_generate_manifest_request(
@@ -67,7 +70,7 @@ class ManifestManager:
         # catalog (aggregated from library declarations) is requested.
         library_names: list[str] = []
         if request.include_libraries or request.include_model_catalog:
-            list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
+            list_result = await self.engine.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
             if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
                 return GenerateManifestResultFailure(
                     result_details=f"Attempted to generate manifest. Failed to list registered libraries: {list_result.result_details}"
@@ -88,7 +91,7 @@ class ManifestManager:
             # System builtins (the always-loaded default project) are included:
             # they are real templates an engine can be working in, so consumers
             # picking from the manifest must be able to reference them.
-            projects_result = await GriptapeNodes.ahandle_request(
+            projects_result = await self.engine.ahandle_request(
                 ListProjectTemplatesRequest(include_system_builtins=True, broadcast_result=False)
             )
             if not isinstance(projects_result, ListProjectTemplatesResultSuccess):
@@ -124,7 +127,7 @@ class ManifestManager:
         """
         entries: list[LibraryManifestEntry] = []
         for name in library_names:
-            metadata_result = await GriptapeNodes.ahandle_request(
+            metadata_result = await self.engine.ahandle_request(
                 GetLibraryMetadataRequest(library=name, broadcast_result=False)
             )
             metadata = None
@@ -137,7 +140,7 @@ class ManifestManager:
                     metadata_result.result_details,
                 )
 
-            source_result = await GriptapeNodes.ahandle_request(
+            source_result = await self.engine.ahandle_request(
                 GetLibrarySourceInfoRequest(library=name, broadcast_result=False)
             )
             path = None
@@ -178,7 +181,7 @@ class ManifestManager:
         providers: dict[str, ModelProviderManifestEntry] = {}
         models: dict[str, ModelManifestEntry] = {}
         for name in library_names:
-            metadata_result = await GriptapeNodes.ahandle_request(
+            metadata_result = await self.engine.ahandle_request(
                 GetLibraryMetadataRequest(library=name, broadcast_result=False)
             )
             if not isinstance(metadata_result, GetLibraryMetadataResultSuccess):
@@ -240,14 +243,14 @@ class ManifestManager:
     def _resolve_engine_id(self) -> str | None:
         """Resolve the engine's identifier, or None when it cannot be determined."""
         try:
-            return GriptapeNodes.EngineIdentityManager().engine_id
+            return self.engine.engine_identity_manager.engine_id
         except Exception:
             logger.warning("Could not resolve engine id while generating manifest.", exc_info=True)
             return None
 
     async def _resolve_engine_version(self) -> str | None:
         """Resolve the engine version string, or None when it cannot be determined."""
-        version_result = await GriptapeNodes.ahandle_request(GetEngineVersionRequest(broadcast_result=False))
+        version_result = await self.engine.ahandle_request(GetEngineVersionRequest(broadcast_result=False))
         if isinstance(version_result, GetEngineVersionResultSuccess):
             return f"{version_result.major}.{version_result.minor}.{version_result.patch}"
         logger.warning(

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -20,6 +20,7 @@ from xdg_base_dirs import xdg_data_home
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.file import File, FileWriteError
 from griptape_nodes.node_library.library_registry import get_declared_models
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
@@ -50,7 +51,6 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultFailure,
     SearchModelsResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     AuthorizationCheckpoint,
     CheckpointAction,
@@ -62,8 +62,10 @@ from griptape_nodes.utils.async_utils import cancel_subprocess
 
 if TYPE_CHECKING:
     from griptape_nodes.node_library.library_declarations import ResolvedModel
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -228,7 +230,7 @@ def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
     return BoundModelDownloadTracker
 
 
-class ModelManager:
+class ModelManager(EngineScoped):
     """A manager for downloading models from Hugging Face Hub.
 
     This manager provides async handlers for downloading models using the Hugging Face Hub API.
@@ -236,12 +238,14 @@ class ModelManager:
     local storage management.
     """
 
-    def __init__(self, event_manager: EventManager | None = None) -> None:
+    def __init__(self, event_manager: EventManager | None = None, *, engine: Engine | None = None) -> None:
         """Initialize the ModelManager.
 
         Args:
             event_manager: The EventManager instance to use for event handling.
+            engine: The owning Engine, used to reach peer managers.
         """
+        super().__init__(engine)
         self._download_tasks = {}
         self._download_processes = {}
 
@@ -734,7 +738,9 @@ class ModelManager:
         )
 
     @staticmethod
-    def _model_checkpoint_attributes(request: DeclareModelInvocationRequest) -> dict[str, Any]:
+    def _model_checkpoint_attributes(
+        request: DeclareModelInvocationRequest, *, object_manager: ObjectManager
+    ) -> dict[str, Any]:
         """Resolve the facts a hook may gate a model invocation on.
 
         `id` is the stable catalog key the node declared -- always present, so a
@@ -748,7 +754,7 @@ class ModelManager:
         node's declared models falls back to the bare id.
         """
         attributes: dict[str, Any] = {CheckpointAttribute.ID: request.model_id}
-        resolved = ModelManager._resolve_invocation_model(request)
+        resolved = ModelManager._resolve_invocation_model(request, object_manager=object_manager)
         if resolved is not None:
             attributes[CheckpointAttribute.PROVIDER_ID] = resolved.provider_id
             if resolved.model.family:
@@ -756,7 +762,9 @@ class ModelManager:
         return attributes
 
     @staticmethod
-    def _resolve_invocation_model(request: DeclareModelInvocationRequest) -> ResolvedModel | None:
+    def _resolve_invocation_model(
+        request: DeclareModelInvocationRequest, *, object_manager: ObjectManager
+    ) -> ResolvedModel | None:
         """Resolve a declared invocation's stable catalog key to its catalog entry.
 
         The declaring node names itself, so the key resolves against that node's
@@ -768,7 +776,7 @@ class ModelManager:
         """
         if request.node_name is None:
             return None
-        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(request.node_name, BaseNode)
+        node = object_manager.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             return None
         return next(
@@ -798,12 +806,12 @@ class ModelManager:
         # gates the invocation, not just a bare-id rule. The node already opted in
         # by declaring; a denial returns a failure so the node does not invoke the
         # model.
-        denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+        denial = self.engine.event_manager.evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.INVOKE_MODEL,
                 subject_type=CheckpointSubjectType.MODEL,
                 subject_id=request.model_id,
-                attributes=self._model_checkpoint_attributes(request),
+                attributes=self._model_checkpoint_attributes(request, object_manager=self.engine.object_manager),
             )
         )
         if denial is not None:
@@ -902,7 +910,7 @@ class ModelManager:
             payload: The app initialization complete payload
         """
         # Get models to download from configuration
-        config_manager = GriptapeNodes.ConfigManager()
+        config_manager = self.engine.config_manager
         models_to_download = config_manager.get_config_value(MODELS_TO_DOWNLOAD_KEY, default=[])
 
         # Find unfinished downloads to resume

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -22,8 +22,10 @@ if TYPE_CHECKING:
 
     from griptape_nodes.node_library.library_declarations import LibraryDeclaration, NodeDeclaration
     from griptape_nodes.node_library.library_registry import LibrarySchema
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
+    from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 from griptape_nodes.exe_types.base_iterative_nodes import (
     BaseIterativeEndNode,
     BaseIterativeStartNode,
@@ -63,6 +65,7 @@ from griptape_nodes.node_library.library_declarations import (
     resolve_node_models,
 )
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.base_events import (
     EventRequest,
     ResultDetails,
@@ -228,7 +231,6 @@ from griptape_nodes.retained_mode.events.validation_events import (
     ValidateNodeDependenciesResultFailure,
     ValidateNodeDependenciesResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     AuthorizationCheckpoint,
     CheckpointAction,
@@ -304,10 +306,11 @@ class _NodeInstantiationDeniedError(Exception):
     """
 
 
-class NodeManager:
+class NodeManager(EngineScoped):
     _name_to_parent_flow_name: dict[str, str]
 
-    def __init__(self, event_manager: EventManager) -> None:
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         self._name_to_parent_flow_name = {}
 
         # Orchestrator-side: node_name → (target_request_id, worker_engine_id, worker_request_topic)
@@ -412,8 +415,8 @@ class NodeManager:
         node = self.get_node_by_name(old_name)
         # Get all connections for this node and update them.
         flow_name = self.get_node_parent_flow_by_name(old_name)
-        flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
-        connections = GriptapeNodes.FlowManager().get_connections()
+        flow = self.engine.flow_manager.get_flow_by_name(flow_name)
+        connections = self.engine.flow_manager.get_connections()
         # Get all incoming and outgoing connections and update them.
         if old_name in connections.incoming_index:
             incoming_connections = connections.incoming_index[old_name]
@@ -461,7 +464,7 @@ class NodeManager:
             node_name: The name of the node to delete
         """
         delete_node_request = DeleteNodeRequest(node_name=node_name)
-        delete_result = GriptapeNodes.handle_request(delete_node_request)
+        delete_result = self.engine.handle_request(delete_node_request)
         if delete_result.failed():
             logger.warning(
                 "Failed to clean up node '%s' after deserialization failure: %s",
@@ -603,6 +606,7 @@ class NodeManager:
         node_type: str,
         node_declarations: Sequence[NodeDeclaration],
         library_declarations: Sequence[LibraryDeclaration],
+        event_manager: EventManager,
     ) -> CheckpointDenial | None:
         """Ask any registered authorization hook whether this node type may be instantiated.
 
@@ -610,7 +614,7 @@ class NodeManager:
         instantiation path (CreateNode) and the library-load fitness preview so both
         resolve the same action and facts from whatever declarations they hold.
         """
-        return GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+        return event_manager.evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.INSTANTIATE_NODE,
                 subject_type=CheckpointSubjectType.NODE_TYPE,
@@ -625,7 +629,7 @@ class NodeManager:
 
     @staticmethod
     def _evaluate_instantiation_checkpoint(
-        *, node_type: str, specific_library_name: str | None
+        *, node_type: str, specific_library_name: str | None, event_manager: EventManager
     ) -> CheckpointDenial | None:
         """Ask any registered authorization hook whether this node type may be instantiated."""
         library = LibraryRegistry.get_library_for_node_type(node_type, specific_library_name)
@@ -633,10 +637,13 @@ class NodeManager:
             node_type=node_type,
             node_declarations=library.get_node_metadata(node_type).declarations,
             library_declarations=library.get_metadata().declarations,
+            event_manager=event_manager,
         )
 
     @staticmethod
-    def _enforce_instantiation_checkpoint(*, node_type: str, specific_library_name: str | None) -> None:
+    def _enforce_instantiation_checkpoint(
+        *, node_type: str, specific_library_name: str | None, event_manager: EventManager
+    ) -> None:
         """Raise `_NodeInstantiationDeniedError` when the policy denies this node type.
 
         Raised rather than returned so a denial joins the Error Proxy substitution
@@ -644,14 +651,16 @@ class NodeManager:
         to load. The message lists every missing permission.
         """
         denial = NodeManager._evaluate_instantiation_checkpoint(
-            node_type=node_type, specific_library_name=specific_library_name
+            node_type=node_type, specific_library_name=specific_library_name, event_manager=event_manager
         )
         if denial is not None:
             message = denial.reason(separator="\n")
             raise _NodeInstantiationDeniedError(message)
 
     @staticmethod
-    def evaluate_schema_node_instantiation_denials(schema: LibrarySchema) -> dict[str, CheckpointDenial]:
+    def evaluate_schema_node_instantiation_denials(
+        schema: LibrarySchema, *, event_manager: EventManager
+    ) -> dict[str, CheckpointDenial]:
         """Denials that would block instantiating each node type a library schema declares.
 
         Lets library-load fitness preview the node-instantiation gate without
@@ -667,6 +676,7 @@ class NodeManager:
                 node_type=node.class_name,
                 node_declarations=node.metadata.declarations,
                 library_declarations=schema.metadata.declarations,
+                event_manager=event_manager,
             )
             if denial is not None:
                 denials[node.class_name] = denial
@@ -678,17 +688,17 @@ class NodeManager:
         parent_flow = None
         if parent_flow_name is None:
             # Try to get the current context flow
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = (
                     "Attempted to create Node in the Current Context. Failed because the Current Context was empty."
                 )
                 return CreateNodeResultFailure(result_details=details)
-            parent_flow = GriptapeNodes.ContextManager().get_current_flow()
+            parent_flow = self.engine.context_manager.get_current_flow()
             parent_flow_name = parent_flow.name
 
         # Does this flow actually exist?
         if parent_flow is None:
-            flow_mgr = GriptapeNodes.FlowManager()
+            flow_mgr = self.engine.flow_manager
             try:
                 parent_flow = flow_mgr.get_flow_by_name(parent_flow_name)
             except KeyError as err:
@@ -713,7 +723,7 @@ class NodeManager:
                 # Fall back to the class name
                 requested_node_name = request.node_type
 
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
         final_node_name = obj_mgr.generate_name_for_object(
             type_name=request.node_type, requested_name=requested_node_name
         )
@@ -730,6 +740,7 @@ class NodeManager:
             self._enforce_instantiation_checkpoint(
                 node_type=request.node_type,
                 specific_library_name=request.specific_library_name,
+                event_manager=self.engine.event_manager,
             )
             node = LibraryRegistry.create_node(
                 name=final_node_name,
@@ -753,7 +764,7 @@ class NodeManager:
                         failure_reason = str(err)
                     else:
                         # Use fitness problem details if available for a more actionable error message
-                        library_metadata_result = GriptapeNodes.handle_request(
+                        library_metadata_result = self.engine.handle_request(
                             GetLibraryMetadataRequest(library=request.specific_library_name or "")
                         )
                         if (
@@ -802,7 +813,7 @@ class NodeManager:
 
         # See if we want to push this into the context of the current flow.
         if request.set_as_new_context:
-            GriptapeNodes.ContextManager().push_node(node=node)
+            self.engine.context_manager.push_node(node=node)
 
         # Success message based on whether we used Current Context or explicit flow
         if request.override_parent_flow_name is None:
@@ -833,7 +844,7 @@ class NodeManager:
                 logger.error(msg)  # while this is bad, it's not unsalvageable, so we'll consider this a success.
             else:
                 # Create the EndNode
-                end_loop = GriptapeNodes.handle_request(
+                end_loop = self.engine.handle_request(
                     CreateNodeRequest(
                         node_type=end_class_name,
                         metadata={
@@ -847,7 +858,7 @@ class NodeManager:
                     logger.error(msg)  # while this is bad, it's not unsalvageable, so we'll consider this a success.
                 else:
                     # Create Loop between output and input to the start node.
-                    GriptapeNodes.handle_request(
+                    self.engine.handle_request(
                         CreateConnectionRequest(
                             source_node_name=node.name,
                             source_parameter_name="loop",
@@ -938,12 +949,12 @@ class NodeManager:
     def _get_flow_for_node_group_operation(self, flow_name: str | None) -> AddNodesToNodeGroupResultFailure | None:
         """Get the flow for a node group operation."""
         if flow_name is None:
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = "Attempted to add node to NodeGroup in the Current Context. Failed because the Current Context was empty."
                 return AddNodesToNodeGroupResultFailure(result_details=details)
         else:
             try:
-                GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
+                self.engine.flow_manager.get_flow_by_name(flow_name)
             except KeyError as err:
                 details = (
                     f"Attempted to add node to NodeGroup. Failed when attempting to find the parent Flow. Error: {err}"
@@ -958,7 +969,7 @@ class NodeManager:
 
         Collects all errors and returns them together if multiple nodes fail.
         """
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
         nodes = []
         errors = []
 
@@ -986,7 +997,7 @@ class NodeManager:
     ) -> BaseNodeGroup | AddNodesToNodeGroupResultFailure:
         """Get the NodeGroup node."""
         try:
-            node_group = GriptapeNodes.ObjectManager().get_object_by_name(node_group_name)
+            node_group = self.engine.object_manager.get_object_by_name(node_group_name)
         except KeyError:
             details = f"Attempted to add nodes '{node_names}' to NodeGroup '{node_group_name}'. Failed because NodeGroup was not found."
             return AddNodesToNodeGroupResultFailure(result_details=details)
@@ -1027,12 +1038,12 @@ class NodeManager:
     def _get_flow_for_remove_operation(self, flow_name: str | None) -> RemoveNodeFromNodeGroupResultFailure | None:
         """Get the flow for a remove node from group operation."""
         if flow_name is None:
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = "Attempted to remove nodes from NodeGroup in the Current Context. Failed because the Current Context was empty."
                 return RemoveNodeFromNodeGroupResultFailure(result_details=details)
         else:
             try:
-                GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
+                self.engine.flow_manager.get_flow_by_name(flow_name)
             except KeyError as err:
                 details = f"Attempted to remove nodes from NodeGroup. Failed when attempting to find the parent Flow. Error: {err}"
                 return RemoveNodeFromNodeGroupResultFailure(result_details=details)
@@ -1045,7 +1056,7 @@ class NodeManager:
 
         Collects all errors and returns them together if multiple nodes fail.
         """
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
         nodes = []
         errors = []
 
@@ -1073,7 +1084,7 @@ class NodeManager:
     ) -> BaseNodeGroup | RemoveNodeFromNodeGroupResultFailure:
         """Get the NodeGroup node for remove operation."""
         try:
-            node_group = GriptapeNodes.ObjectManager().get_object_by_name(node_group_name)
+            node_group = self.engine.object_manager.get_object_by_name(node_group_name)
         except KeyError:
             details = f"Attempted to remove nodes '{node_names}' from NodeGroup '{node_group_name}'. Failed because NodeGroup was not found."
             return RemoveNodeFromNodeGroupResultFailure(result_details=details)
@@ -1133,27 +1144,27 @@ class NodeManager:
             This method also clears the flow queue regardless of whether cancellation occurred,
             to ensure the specified node is not processed in the future.
         """
-        if GriptapeNodes.FlowManager().check_for_existing_running_flow():
+        if self.engine.flow_manager.check_for_existing_running_flow():
             # get the current node executing / resolving
             # if it's in connected nodes, cancel flow.
             # otherwise, leave it.
-            control_node_names, resolving_node_names, _ = GriptapeNodes.FlowManager().flow_state(parent_flow)
+            control_node_names, resolving_node_names, _ = self.engine.flow_manager.flow_state(parent_flow)
             connected_nodes = parent_flow.get_all_connected_nodes(node)
             cancelled = False
             if control_node_names is not None:
                 for control_node_name in control_node_names:
-                    control_node = GriptapeNodes.ObjectManager().get_object_by_name(control_node_name)
+                    control_node = self.engine.object_manager.get_object_by_name(control_node_name)
                     if control_node in connected_nodes:
-                        result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
+                        result = self.engine.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
                         cancelled = True
                         if result.failed():
                             details = f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
                             return DeleteNodeResultFailure(result_details=details)
             if resolving_node_names is not None and not cancelled:
                 for resolving_node_name in resolving_node_names:
-                    resolving_node = GriptapeNodes.ObjectManager().get_object_by_name(resolving_node_name)
+                    resolving_node = self.engine.object_manager.get_object_by_name(resolving_node_name)
                     if resolving_node in connected_nodes:
-                        result = GriptapeNodes.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
+                        result = self.engine.handle_request(CancelFlowRequest(flow_name=parent_flow_name))
                         if result.failed():
                             details = f"Attempted to delete a Node '{node.name}'. Failed because running flow could not cancel."
                             return DeleteNodeResultFailure(result_details=details)
@@ -1167,24 +1178,24 @@ class NodeManager:
         node = None
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = (
                     "Attempted to delete a Node from the Current Context. Failed because the Current Context is empty."
                 )
                 return DeleteNodeResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
         if node is None:
-            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
             details = f"Attempted to delete a Node '{node_name}', but no such Node was found."
             return DeleteNodeResultFailure(result_details=details)
 
-        with GriptapeNodes.ContextManager().node(node=node):
+        with self.engine.context_manager.node(node=node):
             parent_flow_name = self._name_to_parent_flow_name[node_name]
             try:
-                parent_flow = GriptapeNodes.FlowManager().get_flow_by_name(parent_flow_name)
+                parent_flow = self.engine.flow_manager.get_flow_by_name(parent_flow_name)
             except KeyError as err:
                 details = f"Attempted to delete a Node '{node_name}'. Error: {err}"
                 return DeleteNodeResultFailure(result_details=details)
@@ -1206,7 +1217,7 @@ class NodeManager:
                 any_connections_remain = False
 
                 list_node_connections_request = ListConnectionsForNodeRequest(node_name=node_name)
-                list_connections_result = GriptapeNodes.handle_request(request=list_node_connections_request)
+                list_connections_result = self.engine.handle_request(request=list_node_connections_request)
                 if not isinstance(list_connections_result, ListConnectionsForNodeResultSuccess):
                     details = f"Attempted to delete a Node '{node_name}'. Failed because it could not gather Connections to the Node."
                     return DeleteNodeResultFailure(result_details=details)
@@ -1221,7 +1232,7 @@ class NodeManager:
                         target_node_name=node_name,
                         target_parameter_name=connection.target_parameter_name,
                     )
-                    delete_result = GriptapeNodes.handle_request(delete_request)
+                    delete_result = self.engine.handle_request(delete_request)
                     if isinstance(delete_result, ResultPayloadFailure):
                         details = (
                             f"Attempted to delete a Node '{node_name}'. Failed when attempting to delete Connection."
@@ -1239,7 +1250,7 @@ class NodeManager:
                         target_node_name=connection.target_node_name,
                         target_parameter_name=connection.target_parameter_name,
                     )
-                    delete_result = GriptapeNodes.handle_request(delete_request)
+                    delete_result = self.engine.handle_request(delete_request)
                     if isinstance(delete_result, ResultPayloadFailure):
                         details = (
                             f"Attempted to delete a Node '{node_name}'. Failed when attempting to delete Connection."
@@ -1257,12 +1268,12 @@ class NodeManager:
         parent_flow.remove_node(node.name)
 
         # Now remove the record keeping
-        GriptapeNodes.ObjectManager().del_obj_by_name(node_name)
+        self.engine.object_manager.del_obj_by_name(node_name)
         del self._name_to_parent_flow_name[node_name]
 
         # If we were part of the Current Context, pop it.
         if request.node_name is None:
-            GriptapeNodes.ContextManager().pop_node()
+            self.engine.context_manager.pop_node()
 
         details = f"Successfully deleted Node '{node_name}'."
         return DeleteNodeResultSuccess(result_details=details)
@@ -1283,15 +1294,15 @@ class NodeManager:
 
         node_name = request.node_name
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = (
                     "Attempted to move a Node from the Current Context. Failed because the Current Context is empty."
                 )
                 return MoveNodeToNewFlowResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
-        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
             details = f"Attempted to move Node '{node_name}', but no such Node was found."
             return MoveNodeToNewFlowResultFailure(result_details=details)
@@ -1308,13 +1319,13 @@ class NodeManager:
             source_flow_name = self._name_to_parent_flow_name[node_name]
 
         try:
-            source_flow = GriptapeNodes.FlowManager().get_flow_by_name(source_flow_name)
+            source_flow = self.engine.flow_manager.get_flow_by_name(source_flow_name)
         except KeyError:
             details = f"Attempted to move Node '{node_name}' from Flow '{source_flow_name}'. Failed because source flow was not found."
             return MoveNodeToNewFlowResultFailure(result_details=details)
 
         try:
-            target_flow = GriptapeNodes.FlowManager().get_flow_by_name(request.target_flow_name)
+            target_flow = self.engine.flow_manager.get_flow_by_name(request.target_flow_name)
         except KeyError:
             details = f"Attempted to move Node '{node_name}' to Flow '{request.target_flow_name}'. Failed because target flow was not found."
             return MoveNodeToNewFlowResultFailure(result_details=details)
@@ -1340,16 +1351,16 @@ class NodeManager:
         node = None
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to get resolution state for a Node from the Current Context. Failed because the Current Context is empty."
                 return GetNodeResolutionStateResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         if node is None:
             # Does this node exist?
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to get resolution state for a Node '{node_name}', but no such Node was found."
@@ -1367,16 +1378,16 @@ class NodeManager:
         node = None
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to get metadata for a Node from the Current Context. Failed because the Current Context is empty."
                 return GetNodeMetadataResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
 
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
@@ -1395,16 +1406,16 @@ class NodeManager:
         node = None
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to set metadata for a Node from the Current Context. Failed because the Current Context is empty."
                 return SetNodeMetadataResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
 
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
@@ -1429,17 +1440,17 @@ class NodeManager:
             node = None
             if node_name is None:
                 # Get from current context
-                if not GriptapeNodes.ContextManager().has_current_node():
+                if not self.engine.context_manager.has_current_node():
                     failed_nodes["current_context"] = "No current context node available"
                     continue
-                node = GriptapeNodes.ContextManager().get_current_node()
+                node = self.engine.context_manager.get_current_node()
                 actual_node_name = node.name
             else:
                 actual_node_name = node_name
 
             # Look up node if we don't have it yet
             if node is None:
-                obj_mgr = GriptapeNodes.ObjectManager()
+                obj_mgr = self.engine.object_manager
                 node = obj_mgr.attempt_get_object_by_name_as_type(actual_node_name, BaseNode)
                 if node is None:
                     failed_nodes[actual_node_name] = f"Node '{actual_node_name}' not found"
@@ -1469,16 +1480,16 @@ class NodeManager:
         node = None
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to list Connections for a Node from the Current Context. Failed because the Current Context is empty."
                 return ListConnectionsForNodeResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
 
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
@@ -1489,7 +1500,7 @@ class NodeManager:
 
         parent_flow_name = self._name_to_parent_flow_name[node_name]
         try:
-            GriptapeNodes.FlowManager().get_flow_by_name(parent_flow_name)
+            self.engine.flow_manager.get_flow_by_name(parent_flow_name)
         except KeyError as err:
             details = f"Attempted to list Connections for a Node '{node_name}'. Error: {err}"
 
@@ -1497,7 +1508,7 @@ class NodeManager:
             return result
 
         # Kinda gross, but let's do it
-        connection_mgr = GriptapeNodes.FlowManager().get_connections()
+        connection_mgr = self.engine.flow_manager.get_connections()
         # get outgoing connections
         outgoing_connections_list = []
         if node_name in connection_mgr.outgoing_index:
@@ -1545,16 +1556,16 @@ class NodeManager:
 
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to get connections for a parameter from the Current Context. Failed because the Current Context is empty."
                 return GetConnectionsForParameterResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to get connections for parameter '{parameter_name}' on node '{node_name}', but no such node was found."
@@ -1568,7 +1579,7 @@ class NodeManager:
 
         parent_flow_name = self._name_to_parent_flow_name[node_name]
         try:
-            GriptapeNodes.FlowManager().get_flow_by_name(parent_flow_name)
+            self.engine.flow_manager.get_flow_by_name(parent_flow_name)
         except KeyError as err:
             details = (
                 f"Attempted to get connections for parameter '{parameter_name}' on node '{node_name}'. Error: {err}"
@@ -1576,7 +1587,7 @@ class NodeManager:
             return GetConnectionsForParameterResultFailure(result_details=details)
 
         # Get connections for this specific parameter
-        connection_mgr = GriptapeNodes.FlowManager().get_connections()
+        connection_mgr = self.engine.flow_manager.get_connections()
 
         # Get outgoing connections for this parameter
         outgoing_connections_list = []
@@ -1620,16 +1631,16 @@ class NodeManager:
 
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to list Parameters for a Node from the Current Context. Failed because the Current Context is empty."
                 return ListParametersOnNodeResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to list Parameters for a Node '{node_name}', but no such Node was found."
@@ -1668,16 +1679,16 @@ class NodeManager:
 
         if node_name is None:
             # Get from the current context.
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to add Parameter to a Node from the Current Context. Failed because the Current Context is empty."
                 return AddParameterToNodeResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to add Parameter '{request.parameter_name}' to a Node '{node_name}', but no such Node was found."
@@ -1828,15 +1839,15 @@ class NodeManager:
         parent_group: ParameterGroup | None = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to add ParameterGroup to a Node from the Current Context. Failed because the Current Context is empty."
                 return AddParameterGroupToNodeResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to add ParameterGroup '{request.group_name}' to a Node '{node_name}', but no such Node was found."
@@ -1891,18 +1902,18 @@ class NodeManager:
 
         if node_name is None:
             # Get the Current Context
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node, but no Current Context was found."
 
                 result = RemoveParameterFromNodeResultFailure(result_details=details)
                 return result
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to remove Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
@@ -1926,7 +1937,7 @@ class NodeManager:
         # If it's a ParameterGroup, we need to remove all the Parameters inside it.
         if isinstance(element, ParameterGroup):
             for child in element.find_elements_by_type(Parameter):
-                GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(child.name, node_name))
+                self.engine.handle_request(RemoveParameterFromNodeRequest(child.name, node_name))
             node.remove_node_element(element)
 
             return RemoveParameterFromNodeResultSuccess(
@@ -1951,7 +1962,7 @@ class NodeManager:
         # Get all the connections to/from this Parameter.
         if isinstance(element, Parameter):
             list_node_connections_request = ListConnectionsForNodeRequest(node_name=node_name)
-            list_connections_result = GriptapeNodes.handle_request(request=list_node_connections_request)
+            list_connections_result = self.engine.handle_request(request=list_node_connections_request)
             if not isinstance(list_connections_result, ListConnectionsForNodeResultSuccess):
                 details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{node_name}'. Failed because we were unable to get a list of Connections for the Parameter's Node."
 
@@ -1969,7 +1980,7 @@ class NodeManager:
                         target_node_name=node_name,
                         target_parameter_name=incoming_connection.target_parameter_name,
                     )
-                    delete_result = GriptapeNodes.handle_request(delete_request)
+                    delete_result = self.engine.handle_request(delete_request)
                     if isinstance(delete_result, DeleteConnectionResultFailure):
                         details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{node_name}'. Failed because we were unable to delete a Connection for that Parameter."
 
@@ -1984,7 +1995,7 @@ class NodeManager:
                         target_node_name=outgoing_connection.target_node_name,
                         target_parameter_name=outgoing_connection.target_parameter_name,
                     )
-                    delete_result = GriptapeNodes.handle_request(delete_request)
+                    delete_result = self.engine.handle_request(delete_request)
                     if isinstance(delete_result, DeleteConnectionResultFailure):
                         details = f"Attempted to remove Parameter '{request.parameter_name}' from Node '{node_name}'. Failed because we were unable to delete a Connection for that Parameter."
 
@@ -2008,17 +2019,17 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node, but no Current Context was found."
 
                 result = GetParameterDetailsResultFailure(result_details=details)
                 return result
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to get details for Parameter '{request.parameter_name}' from a Node '{node_name}', but no such Node was found."
@@ -2072,16 +2083,16 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to get element details for element '{request.specific_element_id}` from a Node, but no Current Context was found."
 
                 return GetNodeElementDetailsResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to get element details for Node '{node_name}', but no such Node was found."
@@ -2230,7 +2241,7 @@ class NodeManager:
                 source_node = self.get_node_by_name(conn.source_node_name)
                 source_param = source_node.get_parameter_by_name(conn.source_parameter_name)
                 if source_param and not parameter.is_incoming_type_allowed(source_param.output_type):
-                    delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                    delete_result = self.engine.flow_manager.on_delete_connection_request(
                         DeleteConnectionRequest(
                             source_node_name=conn.source_node_name,
                             source_parameter_name=conn.source_parameter_name,
@@ -2248,7 +2259,7 @@ class NodeManager:
                 target_node = self.get_node_by_name(conn.target_node_name)
                 target_param = target_node.get_parameter_by_name(conn.target_parameter_name)
                 if target_param and not target_param.is_incoming_type_allowed(parameter.output_type):
-                    delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                    delete_result = self.engine.flow_manager.on_delete_connection_request(
                         DeleteConnectionRequest(
                             source_node_name=node_name,
                             source_parameter_name=request.parameter_name,
@@ -2267,16 +2278,16 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to alter details for Parameter '{request.parameter_name}' from node in the Current Context. Failed because there was no such Node."
 
                 return AlterParameterDetailsResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to alter details for Parameter '{request.parameter_name}' from Node '{node_name}', but no such Node was found."
@@ -2351,14 +2362,14 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to alter details for ParameterGroup '{request.group_name}' from node in the Current Context. Failed because there was no such Node."
                 return AlterParameterGroupDetailsResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to alter details for ParameterGroup '{request.group_name}' from Node '{node_name}', but no such Node was found."
@@ -2398,11 +2409,11 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to get value for Parameter '{request.parameter_name}' from node in the Current Context. Failed because there was no such Node."
 
                 return GetParameterValueResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Parse the parameter name to check for list indexing
@@ -2410,7 +2421,7 @@ class NodeManager:
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f'"{node_name}" not found'
@@ -2453,10 +2464,10 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = f"Attempted to set parameter '{request.parameter_name}' value. Failed because no Node was found in the Current Context."
                 return SetParameterValueResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Parse the parameter name to check for list indexing
@@ -2464,7 +2475,7 @@ class NodeManager:
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to set parameter '{param_name}' value on node '{node_name}'. Failed because no such Node could be found."
@@ -2477,7 +2488,7 @@ class NodeManager:
 
         # Let versioning system potentially squelch removed parameters.
         # This check must run BEFORE we validate parameter existence, since removed parameters won't exist.
-        version_compat_result = GriptapeNodes.VersionCompatibilityManager().check_set_parameter_version_compatibility(
+        version_compat_result = self.engine.version_compatibility_manager.check_set_parameter_version_compatibility(
             node, param_name, request.value
         )
         if version_compat_result is not None:
@@ -2526,7 +2537,7 @@ class NodeManager:
             and ParameterMode.PROPERTY in parameter.allowed_modes
         ):
             # Check if this parameter has any incoming connections
-            connections = GriptapeNodes.FlowManager().get_connections()
+            connections = self.engine.flow_manager.get_connections()
             target_connections = connections.incoming_index.get(node_name)
             if target_connections is not None:
                 param_connections = target_connections.get(request.parameter_name)
@@ -2584,7 +2595,7 @@ class NodeManager:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
             return SetParameterValueResultFailure(result_details=details)
 
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
         parent_flow = obj_mgr.attempt_get_object_by_name_as_type(parent_flow_name, ControlFlow)
         if not parent_flow:
             details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because the node's parent flow does not exist. Could not unresolve future nodes."
@@ -2602,7 +2613,7 @@ class NodeManager:
             return SetParameterValueResultFailure(result_details=details)
         if not request.initial_setup and modified:
             try:
-                GriptapeNodes.FlowManager().get_connections().unresolve_future_nodes(node)
+                self.engine.flow_manager.get_connections().unresolve_future_nodes(node)
             except Exception as err:
                 details = f"Attempted to set parameter value for '{node_name}.{request.parameter_name}'. Failed because Exception: {err}"
                 return SetParameterValueResultFailure(result_details=details)
@@ -2623,7 +2634,7 @@ class NodeManager:
                 )
                 is_dest_node_locked = target_node.lock
                 if (not is_control_parameter) and (not is_dest_node_locked):
-                    GriptapeNodes.handle_request(
+                    self.engine.handle_request(
                         SetParameterValueRequest(
                             parameter_name=target_parameter.name,
                             node_name=target_node.name,
@@ -2656,7 +2667,7 @@ class NodeManager:
                 for target_node, target_parameter in conn_targets:
                     if target_node.lock:
                         continue
-                    GriptapeNodes.handle_request(
+                    self.engine.handle_request(
                         SetParameterValueRequest(
                             parameter_name=target_parameter.name,
                             node_name=target_node.name,
@@ -2712,16 +2723,16 @@ class NodeManager:
 
         # Get from the current context.
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to get all info for a Node from the Current Context. Failed because the Current Context is empty."
                 return GetAllNodeInfoResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 # Logged at DEBUG: this is usually a benign race where the GUI requests info
@@ -2798,15 +2809,15 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to get compatible parameters for node, but no current node was found."
                 return GetCompatibleParametersResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Vet the node
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = (
@@ -2836,9 +2847,7 @@ class NodeManager:
 
         # Iterate through all nodes in this Flow (yes, this restriction still sucks)
         list_nodes_in_flow_request = ListNodesInFlowRequest(flow_name=flow_name)
-        list_nodes_in_flow_result = GriptapeNodes.FlowManager().on_list_nodes_in_flow_request(
-            list_nodes_in_flow_request
-        )
+        list_nodes_in_flow_result = self.engine.flow_manager.on_list_nodes_in_flow_request(list_nodes_in_flow_request)
         if not list_nodes_in_flow_result.succeeded():
             details = f"Attempted to get compatible parameters for '{node_name}.{request.parameter_name}'. Failed due to inability to list nodes in parent flow '{flow_name}'."
             return GetCompatibleParametersResultFailure(result_details=details)
@@ -2899,7 +2908,7 @@ class NodeManager:
         )
 
     def get_node_by_name(self, name: str) -> BaseNode:
-        obj_mgr = GriptapeNodes.ObjectManager()
+        obj_mgr = self.engine.object_manager
 
         node = obj_mgr.attempt_get_object_by_name_as_type(name, BaseNode)
         if node is None:
@@ -2936,7 +2945,7 @@ class NodeManager:
 
             return ResolveNodeResultFailure(validation_exceptions=[e], result_details=details)
         try:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             flow = obj_mgr.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         except KeyError as e:
             details = f'Failed to fetch parent flow for "{node_name}": {e}'
@@ -2948,7 +2957,7 @@ class NodeManager:
             return ResolveNodeResultFailure(validation_exceptions=[], result_details=details)
 
         # Check for existing running flow
-        flow_mgr = GriptapeNodes.FlowManager()
+        flow_mgr = self.engine.flow_manager
         if flow_mgr.check_for_existing_running_flow() and not flow_mgr._global_single_node_resolution:
             # Behavior should also match if the flow running is a Control Flow, and not a singular node resolution.
             errormsg = f"This workflow is already in progress. Please wait for the current control process to finish before starting {node.name} again."
@@ -2962,7 +2971,7 @@ class NodeManager:
                 result_details=f"Node {node.name} is already executing. Cannot start execution.",
             )
         try:
-            GriptapeNodes.FlowManager().get_connections().unresolve_future_nodes(node)
+            self.engine.flow_manager.get_connections().unresolve_future_nodes(node)
         except Exception as e:
             details = f'Failed to mark future nodes dirty. Unable to kick off flow from "{node_name}": {e}'
             return ResolveNodeResultFailure(validation_exceptions=[e], result_details=details)
@@ -2984,7 +2993,7 @@ class NodeManager:
             details = f"Failed to resolve node '{node_name}'. Flow Validation Failed. Error: {e}"
             return StartFlowResultFailure(validation_exceptions=[e], result_details=details)
         try:
-            await GriptapeNodes.FlowManager().resolve_singular_node(flow, node, debug_mode=debug_mode)
+            await self.engine.flow_manager.resolve_singular_node(flow, node, debug_mode=debug_mode)
         except Exception as e:
             details = f'Failed to resolve "{node_name}".  Error: {e}'
             return ResolveNodeResultFailure(validation_exceptions=[e], result_details=details)
@@ -3012,7 +3021,7 @@ class NodeManager:
         If the orchestrator's lookup succeeds and the node's library is owned by
         a worker, the request is forwarded over the wire to that worker.
         """
-        library_manager = GriptapeNodes.LibraryManager()
+        library_manager = self.engine.library_manager
         is_worker = library_manager.is_worker
 
         if is_worker:
@@ -3021,7 +3030,7 @@ class NodeManager:
                 return worker_node
             node = worker_node
         else:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             orchestrator_node = obj_mgr.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
             if orchestrator_node is None:
                 return ExecuteNodeResultFailure(
@@ -3041,7 +3050,7 @@ class NodeManager:
         # this process is actually going to execute the node.
         if not is_worker:
             worker = library_manager.get_worker_for_library(library_name) if library_name else None
-            wm = GriptapeNodes.WorkerManager()
+            wm = self.engine.worker_manager
             if wm is not None and worker is not None:
                 return await self._execute_node_via_worker(request, wm, worker)
 
@@ -3092,7 +3101,9 @@ class NodeManager:
         # ExecuteNodeRequest straight to a worker, never passing through the
         # gated CreateNode path.
         try:
-            denial = self._evaluate_instantiation_checkpoint(node_type=node_type, specific_library_name=library_name)
+            denial = self._evaluate_instantiation_checkpoint(
+                node_type=node_type, specific_library_name=library_name, event_manager=self.engine.event_manager
+            )
         except KeyError:
             # Node type/library not registered here; let create_node below
             # surface the clearer "node type not found" failure rather than
@@ -3185,7 +3196,7 @@ class NodeManager:
         if entry is None:
             return
         target_request_id, worker_engine_id, worker_request_topic = entry
-        wm = GriptapeNodes.WorkerManager()
+        wm = self.engine.worker_manager
         cancel_request = CancelExecuteNodeRequest(target_request_id=target_request_id)
         await wm.forward_event_to_worker(
             EventRequest(request=cancel_request),
@@ -3251,8 +3262,8 @@ class NodeManager:
         # installed (register_remote_handlers is worker-only), so opening the
         # scope there would just bump a refcount that nothing reads. Skip it
         # to keep the depth counter accurate to its name.
-        is_worker = GriptapeNodes.LibraryManager()._is_worker
-        scope_cm = GriptapeNodes.EventManager().worker_node_execution_scope() if is_worker else contextlib.nullcontext()
+        is_worker = self.engine.library_manager._is_worker
+        scope_cm = self.engine.event_manager.worker_node_execution_scope() if is_worker else contextlib.nullcontext()
         with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
@@ -3310,7 +3321,7 @@ class NodeManager:
 
     def on_validate_node_dependencies_request(self, request: ValidateNodeDependenciesRequest) -> ResultPayload:
         node_name = request.node_name
-        obj_manager = GriptapeNodes.ObjectManager()
+        obj_manager = self.engine.object_manager
         node = obj_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
             details = f'Failed to validate node dependencies. Node with "{node_name}" does not exist.'
@@ -3320,7 +3331,7 @@ class NodeManager:
         except Exception as e:
             details = f'Failed to validate node dependencies. Node with "{node_name}" has no parent flow. Error: {e}'
             return ValidateNodeDependenciesResultFailure(result_details=details)
-        flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+        flow = self.engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
         if not flow:
             details = f'Failed to validate node dependencies. Flow with "{flow_name}" does not exist.'
             return ValidateNodeDependenciesResultFailure(result_details=details)
@@ -3428,22 +3439,22 @@ class NodeManager:
         node = None
 
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to serialize a Node to commands from the Current Context. Failed because the Current Context is empty."
                 return SerializeNodeToCommandsResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # Does this node exist?
         if node is None:
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to serialize Node '{node_name}' to commands. Failed because no Node with that name could be found."
                 return SerializeNodeToCommandsResultFailure(result_details=details)
 
         # This is our current dude.
-        with GriptapeNodes.ContextManager().node(node=node):
+        with self.engine.context_manager.node(node=node):
             # Get the library and version details for all nodes.
             # A node's owning library is normally injected into metadata by
             # LibraryRegistry.create_node, but proxy/placeholder nodes can be created
@@ -3464,7 +3475,7 @@ class NodeManager:
                 if execution_env not in (LOCAL_EXECUTION, PRIVATE_EXECUTION):
                     # Get library details for the execution environment library
                     exec_env_metadata_request = GetLibraryMetadataRequest(library=execution_env)
-                    exec_env_metadata_result = GriptapeNodes.LibraryManager().get_library_metadata_request(
+                    exec_env_metadata_result = self.engine.library_manager.get_library_metadata_request(
                         exec_env_metadata_request
                     )
                     if isinstance(exec_env_metadata_result, GetLibraryMetadataResultSuccess):
@@ -3476,9 +3487,7 @@ class NodeManager:
             library_metadata_request = GetLibraryMetadataRequest(library=library_used)
             # Call LibraryManager directly to avoid error toasts when library is unavailable (expected for ErrorProxyNode)
             # Per https://github.com/griptape-ai/griptape-nodes/issues/1940
-            library_metadata_result = GriptapeNodes.LibraryManager().get_library_metadata_request(
-                library_metadata_request
-            )
+            library_metadata_result = self.engine.library_manager.get_library_metadata_request(library_metadata_request)
 
             if not isinstance(library_metadata_result, GetLibraryMetadataResultSuccess):
                 if isinstance(node, ErrorProxyNode):
@@ -3656,6 +3665,7 @@ class NodeManager:
                     unique_parameter_uuid_to_values=request.unique_parameter_uuid_to_values,
                     serialized_parameter_value_tracker=request.serialized_parameter_value_tracker,
                     create_node_request=create_node_request,
+                    workflow_manager=self.engine.workflow_manager,
                     use_pickling=request.use_pickling,
                 )
                 if set_param_value_requests is not None:
@@ -3725,7 +3735,7 @@ class NodeManager:
 
         """
         connection_info_request = GetParameterDetailsRequest(source_parameter_name, source_node_name)
-        connection_info_response = GriptapeNodes.handle_request(connection_info_request)
+        connection_info_response = self.engine.handle_request(connection_info_request)
         # only get value if it succeeds
         connection_type = NodeManager.check_response(
             self, connection_info_response, GetParameterDetailsResultSuccess, "type"
@@ -3751,7 +3761,7 @@ class NodeManager:
             list_connections_for_node_request = ListConnectionsForNodeRequest(
                 node_name=old_node_name, include_internal=False
             )
-            list_connections_for_node_response = GriptapeNodes.handle_request(list_connections_for_node_request)
+            list_connections_for_node_response = self.engine.handle_request(list_connections_for_node_request)
 
             # Only get incoming/outgoing connections if it returns the proper type
             incoming_connections = NodeManager.check_response(
@@ -3789,7 +3799,7 @@ class NodeManager:
                         target_node_name=new_node_name,
                         target_parameter_name=target_parameter_name,
                     )
-                    GriptapeNodes.handle_request(create_old_incoming_connections_request)
+                    self.engine.handle_request(create_old_incoming_connections_request)
 
             # If there are any outgoing connections, loop over them
             for outgoing_connection in outgoing_connections:
@@ -3813,12 +3823,12 @@ class NodeManager:
                         target_node_name=target_node_name,
                         target_parameter_name=outgoing_connection.target_parameter_name,
                     )
-                    GriptapeNodes.handle_request(create_old_outgoing_connections_request)
+                    self.engine.handle_request(create_old_outgoing_connections_request)
 
     def on_deserialize_node_from_commands(self, request: DeserializeNodeFromCommandsRequest) -> ResultPayload:
         # Issue the creation command first.
         create_node_request = request.serialized_node_commands.create_node_command
-        create_node_result = GriptapeNodes().handle_request(create_node_request)
+        create_node_result = self.engine.handle_request(create_node_request)
         if not isinstance(create_node_result, CreateNodeResultSuccess):
             req_node_name = create_node_request.node_name
             details = f"Attempted to deserialize a serialized set of Node Creation commands. Failed to create node '{req_node_name}'."
@@ -3826,11 +3836,11 @@ class NodeManager:
 
         # Adopt the newly-created node as our current context.
         node_name = create_node_result.node_name
-        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+        node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
             details = f"Attempted to deserialize a serialized set of Node Creation commands. Failed to get node '{node_name}'."
             return DeserializeNodeFromCommandsResultFailure(result_details=details)
-        with GriptapeNodes.ContextManager().node(node=node):
+        with self.engine.context_manager.node(node=node):
             for element_command in request.serialized_node_commands.element_modification_commands:
                 # TODO: https://github.com/griptape-ai/griptape-nodes-engine/issues/4862
                 # This isinstance allowlist must be updated by hand for every new
@@ -3847,7 +3857,7 @@ class NodeManager:
                     ),
                 ):
                     element_command.node_name = node_name
-                element_result = GriptapeNodes().handle_request(element_command)
+                element_result = self.engine.handle_request(element_command)
                 if element_result.failed():
                     details = f"Attempted to deserialize a serialized set of Node Creation commands. Failed to execute an element command for node '{node_name}'."
                     self._cleanup_node_on_failed_deserialization(node_name)
@@ -3884,7 +3894,7 @@ class NodeManager:
 
         for node_name, _ in nodes_to_serialize:
             # Check if this is a group node that needs special handling
-            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to serialize a selection of Nodes. Failed to get node '{node_name}'."
                 return SerializeNodeToCommandsResultFailure(result_details=details)
@@ -3957,12 +3967,12 @@ class NodeManager:
         for node_name in all_selected_for_connections:
             try:
                 flow_name = self.get_node_parent_flow_by_name(node_name)
-                GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
+                self.engine.flow_manager.get_flow_by_name(flow_name)
             except Exception:
                 details = f"Attempted to serialize a selection of Nodes. Failed to get the flow of node {node_name}. Cannot serialize connections for this node."
                 logger.warning(details)
                 continue
-            connections = GriptapeNodes.FlowManager().get_connections()
+            connections = self.engine.flow_manager.get_connections()
             if node_name in connections.outgoing_index:
                 node_connections = [
                     connections.connections[connection_id]
@@ -4118,12 +4128,12 @@ class NodeManager:
 
             created_node_names.append(result.node_name)
             node_uuid_to_name[node_command.node_uuid] = result.node_name
-            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(result.node_name, BaseNode)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(result.node_name, BaseNode)
             if node is None:
                 details = "Attempted to deserialize node but ran into an error on node serialization."
                 self._cleanup_created_nodes(created_node_names)
                 return DeserializeSelectedNodesFromCommandsResultFailure(result_details=details)
-            with GriptapeNodes.ContextManager().node(node=node):
+            with self.engine.context_manager.node(node=node):
                 parameter_commands = commands.set_parameter_value_commands[node_command.node_uuid]
                 for parameter_command in parameter_commands:
                     param_request = parameter_command.set_parameter_value_command
@@ -4139,15 +4149,13 @@ class NodeManager:
                         except Exception:  # noqa: S110
                             pass
                         param_request.value = value
-                        set_parameter_result = GriptapeNodes.handle_request(
-                            parameter_command.set_parameter_value_command
-                        )
+                        set_parameter_result = self.engine.handle_request(parameter_command.set_parameter_value_command)
                         if not set_parameter_result.succeeded():
                             details = f"Failed to set parameter value for {param_request.parameter_name} on node {param_request.node_name}"
                             logger.warning(details)
                 lock_command = commands.set_lock_commands_per_node[node_command.node_uuid]
                 if lock_command is not None:
-                    lock_node_result = GriptapeNodes.handle_request(lock_command)
+                    lock_node_result = self.engine.handle_request(lock_command)
                     if not lock_node_result.succeeded():
                         details = f"Failed to lock node {lock_command.node_name}"
                         logger.warning(details)
@@ -4160,7 +4168,7 @@ class NodeManager:
                 target_node_name=node_uuid_to_name[connection_command.target_node_uuid],
                 target_parameter_name=connection_command.target_parameter_name,
             )
-            result = GriptapeNodes.handle_request(connection_request)
+            result = self.engine.handle_request(connection_request)
             if result.failed():
                 details = f"Failed to create a connection between {connection_request.source_node_name} and {connection_request.target_node_name}"
                 logger.warning(details)
@@ -4174,7 +4182,7 @@ class NodeManager:
         )
 
     def on_duplicate_selected_nodes(self, request: DuplicateSelectedNodesRequest) -> ResultPayload:
-        serialize_result = GriptapeNodes.handle_request(
+        serialize_result = self.engine.handle_request(
             SerializeSelectedNodesToCommandsRequest(nodes_to_serialize=request.nodes_to_duplicate)
         )
         if not isinstance(serialize_result, SerializeSelectedNodesToCommandsResultSuccess):
@@ -4187,7 +4195,7 @@ class NodeManager:
             pickled_values=serialize_result.pickled_values,
             positions=request.positions,
         )
-        result = GriptapeNodes.handle_request(deserialize_request)
+        result = self.engine.handle_request(deserialize_request)
         if not isinstance(result, DeserializeSelectedNodesFromCommandsResultSuccess):
             details = "Failed to deserialize selected nodes."
             return DuplicateSelectedNodesResultFailure(result_details=details)
@@ -4239,6 +4247,7 @@ class NodeManager:
         node_name: str,
         *,
         is_output: bool,
+        workflow_manager: WorkflowManager,
         use_pickling: bool = False,
     ) -> SerializedNodeCommands.IndirectSetParameterValueCommand | None:
         try:
@@ -4276,8 +4285,6 @@ class NodeManager:
                 unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
 
                 if use_pickling:
-                    # Use pickle serialization via WorkflowManager
-                    workflow_manager = GriptapeNodes.WorkflowManager()
                     pickled_bytes = workflow_manager._patch_and_pickle_object(value)
                     unique_parameter_uuid_to_values[unique_uuid] = pickled_bytes
                 else:
@@ -4311,6 +4318,7 @@ class NodeManager:
         serialized_parameter_value_tracker: SerializedParameterValueTracker,
         create_node_request: CreateNodeRequest,
         *,
+        workflow_manager: WorkflowManager,
         use_pickling: bool = False,
         serialize_all_parameter_values: bool = False,
     ) -> list[SerializedNodeCommands.IndirectSetParameterValueCommand] | None:
@@ -4330,6 +4338,7 @@ class NodeManager:
             unique_parameter_uuid_to_values (dict[SerializedNodeCommands.UniqueParameterValueUUID, Any]): Dictionary mapping unique value UUIDs to values
             serialized_parameter_value_tracker (SerializedParameterValueTracker): Object mapping maintaining value hashes to unique value UUIDs, and non-serializable values
             create_node_request (CreateNodeRequest): The node creation request that will be modified if serialization fails
+            workflow_manager (WorkflowManager): Used to pickle values when use_pickling is True
             use_pickling (bool): If True, use pickle-based serialization; if False, use deep copy
             serialize_all_parameter_values (bool): If True, save all parameter values regardless of whether they were explicitly set or match defaults
 
@@ -4371,6 +4380,7 @@ class NodeManager:
             unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
             serialized_parameter_value_tracker=serialized_parameter_value_tracker,
             create_node_request=create_node_request,
+            workflow_manager=workflow_manager,
             use_pickling=use_pickling,
         )
         if internal_command is not None:
@@ -4384,6 +4394,7 @@ class NodeManager:
             unique_parameter_uuid_to_values=unique_parameter_uuid_to_values,
             serialized_parameter_value_tracker=serialized_parameter_value_tracker,
             create_node_request=create_node_request,
+            workflow_manager=workflow_manager,
             use_pickling=use_pickling,
         )
         if output_command is not None:
@@ -4401,6 +4412,7 @@ class NodeManager:
         unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
         serialized_parameter_value_tracker: SerializedParameterValueTracker,
         create_node_request: CreateNodeRequest,
+        workflow_manager: WorkflowManager,
         use_pickling: bool,
     ) -> SerializedNodeCommands.IndirectSetParameterValueCommand | None:
         """Serialize one of a parameter's values (internal-set or output) for workflow save.
@@ -4425,6 +4437,7 @@ class NodeManager:
             is_output=is_output,
             parameter_name=parameter.name,
             node_name=node.name,
+            workflow_manager=workflow_manager,
             use_pickling=use_pickling,
         )
         if command is not None:
@@ -4443,11 +4456,14 @@ class NodeManager:
         return None
 
     @staticmethod
-    def serialize_parameter_output_values(node: BaseNode, *, use_pickling: bool = False) -> SerializedParameterValues:
+    def serialize_parameter_output_values(
+        node: BaseNode, *, workflow_manager: WorkflowManager, use_pickling: bool = False
+    ) -> SerializedParameterValues:
         """Serialize parameter output values with optional pickling for complex objects.
 
         Args:
             node: The node whose parameter output values should be serialized
+            workflow_manager: Used to pickle values when use_pickling is True
             use_pickling: If True, use pickle-based serialization; if False, use safe_unstructure
 
         Returns:
@@ -4461,7 +4477,7 @@ class NodeManager:
         if not use_pickling:
             return NodeManager._serialize_without_pickling(node)
 
-        return NodeManager._serialize_with_pickling(node)
+        return NodeManager._serialize_with_pickling(node, workflow_manager=workflow_manager)
 
     @staticmethod
     def _serialize_without_pickling(node: BaseNode) -> SerializedParameterValues:
@@ -4485,11 +4501,14 @@ class NodeManager:
     @staticmethod
     def _serialize_with_pickling(
         node: BaseNode,
+        *,
+        workflow_manager: WorkflowManager,
     ) -> SerializedParameterValues:
         """Serialize parameter values using pickle-based serialization with UUID references.
 
         Args:
             node: The node whose parameter values should be serialized
+            workflow_manager: Used to pickle values
 
         Returns:
             SerializedParameterValues with pickled values
@@ -4508,6 +4527,7 @@ class NodeManager:
                 serialized_parameter_value_tracker,
                 unique_parameter_uuid_to_values,
                 uuid_referenced_values,
+                workflow_manager=workflow_manager,
             )
 
             uuid_referenced_values[param_name] = unique_uuid
@@ -4530,12 +4550,14 @@ class NodeManager:
         return node.get_parameter_value(param_name)
 
     @staticmethod
-    def _process_parameter_for_pickling(
+    def _process_parameter_for_pickling(  # noqa: PLR0913
         param_value: Any,
         param_name: str,
         tracker: SerializedParameterValueTracker,
         unique_parameter_uuid_to_values: dict,
         uuid_referenced_values: dict,
+        *,
+        workflow_manager: WorkflowManager,
     ) -> SerializedNodeCommands.UniqueParameterValueUUID | None:
         """Process a parameter value for pickle-based serialization.
 
@@ -4545,6 +4567,7 @@ class NodeManager:
             tracker: Tracker for managing serialization state
             unique_parameter_uuid_to_values: Dictionary to store pickled values
             uuid_referenced_values: Dictionary to store UUID references
+            workflow_manager: Used to pickle newly seen values
 
         Returns:
             UUID reference for the value, or None if not serializable
@@ -4565,16 +4588,23 @@ class NodeManager:
                 return None
             case SerializedParameterValueTracker.TrackerState.NOT_IN_TRACKER:
                 return NodeManager._handle_new_value_for_pickling(
-                    param_value, param_name, tracker, unique_parameter_uuid_to_values, uuid_referenced_values
+                    param_value,
+                    param_name,
+                    tracker,
+                    unique_parameter_uuid_to_values,
+                    uuid_referenced_values,
+                    workflow_manager=workflow_manager,
                 )
 
     @staticmethod
-    def _handle_new_value_for_pickling(
+    def _handle_new_value_for_pickling(  # noqa: PLR0913
         param_value: Any,
         param_name: str,
         tracker: SerializedParameterValueTracker,
         unique_parameter_uuid_to_values: dict,
         uuid_referenced_values: dict,
+        *,
+        workflow_manager: WorkflowManager,
     ) -> SerializedNodeCommands.UniqueParameterValueUUID | None:
         """Handle a new value that hasn't been seen before in pickling serialization.
 
@@ -4584,6 +4614,7 @@ class NodeManager:
             tracker: Tracker for managing serialization state
             unique_parameter_uuid_to_values: Dictionary to store pickled values
             uuid_referenced_values: Dictionary to store UUID references
+            workflow_manager: Used to pickle the value
 
         Returns:
             UUID reference for the value, or None if not serializable
@@ -4595,7 +4626,6 @@ class NodeManager:
             value_id = id(param_value)
 
         try:
-            workflow_manager = GriptapeNodes.WorkflowManager()
             pickled_bytes = workflow_manager._patch_and_pickle_object(param_value)
         except Exception:
             tracker.add_as_not_serializable(value_id)
@@ -4619,10 +4649,10 @@ class NodeManager:
         # Get the node
         node_name = request.node_name
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to rename Parameter in the Current Context. Failed because the Current Context was empty."
                 return RenameParameterResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
         else:
             try:
@@ -4659,8 +4689,8 @@ class NodeManager:
 
         # Get all connections for this node
         flow_name = self.get_node_parent_flow_by_name(node_name)
-        GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
-        connections = GriptapeNodes.FlowManager().get_connections()
+        self.engine.flow_manager.get_flow_by_name(flow_name)
+        connections = self.engine.flow_manager.get_connections()
 
         # Update connections that reference this parameter
         if node_name in connections.incoming_index:
@@ -4705,10 +4735,10 @@ class NodeManager:
     def on_toggle_lock_node_request(self, request: SetLockNodeStateRequest) -> ResultPayload:
         node_name = request.node_name
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to lock node in the Current Context. Failed because the Current Context was empty."
                 return SetLockNodeStateResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
         else:
             try:
@@ -4761,16 +4791,16 @@ class NodeManager:
 
         if node_name is None:
             # Get from the current context
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to send message to Node from Current Context. Failed because the Current Context is empty."
                 return SendNodeMessageResultFailure(result_details=details)
 
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         if node is None:
             # Find the node by name
-            obj_mgr = GriptapeNodes.ObjectManager()
+            obj_mgr = self.engine.object_manager
             node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to send message to Node '{node_name}', but no such Node was found."
@@ -4883,7 +4913,7 @@ class NodeManager:
         """Break all incoming and outgoing connections for a parameter."""
         # Break incoming connections
         for incoming_connection in connections_result.incoming_connections:
-            delete_result = GriptapeNodes.handle_request(
+            delete_result = self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=incoming_connection.source_node_name,
                     source_parameter_name=incoming_connection.source_parameter_name,
@@ -4901,7 +4931,7 @@ class NodeManager:
 
         # Break outgoing connections
         for outgoing_connection in connections_result.outgoing_connections:
-            delete_result = GriptapeNodes.handle_request(
+            delete_result = self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=source_node_name,
                     source_parameter_name=source_parameter_name,
@@ -4936,7 +4966,7 @@ class NodeManager:
     def _migrate_parameter_value(self, request: MigrateParameterRequest) -> MigrateParameterResultFailure | None:
         """Handle migrating parameter value when no incoming connections exist."""
         # Get the current value from source
-        get_value_result = GriptapeNodes.handle_request(
+        get_value_result = self.engine.handle_request(
             GetParameterValueRequest(node_name=request.source_node_name, parameter_name=request.source_parameter_name)
         )
 
@@ -4954,7 +4984,7 @@ class NodeManager:
                 return MigrateParameterResultFailure(result_details=f"Failed to apply value transformation: {e!s}")
 
         # Set the value on target
-        set_value_result = GriptapeNodes.handle_request(
+        set_value_result = self.engine.handle_request(
             SetParameterValueRequest(
                 node_name=request.target_node_name, parameter_name=request.target_parameter_name, value=value
             )
@@ -4996,7 +5026,7 @@ class NodeManager:
         # Set additional parameters
         if input_conversion.additional_parameters:
             for param_name, param_value in input_conversion.additional_parameters.items():
-                set_value_result = GriptapeNodes.handle_request(
+                set_value_result = self.engine.handle_request(
                     SetParameterValueRequest(
                         node_name=intermediate_node_name, parameter_name=param_name, value=param_value
                     )
@@ -5008,7 +5038,7 @@ class NodeManager:
 
         # Connect all sources to intermediate node
         for incoming_connection in connections_result.incoming_connections:
-            connection_result = GriptapeNodes.handle_request(
+            connection_result = self.engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=incoming_connection.source_node_name,
                     source_parameter_name=incoming_connection.source_parameter_name,
@@ -5023,7 +5053,7 @@ class NodeManager:
                 )
 
         # Connect intermediate node to target
-        connection_result = GriptapeNodes.handle_request(
+        connection_result = self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=intermediate_node_name,
                 source_parameter_name=input_conversion.output_parameter,
@@ -5044,7 +5074,7 @@ class NodeManager:
     ) -> MigrateParameterResultFailure | None:
         """Create direct incoming connections without conversion."""
         for incoming_connection in connections_result.incoming_connections:
-            connection_result = GriptapeNodes.handle_request(
+            connection_result = self.engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=incoming_connection.source_node_name,
                     source_parameter_name=incoming_connection.source_parameter_name,
@@ -5089,7 +5119,7 @@ class NodeManager:
         # Set additional parameters
         if output_conversion.additional_parameters:
             for param_name, param_value in output_conversion.additional_parameters.items():
-                set_value_result = GriptapeNodes.handle_request(
+                set_value_result = self.engine.handle_request(
                     SetParameterValueRequest(
                         node_name=intermediate_node_name, parameter_name=param_name, value=param_value
                     )
@@ -5100,7 +5130,7 @@ class NodeManager:
                     )
 
         # Connect target to intermediate node
-        connection_result = GriptapeNodes.handle_request(
+        connection_result = self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=request.target_node_name,
                 source_parameter_name=request.target_parameter_name,
@@ -5116,7 +5146,7 @@ class NodeManager:
 
         # Connect intermediate node to all destinations
         for outgoing_connection in connections_result.outgoing_connections:
-            connection_result = GriptapeNodes.handle_request(
+            connection_result = self.engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=intermediate_node_name,
                     source_parameter_name=output_conversion.output_parameter,
@@ -5137,7 +5167,7 @@ class NodeManager:
     ) -> MigrateParameterResultFailure | None:
         """Create direct outgoing connections without conversion."""
         for outgoing_connection in connections_result.outgoing_connections:
-            connection_result = GriptapeNodes.handle_request(
+            connection_result = self.engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=request.target_node_name,
                     source_parameter_name=request.target_parameter_name,
@@ -5177,18 +5207,18 @@ class NodeManager:
 
         # FAILURE CHECK: Validate node_name
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = (
                     "Attempted to check reset eligibility for a Node from the Current Context. "
                     "Failed because the Current Context is empty."
                 )
                 return CanResetNodeToDefaultsResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # FAILURE CHECK: Get source node
         if node is None:
-            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
             details = f"Attempted to check reset eligibility for Node '{node_name}', but no such Node was found."
             return CanResetNodeToDefaultsResultFailure(result_details=details)
@@ -5226,17 +5256,17 @@ class NodeManager:
 
         # FAILURE CHECK: Validate node_name
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = (
                     "Attempted to reset a Node from the Current Context. Failed because the Current Context is empty."
                 )
                 return ResetNodeToDefaultsResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
 
         # FAILURE CHECK: Get source node
         if node is None:
-            node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(node_name, BaseNode)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
         if node is None:
             details = f"Attempted to reset Node '{node_name}', but no such Node was found."
             return ResetNodeToDefaultsResultFailure(result_details=details)
@@ -5311,7 +5341,7 @@ class NodeManager:
                 target_node_name=new_node_name,
                 target_parameter_name=incoming_connection.target_parameter_name,
             )
-            connection_result = GriptapeNodes.FlowManager().on_create_connection_request(connection_request)
+            connection_result = self.engine.flow_manager.on_create_connection_request(connection_request)
             if not isinstance(connection_result, CreateConnectionResultSuccess):
                 failed_incoming.append(incoming_connection)
 
@@ -5322,7 +5352,7 @@ class NodeManager:
                 target_node_name=outgoing_connection.target_node_name,
                 target_parameter_name=outgoing_connection.target_parameter_name,
             )
-            connection_result = GriptapeNodes.FlowManager().on_create_connection_request(connection_request)
+            connection_result = self.engine.flow_manager.on_create_connection_request(connection_request)
             if not isinstance(connection_result, CreateConnectionResultSuccess):
                 failed_outgoing.append(outgoing_connection)
 
@@ -5337,7 +5367,7 @@ class NodeManager:
         rename_request = RenameObjectRequest(
             object_name=new_node_name, requested_name=node_name, allow_next_closest_name_available=False
         )
-        rename_result = GriptapeNodes.ObjectManager().on_rename_object_request(rename_request)
+        rename_result = self.engine.object_manager.on_rename_object_request(rename_request)
         if not isinstance(rename_result, RenameObjectResultSuccess):
             details = f"Attempted to reset Node '{node_name}'. Failed to rename new node to original name."
             return ResetNodeToDefaultsResultFailure(result_details=details)
@@ -5375,10 +5405,10 @@ class NodeManager:
         # Get the node
         node_name = request.node_name
         if node_name is None:
-            if not GriptapeNodes.ContextManager().has_current_node():
+            if not self.engine.context_manager.has_current_node():
                 details = "Attempted to reorder ParameterList item in the Current Context. Failed because the Current Context was empty."
                 return ReorderParameterListItemResultFailure(result_details=details)
-            node = GriptapeNodes.ContextManager().get_current_node()
+            node = self.engine.context_manager.get_current_node()
             node_name = node.name
         else:
             try:
@@ -5443,7 +5473,7 @@ class NodeManager:
 
     def on_unresolve_node_request(self, request: UnresolveNodeRequest) -> ResultPayload:
         """Mark a single node UNRESOLVED and propagate to downstream nodes."""
-        node = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(request.node_name, BaseNode)
+        node = self.engine.object_manager.attempt_get_object_by_name_as_type(request.node_name, BaseNode)
         if node is None:
             return UnresolveNodeResultFailure(
                 result_details=f"Attempted to unresolve Node '{request.node_name}'. Node not found."
@@ -5453,5 +5483,5 @@ class NodeManager:
                 result_details=f"Attempted to unresolve Node '{request.node_name}'. Node is currently RESOLVING."
             )
         node.make_node_unresolved(current_states_to_trigger_change_event={NodeResolutionState.RESOLVED})
-        GriptapeNodes.FlowManager().get_connections().unresolve_future_nodes(node)
+        self.engine.flow_manager.get_connections().unresolve_future_nodes(node)
         return UnresolveNodeResultSuccess(result_details=f"Node '{request.node_name}' marked as unresolved.")

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -9,6 +9,7 @@ from griptape_nodes.exe_types.core_types import (
 )
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.base_events import (
     ResultDetails,
     ResultPayload,
@@ -27,16 +28,16 @@ from griptape_nodes.retained_mode.events.object_events import (
 from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 logger = logging.getLogger("griptape_nodes")
 
 
-class ObjectManager:
+class ObjectManager(EngineScoped):
     _name_to_objects: dict[str, object]
 
-    def __init__(self, _event_manager: EventManager) -> None:
+    def __init__(self, _event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         self._name_to_objects = {}
         _event_manager.assign_manager_to_request_type(
             request_type=RenameObjectRequest, callback=self.on_rename_object_request
@@ -81,9 +82,9 @@ class ObjectManager:
             # Let the object's manager know. TODO: https://github.com/griptape-ai/griptape-nodes/issues/869
         match source_obj:
             case ControlFlow():
-                GriptapeNodes.FlowManager().handle_flow_rename(old_name=request.object_name, new_name=final_name)
+                self.engine.flow_manager.handle_flow_rename(old_name=request.object_name, new_name=final_name)
             case BaseNode():
-                GriptapeNodes.NodeManager().handle_node_rename(old_name=request.object_name, new_name=final_name)
+                self.engine.node_manager.handle_node_rename(old_name=request.object_name, new_name=final_name)
             case _:
                 details = f"Attempted to rename an object named '{request.object_name}', but that object wasn't of a type supported for rename."
                 logger.error(details)
@@ -112,7 +113,7 @@ class ObjectManager:
 
         try:
             # Reset global execution state first to eliminate all references before deletion
-            GriptapeNodes.FlowManager().reset_global_execution_state()
+            self.engine.flow_manager.reset_global_execution_state()
         except Exception as e:
             details = f"Attempted to reset global execution state. Failed with exception: {e}"
             logger.error(details)
@@ -121,9 +122,9 @@ class ObjectManager:
         # Tear down each active workflow: cancel its running flows, delete its child
         # flows, drain its context substack, pop it. Stack depth is typically 1.
         try:
-            context_mgr = GriptapeNodes.ContextManager()
+            context_mgr = self.engine.context_manager
             while context_mgr.has_current_workflow():
-                GriptapeNodes.clear_current_workflow_data()
+                self.engine.clear_current_workflow_data()
         except Exception as e:
             details = f"Attempted to clear all object state and delete everything. Failed with exception: {e}"
             logger.error(details)
@@ -135,10 +136,10 @@ class ObjectManager:
             return ClearAllObjectStateResultFailure(result_details=details)
 
         # Clear all local workflow variables
-        GriptapeNodes.VariablesManager().clear_object_state()
-        GriptapeNodes.WorkflowManager().clear_object_state()
+        self.engine.variables_manager.clear_object_state()
+        self.engine.workflow_manager.clear_object_state()
         # Clear all event suppression
-        GriptapeNodes.EventManager().clear_event_suppression()
+        self.engine.event_manager.clear_event_suppression()
 
         details = "Successfully cleared all object state (deleted everything)."
         return ClearAllObjectStateResultSuccess(result_details=details)
@@ -260,9 +261,9 @@ class ObjectManager:
             for child in children:
                 obj.remove_child(child)
                 if isinstance(child, BaseNode):
-                    GriptapeNodes.handle_request(DeleteNodeRequest(child.name))
+                    self.engine.handle_request(DeleteNodeRequest(child.name))
                     return
                 if isinstance(child, Parameter) and isinstance(obj, BaseNode):
-                    GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(child.name, obj.name))
+                    self.engine.handle_request(RemoveParameterFromNodeRequest(child.name, obj.name))
                     return
         del self._name_to_objects[name]

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -64,6 +64,7 @@ from griptape_nodes.files.path_utils import (
     sanitize_path_string,
     strip_surrounding_quotes,
 )
+from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.base_events import ResultDetails, ResultPayload
 from griptape_nodes.retained_mode.events.os_events import (
     CopyFileRequest,
@@ -141,7 +142,6 @@ from griptape_nodes.retained_mode.events.resource_events import (
     RegisterResourceTypeResultSuccess,
 )
 from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import write_sidecar
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.retained_mode.managers.artifact_providers import WriteVettingPolicy
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.resource_types.compute_resource import ComputeBackend, ComputeResourceType
@@ -155,6 +155,7 @@ if TYPE_CHECKING:
 from griptape_nodes.utils.image_preview import create_image_preview_from_bytes
 
 console = Console()
+logger = logging.getLogger("griptape_nodes")
 
 # Maximum number of indexed candidates to try when CREATE_NEW policy is used
 MAX_INDEXED_CANDIDATES = 1000
@@ -291,7 +292,7 @@ class WindowsSpecialFolderResult(NamedTuple):
     remaining_parts: list[str] | None
 
 
-class OSManager:
+class OSManager(EngineScoped):
     """A class to manage OS-level scenarios.
 
     Making its own class as some runtime environments and some customer requirements may dictate this as optional.
@@ -372,7 +373,8 @@ class OSManager:
         remaining = parts[1:] if len(parts) > 1 else []
         return WindowsSpecialFolderResult(special_path=special_path, remaining_parts=remaining)
 
-    def __init__(self, event_manager: EventManager | None = None):
+    def __init__(self, event_manager: EventManager | None = None, *, engine: Engine | None = None):
+        super().__init__(engine)
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(
                 request_type=OpenAssociatedFileRequest, callback=self.on_open_associated_file_request
@@ -476,7 +478,7 @@ class OSManager:
 
     def _get_workspace_path(self) -> Path:
         """Get the workspace path from config."""
-        return GriptapeNodes.ConfigManager().workspace_path
+        return self.engine.config_manager.workspace_path
 
     def _get_windows_special_folder_path(self, csidl: int) -> Path:
         """Get Windows special folder path using Shell API.
@@ -610,7 +612,7 @@ class OSManager:
             MacroResolutionFailure: Details about resolution failure (missing variables, etc.)
             str: Successfully resolved absolute path string (success path; last)
         """
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             GetPathForMacroRequest(
                 parsed_macro=macro_path.parsed_macro,
                 variables=macro_path.variables,
@@ -712,7 +714,7 @@ class OSManager:
         Returns:
             Tuple of (is_workspace_path, relative_or_absolute_path)
         """
-        workspace = GriptapeNodes.ConfigManager().workspace_path
+        workspace = self.engine.config_manager.workspace_path
 
         # Canonicalize both sides so ~ / env vars / symlinks / relative spellings
         # all compare equal. Non-existent paths don't raise; the resolvable
@@ -907,7 +909,7 @@ class OSManager:
             → Raises ValueError (batch and frame_num both unresolved)
         """
         # Partially resolve to identify unresolved variables
-        secrets_manager = GriptapeNodes.SecretsManager()
+        secrets_manager = self.engine.secrets_manager
         partial = partial_resolve(parsed_macro.template, parsed_macro.segments, variables, secrets_manager)
 
         # Get unresolved variables (optional variables already filtered out)
@@ -1019,7 +1021,7 @@ class OSManager:
             Variables: {"outputs": "/path"}
             → Returns 123
         """
-        secrets_manager = GriptapeNodes.SecretsManager()
+        secrets_manager = self.engine.secrets_manager
 
         # Normalize path separators to POSIX form before reverse-matching. The
         # macro template uses `/` by convention, but the filename comes from
@@ -1317,7 +1319,7 @@ class OSManager:
                 Files: []
                 Returns: 1 (start with index 1)
         """
-        secrets_manager = GriptapeNodes.SecretsManager()
+        secrets_manager = self.engine.secrets_manager
         index_var_name = index_var.info.name
 
         # Check if index variable is optional
@@ -1593,7 +1595,7 @@ class OSManager:
             # Cache workspace path and resolved workspace to avoid repeated lookups/resolutions
             # Only resolve workspace if we need it for relative paths or absolute paths
             need_relative_paths = request.workspace_only is True
-            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            workspace_path = self.engine.config_manager.workspace_path
             if need_relative_paths or request.include_absolute_path:
                 resolved_workspace = canonicalize_for_identity(workspace_path)
             else:
@@ -2015,9 +2017,7 @@ class OSManager:
                 filename_pattern=filename_pattern,
             )
 
-        resolve_result = GriptapeNodes.handle_request(
-            GetPathForMacroRequest(parsed_macro=parsed_directory, variables={})
-        )
+        resolve_result = self.engine.handle_request(GetPathForMacroRequest(parsed_macro=parsed_directory, variables={}))
         if not isinstance(resolve_result, GetPathForMacroResultSuccess):
             return ScanSequencesResultFailure(
                 failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
@@ -2186,7 +2186,7 @@ class OSManager:
 
             # Only check workspace directory for absolute local paths
             if path_obj.is_absolute():
-                config_manager = GriptapeNodes.ConfigManager()
+                config_manager = self.engine.config_manager
                 static_dir = config_manager.workspace_path
 
                 try:
@@ -2197,7 +2197,7 @@ class OSManager:
                     pass
                 else:
                     # File is in static directory, construct URL directly
-                    static_base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+                    static_base_url = self.engine.static_files_manager.static_server_base_url
                     static_url = f"{static_base_url}/workspace/{file_relative_to_static}"
                     msg = f"Image already in workspace directory, returning URL: {static_url}"
                     logger.debug(msg)
@@ -2279,7 +2279,7 @@ class OSManager:
         next_index = self._scan_for_next_available_index(parsed_macro, variables, index_info)
 
         # Resolve path with the index
-        secrets_manager = GriptapeNodes.SecretsManager()
+        secrets_manager = self.engine.secrets_manager
         try:
             if next_index is None:
                 # Optional index variable with base filename available
@@ -2437,7 +2437,7 @@ class OSManager:
         # sniffed_ext also implies ``request.content`` is bytes; downstream code
         # relies on that.
         sniffed_ext = (
-            GriptapeNodes.ArtifactManager().sniff_extension(request.content)
+            self.engine.artifact_manager.sniff_extension(request.content)
             if isinstance(request.content, bytes)
             else None
         )
@@ -2488,9 +2488,9 @@ class OSManager:
         if (
             isinstance(content, bytes)
             and not request.skip_metadata_injection
-            and GriptapeNodes.ConfigManager().get_config_value("auto_inject_workflow_metadata")
+            and self.engine.config_manager.get_config_value("auto_inject_workflow_metadata")
         ):
-            content = GriptapeNodes.ArtifactManager().prepare_content_for_write(content, file_path.name)
+            content = self.engine.artifact_manager.prepare_content_for_write(content, file_path.name)
 
         # Now attempt the write, based on our collision (existing file) policy.
         match request.existing_file_policy:
@@ -2644,7 +2644,7 @@ class OSManager:
                         start_idx = starting_index if starting_index is not None else 1
 
                     # Try indexed candidates on-demand (up to max attempts)
-                    secrets_manager = GriptapeNodes.SecretsManager()
+                    secrets_manager = self.engine.secrets_manager
                     attempted_count = 0
 
                     for idx in range(start_idx, start_idx + MAX_INDEXED_CANDIDATES):
@@ -2837,7 +2837,7 @@ class OSManager:
         Raises ``StagingFailedError`` on any failure, tagged with the
         ``FileIOFailureReason`` that would have appeared in the request result.
         """
-        situation_result = GriptapeNodes.handle_request(
+        situation_result = self.engine.handle_request(
             GetSituationRequest(situation_name=BuiltInSituation.SAVE_TEMP_FILE)
         )
         if not isinstance(situation_result, GetSituationResultSuccess):
@@ -2853,9 +2853,7 @@ class OSManager:
             msg = f"Attempted to write temp file. Failed to parse SAVE_TEMP_FILE macro: {exc}"
             raise StagingFailedError(msg, FileIOFailureReason.INVALID_PATH) from exc
 
-        path_result = GriptapeNodes.handle_request(
-            GetPathForMacroRequest(parsed_macro=parsed_macro, variables=variables)
-        )
+        path_result = self.engine.handle_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables=variables))
         if not isinstance(path_result, GetPathForMacroResultSuccess):
             msg = f"Attempted to write temp file. Failed to resolve SAVE_TEMP_FILE macro: {path_result.result_details}"
             raise StagingFailedError(msg, FileIOFailureReason.INVALID_PATH)
@@ -2929,7 +2927,7 @@ class OSManager:
         except OSError as exc:
             logger.error("Attempted to truncate staged codec-vet temp at '%s'. Failed: %s", staged_path, exc)
 
-        delete_result = GriptapeNodes.handle_request(
+        delete_result = self.engine.handle_request(
             DeleteFileRequest(
                 path=staged_path,
                 workspace_only=False,
@@ -2970,7 +2968,7 @@ class OSManager:
         falling through would let a policy variant added without updating
         this switch bless every write that reached it.
         """
-        artifact_manager = GriptapeNodes.ArtifactManager()
+        artifact_manager = self.engine.artifact_manager
         policy = artifact_manager.get_write_vetting_policy(sniffed_ext)
         denial: CheckpointDenial | None = None
 
@@ -3859,7 +3857,7 @@ class OSManager:
 
         https://stackoverflow.com/a/50924863
         """
-        if not GriptapeNodes.OSManager().is_windows():
+        if not OSManager.is_windows():
             return
 
         long_path = Path(normalize_path_for_platform(Path(path)))
@@ -4297,8 +4295,9 @@ class OSManager:
     def _register_system_resources_direct(self) -> None:
         """Register OS, CPU, and Compute resource types directly during initialization.
 
-        This method is called during __init__ and uses the event_manager directly
-        to avoid singleton recursion issues with GriptapeNodes.handle_request.
+        This method is called during __init__ and uses the event_manager directly so
+        registration does not re-enter the full request pipeline before the engine has
+        finished wiring itself up.
         """
         self._attempt_generate_os_resources_direct()
         self._attempt_generate_cpu_resources_direct()
@@ -4307,7 +4306,8 @@ class OSManager:
     def _handle_request_direct(self, request: Any) -> Any:
         """Handle a request directly through the event_manager during initialization.
 
-        This bypasses GriptapeNodes.handle_request to avoid singleton recursion.
+        Dispatches straight to the registered callback, skipping the result broadcast and
+        re-entrancy the full request path would add while the engine is still constructing.
         """
         request_type = type(request)
         callback = self._event_manager._request_type_to_manager.get(request_type)
@@ -4425,7 +4425,7 @@ class OSManager:
         # Register OS resource type
         os_resource_type = OSResourceType()
         register_request = RegisterResourceTypeRequest(resource_type=os_resource_type)
-        result = GriptapeNodes.handle_request(register_request)
+        result = self.engine.handle_request(register_request)
 
         if not isinstance(result, RegisterResourceTypeResultSuccess):
             logger.error("Attempted to register OS resource type. Failed due to resource type registration failure")
@@ -4440,7 +4440,7 @@ class OSManager:
         # Register CPU resource type
         cpu_resource_type = CPUResourceType()
         register_request = RegisterResourceTypeRequest(resource_type=cpu_resource_type)
-        result = GriptapeNodes.handle_request(register_request)
+        result = self.engine.handle_request(register_request)
 
         if not isinstance(result, RegisterResourceTypeResultSuccess):
             logger.error("Attempted to register CPU resource type. Failed due to resource type registration failure")
@@ -4460,7 +4460,7 @@ class OSManager:
         create_request = CreateResourceInstanceRequest(
             resource_type_name="OSResourceType", capabilities=os_capabilities
         )
-        result = GriptapeNodes.handle_request(create_request)
+        result = self.engine.handle_request(create_request)
 
         if not isinstance(result, CreateResourceInstanceResultSuccess):
             logger.error(
@@ -4479,7 +4479,7 @@ class OSManager:
         create_request = CreateResourceInstanceRequest(
             resource_type_name="CPUResourceType", capabilities=cpu_capabilities
         )
-        result = GriptapeNodes.handle_request(create_request)
+        result = self.engine.handle_request(create_request)
 
         if not isinstance(result, CreateResourceInstanceResultSuccess):
             logger.error(
@@ -4494,7 +4494,7 @@ class OSManager:
         # Register Compute resource type
         compute_resource_type = ComputeResourceType()
         register_request = RegisterResourceTypeRequest(resource_type=compute_resource_type)
-        result = GriptapeNodes.handle_request(register_request)
+        result = self.engine.handle_request(register_request)
 
         if not isinstance(result, RegisterResourceTypeResultSuccess):
             logger.error(
@@ -4514,7 +4514,7 @@ class OSManager:
         create_request = CreateResourceInstanceRequest(
             resource_type_name="ComputeResourceType", capabilities=compute_capabilities
         )
-        result = GriptapeNodes.handle_request(create_request)
+        result = self.engine.handle_request(create_request)
 
         if not isinstance(result, CreateResourceInstanceResultSuccess):
             logger.error(

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -49,6 +49,7 @@ from griptape_nodes.files.path_utils import (
     resolve_path_safely,
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete, CurrentProjectChanged
 from griptape_nodes.retained_mode.events.library_events import (
     ReloadAllLibrariesRequest,
@@ -118,7 +119,6 @@ from griptape_nodes.retained_mode.events.project_events import (
     ValidateProjectTemplateRequest,
     ValidateProjectTemplateResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     AuthorizationCheckpoint,
     CheckpointAction,
@@ -147,6 +147,7 @@ if TYPE_CHECKING:
 
     from griptape_nodes.common.macro_parser.segments import ParsedSegment
     from griptape_nodes.common.project_templates.directory import PerPlatformPathMacro
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -512,7 +513,7 @@ def _find_unresolved_sequence_segment(
     return None
 
 
-class ProjectManager:
+class ProjectManager(EngineScoped):
     """Manages project templates, validation, and file path resolution.
 
     Responsibilities:
@@ -535,6 +536,8 @@ class ProjectManager:
         event_manager: EventManager,
         config_manager: ConfigManager,
         secrets_manager: SecretsManager,
+        *,
+        engine: Engine | None = None,
     ) -> None:
         """Initialize the ProjectManager.
 
@@ -542,7 +545,9 @@ class ProjectManager:
             event_manager: The EventManager instance to use for event handling
             config_manager: ConfigManager instance for accessing configuration
             secrets_manager: SecretsManager instance for macro resolution
+            engine: The owning Engine, injected by Engine.__init__.
         """
+        super().__init__(engine)
         self._event_manager = event_manager
         self._config_manager = config_manager
         self._secrets_manager = secrets_manager
@@ -762,7 +767,7 @@ class ProjectManager:
         # forbids never enters the engine, whether reached by explicit load or
         # directory discovery. Mirrors the activation gate, which resolves the same
         # facts; the name is passed in because the project is not cached yet.
-        load_denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+        load_denial = self._event_manager.evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.LOAD_PROJECT,
                 subject_type=CheckpointSubjectType.PROJECT,
@@ -836,7 +841,7 @@ class ProjectManager:
             encoding="utf-8",
             workspace_only=False,
         )
-        read_result = await GriptapeNodes.ahandle_request(read_request)
+        read_result = await self.engine.ahandle_request(read_request)
 
         if read_result.failed():
             validation = ProjectValidationInfo(status=ProjectValidationStatus.MISSING)
@@ -1329,7 +1334,7 @@ class ProjectManager:
         unclaimed_names = {v.name for v in variable_infos if v.name not in resolution_bag}
         if unclaimed_names:
             stored_substitutable = _substitutable_stored_values(
-                GriptapeNodes.VariablesManager().stored_project_variable_values(project_info.project_id)
+                self.engine.variables_manager.stored_project_variable_values(project_info.project_id)
             )
             for var_name in unclaimed_names & set(stored_substitutable):
                 resolution_bag[var_name] = stored_substitutable[var_name]
@@ -2248,14 +2253,14 @@ class ProjectManager:
         gate included) fails, otherwise None.
         """
         if library_config_changed:
-            reload_result = await GriptapeNodes.ahandle_request(ReloadAllLibrariesRequest())
+            reload_result = await self.engine.ahandle_request(ReloadAllLibrariesRequest())
             if isinstance(reload_result, ReloadAllLibrariesResultFailure):
                 return SetCurrentProjectResultFailure(
                     result_details=f"Attempted to set project '{project_id}'. "
                     f"Config updated but library reload failed: {reload_result.result_details}",
                 )
         if workspace_changed:
-            await GriptapeNodes.WorkflowManager().refresh_workflow_registry()
+            await self.engine.workflow_manager.refresh_workflow_registry()
         return None
 
     def _project_checkpoint_attributes(self, project_id: ProjectID, *, name: str | None = None) -> dict[str, Any]:
@@ -2363,7 +2368,7 @@ class ProjectManager:
         # current project untouched (the activation below never runs). Rollback
         # re-activates the previous project through _activate_project directly, so
         # it never re-enters this gate.
-        denial = GriptapeNodes.EventManager().evaluate_authorization_checkpoint(
+        denial = self._event_manager.evaluate_authorization_checkpoint(
             AuthorizationCheckpoint(
                 action=CheckpointAction.ACTIVATE_PROJECT,
                 subject_type=CheckpointSubjectType.PROJECT,
@@ -2484,7 +2489,7 @@ class ProjectManager:
             # the orchestrator's project must not write it back: both processes share the
             # on-disk config, so a worker write races the orchestrator's. The worker still
             # re-establishes its in-memory layers above; it just skips the persist.
-            if not GriptapeNodes.LibraryManager().is_worker:
+            if not self.engine.library_manager.is_worker:
                 # Persist the active project so the next engine restart restores it via
                 # _resolve_project_file_path(). A file-backed project persists its path.
                 # System defaults persists the SYSTEM_DEFAULTS_KEY sentinel so that a
@@ -2660,7 +2665,7 @@ class ProjectManager:
         for loaded_id, loaded_info in list(self._successfully_loaded_project_templates.items()):
             if loaded_info.project_file_path == canonical_path:
                 self._successfully_loaded_project_templates.pop(loaded_id, None)
-                GriptapeNodes.VariablesManager().remove_project_variables(loaded_id)
+                self.engine.variables_manager.remove_project_variables(loaded_id)
         self._registered_template_status.pop(canonical_path, None)
 
         return SaveProjectTemplateResultSuccess(
@@ -2734,7 +2739,7 @@ class ProjectManager:
         # declared type), so validation here cannot fail for writes made through the API —
         # but persist must never raise past an already-acknowledged write, so guard anyway
         # and report which entry is unpersistable instead of crashing (or coercing).
-        stored_variables = GriptapeNodes.VariablesManager().stored_project_variables(project_id)
+        stored_variables = self.engine.variables_manager.stored_project_variables(project_id)
         rebuilt: dict[str, ProjectVariableDef] = {}
         for variable in stored_variables:
             try:
@@ -3085,7 +3090,7 @@ class ProjectManager:
         # Remove from in-memory caches: the registry is id-keyed, the status map
         # is path-keyed. Drop the project's stored-variable bag with it.
         self._successfully_loaded_project_templates.pop(project_id, None)
-        GriptapeNodes.VariablesManager().remove_project_variables(project_id)
+        self.engine.variables_manager.remove_project_variables(project_id)
         if file_path is not None:
             self._registered_template_status.pop(file_path, None)
 
@@ -3282,7 +3287,7 @@ class ProjectManager:
         if referenced_unsatisfied:
             stored_substitutable_names = set(
                 _substitutable_stored_values(
-                    GriptapeNodes.VariablesManager().stored_project_variable_values(project_info.project_id)
+                    self.engine.variables_manager.stored_project_variable_values(project_info.project_id)
                 )
             )
             satisfiable_names |= stored_substitutable_names
@@ -3769,7 +3774,7 @@ class ProjectManager:
                     permission=var_def.permission,
                 )
             )
-        GriptapeNodes.VariablesManager().set_project_variables(project_id, layer)
+        self.engine.variables_manager.set_project_variables(project_id, layer)
 
     def resolve_project_variable(self, name: str, *, project_id: str | None) -> FlowVariable:
         """Resolve a computed project variable (builtin or template directory) to a snapshot FlowVariable.
@@ -3953,14 +3958,14 @@ class ProjectManager:
                 return str(self._config_manager.workspace_path)
 
             case "workflow_name":
-                context_manager = GriptapeNodes.ContextManager()
+                context_manager = self.engine.context_manager
                 if not context_manager.has_current_workflow():
                     msg = "No current workflow"
                     raise RuntimeError(msg)
                 return context_manager.get_current_workflow_name()
 
             case "workflow_dir":
-                context_manager = GriptapeNodes.ContextManager()
+                context_manager = self.engine.context_manager
                 if not context_manager.has_current_workflow():
                     msg = "No current workflow"
                     raise RuntimeError(msg)
@@ -4416,7 +4421,7 @@ class ProjectManager:
         orchestrator's switch must not write the shared file back, since both
         processes share it and a worker write races the orchestrator's.
         """
-        if GriptapeNodes.LibraryManager().is_worker:
+        if self.engine.library_manager.is_worker:
             return
         try:
             registered: list[str | dict | PerPlatformProjectPath] = (

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -14,6 +14,7 @@ from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 from griptape_nodes.files.path_utils import FilenameParts
+from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.artifact_events import (
     GetPreviewForArtifactRequest,
@@ -46,7 +47,6 @@ from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import (
     SituationMetadata,
     SituationPolicy,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -73,7 +73,7 @@ class ResolvedStaticFilePath(NamedTuple):
     file_metadata: SidecarContent | None = None
 
 
-class StaticFilesManager:
+class StaticFilesManager(EngineScoped):
     """A class to manage the creation and management of static files."""
 
     def __init__(
@@ -81,6 +81,8 @@ class StaticFilesManager:
         config_manager: ConfigManager,
         secrets_manager: SecretsManager,
         event_manager: EventManager | None = None,
+        *,
+        engine: Engine | None = None,
     ) -> None:
         """Initialize the StaticFilesManager.
 
@@ -88,7 +90,9 @@ class StaticFilesManager:
             config_manager: The ConfigManager instance to use for accessing the workspace path.
             event_manager: The EventManager instance to use for event handling.
             secrets_manager: The SecretsManager instance to use for accessing secrets.
+            engine: The owning Engine, used to resolve peer managers.
         """
+        super().__init__(engine)
         self.config_manager = config_manager
         self.secrets_manager = secrets_manager
 
@@ -191,7 +195,7 @@ class StaticFilesManager:
         if not extension:
             return file_path, None
 
-        registry = GriptapeNodes.ArtifactManager()._registry
+        registry = self.engine.artifact_manager._registry
         provider_classes = registry.get_provider_classes_by_format(extension)
         if not provider_classes:
             logger.debug("Skipping preview for unsupported file format: %s", file_path)
@@ -199,7 +203,7 @@ class StaticFilesManager:
 
         provider_name = provider_classes[0].get_friendly_name()
 
-        result = await GriptapeNodes.ahandle_request(
+        result = await self.engine.ahandle_request(
             GetPreviewForArtifactRequest(
                 macro_path=MacroPath(ParsedMacro(str(file_path)), {}),
                 artifact_provider_name=provider_name,
@@ -370,7 +374,7 @@ class StaticFilesManager:
             return CreateStaticFileDownloadUrlResultFailure(error=msg, result_details=msg)
 
         if parsed.get_variables():
-            resolve_result = GriptapeNodes.handle_request(
+            resolve_result = self.engine.handle_request(
                 GetPathForMacroRequest(parsed_macro=parsed, variables=request.macro_variables)
             )
             if not isinstance(resolve_result, GetPathForMacroResultSuccess):
@@ -501,7 +505,7 @@ class StaticFilesManager:
         Returns:
             ResolvedStaticFilePath if situation resolution succeeds, or None on failure.
         """
-        situation_result = GriptapeNodes.handle_request(GetSituationRequest(situation_name=situation_name))
+        situation_result = self.engine.handle_request(GetSituationRequest(situation_name=situation_name))
         if not isinstance(situation_result, GetSituationResultSuccess):
             logger.warning(
                 "Project template does not include '%s' situation; static files will save to the default directory. "
@@ -520,7 +524,7 @@ class StaticFilesManager:
             logger.warning("Failed to parse %s situation macro: %s", situation_name, e)
             return None
 
-        macro_result = GriptapeNodes.handle_request(
+        macro_result = self.engine.handle_request(
             GetPathForMacroRequest(
                 parsed_macro=parsed_macro,
                 variables={"file_name_base": parts.stem, "file_extension": parts.extension},
@@ -530,7 +534,7 @@ class StaticFilesManager:
             logger.warning("Failed to resolve %s situation path: %s", situation_name, macro_result.result_details)
             return None
 
-        workspace_dir = GriptapeNodes.ConfigManager().workspace_path
+        workspace_dir = self.config_manager.workspace_path
         try:
             # Resolve both sides to ensure drive letters match on Windows (drive-relative vs absolute paths).
             workspace_relative_path = macro_result.absolute_path.resolve().relative_to(workspace_dir.resolve())

--- a/src/griptape_nodes/retained_mode/managers/sync_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/sync_manager.py
@@ -14,6 +14,7 @@ from watchfiles import Change, PythonFilter, watch
 from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.files.path_utils import canonicalize_for_identity
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.base_events import AppEvent, ResultDetails
 from griptape_nodes.retained_mode.events.sync_events import (
@@ -26,10 +27,10 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     RegisterWorkflowsFromConfigRequest,
     RegisterWorkflowsFromConfigResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER_KEY
 
 if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -38,10 +39,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger("griptape_nodes")
 
 
-class SyncManager:
+class SyncManager(EngineScoped):
     """Manager for syncing workflows with cloud storage."""
 
-    def __init__(self, event_manager: EventManager, config_manager: ConfigManager) -> None:
+    def __init__(
+        self, event_manager: EventManager, config_manager: ConfigManager, *, engine: Engine | None = None
+    ) -> None:
+        super().__init__(engine)
         self._active_sync_tasks: dict[str, threading.Thread] = {}
         self._watch_task: threading.Thread | None = None
         self._watching_stopped = threading.Event()
@@ -185,7 +189,7 @@ class SyncManager:
             sync_request = StartSyncAllCloudWorkflowsRequest()
 
             # Use handle_request to process through normal event system
-            result = GriptapeNodes.handle_request(sync_request)
+            result = self.engine.handle_request(sync_request)
 
             if isinstance(result, StartSyncAllCloudWorkflowsResultSuccess):
                 logger.debug(
@@ -209,7 +213,7 @@ class SyncManager:
         Raises:
             RuntimeError: If required cloud configuration is missing.
         """
-        secrets_manager = GriptapeNodes.SecretsManager()
+        secrets_manager = self.engine.secrets_manager
 
         # Get cloud storage configuration from secrets
         bucket_id = secrets_manager.get_secret("GT_CLOUD_BUCKET_ID", should_error_on_not_found=False)
@@ -486,14 +490,14 @@ class SyncManager:
             total_workflows=total_workflows,
         )
 
-        GriptapeNodes.EventManager().put_event(AppEvent(payload=sync_complete_event))
+        self.engine.event_manager.put_event(AppEvent(payload=sync_complete_event))
 
         # Register workflows from the synced directory
         if synced_workflows:
             logger.info("Registering %d synced workflows from configuration", len(synced_workflows))
             try:
                 register_request = RegisterWorkflowsFromConfigRequest(config_section=WORKFLOWS_TO_REGISTER_KEY)
-                register_result = GriptapeNodes.handle_request(register_request)
+                register_result = self.engine.handle_request(register_request)
 
                 if isinstance(register_result, RegisterWorkflowsFromConfigResultSuccess):
                     logger.info(

--- a/src/griptape_nodes/retained_mode/managers/variable_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/variable_manager.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, NamedTuple
 
 from griptape_nodes.common.macro_parser.exceptions import MacroResolutionError
+from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.base_events import ResultPayload
 from griptape_nodes.retained_mode.events.variable_events import (
     CreateVariableRequest,
@@ -53,7 +54,6 @@ from griptape_nodes.retained_mode.events.variable_events import (
     SubstitutableSource,
     VariableDetails,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.variable_types import (
     FlowVariable,
@@ -118,10 +118,11 @@ def _project_type_mismatch(new_type: str, current_value: Any) -> str | None:
     return _project_value_mismatch(new_type, current_value)
 
 
-class VariablesManager:
+class VariablesManager(EngineScoped):
     """Manager for variables with scoped access control."""
 
-    def __init__(self, event_manager: EventManager | None = None) -> None:
+    def __init__(self, event_manager: EventManager | None = None, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         # Storage for flow-scoped variables: one VariableLayer per flow, lazily created.
         self._flow_layers: dict[str, VariableLayer] = {}
         # Storage for global variables: single VariableLayer.
@@ -201,7 +202,7 @@ class VariablesManager:
         """Get the starting flow name, using Context Manager if None."""
         if starting_flow is not None:
             # Validate that the specified flow exists
-            flow_manager = GriptapeNodes.FlowManager()
+            flow_manager = self.engine.flow_manager
             try:
                 flow_manager.get_parent_flow(starting_flow)  # This will raise if flow doesn't exist
             except Exception as e:
@@ -210,7 +211,7 @@ class VariablesManager:
             return starting_flow
 
         # Get current flow from Context Manager
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
 
         if not context_manager.has_current_flow():
             msg = "No starting flow specified and no current flow in Context Manager"
@@ -220,7 +221,7 @@ class VariablesManager:
 
     def _get_flow_hierarchy(self, starting_flow: str) -> list[str]:
         """Get the flow hierarchy from starting flow up to root."""
-        flow_manager = GriptapeNodes.FlowManager()
+        flow_manager = self.engine.flow_manager
 
         hierarchy = []
         current_flow = starting_flow
@@ -282,7 +283,7 @@ class VariablesManager:
 
     def _effective_project_id(self, project_id: str | None) -> str | None:
         """Resolve None → current project id; returns None when no project is available."""
-        return GriptapeNodes.ProjectManager().resolve_project_id(project_id)
+        return self.engine.project_manager.resolve_project_id(project_id)
 
     def _get_project_variable(self, name: str, *, project_id: str | None) -> FlowVariable | None:
         """Resolve a single project-layer variable (computed namespace first, then stored layer).
@@ -302,7 +303,7 @@ class VariablesManager:
         # non-computed name and catching ValueError would conflate "unknown name" with any
         # other ValueError the resolution might raise, silently violating the
         # computed-shadows-stored contract once stored entries exist.
-        project_manager = GriptapeNodes.ProjectManager()
+        project_manager = self.engine.project_manager
         if name in project_manager.project_computed_names(project_id=effective):
             try:
                 return project_manager.resolve_project_variable(name, project_id=effective)
@@ -360,7 +361,7 @@ class VariablesManager:
         effective = self._effective_project_id(project_id)
         if effective is None:
             return
-        error = GriptapeNodes.ProjectManager().persist_project_variables(effective)
+        error = self.engine.project_manager.persist_project_variables(effective)
         if error is not None:
             logger.warning("Project variable change for project '%s' not persisted: %s", effective, error)
 
@@ -373,7 +374,7 @@ class VariablesManager:
         effective = self._effective_project_id(project_id)
         if effective is None:
             return []
-        computed = GriptapeNodes.ProjectManager().project_computed_names(project_id=effective)
+        computed = self.engine.project_manager.project_computed_names(project_id=effective)
         names = sorted(computed)
         project_layer = self._project_layers.get(effective)
         if project_layer is not None:
@@ -392,7 +393,7 @@ class VariablesManager:
         effective = self._effective_project_id(project_id)
         if effective is None:
             return frozenset()
-        return GriptapeNodes.ProjectManager().project_computed_names(project_id=effective)
+        return self.engine.project_manager.project_computed_names(project_id=effective)
 
     def _collect_resolvable_project_variables(
         self, seen: set[str], *, project_id: str | None
@@ -1234,14 +1235,14 @@ class VariablesManager:
         from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
         from griptape_nodes.exe_types.variable_resolver import VariableResolver
 
-        flow_manager = GriptapeNodes.FlowManager()
+        flow_manager = self.engine.flow_manager
         if flow_manager.check_for_existing_running_flow():
             # Mid-run: downstream UNRESOLVED nodes pick up new values naturally via ResolveSubstitutionRequest.
             return
 
         connections = flow_manager.get_connections()
 
-        for obj in list(GriptapeNodes.ObjectManager()._name_to_objects.values()):
+        for obj in list(self.engine.object_manager._name_to_objects.values()):
             if not isinstance(obj, BaseNode):
                 continue
             if obj.state not in (NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING):

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import semver
 
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
@@ -23,7 +24,6 @@ from griptape_nodes.retained_mode.events.library_events import (
     ListRegisteredLibrariesResultSuccess,
 )
 from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries.deprecated_node_warning_problem import (
     DeprecatedNodeWarningProblem,
 )
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import BaseNode
     from griptape_nodes.node_library.library_registry import LibrarySchema
     from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.parameter_events import (
         SetParameterValueResultFailure,
         SetParameterValueResultSuccess,
@@ -132,10 +133,11 @@ class SetParameterVersionCompatibilityCheck(ABC):
         """
 
 
-class VersionCompatibilityManager:
+class VersionCompatibilityManager(EngineScoped):
     """Manages version compatibility checks for libraries and other components."""
 
-    def __init__(self, event_manager: EventManager) -> None:
+    def __init__(self, event_manager: EventManager, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         self._event_manager = event_manager
         self._compatibility_checks: list[LibraryVersionCompatibilityCheck] = []
         self._workflow_compatibility_checks: list[WorkflowVersionCompatibilityCheck] = []
@@ -269,7 +271,7 @@ class VersionCompatibilityManager:
         """
         issues: list[WorkflowVersionCompatibilityIssue] = []
 
-        list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
+        list_result = await self.engine.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
 
         if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
             return issues
@@ -287,9 +289,7 @@ class VersionCompatibilityManager:
 
             # Get library metadata to get version
             library_metadata_request = GetLibraryMetadataRequest(library=library_name)
-            library_metadata_result = GriptapeNodes.LibraryManager().get_library_metadata_request(
-                library_metadata_request
-            )
+            library_metadata_result = self.engine.library_manager.get_library_metadata_request(library_metadata_request)
 
             if not isinstance(library_metadata_result, GetLibraryMetadataResultSuccess):
                 # Should not happen since we verified library exists, but handle gracefully
@@ -306,7 +306,7 @@ class VersionCompatibilityManager:
 
             # Check if node type exists in library (silent check - no error logging)
             list_node_types_request = ListNodeTypesInLibraryRequest(library=library_name)
-            list_node_types_result = GriptapeNodes.LibraryManager().on_list_node_types_in_library_request(
+            list_node_types_result = self.engine.library_manager.on_list_node_types_in_library_request(
                 list_node_types_request
             )
 
@@ -331,7 +331,7 @@ class VersionCompatibilityManager:
 
             # Get node metadata from library (we know the node exists now)
             node_metadata_request = GetNodeMetadataFromLibraryRequest(library=library_name, node_type=node_type)
-            node_metadata_result = GriptapeNodes.LibraryManager().get_node_metadata_from_library_request(
+            node_metadata_result = self.engine.library_manager.get_node_metadata_from_library_request(
                 node_metadata_request
             )
 
@@ -388,7 +388,7 @@ class VersionCompatibilityManager:
 
     def _get_current_engine_version(self) -> semver.VersionInfo:
         """Get the current engine version."""
-        result = GriptapeNodes.handle_request(GetEngineVersionRequest())
+        result = self.engine.handle_request(GetEngineVersionRequest())
         if isinstance(result, GetEngineVersionResultSuccess):
             return semver.VersionInfo(major=result.major, minor=result.minor, patch=result.patch)
         msg = "Failed to get engine version"

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -136,7 +136,7 @@ class SetParameterVersionCompatibilityCheck(ABC):
 class VersionCompatibilityManager(EngineScoped):
     """Manages version compatibility checks for libraries and other components."""
 
-    def __init__(self, event_manager: EventManager, engine: Engine | None = None) -> None:
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
         super().__init__(engine)
         self._event_manager = event_manager
         self._compatibility_checks: list[LibraryVersionCompatibilityCheck] = []

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from griptape_nodes.bootstrap.utils.subprocess_websocket_base import WebSocketMessage
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events import worker_events
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged, CurrentProjectChanged, SecretChanged
 from griptape_nodes.retained_mode.events.base_events import EventRequest
@@ -26,8 +27,8 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from griptape_nodes.api_client.request_client import RequestClient
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import RequestPayload
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 logger = logging.getLogger("griptape_nodes_app")
@@ -50,8 +51,8 @@ class _WorkerTransport:
     """Transport-layer dependencies for WorkerManager.
 
     Held separately from WorkerManager so the manager can be constructed up
-    front (e.g. by the GriptapeNodes singleton) and wired to a concrete
-    transport later, once the WebSocket client and request client exist.
+    front (e.g. by the Engine) and wired to a concrete transport later, once
+    the WebSocket client and request client exist.
     """
 
     ws_outgoing_queue: asyncio.Queue
@@ -61,7 +62,7 @@ class _WorkerTransport:
     request_client: RequestClient
 
 
-class WorkerManager:
+class WorkerManager(EngineScoped):
     """Manages worker registration, heartbeating, eviction, and event routing.
 
     Encapsulates all state and logic related to worker engines on both the
@@ -97,10 +98,10 @@ class WorkerManager:
     def __init__(
         self,
         *,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         event_manager: EventManager,
     ) -> None:
-        self._griptape_nodes = griptape_nodes
+        super().__init__(engine)
         self._event_manager = event_manager
         self._transport: _WorkerTransport | None = None
 
@@ -132,7 +133,7 @@ class WorkerManager:
         # Set when an active session becomes available; gates worker spawning.
         self._session_ready_event: asyncio.Event = asyncio.Event()
 
-        config = griptape_nodes._config_manager
+        config = engine.config_manager
         self.heartbeat_interval_s: float = config.get_config_value(
             WORKER_HEARTBEAT_INTERVAL_KEY, default=WorkerManager.DEFAULT_HEARTBEAT_INTERVAL_S, cast_type=float
         )
@@ -209,7 +210,7 @@ class WorkerManager:
             logger.error(details)
             return worker_events.RegisterWorkerResultFailure(result_details=details)
 
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         request_topic = f"sessions/{session_id}/workers/{wid}/request"
         self._workers[wid] = WorkerRegistration(request_topic=request_topic, worker_key=request.library_name)
         self._worker_last_seen[wid] = time.monotonic()
@@ -242,7 +243,7 @@ class WorkerManager:
     ) -> worker_events.UnregisterWorkerResultSuccess | worker_events.UnregisterWorkerResultFailure:
         """Handle a worker unregister request from a worker engine."""
         wid = request.worker_engine_id
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         registration = self._workers.pop(wid, None)
         self._worker_last_seen.pop(wid, None)
         worker_key = registration.worker_key if registration else None
@@ -274,7 +275,7 @@ class WorkerManager:
             for wid in stale:
                 await self.evict_worker(wid)
 
-            session_id = self._griptape_nodes.get_session_id()
+            session_id = self.engine.get_session_id()
             for wid, registration in list(self._workers.items()):
                 hb = EventRequest(
                     request=worker_events.WorkerHeartbeatRequest(heartbeat_id=str(uuid.uuid4())),
@@ -326,13 +327,13 @@ class WorkerManager:
         # same clean env baseline a fresh engine would have. Inheriting the live os.environ
         # would bake the orchestrator's current-project env vars into the worker's restore
         # baseline, leaving the worker unable to unset them on a later project switch.
-        base_environ = self._griptape_nodes.ProjectManager().get_pre_project_environ()
+        base_environ = self.engine.project_manager.get_pre_project_environ()
         worker_environ = {**base_environ, "GTN_ENGINE_ID": str(uuid.uuid4())}
         # Stamp the spawning orchestrator's id so the worker can report it in its discovery
         # heartbeat (orchestrator_engine_id), letting clients identify and nest worker engines.
         # The orchestrator always has an id by the time it spawns a worker; guard the None
         # case anyway so a subprocess env value is never None.
-        orchestrator_engine_id = self._griptape_nodes.EngineIdentityManager().active_engine_id
+        orchestrator_engine_id = self.engine.engine_identity_manager.active_engine_id
         if orchestrator_engine_id is not None:
             worker_environ["GTN_ORCHESTRATOR_ENGINE_ID"] = orchestrator_engine_id
         proc = await asyncio.create_subprocess_exec(*args, env=worker_environ)
@@ -361,7 +362,7 @@ class WorkerManager:
                 for library_name, proc in list(self._managed_worker_processes.items())
             )
         )
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         if session_id and self._transport is not None:
             for wid in list(self._workers):
                 response_topic = f"sessions/{session_id}/workers/{wid}/response"
@@ -412,7 +413,7 @@ class WorkerManager:
 
     async def evict_worker(self, worker_engine_id: str) -> None:
         """Remove a worker from the registry and unsubscribe from its response topic."""
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         registration = self._workers.pop(worker_engine_id, None)
         self._worker_last_seen.pop(worker_engine_id, None)
         lib_name = registration.worker_key if registration else None
@@ -582,7 +583,7 @@ class WorkerManager:
     async def _spawn_when_session_ready(self, library_name: str) -> None:
         """Wait for an active session then spawn a worker subprocess for the given library."""
         # If a session is already active, skip the wait entirely.
-        if not self._griptape_nodes.get_session_id():
+        if not self.engine.get_session_id():
             logger.info(
                 "Worker for library '%s' is waiting for a session to start before spawning. "
                 "Start a session (via the Griptape Nodes GUI or AppStartSessionRequest) to proceed.",
@@ -590,7 +591,7 @@ class WorkerManager:
             )
             await self._session_ready_event.wait()
             logger.info("Session started; spawning worker for library '%s'.", library_name)
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         if not session_id:
             logger.error("Session event set but no session ID available for library '%s'.", library_name)
             return
@@ -623,8 +624,8 @@ class WorkerManager:
         In orchestrator mode it subscribes to the generic "request" topic (MCP/API entry point)
         and the session request topic.
         """
-        engine_id = self._griptape_nodes.get_engine_id()
-        session_id = self._griptape_nodes.get_session_id()
+        engine_id = self.engine.get_engine_id()
+        session_id = self.engine.get_session_id()
 
         topics: list[str] = []
         if engine_id:
@@ -656,7 +657,7 @@ class WorkerManager:
         Future: consult a WorkerRegistry to select the correct worker based on event type
         or target library.
         """
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         worker_response_topic = f"sessions/{session_id}/workers/{worker_engine_id}/response"
         forwarded = event.model_copy(update={"response_topic": worker_response_topic})
         logger.debug("Forwarding %s to worker %s", type(event.request).__name__, worker_engine_id)
@@ -783,10 +784,10 @@ class WorkerManager:
 
     def _determine_response_topic(self) -> str:
         """Determine the response topic based on current session and engine IDs."""
-        session_id = self._griptape_nodes.get_session_id()
+        session_id = self.engine.get_session_id()
         if session_id:
             return f"sessions/{session_id}/response"
-        engine_id = self._griptape_nodes.get_engine_id()
+        engine_id = self.engine.get_engine_id()
         if engine_id:
             return f"engines/{engine_id}/response"
         return "response"

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -43,6 +43,7 @@ from griptape_nodes.node_library.workflow_registry import (
     WorkflowRegistry,
     WorkflowShape,
 )
+from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
     EngineInitializationProgress,
     GetEngineVersionRequest,
@@ -190,9 +191,6 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     WorkflowInfoSummary,
     WorkflowStatus,
 )
-from griptape_nodes.retained_mode.griptape_nodes import (
-    GriptapeNodes,
-)
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
     InvalidDependencyVersionStringProblem,
     InvalidLibraryVersionStringProblem,
@@ -222,6 +220,7 @@ if TYPE_CHECKING:
 
     from griptape_nodes.exe_types.core_types import Parameter
     from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands, SetLockNodeStateRequest
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
@@ -245,7 +244,7 @@ class WorkflowRegistrationResult(NamedTuple):
     failed: list[str]
 
 
-class WorkflowManager:
+class WorkflowManager(EngineScoped):
     WORKFLOW_METADATA_HEADER: ClassVar[str] = "script"
     MAX_MINOR_VERSION_DEVIATION: ClassVar[int] = (
         100  # TODO: https://github.com/griptape-ai/griptape-nodes/issues/1219 <- make the versioning enforcement softer after we get a release going
@@ -350,7 +349,8 @@ class WorkflowManager:
         creation_date: datetime  # When workflow was originally created
         branched_from: str | None  # Workflow this was branched from (if any)
 
-    def __init__(self, event_manager: EventManager) -> None:
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
         self._workflow_file_path_to_info = {}
         self._squelch_workflow_altered_count = 0
         self._referenced_workflow_stack = []
@@ -521,9 +521,7 @@ class WorkflowManager:
         Defaults to True so existing workflows that have never set the flag get
         substitution without any migration.
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if not context_manager.has_current_workflow():
             return True
         workflow_name = context_manager.get_current_workflow_name()
@@ -558,9 +556,7 @@ class WorkflowManager:
         call into build_workflow() so the flag is restored on every subsequent load,
         including direct script execution.
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if not context_manager.has_current_workflow():
             return SetVariableSubstitutionEnabledResultFailure(
                 result_details="Attempted to set variable substitution enabled. Failed because no workflow is active."
@@ -586,7 +582,7 @@ class WorkflowManager:
 
         try:
             default_workflow_section = "app_events.on_app_initialization_complete.workflows_to_register"
-            config_mgr = GriptapeNodes.ConfigManager()
+            config_mgr = self.engine.config_manager
 
             if workflows_to_register is None:
                 workflows_to_register = []
@@ -785,7 +781,7 @@ class WorkflowManager:
 
     async def _ensure_workflow_context_established(self) -> None:
         """Ensure there's a current workflow and flow context after workflow execution."""
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
 
         # First check: Do we have a current workflow? If not, that's a critical failure.
         if not context_manager.has_current_workflow():
@@ -801,14 +797,14 @@ class WorkflowManager:
             )
 
             top_level_flow_request = GetTopLevelFlowRequest()
-            top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+            top_level_flow_result = await self.engine.ahandle_request(top_level_flow_request)
 
             if (
                 isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
                 and top_level_flow_result.flow_name is not None
             ):
                 # Push the flow to the context stack permanently using FlowManager
-                flow_manager = GriptapeNodes.FlowManager()
+                flow_manager = self.engine.flow_manager
                 flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
                 context_manager.push_flow(flow_obj)
                 details = f"Workflow execution completed. Set '{top_level_flow_result.flow_name}' as current context."
@@ -821,7 +817,7 @@ class WorkflowManager:
 
     async def run_workflow(self, relative_file_path: str) -> WorkflowExecutionResult:
         # Resolve path using utility function
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = self.engine.config_manager.workspace_path
         complete_file_path = resolve_workspace_path(Path(relative_file_path), workspace_path)
         try:
             async with await anyio.open_file(Path(complete_file_path), encoding="utf-8") as file:
@@ -898,7 +894,7 @@ class WorkflowManager:
             # behavior where a missing prereq block was survivable.
             return None
         for lib_ref in load_metadata_result.metadata.node_libraries_referenced:
-            register_result = await GriptapeNodes.ahandle_request(
+            register_result = await self.engine.ahandle_request(
                 RegisterLibraryFromFileRequest(
                     library_name=lib_ref.library_name,
                     perform_discovery_if_not_found=True,
@@ -939,7 +935,7 @@ class WorkflowManager:
 
             # Start with a clean slate.
             clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
-            clear_all_result = await GriptapeNodes.ahandle_request(clear_all_request)
+            clear_all_result = await self.engine.ahandle_request(clear_all_request)
             if not clear_all_result.succeeded():
                 details = f"Failed to clear the existing object state when trying to run '{complete_file_path}'."
                 return RunWorkflowFromScratchResultFailure(result_details=details)
@@ -995,21 +991,21 @@ class WorkflowManager:
         # run_with_clean_slate=True, replacement is the explicitly requested behavior, so
         # only warn when clobbering the context was NOT asked for.
         context_warning = None
-        if not request.run_with_clean_slate and GriptapeNodes.ContextManager().has_current_workflow():
-            context_warning = f"Started a new workflow '{request.workflow_name}' but a workflow '{GriptapeNodes.ContextManager().get_current_workflow_name()}' was already in the Current Context. Replacing the old with the new."
+        if not request.run_with_clean_slate and self.engine.context_manager.has_current_workflow():
+            context_warning = f"Started a new workflow '{request.workflow_name}' but a workflow '{self.engine.context_manager.get_current_workflow_name()}' was already in the Current Context. Replacing the old with the new."
 
         # Squelch any ResultPayloads that indicate the workflow was changed, because we are loading it.
         with WorkflowManager.WorkflowSquelchContext(self):
             if request.run_with_clean_slate:
                 # Start with a clean slate.
                 clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
-                clear_all_result = await GriptapeNodes.ahandle_request(clear_all_request)
+                clear_all_result = await self.engine.ahandle_request(clear_all_request)
                 if not clear_all_result.succeeded():
                     details = f"Failed to clear the existing object state when preparing to run workflow '{request.workflow_name}'."
                     return RunWorkflowFromRegistryResultFailure(result_details=details)
 
             # Let's run under the assumption that this Workflow will become our Current Context; if we fail, it will revert.
-            GriptapeNodes.ContextManager().push_workflow(request.workflow_name)
+            self.engine.context_manager.push_workflow(request.workflow_name)
             # run file
             execution_result = await self.run_workflow(relative_file_path=relative_file_path)
 
@@ -1021,7 +1017,7 @@ class WorkflowManager:
 
                 # Attempt to clear everything out, as we modified the engine state getting here.
                 clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
-                clear_all_result = await GriptapeNodes.ahandle_request(clear_all_request)
+                clear_all_result = await self.engine.ahandle_request(clear_all_request)
 
                 # The clear-all above here wipes the ContextManager, so no need to do a pop_workflow().
                 return RunWorkflowFromRegistryResultFailure(result_details=ResultDetails(*result_messages))
@@ -1039,7 +1035,7 @@ class WorkflowManager:
         Self-guarding: paths inside the workspace are discovered by directory scan and need
         no config entry, so this is a no-op for them.
         """
-        config_manager = GriptapeNodes.ConfigManager()
+        config_manager = self.engine.config_manager
         try:
             canonicalize_for_identity(full_path).relative_to(canonicalize_for_identity(config_manager.workspace_path))
         except ValueError:
@@ -1141,9 +1137,9 @@ class WorkflowManager:
         # `DeleteFlowRequest` calls can still push a flow context (they require an
         # active workflow). Non-active deletes (e.g. published-workflow subprocess
         # cleanup) skip this and go straight to the registry/file cleanup.
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if context_manager.has_current_workflow() and context_manager.get_current_workflow_name() == request.name:
-            GriptapeNodes.clear_current_workflow_data()
+            self.engine.clear_current_workflow_data()
         try:
             workflow = WorkflowRegistry.delete_workflow_by_name(request.name)
         except Exception as e:
@@ -1158,7 +1154,7 @@ class WorkflowManager:
                     message=f"Successfully deleted unsaved workflow: {request.name}", level=logging.INFO
                 )
             )
-        config_manager = GriptapeNodes.ConfigManager()
+        config_manager = self.engine.config_manager
         try:
             config_manager.delete_user_workflow(workflow_file_path)
         except Exception as e:
@@ -1172,7 +1168,7 @@ class WorkflowManager:
             workspace_only=False,
             deletion_behavior=DeletionBehavior.PREFER_RECYCLE_BIN,
         )
-        delete_result = await GriptapeNodes.ahandle_request(delete_request)
+        delete_result = await self.engine.ahandle_request(delete_request)
         if isinstance(delete_result, DeleteFileResultFailure):
             details = f"Failed to delete workflow file with path '{workflow_file_path}'. {delete_result.result_details}"
             return DeleteWorkflowResultFailure(result_details=details)
@@ -1213,7 +1209,7 @@ class WorkflowManager:
             if str(source_dir) not in ("", "."):
                 requested_file_name = f"{source_dir}/{sanitized_stem}"
 
-        save_workflow_request = await GriptapeNodes.ahandle_request(
+        save_workflow_request = await self.engine.ahandle_request(
             SaveWorkflowRequest(file_name=requested_file_name, display_name=display_name)
         )
 
@@ -1326,7 +1322,7 @@ class WorkflowManager:
         # Also skip when the key is unchanged (e.g. renaming to the same on-disk name) so we
         # don't delete the file we just saved.
         if source is not None and new_workflow_name != old_workflow_name:
-            delete_workflow_result = await GriptapeNodes.ahandle_request(DeleteWorkflowRequest(name=old_workflow_name))
+            delete_workflow_result = await self.engine.ahandle_request(DeleteWorkflowRequest(name=old_workflow_name))
             if isinstance(delete_workflow_result, DeleteWorkflowResultFailure):
                 return (
                     f"Attempted to rename workflow '{old_workflow_name}' to '{new_workflow_name}'. "
@@ -1335,7 +1331,7 @@ class WorkflowManager:
 
         # If the renamed workflow is the current context, update the context name so the
         # heartbeat and other callers reflect the new registry key immediately.
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if context_manager.has_current_workflow() and context_manager.get_current_workflow_name() == old_workflow_name:
             context_manager.set_current_workflow_name(new_workflow_name)
 
@@ -1347,7 +1343,7 @@ class WorkflowManager:
         Matches the key construction in on_load_workflow_metadata_request, which uses
         workspace_path.joinpath() without resolving symlinks.
         """
-        return str(GriptapeNodes.ConfigManager().workspace_path.joinpath(file_path))
+        return str(self.engine.config_manager.workspace_path.joinpath(file_path))
 
     def _build_workflow_info_payload(self, wf_info: WorkflowInfo) -> WorkflowInfoSummary:
         """Build a WorkflowInfoSummary from a WorkflowInfo, collating problems for display."""
@@ -1449,7 +1445,7 @@ class WorkflowManager:
 
         # Failure: no identifier and no current context
         if workflow_name is None and file_path is None:
-            context_manager = GriptapeNodes.ContextManager()
+            context_manager = self.engine.context_manager
             if not context_manager.has_current_workflow():
                 return GetWorkflowRunCommandResultFailure(
                     result_details=(
@@ -1498,7 +1494,7 @@ class WorkflowManager:
         complete_file_path = WorkflowRegistry.get_complete_file_path(relative_file_path)
 
         # Failure: workflow file does not exist or is not a file (use GetFileInfoRequest for consistency)
-        get_file_info_result = GriptapeNodes.handle_request(
+        get_file_info_result = self.engine.handle_request(
             GetFileInfoRequest(path=relative_file_path, workspace_only=True)
         )
         if isinstance(get_file_info_result, GetFileInfoResultFailure):
@@ -1552,7 +1548,7 @@ class WorkflowManager:
         return GetWorkflowRunCommandResultSuccess(
             run_command=run_command,
             workflow_shape=workflow_shape,
-            engine_os=GriptapeNodes.OSManager()._get_platform_name(),
+            engine_os=self.engine.os_manager._get_platform_name(),
             result_details=ResultDetails(message=f"Run command: {run_command}", level=logging.DEBUG),
         )
 
@@ -1713,7 +1709,7 @@ class WorkflowManager:
             return MoveWorkflowResultFailure(result_details=details)
         old_relative_path = workflow.file_path
 
-        config_manager = GriptapeNodes.ConfigManager()
+        config_manager = self.engine.config_manager
 
         # Get current file path
         current_file_path = WorkflowRegistry.get_complete_file_path(old_relative_path)
@@ -1766,7 +1762,7 @@ class WorkflowManager:
             if old_registry_key != new_registry_key:
                 WorkflowRegistry.rekey_workflow(old_registry_key, new_registry_key)
                 self._rekey_substitution_flag(old_registry_key, new_registry_key)
-                context_manager = GriptapeNodes.ContextManager()
+                context_manager = self.engine.context_manager
                 if (
                     context_manager.has_current_workflow()
                     and context_manager.get_current_workflow_name() == old_registry_key
@@ -1807,9 +1803,9 @@ class WorkflowManager:
         # (observed on Windows, engine cold start). Without this gate, the dependency
         # check below would race LibraryRegistry and return LibraryNotRegisteredProblem
         # for libraries that are milliseconds from being registered.
-        await GriptapeNodes.LibraryManager()._libraries_loading_complete.wait()
+        await self.engine.library_manager._libraries_loading_complete.wait()
         # Let us go into the darkness.
-        complete_file_path = GriptapeNodes.ConfigManager().workspace_path.joinpath(request.file_name)
+        complete_file_path = self.engine.config_manager.workspace_path.joinpath(request.file_name)
         str_path = str(complete_file_path)
         if not await anyio.Path(complete_file_path).is_file():
             self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
@@ -1908,7 +1904,7 @@ class WorkflowManager:
             workflow_metadata.last_modified_date = WorkflowManager.EPOCH_START
             problems.append(MissingLastModifiedDateProblem(default_date=str(WorkflowManager.EPOCH_START)))
 
-        list_libraries_result = await GriptapeNodes.ahandle_request(
+        list_libraries_result = await self.engine.ahandle_request(
             ListRegisteredLibrariesRequest(broadcast_result=False)
         )
 
@@ -1957,9 +1953,7 @@ class WorkflowManager:
 
             # Get library metadata (we know library is registered, so no error logging)
             library_metadata_request = GetLibraryMetadataRequest(library=library_name)
-            library_metadata_result = GriptapeNodes.LibraryManager().get_library_metadata_request(
-                library_metadata_request
-            )
+            library_metadata_result = self.engine.library_manager.get_library_metadata_request(library_metadata_request)
 
             if not isinstance(library_metadata_result, GetLibraryMetadataResultSuccess):
                 # Should not happen since we verified library is registered, but handle gracefully
@@ -2058,8 +2052,8 @@ class WorkflowManager:
             )
 
         # Check for workflow version-based compatibility issues and add to problems
-        workflow_version_issues = (
-            await GriptapeNodes.VersionCompatibilityManager().check_workflow_version_compatibility(workflow_metadata)
+        workflow_version_issues = await self.engine.version_compatibility_manager.check_workflow_version_compatibility(
+            workflow_metadata
         )
         for issue in workflow_version_issues:
             problems.append(issue.problem)
@@ -2086,7 +2080,7 @@ class WorkflowManager:
         )
 
     async def register_workflows_from_config(self, config_section: str) -> None:
-        workflows_to_register = GriptapeNodes.ConfigManager().get_config_value(config_section)
+        workflows_to_register = self.engine.config_manager.get_config_value(config_section)
         if workflows_to_register:
             await self.register_list_of_workflows(workflows_to_register)
 
@@ -2115,7 +2109,7 @@ class WorkflowManager:
         workflow_register_request = RegisterWorkflowRequest(
             metadata=workflow_metadata, file_name=str(workflow_to_register)
         )
-        workflow_register_result = GriptapeNodes.handle_request(workflow_register_request)
+        workflow_register_result = self.engine.handle_request(workflow_register_request)
         if not isinstance(workflow_register_result, RegisterWorkflowResultSuccess):
             err_str = f"Error attempting to register workflow '{workflow_to_register}': {workflow_register_result}. SKIPPING IT."
             logger.error(err_str)
@@ -2187,7 +2181,7 @@ class WorkflowManager:
         )
 
     @staticmethod
-    def _workspace_relative_path(absolute_or_relative_path: str) -> str:
+    def _workspace_relative_path(absolute_or_relative_path: str, engine: Engine) -> str:
         """Return the workspace-relative form of a path, or the absolute path if outside.
 
         Used post-write to reconcile registry state with the actual on-disk
@@ -2195,7 +2189,7 @@ class WorkflowManager:
         is ``foo_v001.py`` while the request asked for ``foo.py``).
         """
         path = Path(absolute_or_relative_path)
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = engine.config_manager.workspace_path
         try:
             relative = canonicalize_for_identity(path).relative_to(canonicalize_for_identity(workspace_path))
         except ValueError:
@@ -2256,7 +2250,7 @@ class WorkflowManager:
         # actual disk-full surface as IO_ERROR from the write.
         check_dir = self._probe_parent_for_disk_check(destination)
         if check_dir is not None:
-            config_manager = GriptapeNodes.ConfigManager()
+            config_manager = self.engine.config_manager
             min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_workflows")
             if not OSManager.check_available_disk_space(check_dir, min_space_gb):
                 error_msg = OSManager.format_disk_space_error(check_dir)
@@ -2312,7 +2306,7 @@ class WorkflowManager:
 
     async def on_save_workflow_request(self, request: SaveWorkflowRequest) -> ResultPayload:  # noqa: C901, PLR0912, PLR0915
         # Determine save target (file path, name, metadata)
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         current_workflow_name = (
             context_manager.get_current_workflow_name() if context_manager.has_current_workflow() else None
         )
@@ -2360,13 +2354,13 @@ class WorkflowManager:
         )
 
         # Serialize current flow and get shape
-        top_level_flow_result = await GriptapeNodes.ahandle_request(GetTopLevelFlowRequest())
+        top_level_flow_result = await self.engine.ahandle_request(GetTopLevelFlowRequest())
         if not isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess):
             details = f"Attempted to save workflow '{relative_file_path}'. Failed when requesting top level flow."
             return SaveWorkflowResultFailure(result_details=details)
         top_level_flow_name = top_level_flow_result.flow_name
 
-        serialized_flow_result = await GriptapeNodes.ahandle_request(
+        serialized_flow_result = await self.engine.ahandle_request(
             SerializeFlowToCommandsRequest(flow_name=top_level_flow_name, include_create_flow_command=True)
         )
         if not isinstance(serialized_flow_result, SerializeFlowToCommandsResultSuccess):
@@ -2441,7 +2435,7 @@ class WorkflowManager:
         # `foo_v001.py` from a `foo.py` request; the registry must key by what
         # ended up on disk, not what was asked for.
         if save_target.destination is not None:
-            written_relative = self._workspace_relative_path(save_file_result.file_path)
+            written_relative = self._workspace_relative_path(save_file_result.file_path, self.engine)
             if written_relative != relative_file_path:
                 relative_file_path = written_relative
                 registry_key = derive_registry_key(relative_file_path)
@@ -2474,7 +2468,7 @@ class WorkflowManager:
                 self._rekey_substitution_flag(unsaved_source_key, registry_key)
                 rekeyed_workflow = WorkflowRegistry.get_workflow_by_name(registry_key)
                 rekeyed_workflow.file_path = relative_file_path
-            for workflow_context_state in GriptapeNodes.ContextManager()._workflow_stack:
+            for workflow_context_state in self.engine.context_manager._workflow_stack:
                 if workflow_context_state._name == unsaved_source_key:
                     workflow_context_state._name = registry_key
             registered_workflows = WorkflowRegistry.list_workflows()
@@ -2533,7 +2527,7 @@ class WorkflowManager:
         Returns:
             A unique filename that doesn't exist in the workspace
         """
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = self.engine.config_manager.workspace_path
         base_path = workspace_path.joinpath(f"{base_name}.py")
         if not base_path.exists():
             return base_name
@@ -2795,7 +2789,7 @@ class WorkflowManager:
         the macro identified — minus builtins, which ProjectManager
         re-derives at resolve time and rejects caller overrides for.
         """
-        result = GriptapeNodes.handle_request(GetSituationRequest(situation_name=situation_name))
+        result = self.engine.handle_request(GetSituationRequest(situation_name=situation_name))
         if not isinstance(result, GetSituationResultSuccess):
             msg = (
                 f"Attempted to build a versioned save destination. "
@@ -2826,7 +2820,7 @@ class WorkflowManager:
         # of OS.
         absolute_path = Path(WorkflowRegistry.get_complete_file_path(file_path)).as_posix()
 
-        match_result = GriptapeNodes.handle_request(
+        match_result = self.engine.handle_request(
             AttemptMatchPathAgainstMacroRequest(
                 parsed_macro=parsed_macro,
                 file_path=absolute_path,
@@ -2893,7 +2887,7 @@ class WorkflowManager:
         mismatch so the user can correct the situation if it doesn't reflect
         their intent.
         """
-        result = GriptapeNodes.handle_request(GetSituationRequest(situation_name=situation_name))
+        result = self.engine.handle_request(GetSituationRequest(situation_name=situation_name))
         if not isinstance(result, GetSituationResultSuccess):
             return  # Missing situation surfaces as a load failure elsewhere; nothing useful to warn about here.
 
@@ -3051,7 +3045,7 @@ class WorkflowManager:
         file_name = Path(file_path).stem
 
         # Serialize the subflow.
-        serialized_flow_result = await GriptapeNodes.ahandle_request(
+        serialized_flow_result = await self.engine.ahandle_request(
             SerializeFlowToCommandsRequest(flow_name=request.flow_name, include_create_flow_command=True)
         )
         if not isinstance(serialized_flow_result, SerializeFlowToCommandsResultSuccess):
@@ -3135,7 +3129,7 @@ class WorkflowManager:
         """Generate workflow metadata from serialized commands."""
         # Get the engine version
         engine_version_request = GetEngineVersionRequest()
-        engine_version_result = GriptapeNodes.handle_request(request=engine_version_request)
+        engine_version_result = self.engine.handle_request(request=engine_version_request)
         if not isinstance(engine_version_result, GetEngineVersionResultSuccess):
             details = f"Failed getting the engine version for workflow '{file_name}'."
             raise TypeError(details)
@@ -3152,7 +3146,7 @@ class WorkflowManager:
         metadata_name = display_name if display_name is not None else str(file_name)
 
         direct_libs: list[LibraryNameAndVersion] = list(serialized_flow_commands.node_dependencies.libraries)
-        all_libs = GriptapeNodes.LibraryManager().resolve_transitive_library_deps(direct_libs)
+        all_libs = self.engine.library_manager.resolve_transitive_library_deps(direct_libs)
 
         return WorkflowMetadata(
             name=metadata_name,
@@ -5540,7 +5534,7 @@ class WorkflowManager:
         """
         workflow_shape: dict[str, Any] = {"input": {}, "output": {}}
 
-        flow_manager = GriptapeNodes.FlowManager()
+        flow_manager = self.engine.flow_manager
         if flow_name is None:
             result = flow_manager.on_get_top_level_flow_request(GetTopLevelFlowRequest())
             if result.failed():
@@ -5619,7 +5613,7 @@ class WorkflowManager:
         return WorkflowShape(inputs=input_node_params, outputs=output_node_params)
 
     def on_get_publish_options_request(self, request: GetPublishOptionsRequest) -> ResultPayload:
-        event_handler_mappings = GriptapeNodes.LibraryManager().get_registered_event_handlers(
+        event_handler_mappings = self.engine.library_manager.get_registered_event_handlers(
             request_type=PublishWorkflowRequest
         )
         publishing_handler = event_handler_mappings.get(request.publisher_name)
@@ -5639,7 +5633,7 @@ class WorkflowManager:
     async def on_publish_workflow_request(self, request: PublishWorkflowRequest) -> ResultPayload:
         try:
             publisher_name = request.publisher_name
-            event_handler_mappings = GriptapeNodes.LibraryManager().get_registered_event_handlers(
+            event_handler_mappings = self.engine.library_manager.get_registered_event_handlers(
                 request_type=type(request)
             )
             publishing_handler = event_handler_mappings.get(publisher_name)
@@ -5667,7 +5661,7 @@ class WorkflowManager:
                     "Saving as a new and registered workflow before proceeding on publish attempt."
                 )
                 logger.info(details)
-            await GriptapeNodes.ahandle_request(SaveWorkflowRequest(file_name=workflow_file_name))
+            await self.engine.ahandle_request(SaveWorkflowRequest(file_name=workflow_file_name))
 
             result = await asyncio.to_thread(publishing_handler.handler, request)
             if isinstance(result, PublishWorkflowResultSuccess) and not result.skip_published_workflow_registration:
@@ -5754,7 +5748,7 @@ class WorkflowManager:
         if request.flow_name is not None:
             flow_name = request.flow_name
         else:
-            flow_name = GriptapeNodes.ContextManager().get_current_flow().name
+            flow_name = self.engine.context_manager.get_current_flow().name
 
         # Execute the import
         return await self._execute_workflow_import(request, workflow, flow_name)
@@ -5792,12 +5786,12 @@ class WorkflowManager:
         # Check target flow
         flow_name = request.flow_name
         if flow_name is None:
-            if not GriptapeNodes.ContextManager().has_current_flow():
+            if not self.engine.context_manager.has_current_flow():
                 details = f"Attempted to import workflow '{request.workflow_name}' into Current Context. Failed because Current Context was empty"
                 return ImportWorkflowAsReferencedSubFlowResultFailure(result_details=details)
         else:
             # Validate that the specified flow exists
-            flow_manager = GriptapeNodes.FlowManager()
+            flow_manager = self.engine.flow_manager
             try:
                 flow_manager.get_flow_by_name(flow_name)
             except KeyError:
@@ -5823,13 +5817,13 @@ class WorkflowManager:
             return ImportWorkflowAsReferencedSubFlowResultFailure(result_details=details)
 
         # Get current flows before importing
-        obj_manager = GriptapeNodes.ObjectManager()
+        obj_manager = self.engine.object_manager
         flows_before = set(obj_manager.get_filtered_subset(type=ControlFlow).keys())
 
         # Execute the workflow within the target flow context.
         # When track_as_referenced is True, wrap in ReferencedWorkflowContext so the flow
         # serializes as an import command. When False, the flow serializes as inline content.
-        with GriptapeNodes.ContextManager().flow(flow_name):
+        with self.engine.context_manager.flow(flow_name):
             if request.track_as_referenced:
                 with self.ReferencedWorkflowContext(self, request.workflow_name):
                     workflow_result = await self.run_workflow(workflow_file_path)
@@ -5848,14 +5842,16 @@ class WorkflowManager:
             details = f"Attempted to import workflow '{request.workflow_name}' as referenced sub flow. Failed because no new flow was created"
             return ImportWorkflowAsReferencedSubFlowResultFailure(result_details=details)
 
-        created_flow_name = self._select_top_level_imported_flow(new_flows, flow_name, request.workflow_name)
+        created_flow_name = self._select_top_level_imported_flow(
+            new_flows, flow_name, request.workflow_name, self.engine
+        )
 
         # Apply imported flow metadata if provided
         if request.imported_flow_metadata:
             set_metadata_request = SetFlowMetadataRequest(
                 flow_name=created_flow_name, metadata=request.imported_flow_metadata
             )
-            set_metadata_result = GriptapeNodes.handle_request(set_metadata_request)
+            set_metadata_result = self.engine.handle_request(set_metadata_request)
 
             if not isinstance(set_metadata_result, SetFlowMetadataResultSuccess):
                 details = f"Attempted to import workflow '{request.workflow_name}' as referenced sub flow. Failed because metadata could not be applied to created flow '{created_flow_name}'"
@@ -5873,7 +5869,9 @@ class WorkflowManager:
         )
 
     @staticmethod
-    def _select_top_level_imported_flow(new_flows: set[str], parent_flow_name: str, workflow_name: str) -> str:
+    def _select_top_level_imported_flow(
+        new_flows: set[str], parent_flow_name: str, workflow_name: str, engine: Engine
+    ) -> str:
         """Select the top-level flow among those created by importing a referenced workflow.
 
         A workflow that contains node groups (ForEach, etc.) imports as more than one flow: its
@@ -5884,11 +5882,12 @@ class WorkflowManager:
             new_flows: Names of the flows created during the import.
             parent_flow_name: The flow the workflow was imported into (the import target).
             workflow_name: Name of the imported workflow, for diagnostics.
+            engine: The engine whose FlowManager resolves flow parentage.
 
         Returns:
             The name of the top-level imported flow.
         """
-        flow_manager = GriptapeNodes.FlowManager()
+        flow_manager = engine.flow_manager
         top_level_flows = [flow for flow in new_flows if flow_manager.get_parent_flow(flow) == parent_flow_name]
 
         if len(top_level_flows) == 1:
@@ -6417,10 +6416,8 @@ class WorkflowManager:
         def patch_class(class_type: type, instance: Any) -> None:
             """Patch a single class instance to use stable namespace."""
             module = getmodule(class_type)
-            if module and GriptapeNodes.LibraryManager().is_dynamic_module(module.__name__):
-                stable_namespace = GriptapeNodes.LibraryManager().get_stable_namespace_for_dynamic_module(
-                    module.__name__
-                )
+            if module and self.engine.library_manager.is_dynamic_module(module.__name__):
+                stable_namespace = self.engine.library_manager.get_stable_namespace_for_dynamic_module(module.__name__)
                 if stable_namespace:
                     # Patch class __module__ (affects pickle class reference)
                     if class_type.__module__ != stable_namespace:
@@ -6481,11 +6478,11 @@ class WorkflowManager:
             """Collect import statement for a single class."""
             module = getmodule(class_type)
             if module and module.__name__ not in global_modules_set:
-                if GriptapeNodes.LibraryManager().is_dynamic_module(module.__name__):
+                if self.engine.library_manager.is_dynamic_module(module.__name__):
                     # Use stable namespace for dynamic modules. Route into deferred_imports
                     # so the caller can emit these inside build_workflow() after
                     # RegisterLibraryFromFileRequest has added the library to sys.path.
-                    stable_namespace = GriptapeNodes.LibraryManager().get_stable_namespace_for_dynamic_module(
+                    stable_namespace = self.engine.library_manager.get_stable_namespace_for_dynamic_module(
                         module.__name__
                     )
                     if stable_namespace:
@@ -6515,7 +6512,7 @@ class WorkflowManager:
     ) -> ResultPayload:
         """Register workflows from a configuration section."""
         try:
-            workflows_to_register = GriptapeNodes.ConfigManager().get_config_value(request.config_section)
+            workflows_to_register = self.engine.config_manager.get_config_value(request.config_section)
             if not workflows_to_register:
                 details = f"No workflows found in configuration section '{request.config_section}'"
                 return RegisterWorkflowsFromConfigResultSuccess(
@@ -6546,8 +6543,6 @@ class WorkflowManager:
         Returns:
             WorkflowRegistrationResult with succeeded and failed workflow names
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         succeeded = []
         failed = []
 
@@ -6557,7 +6552,7 @@ class WorkflowManager:
         # LibraryManager._collect_library_workflow_files before this scan runs. Sandbox
         # libraries are intentionally left scannable so in-development workflows appear.
         library_exclusion_roots: list[Path] = []
-        for library_info in GriptapeNodes.LibraryManager()._library_file_path_to_info.values():
+        for library_info in self.engine.library_manager._library_file_path_to_info.values():
             if library_info.is_sandbox:
                 continue
             library_exclusion_roots.append(Path(library_info.library_path).parent.resolve())
@@ -6617,7 +6612,7 @@ class WorkflowManager:
             workflow_name = str(workflow_file.name)
 
             # Emit loading event
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 AppEvent(
                     payload=EngineInitializationProgress(
                         phase=InitializationPhase.WORKFLOWS,
@@ -6634,7 +6629,7 @@ class WorkflowManager:
             if result_name:
                 succeeded.append(result_name)
                 # Emit success event
-                GriptapeNodes.EventManager().put_event(
+                self.engine.event_manager.put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
                             phase=InitializationPhase.WORKFLOWS,
@@ -6648,7 +6643,7 @@ class WorkflowManager:
             else:
                 failed.append(str(workflow_file))
                 # Emit failure event
-                GriptapeNodes.EventManager().put_event(
+                self.engine.event_manager.put_event(
                     AppEvent(
                         payload=EngineInitializationProgress(
                             phase=InitializationPhase.WORKFLOWS,
@@ -6669,8 +6664,6 @@ class WorkflowManager:
         Returns:
             Workflow name if registered successfully, None if failed or skipped
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Parse metadata once and use it for both registration check and actual registration
         load_metadata_request = LoadWorkflowMetadata(file_name=str(workflow_file))
         load_metadata_result = await self.on_load_workflow_metadata_request(load_metadata_request)
@@ -6680,7 +6673,7 @@ class WorkflowManager:
             return None
 
         # Convert to relative path if the workflow is under workspace_path before checking registry
-        config_mgr = GriptapeNodes.ConfigManager()
+        config_mgr = self.engine.config_manager
         workspace_path = config_mgr.workspace_path
 
         if workflow_file.is_relative_to(workspace_path):

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -533,9 +533,7 @@ class WorkflowManager(EngineScoped):
         request: GetVariableSubstitutionEnabledRequest,  # noqa: ARG002
     ) -> ResultPayload:
         """Return whether variable substitution is enabled for the current workflow."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if not context_manager.has_current_workflow():
             return GetVariableSubstitutionEnabledResultFailure(
                 result_details="Attempted to get variable substitution enabled. Failed because no workflow is active."

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from griptape_nodes.retained_mode.events.arbitrary_python_events import RunArbitraryPythonStringRequest
 from griptape_nodes.retained_mode.events.base_events import (
@@ -49,12 +49,14 @@ from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeLockStateResultSuccess,
     CreateNodeRequest,
     CreateNodeResultFailure,
+    CreateNodeResultSuccess,
     DeleteNodeRequest,
     GetNodeMetadataRequest,
     GetNodeMetadataResultFailure,
     GetNodeMetadataResultSuccess,
     GetNodeResolutionStateRequest,
     ListParametersOnNodeRequest,
+    ListParametersOnNodeResultSuccess,
     SetLockNodeStateRequest,
     SetLockNodeStateResultFailure,
     SetLockNodeStateResultSuccess,
@@ -73,6 +75,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     GetParameterDetailsRequest,
     GetParameterValueRequest,
     GetParameterValueResultFailure,
+    GetParameterValueResultSuccess,
     MigrateParameterRequest,
     MigrateParameterResultFailure,
     MigrateParameterResultSuccess,
@@ -292,11 +295,11 @@ class RetainedMode:
         )
         result = GriptapeNodes().handle_request(request)
         # Check if result is successful before accessing node_name
-        if hasattr(result, "node_name"):
+        if isinstance(result, CreateNodeResultSuccess):
             return result.node_name
         # You could return the result object for debugging
         logger.error("Failed to create node: %s", result)
-        return result
+        return cast("CreateNodeResultFailure", result)
 
     @classmethod
     def delete_node(
@@ -404,7 +407,7 @@ class RetainedMode:
         """
         request = SetLockNodeStateRequest(node_name=node_name, lock=lock)
         result = GriptapeNodes().handle_request(request)
-        return result
+        return cast("SetLockNodeStateResultSuccess | SetLockNodeStateResultFailure", result)
 
     @classmethod
     def batch_set_lock_node_state(
@@ -418,7 +421,7 @@ class RetainedMode:
         """
         request = BatchSetNodeLockStateRequest(node_names=node_names, lock=lock)
         result = GriptapeNodes().handle_request(request)
-        return result
+        return cast("BatchSetNodeLockStateResultSuccess | BatchSetNodeLockStateResultFailure", result)
 
     @classmethod
     def get_connections_for_node(cls, node_name: str) -> ResultPayload:
@@ -465,14 +468,14 @@ class RetainedMode:
         return result
 
     @classmethod
-    def list_params(cls, node: str) -> ResultPayload:
+    def list_params(cls, node: str) -> list[str]:
         """Lists all parameters associated with a node.
 
         Args:
             node (str): Name of the node to list parameters for.
 
         Returns:
-            ResultPayload: Contains a list of parameter names.
+            list[str]: List of parameter names.
 
         Example:
             # List all parameters on a node
@@ -480,7 +483,7 @@ class RetainedMode:
         """
         request = ListParametersOnNodeRequest(node_name=node)
         result = GriptapeNodes().handle_request(request)
-        return result.parameter_names
+        return cast("ListParametersOnNodeResultSuccess", result).parameter_names
 
     @classmethod
     def add_param(  # noqa: PLR0913, PLR0917
@@ -656,7 +659,7 @@ class RetainedMode:
         if not isinstance(get_metadata_result, GetNodeMetadataResultSuccess):
             msg = f"{reference_node_name}: Failed to get reference node's metadata: {get_metadata_result}"
             logger.warning(msg)
-            return get_metadata_result
+            return cast("GetNodeMetadataResultFailure", get_metadata_result)
 
         reference_metadata = get_metadata_result.metadata
         reference_position = reference_metadata.get("position", {"x": 0, "y": 0})
@@ -709,7 +712,7 @@ class RetainedMode:
             if not isinstance(set_metadata_result, SetNodeMetadataResultSuccess):
                 msg = f"{reference_node_name} -> {new_node_name}: Failed to set new node's position: {set_metadata_result}"
                 logger.warning(msg)
-                return set_metadata_result
+                return cast("SetNodeMetadataResultFailure", set_metadata_result)
 
             # Move the reference node to its new position
             set_reference_metadata_result = GriptapeNodes().handle_request(
@@ -718,7 +721,7 @@ class RetainedMode:
             if not isinstance(set_reference_metadata_result, SetNodeMetadataResultSuccess):
                 msg = f"{reference_node_name} -> {new_node_name}: Failed to set reference node's position: {set_reference_metadata_result}"
                 logger.warning(msg)
-                return set_reference_metadata_result
+                return cast("SetNodeMetadataResultFailure", set_reference_metadata_result)
 
         else:
             # Normal mode: Create new node relative to reference node
@@ -733,7 +736,7 @@ class RetainedMode:
             if not isinstance(set_metadata_result, SetNodeMetadataResultSuccess):
                 msg = f"{reference_node_name} -> {new_node_name}: Failed to set new node's position: {set_metadata_result}"
                 logger.warning(msg)
-                return set_metadata_result
+                return cast("SetNodeMetadataResultFailure", set_metadata_result)
 
         if lock:
             set_lock_node_state_result = cls.set_lock_node_state(node_name=reference_node_name, lock=True)
@@ -866,7 +869,7 @@ class RetainedMode:
             break_connections=break_connections,
         )
         result = GriptapeNodes().handle_request(request)
-        return result
+        return cast("MigrateParameterResultSuccess | MigrateParameterResultFailure", result)
 
     @classmethod
     @command_arg_handler(node_param_split_func=node_param_split)
@@ -975,6 +978,7 @@ class RetainedMode:
             return False, result
 
         # Navigate through indices
+        result = cast("GetParameterValueResultSuccess", result)
         curr_value = result.value
         for idx_or_key in indices:
             if isinstance(curr_value, list):
@@ -1030,6 +1034,7 @@ class RetainedMode:
             return result
 
         # Navigate to the proper location and set the value
+        result = cast("GetParameterValueResultSuccess", result)
         container = result.value
         curr = container
 
@@ -1116,6 +1121,7 @@ class RetainedMode:
 
         if result.succeeded():
             # Now see if there were any indices specified.
+            result = cast("GetParameterValueResultSuccess", result)
             curr_pos_value = result.value
             for idx_or_key in indices:
                 # What is the type of the current object in the chain?
@@ -1221,7 +1227,7 @@ class RetainedMode:
                 )
                 return result
 
-            base_container = result.value
+            base_container = cast("GetParameterValueResultSuccess", result).value
             # Start progress at the base
             curr_pos_value = base_container
             for index_ctr, idx_or_key in enumerate(indices):
@@ -1332,7 +1338,7 @@ class RetainedMode:
             results[f"{source_node} -> {target_node}"] = result
 
             # Track failures without halting execution
-            if not hasattr(result, "success") or not result.success:
+            if not hasattr(result, "success") or not getattr(result, "success", False):
                 failures.append(f"{source_node} -> {target_node}")
 
         # Add summary of failures to the results

--- a/src/griptape_nodes/traits/trait_registry.py
+++ b/src/griptape_nodes/traits/trait_registry.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from griptape_nodes.utils.metaclasses import SingletonMeta
-
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Trait
 
 
 # This should probably register upon creation
-class TraitRegistry(metaclass=SingletonMeta):
+class TraitRegistry:
     # I'm going to create a dictionary that stores all of the created traits we have so far?
     # Traits will be associated with certain key words
     key_to_trait: ClassVar[dict[str, list[Trait.__class__]]] = {}
 
     @classmethod
     def create_traits(cls, key_word: str) -> list[Trait] | None:
-        if key_word not in cls().key_to_trait:
+        if key_word not in cls.key_to_trait:
             return None
-        values = cls().key_to_trait[key_word]
+        values = cls.key_to_trait[key_word]
         return [trait() for trait in values]
 
     @classmethod
@@ -26,9 +24,9 @@ class TraitRegistry(metaclass=SingletonMeta):
         key_words = trait.get_trait_keys()
         for key in key_words:
             if key in cls.key_to_trait:
-                cls().key_to_trait[key].append(trait.__class__)
+                cls.key_to_trait[key].append(trait.__class__)
             else:
-                cls().key_to_trait[key] = [trait.__class__]
+                cls.key_to_trait[key] = [trait.__class__]
 
     @classmethod
     def register_trait_from_json(cls) -> None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,13 +14,13 @@ import pytest
 import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
 import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import reset_root_engine
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionRequest,
     CreateConnectionResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.utils.metaclasses import SingletonMeta
 from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
@@ -36,12 +36,11 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     developer's real ``GT_CLOUD_BUCKET_ID`` and runs in Griptape Cloud mode, whose
     background threads segfault the child at interpreter shutdown.
 
-    Clearing ``SingletonMeta._instances`` forces the managers to re-initialize against the
-    patched paths and gives each test a fresh object registry. ``LibraryRegistry`` keeps its
-    state in ``ClassVar`` dicts that ``SingletonMeta`` clearing does not touch, so it is
-    reset explicitly.
+    Dropping the root engine forces the managers to re-initialize against the patched paths
+    and gives each test a fresh object registry. ``LibraryRegistry`` keeps its state in
+    ``ClassVar`` dicts that the engine does not own, so it is reset explicitly.
     """
-    SingletonMeta._instances.clear()
+    reset_root_engine()
     LibraryRegistry._clear()
 
     for key in list(os.environ):
@@ -59,7 +58,7 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
             ):
                 yield
     finally:
-        SingletonMeta._instances.clear()
+        reset_root_engine()
         LibraryRegistry._clear()
 
 

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -66,11 +66,11 @@ def worker_manager() -> WorkerManager:
     gtn.get_engine_id.return_value = _ENGINE
     # WorkerManager reads several float config values at construction; hand back
     # the declared default so asyncio.wait_for / time arithmetic gets a real number.
-    gtn._config_manager.get_config_value.side_effect = lambda _key, default, cast_type=float: cast_type(default)
+    gtn.config_manager.get_config_value.side_effect = lambda _key, default, cast_type=float: cast_type(default)
     # spawn_worker builds the child env from the orchestrator's pre-project environ;
     # hand back a real dict so {**base_environ, ...} doesn't choke on a MagicMock.
-    gtn.ProjectManager().get_pre_project_environ.return_value = {}
-    wm = WorkerManager(griptape_nodes=gtn, event_manager=MagicMock())
+    gtn.project_manager.get_pre_project_environ.return_value = {}
+    wm = WorkerManager(engine=gtn, event_manager=MagicMock())
     wm.attach_transport(
         ws_outgoing_queue=asyncio.Queue(),
         send_message=AsyncMock(),
@@ -466,7 +466,7 @@ class TestSpawnWorker:
     async def test_spawn_env_stamps_orchestrator_engine_id(self, worker_manager: WorkerManager) -> None:
         # The worker must learn its parent orchestrator's id so it can report it in its
         # discovery heartbeat (orchestrator_engine_id), which the GUI uses to nest workers.
-        worker_manager._griptape_nodes.EngineIdentityManager().active_engine_id = _ENGINE  # type: ignore[union-attr]
+        worker_manager.engine.engine_identity_manager.active_engine_id = _ENGINE  # type: ignore[union-attr]
 
         with patch("asyncio.create_subprocess_exec", return_value=MagicMock()) as mock_exec:
             await worker_manager.spawn_worker(["/usr/bin/gtn", "engine"], "my-key")
@@ -480,7 +480,7 @@ class TestSpawnWorker:
     async def test_spawn_env_omits_orchestrator_id_when_unknown(self, worker_manager: WorkerManager) -> None:
         # Defensive: never put a None into the subprocess env dict. If the orchestrator has
         # no id yet, the key is simply absent (worker heartbeats as an orchestrator).
-        worker_manager._griptape_nodes.EngineIdentityManager().active_engine_id = None  # type: ignore[union-attr]
+        worker_manager.engine.engine_identity_manager.active_engine_id = None  # type: ignore[union-attr]
 
         with patch("asyncio.create_subprocess_exec", return_value=MagicMock()) as mock_exec:
             await worker_manager.spawn_worker(["/usr/bin/gtn", "engine"], "my-key")
@@ -736,7 +736,7 @@ class TestSpawnWhenSessionReady:
     @pytest.mark.asyncio
     async def test_skips_wait_when_session_already_active(self, worker_manager: WorkerManager) -> None:
         """If a session is already active, spawn proceeds without waiting for the event."""
-        worker_manager._griptape_nodes.get_session_id.return_value = _SESSION  # type: ignore[union-attr]
+        worker_manager.engine.get_session_id.return_value = _SESSION  # type: ignore[union-attr]
 
         with patch.object(worker_manager, "spawn_worker", new=AsyncMock()) as mock_spawn:
             await worker_manager._spawn_when_session_ready("My Library")
@@ -748,7 +748,7 @@ class TestSpawnWhenSessionReady:
     async def test_waits_then_spawns_after_session_ready(self, worker_manager: WorkerManager) -> None:
         """If no session yet, waits for the event and spawns once the session is available."""
         # First call (pre-check) returns None; second call (post-wait) returns session ID.
-        worker_manager._griptape_nodes.get_session_id.side_effect = [None, _SESSION]  # type: ignore[union-attr]
+        worker_manager.engine.get_session_id.side_effect = [None, _SESSION]  # type: ignore[union-attr]
 
         with patch.object(worker_manager, "spawn_worker", new=AsyncMock()) as mock_spawn:
             task = asyncio.create_task(worker_manager._spawn_when_session_ready("My Library"))
@@ -761,7 +761,7 @@ class TestSpawnWhenSessionReady:
     @pytest.mark.asyncio
     async def test_logs_error_when_no_session_after_event(self, worker_manager: WorkerManager) -> None:
         """If the session event fires but get_session_id still returns None, spawn is not attempted."""
-        worker_manager._griptape_nodes.get_session_id.side_effect = [None, None]  # type: ignore[union-attr]
+        worker_manager.engine.get_session_id.side_effect = [None, None]  # type: ignore[union-attr]
         worker_manager._session_ready_event.set()
 
         with patch.object(worker_manager, "spawn_worker", new=AsyncMock()) as mock_spawn:
@@ -863,7 +863,7 @@ class TestGetTopicsToSubscribe:
         assert f"sessions/{_SESSION}/workers/{_ENGINE}/request" not in topics
 
     def test_orchestrator_mode_no_session_excludes_session_topic(self, worker_manager: WorkerManager) -> None:
-        worker_manager._griptape_nodes.get_session_id.return_value = None  # type: ignore[union-attr]
+        worker_manager.engine.get_session_id.return_value = None  # type: ignore[union-attr]
 
         topics = worker_manager.get_topics_to_subscribe(is_worker=False)
 
@@ -908,15 +908,15 @@ class TestDetermineResponseTopic:
         assert topic == f"sessions/{_SESSION}/response"
 
     def test_returns_engine_response_topic_when_no_session(self, worker_manager: WorkerManager) -> None:
-        worker_manager._griptape_nodes.get_session_id.return_value = None  # type: ignore[union-attr]
+        worker_manager.engine.get_session_id.return_value = None  # type: ignore[union-attr]
 
         topic = worker_manager._determine_response_topic()
 
         assert topic == f"engines/{_ENGINE}/response"
 
     def test_returns_default_when_no_session_or_engine(self, worker_manager: WorkerManager) -> None:
-        worker_manager._griptape_nodes.get_session_id.return_value = None  # type: ignore[union-attr]
-        worker_manager._griptape_nodes.get_engine_id.return_value = None  # type: ignore[union-attr]
+        worker_manager.engine.get_session_id.return_value = None  # type: ignore[union-attr]
+        worker_manager.engine.get_engine_id.return_value = None  # type: ignore[union-attr]
 
         topic = worker_manager._determine_response_topic()
 
@@ -1060,8 +1060,8 @@ class TestWorkerManagerDomainEventListeners:
         gtn = MagicMock()
         gtn.get_session_id.return_value = _SESSION
         gtn.get_engine_id.return_value = _ENGINE
-        gtn._config_manager.get_config_value.side_effect = lambda _key, default, cast_type=float: cast_type(default)
-        wm = WorkerManager(griptape_nodes=gtn, event_manager=EventManager())
+        gtn.config_manager.get_config_value.side_effect = lambda _key, default, cast_type=float: cast_type(default)
+        wm = WorkerManager(engine=gtn, event_manager=EventManager())
         wm.attach_transport(
             ws_outgoing_queue=asyncio.Queue(),
             send_message=AsyncMock(),

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 
 from griptape_nodes.common.sequences import MissingItemPolicy, NoTokenBehavior
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.os_events import (
     FileIOFailureReason,
     FileSystemEntry,
@@ -637,7 +638,7 @@ class TestPathRoundTrip:
         filenames = [f"abc{n:03d}.png" for n in [1, 2, 3]]
         path = f"{macro_directory}/abc###.png"
         with patch.object(
-            GriptapeNodes,
+            Engine,
             "handle_request",
             side_effect=_stub_listing_with_macro(
                 macro_directory=macro_directory,
@@ -789,7 +790,7 @@ class TestNoTokenBehavior:
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
         path = f"{macro_directory}/render.0002.png"
         with patch.object(
-            GriptapeNodes,
+            Engine,
             "handle_request",
             side_effect=_stub_listing_with_macro(
                 macro_directory=macro_directory,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,17 +8,16 @@ from unittest.mock import patch
 
 import pytest
 
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import Engine, current_engine, reset_root_engine
 
 
 @pytest.fixture(autouse=True)
 def isolate_user_config() -> Generator[Path, None, None]:
     """Isolate the user config file during tests to prevent pollution of the real config."""
     import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
-    from griptape_nodes.utils.metaclasses import SingletonMeta
 
-    # Clear any existing singleton instances to force re-initialization with patched config
-    SingletonMeta._instances.clear()
+    # Drop the root engine so managers re-initialize against the patched config below.
+    reset_root_engine()
 
     # Create a temporary directory for the test config
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -31,12 +30,17 @@ def isolate_user_config() -> Generator[Path, None, None]:
         with patch.object(config_manager_module, "USER_CONFIG_PATH", temp_config_path):
             yield temp_config_path
 
-            # Clear singleton instances after test to ensure clean state
-            SingletonMeta._instances.clear()
+            # Drop it again so the next test doesn't inherit this one's object graph.
+            reset_root_engine()
 
 
 @pytest.fixture
-def griptape_nodes() -> GriptapeNodes:
-    """Provide a properly initialized GriptapeNodes instance for testing."""
-    # Initialize GriptapeNodes (it's a singleton, so this returns the existing instance)
-    return GriptapeNodes()
+def engine() -> Engine:
+    """Provide the engine for this test, building it on first use."""
+    return current_engine()
+
+
+@pytest.fixture
+def griptape_nodes() -> Engine:
+    """Alias of `engine`, named for the tests written against the old facade."""
+    return current_engine()

--- a/tests/unit/node_library/test_unregister_library.py
+++ b/tests/unit/node_library/test_unregister_library.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -34,7 +34,7 @@ class TestUnregisterLibraryTeardownHook:
                 calls.append(True)
 
         _register_library(advanced_library=MyLib())
-        LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=MagicMock())
         assert calls == [True]
 
     def test_exception_in_teardown_does_not_prevent_unregistration(self) -> None:
@@ -45,7 +45,7 @@ class TestUnregisterLibraryTeardownHook:
 
         _register_library(advanced_library=BoomLib())
         # Should not raise
-        LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=MagicMock())
         # Library should be gone
         registry = LibraryRegistry()
         assert "TestLib" not in registry._libraries
@@ -53,63 +53,51 @@ class TestUnregisterLibraryTeardownHook:
     def test_teardown_not_called_when_no_advanced_library(self) -> None:
         _register_library(advanced_library=None)
         # Should complete without error
-        LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=MagicMock())
         registry = LibraryRegistry()
         assert "TestLib" not in registry._libraries
 
 
 class TestUnregisterLibraryEventManagerCleanup:
     def test_request_handler_types_are_deregistered(self) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         library = _register_library()
         library._registered_request_handler_types.append(str)
         library._registered_request_handler_types.append(int)
 
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
-            LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
 
         called_types = {c.args[0] for c in event_manager.remove_manager_from_request_type.call_args_list}
         assert called_types == {str, int}
 
     def test_app_event_listeners_are_deregistered(self) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         listener = MagicMock()
         library = _register_library()
         library._registered_app_event_listeners.append((str, listener))
 
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
-            LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
 
         event_manager.remove_listener_for_app_event.assert_called_once_with(str, listener)
 
     def test_pre_dispatch_hooks_are_deregistered(self) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         hook = MagicMock()
         library = _register_library()
         library._registered_pre_dispatch_hooks.append(hook)
 
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
-            LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
 
         event_manager.remove_pre_dispatch_hook.assert_called_once_with(hook)
 
     def test_tracking_fields_cleared_after_deregistration(self) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         library = _register_library()
         library._registered_request_handler_types.append(str)
         library._registered_app_event_listeners.append((str, MagicMock()))
         library._registered_pre_dispatch_hooks.append(MagicMock())
 
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
-            LibraryRegistry.unregister_library("TestLib")
+        LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
 
         # Library object still exists locally; check fields are cleared
         assert library._registered_request_handler_types == []
@@ -118,4 +106,4 @@ class TestUnregisterLibraryEventManagerCleanup:
 
     def test_unregister_raises_for_unknown_library(self) -> None:
         with pytest.raises(KeyError):
-            LibraryRegistry.unregister_library("DoesNotExist")
+            LibraryRegistry.unregister_library("DoesNotExist", event_manager=MagicMock())

--- a/tests/unit/retained_mode/managers/test_artifact_manager.py
+++ b/tests/unit/retained_mode/managers/test_artifact_manager.py
@@ -4,6 +4,7 @@ import tempfile
 from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
+from unittest.mock import Mock
 
 import anyio
 import pytest
@@ -50,7 +51,7 @@ if TYPE_CHECKING:
 # to the REAL user config files at ~/.config/griptape_nodes/
 #
 # To prevent test pollution of real config files, we MUST mock
-# GriptapeNodes.handle_request to intercept SetConfigValueRequest calls.
+# Engine.handle_request to intercept SetConfigValueRequest calls.
 #
 # Without this mock, running tests will write test provider configs to your
 # actual config files, causing the errors you saw in the editor.
@@ -59,27 +60,31 @@ if TYPE_CHECKING:
 
 @pytest.fixture(autouse=True)
 def mock_config_writes(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Mock GriptapeNodes.handle_request to prevent tests from writing to real config files.
+    """Mock Engine.handle_request to prevent tests from writing to real config files.
 
     This fixture is autouse=True, so it applies to ALL tests in this file automatically.
     Any test that registers providers would otherwise pollute the real user config.
+
+    ArtifactManager resolves its engine through `self.engine`, which falls back to the
+    process-wide current engine when a test constructs it bare (as most tests here do).
+    Patching `Engine.handle_request` at the class level intercepts every such instance's
+    calls, mirroring how the old `GriptapeNodes.handle_request` classmethod patch worked.
     """
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.config_events import SetConfigValueRequest
 
     # Store the original handle_request method
-    original_handle_request = GriptapeNodes.handle_request
+    original_handle_request = Engine.handle_request
 
-    def selective_mock(request: RequestPayload) -> ResultPayload:
+    def selective_mock(self: Engine, request: RequestPayload) -> ResultPayload:
         """Only mock SetConfigValueRequest, let all other requests through."""
         if isinstance(request, SetConfigValueRequest):
             # Mock config writes to prevent test pollution
             return SetConfigValueResultSuccess(result_details="Mocked config write")
         # Let all other requests go to the real handler
-        return original_handle_request(request)
+        return original_handle_request(self, request)
 
-    monkeypatch.setattr(
-        "griptape_nodes.retained_mode.managers.artifact_manager.GriptapeNodes.handle_request", selective_mock
-    )
+    monkeypatch.setattr(Engine, "handle_request", selective_mock)
 
 
 class TestArtifactManager:
@@ -1630,20 +1635,15 @@ class TestProviderRegistrationConfigLogLevels:
             PILThumbnailGenerator,
         )
 
-        manager = ArtifactManager()
+        manager = ArtifactManager(engine=Mock())
         captured_requests: list[RequestPayload] = []
-
-        original = GriptapeNodes.handle_request
 
         def capture_requests(request: RequestPayload) -> ResultPayload:
             captured_requests.append(request)
-            return original(request)
+            return GriptapeNodes.handle_request(request)
 
-        try:
-            GriptapeNodes.handle_request = staticmethod(capture_requests)
-            manager._read_generator_config(ImageArtifactProvider, PILThumbnailGenerator)
-        finally:
-            GriptapeNodes.handle_request = original
+        manager.engine.handle_request = capture_requests
+        manager._read_generator_config(ImageArtifactProvider, PILThumbnailGenerator)
 
         category_requests = [r for r in captured_requests if isinstance(r, GetConfigCategoryRequest)]
         assert len(category_requests) == 1
@@ -1657,20 +1657,15 @@ class TestProviderRegistrationConfigLogLevels:
             GetConfigValueRequest,
         )
 
-        manager = ArtifactManager()
+        manager = ArtifactManager(engine=Mock())
         captured_requests: list[RequestPayload] = []
-
-        original = GriptapeNodes.handle_request
 
         def capture_requests(request: RequestPayload) -> ResultPayload:
             captured_requests.append(request)
-            return original(request)
+            return GriptapeNodes.handle_request(request)
 
-        try:
-            GriptapeNodes.handle_request = staticmethod(capture_requests)
-            manager._validate_and_write_provider_settings(ImageArtifactProvider)
-        finally:
-            GriptapeNodes.handle_request = original
+        manager.engine.handle_request = capture_requests
+        manager._validate_and_write_provider_settings(ImageArtifactProvider)
 
         value_requests = [r for r in captured_requests if isinstance(r, GetConfigValueRequest)]
         assert len(value_requests) >= 2  # noqa: PLR2004

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -6,13 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestPushWorkflow:
     """Tests for ContextManager.push_workflow."""
 
-    def test_push_workflow_with_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_push_workflow_with_name(self, griptape_nodes: Engine) -> None:
         """workflow_name is used directly as the registry key."""
         context_manager = griptape_nodes.ContextManager()
         result = context_manager.push_workflow(workflow_name="my_workflow")
@@ -22,7 +22,7 @@ class TestPushWorkflow:
 
         context_manager.pop_workflow()
 
-    def test_push_workflow_with_file_path_inside_workspace(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_push_workflow_with_file_path_inside_workspace(self, griptape_nodes: Engine) -> None:
         """file_path inside workspace produces a workspace-relative registry key."""
         context_manager = griptape_nodes.ContextManager()
         config_manager = griptape_nodes.ConfigManager()
@@ -42,7 +42,7 @@ class TestPushWorkflow:
 
         context_manager.pop_workflow()
 
-    def test_push_workflow_with_file_path_outside_workspace(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_push_workflow_with_file_path_outside_workspace(self, griptape_nodes: Engine) -> None:
         """file_path outside workspace uses the absolute path as the registry key."""
         context_manager = griptape_nodes.ContextManager()
         config_manager = griptape_nodes.ConfigManager()
@@ -63,21 +63,21 @@ class TestPushWorkflow:
 
         context_manager.pop_workflow()
 
-    def test_push_workflow_raises_when_both_provided(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_push_workflow_raises_when_both_provided(self, griptape_nodes: Engine) -> None:
         """Raises ValueError when both workflow_name and file_path are given."""
         context_manager = griptape_nodes.ContextManager()
 
         with pytest.raises(ValueError, match="not both"):
             context_manager.push_workflow(workflow_name="my_workflow", file_path="/some/path.py")
 
-    def test_push_workflow_raises_when_neither_provided(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_push_workflow_raises_when_neither_provided(self, griptape_nodes: Engine) -> None:
         """Raises ValueError when neither workflow_name nor file_path is given."""
         context_manager = griptape_nodes.ContextManager()
 
         with pytest.raises(ValueError, match="must be provided"):
             context_manager.push_workflow()
 
-    def test_push_workflow_strips_extension(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_push_workflow_strips_extension(self, griptape_nodes: Engine) -> None:
         """Registry key derived from file_path has no file extension."""
         context_manager = griptape_nodes.ContextManager()
         config_manager = griptape_nodes.ConfigManager()
@@ -101,7 +101,7 @@ class TestPushWorkflow:
 class TestGeneratedWorkflowCode:
     """Tests that generated workflow code uses push_workflow(file_path=__file__)."""
 
-    def test_generated_code_uses_file_path_not_workflow_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_generated_code_uses_file_path_not_workflow_name(self, griptape_nodes: Engine) -> None:
         """_generate_workflow_run_prerequisite_code emits push_workflow(file_path=__file__)."""
         from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder
 
@@ -124,13 +124,13 @@ class TestGeneratedWorkflowCode:
 class TestEnsureWorkflowAndFlowRequest:
     """Tests for ContextManager.on_ensure_workflow_and_flow_request."""
 
-    def _cleanup(self, griptape_nodes: GriptapeNodes) -> None:
+    def _cleanup(self, griptape_nodes: Engine) -> None:
         """Tear down any workflow/flow state left over between tests."""
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
         griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-    def test_creates_workflow_and_flow_from_cold_start(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_creates_workflow_and_flow_from_cold_start(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,
             EnsureWorkflowAndFlowResultSuccess,
@@ -155,7 +155,7 @@ class TestEnsureWorkflowAndFlowRequest:
 
         self._cleanup(griptape_nodes)
 
-    def test_reuses_existing_workflow_and_flow(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_reuses_existing_workflow_and_flow(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,
             EnsureWorkflowAndFlowResultSuccess,
@@ -183,7 +183,7 @@ class TestEnsureWorkflowAndFlowRequest:
 
         self._cleanup(griptape_nodes)
 
-    def test_auto_generates_workflow_name_when_none_given(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_auto_generates_workflow_name_when_none_given(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -12,9 +12,6 @@ from griptape_nodes.retained_mode.events.execution_events import (
 )
 from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
-_LIBRARY_MANAGER_PATH = "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager"
-_WORKER_MANAGER_PATH = "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager"
-_OBJECT_MANAGER_PATH = "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager"
 _LIBRARY_REGISTRY_CREATE_NODE_PATH = "griptape_nodes.retained_mode.managers.node_manager.LibraryRegistry.create_node"
 
 
@@ -37,8 +34,23 @@ def _make_mock_obj_mgr(existing_node: MagicMock | None = None) -> MagicMock:
 def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     lib_mgr = MagicMock()
     lib_mgr.is_worker = is_worker
+    lib_mgr._is_worker = is_worker
     lib_mgr.get_worker_for_library.return_value = None
     return lib_mgr
+
+
+def _make_node_manager(
+    *,
+    object_manager: MagicMock | None = None,
+    library_manager: MagicMock | None = None,
+    worker_manager: MagicMock | None = None,
+) -> NodeManager:
+    """Build a NodeManager wired to a mock engine instead of the process-wide facade."""
+    mock_engine = MagicMock()
+    mock_engine.object_manager = object_manager
+    mock_engine.library_manager = library_manager
+    mock_engine.worker_manager = worker_manager
+    return NodeManager(MagicMock(), engine=mock_engine)
 
 
 class TestExecuteNodeOrchestratorPath:
@@ -50,23 +62,14 @@ class TestExecuteNodeOrchestratorPath:
     bugs with a stub that has no connections or flow parentage.
     """
 
-    def _get_node_manager(self) -> NodeManager:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        return GriptapeNodes.NodeManager()
-
     @pytest.mark.asyncio
     async def test_missing_node_fails_without_fallback_to_create(self) -> None:
         """Orchestrator lookup miss returns failure; LibraryRegistry.create_node NOT called."""
-        node_manager = self._get_node_manager()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH) as mock_create,
-        ):
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH) as mock_create:
             request = ExecuteNodeRequest(
                 node_name="nonexistent_node",
                 node_metadata=cast("NodeMetadata", {"node_type": "SomeNodeType", "library": "some_library"}),
@@ -82,16 +85,12 @@ class TestExecuteNodeOrchestratorPath:
     @pytest.mark.asyncio
     async def test_reuses_existing_node(self) -> None:
         """Node already in ObjectManager: skip creation, execute in place."""
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH) as mock_create,
-        ):
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH) as mock_create:
             request = ExecuteNodeRequest(
                 node_name="test_node",
                 parameter_values={"input_param": "input_value"},
@@ -107,17 +106,13 @@ class TestExecuteNodeOrchestratorPath:
 
     @pytest.mark.asyncio
     async def test_no_params(self) -> None:
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(node_name="test_node", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(node_name="test_node", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         mock_node.set_parameter_value.assert_not_called()
@@ -125,21 +120,17 @@ class TestExecuteNodeOrchestratorPath:
 
     @pytest.mark.asyncio
     async def test_set_parameter_fails(self) -> None:
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_node.set_parameter_value.side_effect = ValueError("bad value")
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="test_node",
-                parameter_values={"bad_param": "bad_value"},
-            )
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(
+            node_name="test_node",
+            parameter_values={"bad_param": "bad_value"},
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "bad_param" in str(result.result_details)
@@ -147,38 +138,30 @@ class TestExecuteNodeOrchestratorPath:
 
     @pytest.mark.asyncio
     async def test_aprocess_fails(self) -> None:
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_node.aprocess.side_effect = RuntimeError("process exploded")
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(node_name="test_node")
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(node_name="test_node")
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "process exploded" in str(result.result_details)
 
     @pytest.mark.asyncio
     async def test_multiple_params(self) -> None:
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="test_node",
-                parameter_values={"param_a": 1, "param_b": "two", "param_c": [3]},
-            )
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(
+            node_name="test_node",
+            parameter_values={"param_a": 1, "param_b": "two", "param_c": [3]},
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         expected_param_count = 3
@@ -187,22 +170,18 @@ class TestExecuteNodeOrchestratorPath:
     @pytest.mark.asyncio
     async def test_hydrate_skips_identical_values(self) -> None:
         """Identity-skip guard: hydrate does not re-call set_parameter_value for matching values."""
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         # Pre-populate parameter_values so each hydrate lookup finds a match.
         mock_node.parameter_values = {"param_a": 1, "param_b": "two", "param_c": [3]}
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="test_node",
-                parameter_values=dict(mock_node.parameter_values),
-            )
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(
+            node_name="test_node",
+            parameter_values=dict(mock_node.parameter_values),
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         mock_node.set_parameter_value.assert_not_called()
@@ -211,21 +190,17 @@ class TestExecuteNodeOrchestratorPath:
     @pytest.mark.asyncio
     async def test_hydrate_calls_set_for_differing_values(self) -> None:
         """Identity-skip does not fire when the incoming value differs from current."""
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_node.parameter_values = {"param_a": 1}  # existing, but stale
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=mock_node)
         lib_mgr = _make_mock_library_manager(is_worker=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="test_node",
-                parameter_values={"param_a": 999},  # differs from current
-            )
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(
+            node_name="test_node",
+            parameter_values={"param_a": 999},  # differs from current
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         mock_node.set_parameter_value.assert_called_once_with("param_a", 999)
@@ -240,24 +215,15 @@ class TestExecuteNodeWorkerPathStateless:
     of truth for node identity and parameter values.
     """
 
-    def _get_node_manager(self) -> NodeManager:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        return GriptapeNodes.NodeManager()
-
     @pytest.mark.asyncio
     async def test_constructs_fresh_node_and_executes(self) -> None:
         """Worker path: no prior ObjectManager entry, construct from metadata, run."""
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
         lib_mgr = _make_mock_library_manager(is_worker=True)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=mock_node) as mock_create,
-        ):
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=mock_node) as mock_create:
             request = ExecuteNodeRequest(
                 node_name="test_node",
                 parameter_values={"input_param": "value"},
@@ -278,16 +244,12 @@ class TestExecuteNodeWorkerPathStateless:
     @pytest.mark.asyncio
     async def test_never_persists_node_in_object_manager(self) -> None:
         """Worker path never calls add_object_by_name; node is transient per request."""
-        node_manager = self._get_node_manager()
         mock_node = _make_mock_node()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
         lib_mgr = _make_mock_library_manager(is_worker=True)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=mock_node),
-        ):
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=mock_node):
             request = ExecuteNodeRequest(
                 node_name="test_node",
                 node_metadata={"node_type": "SomeNodeType", "library": "some_library"},
@@ -305,17 +267,13 @@ class TestExecuteNodeWorkerPathStateless:
         future mid-transition case where old code paths coexist); the worker must
         not trust it.
         """
-        node_manager = self._get_node_manager()
         stale_node = _make_mock_node(name="stale")
         fresh_node = _make_mock_node(name="test_node")
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=stale_node)
         lib_mgr = _make_mock_library_manager(is_worker=True)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=fresh_node) as mock_create,
-        ):
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=fresh_node) as mock_create:
             request = ExecuteNodeRequest(
                 node_name="test_node",
                 node_metadata={"node_type": "SomeNodeType", "library": "some_library"},
@@ -331,35 +289,27 @@ class TestExecuteNodeWorkerPathStateless:
     @pytest.mark.asyncio
     async def test_missing_metadata_fails(self) -> None:
         """Worker path requires node_metadata; absent → failure."""
-        node_manager = self._get_node_manager()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
         lib_mgr = _make_mock_library_manager(is_worker=True)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(node_name="nonexistent_node")
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(node_name="nonexistent_node")
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "nonexistent_node" in str(result.result_details)
 
     @pytest.mark.asyncio
     async def test_missing_node_type_in_metadata_fails(self) -> None:
-        node_manager = self._get_node_manager()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
         lib_mgr = _make_mock_library_manager(is_worker=True)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="some_node",
-                node_metadata=cast("NodeMetadata", {"library": "some_library"}),
-            )
-            result = await node_manager.on_execute_node_request(request)
+        request = ExecuteNodeRequest(
+            node_name="some_node",
+            node_metadata=cast("NodeMetadata", {"library": "some_library"}),
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "node_type" in str(result.result_details)
@@ -367,15 +317,11 @@ class TestExecuteNodeWorkerPathStateless:
     @pytest.mark.asyncio
     async def test_creation_failure_returns_failure(self) -> None:
         """LibraryRegistry.create_node raises → ExecuteNodeResultFailure."""
-        node_manager = self._get_node_manager()
         mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
         lib_mgr = _make_mock_library_manager(is_worker=True)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, side_effect=RuntimeError("library not loaded")),
-        ):
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, side_effect=RuntimeError("library not loaded")):
             request = ExecuteNodeRequest(
                 node_name="test_node",
                 node_metadata={"node_type": "SomeNodeType", "library": "some_library"},
@@ -396,11 +342,6 @@ class TestExecuteNodeWorkerRoute:
     without calling aprocess locally.
     """
 
-    def _get_node_manager(self) -> NodeManager:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        return GriptapeNodes.NodeManager()
-
     def _make_mock_node(self, name: str = "worker_node") -> MagicMock:
         node = MagicMock(spec=BaseNode)
         node.name = name
@@ -417,7 +358,6 @@ class TestExecuteNodeWorkerRoute:
 
     @pytest.mark.asyncio
     async def test_routes_to_worker_and_returns_worker_result(self) -> None:
-        node_manager = self._get_node_manager()
         mock_node = self._make_mock_node()
         mock_obj_mgr = self._make_mock_obj_mgr(existing_node=mock_node)
 
@@ -430,18 +370,16 @@ class TestExecuteNodeWorkerRoute:
         )
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
+        lib_mgr._is_worker = False
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_WORKER_MANAGER_PATH, return_value=wm),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="worker_node",
-                node_metadata=cast("NodeMetadata", {"node_type": "WorkerNode", "library": "worker_library"}),
-            )
-            result = await node_manager.on_execute_node_request(request)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)
+
+        request = ExecuteNodeRequest(
+            node_name="worker_node",
+            node_metadata=cast("NodeMetadata", {"node_type": "WorkerNode", "library": "worker_library"}),
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         assert result.parameter_output_values == {"out": 42}
@@ -451,7 +389,6 @@ class TestExecuteNodeWorkerRoute:
 
     @pytest.mark.asyncio
     async def test_worker_failure_returns_failure(self) -> None:
-        node_manager = self._get_node_manager()
         mock_node = self._make_mock_node()
         mock_obj_mgr = self._make_mock_obj_mgr(existing_node=mock_node)
 
@@ -464,18 +401,16 @@ class TestExecuteNodeWorkerRoute:
         )
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
+        lib_mgr._is_worker = False
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_WORKER_MANAGER_PATH, return_value=wm),
-        ):
-            request = ExecuteNodeRequest(
-                node_name="worker_node",
-                node_metadata=cast("NodeMetadata", {"node_type": "WorkerNode", "library": "worker_library"}),
-            )
-            result = await node_manager.on_execute_node_request(request)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)
+
+        request = ExecuteNodeRequest(
+            node_name="worker_node",
+            node_metadata=cast("NodeMetadata", {"node_type": "WorkerNode", "library": "worker_library"}),
+        )
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "worker exploded" in str(result.result_details)
@@ -490,7 +425,6 @@ class TestExecuteNodeWorkerRoute:
         worker constructs the node from metadata; it does not consult
         ObjectManager at all, so any existing entry there is irrelevant.
         """
-        node_manager = self._get_node_manager()
         mock_node = self._make_mock_node()
         mock_obj_mgr = self._make_mock_obj_mgr(existing_node=None)
 
@@ -498,14 +432,12 @@ class TestExecuteNodeWorkerRoute:
         wm.route_to_worker = AsyncMock()
         lib_mgr = MagicMock()
         lib_mgr.is_worker = True
+        lib_mgr._is_worker = True
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
-        with (
-            patch(_OBJECT_MANAGER_PATH, return_value=mock_obj_mgr),
-            patch(_LIBRARY_MANAGER_PATH, return_value=lib_mgr),
-            patch(_WORKER_MANAGER_PATH, return_value=wm),
-            patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=mock_node),
-        ):
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)
+
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, return_value=mock_node):
             request = ExecuteNodeRequest(
                 node_name="worker_node",
                 node_metadata=cast("NodeMetadata", {"node_type": "WorkerNode", "library": "worker_library"}),

--- a/tests/unit/retained_mode/managers/test_griptape_nodes.py
+++ b/tests/unit/retained_mode/managers/test_griptape_nodes.py
@@ -29,7 +29,7 @@ class TestHandleRequestBroadcast:
             patch.object(event_mgr, "put_event") as mock_put,
             # GriptapeNodeEvent is a Pydantic model that validates its wrapped_event arg;
             # patching it here prevents the Pydantic validation from rejecting the MagicMock.
-            patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodeEvent"),
+            patch("griptape_nodes.retained_mode.engine.GriptapeNodeEvent"),
         ):
             GriptapeNodes.handle_request(_BroadcastingRequest())
 
@@ -58,7 +58,7 @@ class TestHandleRequestBroadcast:
             patch.object(event_mgr, "handle_request", return_value=mock_result_event),
             patch.object(event_mgr, "should_suppress_event", return_value=False),
             patch.object(event_mgr, "put_event") as mock_put,
-            patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodeEvent"),
+            patch("griptape_nodes.retained_mode.engine.GriptapeNodeEvent"),
         ):
             GriptapeNodes.handle_request(ReadFileRequest(broadcast_result=True))
 
@@ -90,7 +90,7 @@ class TestAHandleRequestBroadcast:
             patch.object(event_mgr, "ahandle_request", return_value=mock_result_event),
             patch.object(event_mgr, "should_suppress_event", return_value=False),
             patch.object(event_mgr, "aput_event") as mock_aput,
-            patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodeEvent"),
+            patch("griptape_nodes.retained_mode.engine.GriptapeNodeEvent"),
         ):
             await GriptapeNodes.ahandle_request(_BroadcastingRequest())
 
@@ -121,7 +121,7 @@ class TestAHandleRequestBroadcast:
             patch.object(event_mgr, "ahandle_request", return_value=mock_result_event),
             patch.object(event_mgr, "should_suppress_event", return_value=False),
             patch.object(event_mgr, "aput_event") as mock_aput,
-            patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodeEvent"),
+            patch("griptape_nodes.retained_mode.engine.GriptapeNodeEvent"),
         ):
             await GriptapeNodes.ahandle_request(ReadFileRequest(broadcast_result=True))
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import logging
 import subprocess
@@ -61,6 +62,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LibraryDownload,
     LibraryRegistration,
 )
+from griptape_nodes.utils.file_utils import DEFAULT_MAX_SEARCH_DEPTH
 from griptape_nodes.utils.library_utils import extract_library_path
 
 
@@ -395,10 +397,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -422,10 +421,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         mock_config_manager.get_config_value.return_value = valid_paths
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -442,10 +438,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         mock_config_manager = MagicMock()
         mock_config_manager.get_config_value.return_value = []
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
-        ):
+        with patch.object(griptape_nodes, "_config_manager", mock_config_manager):
             library_manager._migrate_old_xdg_library_paths()
 
             # Verify config was NOT updated (empty config)
@@ -458,10 +451,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         mock_config_manager = MagicMock()
         mock_config_manager.get_config_value.return_value = None
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
-        ):
+        with patch.object(griptape_nodes, "_config_manager", mock_config_manager):
             library_manager._migrate_old_xdg_library_paths()
 
             # Verify config was NOT updated (None config)
@@ -492,10 +482,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -530,10 +517,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -566,10 +550,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -608,10 +589,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -648,10 +626,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -693,10 +668,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
-            ),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -2137,19 +2109,17 @@ class TestLibraryManagerEngineVersionCheck:
     def test_satisfied_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "_config_manager", self._config_manager_returning(">=0.5,<1.0")),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
-            mock_gn.ConfigManager.return_value = self._config_manager_returning(">=0.5,<1.0")
             assert library_manager._check_engine_version() is None
 
     def test_unsatisfied_returns_detail_naming_running_version(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "_config_manager", self._config_manager_returning(">=2.0,<3.0")),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
-            mock_gn.ConfigManager.return_value = self._config_manager_returning(">=2.0,<3.0")
             detail = library_manager._check_engine_version()
 
         assert detail is not None
@@ -2158,10 +2128,9 @@ class TestLibraryManagerEngineVersionCheck:
     def test_malformed_specifier_returns_detail(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "_config_manager", self._config_manager_returning("not-a-specifier")),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
-            mock_gn.ConfigManager.return_value = self._config_manager_returning("not-a-specifier")
             detail = library_manager._check_engine_version()
 
         assert detail is not None
@@ -2169,8 +2138,7 @@ class TestLibraryManagerEngineVersionCheck:
 
     def test_no_key_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = self._config_manager_returning(None)
+        with patch.object(griptape_nodes, "_config_manager", self._config_manager_returning(None)):
             assert library_manager._check_engine_version() is None
 
 
@@ -2247,6 +2215,10 @@ class TestInstalledLibraryVersion:
     def _config_manager_for(libraries_dir: Path) -> MagicMock:
         config_manager = MagicMock()
         config_manager.resolved_libraries_root.return_value = libraries_dir
+        # find_files_recursive resolves `discovery_max_depth` through this same
+        # config manager (via GriptapeNodes.ConfigManager()), so it needs a real
+        # int here or the recursive walk's depth comparison blows up on a MagicMock.
+        config_manager.get_config_value.return_value = DEFAULT_MAX_SEARCH_DEPTH
         return config_manager
 
     @pytest.mark.asyncio
@@ -2254,25 +2226,23 @@ class TestInstalledLibraryVersion:
         library_manager = griptape_nodes.LibraryManager()
         libraries_dir = tmp_path / "libraries"
         self._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", "0.78.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = self._config_manager_for(libraries_dir)
-            assert await library_manager._installed_library_version("Griptape Nodes Library") == "0.78.0"
+        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+            assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) == "0.78.0"
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_manifest_matches(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
         library_manager = griptape_nodes.LibraryManager()
         libraries_dir = tmp_path / "libraries"
         self._write_manifest(libraries_dir / "other", "Some Other Library", "1.0.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = self._config_manager_for(libraries_dir)
-            assert await library_manager._installed_library_version("Griptape Nodes Library") is None
+        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+            assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) is None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_libraries_root_empty(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
         library_manager = griptape_nodes.LibraryManager()
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = self._config_manager_for(tmp_path / "empty-libraries")
-            assert await library_manager._installed_library_version("Griptape Nodes Library") is None
+        libraries_dir = tmp_path / "empty-libraries"
+        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+            assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) is None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_manifest_has_no_version(
@@ -2281,9 +2251,8 @@ class TestInstalledLibraryVersion:
         library_manager = griptape_nodes.LibraryManager()
         libraries_dir = tmp_path / "libraries"
         self._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", None)
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = self._config_manager_for(libraries_dir)
-            assert await library_manager._installed_library_version("Griptape Nodes Library") is None
+        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+            assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) is None
 
 
 class TestInstalledLibraryManifestPath:
@@ -2299,9 +2268,10 @@ class TestInstalledLibraryManifestPath:
         library_manager = griptape_nodes.LibraryManager()
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", "0.78.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            result = await library_manager._installed_library_manifest_path("Griptape Nodes Library")
+        with patch.object(
+            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        ):
+            result = await library_manager._installed_library_manifest_path("Griptape Nodes Library", libraries_dir)
         assert result == libraries_dir / "git-lib" / "griptape_nodes_library.json"
 
     @pytest.mark.asyncio
@@ -2309,18 +2279,25 @@ class TestInstalledLibraryManifestPath:
         library_manager = griptape_nodes.LibraryManager()
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "other", "Some Other Library", "1.0.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            assert await library_manager._installed_library_manifest_path("Griptape Nodes Library") is None
+        with patch.object(
+            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        ):
+            assert (
+                await library_manager._installed_library_manifest_path("Griptape Nodes Library", libraries_dir) is None
+            )
 
     @pytest.mark.asyncio
     async def test_returns_none_when_libraries_root_empty(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
         library_manager = griptape_nodes.LibraryManager()
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(
-                tmp_path / "empty-libraries"
+        libraries_dir = tmp_path / "empty-libraries"
+        with patch.object(
+            griptape_nodes,
+            "_config_manager",
+            TestInstalledLibraryVersion._config_manager_for(libraries_dir),
+        ):
+            assert (
+                await library_manager._installed_library_manifest_path("Griptape Nodes Library", libraries_dir) is None
             )
-            assert await library_manager._installed_library_manifest_path("Griptape Nodes Library") is None
 
 
 class TestInstalledDownloadVersion:
@@ -2342,9 +2319,10 @@ class TestInstalledDownloadVersion:
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", "1.2.3")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            assert await library_manager._installed_download_version(download) == "1.2.3"
+        with patch.object(
+            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        ):
+            assert await library_manager._installed_download_version(download, libraries_dir) == "1.2.3"
 
     @pytest.mark.asyncio
     async def test_returns_none_when_repo_directory_absent(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
@@ -2352,9 +2330,10 @@ class TestInstalledDownloadVersion:
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "other-lib", "Other", "1.0.0")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            assert await library_manager._installed_download_version(download) is None
+        with patch.object(
+            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        ):
+            assert await library_manager._installed_download_version(download, libraries_dir) is None
 
     @pytest.mark.asyncio
     async def test_name_overrides_directory_match(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
@@ -2364,19 +2343,22 @@ class TestInstalledDownloadVersion:
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "legacy-dir", "Griptape Nodes Library", "0.9.0")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0", name="Griptape Nodes Library")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            assert await library_manager._installed_download_version(download) == "0.9.0"
+        with patch.object(
+            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        ):
+            assert await library_manager._installed_download_version(download, libraries_dir) == "0.9.0"
 
     @pytest.mark.asyncio
     async def test_returns_none_when_libraries_root_empty(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
         library_manager = griptape_nodes.LibraryManager()
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = TestInstalledLibraryVersion._config_manager_for(
-                tmp_path / "empty-libraries"
-            )
-            assert await library_manager._installed_download_version(download) is None
+        libraries_dir = tmp_path / "empty-libraries"
+        with patch.object(
+            griptape_nodes,
+            "_config_manager",
+            TestInstalledLibraryVersion._config_manager_for(libraries_dir),
+        ):
+            assert await library_manager._installed_download_version(download, libraries_dir) is None
 
     @pytest.mark.asyncio
     async def test_explicit_libraries_path_probes_target_not_live(
@@ -2393,8 +2375,7 @@ class TestInstalledDownloadVersion:
         # libraries_directory must never be read.
         live_config.get_config_value.return_value = str(tmp_path / "live" / "libraries")
         live_config.workspace_path = str(tmp_path / "live")
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = live_config
+        with patch.object(griptape_nodes, "_config_manager", live_config):
             assert await library_manager._installed_download_version(download, target_libs) == "3.3.0"
         live_config.get_config_value.assert_not_called()
 
@@ -2421,10 +2402,9 @@ class TestDiscoverProvisionedManifestPaths:
         # provisioning the pinned library.
         config = [str(expected_manifest)]
 
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            config_manager = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            config_manager.get_config_value.side_effect = _config_value_dispatcher(libraries_dir, config)
-            mock_gn.ConfigManager.return_value = config_manager
+        config_manager = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        config_manager.get_config_value.side_effect = _config_value_dispatcher(libraries_dir, config)
+        with patch.object(griptape_nodes, "_config_manager", config_manager):
             result = await library_manager._discover_library_files()
 
         discovered_paths = [Path(entry.registration.path) for entry in result if entry.registration.path is not None]
@@ -2439,10 +2419,9 @@ class TestDiscoverProvisionedManifestPaths:
         # A register entry whose path is not on disk yet: nothing to discover.
         config = [str(libraries_dir / "missing" / "griptape_nodes_library.json")]
 
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            config_manager = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-            config_manager.get_config_value.side_effect = _config_value_dispatcher(libraries_dir, config)
-            mock_gn.ConfigManager.return_value = config_manager
+        config_manager = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
+        config_manager.get_config_value.side_effect = _config_value_dispatcher(libraries_dir, config)
+        with patch.object(griptape_nodes, "_config_manager", config_manager):
             result = await library_manager._discover_library_files()
 
         assert result == []
@@ -2519,11 +2498,10 @@ class TestReconcileLibrariesFromConfig:
         register_config = ["griptape_nodes_library.json", {"path": "../shared/lib"}]
         config_manager = self._config_manager_for_keys(downloads=download_config, register=register_config)
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "_config_manager", config_manager),
             patch.object(library_manager, "_check_engine_version", return_value=None),
             patch.object(library_manager, "_provision_one_library", new=AsyncMock(return_value=None)) as mock_provision,
         ):
-            mock_gn.ConfigManager.return_value = config_manager
             failures = await library_manager._reconcile_libraries_from_config()
 
         assert failures == []
@@ -2536,11 +2514,10 @@ class TestReconcileLibrariesFromConfig:
         download_config = [{"name": "git-lib", "git_url": "griptape-ai/git-lib@v2", "version": ">=2.0"}]
         config_manager = self._config_manager_for_keys(downloads=download_config)
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "_config_manager", config_manager),
             patch.object(library_manager, "_check_engine_version", return_value=None),
             patch.object(library_manager, "_provision_one_library", new=AsyncMock(return_value="clone failed")),
         ):
-            mock_gn.ConfigManager.return_value = config_manager
             failures = await library_manager._reconcile_libraries_from_config()
 
         assert failures == ["clone failed"]
@@ -2579,27 +2556,45 @@ class TestPreviewProjectProvisioning:
         }
 
     @staticmethod
-    def _patch_managers(mock_gn: MagicMock, *, dirs: object, merged: object, libraries_root: object = None) -> None:
+    @contextlib.contextmanager
+    def _patch_managers(
+        griptape_nodes: GriptapeNodes, *, dirs: object, merged: object, libraries_root: object = None
+    ) -> Generator[tuple[MagicMock, MagicMock], None, None]:
         """Wire the mocked ProjectManager/ConfigManager the new handler calls.
 
         `libraries_root` is what resolve_libraries_root_for_project_id returns: None (the default)
         makes the preview fall back to the merged config's workspace-relative libraries dir.
         """
-        mock_gn.ProjectManager.return_value.resolve_provisioning_config_dirs = AsyncMock(return_value=dirs)
-        mock_gn.ProjectManager.return_value.resolve_libraries_root_for_project_id = AsyncMock(
-            return_value=libraries_root
-        )
-        mock_gn.ConfigManager.return_value.compute_project_provisioning_config.return_value = merged
+        mock_project_manager = MagicMock()
+        mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=dirs)
+        mock_project_manager.resolve_libraries_root_for_project_id = AsyncMock(return_value=libraries_root)
+        mock_config_manager = MagicMock()
+        mock_config_manager.compute_project_provisioning_config.return_value = merged
+        with (
+            patch.object(griptape_nodes, "_project_manager", mock_project_manager),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+        ):
+            yield mock_project_manager, mock_config_manager
 
     @staticmethod
-    def _patch_system_defaults(mock_gn: MagicMock, *, merged: object) -> None:
+    @contextlib.contextmanager
+    def _patch_system_defaults(
+        griptape_nodes: GriptapeNodes, *, merged: object
+    ) -> Generator[tuple[MagicMock, MagicMock], None, None]:
         """Wire the mocked ConfigManager for the system-defaults branch.
 
         System defaults reads its merged config from compute_system_defaults_provisioning_config
         (defaults -> user -> env, no project-adjacent or workspace file), so the handler never
         calls ProjectManager.resolve_provisioning_config_dirs for it.
         """
-        mock_gn.ConfigManager.return_value.compute_system_defaults_provisioning_config.return_value = merged
+        mock_project_manager = MagicMock()
+        mock_config_manager = MagicMock()
+        mock_config_manager.compute_system_defaults_provisioning_config.return_value = merged
+        with (
+            patch.object(griptape_nodes, "_project_manager", mock_project_manager),
+            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+        ):
+            yield mock_project_manager, mock_config_manager
 
     @pytest.mark.asyncio
     async def test_not_loaded_project_is_failure(self, griptape_nodes: GriptapeNodes) -> None:
@@ -2609,8 +2604,9 @@ class TestPreviewProjectProvisioning:
         )
 
         library_manager = griptape_nodes.LibraryManager()
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ProjectManager.return_value.resolve_provisioning_config_dirs = AsyncMock(return_value=None)
+        mock_project_manager = MagicMock()
+        mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=None)
+        with patch.object(griptape_nodes, "_project_manager", mock_project_manager):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id="/nope/project.yml")
             )
@@ -2626,8 +2622,7 @@ class TestPreviewProjectProvisioning:
 
         library_manager = griptape_nodes.LibraryManager()
         merged = self._merged_config([])
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged)
+        with self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2656,14 +2651,13 @@ class TestPreviewProjectProvisioning:
         )
         installed = {"skip-lib": "2.1.0", "install-lib": None, "overwrite-lib": "1.0.0"}
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged),
             patch.object(
                 library_manager,
                 "_installed_download_version",
                 new=AsyncMock(side_effect=lambda download, _libraries_path=None: installed[download.name]),
             ),
         ):
-            self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged)
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2703,15 +2697,17 @@ class TestPreviewProjectProvisioning:
         # project-adjacent file alone would carry; the plan must reflect this entry.
         merged = self._merged_config([{"name": "merged-lib", "git_url": "griptape-ai/merged-lib@v2", "version": ">=2"}])
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            self._patch_managers(griptape_nodes, dirs=dirs, merged=merged) as (
+                _mock_project_manager,
+                mock_config_manager,
+            ),
             patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value=None)),
         ):
-            self._patch_managers(mock_gn, dirs=dirs, merged=merged)
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
 
-        compute = mock_gn.ConfigManager.return_value.compute_project_provisioning_config
+        compute = mock_config_manager.compute_project_provisioning_config
         compute.assert_called_once_with(dirs.project_dir, dirs.workspace_dir, apply_override=dirs.apply_override)
         assert isinstance(result, PreviewProjectProvisioningResultSuccess)
         assert [a.library_name for a in result.actions] == ["merged-lib"]
@@ -2750,9 +2746,14 @@ class TestPreviewProjectProvisioning:
         # used the target/merged workspace instead, the plan would wrongly be a non-destructive INSTALL.
         live_config = MagicMock()
         live_config.configured_global_workspace_path.return_value = global_ws
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ConfigManager.return_value = live_config
-            self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged)
+        live_config.compute_project_provisioning_config.return_value = merged
+        mock_project_manager = MagicMock()
+        mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=MagicMock())
+        mock_project_manager.resolve_libraries_root_for_project_id = AsyncMock(return_value=None)
+        with (
+            patch.object(griptape_nodes, "_project_manager", mock_project_manager),
+            patch.object(griptape_nodes, "_config_manager", live_config),
+        ):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2790,8 +2791,7 @@ class TestPreviewProjectProvisioning:
             workspace_directory=str(tmp_path / "ws"),
             libraries_directory="libraries",
         )
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged, libraries_root=resolved_root)
+        with self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged, libraries_root=resolved_root):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2813,10 +2813,9 @@ class TestPreviewProjectProvisioning:
         library_manager = griptape_nodes.LibraryManager()
         merged = self._merged_config([], engine_version=">=2.0,<3.0")
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
-            self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged)
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2838,10 +2837,9 @@ class TestPreviewProjectProvisioning:
         library_manager = griptape_nodes.LibraryManager()
         merged = self._merged_config([], engine_version=">=0.5,<1.0")
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
-            self._patch_managers(mock_gn, dirs=MagicMock(), merged=merged)
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2870,15 +2868,14 @@ class TestPreviewProjectProvisioning:
         library_manager = griptape_nodes.LibraryManager()
         merged = self._merged_config([{"name": "user-pin", "git_url": "griptape-ai/user-pin@v2", "version": "==2.0.0"}])
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            self._patch_system_defaults(griptape_nodes, merged=merged) as (mock_project_manager, _mock_config_manager),
             patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value="1.0.0")),
         ):
-            self._patch_system_defaults(mock_gn, merged=merged)
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=SYSTEM_DEFAULTS_KEY)
             )
 
-        mock_gn.ProjectManager.return_value.resolve_provisioning_config_dirs.assert_not_called()
+        mock_project_manager.resolve_provisioning_config_dirs.assert_not_called()
         assert isinstance(result, PreviewProjectProvisioningResultSuccess)
         assert [a.library_name for a in result.actions] == ["user-pin"]
         assert result.actions[0].kind == LibraryProvisioningActionKind.OVERWRITE
@@ -2897,10 +2894,9 @@ class TestPreviewProjectProvisioning:
         library_manager = griptape_nodes.LibraryManager()
         merged = self._merged_config([], engine_version=">=2.0,<3.0")
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            self._patch_system_defaults(griptape_nodes, merged=merged),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
-            self._patch_system_defaults(mock_gn, merged=merged)
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=SYSTEM_DEFAULTS_KEY)
             )
@@ -2919,8 +2915,7 @@ class TestPreviewProjectProvisioning:
 
         library_manager = griptape_nodes.LibraryManager()
         merged = self._merged_config([])
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn:
-            self._patch_system_defaults(mock_gn, merged=merged)
+        with self._patch_system_defaults(griptape_nodes, merged=merged):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=SYSTEM_DEFAULTS_KEY)
             )
@@ -2960,12 +2955,11 @@ class TestProvisionGitLibraryOverwriteDir:
         success = MagicMock(spec=DownloadLibraryResultSuccess)
         ahandle = AsyncMock(return_value=success)
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "ahandle_request", ahandle),
             patch.object(
                 library_manager, "_installed_library_manifest_path", new=AsyncMock(return_value=manifest_path)
             ),
         ):
-            mock_gn.ahandle_request = ahandle
             failure = await library_manager._provision_git_library(
                 download, git_url="griptape-ai/repo-name@v2.0", installed_version="1.0.0"
             )
@@ -2998,10 +2992,9 @@ class TestProvisionGitLibraryOverwriteDir:
         success = MagicMock(spec=DownloadLibraryResultSuccess)
         ahandle = AsyncMock(return_value=success)
         with (
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gn,
+            patch.object(griptape_nodes, "ahandle_request", ahandle),
             patch.object(library_manager, "_installed_library_manifest_path", new=AsyncMock()) as mock_resolve,
         ):
-            mock_gn.ahandle_request = ahandle
             failure = await library_manager._provision_git_library(
                 download, git_url="griptape-ai/repo-name@v2.0", installed_version=None
             )
@@ -3134,7 +3127,7 @@ class TestDownloadLibraryRegisterPersistence:
         library_manager = griptape_nodes.LibraryManager()
         config_mgr = griptape_nodes.ConfigManager()
 
-        # download_library_request routes registration through GriptapeNodes.ahandle_request;
+        # download_library_request routes registration through the engine's ahandle_request;
         # the minimal fake manifest can't pass full LibrarySchema validation, so mock the
         # registration step to return success so the test stays focused on config persistence.
         mock_register_result = RegisterLibraryFromFileResultSuccess(
@@ -3147,7 +3140,7 @@ class TestDownloadLibraryRegisterPersistence:
                 side_effect=self._make_clone("explicit_lib"),
             ),
             patch.object(
-                GriptapeNodes,
+                griptape_nodes,
                 "ahandle_request",
                 new=AsyncMock(return_value=mock_register_result),
             ),
@@ -3784,16 +3777,18 @@ class TestLibraryManagerDuplicateEntryHygiene:
 
         with (
             patch.object(library_manager, "_library_file_path_to_info", entries),
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.handle_request",
+            patch.object(
+                griptape_nodes,
+                "handle_request",
                 return_value=UnloadLibraryFromRegistryResultSuccess(result_details="ok"),
             ),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.find_file_in_directory",
                 return_value=Path(new_path),
             ),
-            patch(
-                "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes.ahandle_request",
+            patch.object(
+                griptape_nodes,
+                "ahandle_request",
                 AsyncMock(return_value=RegisterLibraryFromFileResultSuccess(library_name="MyLib", result_details="ok")),
             ),
             patch.object(LibraryRegistry, "get_library", return_value=mock_library),

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,7 +26,6 @@ from griptape_nodes.retained_mode.events.library_events import (
     UpdateLibraryResultFailure,
     UpdateLibraryResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import (
     LibraryGitOperationContext,
     LibraryManager,
@@ -36,6 +36,9 @@ from griptape_nodes.retained_mode.managers.settings import (
 )
 from griptape_nodes.utils.git_utils import GitError
 from griptape_nodes.utils.library_utils import LibraryVersionInfo
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
 MIN_AGE_HOURS = 24.0
@@ -61,7 +64,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)):
             decision = library_manager._evaluate_update_age_gate(young_commit)
 
         assert decision.enabled is False
@@ -71,9 +74,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
 
-        with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-        ):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(young_commit)
 
         assert decision.enabled is True
@@ -86,9 +87,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
-        with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-        ):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(old_commit)
 
         assert decision.enabled is True
@@ -100,9 +99,7 @@ class TestEvaluateUpdateAgeGate:
         """A missing commit timestamp cannot be verified, so the update is allowed (not wedged)."""
         library_manager = griptape_nodes.LibraryManager()
 
-        with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-        ):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(None)
 
         assert decision.enabled is True
@@ -113,9 +110,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         naive_young_commit = datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(hours=1)
 
-        with patch.object(
-            GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-        ):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(naive_young_commit)
 
         assert decision.gated is True
@@ -126,9 +121,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
 
         with (
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-            ),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             caplog.at_level("WARNING"),
         ):
             decision = library_manager._evaluate_update_age_gate(None)
@@ -142,7 +135,7 @@ class TestEvaluateUpdateAgeGate:
         library_manager = griptape_nodes.LibraryManager()
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)),
             caplog.at_level("WARNING"),
         ):
             decision = library_manager._evaluate_update_age_gate(None)
@@ -156,7 +149,7 @@ class TestEvaluateUpdateAgeGate:
         config_mgr = _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr):
+        with patch.object(griptape_nodes, "_config_manager", config_mgr):
             decision = library_manager._evaluate_update_age_gate(
                 old_commit, config=MinimumReleaseAgeConfig(hours=MIN_AGE_HOURS)
             )
@@ -172,7 +165,7 @@ class TestReadMinimumReleaseAgeConfig:
     def test_reads_configured_hours(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=12.0)):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=12.0)):
             config = library_manager._read_minimum_release_age_config()
 
         assert config == MinimumReleaseAgeConfig(hours=12.0)
@@ -181,7 +174,7 @@ class TestReadMinimumReleaseAgeConfig:
     def test_zero_hours_disables_the_gate(self, griptape_nodes: GriptapeNodes) -> None:
         library_manager = griptape_nodes.LibraryManager()
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)):
+        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)):
             config = library_manager._read_minimum_release_age_config()
 
         assert config == MinimumReleaseAgeConfig(hours=0.0)
@@ -197,7 +190,7 @@ class TestReadMinimumReleaseAgeConfig:
         null_config_mgr = MagicMock()
         null_config_mgr.get_config_value.return_value = None
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=null_config_mgr):
+        with patch.object(griptape_nodes, "_config_manager", null_config_mgr):
             config = library_manager._read_minimum_release_age_config()
 
         assert config == MinimumReleaseAgeConfig(hours=0.0)
@@ -229,9 +222,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-            ),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -261,9 +252,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-            ),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -298,7 +287,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=0.0)),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -332,9 +321,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(
-                GriptapeNodes, "ConfigManager", return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
-            ),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -397,6 +384,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
     async def _run_check(
         self,
         library_manager: LibraryManager,
+        griptape_nodes: GriptapeNodes,
         *,
         commit_datetime: datetime | None,
         enabled: bool,
@@ -435,9 +423,9 @@ class TestCheckLibraryUpdateRequestAgeGate:
             patch(f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version", return_value=version_info),
             patch.object(library_manager, "_check_engine_version_compatibility", return_value=(True, "1.0.0")),
             patch.object(
-                GriptapeNodes,
-                "ConfigManager",
-                return_value=_config_manager(minimum_release_age_hours=minimum_release_age_hours),
+                griptape_nodes,
+                "_config_manager",
+                _config_manager(minimum_release_age_hours=minimum_release_age_hours),
             ),
         ):
             result = await library_manager.check_library_update_request(
@@ -453,7 +441,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
 
-        result = await self._run_check(library_manager, commit_datetime=young_commit, enabled=True)
+        result = await self._run_check(library_manager, griptape_nodes, commit_datetime=young_commit, enabled=True)
 
         assert result.has_update is True
         assert result.update_gated_by_age is True
@@ -467,7 +455,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
-        result = await self._run_check(library_manager, commit_datetime=old_commit, enabled=True)
+        result = await self._run_check(library_manager, griptape_nodes, commit_datetime=old_commit, enabled=True)
 
         assert result.has_update is True
         assert result.update_gated_by_age is False
@@ -481,7 +469,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
         library_manager = griptape_nodes.LibraryManager()
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
 
-        result = await self._run_check(library_manager, commit_datetime=young_commit, enabled=False)
+        result = await self._run_check(library_manager, griptape_nodes, commit_datetime=young_commit, enabled=False)
 
         assert result.has_update is True
         assert result.update_gated_by_age is False
@@ -495,6 +483,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
 
         result = await self._run_check(
             library_manager,
+            griptape_nodes,
             commit_datetime=young_commit,
             enabled=True,
             has_update=False,
@@ -552,12 +541,8 @@ class TestSyncLibrariesRequestAgeGate:
             raise AssertionError(error)
 
         with (
-            patch.object(
-                GriptapeNodes,
-                "ConfigManager",
-                return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS),
-            ),
-            patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(griptape_nodes, "ahandle_request", AsyncMock(side_effect=dispatch)),
         ):
             result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
 
@@ -601,12 +586,8 @@ class TestSyncLibrariesRequestAgeGate:
             raise AssertionError(error)
 
         with (
-            patch.object(
-                GriptapeNodes,
-                "ConfigManager",
-                return_value=_config_manager(minimum_release_age_hours=MIN_AGE_HOURS),
-            ),
-            patch.object(GriptapeNodes, "ahandle_request", new=AsyncMock(side_effect=dispatch)),
+            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(griptape_nodes, "ahandle_request", AsyncMock(side_effect=dispatch)),
         ):
             result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
 

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -338,9 +338,8 @@ class TestLibraryDependencyResolution:
             patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
             patch.object(mgr, "download_library_request") as mock_download,
             patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn,
+            patch.object(griptape_nodes, "_config_manager", config_mock),
         ):
-            mock_gtn.ConfigManager.return_value = config_mock
             await mgr._progress_library_through_lifecycle(
                 library_info=lib_info,
                 file_path="/mock.json",
@@ -368,9 +367,8 @@ class TestLibraryDependencyResolution:
             patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
             patch.object(mgr, "download_library_request") as mock_download,
             patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
-            patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn,
+            patch.object(griptape_nodes, "_config_manager", config_mock),
         ):
-            mock_gtn.ConfigManager.return_value = config_mock
             await mgr._progress_library_through_lifecycle(
                 library_info=lib_info,
                 file_path="/mock.json",
@@ -694,7 +692,7 @@ class TestDownloadLibraryRequestAutoRegister:
                     return_value=fake_json_path,
                 ),
                 patch.object(
-                    GriptapeNodes,
+                    griptape_nodes,
                     "ahandle_request",
                     new_callable=AsyncMock,
                     return_value=RegisterLibraryFromFileResultFailure(result_details="schema validation error"),

--- a/tests/unit/retained_mode/managers/test_library_manager_directory_paths.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_directory_paths.py
@@ -27,7 +27,7 @@ class TestGetSandboxDirectory:
         config_mgr.workspace_path = Path("/workspace")
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch.object(griptape_nodes, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
                 return_value=Path("/workspace/sandbox_library"),
@@ -47,7 +47,7 @@ class TestGetSandboxDirectory:
         config_mgr.workspace_path = Path("/workspace")
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch.object(griptape_nodes, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
                 return_value=Path("/opt/sandbox"),
@@ -66,7 +66,7 @@ class TestGetSandboxDirectory:
         config_mgr.get_config_value.return_value = ""
         config_mgr.workspace_path = Path("/workspace")
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr):
+        with patch.object(griptape_nodes, "_config_manager", config_mgr):
             result = library_manager._get_sandbox_directory()
 
         assert result is None
@@ -79,7 +79,7 @@ class TestGetSandboxDirectory:
         config_mgr.workspace_path = Path("/workspace")
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch.object(griptape_nodes, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
                 return_value=Path("/workspace/sandbox_library"),
@@ -101,7 +101,7 @@ class TestDownloadLibrariesFromGitUrlsPath:
         config_mgr = MagicMock()
         config_mgr.resolved_libraries_root.return_value = Path("/workspace/libraries")
 
-        with patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr):
+        with patch.object(griptape_nodes, "_config_manager", config_mgr):
             result = await library_manager._download_libraries_from_git_urls([])
 
         config_mgr.resolved_libraries_root.assert_called_once_with()
@@ -125,7 +125,7 @@ class TestDownloadLibraryRequestPath:
         request.download_directory = None
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch.object(griptape_nodes, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
                 return_value="https://github.com/user/repo.git",
@@ -153,7 +153,7 @@ class TestDownloadLibraryRequestPath:
         request.download_directory = "/custom/dir"
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch.object(griptape_nodes, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
                 return_value="https://github.com/user/repo.git",
@@ -188,7 +188,7 @@ class TestDownloadLibraryRequestPath:
         request.fail_on_exists = True
 
         with (
-            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch.object(griptape_nodes, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
                 return_value="https://github.com/user/repo.git",

--- a/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Never
+from typing import TYPE_CHECKING, Never
 from unittest.mock import MagicMock, patch
 
 from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
 from griptape_nodes.node_library.library_registry import Library, LibrarySchema
 from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     RequestHandlerRegistrationProblem,
     RequestHandlersWorkerIncompatibleProblem,
 )
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 @dataclass
@@ -67,7 +69,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -89,7 +91,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -114,7 +116,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -132,7 +134,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -153,7 +155,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -178,7 +180,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -202,7 +204,7 @@ class TestRequestHandlerRegistration:
 
         lm = griptape_nodes.LibraryManager()
         event_manager = MagicMock()
-        with patch.object(GriptapeNodes, "EventManager", return_value=event_manager):
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import MagicMock, patch
+from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -71,13 +71,12 @@ class TestGetWorkerForLibrary:
             requires_worker=True,
         )
 
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn:
-            mock_gtn.WorkerManager.return_value.get_worker_for_key.return_value = (
-                worker_engine_id,
-                worker_request_topic,
-            )
-            mgr._library_file_path_to_info["/some/path.json"] = lib_info
-            result = mgr.get_worker_for_library("my_lib")
+        cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = (
+            worker_engine_id,
+            worker_request_topic,
+        )
+        mgr._library_file_path_to_info["/some/path.json"] = lib_info
+        result = mgr.get_worker_for_library("my_lib")
 
         assert result == (worker_engine_id, worker_request_topic)
 
@@ -92,10 +91,9 @@ class TestGetWorkerForLibrary:
             requires_worker=False,
         )
 
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn:
-            mock_gtn.WorkerManager.return_value.get_worker_for_key.return_value = None
-            mgr._library_file_path_to_info["/some/path.json"] = lib_info
-            result = mgr.get_worker_for_library("my_lib")
+        cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = None
+        mgr._library_file_path_to_info["/some/path.json"] = lib_info
+        result = mgr.get_worker_for_library("my_lib")
 
         assert result is None
 
@@ -110,12 +108,11 @@ class TestGetWorkerForLibrary:
             requires_worker=True,
         )
 
-        with patch("griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes") as mock_gtn:
-            mock_gtn.WorkerManager.return_value.get_worker_for_key.return_value = None
-            mgr._library_file_path_to_info["/some/path.json"] = lib_info
+        cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = None
+        mgr._library_file_path_to_info["/some/path.json"] = lib_info
 
-            with pytest.raises(RuntimeError, match="requires a dedicated worker"):
-                mgr.get_worker_for_library("my_lib")
+        with pytest.raises(RuntimeError, match="requires a dedicated worker"):
+            mgr.get_worker_for_library("my_lib")
 
 
 class TestOnLibraryLoadedNotification:

--- a/tests/unit/retained_mode/managers/test_library_worker_mode_override.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_mode_override.py
@@ -21,16 +21,16 @@ def _make_library_manager() -> LibraryManager:
 
 
 def _patch_libraries_to_register(raw_entries: list[Any]) -> Any:
-    """Build a GriptapeNodes mock whose ConfigManager returns the given entries."""
+    """Build a fake engine whose config_manager returns the given entries."""
 
     def get_config_value(key: str, *_args: Any, **_kwargs: Any) -> Any:
         if key.endswith("libraries_to_register"):
             return raw_entries
         return None
 
-    mock_gtn = MagicMock()
-    mock_gtn.ConfigManager.return_value.get_config_value.side_effect = get_config_value
-    return mock_gtn
+    mock_engine = MagicMock()
+    mock_engine.config_manager.get_config_value.side_effect = get_config_value
+    return mock_engine
 
 
 def _decls(
@@ -50,10 +50,7 @@ class TestResolveRequiresWorker:
     def test_no_declarations_returns_false(self) -> None:
         mgr = _make_library_manager()
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([])):
             assert mgr._resolve_requires_worker("/p.json", []) is False
 
     def test_incompatible_ignores_override(self) -> None:
@@ -61,30 +58,21 @@ class TestResolveRequiresWorker:
         decls = _decls(compatibility=WorkerCompatibility.INCOMPATIBLE)
         entry = LibraryRegistration(path="/p.json", worker_mode_override=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             assert mgr._resolve_requires_worker("/p.json", decls) is False
 
     def test_compatible_with_suggested_orchestrator_no_override(self) -> None:
         mgr = _make_library_manager()
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.ORCHESTRATOR)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([LibraryRegistration(path="/p.json")]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([LibraryRegistration(path="/p.json")])):
             assert mgr._resolve_requires_worker("/p.json", decls) is False
 
     def test_compatible_with_suggested_worker_no_override(self) -> None:
         mgr = _make_library_manager()
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([LibraryRegistration(path="/p.json")]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([LibraryRegistration(path="/p.json")])):
             assert mgr._resolve_requires_worker("/p.json", decls) is True
 
     def test_compatible_with_override_to_worker(self) -> None:
@@ -92,10 +80,7 @@ class TestResolveRequiresWorker:
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.ORCHESTRATOR)
         entry = LibraryRegistration(path="/p.json", worker_mode_override=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             assert mgr._resolve_requires_worker("/p.json", decls) is True
 
     def test_compatible_with_override_to_orchestrator(self) -> None:
@@ -103,10 +88,7 @@ class TestResolveRequiresWorker:
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.WORKER)
         entry = LibraryRegistration(path="/p.json", worker_mode_override=WorkerMode.ORCHESTRATOR)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             assert mgr._resolve_requires_worker("/p.json", decls) is False
 
     def test_dict_entry_with_override(self) -> None:
@@ -115,20 +97,14 @@ class TestResolveRequiresWorker:
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.ORCHESTRATOR)
         entry = {"path": "/p.json", "worker_mode_override": "WORKER"}
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             assert mgr._resolve_requires_worker("/p.json", decls) is True
 
     def test_bare_string_entry_no_override(self) -> None:
         mgr = _make_library_manager()
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register(["/p.json"]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register(["/p.json"])):
             # Bare-string entry has no override; falls back to the manifest's suggested mode.
             assert mgr._resolve_requires_worker("/p.json", decls) is True
 
@@ -138,10 +114,7 @@ class TestResolveRequiresWorker:
         # Hand-edited config with garbage value.
         entry = {"path": "/p.json", "worker_mode_override": "BOGUS"}
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             assert mgr._resolve_requires_worker("/p.json", decls) is True
 
     def test_path_match_is_case_insensitive(self) -> None:
@@ -150,20 +123,14 @@ class TestResolveRequiresWorker:
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.ORCHESTRATOR)
         entry = LibraryRegistration(path="/Some/Path.json", worker_mode_override=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             assert mgr._resolve_requires_worker("/some/path.json", decls) is True
 
     def test_no_matching_entry_falls_back_to_manifest(self) -> None:
         mgr = _make_library_manager()
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([LibraryRegistration(path="/other.json")]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([LibraryRegistration(path="/other.json")])):
             assert mgr._resolve_requires_worker("/p.json", decls) is True
 
     def test_resolver_matches_by_registered_path_not_resolved_path(self) -> None:
@@ -176,10 +143,7 @@ class TestResolveRequiresWorker:
         decls = _decls(compatibility=WorkerCompatibility.COMPATIBLE, suggested=WorkerMode.ORCHESTRATOR)
         entry = LibraryRegistration(path="~/dev/lib.json", worker_mode_override=WorkerMode.WORKER)
 
-        with patch(
-            "griptape_nodes.retained_mode.managers.library_manager.GriptapeNodes",
-            _patch_libraries_to_register([entry]),
-        ):
+        with patch.object(mgr, "_engine", _patch_libraries_to_register([entry])):
             # Caller passes the user's `registered_path` (matches the entry verbatim), not
             # the resolved absolute path the engine would otherwise produce.
             assert mgr._resolve_requires_worker("~/dev/lib.json", decls) is True

--- a/tests/unit/retained_mode/managers/test_manifest_manager.py
+++ b/tests/unit/retained_mode/managers/test_manifest_manager.py
@@ -1,6 +1,7 @@
 """Tests for ManifestManager.on_generate_manifest_request."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -25,8 +26,6 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
 from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
-
-MODULE_PATH = "griptape_nodes.retained_mode.managers.manifest_manager"
 
 
 def _library_metadata() -> LibraryMetadata:
@@ -53,37 +52,37 @@ class TestManifestManager:
 
     @pytest.fixture
     def manifest_manager(self) -> ManifestManager:
-        return ManifestManager(MagicMock())
+        return ManifestManager(MagicMock(), engine=MagicMock())
 
     @pytest.mark.asyncio
     async def test_generate_manifest_includes_libraries_and_project_templates(
         self, manifest_manager: ManifestManager
     ) -> None:
         """A full run includes libraries, project templates, engine id, and engine version."""
-        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
-            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
-            mock_gn.ahandle_request = AsyncMock(
-                side_effect=[
-                    ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
-                    GetLibraryMetadataResultSuccess(metadata=_library_metadata(), result_details="ok"),
-                    GetLibrarySourceInfoResultSuccess(
-                        library_name="Lib A",
-                        library_json_path="/libs/a/griptape_nodes_library.json",
-                        library_directory="/libs/a",
-                        result_details="ok",
-                    ),
-                    ListProjectTemplatesResultSuccess(
-                        successfully_loaded=[_project_info()],
-                        failed_to_load=[],
-                        result_details="ok",
-                    ),
-                    GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
-                ]
-            )
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.engine_identity_manager.engine_id = "engine-uuid-1"
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[
+                ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
+                GetLibraryMetadataResultSuccess(metadata=_library_metadata(), result_details="ok"),
+                GetLibrarySourceInfoResultSuccess(
+                    library_name="Lib A",
+                    library_json_path="/libs/a/griptape_nodes_library.json",
+                    library_directory="/libs/a",
+                    result_details="ok",
+                ),
+                ListProjectTemplatesResultSuccess(
+                    successfully_loaded=[_project_info()],
+                    failed_to_load=[],
+                    result_details="ok",
+                ),
+                GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+            ]
+        )
 
-            result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_model_catalog=False)
-            )
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(include_model_catalog=False)
+        )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         manifest = result.manifest
@@ -93,7 +92,7 @@ class TestManifestManager:
 
         # Project templates are requested with system builtins included, so the
         # always-loaded default project is part of the manifest.
-        list_templates_request = mock_gn.ahandle_request.await_args_list[3].args[0]
+        list_templates_request = mock_engine.ahandle_request.await_args_list[3].args[0]
         assert isinstance(list_templates_request, ListProjectTemplatesRequest)
         assert list_templates_request.include_system_builtins is True
 
@@ -116,14 +115,14 @@ class TestManifestManager:
     @pytest.mark.asyncio
     async def test_generate_manifest_fails_when_library_listing_fails(self, manifest_manager: ManifestManager) -> None:
         """A failure listing libraries surfaces as a manifest generation failure."""
-        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
-            mock_gn.ahandle_request = AsyncMock(
-                side_effect=[ListRegisteredLibrariesResultFailure(result_details="registry down")]
-            )
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[ListRegisteredLibrariesResultFailure(result_details="registry down")]
+        )
 
-            result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_model_catalog=False)
-            )
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(include_model_catalog=False)
+        )
 
         assert isinstance(result, GenerateManifestResultFailure)
 
@@ -132,30 +131,30 @@ class TestManifestManager:
         self, manifest_manager: ManifestManager
     ) -> None:
         """A library whose metadata fails is still included with what could be gathered."""
-        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
-            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
-            mock_gn.ahandle_request = AsyncMock(
-                side_effect=[
-                    ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
-                    GetLibraryMetadataResultFailure(result_details="not loaded"),
-                    GetLibrarySourceInfoResultSuccess(
-                        library_name="Lib A",
-                        library_json_path="/libs/a/griptape_nodes_library.json",
-                        library_directory="/libs/a",
-                        result_details="ok",
-                    ),
-                    ListProjectTemplatesResultSuccess(
-                        successfully_loaded=[],
-                        failed_to_load=[],
-                        result_details="ok",
-                    ),
-                    GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
-                ]
-            )
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.engine_identity_manager.engine_id = "engine-uuid-1"
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[
+                ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
+                GetLibraryMetadataResultFailure(result_details="not loaded"),
+                GetLibrarySourceInfoResultSuccess(
+                    library_name="Lib A",
+                    library_json_path="/libs/a/griptape_nodes_library.json",
+                    library_directory="/libs/a",
+                    result_details="ok",
+                ),
+                ListProjectTemplatesResultSuccess(
+                    successfully_loaded=[],
+                    failed_to_load=[],
+                    result_details="ok",
+                ),
+                GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+            ]
+        )
 
-            result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_model_catalog=False)
-            )
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(include_model_catalog=False)
+        )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         assert len(result.manifest.libraries) == 1
@@ -175,22 +174,22 @@ class TestManifestManager:
         default_info.project_file_path = None
         default_info.parent_project_id = None
 
-        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
-            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
-            mock_gn.ahandle_request = AsyncMock(
-                side_effect=[
-                    ListProjectTemplatesResultSuccess(
-                        successfully_loaded=[default_info],
-                        failed_to_load=[],
-                        result_details="ok",
-                    ),
-                    GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
-                ]
-            )
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.engine_identity_manager.engine_id = "engine-uuid-1"
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[
+                ListProjectTemplatesResultSuccess(
+                    successfully_loaded=[default_info],
+                    failed_to_load=[],
+                    result_details="ok",
+                ),
+                GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+            ]
+        )
 
-            result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_libraries=False, include_model_catalog=False)
-            )
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(include_libraries=False, include_model_catalog=False)
+        )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         assert len(result.manifest.project_templates) == 1
@@ -202,23 +201,23 @@ class TestManifestManager:
     @pytest.mark.asyncio
     async def test_generate_manifest_respects_toggles(self, manifest_manager: ManifestManager) -> None:
         """Disabling both toggles only resolves the engine version."""
-        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
-            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
-            mock_gn.ahandle_request = AsyncMock(
-                side_effect=[GetEngineVersionResultSuccess(major=2, minor=0, patch=0, result_details="ok")]
-            )
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.engine_identity_manager.engine_id = "engine-uuid-1"
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[GetEngineVersionResultSuccess(major=2, minor=0, patch=0, result_details="ok")]
+        )
 
-            result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(
-                    include_libraries=False, include_project_templates=False, include_model_catalog=False
-                )
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(
+                include_libraries=False, include_project_templates=False, include_model_catalog=False
             )
+        )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         assert result.manifest.libraries == []
         assert result.manifest.project_templates == []
         assert result.manifest.engine_version == "2.0.0"
-        assert mock_gn.ahandle_request.await_count == 1
+        assert mock_engine.ahandle_request.await_count == 1
 
     @pytest.mark.asyncio
     async def test_generate_manifest_aggregates_model_catalog(self, manifest_manager: ManifestManager) -> None:
@@ -256,19 +255,19 @@ class TestManifestManager:
             ],
         )
 
-        with patch(f"{MODULE_PATH}.GriptapeNodes") as mock_gn:
-            mock_gn.EngineIdentityManager.return_value.engine_id = "engine-uuid-1"
-            mock_gn.ahandle_request = AsyncMock(
-                side_effect=[
-                    ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
-                    GetLibraryMetadataResultSuccess(metadata=metadata, result_details="ok"),
-                    GetEngineVersionResultSuccess(major=1, minor=0, patch=0, result_details="ok"),
-                ]
-            )
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.engine_identity_manager.engine_id = "engine-uuid-1"
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[
+                ListRegisteredLibrariesResultSuccess(libraries=["Lib A"], result_details="ok"),
+                GetLibraryMetadataResultSuccess(metadata=metadata, result_details="ok"),
+                GetEngineVersionResultSuccess(major=1, minor=0, patch=0, result_details="ok"),
+            ]
+        )
 
-            result = await manifest_manager.on_generate_manifest_request(
-                GenerateManifestRequest(include_libraries=False, include_project_templates=False)
-            )
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(include_libraries=False, include_project_templates=False)
+        )
 
         assert isinstance(result, GenerateManifestResultSuccess)
         assert [provider.provider_id for provider in result.manifest.model_providers] == ["anthropic"]

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -35,7 +35,7 @@ from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, 
 @pytest.fixture
 def model_manager() -> ModelManager:
     """Bare ModelManager without event wiring."""
-    return ModelManager.__new__(ModelManager)
+    return ModelManager()
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +255,7 @@ class TestOnHandleDeclareModelInvocationRequest:
             return None
 
         GriptapeNodes.EventManager().add_authorization_hook(deny)
-        manager = ModelManager.__new__(ModelManager)
+        manager = ModelManager()
 
         denied = manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(model_id="gtc_claude_opus_4_7")
@@ -282,7 +282,7 @@ class TestOnHandleDeclareModelInvocationRequest:
             return CheckpointDenial(failures=())
 
         GriptapeNodes.EventManager().add_authorization_hook(deny)
-        manager = ModelManager.__new__(ModelManager)
+        manager = ModelManager()
 
         denied = manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(model_id="gtc_claude_opus_4_7")
@@ -400,7 +400,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             return None
 
         griptape_nodes.EventManager().add_authorization_hook(capture)
-        manager = ModelManager.__new__(ModelManager)
+        manager = ModelManager()
 
         result = manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(model_id="gtc_gpt_image_1_mini", node_name="Probe_1")
@@ -434,7 +434,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             return None
 
         griptape_nodes.EventManager().add_authorization_hook(deny)
-        manager = ModelManager.__new__(ModelManager)
+        manager = ModelManager()
 
         result = manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(model_id="gtc_gpt_image_1_mini", node_name="Probe_1")
@@ -460,7 +460,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             return None
 
         griptape_nodes.EventManager().add_authorization_hook(capture)
-        manager = ModelManager.__new__(ModelManager)
+        manager = ModelManager()
 
         manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(model_id="gtc_not_declared", node_name="Probe_1")
@@ -481,7 +481,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             return None
 
         griptape_nodes.EventManager().add_authorization_hook(capture)
-        manager = ModelManager.__new__(ModelManager)
+        manager = ModelManager()
 
         manager.on_handle_declare_model_invocation_request(
             DeclareModelInvocationRequest(model_id="gtc_gpt_image_1_mini")

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -6,6 +6,7 @@ import pytest
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeMetadataRequest,
     BatchSetNodeMetadataResultFailure,
@@ -89,6 +90,7 @@ class TestNodeManagerResolutionStateSerialization:
             unique_parameter_uuid_to_values={},
             serialized_parameter_value_tracker=MagicMock(),
             create_node_request=create_node_request,
+            workflow_manager=MagicMock(),
         )
 
         # Should return None (no values to serialize) but preserve resolution
@@ -130,6 +132,7 @@ class TestNodeManagerResolutionStateSerialization:
             unique_parameter_uuid_to_values={},
             serialized_parameter_value_tracker=mock_tracker,
             create_node_request=create_node_request,
+            workflow_manager=MagicMock(),
         )
 
         # Resolution should be reset to UNRESOLVED due to serialization failure
@@ -177,6 +180,7 @@ class TestNodeManagerResolutionStateSerialization:
             unique_parameter_uuid_to_values={},
             serialized_parameter_value_tracker=mock_tracker,
             create_node_request=create_node_request,
+            workflow_manager=MagicMock(),
         )
 
         warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
@@ -218,6 +222,7 @@ class TestNodeManagerResolutionStateSerialization:
             unique_parameter_uuid_to_values={},
             serialized_parameter_value_tracker=mock_tracker,
             create_node_request=create_node_request,
+            workflow_manager=MagicMock(),
         )
 
         warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
@@ -258,7 +263,7 @@ class TestSerializeNodeWithoutLibraryMetadata:
         assert node.metadata["library"] == "Original Library"
         assert node.metadata["node_type"] == "OriginalType"
 
-    def test_serialize_node_without_library_metadata_does_not_crash(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_serialize_node_without_library_metadata_does_not_crash(self, griptape_nodes: Engine) -> None:
         """Regression for griptape-ai/griptape-nodes-app#154: a missing 'library' key must not raise."""
         from griptape_nodes.exe_types.node_types import ErrorProxyNode
         from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
@@ -380,7 +385,7 @@ class TestNodeManagerAlterParameterDetailsClearDefaultValue:
     """Test AlterParameterDetailsRequest behavior when clear_default_value and default_value are both set."""
 
     def test_clear_default_value_with_default_value_logs_warning_and_clears(
-        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
+        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         """When both clear_default_value and default_value are provided, default is cleared and a warning is logged."""
         parameter = Parameter(name="test_param", default_value="original_value")
@@ -408,7 +413,7 @@ class TestNodeManagerAlterParameterDetailsClearDefaultValue:
 class TestGetParameterValueOutputPriority:
     """Output values must take priority over input/property values in GetParameterValueRequest."""
 
-    def test_output_value_takes_priority_over_parameter_value(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_output_value_takes_priority_over_parameter_value(self, griptape_nodes: Engine) -> None:
         """When both parameter_values and parameter_output_values contain a key, the output value wins."""
         from unittest.mock import MagicMock
 
@@ -439,7 +444,7 @@ class TestGetParameterValueOutputPriority:
         assert isinstance(result, GetParameterValueResultSuccess)
         assert result.value == output_value
 
-    def test_falls_back_to_parameter_value_when_no_output(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_falls_back_to_parameter_value_when_no_output(self, griptape_nodes: Engine) -> None:
         """When parameter_output_values is empty, parameter_values is used."""
         from unittest.mock import MagicMock
 
@@ -469,7 +474,7 @@ class TestGetParameterValueOutputPriority:
         assert isinstance(result, GetParameterValueResultSuccess)
         assert result.value == input_value
 
-    def test_falls_back_to_default_when_no_values(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_falls_back_to_default_when_no_values(self, griptape_nodes: Engine) -> None:
         """When neither dict contains the key, the parameter default is returned."""
         from unittest.mock import MagicMock
 
@@ -504,7 +509,7 @@ class TestNodeManagerCancelExecuteNode:
     """Tests for the CancelExecuteNodeRequest handler and cancel_worker_execution dispatch."""
 
     @pytest.mark.asyncio
-    async def test_handler_no_inflight_returns_success(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_handler_no_inflight_returns_success(self, griptape_nodes: Engine) -> None:
         """Cancelling a request_id that isn't tracked is idempotent success."""
         from griptape_nodes.retained_mode.events.execution_events import (
             CancelExecuteNodeRequest,
@@ -519,7 +524,7 @@ class TestNodeManagerCancelExecuteNode:
         assert isinstance(result, CancelExecuteNodeResultSuccess)
 
     @pytest.mark.asyncio
-    async def test_handler_cancels_tracked_task_and_sets_flag(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_handler_cancels_tracked_task_and_sets_flag(self, griptape_nodes: Engine) -> None:
         """With an in-flight task registered, the handler sets the node's cancel flag and cancels the task."""
         import asyncio
 
@@ -565,7 +570,7 @@ class TestNodeManagerCancelExecuteNode:
                 task.cancel()
 
     @pytest.mark.asyncio
-    async def test_cancel_worker_execution_noop_when_not_tracked(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_cancel_worker_execution_noop_when_not_tracked(self, griptape_nodes: Engine) -> None:
         """cancel_worker_execution is a no-op when the node isn't routed to a worker."""
         node_manager = griptape_nodes.NodeManager()
 
@@ -620,7 +625,8 @@ class TestDeserializeNodeFromCommandsRetargetsElementCommands:
         )
         request = DeserializeNodeFromCommandsRequest(serialized_node_commands=serialized)
 
-        manager = NodeManager(MagicMock())
+        mock_engine = MagicMock()
+        manager = NodeManager(MagicMock(), engine=mock_engine)
 
         create_result = CreateNodeResultSuccess(
             node_name=copy_name,
@@ -636,13 +642,10 @@ class TestDeserializeNodeFromCommandsRetargetsElementCommands:
             return create_result if req is request.serialized_node_commands.create_node_command else success
 
         mock_node = MagicMock(spec=BaseNode)
-        with (
-            patch("griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes") as mock_griptape_nodes,
-            patch.object(NodeManager, "_cleanup_node_on_failed_deserialization"),
-        ):
-            mock_griptape_nodes.return_value.handle_request.side_effect = fake_handle_request
-            mock_griptape_nodes.ObjectManager.return_value.attempt_get_object_by_name_as_type.return_value = mock_node
+        mock_engine.handle_request.side_effect = fake_handle_request
+        mock_engine.object_manager.attempt_get_object_by_name_as_type.return_value = mock_node
 
+        with patch.object(NodeManager, "_cleanup_node_on_failed_deserialization"):
             result = manager.on_deserialize_node_from_commands(request)
 
         assert isinstance(result, DeserializeNodeFromCommandsResultSuccess)
@@ -751,7 +754,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         )
         assert self._attrs(library)["executes_arbitrary_code"] is True
 
-    def test_enforce_raises_on_denial(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_enforce_raises_on_denial(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager, _NodeInstantiationDeniedError
@@ -765,23 +768,27 @@ class TestNodeInstantiationAuthorizationCheckpoint:
             seen["stage"] = checkpoint.attributes.get("lifecycle_stage")  # type: ignore[attr-defined]
             return CheckpointDenial(failures=(CheckpointFailure(detail="Ask your admin to enable Labs nodes."),))
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        griptape_nodes.event_manager.add_authorization_hook(deny)
         with pytest.raises(_NodeInstantiationDeniedError, match="Ask your admin to enable Labs nodes"):
             NodeManager._enforce_instantiation_checkpoint(
-                node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME
+                node_type=_GateProbe.__name__,
+                specific_library_name=self._LIBRARY_NAME,
+                event_manager=griptape_nodes.event_manager,
             )
         assert seen == {"action": "InstantiateNode", "stage": "LABS"}
 
-    def test_enforce_allows_without_hook(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_enforce_allows_without_hook(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         self._register()
         # No hook registered -> no denial, no raise.
         NodeManager._enforce_instantiation_checkpoint(
-            node_type=_GateProbe.__name__, specific_library_name=self._LIBRARY_NAME
+            node_type=_GateProbe.__name__,
+            specific_library_name=self._LIBRARY_NAME,
+            event_manager=griptape_nodes.event_manager,
         )
 
-    def test_worker_materialize_denied_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_worker_materialize_denied_returns_failure(self, griptape_nodes: Engine) -> None:
         """Worker-side construction from caller-supplied metadata is gated by the same checkpoint."""
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.events.execution_events import (
@@ -797,7 +804,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Labs nodes are disabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        griptape_nodes.event_manager.add_authorization_hook(deny)
         request = ExecuteNodeRequest(
             node_name="probe-1",
             node_metadata={"node_type": _GateProbe.__name__, "library": self._LIBRARY_NAME},
@@ -806,7 +813,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "Labs nodes are disabled." in str(result.result_details)
 
-    def test_worker_materialize_allows_without_hook(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_worker_materialize_allows_without_hook(self, griptape_nodes: Engine) -> None:
         """With no policy hook the worker path builds the node, matching the no-denial contract."""
         from griptape_nodes.exe_types.node_types import BaseNode
         from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeRequest
@@ -820,7 +827,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         assert isinstance(result, BaseNode)
         assert result.name == "probe-1"
 
-    def test_schema_preview_returns_denied_node_types(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_schema_preview_returns_denied_node_types(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
@@ -832,16 +839,23 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Labs nodes are disabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
-        denials = NodeManager.evaluate_schema_node_instantiation_denials(schema)
+        griptape_nodes.event_manager.add_authorization_hook(deny)
+        denials = NodeManager.evaluate_schema_node_instantiation_denials(
+            schema, event_manager=griptape_nodes.event_manager
+        )
         assert set(denials) == {_GateProbe.__name__}
         assert denials[_GateProbe.__name__].messages() == ["Labs nodes are disabled."]
 
-    def test_schema_preview_empty_without_hook(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_schema_preview_empty_without_hook(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         # No hook -> nothing denied.
-        assert NodeManager.evaluate_schema_node_instantiation_denials(self._schema_with_node()) == {}
+        assert (
+            NodeManager.evaluate_schema_node_instantiation_denials(
+                self._schema_with_node(), event_manager=griptape_nodes.event_manager
+            )
+            == {}
+        )
 
     def test_model_usage_resolves_catalog_facts(self) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
@@ -895,7 +909,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         assert "provider_ids" not in attrs
         assert "model_families" not in attrs
 
-    def test_model_facts_reach_the_checkpoint_and_can_be_denied(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_model_facts_reach_the_checkpoint_and_can_be_denied(self, griptape_nodes: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
@@ -914,8 +928,10 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Anthropic is not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
-        denials = NodeManager.evaluate_schema_node_instantiation_denials(schema)
+        griptape_nodes.event_manager.add_authorization_hook(deny)
+        denials = NodeManager.evaluate_schema_node_instantiation_denials(
+            schema, event_manager=griptape_nodes.event_manager
+        )
         assert seen == {"provider_ids": ["anthropic"], "model_families": ["Claude 4"]}
         assert set(denials) == {_GateProbe.__name__}
         assert denials[_GateProbe.__name__].messages() == ["Anthropic is not enabled."]

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -22,17 +22,26 @@ from griptape_nodes.retained_mode.events.execution_events import (
     ExecuteNodeResultFailure,
     ExecuteNodeResultSuccess,
 )
+from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.execution_events import NodeMetadata
-    from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
 
 class TestExecuteNodeStrictMode:
-    def _get_node_manager(self) -> NodeManager:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        return GriptapeNodes.NodeManager()
+    def _make_node_manager(
+        self,
+        *,
+        object_manager: MagicMock | None = None,
+        library_manager: MagicMock | None = None,
+        worker_manager: MagicMock | None = None,
+    ) -> NodeManager:
+        """Build a NodeManager wired to a mock engine instead of the process-wide facade."""
+        mock_engine = MagicMock()
+        mock_engine.object_manager = object_manager
+        mock_engine.library_manager = library_manager
+        mock_engine.worker_manager = worker_manager
+        return NodeManager(MagicMock(), engine=mock_engine)
 
     def _make_mock_node(self, *, aprocess_reports: bool = False) -> MagicMock:
         node = MagicMock(spec=BaseNode)
@@ -67,23 +76,10 @@ class TestExecuteNodeStrictMode:
         node = self._make_mock_node(aprocess_reports=True)
         obj_mgr = self._make_mock_obj_mgr(existing_node=node)
         lib_mgr = self._make_mock_library_manager(is_worker=False)
+        node_manager = self._make_node_manager(object_manager=obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
-                return_value=obj_mgr,
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
-                return_value=lib_mgr,
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
-                return_value=None,
-            ),
-        ):
-            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
-            result = await self._get_node_manager().on_execute_node_request(request)
+        request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         node.aprocess.assert_awaited_once()
@@ -92,15 +88,9 @@ class TestExecuteNodeStrictMode:
     async def test_worker_violation_elevates_to_failure(self) -> None:
         node = self._make_mock_node(aprocess_reports=True)
         lib_mgr = self._make_mock_library_manager(is_worker=True)
-        node_manager = self._get_node_manager()
+        node_manager = self._make_node_manager(library_manager=lib_mgr)
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
-                return_value=lib_mgr,
-            ),
-            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
-        ):
+        with patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node):
             request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
             result = await node_manager.on_execute_node_request(request)
 
@@ -114,15 +104,9 @@ class TestExecuteNodeStrictMode:
     async def test_worker_no_violations_unchanged(self) -> None:
         node = self._make_mock_node(aprocess_reports=False)
         lib_mgr = self._make_mock_library_manager(is_worker=True)
-        node_manager = self._get_node_manager()
+        node_manager = self._make_node_manager(library_manager=lib_mgr)
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
-                return_value=lib_mgr,
-            ),
-            patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node),
-        ):
+        with patch.object(node_manager, "_materialize_transient_node_from_metadata", return_value=node):
             request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
             result = await node_manager.on_execute_node_request(request)
 
@@ -134,23 +118,10 @@ class TestExecuteNodeStrictMode:
         node = self._make_mock_node(aprocess_reports=False)
         obj_mgr = self._make_mock_obj_mgr(existing_node=node)
         lib_mgr = self._make_mock_library_manager(is_worker=False)
+        node_manager = self._make_node_manager(object_manager=obj_mgr, library_manager=lib_mgr)
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.ObjectManager",
-                return_value=obj_mgr,
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.LibraryManager",
-                return_value=lib_mgr,
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.node_manager.GriptapeNodes.WorkerManager",
-                return_value=None,
-            ),
-        ):
-            request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
-            result = await self._get_node_manager().on_execute_node_request(request)
+        request = ExecuteNodeRequest(node_name="n", node_metadata=cast("NodeMetadata", {"node_type": "T"}))
+        result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultSuccess)
         node.aprocess.assert_awaited_once()

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -5,7 +5,7 @@ import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -251,10 +251,8 @@ class TestProjectManagerMacroHandlers:
             GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
             GriptapeNodes.ConfigManager().workspace_path = original_workspace
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_match_path_auto_resolve_supplies_non_directory_builtin_verbatim(
         self,
-        mock_griptape_nodes: Mock,
         project_manager: ProjectManager,
         tmp_path: Path,
     ) -> None:
@@ -294,7 +292,8 @@ class TestProjectManagerMacroHandlers:
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "My Cool Workflow"
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager._engine = MagicMock()
+        project_manager._engine.context_manager = mock_context_manager
 
         cast("Mock", project_manager._config_manager).workspace_path = tmp_path.resolve()
 
@@ -381,10 +380,8 @@ class TestProjectManagerMacroHandlers:
         assert "workspace_dir" in result.conflicts
         assert result.unavailable == {}
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_resolve_builtins_into_bag_records_unavailable_when_no_workflow(
         self,
-        mock_griptape_nodes: Mock,
         project_manager: ProjectManager,
         tmp_path: Path,
     ) -> None:
@@ -411,7 +408,8 @@ class TestProjectManagerMacroHandlers:
         # No current workflow → workflow_name / workflow_dir resolvers raise RuntimeError.
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = False
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager._engine = MagicMock()
+        project_manager._engine.context_manager = mock_context_manager
 
         cast("Mock", project_manager._config_manager).workspace_path = tmp_path.resolve()
 
@@ -595,10 +593,7 @@ class TestProjectManagerBuiltinVariables:
         assert isinstance(result, GetPathForMacroResultSuccess)
         assert result.resolved_path == Path("/workspace/output.txt")
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
-    def test_builtin_workflow_name_resolves_correctly(
-        self, mock_griptape_nodes: Mock, project_manager_with_template: ProjectManager
-    ) -> None:
+    def test_builtin_workflow_name_resolves_correctly(self, project_manager_with_template: ProjectManager) -> None:
         """Test that {workflow_name} builtin resolves from ContextManager."""
         from griptape_nodes.common.macro_parser import ParsedMacro
 
@@ -607,7 +602,8 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "my_workflow"
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         parsed_macro = ParsedMacro("{workflow_name}_output.txt")
 
@@ -620,16 +616,14 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager.has_current_workflow.assert_called_once()
         mock_context_manager.get_current_workflow_name.assert_called_once()
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
-    def test_builtin_workflow_name_no_current_workflow(
-        self, mock_griptape_nodes: Mock, project_manager_with_template: ProjectManager
-    ) -> None:
+    def test_builtin_workflow_name_no_current_workflow(self, project_manager_with_template: ProjectManager) -> None:
         """Test that {workflow_name} raises RuntimeError when no current workflow."""
         from griptape_nodes.common.macro_parser import ParsedMacro
 
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = False
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         parsed_macro = ParsedMacro("{workflow_name}_output.txt")
 
@@ -662,10 +656,8 @@ class TestProjectManagerBuiltinVariables:
         assert "project_name not yet implemented" in str(result.result_details)
 
     @patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry")
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_builtin_workflow_dir_resolves_correctly(
         self,
-        mock_griptape_nodes: Mock,
         mock_workflow_registry: Mock,
         project_manager_with_template: ProjectManager,
     ) -> None:
@@ -675,7 +667,8 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "my_workflow"
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         mock_workflow = Mock()
         mock_workflow.file_path = "my_project/my_workflow.json"
@@ -690,16 +683,14 @@ class TestProjectManagerBuiltinVariables:
         assert isinstance(result, GetPathForMacroResultSuccess)
         assert result.resolved_path == Path("/workspace/my_project/output.txt")
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
-    def test_builtin_workflow_dir_no_current_workflow(
-        self, mock_griptape_nodes: Mock, project_manager_with_template: ProjectManager
-    ) -> None:
+    def test_builtin_workflow_dir_no_current_workflow(self, project_manager_with_template: ProjectManager) -> None:
         """Test that required {workflow_dir} fails when there is no current workflow."""
         from griptape_nodes.common.macro_parser import ParsedMacro
 
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = False
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         parsed_macro = ParsedMacro("{workflow_dir}/output.txt")
         request = GetPathForMacroRequest(parsed_macro=parsed_macro, variables={})
@@ -713,9 +704,8 @@ class TestProjectManagerBuiltinVariables:
         assert isinstance(result.result_details, ResultDetails)
         assert "No current workflow" in str(result.result_details)
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_builtin_workflow_dir_optional_skipped_when_no_workflow(
-        self, mock_griptape_nodes: Mock, project_manager_with_template: ProjectManager
+        self, project_manager_with_template: ProjectManager
     ) -> None:
         """Test that optional {workflow_dir?:/} is skipped (not an error) when no current workflow."""
         from griptape_nodes.common.macro_parser import ParsedMacro
@@ -724,7 +714,8 @@ class TestProjectManagerBuiltinVariables:
 
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = False
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         parsed_macro = ParsedMacro("{workflow_dir?:/}staticfiles/output.txt")
         request = GetPathForMacroRequest(parsed_macro=parsed_macro, variables={})
@@ -735,10 +726,8 @@ class TestProjectManagerBuiltinVariables:
         assert result.resolved_path == Path("staticfiles/output.txt")
 
     @patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry")
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_builtin_workflow_dir_unregistered_workflow_fails(
         self,
-        mock_griptape_nodes: Mock,
         mock_workflow_registry: Mock,
         project_manager_with_template: ProjectManager,
     ) -> None:
@@ -748,7 +737,8 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "workflow_5"
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         mock_workflow_registry.get_workflow_by_name.side_effect = KeyError("workflow_5")
 
@@ -765,10 +755,8 @@ class TestProjectManagerBuiltinVariables:
         assert "workflow_5" in str(result.result_details)
 
     @patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry")
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_builtin_workflow_dir_optional_skipped_when_workflow_unregistered(
         self,
-        mock_griptape_nodes: Mock,
         mock_workflow_registry: Mock,
         project_manager_with_template: ProjectManager,
     ) -> None:
@@ -780,7 +768,8 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "workflow_5"
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
 
         mock_workflow_registry.get_workflow_by_name.side_effect = KeyError("workflow_5")
 
@@ -1169,16 +1158,11 @@ class TestProjectManagerGetStateForMacro:
         assert "inputs" in result.conflicting_variables
         assert result.can_resolve is False
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_get_state_for_macro_builtin_variable_satisfied(
-        self, mock_griptape_nodes: Mock, project_manager_with_current_project: ProjectManager
+        self, project_manager_with_current_project: ProjectManager
     ) -> None:
         """Test GetStateForMacro with satisfied builtin variable."""
         from griptape_nodes.common.macro_parser import ParsedMacro
-
-        mock_config_manager = Mock()
-        mock_config_manager.get_config_value.return_value = "/workspace"
-        mock_griptape_nodes.ConfigManager.return_value = mock_config_manager
 
         parsed_macro = ParsedMacro("{workspace_dir}/output.txt")
 
@@ -1190,16 +1174,16 @@ class TestProjectManagerGetStateForMacro:
         assert result.satisfied_variables == {"workspace_dir"}
         assert result.can_resolve is True
 
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     def test_get_state_for_macro_builtin_variable_fails(
-        self, mock_griptape_nodes: Mock, project_manager_with_current_project: ProjectManager
+        self, project_manager_with_current_project: ProjectManager
     ) -> None:
         """Test GetStateForMacro fails when builtin variable cannot be resolved."""
         from griptape_nodes.common.macro_parser import ParsedMacro
 
         mock_context_manager = Mock()
         mock_context_manager.has_current_workflow.return_value = False
-        mock_griptape_nodes.ContextManager.return_value = mock_context_manager
+        project_manager_with_current_project._engine = MagicMock()
+        project_manager_with_current_project._engine.context_manager = mock_context_manager
 
         parsed_macro = ParsedMacro("{workflow_name}_output.txt")
 
@@ -1630,11 +1614,12 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes.ContextManager()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(project_manager, "_engine", mock_engine):
+            cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             # Test path inside outputs directory
             absolute_path = project_base / "outputs" / "renders" / "file.png"
@@ -1683,11 +1668,12 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(project_manager, "_engine", mock_engine):
+            cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             # Test path outside project
             absolute_path = Path("/Users/test/Downloads/file.png")
@@ -1752,11 +1738,12 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(project_manager, "_engine", mock_engine):
+            cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             # Test path inside outputs/inputs subdirectory (should match outputs, not inputs)
             absolute_path = project_base / "outputs" / "inputs" / "file.png"
@@ -1805,11 +1792,12 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(project_manager, "_engine", mock_engine):
+            cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow needed for this test
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             # Test path exactly at outputs directory
             absolute_path = project_base / "outputs"
@@ -1856,11 +1844,12 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes.ConfigManager() and ContextManager()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(project_manager, "_engine", mock_engine):
+            cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             # Test path inside project_base_dir but not in any defined directory
             absolute_path = project_base / "random_folder" / "file.txt"
@@ -1919,16 +1908,16 @@ class TestProjectManagerAttemptMapAbsolutePathToProject:
         cast("Mock", project_manager._config_manager).workspace_path = project_base
 
         # Mock GriptapeNodes - workflow_name will fail because no workflow
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(project_manager, "_engine", mock_engine):
+            cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = str(project_base)
             mock_config.workspace_path = project_base
-            mock_gn.ConfigManager.return_value = mock_config
 
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False  # No workflow available
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             absolute_path = project_base / "outputs" / "file.png"
 
@@ -1959,6 +1948,7 @@ situations:
     @pytest.fixture
     def pm(self) -> ProjectManager:
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         mock_config_manager = Mock()
         mock_config_manager.project_config = {}
         mock_config_manager.env_config = {}
@@ -2043,7 +2033,6 @@ situations:
     async def test_load_project_denied_by_policy_is_not_cached(self, pm: ProjectManager, tmp_path: Path) -> None:
         """A LoadProject denial blocks the load: the project is not cached as usable."""
         from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointDenial,
@@ -2066,16 +2055,12 @@ situations:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Ask your admin to grant this project."),))
             return None
 
-        event_manager = GriptapeNodes.EventManager()
-        event_manager.add_authorization_hook(deny)
-        try:
-            with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
-                mock_file_instance = Mock()
-                mock_file_instance.aread_text = AsyncMock(return_value=self.VALID_PROJECT_YAML)
-                mock_file_cls.return_value = mock_file_instance
-                result = await pm._load_and_cache_project_template(project_path, persist_path=False)
-        finally:
-            event_manager.remove_authorization_hook(deny)
+        cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.side_effect = deny
+        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
+            mock_file_instance = Mock()
+            mock_file_instance.aread_text = AsyncMock(return_value=self.VALID_PROJECT_YAML)
+            mock_file_cls.return_value = mock_file_instance
+            result = await pm._load_and_cache_project_template(project_path, persist_path=False)
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
         assert "Ask your admin to grant this project." in str(result.result_details)
@@ -2267,7 +2252,6 @@ situations:
         block boot -- the ACTIVATE_PROJECT checkpoint is never evaluated for SYSTEM_DEFAULTS_KEY.
         """
         from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointAction,
@@ -2303,17 +2287,13 @@ situations:
                     )
             return None
 
-        event_manager = GriptapeNodes.EventManager()
-        event_manager.add_authorization_hook(deny_defaults)
-        try:
-            with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
-                mock_file_instance = Mock()
-                mock_file_instance.aread_text = AsyncMock(return_value=self.VALID_PROJECT_YAML)
-                mock_file_cls.return_value = mock_file_instance
+        cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.side_effect = deny_defaults
+        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
+            mock_file_instance = Mock()
+            mock_file_instance.aread_text = AsyncMock(return_value=self.VALID_PROJECT_YAML)
+            mock_file_cls.return_value = mock_file_instance
 
-                await pm.on_app_initialization_complete(AppInitializationComplete())
-        finally:
-            event_manager.remove_authorization_hook(deny_defaults)
+            await pm.on_app_initialization_complete(AppInitializationComplete())
 
         assert pm._current_project_id == str(workspace_project_path)
         assert pm._initialization_complete is True
@@ -2374,7 +2354,6 @@ situations:
         surfaces the failure rather than pretending to have activated a project.
         """
         from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointAction,
@@ -2402,12 +2381,8 @@ situations:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="No license covers the default project."),))
             return None
 
-        event_manager = GriptapeNodes.EventManager()
-        event_manager.add_authorization_hook(deny_defaults)
-        try:
-            await pm.on_app_initialization_complete(AppInitializationComplete())
-        finally:
-            event_manager.remove_authorization_hook(deny_defaults)
+        cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.side_effect = deny_defaults
+        await pm.on_app_initialization_complete(AppInitializationComplete())
 
         # The denied activation left the current project untouched and boot short-circuited.
         assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
@@ -2660,6 +2635,7 @@ name: Modern Project
     @pytest.fixture
     def pm(self) -> ProjectManager:
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         mock_config_manager = Mock()
         mock_config_manager.project_config = {}
         mock_config_manager.env_config = {}
@@ -2719,6 +2695,7 @@ name: Legacy Project
     @pytest.fixture
     def pm(self) -> ProjectManager:
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         mock_config_manager = Mock()
         mock_config_manager.project_config = {}
         mock_config_manager.env_config = {}
@@ -4140,8 +4117,9 @@ class TestResolveWorkspaceDirForProjectId:
         read_failure = ReadFileResultFailure(
             failure_reason=FileIOFailureReason.FILE_NOT_FOUND, result_details="not found"
         )
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.ahandle_request = AsyncMock(return_value=read_failure)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            mock_engine.ahandle_request = AsyncMock(return_value=read_failure)
 
             probe = await pm._read_overlay(missing_file, record_status=False)
             assert missing_file not in pm._registered_template_status
@@ -4579,6 +4557,7 @@ class TestProjectManagerProjectWorkspaces:
         from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
 
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         mock_secrets = Mock()
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
@@ -4927,6 +4906,7 @@ class TestProjectManagerProjectWorkspaces:
             update={"id": "C", "parent_project_id": "P", **(child_overlay_kwargs or {})}
         )
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         pm = ProjectManager(mock_event_manager, mock_config, Mock())
         pm._read_overlay = fake_read_overlay  # type: ignore[method-assign]
         pm._resolve_registered_entry_paths = lambda _entries: [_canon(parent_file), _canon(child_file)]  # type: ignore[method-assign]
@@ -5098,16 +5078,17 @@ class TestProjectManagerProjectWorkspaces:
             parsed_directory_schemas=pm._parse_directory_macros(DEFAULT_PROJECT_TEMPLATE.directories, validation),
         )
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
-            mock_gn.WorkflowManager.return_value = Mock()
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
+            mock_engine.workflow_manager = Mock()
 
             # Activate the pinned project: the project layer adds pinned-lib, firing a reload.
             await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(pinned_file)))
             assert state["project_layer_active"] is True
 
-            mock_gn.ahandle_request.reset_mock()
+            mock_engine.ahandle_request.reset_mock()
 
             # Switch to system defaults: clear_project_layers drops the pinned-lib layer.
             await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=SYSTEM_DEFAULTS_KEY))
@@ -5116,7 +5097,7 @@ class TestProjectManagerProjectWorkspaces:
         assert state["project_layer_active"] is False
         assert mock_config.get_config_value(LIBRARIES_TO_REGISTER_KEY) == ["base-lib"]
         # ...and the reload fired on the switch to actually unload the pinned library.
-        mock_gn.ahandle_request.assert_called_once()
+        mock_engine.ahandle_request.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_unknown_project_id_remerges_after_clearing_layers(self, tmp_path: Path) -> None:
@@ -5144,9 +5125,10 @@ class TestProjectManagerProjectWorkspaces:
         pm = ProjectManager(mock_event_manager, mock_config, Mock())
         pm._initialization_complete = True
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock()
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock()
             await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(unknown_file)))
 
         mock_config.clear_project_layers.assert_called_once()
@@ -5172,12 +5154,13 @@ class TestProjectManagerProjectWorkspaces:
 
         from griptape_nodes.retained_mode.events.project_events import SetCurrentProjectRequest
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock()
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock()
             await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(project_file)))
-            mock_gn.ahandle_request.assert_not_called()
-            mock_gn.WorkflowManager.assert_not_called()
+            mock_engine.ahandle_request.assert_not_called()
+            mock_engine.workflow_manager.refresh_workflow_registry.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_initialization_complete_same_workspace_reloads_libraries_only(self, tmp_path: Path) -> None:
@@ -5205,14 +5188,15 @@ class TestProjectManagerProjectWorkspaces:
         from griptape_nodes.retained_mode.events.project_events import SetCurrentProjectRequest
 
         mock_workflow_manager = Mock()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
-            mock_gn.WorkflowManager.return_value = mock_workflow_manager
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
+            mock_engine.workflow_manager = mock_workflow_manager
 
             result = await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(project_file)))
 
-        mock_gn.ahandle_request.assert_called_once()
+        mock_engine.ahandle_request.assert_called_once()
         mock_workflow_manager.refresh_workflow_registry.assert_not_called()
         assert not result.altered_workflow_state
 
@@ -5247,10 +5231,11 @@ class TestProjectManagerProjectWorkspaces:
         from griptape_nodes.retained_mode.events.project_events import SetCurrentProjectRequest
 
         mock_workflow_manager = Mock()
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
-            mock_gn.WorkflowManager.return_value = mock_workflow_manager
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(return_value=ReloadAllLibrariesResultSuccess(result_details="ok"))
+            mock_engine.workflow_manager = mock_workflow_manager
 
             # Simulate workspace changing after config is applied
             def side_effect_set_workspace_override(_: object) -> None:
@@ -5261,7 +5246,7 @@ class TestProjectManagerProjectWorkspaces:
 
             result = await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(project_file)))
 
-        mock_gn.ahandle_request.assert_called_once()
+        mock_engine.ahandle_request.assert_called_once()
         mock_workflow_manager.refresh_workflow_registry.assert_called_once()
         assert result.altered_workflow_state
 
@@ -5292,9 +5277,10 @@ class TestProjectManagerProjectWorkspaces:
             SetCurrentProjectResultFailure,
         )
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReloadAllLibrariesResultFailure(result_details="reload failed")
             )
 
@@ -5428,11 +5414,11 @@ class TestRegisterProjectPath:
         """If the project_id is already registered, set_config_value is not called."""
         project_id = "/path/to/project.yml"
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = [project_id]
-            mock_gn.ConfigManager.return_value = mock_config
 
             pm._register_project_path(project_id)
 
@@ -5440,11 +5426,11 @@ class TestRegisterProjectPath:
 
     def test_register_exception_is_swallowed(self, pm: ProjectManager) -> None:
         """A config manager exception does not propagate out of _register_project_path."""
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.side_effect = RuntimeError("config failure")
-            mock_gn.ConfigManager.return_value = mock_config
 
             # Should not raise
             pm._register_project_path("/path/to/project.yml")
@@ -5477,11 +5463,11 @@ situations:
     @pytest.mark.asyncio
     async def test_empty_list_does_nothing(self, pm: ProjectManager) -> None:
         """An empty projects_to_register list results in no load attempts."""
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = []
-            mock_gn.ConfigManager.return_value = mock_config
 
             with patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load:
                 await pm._load_registered_projects()
@@ -5490,11 +5476,11 @@ situations:
     @pytest.mark.asyncio
     async def test_none_config_return_does_nothing(self, pm: ProjectManager) -> None:
         """None from config (treated as empty via 'or []') results in no load attempts."""
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = None
-            mock_gn.ConfigManager.return_value = mock_config
 
             with patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load:
                 await pm._load_registered_projects()
@@ -5522,11 +5508,11 @@ situations:
         )
         pm._successfully_loaded_project_templates[existing_path] = project_info
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_config = Mock()
             mock_config.get_config_value.return_value = [existing_path]
-            mock_gn.ConfigManager.return_value = mock_config
 
             with patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load:
                 await pm._load_registered_projects()
@@ -5548,9 +5534,10 @@ situations:
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=yaml_content,
                     file_size=len(yaml_content),
@@ -5587,12 +5574,13 @@ situations:
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
+        mock_engine = MagicMock()
         with (
-            patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn,
+            patch.object(pm, "_engine", mock_engine),
             patch.object(pm, "_register_project_path") as mock_register,
         ):
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=yaml_content,
                     file_size=len(yaml_content),
@@ -5684,9 +5672,10 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
         cast("Mock", pm._config_manager).workspace_path = tmp_path
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=yaml_content,
                     file_size=len(yaml_content),
@@ -5865,9 +5854,10 @@ situations:
 
         absolute_path = (tmp_path / "project.yml").resolve()
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
                     file_size=len(self.VALID_PROJECT_YAML),
@@ -5930,9 +5920,10 @@ situations:
         absolute_path = (tmp_path / "project.yml").resolve()
         tilde_path = Path("~/project.yml")
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
                     file_size=len(self.VALID_PROJECT_YAML),
@@ -6192,11 +6183,12 @@ class TestProjectEnvironmentVariableRecursion:
         from griptape_nodes.common.macro_parser import ParsedMacro
 
         pm = self._make_pm_with_template(environment={"WF": "{workflow_name}_suffix"})
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             result = pm.on_get_path_for_macro_request(
                 GetPathForMacroRequest(parsed_macro=ParsedMacro("{outputs}/{WF}/x.png"), variables={})
@@ -6212,11 +6204,12 @@ class TestProjectEnvironmentVariableRecursion:
             environment={},
             directories={"inputs": "{workflow_dir?:/}inputs"},
         )
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             result = pm.on_get_path_for_macro_request(
                 GetPathForMacroRequest(parsed_macro=ParsedMacro("{inputs}/img.png"), variables={})
@@ -6232,11 +6225,12 @@ class TestProjectEnvironmentVariableRecursion:
             environment={},
             directories={"inputs": "{workflow_dir}/inputs"},
         )
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             result = pm.on_get_path_for_macro_request(
                 GetPathForMacroRequest(parsed_macro=ParsedMacro("{inputs}/img.png"), variables={})
@@ -6252,20 +6246,21 @@ class TestProjectEnvironmentVariableRecursion:
             environment={},
             directories={"inputs": "{workflow_dir?:/}inputs"},
         )
+        mock_engine = MagicMock()
         with (
-            patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn,
-            patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry") as mock_registry,
+            patch.object(pm, "_engine", mock_engine),
+            patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry") as mock_workflow_registry,
         ):
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = True
             mock_context.get_current_workflow_name.return_value = "my_workflow"
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             mock_workflow = Mock()
             mock_workflow.file_path = "my_project/my_workflow.json"
-            mock_registry.get_workflow_by_name.return_value = mock_workflow
-            mock_registry.get_complete_file_path.return_value = "/workspace/my_project/my_workflow.json"
+            mock_workflow_registry.get_workflow_by_name.return_value = mock_workflow
+            mock_workflow_registry.get_complete_file_path.return_value = "/workspace/my_project/my_workflow.json"
 
             result = pm.on_get_path_for_macro_request(
                 GetPathForMacroRequest(parsed_macro=ParsedMacro("{inputs}/img.png"), variables={})
@@ -6278,11 +6273,12 @@ class TestProjectEnvironmentVariableRecursion:
         from griptape_nodes.common.macro_parser import ParsedMacro
 
         pm = self._make_pm_with_template(environment={"WF": "{workflow_dir?:/}sub"})
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
             mock_context = Mock()
             mock_context.has_current_workflow.return_value = False
-            mock_gn.ContextManager.return_value = mock_context
+            mock_engine.context_manager = mock_context
 
             result = pm.on_get_path_for_macro_request(
                 GetPathForMacroRequest(parsed_macro=ParsedMacro("{outputs}/{WF}/x.png"), variables={})
@@ -6684,9 +6680,10 @@ directories:
         files = {
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.replace('parent_project_path: "{parent}"\n', "").format(),
         }
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -6710,9 +6707,10 @@ directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=base_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -6742,9 +6740,10 @@ directories:
             grandchild_path: self.GRANDCHILD_PROJECT_YAML_TEMPLATE.format(parent=child_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=grandchild_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -6771,9 +6770,10 @@ directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent="../base.yml"),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -6790,9 +6790,10 @@ directories:
         self_path = (tmp_path / "self.yml").resolve()
         files = {self_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=self_path.as_posix())}
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=self_path))
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
@@ -6813,9 +6814,10 @@ directories:
             b_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=a_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=a_path))
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
@@ -6833,9 +6835,10 @@ directories:
         child_path = (tmp_path / "child.yml").resolve()
         files = {child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=missing_parent.as_posix())}
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
@@ -6870,9 +6873,10 @@ directories:
             child_path: child_yaml,
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -6907,9 +6911,10 @@ directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent="../base.yml"),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             base_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=base_path))
             child_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -6946,9 +6951,10 @@ directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent="./base.yml"),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=base_path))
             child_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -6976,9 +6982,10 @@ directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=base_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -7027,9 +7034,10 @@ directories:
             grandchild_path: grandchild_yaml,
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=grandchild_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -7078,9 +7086,10 @@ file_extension_directories:
             child_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=base_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -7108,9 +7117,10 @@ file_extension_directories:
             sibling_b_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=base_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             a_result = await pm.on_load_project_template_request(
                 LoadProjectTemplateRequest(project_path=sibling_a_path)
             )
@@ -7141,9 +7151,10 @@ file_extension_directories:
             c_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent=a_path.as_posix()),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=a_path))
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
@@ -7164,9 +7175,10 @@ file_extension_directories:
             b_path: self.CHILD_PROJECT_YAML_TEMPLATE.format(parent="./a.yml"),
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=a_path))
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
@@ -7256,9 +7268,10 @@ directories:
         )
 
         files = {parent_path: parent_yaml}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=parent_path))
         assert isinstance(result, LoadProjectTemplateResultSuccess)
 
@@ -7467,9 +7480,10 @@ directories:
 
         # Round-trip: reload the child and confirm the inherited description is cleared.
         files = {parent_path: parent_yaml, child_path: child_path.read_text()}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             child_load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
         assert isinstance(child_load, LoadProjectTemplateResultSuccess)
         assert child_load.template.directories["outputs"].description is None
@@ -7674,9 +7688,10 @@ parent_project_path: "{grandparent_path.as_posix()}"
             grandparent_path: grandparent_yaml,
             parent_path: parent_yaml,
         }
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             gp_load = await pm.on_load_project_template_request(
                 LoadProjectTemplateRequest(project_path=grandparent_path)
             )
@@ -7900,9 +7915,10 @@ situations:
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
                     file_size=len(self.VALID_PROJECT_YAML),
@@ -7939,9 +7955,10 @@ situations:
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
                     file_size=len(self.VALID_PROJECT_YAML),
@@ -8037,9 +8054,10 @@ situations:
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = AsyncMock(
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
                 return_value=ReadFileResultSuccess(
                     content=self.VALID_PROJECT_YAML,
                     file_size=len(self.VALID_PROJECT_YAML),
@@ -8132,9 +8150,10 @@ directories:
             child_path: child_yaml,
         }
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -8165,9 +8184,10 @@ directories:
         )
         files = {child_path: child_yaml}
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -8199,9 +8219,10 @@ directories:
         )
         files = {base_path: self.BASE_PROJECT_YAML, child_path: child_yaml}
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -8231,9 +8252,10 @@ directories:
         )
         files = {base_path: self.BASE_PROJECT_YAML, child_path: child_yaml}
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -8307,6 +8329,7 @@ situations:
     @pytest.fixture
     def pm(self) -> ProjectManager:
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         mock_config_manager = Mock()
         mock_config_manager.project_config = {}
         mock_config_manager.env_config = {}
@@ -8588,6 +8611,7 @@ parent_project_id: "ghost-parent-id"
     @pytest.fixture
     def pm(self, tmp_path: Path) -> ProjectManager:
         mock_event_manager = Mock()
+        mock_event_manager.evaluate_authorization_checkpoint.return_value = None
         mock_config_manager = Mock()
         mock_config_manager.project_config = {}
         mock_config_manager.env_config = {}
@@ -8645,9 +8669,10 @@ parent_project_id: "ghost-parent-id"
 
         project_path = (tmp_path / "explicit.yml").resolve()
         files = {project_path: self.EXPLICIT_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -8671,9 +8696,10 @@ parent_project_id: "ghost-parent-id"
 
         project_path = (tmp_path / "legacy.yml").resolve()
         files = {project_path: self.LEGACY_NO_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
 
         assert isinstance(result, LoadProjectTemplateResultSuccess)
@@ -8692,9 +8718,10 @@ parent_project_id: "ghost-parent-id"
         path_a = (tmp_path / "a.yml").resolve()
         path_b = (tmp_path / "b.yml").resolve()
         files = {path_a: self.EXPLICIT_ID_YAML, path_b: self.EXPLICIT_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             first = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=path_a))
             second = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=path_b))
 
@@ -8717,9 +8744,10 @@ parent_project_id: "ghost-parent-id"
 
         project_path = (tmp_path / "explicit.yml").resolve()
         files = {project_path: self.EXPLICIT_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             first = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
             second = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
 
@@ -8892,9 +8920,10 @@ parent_project_id: "ghost-parent-id"
 
         project_path = (tmp_path / "explicit.yml").resolve()
         files = {project_path: self.EXPLICIT_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             load = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
         assert isinstance(load, LoadProjectTemplateResultSuccess)
 
@@ -8929,9 +8958,10 @@ parent_project_id: "ghost-parent-id"
         parent_path = (tmp_path / "parent.yml").resolve()
         child_path = (tmp_path / "child.yml").resolve()
         files = {parent_path: self.PARENT_WITH_ID_YAML, child_path: self.CHILD_BY_PARENT_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             parent = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=parent_path))
             child = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
@@ -8955,9 +8985,10 @@ parent_project_id: "ghost-parent-id"
 
         child_path = (tmp_path / "orphan.yml").resolve()
         files = {child_path: self.CHILD_MISSING_PARENT_ID_YAML}
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
         assert isinstance(result, LoadProjectTemplateResultFailure)
@@ -8981,9 +9012,10 @@ parent_project_id: "ghost-parent-id"
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
-        with patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes") as mock_gn:
-            mock_gn.EventManager.return_value.evaluate_authorization_checkpoint.return_value = None
-            mock_gn.ahandle_request = self._file_router(files)
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
             await pm._load_registered_projects()
 
         # Both loaded despite the child-before-parent ordering.
@@ -9003,9 +9035,8 @@ class TestProjectActivationAuthorizationCheckpoint:
         return ProjectManager(Mock(), Mock(), Mock())
 
     @pytest.mark.asyncio
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
     async def test_denied_activation_is_rejected_and_leaves_current_project(
-        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
+        self, project_manager: ProjectManager
     ) -> None:
         from griptape_nodes.retained_mode.events.project_events import (
             SetCurrentProjectRequest,
@@ -9014,7 +9045,7 @@ class TestProjectActivationAuthorizationCheckpoint:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
-        mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint.return_value = CheckpointDenial(
+        cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = CheckpointDenial(
             failures=(CheckpointFailure(detail="Ask your admin to grant access to acme-prod."),)
         )
         # A denying activation must roll nowhere: _activate_project never runs.
@@ -9031,10 +9062,7 @@ class TestProjectActivationAuthorizationCheckpoint:
         activate.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
-    async def test_empty_failure_denial_still_yields_a_reason(
-        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
-    ) -> None:
+    async def test_empty_failure_denial_still_yields_a_reason(self, project_manager: ProjectManager) -> None:
         # A hook that misuses the contract by returning a denial with no failures
         # (it should return None to allow) must still produce a reason, not an
         # empty "Failed because: " tail.
@@ -9044,7 +9072,7 @@ class TestProjectActivationAuthorizationCheckpoint:
         )
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
 
-        mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint.return_value = CheckpointDenial(
+        cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = CheckpointDenial(
             failures=()
         )
         activate = AsyncMock()
@@ -9058,10 +9086,7 @@ class TestProjectActivationAuthorizationCheckpoint:
         activate.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
-    async def test_system_defaults_evaluates_checkpoint(
-        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
-    ) -> None:
+    async def test_system_defaults_evaluates_checkpoint(self, project_manager: ProjectManager) -> None:
         from griptape_nodes.retained_mode.events.project_events import (
             SetCurrentProjectRequest,
             SetCurrentProjectResultSuccess,
@@ -9070,7 +9095,7 @@ class TestProjectActivationAuthorizationCheckpoint:
 
         # The engine bakes in no exemption: the rest state is gated like any other
         # project. The consumer allows it (returns None), so activation proceeds.
-        checkpoint = mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint
+        checkpoint = cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint
         checkpoint.return_value = None
         outcome = _ProjectActivationOutcome(failure=None, workspace_changed=False)
         with patch.object(project_manager, "_activate_project", new=AsyncMock(return_value=outcome)):
@@ -9082,10 +9107,7 @@ class TestProjectActivationAuthorizationCheckpoint:
         assert checkpoint.call_args.args[0].subject_id == SYSTEM_DEFAULTS_KEY
 
     @pytest.mark.asyncio
-    @patch("griptape_nodes.retained_mode.managers.project_manager.GriptapeNodes")
-    async def test_system_defaults_denial_blocks_activation(
-        self, mock_griptape_nodes: Mock, project_manager: ProjectManager
-    ) -> None:
+    async def test_system_defaults_denial_blocks_activation(self, project_manager: ProjectManager) -> None:
         from griptape_nodes.retained_mode.events.project_events import (
             SetCurrentProjectRequest,
             SetCurrentProjectResultFailure,
@@ -9094,7 +9116,7 @@ class TestProjectActivationAuthorizationCheckpoint:
 
         # A consumer is free to deny even the rest state; the engine enforces that
         # decision rather than exempting the defaults on its own.
-        mock_griptape_nodes.EventManager.return_value.evaluate_authorization_checkpoint.return_value = CheckpointDenial(
+        cast("Mock", project_manager._event_manager).evaluate_authorization_checkpoint.return_value = CheckpointDenial(
             failures=(CheckpointFailure(detail="No license covers the default project."),)
         )
         activate = AsyncMock()

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -368,7 +368,10 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
         """Create StaticFilesManager instance with mocked dependencies."""
         with patch("griptape_nodes.retained_mode.managers.static_files_manager.LocalStorageDriver"):
             manager = StaticFilesManager(
-                config_manager=mock_config_manager, secrets_manager=mock_secrets_manager, event_manager=None
+                config_manager=mock_config_manager,
+                secrets_manager=mock_secrets_manager,
+                event_manager=None,
+                engine=Mock(),
             )
             manager.storage_driver = Mock()
             return manager
@@ -547,7 +550,6 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
             CreateStaticFileDownloadUrlFromPathRequest,
             CreateStaticFileDownloadUrlResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         resolved_path = Path("/mock/workspace/outputs/file.png")
 
@@ -557,7 +559,7 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
         request = CreateStaticFileDownloadUrlFromPathRequest(file_path="{outputs}/file.png")
 
         with patch.object(
-            GriptapeNodes,
+            mock_static_files_manager.engine,
             "handle_request",
             return_value=GetPathForMacroResultSuccess(
                 result_details="resolved",
@@ -587,12 +589,11 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
             CreateStaticFileDownloadUrlFromPathRequest,
             CreateStaticFileDownloadUrlResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         request = CreateStaticFileDownloadUrlFromPathRequest(file_path="{outputs}/file.png")
 
         with patch.object(
-            GriptapeNodes,
+            mock_static_files_manager.engine,
             "handle_request",
             return_value=GetPathForMacroResultFailure(
                 result_details="missing variables",
@@ -636,7 +637,9 @@ class TestStaticFilesManagerResolveStaticFilePath:
         mock_config.get_config_value.return_value = "local"
         mock_config.workspace_path = Path("/mock/workspace")
         with patch("griptape_nodes.retained_mode.managers.static_files_manager.LocalStorageDriver"):
-            manager = StaticFilesManager(config_manager=mock_config, secrets_manager=Mock(), event_manager=None)
+            manager = StaticFilesManager(
+                config_manager=mock_config, secrets_manager=Mock(), event_manager=None, engine=Mock()
+            )
         return manager
 
     def test_resolve_returns_path_and_policy_on_success(self, mock_static_files_manager: StaticFilesManager) -> None:
@@ -650,7 +653,6 @@ class TestStaticFilesManagerResolveStaticFilePath:
             GetPathForMacroResultSuccess,
             GetSituationResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         situation = SituationTemplate(
             name="save_static_file",
@@ -681,11 +683,9 @@ class TestStaticFilesManagerResolveStaticFilePath:
         mock_config_manager = Mock()
         mock_config_manager.get_config_value.return_value = str(workspace_dir)
         mock_config_manager.workspace_path = workspace_dir
+        mock_static_files_manager.config_manager = mock_config_manager
 
-        with (
-            patch.object(GriptapeNodes, "handle_request", side_effect=handle_request),
-            patch.object(GriptapeNodes, "ConfigManager", return_value=mock_config_manager),
-        ):
+        with patch.object(mock_static_files_manager.engine, "handle_request", side_effect=handle_request):
             result = mock_static_files_manager._resolve_static_file_path("output.png")
 
         assert result is not None
@@ -699,11 +699,10 @@ class TestStaticFilesManagerResolveStaticFilePath:
         import logging
 
         from griptape_nodes.retained_mode.events.project_events import GetSituationResultFailure
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         with (
             patch.object(
-                GriptapeNodes,
+                mock_static_files_manager.engine,
                 "handle_request",
                 return_value=GetSituationResultFailure(result_details="situation not found"),
             ),
@@ -728,7 +727,6 @@ class TestStaticFilesManagerResolveStaticFilePath:
             SituationTemplate,
         )
         from griptape_nodes.retained_mode.events.project_events import GetSituationResultSuccess
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         situation = SituationTemplate(
             name="save_static_file",
@@ -738,7 +736,7 @@ class TestStaticFilesManagerResolveStaticFilePath:
 
         with (
             patch.object(
-                GriptapeNodes,
+                mock_static_files_manager.engine,
                 "handle_request",
                 return_value=GetSituationResultSuccess(situation=situation, result_details="ok"),
             ),
@@ -769,7 +767,6 @@ class TestStaticFilesManagerResolveStaticFilePath:
             GetSituationResultSuccess,
             PathResolutionFailureReason,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         situation = SituationTemplate(
             name="save_static_file",
@@ -795,7 +792,7 @@ class TestStaticFilesManagerResolveStaticFilePath:
             raise AssertionError(msg)
 
         with (
-            patch.object(GriptapeNodes, "handle_request", side_effect=handle_request),
+            patch.object(mock_static_files_manager.engine, "handle_request", side_effect=handle_request),
             caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             result = mock_static_files_manager._resolve_static_file_path("output.png")
@@ -818,7 +815,6 @@ class TestStaticFilesManagerResolveStaticFilePath:
             GetPathForMacroResultSuccess,
             GetSituationResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         situation = SituationTemplate(
             name="save_static_file",
@@ -854,8 +850,7 @@ class TestStaticFilesManagerResolveStaticFilePath:
         mock_static_files_manager.config_manager = mock_config_manager
 
         with (
-            patch.object(GriptapeNodes, "handle_request", side_effect=handle_request),
-            patch.object(GriptapeNodes, "ConfigManager", return_value=mock_config_manager),
+            patch.object(mock_static_files_manager.engine, "handle_request", side_effect=handle_request),
             caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             result = mock_static_files_manager._resolve_static_file_path("output.png")

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import NodeDependencies
 from griptape_nodes.node_library.workflow_registry import Workflow, WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 from griptape_nodes.retained_mode.events.workflow_events import (
@@ -150,7 +151,7 @@ class TestWorkflowManager:
         assert isinstance(result["is_user_defined"], bool)
         assert result["is_user_defined"] is True
 
-    def test_on_import_workflow_request_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_import_workflow_request_success(self, griptape_nodes: Engine) -> None:
         """Test successful workflow import."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
@@ -181,7 +182,7 @@ class TestWorkflowManager:
             # Registry key is derived from the file path (minus extension), not from metadata.name.
             assert result.workflow_name == "workflow"
 
-    def test_on_import_workflow_request_already_registered(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_import_workflow_request_already_registered(self, griptape_nodes: Engine) -> None:
         """Test import when workflow is already registered."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
@@ -205,7 +206,7 @@ class TestWorkflowManager:
             # Registry key is derived from the file path (minus extension), not from metadata.name.
             assert result.workflow_name == "/path/to/workflow"
 
-    def test_on_import_workflow_request_metadata_load_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_import_workflow_request_metadata_load_failure(self, griptape_nodes: Engine) -> None:
         """Test import when metadata loading fails."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
@@ -221,7 +222,7 @@ class TestWorkflowManager:
             assert isinstance(result.result_details, ResultDetails)
             assert result.result_details.result_details[0].message == "Failed to load metadata"
 
-    def test_on_import_workflow_request_registration_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_import_workflow_request_registration_failure(self, griptape_nodes: Engine) -> None:
         """Test import when registration fails."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
@@ -250,7 +251,7 @@ class TestWorkflowManager:
             assert isinstance(result.result_details, ResultDetails)
             assert result.result_details.result_details[0].message == "Registration failed"
 
-    def test_get_workflow_metadata_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_workflow_metadata_success(self, griptape_nodes: Engine) -> None:
         """Ensure GetWorkflowMetadataRequest returns workflow.metadata directly."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = GetWorkflowMetadataRequest(workflow_name="my_workflow")
@@ -265,7 +266,7 @@ class TestWorkflowManager:
         assert isinstance(result, GetWorkflowMetadataResultSuccess)
         assert result.workflow_metadata is mock_metadata
 
-    def test_get_workflow_metadata_not_found(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_workflow_metadata_not_found(self, griptape_nodes: Engine) -> None:
         """Ensure GetWorkflowMetadataRequest returns failure when workflow missing."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = GetWorkflowMetadataRequest(workflow_name="missing_workflow")
@@ -275,7 +276,7 @@ class TestWorkflowManager:
 
         assert isinstance(result, GetWorkflowMetadataResultFailure)
 
-    def test_set_workflow_metadata_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_set_workflow_metadata_success(self, griptape_nodes: Engine) -> None:
         """Ensure SetWorkflowMetadataRequest replaces metadata and persists header."""
         workflow_manager = griptape_nodes.WorkflowManager()
         workflow_manager._workflows_loading_complete.set()  # type: ignore[attr-defined]
@@ -306,7 +307,7 @@ class TestWorkflowManager:
         assert isinstance(result, SetWorkflowMetadataResultSuccess)
         write_mock.assert_called_once()
 
-    def test_on_create_workflow_from_template_request_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_create_workflow_from_template_request_success(self, griptape_nodes: Engine) -> None:
         """Test successful create workflow from template (Griptape or user-provided)."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = CreateWorkflowFromTemplateRequest(template_name="my_template")
@@ -364,7 +365,7 @@ class TestWorkflowManager:
         assert result.workflow_name == "my_template_1"
         assert result.file_path == new_full_path
 
-    def test_on_create_workflow_from_template_request_absolute_file_path(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_create_workflow_from_template_request_absolute_file_path(self, griptape_nodes: Engine) -> None:
         """Test that templates with absolute file paths save the new workflow in the workspace, not at the template path."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = CreateWorkflowFromTemplateRequest(
@@ -426,7 +427,7 @@ class TestWorkflowManager:
         # not the full absolute path, so the file is saved in the workspace.
         assert generate_unique_filename_calls == ["my_template"]
 
-    def test_on_create_workflow_from_template_request_template_not_found(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_create_workflow_from_template_request_template_not_found(self, griptape_nodes: Engine) -> None:
         """Test create from template when template is not in registry."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = CreateWorkflowFromTemplateRequest(template_name="missing_template")
@@ -441,7 +442,7 @@ class TestWorkflowManager:
         assert isinstance(result, CreateWorkflowFromTemplateResultFailure)
         assert "missing_template" in str(result.result_details)
 
-    def test_on_create_workflow_from_template_request_not_a_template(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_create_workflow_from_template_request_not_a_template(self, griptape_nodes: Engine) -> None:
         """Test create from template when workflow is not marked as template."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = CreateWorkflowFromTemplateRequest(template_name="regular_workflow")
@@ -461,9 +462,7 @@ class TestWorkflowManager:
         assert isinstance(result, CreateWorkflowFromTemplateResultFailure)
         assert "not marked as a template" in str(result.result_details)
 
-    def test_on_create_workflow_from_template_request_template_file_not_found(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_on_create_workflow_from_template_request_template_file_not_found(self, griptape_nodes: Engine) -> None:
         """Test create from template when template file does not exist."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = CreateWorkflowFromTemplateRequest(template_name="my_template")
@@ -489,7 +488,7 @@ class TestWorkflowManager:
 
     # Removed tests for invalid keys/types; metadata is replaced as a whole object
 
-    def test_on_move_workflow_request_workflow_not_found(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_move_workflow_request_workflow_not_found(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         request = MoveWorkflowRequest(workflow_name="nonexistent", target_directory="subdir")
 
@@ -499,7 +498,7 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultFailure)
         assert "nonexistent" in str(result.result_details)
 
-    def test_on_move_workflow_request_source_file_missing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_move_workflow_request_source_file_missing(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
@@ -516,7 +515,7 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultFailure)
         assert "/workspace/my_workflow.py" in str(result.result_details)
 
-    def test_on_move_workflow_request_target_already_exists(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_move_workflow_request_target_already_exists(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
@@ -534,7 +533,7 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultFailure)
         assert "already exists" in str(result.result_details)
 
-    def test_on_move_workflow_request_success_directory_change(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_move_workflow_request_success_directory_change(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
@@ -558,7 +557,7 @@ class TestWorkflowManager:
         assert result.new_workflow_name == "subdir/my_workflow"
         mock_rekey.assert_called_once_with("my_workflow", "subdir/my_workflow")
 
-    def test_on_move_workflow_request_no_rekey_same_directory(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_move_workflow_request_no_rekey_same_directory(self, griptape_nodes: Engine) -> None:
         """Moving within the same directory level produces the same registry key; no rekey occurs."""
         workflow_manager = griptape_nodes.WorkflowManager()
         # Workflow already in "subdir", moving target is also "subdir" — key stays the same.
@@ -583,7 +582,7 @@ class TestWorkflowManager:
         assert result.new_workflow_name == "subdir/my_workflow"
         mock_rekey.assert_not_called()
 
-    def test_on_move_workflow_request_updates_context_for_current_workflow(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_move_workflow_request_updates_context_for_current_workflow(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
@@ -609,9 +608,7 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultSuccess)
         mock_set_name.assert_called_once_with("subdir/my_workflow")
 
-    def test_on_move_workflow_request_does_not_update_context_for_other_workflow(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_on_move_workflow_request_does_not_update_context_for_other_workflow(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
@@ -639,7 +636,7 @@ class TestWorkflowManager:
 
     # --- Save workflow: unsaved -> saved transition ---
 
-    def test_on_save_workflow_rekeys_context_stack_on_first_save(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_save_workflow_rekeys_context_stack_on_first_save(self, griptape_nodes: Engine) -> None:
         """First save of an unsaved workflow rekeys the registry entry and updates the context stack in-place."""
         from datetime import UTC, datetime
 
@@ -711,7 +708,7 @@ class TestWorkflowManager:
 
             try:
                 with (
-                    patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+                    patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
                     patch.object(
                         workflow_manager,
                         "_save_workflow_file_inline",
@@ -742,7 +739,7 @@ class TestWorkflowManager:
                 if context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_on_set_workflow_metadata_updates_unsaved_workflow_in_memory(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_set_workflow_metadata_updates_unsaved_workflow_in_memory(self, griptape_nodes: Engine) -> None:
         """SetWorkflowMetadataRequest on an unsaved workflow updates registry metadata without touching disk."""
         workflow_manager = griptape_nodes.WorkflowManager()
         workflow_manager._workflows_loading_complete.set()
@@ -769,9 +766,7 @@ class TestWorkflowManager:
             # Still unsaved — no disk file materialized.
             assert workflow.file_path is None
 
-    def test_first_save_uses_display_name_when_requested_name_is_unsaved_key(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_first_save_uses_display_name_when_requested_name_is_unsaved_key(self, griptape_nodes: Engine) -> None:
         """First save of an unsaved workflow derives the filename from metadata.name, not the synthetic key."""
         from griptape_nodes.retained_mode.events.flow_events import (
             GetTopLevelFlowResultSuccess,
@@ -854,7 +849,7 @@ class TestWorkflowManager:
 
             try:
                 with (
-                    patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+                    patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
                     patch.object(
                         workflow_manager,
                         "_save_workflow_file_inline",
@@ -939,7 +934,7 @@ class TestWorkflowManager:
             patch.object(WorkflowRegistry, "has_workflow_with_name", return_value=True),
             patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_source),
             patch.object(workflow_manager, "_persist_external_workflow_registration") as mock_persist,
-            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(workflow_manager.engine, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager.on_rename_workflow_request(
@@ -956,7 +951,7 @@ class TestWorkflowManager:
         captured["persist_calls"] = mock_persist.call_args_list
         return captured
 
-    def test_rename_preserves_workspace_subdir(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_preserves_workspace_subdir(self, griptape_nodes: Engine) -> None:
         """Renaming a workflow in a sub-directory keeps it there (bar/workflow -> bar/new_name)."""
         captured = self._run_rename(
             griptape_nodes.WorkflowManager(),
@@ -970,7 +965,7 @@ class TestWorkflowManager:
         )
         assert captured["save_file_name"] == "bar/new_name"
 
-    def test_rename_root_workflow_has_no_directory(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_root_workflow_has_no_directory(self, griptape_nodes: Engine) -> None:
         """Renaming a workspace-root workflow has no directory prefix."""
         captured = self._run_rename(
             griptape_nodes.WorkflowManager(),
@@ -984,7 +979,7 @@ class TestWorkflowManager:
         )
         assert captured["save_file_name"] == "new_name"
 
-    def test_rename_preserves_absolute_dir_and_reregisters(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_preserves_absolute_dir_and_reregisters(self, griptape_nodes: Engine) -> None:
         """Renaming an externally-registered (absolute path) workflow keeps it external and re-registers it."""
         captured = self._run_rename(
             griptape_nodes.WorkflowManager(),
@@ -1001,7 +996,7 @@ class TestWorkflowManager:
         persist_calls = captured["persist_calls"]
         assert persist_calls == [call("/ext/new_name.py")]
 
-    def test_rename_returns_new_registry_key(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_returns_new_registry_key(self, griptape_nodes: Engine) -> None:
         """The returned new_workflow_name is the real directory-qualified key, not the bare stem."""
         captured = self._run_rename(
             griptape_nodes.WorkflowManager(),
@@ -1015,7 +1010,7 @@ class TestWorkflowManager:
         )
         assert captured["result_new_name"] == "bar/new_name"
 
-    def test_rename_default_matches_file_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_default_matches_file_name(self, griptape_nodes: Engine) -> None:
         """Default behavior (MATCH_FILE_NAME): display name tracks the new file basename.
 
         Preserves historical wire behavior — callers who don't set display_name_behavior see the
@@ -1034,7 +1029,7 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "my_workflow_renamed"
 
-    def test_rename_preserve_existing_keeps_display_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_preserve_existing_keeps_display_name(self, griptape_nodes: Engine) -> None:
         """PRESERVE_EXISTING opt-in: SaveWorkflowRequest receives the source's metadata.name, not the new file stem.
 
         Fix for issue #4992 — with this enum value, renaming a workflow whose display name diverges
@@ -1056,7 +1051,7 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "My Cool Workflow"
 
-    def test_rename_override_uses_provided_display_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_override_uses_provided_display_name(self, griptape_nodes: Engine) -> None:
         """OVERRIDE forwards the caller-supplied display_name to SaveWorkflowRequest."""
         from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
 
@@ -1077,7 +1072,7 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "Renamed On Purpose"
 
-    def test_rename_override_strips_surrounding_whitespace(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_override_strips_surrounding_whitespace(self, griptape_nodes: Engine) -> None:
         """OVERRIDE forwards ``display_name`` stripped so validation and resolution agree on the canonical form.
 
         Regression coverage: ``_validate_rename_display_name`` gates OVERRIDE on
@@ -1113,7 +1108,7 @@ class TestWorkflowManager:
     )
     def test_rename_rejects_display_name_without_override(
         self,
-        griptape_nodes: GriptapeNodes,
+        griptape_nodes: Engine,
         non_override_behavior: str,
     ) -> None:
         """Supplying display_name with a non-OVERRIDE behavior fails fast so it can't be silently ignored."""
@@ -1147,7 +1142,7 @@ class TestWorkflowManager:
     @pytest.mark.parametrize("empty_display_name", [None, "", "   "])
     def test_rename_override_rejects_missing_display_name(
         self,
-        griptape_nodes: GriptapeNodes,
+        griptape_nodes: Engine,
         empty_display_name: str | None,
     ) -> None:
         """OVERRIDE without a non-empty display_name fails fast without invoking the save pipeline."""
@@ -1179,7 +1174,7 @@ class TestWorkflowManager:
         assert "OVERRIDE" in str(result.result_details)
 
     def test_rename_preserve_existing_falls_back_to_requested_name_when_source_display_name_blank(
-        self, griptape_nodes: GriptapeNodes
+        self, griptape_nodes: Engine
     ) -> None:
         """PRESERVE_EXISTING with a blank source metadata.name falls back to the requested name.
 
@@ -1205,7 +1200,7 @@ class TestWorkflowManager:
         assert captured["save_display_name"] == "my_workflow_renamed"
 
     def test_rename_preserve_existing_falls_back_to_requested_name_when_source_missing(
-        self, griptape_nodes: GriptapeNodes
+        self, griptape_nodes: Engine
     ) -> None:
         """PRESERVE_EXISTING with an unregistered source workflow falls back to the requested name.
 
@@ -1240,7 +1235,7 @@ class TestWorkflowManager:
             # Force the source lookup to miss — no registry entry to preserve from.
             patch.object(WorkflowRegistry, "has_workflow_with_name", return_value=False),
             patch.object(workflow_manager, "_persist_external_workflow_registration"),
-            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(workflow_manager.engine, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager.on_rename_workflow_request(
@@ -1255,7 +1250,7 @@ class TestWorkflowManager:
         assert isinstance(result, RenameWorkflowResultSuccess)
         assert captured["save_display_name"] == "never_registered_renamed"
 
-    def test_rename_surfaces_delete_failure_from_bookkeeping(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_surfaces_delete_failure_from_bookkeeping(self, griptape_nodes: Engine) -> None:
         """When the post-save delete of the old registry entry fails, rename surfaces RenameWorkflowResultFailure.
 
         Save succeeds, but the follow-up DeleteWorkflowRequest for the old key comes back as
@@ -1306,7 +1301,7 @@ class TestWorkflowManager:
         assert "'old'" in str(result.result_details)
         assert "'new'" in str(result.result_details)
 
-    def test_resolve_named_save_path_absolute_skips_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_resolve_named_save_path_absolute_skips_sub_dirs(self, griptape_nodes: Engine) -> None:
         """An absolute requested name routes the full path to _build_workflow_save_path with no sub_dirs."""
         workflow_manager = griptape_nodes.WorkflowManager()
         # Anchor to the current filesystem root so the path is absolute on Windows
@@ -1328,7 +1323,7 @@ class TestWorkflowManager:
         assert resolved.file_name == "new_name"
         assert resolved.relative_file_path == str(abs_path)
 
-    def test_resolve_named_save_path_relative_passes_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_resolve_named_save_path_relative_passes_sub_dirs(self, griptape_nodes: Engine) -> None:
         """A relative requested name splits into stem + sub_dirs (unchanged behavior)."""
         workflow_manager = griptape_nodes.WorkflowManager()
         fake_destination = MagicMock()
@@ -1345,7 +1340,7 @@ class TestWorkflowManager:
         mock_build.assert_called_once_with("new_name.py", sub_dirs="team", situation_name="save_workflow")
         assert resolved.file_name == "new_name"
 
-    def test_delete_active_workflow_clears_context_stack(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_delete_active_workflow_clears_context_stack(self, griptape_nodes: Engine) -> None:
         """Deleting the active workflow tears down its flows and pops the context stack.
 
         Regression guard for the "phantom workflow" bug: a frontend that reloads after
@@ -1388,7 +1383,7 @@ class TestWorkflowManager:
                 if context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_delete_non_active_workflow_leaves_context_untouched(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_delete_non_active_workflow_leaves_context_untouched(self, griptape_nodes: Engine) -> None:
         """Deleting a workflow that isn't the active one must not touch the context stack.
 
         Covers the published-workflow subprocess cleanup path, which deletes by key without
@@ -1423,7 +1418,7 @@ class TestWorkflowManager:
                     context_manager.pop_workflow()
 
     @pytest.mark.asyncio
-    async def test_startup_scan_skips_unsaved_prefix_files(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    async def test_startup_scan_skips_unsaved_prefix_files(self, griptape_nodes: Engine, tmp_path: Path) -> None:
         """Leaked `unsaved:<uuid>.py` files on disk must be skipped during the workspace scan.
 
         Pre-fix saves wrote these files; `_determine_save_target` no longer does, but any
@@ -1518,7 +1513,7 @@ class TestWorkflowManager:
 
     # --- WorkflowInfo payload helpers ---
 
-    def test_build_workflow_info_key_uses_workspace_join(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_build_workflow_info_key_uses_workspace_join(self, griptape_nodes: Engine) -> None:
         """_build_workflow_info_key matches the key construction used when storing info (no symlink resolution)."""
         workflow_manager = griptape_nodes.WorkflowManager()
         workspace = griptape_nodes.ConfigManager().workspace_path
@@ -1527,7 +1522,7 @@ class TestWorkflowManager:
 
         assert key == str(workspace / "workflows/my_workflow.py")
 
-    def test_build_workflow_info_payload_good_status_no_problems(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_build_workflow_info_payload_good_status_no_problems(self, griptape_nodes: Engine) -> None:
         """_build_workflow_info_payload produces correct payload for a GOOD workflow with no problems."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
@@ -1547,7 +1542,7 @@ class TestWorkflowManager:
         assert payload.problems == []
         assert payload.workflow_dependencies == []
 
-    def test_build_workflow_info_payload_collates_problems(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_build_workflow_info_payload_collates_problems(self, griptape_nodes: Engine) -> None:
         """_build_workflow_info_payload calls collate_problems_for_display on each problem type."""
         from griptape_nodes.retained_mode.managers.fitness_problems.workflows.library_not_registered_problem import (
             LibraryNotRegisteredProblem,
@@ -1571,7 +1566,7 @@ class TestWorkflowManager:
         assert "lib-a" in payload.problems[0]
         assert "lib-b" in payload.problems[0]
 
-    def test_build_workflow_info_payload_includes_dependencies(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_build_workflow_info_payload_includes_dependencies(self, griptape_nodes: Engine) -> None:
         """_build_workflow_info_payload passes WorkflowDependencyInfo instances through directly."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
@@ -1602,7 +1597,7 @@ class TestWorkflowManager:
 
     # --- GetWorkflowInfoRequest ---
 
-    def test_on_get_workflow_info_request_workflow_not_in_registry_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_get_workflow_info_request_workflow_not_in_registry_fails(self, griptape_nodes: Engine) -> None:
         """GetWorkflowInfoRequest with unknown workflow_name returns failure."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = GetWorkflowInfoRequest(workflow_name="missing_workflow")
@@ -1613,7 +1608,7 @@ class TestWorkflowManager:
         assert isinstance(result, GetWorkflowInfoResultFailure)
         assert "missing_workflow" in str(result.result_details)
 
-    def test_on_get_workflow_info_request_no_info_for_path_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_get_workflow_info_request_no_info_for_path_fails(self, griptape_nodes: Engine) -> None:
         """GetWorkflowInfoRequest returns failure when no WorkflowInfo is stored for the resolved path."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = GetWorkflowInfoRequest(workflow_name="my_workflow")
@@ -1627,7 +1622,7 @@ class TestWorkflowManager:
 
         assert isinstance(result, GetWorkflowInfoResultFailure)
 
-    def test_on_get_workflow_info_request_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_get_workflow_info_request_success(self, griptape_nodes: Engine) -> None:
         """GetWorkflowInfoRequest succeeds when WorkflowInfo exists for the workflow."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
@@ -1657,7 +1652,7 @@ class TestWorkflowManager:
 
     # --- ListAllWorkflowInfoRequest ---
 
-    def test_on_list_all_workflow_info_request_registry_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_list_all_workflow_info_request_registry_failure(self, griptape_nodes: Engine) -> None:
         """ListAllWorkflowInfoRequest returns failure when listing workflows raises."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ListAllWorkflowInfoRequest()
@@ -1668,7 +1663,7 @@ class TestWorkflowManager:
         assert isinstance(result, ListAllWorkflowInfoResultFailure)
         assert "registry error" in str(result.result_details)
 
-    def test_on_list_all_workflow_info_request_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_list_all_workflow_info_request_success(self, griptape_nodes: Engine) -> None:
         """ListAllWorkflowInfoRequest returns info for every workflow that has a stored WorkflowInfo."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
@@ -1697,9 +1692,7 @@ class TestWorkflowManager:
         assert "my_workflow" in result.workflow_infos
         assert result.workflow_infos["my_workflow"].status == "GOOD"
 
-    def test_on_list_all_workflow_info_request_skips_workflows_without_info(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_on_list_all_workflow_info_request_skips_workflows_without_info(self, griptape_nodes: Engine) -> None:
         """ListAllWorkflowInfoRequest omits workflows that have no stored WorkflowInfo."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ListAllWorkflowInfoRequest()
@@ -1717,7 +1710,7 @@ class TestWorkflowManager:
         assert isinstance(result, ListAllWorkflowInfoResultSuccess)
         assert result.workflow_infos == {}
 
-    def test_on_list_all_workflow_info_request_skips_unknown_registry_keys(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_on_list_all_workflow_info_request_skips_unknown_registry_keys(self, griptape_nodes: Engine) -> None:
         """ListAllWorkflowInfoRequest skips registry keys that can't be looked up."""
         workflow_manager = griptape_nodes.WorkflowManager()
         request = ListAllWorkflowInfoRequest()
@@ -1733,7 +1726,7 @@ class TestWorkflowManager:
 
     # --- _build_workflow_save_path ---
 
-    def test_build_workflow_save_path_returns_destination_from_situation(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_build_workflow_save_path_returns_destination_from_situation(self, griptape_nodes: Engine) -> None:
         """The destination from the save_workflow situation is returned verbatim — no upstream macro resolution.
 
         Resolving the macro upstream would strip the seed-and-retry context needed
@@ -1755,7 +1748,7 @@ class TestWorkflowManager:
         fake_destination.resolve.assert_not_called()
         assert save_path.relative_file_path == "my_workflow.py"
 
-    def test_build_workflow_save_path_preserves_sub_dirs(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_build_workflow_save_path_preserves_sub_dirs(self, griptape_nodes: Engine) -> None:
         """sub_dirs flow through as macro variables and into the registry-relative display string."""
         workflow_manager = griptape_nodes.WorkflowManager()
 
@@ -1798,7 +1791,7 @@ class TestWorkflowManager:
             workflow_shape=WorkflowShape(inputs={}, outputs={}) if with_shape else None,
         )
 
-    def _generate(self, griptape_nodes: GriptapeNodes, *, with_shape: bool = False) -> str:
+    def _generate(self, griptape_nodes: Engine, *, with_shape: bool = False) -> str:
         workflow_manager = griptape_nodes.WorkflowManager()
         return workflow_manager._generate_workflow_file_content(
             serialized_flow_commands=self._empty_serialized_flow_commands(),
@@ -1806,7 +1799,7 @@ class TestWorkflowManager:
         )
 
     def test_generate_workflow_file_content_wraps_graph_building_in_async_build_workflow(
-        self, griptape_nodes: GriptapeNodes
+        self, griptape_nodes: Engine
     ) -> None:
         """Saved workflows must wrap graph-building statements in `async def build_workflow()`."""
         content = self._generate(griptape_nodes)
@@ -1818,7 +1811,7 @@ class TestWorkflowManager:
         ]
         assert len(build_workflow_defs) == 1, "build_workflow must be defined exactly once as async"
 
-    def test_generate_workflow_file_content_is_inert_at_import(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_generate_workflow_file_content_is_inert_at_import(self, griptape_nodes: Engine) -> None:
         """A shape-free saved workflow must contain no module-level side effects.
 
         Only function/class definitions and imports should appear at the top level so that
@@ -1840,9 +1833,7 @@ class TestWorkflowManager:
                 f"Unexpected top-level statement of type {type(node).__name__} in shape-free workflow"
             )
 
-    def test_generate_workflow_file_content_prereq_lives_inside_build_workflow(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_generate_workflow_file_content_prereq_lives_inside_build_workflow(self, griptape_nodes: Engine) -> None:
         """Prerequisite code (context_manager setup) must live inside build_workflow, not at module scope."""
         content = self._generate(griptape_nodes)
         module = ast.parse(content)
@@ -1855,7 +1846,7 @@ class TestWorkflowManager:
         assert "context_manager.push_workflow(file_path=__file__)" in body_src
 
     def test_generate_workflow_file_content_registers_declared_libraries_in_build_workflow(
-        self, griptape_nodes: GriptapeNodes
+        self, griptape_nodes: Engine
     ) -> None:
         """build_workflow() must register every library named in node_libraries_referenced.
 
@@ -1905,7 +1896,7 @@ class TestWorkflowManager:
         assert "RegisterLibraryFromFileRequest" in top_level_imports
 
     def test_generate_workflow_file_content_omits_register_calls_when_no_libraries_declared(
-        self, griptape_nodes: GriptapeNodes
+        self, griptape_nodes: Engine
     ) -> None:
         """With an empty node_libraries_referenced list, no register calls are emitted.
 
@@ -1916,9 +1907,7 @@ class TestWorkflowManager:
         content = self._generate(griptape_nodes)
         assert "RegisterLibraryFromFileRequest" not in content
 
-    def test_generated_build_workflow_registers_libraries_before_creating_nodes(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_generated_build_workflow_registers_libraries_before_creating_nodes(self, griptape_nodes: Engine) -> None:
         """build_workflow() must dispatch RegisterLibraryFromFileRequest before any CreateNodeRequest.
 
         Captures the runtime contract for issue #4584: when a generated workflow runs as a
@@ -2001,9 +1990,7 @@ class TestWorkflowManager:
             f" got order {[type(r).__name__ for r in dispatched]}"
         )
 
-    def test_generate_workflow_file_content_empty_build_workflow_has_pass_body(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_generate_workflow_file_content_empty_build_workflow_has_pass_body(self, griptape_nodes: Engine) -> None:
         """If we somehow produce no graph-building statements, build_workflow should still be valid Python."""
         workflow_manager = griptape_nodes.WorkflowManager()
         # Stub out the two generators so main_body ends up empty and the `or [ast.Pass()]` branch runs.
@@ -2027,9 +2014,7 @@ class TestWorkflowManager:
         assert len(build_workflow.body) == 1
         assert isinstance(build_workflow.body[0], ast.Pass)
 
-    def test_generate_workflow_file_content_aexecute_awaits_build_workflow_first(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_generate_workflow_file_content_aexecute_awaits_build_workflow_first(self, griptape_nodes: Engine) -> None:
         """aexecute_workflow must `await build_workflow()` before running the executor.
 
         Shape-bearing workflows emit execute_workflow + aexecute_workflow, and the async
@@ -2050,7 +2035,7 @@ class TestWorkflowManager:
         assert isinstance(call.func, ast.Name)
         assert call.func.id == "build_workflow"
 
-    def test_generate_workflow_file_content_ensure_context_is_async(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_generate_workflow_file_content_ensure_context_is_async(self, griptape_nodes: Engine) -> None:
         """_ensure_workflow_context is now async and must await ahandle_request."""
         content = self._generate(griptape_nodes, with_shape=True)
         module = ast.parse(content)
@@ -2065,13 +2050,13 @@ class TestWorkflowManager:
         # Sanity check: the old sync variant is gone.
         assert "GriptapeNodes.handle_request(" not in body_src
 
-    def test_generate_workflow_file_content_is_valid_python(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_generate_workflow_file_content_is_valid_python(self, griptape_nodes: Engine) -> None:
         """Generated content must parse cleanly (no smuggled-string comments left behind)."""
         content = self._generate(griptape_nodes, with_shape=True)
         # ast.parse raises SyntaxError if rewrite_string_comments left bad output behind.
         ast.parse(content)
 
-    def test_collect_object_imports_routes_dynamic_module_to_deferred(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_collect_object_imports_routes_dynamic_module_to_deferred(self, griptape_nodes: Engine) -> None:
         """Dynamic library class imports must go into deferred_imports, not import_recorder.
 
         Regression for #4738: _collect_object_imports previously routed all imports through
@@ -2123,7 +2108,7 @@ class TestWorkflowVariablePersistence:
             node_libraries_referenced=[],
         )
 
-    def test_generate_create_variable_code_emits_expected_call(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_generate_create_variable_code_emits_expected_call(self, griptape_nodes: Engine) -> None:
         """The AST helper should produce a single CreateVariableRequest call per command."""
         import ast
 
@@ -2167,7 +2152,7 @@ class TestWorkflowVariablePersistence:
         imports_text = import_recorder.generate_imports()
         assert "CreateVariableRequest" in imports_text
 
-    def _push_clean_flow_context(self, griptape_nodes: GriptapeNodes, flow_name: str = "ControlFlow_1") -> str:
+    def _push_clean_flow_context(self, griptape_nodes: Engine, flow_name: str = "ControlFlow_1") -> str:
         """Clear state, push a workflow context, and create a single empty flow. Returns the flow name."""
         from griptape_nodes.retained_mode.events.flow_events import (
             CreateFlowRequest,
@@ -2189,7 +2174,7 @@ class TestWorkflowVariablePersistence:
         assert isinstance(flow_result, CreateFlowResultSuccess)
         return flow_result.flow_name
 
-    def test_declared_variable_gets_serialized(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_declared_variable_gets_serialized(self, griptape_nodes: Engine) -> None:
         """A flow-scoped variable that is declared via a VariableReference should be serialized."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.events.variable_events import (
@@ -2220,7 +2205,7 @@ class TestWorkflowVariablePersistence:
         assert {cmd.create_variable_command.name for cmd in commands} == {"declared_var"}
         assert len(unique_values) == 1
 
-    def test_orphan_variable_is_dropped(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_orphan_variable_is_dropped(self, griptape_nodes: Engine) -> None:
         """A variable in engine state with no declared reference must not be serialized."""
         from griptape_nodes.retained_mode.events.variable_events import (
             CreateVariableRequest,
@@ -2249,7 +2234,7 @@ class TestWorkflowVariablePersistence:
         assert commands == []
         assert unique_values == {}
 
-    def test_declared_but_missing_variable_is_dropped(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_declared_but_missing_variable_is_dropped(self, griptape_nodes: Engine) -> None:
         """A reference to a variable that does not exist in the flow should not produce a command."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.variable_types import VariableScope
@@ -2266,7 +2251,7 @@ class TestWorkflowVariablePersistence:
 
         assert commands == []
 
-    def test_global_only_scope_is_skipped(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_global_only_scope_is_skipped(self, griptape_nodes: Engine) -> None:
         """GLOBAL_ONLY references are deferred for now and must not produce a command."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.events.variable_events import (
@@ -2298,7 +2283,7 @@ class TestWorkflowVariablePersistence:
 
         assert commands == []
 
-    def test_hierarchical_reference_only_serializes_at_owning_flow(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_hierarchical_reference_only_serializes_at_owning_flow(self, griptape_nodes: Engine) -> None:
         """A HIERARCHICAL reference resolved against a child flow must not serialize an ancestor-owned variable."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.events.flow_events import (
@@ -2354,7 +2339,7 @@ class TestWorkflowVariablePersistence:
         )
         assert {cmd.create_variable_command.name for cmd in parent_commands} == {"ancestor_var"}
 
-    def test_save_load_preserves_flow_scoped_variables(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_save_load_preserves_flow_scoped_variables(self, griptape_nodes: Engine) -> None:
         """Round-trip: declare a flow-scoped variable, serialize, clear, exec, confirm it is restored."""
         from griptape_nodes.exe_types.node_types import NodeDependencies, VariableReference
         from griptape_nodes.retained_mode.events.flow_events import (
@@ -2448,7 +2433,7 @@ class TestWorkflowVariablePersistence:
         assert isinstance(flow_value, GetVariableValueResultSuccess)
         assert flow_value.value == "dog"
 
-    def test_save_drops_orphan_variables_end_to_end(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_save_drops_orphan_variables_end_to_end(self, griptape_nodes: Engine) -> None:
         """The var.py scenario: a variable with no declaring node must not survive serialization."""
         from griptape_nodes.retained_mode.events.flow_events import (
             SerializeFlowToCommandsRequest,
@@ -2524,7 +2509,7 @@ class TestVariableReferenceAccess:
             VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ_WRITE),
         }
 
-    def test_serializer_ignores_access(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_serializer_ignores_access(self, griptape_nodes: Engine) -> None:
         """Serialization filtering is access-agnostic: any declared reference keeps the variable."""
         from griptape_nodes.exe_types.node_types import VariableAccess, VariableReference
         from griptape_nodes.retained_mode.events.variable_events import (
@@ -2560,7 +2545,7 @@ class TestVariableReferenceAccess:
 class TestLibraryResolutionOnLoad:
     """run_workflow resolves declared libraries before exec via the metadata header."""
 
-    def test_ensure_libraries_dispatches_ahandle_request_per_library(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_ensure_libraries_dispatches_ahandle_request_per_library(self, griptape_nodes: Engine) -> None:
         """_ensure_libraries_for_workflow dispatches one RegisterLibraryFromFileRequest per declared library."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2593,7 +2578,7 @@ class TestLibraryResolutionOnLoad:
 
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager._ensure_libraries_for_workflow(
@@ -2606,7 +2591,7 @@ class TestLibraryResolutionOnLoad:
         assert [r.library_name for r in dispatched] == ["Example Library", "Other Library"]
         assert all(r.perform_discovery_if_not_found for r in dispatched)
 
-    def test_ensure_libraries_returns_failure_when_registration_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_ensure_libraries_returns_failure_when_registration_fails(self, griptape_nodes: Engine) -> None:
         """A failed library registration short-circuits with a WorkflowExecutionResult failure."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2643,9 +2628,7 @@ class TestLibraryResolutionOnLoad:
         assert result.execution_successful is False
         assert "Missing Library" in result.execution_details
 
-    def test_ensure_libraries_failure_message_uses_filename_and_renders_semver(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_ensure_libraries_failure_message_uses_filename_and_renders_semver(self, griptape_nodes: Engine) -> None:
         """Failure message uses the workflow file name (not full path) and renders v<version> for semver values."""
         import logging as _logging
 
@@ -2676,7 +2659,7 @@ class TestLibraryResolutionOnLoad:
 
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager._ensure_libraries_for_workflow(
@@ -2697,7 +2680,7 @@ class TestLibraryResolutionOnLoad:
         assert len(dispatched) == 1
         assert dispatched[0].failure_log_level == _logging.DEBUG
 
-    def test_ensure_libraries_failure_message_omits_non_semver_version(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_ensure_libraries_failure_message_omits_non_semver_version(self, griptape_nodes: Engine) -> None:
         """Non-semver `library_version` values (e.g. unavailable-library placeholder) are not rendered as v<...>."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2738,7 +2721,7 @@ class TestLibraryResolutionOnLoad:
         assert placeholder not in result.execution_details
         assert " v" not in result.execution_details.split("Missing Library", 1)[1]
 
-    def test_ensure_libraries_failure_message_omits_empty_version(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_ensure_libraries_failure_message_omits_empty_version(self, griptape_nodes: Engine) -> None:
         """An empty `library_version` falls through the semver check and renders no version suffix."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2776,7 +2759,7 @@ class TestLibraryResolutionOnLoad:
         assert "Missing Library" in result.execution_details
         assert " v" not in result.execution_details.split("Missing Library", 1)[1]
 
-    def test_ensure_libraries_is_noop_when_metadata_missing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_ensure_libraries_is_noop_when_metadata_missing(self, griptape_nodes: Engine) -> None:
         """If metadata can't be loaded, _ensure_libraries_for_workflow returns None (tolerant fallback)."""
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultFailure
 
@@ -2802,7 +2785,7 @@ class TestLibraryResolutionOnLoad:
 class TestWorkflowsLoadingGate:
     """Gated handlers must not deadlock when invoked during library load (issue #4470)."""
 
-    def test_workflows_loading_complete_is_set_on_init(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_workflows_loading_complete_is_set_on_init(self, griptape_nodes: Engine) -> None:
         """The gate starts as set so handlers invoked before first refresh return immediately.
 
         The hazard is: a node __init__ fires a workflow query during library load, but
@@ -2814,7 +2797,7 @@ class TestWorkflowsLoadingGate:
 
         assert workflow_manager._workflows_loading_complete.is_set()
 
-    def test_list_all_workflows_returns_immediately_before_first_refresh(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_list_all_workflows_returns_immediately_before_first_refresh(self, griptape_nodes: Engine) -> None:
         """on_list_all_workflows_request does not hang when invoked before refresh_workflow_registry."""
         from griptape_nodes.retained_mode.events.workflow_events import (
             ListAllWorkflowsRequest,
@@ -2837,7 +2820,7 @@ class TestWorkflowsLoadingGate:
 class TestWorkflowMetadataTransitiveDeps:
     """node_libraries_referenced in saved workflow metadata includes transitive library_dependencies."""
 
-    def test_transitive_library_dep_included_in_metadata(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_transitive_library_dep_included_in_metadata(self, griptape_nodes: Engine) -> None:
         """When lib-a has library_dependency on lib-b, generated metadata lists both in node_libraries_referenced."""
         from datetime import UTC, datetime
 
@@ -2913,7 +2896,7 @@ class TestWorkflowSaveSituationMacro:
 
     @pytest.fixture(autouse=True)
     def setup_versioned_save_workflow_project(
-        self, temp_dir: Path, griptape_nodes: GriptapeNodes
+        self, temp_dir: Path, griptape_nodes: Engine
     ) -> "Generator[None, None, None]":
         """Load a project that overrides save_workflow to CREATE_NEW with a `{_index:03}` slot.
 
@@ -2975,7 +2958,7 @@ class TestWorkflowSaveSituationMacro:
             node_types_used=set(),
         )
 
-    def _save(self, griptape_nodes: GriptapeNodes, file_name: str) -> str:
+    def _save(self, griptape_nodes: Engine, file_name: str) -> str:
         """Drive _save_workflow_file_inline against the versioned save_workflow situation."""
         workflow_manager = griptape_nodes.WorkflowManager()
         destination, _relative = workflow_manager._build_workflow_save_path(f"{file_name}.py")
@@ -3002,14 +2985,14 @@ class TestWorkflowSaveSituationMacro:
         )
         return result.file_path
 
-    def test_first_save_writes_v001(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_first_save_writes_v001(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """Bug #4941: the first save with `{_index:03}` must produce v001 (not fail with MISSING_REQUIRED)."""
         saved_path = self._save(griptape_nodes, "my_workflow")
 
         assert Path(saved_path) == temp_dir / "my_workflow_v001.py"
         assert (temp_dir / "my_workflow_v001.py").exists()
 
-    def test_successive_saves_increment_padded_index(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_successive_saves_increment_padded_index(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """Saving the same workflow three times produces v001, v002, v003 (padding preserved)."""
         for _ in range(3):
             self._save(griptape_nodes, "my_workflow")
@@ -3018,7 +3001,7 @@ class TestWorkflowSaveSituationMacro:
         assert (temp_dir / "my_workflow_v002.py").exists()
         assert (temp_dir / "my_workflow_v003.py").exists()
 
-    def test_sub_dirs_route_into_subdirectory(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_sub_dirs_route_into_subdirectory(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """A sub-directory in the requested name routes into `{sub_dirs?:/}` and still picks v001."""
         workflow_manager = griptape_nodes.WorkflowManager()
         destination, relative = workflow_manager._build_workflow_save_path("my_workflow.py", sub_dirs="episode")
@@ -3060,7 +3043,7 @@ class TestCreateVersionedWorkflow:
         return tmp_path.resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_default_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> "Generator[None, None, None]":
+    def setup_default_project(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
         """Load the default project template (which ships create_versioned_workflow).
 
         Same fixture ordering as TestWorkflowSaveSituationMacro: load + activate
@@ -3092,7 +3075,7 @@ class TestCreateVersionedWorkflow:
 
     @staticmethod
     def _determine(
-        griptape_nodes: GriptapeNodes,
+        griptape_nodes: Engine,
         *,
         requested_file_name: str | None,
         current_workflow_name: str | None,
@@ -3122,9 +3105,7 @@ class TestCreateVersionedWorkflow:
         )
         WorkflowRegistry.generate_new_workflow(registry_key=registry_key, metadata=metadata, file_path=file_name)
 
-    def test_create_versioned_short_circuits_overwrite_existing(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_create_versioned_short_circuits_overwrite_existing(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """Even when the workflow is already saved, create_versioned=True routes through the versioned situation.
 
         Without this fix, the OVERWRITE_EXISTING branch would win on the second
@@ -3156,7 +3137,7 @@ class TestCreateVersionedWorkflow:
             assert target.file_path is None
 
     def test_create_versioned_match_path_passes_full_matched_dict_through(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, griptape_nodes: Engine, temp_dir: Path
     ) -> None:
         """Saving over `my_flow_v001` produces a destination whose MacroPath carries every matched variable.
 
@@ -3192,7 +3173,7 @@ class TestCreateVersionedWorkflow:
             assert macro_vars.get("_index") == 1
 
     def test_create_versioned_match_recovers_index_when_stem_contains_v(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, griptape_nodes: Engine, temp_dir: Path
     ) -> None:
         """Reverse-match handles base names that themselves contain the ``_v`` anchor lookalike.
 
@@ -3229,7 +3210,7 @@ class TestCreateVersionedWorkflow:
             assert macro_vars.get("file_extension") == "py"
 
     def test_create_versioned_with_requested_name_matching_existing_workflow_runs_match(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, griptape_nodes: Engine, temp_dir: Path
     ) -> None:
         """The UI re-sends the open workflow's key as ``file_name``; we still reverse-match.
 
@@ -3270,9 +3251,7 @@ class TestCreateVersionedWorkflow:
             # the whole prior stem ("my_flow_v002") and _index would be unbound.
             assert macro_vars.get("file_name_base") != "my_flow_v002"
 
-    def test_create_versioned_false_preserves_overwrite_existing(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_create_versioned_false_preserves_overwrite_existing(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """create_versioned=False against a saved workflow keeps the standard OVERWRITE_EXISTING path."""
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             self._register_saved_workflow(
@@ -3292,7 +3271,7 @@ class TestCreateVersionedWorkflow:
             assert target.file_path.name == "my_flow.py"
 
     def test_warning_logged_when_save_workflow_customized_to_create_new(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, griptape_nodes: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A project that flips `save_workflow` to create_new triggers a warning on non-versioned saves.
 
@@ -3342,7 +3321,7 @@ class TestCreateVersionedWorkflow:
         )
 
     def test_warning_logged_when_create_versioned_workflow_customized_to_overwrite(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, griptape_nodes: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Inverse mismatch: create_versioned=True against a `create_versioned_workflow` flipped to overwrite.
 
@@ -3415,7 +3394,7 @@ class TestCreateVersionedWorkflow:
         # is what makes the seed-and-retry produce v001/v002/...
         assert "_index" in situation.macro or "#" in situation.macro
 
-    def test_first_versioned_save_with_no_registry_entry(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_first_versioned_save_with_no_registry_entry(self, griptape_nodes: Engine) -> None:
         """create_versioned=True on a brand-new workflow uses the requested name and lands at CREATE_VERSIONED."""
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             target = self._determine(
@@ -3438,9 +3417,7 @@ class TestCreateVersionedWorkflow:
 
     # --- #4956 helper: Step 2 (match) / Step 3 (no-match) / Step 1b (unsaved) -----------
 
-    def test_step2_match_path_with_customized_versioned_macro(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_step2_match_path_with_customized_versioned_macro(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """Customizing the versioned situation's macro still round-trips: matched dict goes through verbatim.
 
         Regression coverage for #4956 — confirms we don't hardcode any variable
@@ -3510,7 +3487,7 @@ class TestCreateVersionedWorkflow:
             assert macro_vars.get("_index") == 17  # noqa: PLR2004 - literal version from setup
             assert macro_vars.get("file_extension") == "py"
 
-    def test_step3_no_match_path_falls_back_to_file_stem(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_step3_no_match_path_falls_back_to_file_stem(self, griptape_nodes: Engine, temp_dir: Path) -> None:
         """A workflow saved under a NON-versioned situation produces a new versioned series on create_versioned.
 
         The file `random_name.py` doesn't match the versioned situation's macro
@@ -3545,7 +3522,7 @@ class TestCreateVersionedWorkflow:
                 "Step 3 (no-match) must leave _index unbound so the seed-and-retry assigns 1 on write."
             )
 
-    def test_step1b_unsaved_workflow_uses_display_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_step1b_unsaved_workflow_uses_display_name(self, griptape_nodes: Engine) -> None:
         """create_versioned=True on an unsaved workflow uses display_name as the base.
 
         The unsaved workflow has no file_path → Step 1b kicks in →
@@ -3573,7 +3550,7 @@ class TestCreateVersionedWorkflow:
             assert "_index" not in macro_vars
 
     def test_create_versioned_invalid_situation_macro_raises_value_error(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, griptape_nodes: Engine, temp_dir: Path
     ) -> None:
         """A malformed situation macro surfaces as a clear ValueError, not an opaque crash.
 
@@ -3608,7 +3585,7 @@ class TestCreateVersionedWorkflow:
                 )
 
     def test_create_versioned_missing_situation_raises_value_error(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, griptape_nodes: Engine, temp_dir: Path
     ) -> None:
         """When the active project lacks the versioned situation, the reverse-match raises with the situation name.
 
@@ -3629,7 +3606,7 @@ class TestCreateVersionedWorkflow:
                 temp_dir, registry_key="my_flow_v001", file_name="my_flow_v001.py", display_name="my_flow"
             )
 
-            real_handle = GriptapeNodes.handle_request
+            real_handle = griptape_nodes.handle_request
 
             def fake_handle(req: RequestPayload) -> object:
                 if isinstance(req, GetSituationRequest):
@@ -3637,7 +3614,7 @@ class TestCreateVersionedWorkflow:
                 return real_handle(req)
 
             with (
-                patch.object(GriptapeNodes, "handle_request", side_effect=fake_handle),
+                patch.object(griptape_nodes, "handle_request", side_effect=fake_handle),
                 pytest.raises(ValueError, match="not found in the active project template"),
             ):
                 self._determine(
@@ -3648,7 +3625,7 @@ class TestCreateVersionedWorkflow:
                 )
 
     def test_create_versioned_match_dispatch_failure_surfaces_underlying_cause(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, griptape_nodes: Engine, temp_dir: Path
     ) -> None:
         """When the match handler crashes, the error message includes the underlying exception.
 
@@ -3669,7 +3646,7 @@ class TestCreateVersionedWorkflow:
                 temp_dir, registry_key="my_flow_v001", file_name="my_flow_v001.py", display_name="my_flow"
             )
 
-            real_handle = GriptapeNodes.handle_request
+            real_handle = griptape_nodes.handle_request
             synthetic_exc = RuntimeError("synthetic match-handler crash for test")
 
             def fake_handle(req: RequestPayload) -> object:
@@ -3681,7 +3658,7 @@ class TestCreateVersionedWorkflow:
                 return real_handle(req)
 
             with (
-                patch.object(GriptapeNodes, "handle_request", side_effect=fake_handle),
+                patch.object(griptape_nodes, "handle_request", side_effect=fake_handle),
                 pytest.raises(ValueError, match="synthetic match-handler crash") as exc_info,
             ):
                 self._determine(
@@ -3698,7 +3675,7 @@ class TestCreateVersionedWorkflow:
 
     def test_create_versioned_timestamp_fallback_when_no_candidate_workflow(
         self,
-        griptape_nodes: GriptapeNodes,
+        griptape_nodes: Engine,
     ) -> None:
         """Step 5: no current AND no target workflow → timestamp-derived filename.
 
@@ -3748,7 +3725,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
     @staticmethod
     def _capture_display_name(
-        griptape_nodes: GriptapeNodes,
+        griptape_nodes: Engine,
         *,
         request_file_name: str | None,
         request_display_name: str | None,
@@ -3821,7 +3798,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
         try:
             with (
-                patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+                patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
                 patch.object(workflow_manager, "_save_workflow_file_inline", side_effect=capture_inline),
                 patch.object(workflow_manager, "extract_workflow_shape", side_effect=ValueError("no shape")),
             ):
@@ -3836,7 +3813,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
         return captured.get("display_name")
 
-    def test_explicit_request_display_name_wins(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_explicit_request_display_name_wins(self, griptape_nodes: Engine) -> None:
         """Branch 1: ``request.display_name`` is explicit caller intent and always wins.
 
         Even when the registry has an existing display_name AND request.file_name
@@ -3855,7 +3832,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
             assert captured == "Caller-Specified Label"
 
-    def test_existing_registry_display_name_used_when_request_omits(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_existing_registry_display_name_used_when_request_omits(self, griptape_nodes: Engine) -> None:
         """Branch 2: when request.display_name is None, the registry's existing display_name wins over the file_name.
 
         Pins the "preserve human-readable label across re-saves" rule — a
@@ -3895,7 +3872,7 @@ class TestSaveWorkflowDisplayNameFallback:
                 stub_path.unlink(missing_ok=True)
 
     def test_no_request_display_name_no_existing_metadata_uses_resolved_file_name_stem(
-        self, griptape_nodes: GriptapeNodes
+        self, griptape_nodes: Engine
     ) -> None:
         """Branch 3: fresh Save As with no registry entry — the resolved stem becomes the display name.
 
@@ -3919,9 +3896,7 @@ class TestSaveWorkflowDisplayNameFallback:
             # _resolve_named_save_path returns parts.stem — "my_wf", not "episode/my_wf".
             assert captured == "my_wf"
 
-    def test_first_save_of_unsaved_uses_metadata_derived_stem_not_synthetic_key(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_first_save_of_unsaved_uses_metadata_derived_stem_not_synthetic_key(self, griptape_nodes: Engine) -> None:
         """Fresh save of an unsaved workflow must not surface "unsaved:<uuid>" as the display name.
 
         Regression guard for the bug where branch 3 read ``Path(request.file_name).stem``
@@ -3945,7 +3920,7 @@ class TestSaveWorkflowDisplayNameFallback:
             # The resolved stem is the sanitized metadata.name.
             assert captured == "My_Cool_Workflow"
 
-    def test_typed_save_as_name_survives_versioned_resolution(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_typed_save_as_name_survives_versioned_resolution(self, griptape_nodes: Engine) -> None:
         """The user typed "a" — display name stays "a" even when the macro resolves the file to "a_v001".
 
         Pins the versioned-save UI re-save fix from commit 5c3f0bf3: branch 3 must feed off
@@ -3966,7 +3941,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
             assert captured == "a"
 
-    def test_metadata_derived_stem_used_when_no_file_name_and_no_existing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_metadata_derived_stem_used_when_no_file_name_and_no_existing(self, griptape_nodes: Engine) -> None:
         """Branch 3 (no request.file_name path): the metadata-derived stem still fills the display name.
 
         Prior expectation for this scenario was ``None`` (rung 4), because rung 3 keyed off
@@ -4077,7 +4052,7 @@ class TestScrubForAstConstant:
         assert result.value == (1,)
         assert type(result.value) is tuple
 
-    def test_generate_workflow_file_content_scrubs_button_in_ui_options(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_generate_workflow_file_content_scrubs_button_in_ui_options(self, griptape_nodes: Engine) -> None:
         """End-to-end regression for #5013: a Button in ui_options must not break the saved file.
 
         Drives the real generator (``_generate_workflow_file_content``) with a node whose
@@ -4148,33 +4123,35 @@ class TestScrubForAstConstant:
 class TestSelectTopLevelImportedFlow:
     """WorkflowManager._select_top_level_imported_flow picks the top-level imported flow."""
 
-    def _flow_manager_with_parents(self, monkeypatch: pytest.MonkeyPatch, parents: dict[str, str]) -> None:
-        """Stub GriptapeNodes.FlowManager().get_parent_flow via the given name->parent mapping."""
+    def _flow_manager_with_parents(self, parents: dict[str, str]) -> Engine:
+        """Build a mock engine whose flow_manager.get_parent_flow resolves via the given name->parent mapping."""
         flow_manager = Mock(spec=FlowManager)
         flow_manager.get_parent_flow.side_effect = lambda flow: parents[flow]
-        monkeypatch.setattr(GriptapeNodes, "FlowManager", lambda: flow_manager)
+        engine = Mock(spec=Engine)
+        engine.flow_manager = flow_manager
+        return engine
 
-    def test_selects_flow_parented_to_import_target(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_selects_flow_parented_to_import_target(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
         # Top-level flow is parented to the target; the group's body flow is parented to the top-level.
-        self._flow_manager_with_parents(monkeypatch, {"ControlFlow_2": "ParentFlow", "Group_subflow": "ControlFlow_2"})
+        mock_engine = self._flow_manager_with_parents({"ControlFlow_2": "ParentFlow", "Group_subflow": "ControlFlow_2"})
 
         selected = workflow_manager._select_top_level_imported_flow(
-            {"ControlFlow_2", "Group_subflow"}, "ParentFlow", "grouped_inner_workflow"
+            {"ControlFlow_2", "Group_subflow"}, "ParentFlow", "grouped_inner_workflow", mock_engine
         )
 
         assert selected == "ControlFlow_2"
 
     def test_falls_back_deterministically_when_none_parented_to_target(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
-        self._flow_manager_with_parents(monkeypatch, {"Zeta_flow": "Other", "Alpha_flow": "Other"})
+        mock_engine = self._flow_manager_with_parents({"Zeta_flow": "Other", "Alpha_flow": "Other"})
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            selected = workflow_manager._select_top_level_imported_flow({"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf")
+            selected = workflow_manager._select_top_level_imported_flow(
+                {"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf", mock_engine
+            )
 
         # No flow parented to the target: deterministic sorted fallback, never hash-ordered.
         assert selected == "Alpha_flow"
@@ -4184,13 +4161,15 @@ class TestSelectTopLevelImportedFlow:
         ), f"expected a fallback warning, got: {[r.getMessage() for r in caplog.records]}"
 
     def test_falls_back_deterministically_when_multiple_parented_to_target(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
-        self._flow_manager_with_parents(monkeypatch, {"Zeta_flow": "ParentFlow", "Alpha_flow": "ParentFlow"})
+        mock_engine = self._flow_manager_with_parents({"Zeta_flow": "ParentFlow", "Alpha_flow": "ParentFlow"})
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            selected = workflow_manager._select_top_level_imported_flow({"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf")
+            selected = workflow_manager._select_top_level_imported_flow(
+                {"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf", mock_engine
+            )
 
         # More than one candidate parented to the target: deterministic sorted fallback.
         assert selected == "Alpha_flow"
@@ -4205,7 +4184,7 @@ class TestExecuteWorkflowImport:
 
     @pytest.mark.asyncio
     async def test_returns_top_level_imported_flow(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+        self, griptape_nodes: Engine, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
 
@@ -4222,11 +4201,11 @@ class TestExecuteWorkflowImport:
             {"ParentFlow": object()},
             {"ParentFlow": object(), "ControlFlow_2": object(), "Group_subflow": object()},
         ]
-        monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+        monkeypatch.setattr(griptape_nodes, "_object_manager", object_manager)
 
         # ContextManager().flow(...) is used purely as a context manager wrapping the import.
         context_manager = MagicMock(spec=ContextManager)
-        monkeypatch.setattr(GriptapeNodes, "ContextManager", lambda: context_manager)
+        monkeypatch.setattr(griptape_nodes, "_context_manager", context_manager)
 
         monkeypatch.setattr(
             workflow_manager,
@@ -4242,8 +4221,8 @@ class TestExecuteWorkflowImport:
 
         result = await workflow_manager._execute_workflow_import(request, workflow, "ParentFlow")
 
-        # It selects via the helper (passing the new-flows set, target flow, and workflow name)...
-        select_mock.assert_called_once_with({"ControlFlow_2", "Group_subflow"}, "ParentFlow", "wf")
+        # It selects via the helper (passing the new-flows set, target flow, workflow name, and engine)...
+        select_mock.assert_called_once_with({"ControlFlow_2", "Group_subflow"}, "ParentFlow", "wf", griptape_nodes)
         # ...and returns exactly what the helper chose.
         assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess)
         assert result.created_flow_name == "ControlFlow_2"

--- a/tests/unit/retained_mode/test_engine.py
+++ b/tests/unit/retained_mode/test_engine.py
@@ -1,0 +1,216 @@
+"""Tests for the Engine object graph and how the current engine is resolved.
+
+These pin the guarantees the refactor away from a process-wide singleton was for: engines
+are independent, managers are wired to the engine that built them, and the current engine
+can be rebound for a scope without leaking into the rest of the process.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from griptape_nodes.retained_mode.engine import (
+    Engine,
+    EngineScoped,
+    current_engine,
+    engine_scope,
+    has_current_engine,
+    reset_root_engine,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class TestEngineIndependence:
+    def test_engines_do_not_share_managers(self) -> None:
+        first = Engine()
+        second = Engine()
+
+        assert first.object_manager is not second.object_manager
+        assert first.event_manager is not second.event_manager
+        assert first.flow_manager is not second.flow_manager
+
+    def test_managers_are_wired_to_their_own_engine(self) -> None:
+        first = Engine()
+        second = Engine()
+
+        assert first.flow_manager.engine is first
+        assert second.flow_manager.engine is second
+
+    def test_every_engine_scoped_manager_is_bound(self) -> None:
+        """No manager should be left resolving the engine through the module-level fallback."""
+        engine = Engine()
+
+        unbound = [
+            name
+            for name in dir(Engine)
+            if name.endswith("_manager")
+            and isinstance(manager := getattr(engine, name), EngineScoped)
+            and manager._engine is not engine
+        ]
+
+        assert unbound == []
+
+    def test_object_registered_in_one_engine_is_invisible_to_the_other(self) -> None:
+        first = Engine()
+        second = Engine()
+
+        first.object_manager.add_object_by_name("shared_name", object())
+
+        assert first.object_manager.has_object_with_name("shared_name")
+        assert not second.object_manager.has_object_with_name("shared_name")
+
+
+class TestEngineScopedFallback:
+    def test_manager_built_without_an_engine_falls_back_to_the_current_engine(self) -> None:
+        scoped = EngineScoped()
+
+        assert scoped.engine is current_engine()
+
+    def test_manager_built_with_an_engine_ignores_the_current_engine(self) -> None:
+        explicit = Engine()
+        scoped = EngineScoped(explicit)
+
+        assert scoped.engine is explicit
+        assert scoped.engine is not current_engine()
+
+
+class TestEngineScope:
+    def test_scope_binds_and_restores(self) -> None:
+        root = current_engine()
+        scoped = Engine()
+
+        with engine_scope(scoped) as bound:
+            assert bound is scoped
+            assert current_engine() is scoped
+
+        assert current_engine() is root
+
+    def test_scope_without_an_argument_builds_a_fresh_engine(self) -> None:
+        root = current_engine()
+
+        with engine_scope() as bound:
+            assert bound is not root
+            assert current_engine() is bound
+
+        assert current_engine() is root
+
+    def test_scopes_nest_and_unwind_in_order(self) -> None:
+        outer = Engine()
+        inner = Engine()
+
+        with engine_scope(outer):
+            assert current_engine() is outer
+            with engine_scope(inner):
+                assert current_engine() is inner
+            assert current_engine() is outer
+
+    def test_scope_restores_when_the_body_raises(self) -> None:
+        root = current_engine()
+
+        def explode() -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="boom"), engine_scope(Engine()):
+            explode()
+
+        assert current_engine() is root
+
+    def test_facade_follows_the_scoped_engine(self) -> None:
+        """The `GriptapeNodes` facade must resolve the scoped engine, not the root."""
+        scoped = Engine()
+
+        with engine_scope(scoped):
+            assert GriptapeNodes() is scoped
+            assert GriptapeNodes.get_instance() is scoped
+            assert GriptapeNodes.FlowManager() is scoped.flow_manager
+            assert GriptapeNodes.ObjectManager() is scoped.object_manager
+
+    @pytest.mark.asyncio
+    async def test_task_created_inside_the_scope_inherits_the_binding(self) -> None:
+        """Asyncio tasks copy the context at creation, so work spawned in a scope stays bound."""
+        scoped = Engine()
+
+        async def read_engine() -> Engine:
+            await asyncio.sleep(0)
+            return current_engine()
+
+        with engine_scope(scoped):
+            task = asyncio.create_task(read_engine())
+            observed = await task
+
+        assert observed is scoped
+
+    @pytest.mark.asyncio
+    async def test_scope_survives_an_await_in_its_body(self) -> None:
+        """Entering and exiting around an await must not trip the ContextVar token reset."""
+        root = current_engine()
+        scoped = Engine()
+
+        with engine_scope(scoped):
+            await asyncio.sleep(0)
+            assert current_engine() is scoped
+
+        assert current_engine() is root
+
+    @pytest.mark.asyncio
+    async def test_concurrent_tasks_can_hold_different_engines(self) -> None:
+        """The point of a ContextVar: two concurrent flows of control, two engines."""
+        first = Engine()
+        second = Engine()
+
+        async def observe(engine: Engine) -> Engine:
+            with engine_scope(engine):
+                await asyncio.sleep(0)
+                return current_engine()
+
+        observed = await asyncio.gather(observe(first), observe(second))
+
+        assert observed == [first, second]
+
+
+class TestRootEngine:
+    def test_root_engine_is_cached(self) -> None:
+        assert current_engine() is current_engine()
+
+    def test_reset_root_engine_builds_a_fresh_one(self) -> None:
+        first = current_engine()
+        reset_root_engine()
+
+        assert current_engine() is not first
+
+    def test_has_current_engine_does_not_build_one(self) -> None:
+        reset_root_engine()
+
+        assert has_current_engine() is False
+
+        current_engine()
+
+        assert has_current_engine() is True
+
+    def test_has_current_engine_is_true_inside_a_scope(self) -> None:
+        reset_root_engine()
+
+        with engine_scope(Engine()):
+            assert has_current_engine() is True
+
+    def test_racing_threads_share_one_root_engine(self) -> None:
+        """The lazy build is locked, so a cold start under load cannot orphan an engine."""
+        racer_count = 8
+        reset_root_engine()
+        observed: list[Engine] = []
+        start = threading.Barrier(racer_count)
+
+        def resolve() -> None:
+            start.wait()
+            observed.append(current_engine())
+
+        threads = [threading.Thread(target=resolve) for _ in range(racer_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(observed) == racer_count
+        assert all(engine is observed[0] for engine in observed)

--- a/tests/unit/retained_mode/test_engine_heartbeat.py
+++ b/tests/unit/retained_mode/test_engine_heartbeat.py
@@ -12,7 +12,7 @@ from griptape_nodes.retained_mode.events.app_events import (
 )
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestEngineHeartbeatOrchestratorId:
@@ -23,7 +23,7 @@ class TestEngineHeartbeatOrchestratorId:
     identify a worker engine and nest it under its orchestrator.
     """
 
-    def test_orchestrator_reports_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_orchestrator_reports_none(self, griptape_nodes: Engine) -> None:
         # No GTN_ORCHESTRATOR_ENGINE_ID in the environment -> this engine IS the orchestrator.
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("GTN_ORCHESTRATOR_ENGINE_ID", None)
@@ -32,7 +32,7 @@ class TestEngineHeartbeatOrchestratorId:
         assert isinstance(result, EngineHeartbeatResultSuccess)
         assert result.orchestrator_engine_id is None
 
-    def test_worker_reports_spawning_orchestrator_id(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_worker_reports_spawning_orchestrator_id(self, griptape_nodes: Engine) -> None:
         # A worker process is spawned with GTN_ORCHESTRATOR_ENGINE_ID set to its parent's id;
         # the heartbeat echoes it so the client can nest this worker under that orchestrator.
         with patch.dict(os.environ, {"GTN_ORCHESTRATOR_ENGINE_ID": "eng-orchestrator"}):


### PR DESCRIPTION
 ## Problem

 "Engine" is a loosely defined term that roughly means the singleton `GriptapeNodes`. Being a singleton causes three problems:

 - We can't instantiate a second one without a second process.
 - Cross-referencing managers through the singleton forces circular imports. Managers reach peers via `GriptapeNodes.FooManager()`, but `GriptapeNodes` imports the managers, so 22 of those call sites had to be lazy in-function imports to break the cycle.
 - Global state leaks between tests. Isolation depended on reaching into `SingletonMeta._instances` and clearing it, which also missed registries keeping state in `ClassVars`, so those needed a second manual reset.

 ## Solution

 A new Engine class owns the manager graph `GriptapeNodes` used to own, and injects itself into each manager. Managers resolve peers through `self.engine.foo_manager` instead of a global lookup, which breaks the import cycle and lets all 22 lazy imports go away.

 `GriptapeNodes` stays as the process-wide facade. It holds no state itself: it resolves the current engine (a module-level root in `engine.py`, overridable for a scope via a `ContextVar`) and forwards to it.

 Consumers that own their process, like the app, can construct and manage Engine instances directly, so multiple engines no longer need process-level isolation (except for libraries).
