### PR TITLE
docs: advise against BlobArtifacts

### DIFF
--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -531,6 +531,7 @@ ParameterImage(
 
 **Benefits:**
 
+- Declares `ImageUrlArtifact` instead of `ImageArtifact`, keeping the parameter's value small — see [Parameter Payload Size](error_handling.md#parameter-payload-size)
 - Handles ImageArtifact, ImageUrlArtifact, and strings consistently
 - Built-in support for URLs, file paths, and data URIs
 - Graceful error handling for various input formats

--- a/docs/development/custom_nodes/error_handling.md
+++ b/docs/development/custom_nodes/error_handling.md
@@ -39,6 +39,23 @@ class MyNode(DataNode):
 - Define `API_KEY_NAME` as a class constant for consistency
 - Always validate that the secret exists before using it
 
+### Parameter Payload Size
+
+A parameter value can end up fully embedded in two places:
+
+- **Saved workflow files.** The workflow serializer writes unique parameter values inline into the saved `.py` file, with no size limit — whatever Python state the value holds gets written out whole.
+- **WebSocket events.** Parameter values traveling in request/response events are serialized and sent to every connected client (the editor UI, the MCP server).
+
+Neither path checks the size of the value first, so by default a large value bloats both the saved workflow file and the traffic to every connected client. Store large binary data (images, audio, video, 3D assets, model weights) by reference — a file path or URL — rather than inlining the bytes, wherever the node's underlying API allows it.
+
+`Parameter(serializable=False)` (see [Parameter Attributes](parameters.md#parameter-attributes)) covers **only the first path**. It keeps a value out of saved workflow files — the right choice for values that should never persist, such as drivers, file handles, and large transient buffers — but it has no effect on the second: the value is still sent to every connected client. There is no per-parameter opt-out of the WebSocket path, so keeping the value small is the only lever you have over it.
+
+!!! warning "Keep parameter values small"
+
+    `griptape.artifacts.BlobArtifact` stores raw bytes, and `ImageArtifact` / `AudioArtifact` both subclass it — so a node using one of these as a parameter type sends the entire byte payload to every connected client, and writes it into saved workflows unless the parameter is declared `serializable=False`. Use `ImageUrlArtifact` / `AudioUrlArtifact` instead (the `ParameterImage` / `ParameterAudio` helper classes enforce them — see [Parameters](parameters.md#parameterimage-recommended-for-image-parameters)), which hold only a short URL string no matter how large the file they point to is.
+
+    Raw bytes aren't confined to `BlobArtifact` and its subclasses — `ThreeDArtifact` holds them too (though does not send its bytes over the WebSocket). Judge a parameter by the size of the value it will actually hold, not by whether its type name looks safe.
+
 ### Import Best Practices
 
 **Always import dependencies at module level, not inside functions:**

--- a/docs/development/custom_nodes/examples.md
+++ b/docs/development/custom_nodes/examples.md
@@ -685,6 +685,8 @@ def _poll_for_completion(self, task_id: str, api_key: str) -> dict[str, Any]:
 
 ## Flexible Artifact Processing
 
+The patterns below handle values that may still arrive as `ImageArtifact` from older workflows or upstream nodes — they're runtime input handling, not a template for declaring new parameters. New parameters should declare `ImageUrlArtifact` (see [Parameter Payload Size](error_handling.md#parameter-payload-size)).
+
 ### Duck Typing for Artifacts
 
 Handle multiple artifact formats gracefully:

--- a/docs/development/custom_nodes/execution_and_lifecycle.md
+++ b/docs/development/custom_nodes/execution_and_lifecycle.md
@@ -263,6 +263,8 @@ This avoids requiring image inputs when the user wants text-only generation, and
 
 ### Image Artifact Conversion to Base64
 
+The `ImageArtifact` branch below exists to keep working with values that may still arrive from older saved workflows or upstream nodes that haven't been updated. New parameters should declare `ImageUrlArtifact` (via `ParameterImage`) rather than `ImageArtifact` — see [Parameter Payload Size](error_handling.md#parameter-payload-size).
+
 **CRITICAL: Localhost URL Handling**
 
 When sending images to external APIs, ImageUrlArtifact URLs from static storage are localhost and inaccessible to external services. Always detect and convert localhost URLs to base64:
@@ -360,8 +362,8 @@ def _get_image_data(self, image_artifact: ImageArtifact | ImageUrlArtifact) -> s
 ```python
 Parameter(
     name="image_input",
-    input_types=["ImageArtifact", "ImageUrlArtifact"],  # Accept both
-    type="ImageArtifact",
+    input_types=["ImageUrlArtifact", "ImageArtifact"],  # ImageArtifact: legacy input compatibility only
+    type="ImageUrlArtifact",
     tooltip="Image input (file or URL)",
     ui_options={"clickable_file_browser": True},  # Enable file browser
 )
@@ -369,7 +371,7 @@ Parameter(
 
 ### Multi-Image Input Validation
 
-When nodes accept multiple image parameters, use a reusable validation method with clear parameter identification:
+When nodes accept multiple image parameters, use a reusable validation method with clear parameter identification. As above, the `ImageArtifact` branch is legacy-input handling, not a reason to declare new parameters against `ImageArtifact`:
 
 ```python
 def _validate_image(self, image_artifact: ImageArtifact | ImageUrlArtifact, param_name: str) -> list[Exception]:

--- a/docs/development/custom_nodes/index.md
+++ b/docs/development/custom_nodes/index.md
@@ -104,7 +104,7 @@ class MyNode(DataNode):
 - **[Parameter UI Reference](parameter_ui_reference.md)** — Parameter type to widget mapping, supported `ui_options` keys, and traits
 - **[Execution and Lifecycle](execution_and_lifecycle.md)** — Lifecycle callbacks and asynchronous API integration patterns
 - **[Working with the Project System](project_system.md)** — Saving files through situations, macros, and `ProjectFileParameter`
-- **[Best Practices and Error Handling](error_handling.md)** — Secrets, imports, validation, error handling, and logging
+- **[Best Practices and Error Handling](error_handling.md)** — Secrets, imports, parameter payload size, validation, error handling, and logging
 - **[Authoring Libraries](authoring_libraries.md)** — Library manifests, declarations, dependency management, and contributing to the standard library
 - **[Custom Widgets](custom_widgets.md)** — Custom JavaScript widget components and the widget testbed
 - **[Patterns and Examples](examples.md)** — Advanced patterns from production nodes and quick-reference material

--- a/docs/development/custom_nodes/parameter_ui_reference.md
+++ b/docs/development/custom_nodes/parameter_ui_reference.md
@@ -2,7 +2,7 @@
 
 This page maps what you declare on a `Parameter` in Python to what the editor renders for it. Three things determine a parameter's UI:
 
-1. **The parameter's `type`** selects the widget: `str` gets a text field, `bool` gets a toggle, `ImageArtifact` gets the image viewer, and so on.
+1. **The parameter's `type`** selects the widget: `str` gets a text field, `bool` gets a toggle, `ImageUrlArtifact` gets the image viewer, and so on.
 1. **`ui_options`** tweaks that widget: hide it, stretch it full-width, make a text field multiline, add a webcam capture button.
 1. **Traits** bundle UI and behavior together: `Slider` renders a slider *and* validates the range, `Options` renders a dropdown *and* constrains the value to its choices. Under the hood, a trait writes its own keys into `ui_options` — traits are the supported way to get those keys right.
 
@@ -35,7 +35,7 @@ For each parameter, the editor picks a widget in this order:
 | `button`                                                                                                                                                                                       | Clickable button (configure with the `Button` trait)                                                                         |
 | `Status`                                                                                                                                                                                       | Status/message block                                                                                                         |
 | `UrlArtifact`                                                                                                                                                                                  | URL display                                                                                                                  |
-| `ImageArtifact` / `ImageUrlArtifact`, `VideoArtifact` / `VideoUrlArtifact`, `AudioArtifact` / `AudioUrlArtifact`, `ThreeDArtifact` / `ThreeDUrlArtifact`, `SplatArtifact` / `SplatUrlArtifact` | The media viewers and editors — see [Media Viewers and Editors](../../guides/editor/media_editors.md) for what each one does |
+| `ImageUrlArtifact` / `ImageArtifact`, `VideoUrlArtifact` / `VideoArtifact`, `AudioUrlArtifact` / `AudioArtifact`, `ThreeDUrlArtifact` / `ThreeDArtifact`, `SplatUrlArtifact` / `SplatArtifact` | The media viewers and editors — see [Media Viewers and Editors](../../guides/editor/media_editors.md) for what each one does |
 | anything else                                                                                                                                                                                  | No inline widget; label and connection handles only                                                                          |
 
 `GLTFArtifact` / `GLTFUrlArtifact` still render (as the 3D viewer) for backward compatibility; use the `ThreeD` types in new nodes.

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -116,6 +116,8 @@ They exist to make common parameter patterns **simple, consistent, and runtime-m
 - Built-in UI options for file browser, webcam capture, and mask editing
 - Consistent behavior across all image-handling nodes
 
+This also keeps parameter values small: `ImageUrlArtifact` holds a short URL string, while the generic alternative `ImageArtifact` inlines the image's entire byte payload into WebSocket traffic, and into saved workflows unless the parameter is declared `serializable=False` — see [Parameter Payload Size](error_handling.md#parameter-payload-size).
+
 **Basic Usage:**
 
 ```python
@@ -218,6 +220,7 @@ self.add_parameter(
 
 **Why `ParameterImage` is better:**
 
+- **Small parameter values:** Declares `ImageUrlArtifact`, not `ImageArtifact` — see [Parameter Payload Size](error_handling.md#parameter-payload-size)
 - **Standardized type conversion logic:** Handles ImageArtifact, ImageUrlArtifact, and string inputs consistently
 - **Built-in UI features:** File browser, webcam capture, mask editing
 - **Less boilerplate:** Automatically configures types and options
@@ -243,6 +246,9 @@ self.add_parameter(
 - Enforce their corresponding `*UrlArtifact` `type` / `output_type` (e.g., `AudioUrlArtifact`, `VideoUrlArtifact`, `ThreeDUrlArtifact`).
 - These helpers primarily provide UI options (file browser / capture / editing / expanders). If you need coercion from e.g. `str` → artifact, supply `converters` and/or handle it in your node's `before_value_set()` / `process()` logic.
 - Follow the same patterns as `ParameterImage` for these media types.
+- **Audio:** `ParameterAudio` matters for payload size the same way `ParameterImage` does — `AudioArtifact` (the generic alternative) inlines its entire byte payload into WebSocket traffic, and into saved workflows unless the parameter is declared `serializable=False`; `AudioUrlArtifact` holds only a short URL. See [Parameter Payload Size](error_handling.md#parameter-payload-size).
+- **Video:** there is no raw-bytes `VideoArtifact` class, so that name carries no payload-size risk. Declare `VideoUrlArtifact` in new nodes — it's the type actually produced, and connection type-checking matches type names exactly, so `"VideoArtifact"` and `"VideoUrlArtifact"` are *not* interchangeable. Some libraries list both in `input_types` to accept either spelling.
+- **3D:** `ThreeDArtifact` holds raw bytes too, so prefer `ThreeDUrlArtifact` (which `Parameter3D` enforces). See [Parameter Payload Size](error_handling.md#parameter-payload-size).
 
 #### `ParameterButton`
 
@@ -536,18 +542,31 @@ Parameter(
 )
 ```
 
-### File Upload with Browser
+### File Path with Browser
+
+To let the user pick a file or directory from disk, add the `FileSystemPicker` trait to a `str` parameter. The parameter's value is the chosen path:
 
 ```python
+from griptape_nodes.traits.file_system_picker import FileSystemPicker
+
 Parameter(
-    name="image",
-    input_types=["ImageArtifact", "ImageUrlArtifact", "str"],
-    type="ImageArtifact",
-    tooltip="Input image file",
+    name="config_path",
+    type="str",
+    tooltip="Path to the configuration file",
     allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-    ui_options={"clickable_file_browser": True},
+    traits={
+        FileSystemPicker(
+            allow_files=True,
+            allow_directories=False,
+            file_extensions=[".json", ".yaml"],
+        )
+    },
 )
 ```
+
+`FileSystemPicker` defaults to directories only, so pass `allow_files=True` when you want a file picker. It also supports `multiple`, `workspace_only`, size limits, and include/exclude patterns — see [Parameter UI Reference](parameter_ui_reference.md#traits).
+
+Media parameters work differently. `ParameterImage`, `ParameterAudio`, `ParameterVideo`, and `Parameter3D` each provide their own click-to-browse upload in the media viewer (`clickable_file_browser`, on by default), and the picked file is uploaded and handed to your node as a `*UrlArtifact` rather than a path string. Reach for those helpers for media instead of a `str` path — see [`ParameterImage`](#parameterimage-recommended-for-image-parameters) above.
 
 ## Advanced Parameter Patterns
 
@@ -605,6 +624,8 @@ One consequence of always-replace: a replaced parameter's stored *property* valu
 #### Walkthrough — Multi-model image generation (hypothetical)
 
 > **Note on this example.** The `MultiModelImageGenerator` node used below is **hypothetical** — it does not exist in Griptape today, and this walkthrough is not a description of how any shipped node works. We use a hypothetical consolidated node here because it's the kind of node an author might build *on top of* `ParameterTransitionComponent`, and it makes the "switching between shapes" story concrete for an artist audience.
+>
+> It illustrates the mechanics of type narrowing, not a recommendation about parameter types. `reference_image` is typed `ImageArtifact` below purely because it makes the SDXL-vs-SD3 signature change easy to follow. A real node would declare `ImageUrlArtifact` — see [Parameter Payload Size](error_handling.md#parameter-payload-size).
 
 **The hypothetical node.** `MultiModelImageGenerator` has a **Model** dropdown offering **FLUX**, **SDXL**, and **Stable Diffusion 3**, plus a "— none —" option for an unconfigured starting state. Every model shares some parameters; each has its own extras. Here's the parameter surface per model:
 
@@ -718,19 +739,19 @@ The component manages individual parameters by name. If your dynamic surface use
 
 ### Advanced ParameterList Usage
 
-Include both individual and list types for maximum flexibility:
+Include both individual and list types for maximum flexibility. `ImageArtifact` entries here are for accepting connections from older workflows only — declare new list parameters against `ImageUrlArtifact` (see [Parameter Payload Size](error_handling.md#parameter-payload-size)):
 
 ```python
 self.add_parameter(
     ParameterList(
         name="images",
         input_types=[
-            "ImageArtifact",
             "ImageUrlArtifact",
+            "ImageArtifact",  # legacy input compatibility only
             "str",
             "list",
-            "list[ImageArtifact]",
             "list[ImageUrlArtifact]",
+            "list[ImageArtifact]",  # legacy input compatibility only
         ],
         default_value=[],
         tooltip="Input images (up to 10 images total)",

--- a/docs/nodes/audio/microphone.md
+++ b/docs/nodes/audio/microphone.md
@@ -24,7 +24,7 @@ Use this node when you want to:
 
 ### Parameters
 
-- **audio**: The captured audio output (AudioArtifact)
+- **audio**: The captured audio output (AudioUrlArtifact)
 
 ### Outputs
 
@@ -44,7 +44,7 @@ A simple workflow to record and transcribe audio:
 - The node requires microphone permissions in your browser
 - Audio is captured in real-time
 - The quality of the recording depends on your microphone and system settings
-- The node supports various audio formats through the AudioArtifact interface
+- Whatever format your browser records in, the capture is saved to a file and output as an AudioUrlArtifact
 
 ## Common Issues
 

--- a/docs/nodes/image/create_image.md
+++ b/docs/nodes/image/create_image.md
@@ -29,7 +29,7 @@ Use the GenerateImage node when:
 
 ### Outputs
 
-- **output**: The generated image as an ImageArtifact
+- **output**: The generated image as an ImageUrlArtifact
 
 ## Example
 

--- a/docs/nodes/image/load_image.md
+++ b/docs/nodes/image/load_image.md
@@ -43,4 +43,4 @@ Imagine you've created an image with the CreateImage and now want to use it else
 ## Common Issues
 
 - **No Image Showing**: Make sure you've properly connected an image source to this node
-- **Wrong Image Type**: Make sure you're connecting an ImageArtifact or BlobArtifact to this node
+- **Wrong Image Type**: Make sure you're connecting an ImageUrlArtifact, ImageArtifact, or string path/URL to this node

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,7 +175,7 @@ plugins:
           - development/custom_nodes/parameter_ui_reference.md: Parameter type to widget mapping, supported ui_options keys, and traits
           - development/custom_nodes/execution_and_lifecycle.md: Lifecycle callbacks and asynchronous API integration patterns
           - development/custom_nodes/project_system.md: Saving files from nodes through the project system (situations, macros, ProjectFileParameter)
-          - development/custom_nodes/error_handling.md: Best practices for secrets, imports, validation, error handling, and logging
+          - development/custom_nodes/error_handling.md: Best practices for secrets, imports, parameter payload size, validation, error handling, and logging
           - development/custom_nodes/authoring_libraries.md: Library manifests, declarations, dependency management, and contributing to the standard library
           - development/custom_nodes/custom_widgets.md: Custom JavaScript widget components and the widget testbed
           - development/custom_nodes/examples.md: Advanced patterns from production nodes and quick-reference material


### PR DESCRIPTION
Closes #5177.

When a human or agent uses the docs for best practices when writing new nodes, the docs often promoted making use of `ImageArtifact` or `AudioArtifact`, which are derived from `BlobArtifact`, and serialise to large payloads over websocket, potentially breaking the connection.

So update the advice to promote use of `*UrlArtifact`s instead. Add a section to best practices (error_handling.md) explaining the two serialization paths (workflow vs. wire) and why blobs should be avoided; then link to that section in various places.

Also update the docs for some of the standard library nodes to recommend against blob parameter types - some of which was stale anyway.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5241.org.readthedocs.build/en/5241/

<!-- readthedocs-preview griptape-nodes end -->