### PR TITLE
Optimize workflow registration for speed

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2068,13 +2068,15 @@ class WorkflowManager:
     async def register_list_of_workflows(self, workflows_to_register: list[str]) -> None:
         await self._process_workflows_for_registration(workflows_to_register)
 
-    async def _register_workflow(self, workflow_to_register: str) -> bool:
+    def _register_workflow(self, workflow_to_register: str, workflow_metadata: WorkflowMetadata) -> bool:
         """Registers a workflow from a file.
 
         Args:
-            config_mgr: The ConfigManager instance to use for path resolution.
-            workflow_mgr: The WorkflowManager instance to use for workflow registration.
             workflow_to_register: The path to the workflow file to register.
+            workflow_metadata: Metadata already loaded from that file by the caller.
+                Passed in rather than re-read here: loading it parses the file's TOML
+                header, and the caller has to do that anyway to decide the file is
+                registerable, so re-reading would parse every workflow twice.
 
         Returns:
             bool: True if the workflow was successfully registered, False otherwise.
@@ -2083,22 +2085,6 @@ class WorkflowManager:
         # However, the table of WorkflowInfo DOES get updated in this request, which may present a confusing state of affairs to the user.
         # On one hand, we want the user to know how a specific workflow fared, but also not let them think it was registered when it wasn't.
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/996
-
-        # Attempt to extract the metadata out of the workflow.
-        load_metadata_request = LoadWorkflowMetadata(file_name=str(workflow_to_register))
-        load_metadata_result = await self.on_load_workflow_metadata_request(load_metadata_request)
-        if not load_metadata_result.succeeded():
-            # SKIP IT
-            return False
-
-        if not isinstance(load_metadata_result, LoadWorkflowMetadataResultSuccess):
-            err_str = (
-                f"Attempted to register workflow '{workflow_to_register}', but failed to extract metadata. SKIPPING IT."
-            )
-            logger.error(err_str)
-            return False
-
-        workflow_metadata = load_metadata_result.metadata
 
         # Prepend the image paths appropriately.
         if workflow_metadata.image is not None:
@@ -6694,10 +6680,9 @@ class WorkflowManager:
             logger.debug("Skipping already registered workflow: %s", workflow_file)
             return None
 
-        # Register workflow using existing method with parsed metadata available
-        # The _register_workflow method will re-parse metadata, but this is acceptable
-        # since we've already validated it's parseable and the duplicate work is minimal
-        if await self._register_workflow(file_path_to_register):
+        # Hand the already-parsed metadata to the registrar so the file's TOML header is
+        # read once per workflow rather than twice.
+        if self._register_workflow(file_path_to_register, load_metadata_result.metadata):
             return registry_key
         return None
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -6,6 +6,7 @@ import logging
 import pickle
 import re
 import sys
+import tomllib
 from collections import defaultdict
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import UTC, datetime
@@ -1816,9 +1817,13 @@ class WorkflowManager:
             for line in matches[0].group("content").splitlines(keepends=True)
         )
 
+        # tomllib, not tomlkit: this is a read-only path, and tomlkit builds a
+        # formatting-preserving document model that costs ~20x more per header. Only the
+        # save path (_generate_workflow_metadata_header) needs tomlkit, to keep the
+        # formatting of headers it rewrites.
         try:
-            toml_doc = tomlkit.parse(metadata_content_toml)
-        except Exception as err:
+            toml_doc = tomllib.loads(metadata_content_toml)
+        except tomllib.TOMLDecodeError as err:
             self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
                 status=WorkflowManager.WorkflowStatus.UNUSABLE,
                 workflow_path=str_path,
@@ -1832,8 +1837,8 @@ class WorkflowManager:
         tool_header = "tool"
         griptape_nodes_header = "griptape-nodes"
         try:
-            griptape_nodes_tool_section = toml_doc[tool_header][griptape_nodes_header]  # type: ignore (this is the only way I could find to get tomlkit to do the dotted notation correctly)
-        except Exception as err:
+            griptape_nodes_tool_section = toml_doc[tool_header][griptape_nodes_header]
+        except (KeyError, TypeError) as err:
             self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
                 status=WorkflowManager.WorkflowStatus.UNUSABLE,
                 workflow_path=str_path,

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2086,15 +2086,6 @@ class WorkflowManager:
         # On one hand, we want the user to know how a specific workflow fared, but also not let them think it was registered when it wasn't.
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/996
 
-        # Prepend the image paths appropriately.
-        if workflow_metadata.image is not None:
-            if workflow_metadata.is_griptape_provided:
-                workflow_metadata.image = workflow_metadata.image
-            else:
-                # For user workflows, the image should be just the filename, not a full path
-                # The frontend now sends just filenames, so we don't need to prepend the workspace path
-                workflow_metadata.image = workflow_metadata.image
-
         # Register it as a success.
         workflow_register_request = RegisterWorkflowRequest(
             metadata=workflow_metadata, file_name=str(workflow_to_register)

--- a/src/griptape_nodes/utils/file_utils.py
+++ b/src/griptape_nodes/utils/file_utils.py
@@ -7,11 +7,11 @@ import os
 import tempfile
 from dataclasses import dataclass
 from fnmatch import fnmatch
+from functools import partial
 from pathlib import Path
 
 import anyio
-
-from griptape_nodes.utils.async_utils import to_thread
+import anyio.to_thread
 
 logger = logging.getLogger(__name__)
 
@@ -223,8 +223,17 @@ async def _arecurse_find(path: Path, depth: int, params: _AsyncWalkParams) -> No
 
     max_depth is what bounds a symlink loop, so there is no visited-set.
     """
+    # abandon_on_cancel: a cancelled await returns immediately instead of waiting for the
+    # in-flight scandir, which is what makes the timeout above a real bound -- on a hung
+    # mount, waiting for the thread would leave discovery unbounded. Safe here because the
+    # scan is read-only; the shielding in async_utils.to_thread exists to protect a
+    # partially-completed write, which this is not. run_sync is positional-only, hence the
+    # partial for the keyword argument.
     try:
-        entries = await to_thread(_scan_directory, path, skip_hidden=params.skip_hidden)
+        entries = await anyio.to_thread.run_sync(
+            partial(_scan_directory, path, skip_hidden=params.skip_hidden),
+            abandon_on_cancel=True,
+        )
     except (PermissionError, OSError) as e:
         logger.debug("Cannot access directory %s: %s", path, e)
         return

--- a/src/griptape_nodes/utils/file_utils.py
+++ b/src/griptape_nodes/utils/file_utils.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import anyio
 
+from griptape_nodes.utils.async_utils import to_thread
+
 logger = logging.getLogger(__name__)
 
 # Fallback ceiling on how deep recursive discovery walks, used only when the
@@ -154,7 +156,7 @@ def find_all_files_in_directory(directory: Path, pattern: str) -> list[Path]:
 
 @dataclass
 class _AsyncWalkParams:
-    """Immutable walk settings shared across recursion levels of the async finder."""
+    """Immutable walk settings shared across recursion levels of the finder."""
 
     pattern: str
     skip_hidden: bool
@@ -163,39 +165,46 @@ class _AsyncWalkParams:
     matches: list[Path]
 
 
-async def _arecurse_find(path: anyio.Path, depth: int, params: _AsyncWalkParams) -> None:
-    """Depth-bounded async walk that appends matching files into ``params.matches``.
+def _recurse_find(path: Path, depth: int, params: _AsyncWalkParams) -> None:
+    """Depth-bounded walk that appends matching files into ``params.matches``.
 
-    Manual recursion via iterdir, because anyio.Path.rglob cannot express a
-    max_depth limit.
+    Uses os.scandir rather than Path.iterdir + is_file/is_dir: scandir carries the
+    entry type along with the directory read, so classifying an entry costs no extra
+    stat call. The previous per-entry await pair dispatched two thread hops per entry,
+    which dominated boot-time discovery on large trees.
+
+    Symlinked directories are followed (matching the DirEntry.is_dir default), because
+    a workspace may reach its libraries or workflows through a link. max_depth is what
+    bounds a symlink loop, so there is no visited-set.
     """
     try:
-        entries = [entry async for entry in path.iterdir()]
+        with os.scandir(path) as scan:
+            entries = sorted(scan, key=lambda entry: entry.name)
     except (PermissionError, OSError) as e:
         logger.debug("Cannot access directory %s: %s", path, e)
         return
 
-    for item in sorted(entries):
+    for item in entries:
         if params.max_files is not None and len(params.matches) >= params.max_files:
             return
         if params.skip_hidden and item.name.startswith("."):
             continue
 
-        # is_file/is_dir stat the entry, which can raise on protected paths
-        # (e.g. macOS system caches). Skip the offending entry rather than
-        # aborting the whole directory.
+        # is_file/is_dir may still stat when the entry is a symlink, which can raise on
+        # protected paths (e.g. macOS system caches). Skip the offending entry rather
+        # than aborting the whole directory.
         try:
-            item_is_file = await item.is_file()
-            item_is_dir = await item.is_dir()
+            item_is_file = item.is_file()
+            item_is_dir = item.is_dir()
         except (PermissionError, OSError) as e:
-            logger.debug("Cannot access entry %s: %s", item, e)
+            logger.debug("Cannot access entry %s: %s", item.path, e)
             continue
 
         if item_is_file:
             if fnmatch(item.name, params.pattern):
-                params.matches.append(Path(item))
+                params.matches.append(Path(item.path))
         elif item_is_dir and depth < params.max_depth:
-            await _arecurse_find(item, depth + 1, params)
+            _recurse_find(Path(item.path), depth + 1, params)
 
 
 async def find_files_recursive(
@@ -207,8 +216,8 @@ async def find_files_recursive(
 ) -> list[Path]:
     """Asynchronously search directory recursively for files matching pattern.
 
-    Depth-bounded async finder suitable for the engine boot path: it walks via
-    anyio so it yields to the event loop instead of blocking it, and the
+    Depth-bounded finder suitable for the engine boot path: the whole walk runs in a
+    single worker thread so it never blocks the event loop, and the
     `discovery_max_depth` setting bounds recursion so a pathologically deep tree
     or symlink loop can't stall startup.
 
@@ -238,7 +247,11 @@ async def find_files_recursive(
         max_files=max_files,
         matches=matches,
     )
-    await _arecurse_find(anyio.Path(directory), 0, params)
+    # One thread hop for the entire walk. Offloading per-entry instead (the anyio.Path
+    # approach) cost two hops per directory entry, which is what made discovery slow.
+    # _resolve_discovery_max_depth is read above, on the event loop, so the thread does
+    # nothing but filesystem work.
+    await to_thread(_recurse_find, Path(directory), 0, params)
 
     if not matches:
         logger.debug("No files matching pattern '%s' found in directory: %s", pattern, directory)

--- a/src/griptape_nodes/utils/file_utils.py
+++ b/src/griptape_nodes/utils/file_utils.py
@@ -156,7 +156,7 @@ def find_all_files_in_directory(directory: Path, pattern: str) -> list[Path]:
 
 @dataclass
 class _AsyncWalkParams:
-    """Immutable walk settings shared across recursion levels of the finder."""
+    """Immutable walk settings shared across recursion levels of the async finder."""
 
     pattern: str
     skip_hidden: bool
@@ -165,21 +165,66 @@ class _AsyncWalkParams:
     matches: list[Path]
 
 
-def _recurse_find(path: Path, depth: int, params: _AsyncWalkParams) -> None:
-    """Depth-bounded walk that appends matching files into ``params.matches``.
+@dataclass(frozen=True)
+class _ScannedEntry:
+    """One directory entry, classified while its ``scandir`` iterator was still open.
+
+    A ``DirEntry``'s cached stat is tied to the ``scandir`` iterator that produced it,
+    so it cannot outlive the ``with`` block. Copying the three fields the walk needs
+    lets the classification happen in the worker thread while the recursion stays on
+    the event loop.
+    """
+
+    name: str
+    path: str
+    is_file: bool
+    is_dir: bool
+
+
+def _scan_directory(path: Path, *, skip_hidden: bool) -> list[_ScannedEntry]:
+    """List one directory, classifying each entry, for a single thread hop.
 
     Uses os.scandir rather than Path.iterdir + is_file/is_dir: scandir carries the
     entry type along with the directory read, so classifying an entry costs no extra
-    stat call. The previous per-entry await pair dispatched two thread hops per entry,
-    which dominated boot-time discovery on large trees.
+    stat call. Hidden entries are dropped here so they are never classified.
 
-    Symlinked directories are followed (matching the DirEntry.is_dir default), because
-    a workspace may reach its libraries or workflows through a link. max_depth is what
-    bounds a symlink loop, so there is no visited-set.
+    Symlinked directories are reported as directories (matching the DirEntry.is_dir
+    default), because a workspace may reach its libraries or workflows through a link.
+    """
+    entries = []
+    with os.scandir(path) as scan:
+        for entry in scan:
+            if skip_hidden and entry.name.startswith("."):
+                continue
+
+            # is_file/is_dir may still stat when the entry is a symlink, which can raise
+            # on protected paths (e.g. macOS system caches). Skip the offending entry
+            # rather than aborting the whole directory.
+            try:
+                entry_is_file = entry.is_file()
+                entry_is_dir = entry.is_dir()
+            except (PermissionError, OSError) as e:
+                logger.debug("Cannot access entry %s: %s", entry.path, e)
+                continue
+
+            entries.append(_ScannedEntry(name=entry.name, path=entry.path, is_file=entry_is_file, is_dir=entry_is_dir))
+
+    return sorted(entries, key=lambda entry: entry.name)
+
+
+async def _arecurse_find(path: Path, depth: int, params: _AsyncWalkParams) -> None:
+    """Depth-bounded async walk that appends matching files into ``params.matches``.
+
+    Offloads one thread hop per directory rather than per entry. The per-entry variant
+    (anyio.Path.iterdir plus an await pair per entry) dispatched two hops for every
+    entry, which dominated boot-time discovery on large trees; hopping per directory
+    recovers nearly all of that while keeping the walk a coroutine, so a caller can
+    still bound discovery with a timeout and cancellation lands at a directory edge.
+
+    max_depth is what bounds a symlink loop, so there is no visited-set.
     """
     try:
-        with os.scandir(path) as scan:
-            entries = sorted(scan, key=lambda entry: entry.name)
+        entries = await to_thread(_scan_directory, path, skip_hidden=params.skip_hidden)
     except (PermissionError, OSError) as e:
         logger.debug("Cannot access directory %s: %s", path, e)
         return
@@ -187,24 +232,12 @@ def _recurse_find(path: Path, depth: int, params: _AsyncWalkParams) -> None:
     for item in entries:
         if params.max_files is not None and len(params.matches) >= params.max_files:
             return
-        if params.skip_hidden and item.name.startswith("."):
-            continue
 
-        # is_file/is_dir may still stat when the entry is a symlink, which can raise on
-        # protected paths (e.g. macOS system caches). Skip the offending entry rather
-        # than aborting the whole directory.
-        try:
-            item_is_file = item.is_file()
-            item_is_dir = item.is_dir()
-        except (PermissionError, OSError) as e:
-            logger.debug("Cannot access entry %s: %s", item.path, e)
-            continue
-
-        if item_is_file:
+        if item.is_file:
             if fnmatch(item.name, params.pattern):
                 params.matches.append(Path(item.path))
-        elif item_is_dir and depth < params.max_depth:
-            _recurse_find(Path(item.path), depth + 1, params)
+        elif item.is_dir and depth < params.max_depth:
+            await _arecurse_find(Path(item.path), depth + 1, params)
 
 
 async def find_files_recursive(
@@ -216,8 +249,8 @@ async def find_files_recursive(
 ) -> list[Path]:
     """Asynchronously search directory recursively for files matching pattern.
 
-    Depth-bounded finder suitable for the engine boot path: the whole walk runs in a
-    single worker thread so it never blocks the event loop, and the
+    Depth-bounded async finder suitable for the engine boot path: each directory read is
+    offloaded to a worker thread so it never blocks the event loop, and the
     `discovery_max_depth` setting bounds recursion so a pathologically deep tree
     or symlink loop can't stall startup.
 
@@ -247,11 +280,7 @@ async def find_files_recursive(
         max_files=max_files,
         matches=matches,
     )
-    # One thread hop for the entire walk. Offloading per-entry instead (the anyio.Path
-    # approach) cost two hops per directory entry, which is what made discovery slow.
-    # _resolve_discovery_max_depth is read above, on the event loop, so the thread does
-    # nothing but filesystem work.
-    await to_thread(_recurse_find, Path(directory), 0, params)
+    await _arecurse_find(Path(directory), 0, params)
 
     if not matches:
         logger.debug("No files matching pattern '%s' found in directory: %s", pattern, directory)

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -41,6 +41,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowInfoRequest,
     ListAllWorkflowInfoResultFailure,
     ListAllWorkflowInfoResultSuccess,
+    LoadWorkflowMetadata,
     LoadWorkflowMetadataResultFailure,
     LoadWorkflowMetadataResultSuccess,
     MoveWorkflowRequest,
@@ -57,6 +58,10 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.context_manager import ContextManager
+from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
+    InvalidTomlFormatProblem,
+    MissingTomlSectionProblem,
+)
 from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
 from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
 from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
@@ -1450,6 +1455,66 @@ class TestWorkflowManager:
         assert leaked_path.name not in scanned_names
         # Sanity check: a regular file in the same directory still reaches the processor.
         assert good_path.name in scanned_names
+
+    # --- Metadata header parse failures ---
+
+    @pytest.mark.asyncio
+    async def test_malformed_toml_header_reports_unusable(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        """A header that is not valid TOML is UNUSABLE, not a crash.
+
+        The read path parses with tomllib, which is stricter than the tomlkit it replaced,
+        so this pins the strictness: a header this rejects must land in UNUSABLE with an
+        InvalidTomlFormatProblem rather than reaching schema validation.
+        """
+        workflow_manager = griptape_nodes.WorkflowManager()
+        griptape_nodes.ConfigManager().workspace_path = tmp_path
+        griptape_nodes.LibraryManager()._libraries_loading_complete.set()
+
+        header = WorkflowManager.WORKFLOW_METADATA_HEADER
+        # Unclosed table declaration: parses as a header block, fails as TOML.
+        (tmp_path / "bad_toml.py").write_text(
+            "\n".join([f"# /// {header}", "# [tool.griptape-nodes", '# name = "x"', "# ///", ""]),
+            encoding="utf-8",
+        )
+
+        result = await workflow_manager.on_load_workflow_metadata_request(LoadWorkflowMetadata(file_name="bad_toml.py"))
+
+        assert isinstance(result, LoadWorkflowMetadataResultFailure)
+        info = workflow_manager._workflow_file_path_to_info[str(tmp_path / "bad_toml.py")]
+        assert info.status is WorkflowManager.WorkflowStatus.UNUSABLE
+        assert any(isinstance(problem, InvalidTomlFormatProblem) for problem in info.problems)
+
+    @pytest.mark.asyncio
+    async def test_header_missing_griptape_nodes_section_reports_unusable(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+    ) -> None:
+        """A header without [tool.griptape-nodes] is UNUSABLE.
+
+        Covers both ways the section lookup can fail now that tomllib returns plain dicts:
+        the key being absent (KeyError) and `tool` being a scalar, so subscripting it raises
+        TypeError. Both must be caught and reported, not escape as an unhandled error.
+        """
+        workflow_manager = griptape_nodes.WorkflowManager()
+        griptape_nodes.ConfigManager().workspace_path = tmp_path
+        griptape_nodes.LibraryManager()._libraries_loading_complete.set()
+
+        header = WorkflowManager.WORKFLOW_METADATA_HEADER
+        cases = {
+            # Valid TOML, but the section the engine needs is a different table.
+            "missing_section.py": [f"# /// {header}", "# [tool.something-else]", '# name = "x"', "# ///", ""],
+            # Valid TOML where `tool` is a scalar, so tool["griptape-nodes"] raises TypeError.
+            "tool_is_scalar.py": [f"# /// {header}", "# tool = 5", "# ///", ""],
+        }
+
+        for file_name, lines in cases.items():
+            (tmp_path / file_name).write_text("\n".join(lines), encoding="utf-8")
+
+            result = await workflow_manager.on_load_workflow_metadata_request(LoadWorkflowMetadata(file_name=file_name))
+
+            assert isinstance(result, LoadWorkflowMetadataResultFailure), file_name
+            info = workflow_manager._workflow_file_path_to_info[str(tmp_path / file_name)]
+            assert info.status is WorkflowManager.WorkflowStatus.UNUSABLE, file_name
+            assert any(isinstance(problem, MissingTomlSectionProblem) for problem in info.problems), file_name
 
     # --- WorkflowInfo payload helpers ---
 

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -389,6 +389,46 @@ class TestAfindFilesRecursive:
 
         assert len(result) == 2  # noqa: PLR2004
 
+    @pytest.mark.asyncio
+    async def test_follows_symlinked_directories(self, temp_dir: Path) -> None:
+        """A symlinked directory is walked, so a workspace can reach content through a link.
+
+        Guards against a walk that skips links (os.walk's default), which would silently
+        stop discovering libraries or workflows reached that way.
+        """
+        real_dir = temp_dir / "real"
+        real_dir.mkdir()
+        (real_dir / "found.json").write_text("{}")
+        scan_root = temp_dir / "root"
+        scan_root.mkdir()
+        (scan_root / "linked").symlink_to(real_dir)
+
+        result = await find_files_recursive(scan_root, "*.json")
+
+        assert result == [scan_root / "linked" / "found.json"]
+
+    @pytest.mark.asyncio
+    async def test_symlink_loop_terminates(self, temp_dir: Path) -> None:
+        """A directory symlink pointing back at an ancestor terminates via the depth cap."""
+        nested = temp_dir / "a"
+        nested.mkdir()
+        (nested / "f.json").write_text("{}")
+        (nested / "loop").symlink_to(temp_dir)
+
+        result = await find_files_recursive(temp_dir, "*.json")
+
+        assert nested / "f.json" in result
+
+    @pytest.mark.asyncio
+    async def test_broken_symlink_is_skipped(self, temp_dir: Path) -> None:
+        """A dangling symlink is neither matched nor fatal to the walk."""
+        (temp_dir / "real.json").write_text("{}")
+        (temp_dir / "broken.json").symlink_to(temp_dir / "does_not_exist")
+
+        result = await find_files_recursive(temp_dir, "*.json")
+
+        assert result == [temp_dir / "real.json"]
+
 
 class TestAtomicWriteBytes:
     """Test atomic_write_bytes function."""

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -10,6 +12,8 @@ from unittest.mock import patch
 import pytest
 
 from griptape_nodes.utils.file_utils import (
+    _arecurse_find,
+    _AsyncWalkParams,
     atomic_write_bytes,
     find_all_files_in_directory,
     find_file_in_directory,
@@ -18,6 +22,40 @@ from griptape_nodes.utils.file_utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+
+class _RaisingDirEntry:
+    """Stands in for a DirEntry whose type cannot be determined.
+
+    os.DirEntry cannot be constructed or subclassed from Python, so the walk's
+    "skip the entry that will not stat" path needs a stand-in to exercise it.
+    """
+
+    def __init__(self, name: str, path: str) -> None:
+        self.name = name
+        self.path = path
+
+    def is_file(self) -> bool:
+        raise PermissionError(13, "Permission denied")
+
+    def is_dir(self) -> bool:
+        raise PermissionError(13, "Permission denied")
+
+
+class _FakeScandir:
+    """Context-manager iterator matching the os.scandir interface the walk relies on."""
+
+    def __init__(self, entries: list[object]) -> None:
+        self._entries = entries
+
+    def __enter__(self) -> object:
+        return iter(self._entries)
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def __iter__(self) -> object:
+        return iter(self._entries)
 
 
 class TestFindFileInDirectory:
@@ -428,6 +466,90 @@ class TestAfindFilesRecursive:
         result = await find_files_recursive(temp_dir, "*.json")
 
         assert result == [temp_dir / "real.json"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_directory_does_not_abort_walk(self, temp_dir: Path) -> None:
+        """A directory that cannot be listed is skipped, and its siblings still resolve.
+
+        Uses a patched scandir rather than chmod so the case is exercised on Windows too,
+        where permissions do not deny directory listing the same way.
+        """
+        (temp_dir / "sibling").mkdir()
+        (temp_dir / "sibling" / "found.json").write_text("{}")
+        unreadable = temp_dir / "unreadable"
+        unreadable.mkdir()
+        (unreadable / "hidden_by_permissions.json").write_text("{}")
+
+        real_scandir = os.scandir
+
+        def scandir_denying_one_dir(path: object) -> object:
+            if Path(path) == unreadable:  # type: ignore[arg-type]
+                raise PermissionError(13, "Permission denied")
+            return real_scandir(path)  # type: ignore[arg-type]
+
+        with patch("griptape_nodes.utils.file_utils.os.scandir", side_effect=scandir_denying_one_dir):
+            result = await find_files_recursive(temp_dir, "*.json")
+
+        assert result == [temp_dir / "sibling" / "found.json"]
+
+    @pytest.mark.asyncio
+    async def test_unclassifiable_entry_does_not_abort_directory(self, temp_dir: Path) -> None:
+        """An entry whose type cannot be determined is skipped, not fatal to its siblings.
+
+        Mirrors a macOS protected path, where stat-ing one entry raises while the rest of
+        the directory reads fine.
+        """
+        (temp_dir / "good.json").write_text("{}")
+        (temp_dir / "protected.json").write_text("{}")
+
+        real_scandir = os.scandir
+
+        def scandir_with_one_bad_entry(path: object) -> object:
+            entries = []
+            for entry in real_scandir(path):  # type: ignore[arg-type]
+                if entry.name == "protected.json":
+                    entries.append(_RaisingDirEntry(entry.name, entry.path))
+                else:
+                    entries.append(entry)
+            return _FakeScandir(entries)
+
+        with patch("griptape_nodes.utils.file_utils.os.scandir", side_effect=scandir_with_one_bad_entry):
+            result = await find_files_recursive(temp_dir, "*.json")
+
+        assert result == [temp_dir / "good.json"]
+
+    @pytest.mark.asyncio
+    async def test_walk_is_cancellable_between_directories(self, temp_dir: Path) -> None:
+        """Cancelling the walk stops it partway rather than running the whole tree.
+
+        The walk offloads one thread hop per directory specifically so a caller can bound
+        discovery with a timeout. Collapsing it back into a single hop for the entire tree
+        would run to completion before the cancellation was observed, so this asserts the
+        walk is actually abandoned partway through.
+        """
+        expected_total = 20
+        for index in range(expected_total):
+            subdir = temp_dir / f"dir{index:02d}"
+            subdir.mkdir()
+            (subdir / "file.json").write_text("{}")
+
+        matches: list[Path] = []
+        params = _AsyncWalkParams(
+            pattern="*.json",
+            skip_hidden=True,
+            max_depth=5,
+            max_files=None,
+            matches=matches,
+        )
+        task = asyncio.create_task(_arecurse_find(temp_dir, 0, params))
+        # Let the walk reach its first thread hop, then cancel while it is suspended.
+        await asyncio.sleep(0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert len(matches) < expected_total
 
 
 class TestAtomicWriteBytes:

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -550,6 +551,44 @@ class TestAfindFilesRecursive:
             await task
 
         assert len(matches) < expected_total
+
+    @pytest.mark.asyncio
+    async def test_cancelling_the_walk_returns_without_awaiting_the_scan(self, temp_dir: Path) -> None:
+        """Cancellation returns promptly instead of blocking on the in-flight directory scan.
+
+        Cancelling at a directory edge is only a real bound if the await also *returns* at
+        that edge. A thread-offload that waits for its worker would make a hung mount block
+        discovery for as long as the scan takes, no matter what timeout the caller set, so
+        this pins the promptness rather than just the fact that the walk stopped early.
+        """
+        (temp_dir / "unreachable.json").write_text("{}")
+        scan_duration_s = 5.0
+
+        def hung_scan(*_args: object, **_kwargs: object) -> list[object]:
+            time.sleep(scan_duration_s)
+            return []
+
+        params = _AsyncWalkParams(
+            pattern="*.json",
+            skip_hidden=True,
+            max_depth=5,
+            max_files=None,
+            matches=[],
+        )
+
+        with patch("griptape_nodes.utils.file_utils._scan_directory", hung_scan):
+            task = asyncio.create_task(_arecurse_find(temp_dir, 0, params))
+            # Let the walk dispatch the scan, so the cancel lands while it is in flight.
+            await asyncio.sleep(0.05)
+            task.cancel()
+
+            started_at = time.perf_counter()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            elapsed_s = time.perf_counter() - started_at
+
+        # Generous bound: the point is "did not wait for the 5s scan", not a precise timing.
+        assert elapsed_s < scan_duration_s / 2
 
 
 class TestAtomicWriteBytes:


### PR DESCRIPTION
Optimizations in `_process_workflows_for_registration` resulting in ~8x speed increase.

Commit | Registration | Cumulative
-- | -- | --
before Win 1 | 2.61 s | —
Win 1 tomllib | 1.36 s | 1.9x
Win 2 scandir | 0.45 s | 5.8x
Win 3 single parse | 0.32 s | 8.2x

<br class="Apple-interchange-newline">

Closes the root issue from https://github.com/griptape-ai/griptape-nodes-engine/issues/5234