### PR TITLE
chore: bump v0.96.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-engine"
-version = "0.95.0"
+version = "0.96.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.95.0"
+version = "0.96.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Advances `main` to the next version (`0.96.0`) following the `v0.95.0` release.

Generated automatically by the `Bump Main to Next Version` workflow.