### PR TITLE
feat(access): migrate legacy model dropdown values via deprecated_values

### DIFF
--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -192,6 +192,20 @@ A few rules worth knowing:
 - **Model IDs must be unique across the entire library.** Pydantic enforces uniqueness within each provider's `models` dict for free; collisions across providers are caught at library-load time as `DuplicateModelIdProblem`.
 - **At most one `model_catalog` per library.** Declaring two is rejected at validation time; merge their providers into one.
 
+A node's model-selection dropdown stores the provider's own model id (`kling-v2-master`, not `Kling v2`), and `ModelAccessComponent` resolves it to the catalog key that the permission layer gates on. Storing a display name instead means the selection cannot be resolved, so it cannot be checked against license policy. If a dropdown historically stored something else, migrate those saved values with the component's `deprecated_values` mapping rather than renaming the catalog entry to match them:
+
+```python
+self._model_access = ModelAccessComponent(
+    node=self,
+    parameter=model_param,
+    model_choices=["kling-v2-master", "kling-v2-1-master"],
+    default_model="kling-v2-master",
+    deprecated_values={"Kling v2": "kling-v2-master", "Kling v2.1": "kling-v2-1-master"},
+)
+```
+
+Each key is accepted wherever a value is assigned, including workflow load, and migrated to its mapped choice. Keys are never offered in the dropdown, so retiring a model means moving it from `model_choices` into `deprecated_values` pointed at its replacement. Every mapped value must be one of `model_choices`, and no key may already be a choice; either mistake raises when the node is constructed.
+
 ##### `model_usage`
 
 A node references one or more catalog models by their dict keys. Use this when the node binds to a specific, named set of models. Each entry must resolve to a model somewhere in the catalog at library-load time; unresolved references surface as `UnresolvedModelUsageReferenceProblem`.

--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -204,7 +204,7 @@ self._model_access = ModelAccessComponent(
 )
 ```
 
-Each key is accepted wherever a value is assigned, including workflow load, and migrated to its mapped choice. Keys are never offered in the dropdown, so retiring a model means moving it from `model_choices` into `deprecated_values` pointed at its replacement. Every mapped value must be one of `model_choices`, and no key may already be a choice; either mistake raises when the node is constructed.
+Each key is accepted wherever a value is assigned, including workflow load, and migrated to its mapped choice. Keys are never offered in the dropdown, so retiring a model means moving it from `model_choices` into `deprecated_values` pointed at its replacement. Every mapped value must be one of `model_choices`, and no key may already be a choice; either mistake raises when the node is constructed. If the model you are retiring was also the `default_model`, point `default_model` at its replacement in the same edit -- `default_model` must always name a current choice, never a retired key, and the component raises if it does not.
 
 ##### `model_usage`
 

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -2118,6 +2118,15 @@ class Parameter(BaseNodeElement, UIOptionsMixin):
         # You are NOT ALLOWED TO ADD DUPLICATE TRAITS (kate)
         self.remove_child(trait_type)
 
+    def add_converter(self, converter: Callable[[Any], Any]) -> None:
+        """Append a converter to this parameter's directly-attached converter list.
+
+        Trait converters run BEFORE directly-attached ones (see the
+        ``converters`` property), so a converter added here observes the
+        value only after every attached trait has already converted it.
+        """
+        self._converters.append(converter)
+
     def is_incoming_type_allowed(self, incoming_type: str | None) -> bool:
         if incoming_type is None:
             return False

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -6,6 +6,13 @@ icons + subtitles, an error badge on denied selections, and runtime denial
 queries. Node identity (parameter name, type, input_types, tooltip) stays with
 the node so saved workflows round-trip byte-identically.
 
+``model_choices`` are ``provider_model_id``s, which the component resolves to
+the catalog ``model_id`` the permission layer gates on. ``deprecated_values``
+covers the values a parameter stored before it adopted that convention (an old
+display label, a retired provider id): each is accepted wherever a value is
+assigned, migrated to its canonical choice, and never offered as a fresh
+selection.
+
 Usage — one construction step per parameter:
 
     class DescribeImage(ControlNode):
@@ -148,8 +155,21 @@ class ModelAccessComponent:
         parameter: Parameter,
         model_choices: list[str],
         default_model: str,
+        deprecated_values: dict[str, str] | None = None,
     ) -> None:
         """Attach the component to an already-added Parameter and decorate it.
+
+        ``deprecated_values`` maps a historical stored value to the current
+        choice it becomes. Every value in the mapping must be one of
+        ``model_choices``, and no key may itself already be a current choice;
+        either problem raises at construction.
+
+        A legacy value is accepted wherever it is assigned -- the ``Options``
+        trait's ``choices`` include it -- but migrated to its canonical choice
+        by a converter, and never offered as a fresh selection: the dropdown's
+        ``ui_options["data"]`` rows come from ``model_choices`` alone. The
+        parameter's current stored value is migrated the same way at
+        construction, before the denied-default relocation described below.
 
         Preconditions (checked; a misuse raises rather than silently misbehaving):
 
@@ -167,6 +187,7 @@ class ModelAccessComponent:
         self._parameter = parameter
         self._model_choices = list(model_choices)
         self._default_model = default_model
+        self._deprecated_values = dict(deprecated_values or {})
 
         # Fail-fast preconditions -- see docstring.
         if self._node.get_parameter_by_name(parameter.name) is not parameter:
@@ -190,14 +211,32 @@ class ModelAccessComponent:
                 "refresh Button itself."
             )
             raise ValueError(msg)
+        choice_set = set(self._model_choices)
+        invalid_values = sorted(
+            {legacy for legacy, canonical in self._deprecated_values.items() if canonical not in choice_set}
+        )
+        colliding_keys = sorted(legacy for legacy in self._deprecated_values if legacy in choice_set)
+        if invalid_values or colliding_keys:
+            problems = []
+            if invalid_values:
+                problems.append(f"value(s) not in model_choices: {', '.join(repr(v) for v in invalid_values)}")
+            if colliding_keys:
+                problems.append(f"key(s) already a current choice: {', '.join(repr(k) for k in colliding_keys)}")
+            msg = (
+                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
+                f"deprecated_values is invalid: {'; '.join(problems)}."
+            )
+            raise ValueError(msg)
 
         # Cached result of the last QueryModelAccessForNodeRequest. Replaced
         # atomically on refresh so its two lookup tables never drift. See
         # _AccessSnapshot's docstring for the contract.
         self._snapshot: _AccessSnapshot = self._fetch_snapshot()
 
-        # Install decoration + traits.
-        parameter.add_trait(Options(choices=list(self._model_choices)))
+        # Install decoration + traits. Options accepts legacy values too, so an
+        # assignment carrying one is never snapped to choices[0] before the
+        # migration converter (added below) gets a chance to run.
+        parameter.add_trait(Options(choices=[*self._model_choices, *self._deprecated_values]))
         parameter.add_trait(
             Button(
                 icon=_REFRESH_ICON,
@@ -208,6 +247,15 @@ class ModelAccessComponent:
             )
         )
         parameter.update_ui_options(self._build_ui_options())
+        parameter.add_converter(self._convert_legacy_value)
+
+        # Migrate a legacy stored value to its canonical choice before
+        # considering whether that choice is currently permitted.
+        current_value = self._node.get_parameter_value(parameter.name)
+        migrated_value = self.migrate_value(current_value)
+        if migrated_value is not None:
+            self._node.set_parameter_value(parameter.name, migrated_value, initial_setup=True)
+            current_value = migrated_value
 
         # If the caller's declared default_value is denied but another choice
         # IS permitted, move the parameter's stored value to that permitted
@@ -215,7 +263,6 @@ class ModelAccessComponent:
         # The Parameter's declarative default_value is untouched -- the
         # override is a stored-value change only, via set_parameter_value
         # with initial_setup=True so no change events fire.
-        current_value = self._node.get_parameter_value(parameter.name)
         if isinstance(current_value, str) and current_value in self._snapshot.denial_by_provider_id:
             replacement = self.pick_permitted_default()
             if replacement is not None and replacement != current_value:
@@ -244,7 +291,7 @@ class ModelAccessComponent:
         already present -- ``add_trait`` will replace the existing instance.
         """
         parameter = self._parameter
-        parameter.add_trait(Options(choices=list(self._model_choices)))
+        parameter.add_trait(Options(choices=[*self._model_choices, *self._deprecated_values]))
         parameter.update_ui_options(self._build_ui_options())
         self.on_value_changed(self._node.get_parameter_value(parameter.name))
 
@@ -371,6 +418,35 @@ class ModelAccessComponent:
                 return choice
         return None
 
+    def migrate_value(self, value: Any) -> str | None:
+        """The canonical choice ``value`` migrates to if it is a deprecated key, else ``None``.
+
+        Non-``str`` input returns ``None`` -- the same rationale as
+        ``query_for_denial``: a connected driver's value isn't a dropdown token
+        this component's tables cover.
+        """
+        if not isinstance(value, str):
+            return None
+        return self._deprecated_values.get(value)
+
+    def _convert_legacy_value(self, value: Any) -> Any:
+        """Migrate a legacy stored value to its canonical choice; everything else passes through.
+
+        Installed as a directly-attached converter (``Parameter.add_converter``)
+        rather than hooked into ``before_value_set`` / ``after_value_set``,
+        because ``BaseNode.set_parameter_value`` runs every converter
+        unconditionally on every assignment path -- including workflow load,
+        which calls it with ``initial_setup=True`` and
+        ``skip_before_value_set=True`` and therefore never calls
+        ``before_value_set`` at all. A converter is the only hook a saved
+        workflow's stored value is guaranteed to pass through, so it is the
+        only place this migration can live.
+        """
+        migrated = self.migrate_value(value)
+        if migrated is not None:
+            return migrated
+        return value
+
     def _fetch_snapshot(self) -> _AccessSnapshot:
         """Ask the engine and build a fresh ``_AccessSnapshot`` from the response.
 
@@ -413,7 +489,12 @@ class ModelAccessComponent:
         return snapshot
 
     def _build_ui_options(self) -> dict[str, Any]:
-        """Build the ``ui_options`` dict that decorates the dropdown row-by-row."""
+        """Build the ``ui_options`` dict that decorates the dropdown row-by-row.
+
+        Built from ``model_choices`` alone, never ``deprecated_values`` -- a
+        legacy value is accepted when assigned but never offered as a fresh
+        selection.
+        """
         denials = self._snapshot.denial_by_provider_id
         data: list[dict[str, str]] = []
         for choice in self._model_choices:

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -213,7 +213,7 @@ class ModelAccessComponent:
             raise ValueError(msg)
         choice_set = set(self._model_choices)
         invalid_values = sorted(
-            {legacy for legacy, canonical in self._deprecated_values.items() if canonical not in choice_set}
+            {canonical for canonical in self._deprecated_values.values() if canonical not in choice_set}
         )
         colliding_keys = sorted(legacy for legacy in self._deprecated_values if legacy in choice_set)
         if invalid_values or colliding_keys:
@@ -236,7 +236,7 @@ class ModelAccessComponent:
         # Install decoration + traits. Options accepts legacy values too, so an
         # assignment carrying one is never snapped to choices[0] before the
         # migration converter (added below) gets a chance to run.
-        parameter.add_trait(Options(choices=[*self._model_choices, *self._deprecated_values]))
+        parameter.add_trait(Options(choices=self._dropdown_choices()))
         parameter.add_trait(
             Button(
                 icon=_REFRESH_ICON,
@@ -291,7 +291,7 @@ class ModelAccessComponent:
         already present -- ``add_trait`` will replace the existing instance.
         """
         parameter = self._parameter
-        parameter.add_trait(Options(choices=[*self._model_choices, *self._deprecated_values]))
+        parameter.add_trait(Options(choices=self._dropdown_choices()))
         parameter.update_ui_options(self._build_ui_options())
         self.on_value_changed(self._node.get_parameter_value(parameter.name))
 
@@ -446,6 +446,17 @@ class ModelAccessComponent:
         if migrated is not None:
             return migrated
         return value
+
+    def _dropdown_choices(self) -> list[str]:
+        """The list handed to ``Options.choices``: current choices plus legacy keys.
+
+        ``Options`` rewrites any assigned value outside ``choices`` to
+        ``choices[0]``, so the legacy keys have to be in here for a stored
+        legacy value to survive long enough for the migration converter to
+        translate it. They are deliberately absent from ``_build_ui_options``,
+        so they are accepted but never offered.
+        """
+        return [*self._model_choices, *self._deprecated_values]
 
     def _fetch_snapshot(self) -> _AccessSnapshot:
         """Ask the engine and build a fresh ``_AccessSnapshot`` from the response.

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -169,7 +169,8 @@ class ModelAccessComponent:
         by a converter, and never offered as a fresh selection: the dropdown's
         ``ui_options["data"]`` rows come from ``model_choices`` alone. The
         parameter's current stored value is migrated the same way at
-        construction, before the denied-default relocation described below.
+        construction, before the denied-default relocation described in the
+        class docstring.
 
         Preconditions (checked; a misuse raises rather than silently misbehaving):
 
@@ -181,6 +182,10 @@ class ModelAccessComponent:
           adding a second ``Button`` overloads the refresh row. Migrate the
           node to construct the parameter without those traits and let the
           component add them.
+        - ``default_model`` must be one of ``model_choices``. In particular it
+          may not be a ``deprecated_values`` key: legacy keys are not real
+          provider ids, so they never appear in the access verdicts and would
+          make ``pick_permitted_default`` report a denied model as permitted.
         """
         # Constructor inputs -- immutable across the component's lifetime.
         self._node = node
@@ -190,43 +195,7 @@ class ModelAccessComponent:
         self._deprecated_values = dict(deprecated_values or {})
 
         # Fail-fast preconditions -- see docstring.
-        if self._node.get_parameter_by_name(parameter.name) is not parameter:
-            msg = (
-                f"ModelAccessComponent: parameter '{parameter.name}' is not attached to node "
-                f"'{self._node.name}'. Call node.add_parameter(parameter) BEFORE constructing "
-                "the component."
-            )
-            raise ValueError(msg)
-        if parameter.find_elements_by_type(Options):
-            msg = (
-                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
-                "already carries an Options trait. Remove traits={Options(...)} from the "
-                "Parameter constructor -- ModelAccessComponent adds Options itself."
-            )
-            raise ValueError(msg)
-        if parameter.find_elements_by_type(Button):
-            msg = (
-                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
-                "already carries a Button trait. Remove it -- ModelAccessComponent adds the "
-                "refresh Button itself."
-            )
-            raise ValueError(msg)
-        choice_set = set(self._model_choices)
-        invalid_values = sorted(
-            {canonical for canonical in self._deprecated_values.values() if canonical not in choice_set}
-        )
-        colliding_keys = sorted(legacy for legacy in self._deprecated_values if legacy in choice_set)
-        if invalid_values or colliding_keys:
-            problems = []
-            if invalid_values:
-                problems.append(f"value(s) not in model_choices: {', '.join(repr(v) for v in invalid_values)}")
-            if colliding_keys:
-                problems.append(f"key(s) already a current choice: {', '.join(repr(k) for k in colliding_keys)}")
-            msg = (
-                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
-                f"deprecated_values is invalid: {'; '.join(problems)}."
-            )
-            raise ValueError(msg)
+        self._raise_if_misconfigured()
 
         # Cached result of the last QueryModelAccessForNodeRequest. Replaced
         # atomically on refresh so its two lookup tables never drift. See
@@ -405,6 +374,10 @@ class ModelAccessComponent:
         back to the first allowed entry in ``model_choices``. Returns ``None``
         when every declared choice is currently denied.
 
+        The denial lookup is keyed by provider id, so it only means anything
+        for a real choice. ``__init__`` guarantees ``default_model`` is one of
+        ``model_choices``, which is what makes the first check below sound.
+
         Called internally by ``__init__`` to move the parameter's stored value
         off a denied default. Kept public for callers that want to consult the
         permitted-default separately (e.g. logging, picking a value for a
@@ -446,6 +419,60 @@ class ModelAccessComponent:
         if migrated is not None:
             return migrated
         return value
+
+    def _raise_if_misconfigured(self) -> None:
+        """Raise on any constructor misuse, before the component touches the parameter.
+
+        Every precondition in ``__init__``'s docstring is checked here so a
+        misconfigured node fails loudly at construction rather than shipping a
+        dropdown that silently misbehaves.
+        """
+        parameter = self._parameter
+        if self._node.get_parameter_by_name(parameter.name) is not parameter:
+            msg = (
+                f"ModelAccessComponent: parameter '{parameter.name}' is not attached to node "
+                f"'{self._node.name}'. Call node.add_parameter(parameter) BEFORE constructing "
+                "the component."
+            )
+            raise ValueError(msg)
+        if parameter.find_elements_by_type(Options):
+            msg = (
+                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
+                "already carries an Options trait. Remove traits={Options(...)} from the "
+                "Parameter constructor -- ModelAccessComponent adds Options itself."
+            )
+            raise ValueError(msg)
+        if parameter.find_elements_by_type(Button):
+            msg = (
+                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
+                "already carries a Button trait. Remove it -- ModelAccessComponent adds the "
+                "refresh Button itself."
+            )
+            raise ValueError(msg)
+        choice_set = set(self._model_choices)
+        if self._default_model not in choice_set:
+            msg = (
+                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
+                f"declares default_model {self._default_model!r}, which is not one of model_choices. "
+                "Point default_model at a current choice -- a retired value belongs in "
+                "deprecated_values, not default_model."
+            )
+            raise ValueError(msg)
+        invalid_values = sorted(
+            {canonical for canonical in self._deprecated_values.values() if canonical not in choice_set}
+        )
+        colliding_keys = sorted(legacy for legacy in self._deprecated_values if legacy in choice_set)
+        if invalid_values or colliding_keys:
+            problems = []
+            if invalid_values:
+                problems.append(f"value(s) not in model_choices: {', '.join(repr(v) for v in invalid_values)}")
+            if colliding_keys:
+                problems.append(f"key(s) already a current choice: {', '.join(repr(k) for k in colliding_keys)}")
+            msg = (
+                f"ModelAccessComponent: parameter '{parameter.name}' on node '{self._node.name}' "
+                f"deprecated_values is invalid: {'; '.join(problems)}."
+            )
+            raise ValueError(msg)
 
     def _dropdown_choices(self) -> list[str]:
         """The list handed to ``Options.choices``: current choices plus legacy keys.

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -42,14 +42,19 @@ different value is currently permitted — resets the parameter's stored value
 to a permitted alternative via ``set_parameter_value(..., initial_setup=True)``.
 The parameter's declarative ``default_value`` is untouched.
 
-Nodes then forward ``after_value_set`` for the model parameter to
-``self._model_access.on_value_changed(value)``, and pick a failure-routing
-idiom that matches their base class:
+Nodes then forward ``after_value_set`` to ``self._model_access.on_value_set(
+parameter, value)`` -- the component filters for its own parameter -- and pick a
+failure-routing idiom that matches their base class:
 
-  - ControlNode / raise-based execute paths call ``raise_if_denied(value)``.
-  - SuccessFailureNode / GriptapeProxyNode nodes call ``query_for_denial(value)``
+  - ControlNode / raise-based execute paths call ``raise_if_selection_denied()``.
+  - SuccessFailureNode / GriptapeProxyNode nodes call ``selection_denial()``
     and route the reason into ``self._set_status_results(was_successful=False,
     result_details=denial.reason())``.
+
+Both read the current selection off the parameter the component owns, so a node
+never restates its own parameter's name. ``query_for_denial(value)`` and
+``raise_if_denied(value)`` remain for the rare caller holding a model id from
+somewhere other than the dropdown.
 
 Nodes that reinstall the ``Options`` trait themselves (e.g. after a driver
 disconnect) call ``reinstall_options()`` to put the component's trait +
@@ -251,6 +256,26 @@ class ModelAccessComponent:
         """
         return list(self._model_choices)
 
+    @property
+    def parameter_name(self) -> str:
+        """Name of the parameter this component decorates.
+
+        A node base class that forwards hooks generically reads the name from
+        here rather than hardcoding it, since it differs across nodes (``model``
+        on most, ``model_name`` or ``model_id`` on others).
+        """
+        return self._parameter.name
+
+    @property
+    def selected_value(self) -> Any:
+        """The parameter's current stored value.
+
+        Typed ``Any`` rather than ``str`` on purpose: an upstream connection can
+        replace the dropdown selection with a driver object, which the gating
+        methods deliberately pass through untouched.
+        """
+        return self._node.get_parameter_value(self._parameter.name)
+
     def reinstall_options(self) -> None:
         """Reinstall the ``Options`` trait and reapply decoration + badge.
 
@@ -286,6 +311,21 @@ class ModelAccessComponent:
             message=f"Model `{value}` is not permitted. Running this node will fail.\n\nReason(s): {denial.reason()}",
             icon=_DENIED_ROW_ICON,
         )
+
+    def on_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Forward from ``BaseNode.after_value_set``, ignoring every other parameter.
+
+        A node's ``after_value_set`` fires for all of its parameters, so the
+        component filters on its own before updating the badge. Nodes forward
+        unconditionally and let this decide:
+
+            def after_value_set(self, parameter, value) -> None:
+                self._model_access.on_value_set(parameter, value)
+                return super().after_value_set(parameter, value)
+        """
+        if parameter.name != self._parameter.name:
+            return
+        self.on_value_changed(value)
 
     def refresh(self) -> None:
         """Re-query the engine and rebuild the decoration + current-selection badge.
@@ -366,6 +406,20 @@ class ModelAccessComponent:
             return
         msg = f"Cannot run {type(self._node).__name__}: '{value}' is not permitted. {denial.reason()}"
         raise RuntimeError(msg)
+
+    def selection_denial(self) -> CheckpointDenial | None:
+        """``query_for_denial`` against the current selection.
+
+        The component owns the parameter, so it reads the stored value itself.
+        Prefer this over passing ``get_parameter_value(...)`` back in: a caller
+        that re-derives the value has to know the parameter's name, which varies
+        per node.
+        """
+        return self.query_for_denial(self.selected_value)
+
+    def raise_if_selection_denied(self) -> None:
+        """``raise_if_denied`` against the current selection. See ``selection_denial``."""
+        self.raise_if_denied(self.selected_value)
 
     def pick_permitted_default(self) -> str | None:
         """Return the value the node should use as its ``default_value=``, or ``None``.

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -118,6 +118,7 @@ def _build_probe_node_with_component(
     model_choices: list[str],
     default_model: str,
     initial_stored_value: str | None = None,
+    deprecated_values: dict[str, str] | None = None,
 ) -> tuple[_AccessProbeNode, ModelAccessComponent, Parameter]:
     """Build node + parameter + component (fully installed) and return all three.
 
@@ -128,7 +129,8 @@ def _build_probe_node_with_component(
     ``initial_stored_value``: if set, the parameter's stored value is set to
     this via ``set_parameter_value(initial_setup=True)`` BEFORE the component
     is constructed, so the constructor sees it as the current value. Use this
-    to test the "born with a denied value" path.
+    to test the "born with a denied value" path, or a legacy value awaiting
+    migration.
     """
     from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
 
@@ -153,6 +155,7 @@ def _build_probe_node_with_component(
         parameter=param,
         model_choices=model_choices,
         default_model=default_model,
+        deprecated_values=deprecated_values,
     )
     return node, component, param
 
@@ -808,3 +811,157 @@ class TestReinstallOptions:
             assert "Alpha not enabled." in badge.message
         finally:
             griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+
+
+class TestDeprecatedValuesValidation:
+    """deprecated_values is validated at construction, same as the component's other preconditions."""
+
+    def test_raises_when_a_value_is_not_a_current_choice(self) -> None:
+        with pytest.raises(ValueError, match="not in model_choices"):
+            _build_probe_node_with_component(
+                model_choices=["alpha", "beta"],
+                default_model="alpha",
+                deprecated_values={"Alpha": "gamma"},
+            )
+
+    def test_raises_when_a_key_collides_with_a_current_choice(self) -> None:
+        with pytest.raises(ValueError, match="already a current choice"):
+            _build_probe_node_with_component(
+                model_choices=["alpha", "beta"],
+                default_model="alpha",
+                deprecated_values={"beta": "alpha"},
+            )
+
+
+class TestDeprecatedValuesMigration:
+    """A legacy stored value is accepted wherever assigned, migrated, and never offered as a fresh selection.
+
+    Every migration here targets ``"beta"``, which is deliberately NOT
+    ``choices[0]``. ``Options`` rewrites a value outside ``choices`` to
+    ``choices[0]``, so a test whose expected result IS ``choices[0]`` would pass
+    even if migration never ran.
+    """
+
+    def test_legacy_value_is_accepted_and_migrated_on_assignment(self) -> None:
+        node, _helper, param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            deprecated_values={"Beta": "beta"},
+        )
+
+        node.set_parameter_value(param.name, "Beta")
+
+        assert node.get_parameter_value(param.name) == "beta"
+
+    def test_legacy_value_is_migrated_on_the_workflow_load_path(self) -> None:
+        """The regression that matters most: workflow load sets values with initial_setup=True.
+
+        Converters run on every set_parameter_value call regardless of
+        initial_setup, so a legacy value is migrated on this path exactly the
+        same as on an artist-driven change -- it is never left un-migrated
+        just because before_value_set / after_value_set didn't fire.
+        """
+        node, _helper, param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            deprecated_values={"Beta": "beta"},
+        )
+
+        node.set_parameter_value(param.name, "Beta", initial_setup=True)
+
+        assert node.get_parameter_value(param.name) == "beta"
+
+    def test_legacy_value_is_in_options_choices_but_not_in_ui_options_data(self) -> None:
+        """A legacy value must be accepted (in the trait's choices) but never offered (not in the UI rows)."""
+        _node, _helper, param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            deprecated_values={"Beta": "beta"},
+        )
+
+        (options_trait,) = param.find_elements_by_type(Options)
+        assert "Beta" in options_trait.choices
+
+        data_names = {row["name"] for row in param.ui_options["data"]}
+        assert data_names == {"alpha", "beta"}
+
+    def test_constructor_migrates_an_already_stored_legacy_value(self) -> None:
+        node, _helper, param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            initial_stored_value="Beta",
+            deprecated_values={"Beta": "beta"},
+        )
+
+        assert node.get_parameter_value(param.name) == "beta"
+
+    def test_a_legacy_value_shaped_like_a_catalog_key_migrates(self) -> None:
+        """Legacy keys are arbitrary tokens, not just old display labels.
+
+        A node whose dropdown once stored the catalog's own key for a model
+        declares that migration path here like any other. Nothing about the
+        key's shape is special to the component.
+        """
+        node, _helper, param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            initial_stored_value="gtc_test_beta",
+            deprecated_values={"gtc_test_beta": "beta"},
+        )
+
+        assert node.get_parameter_value(param.name) == "beta"
+
+
+class TestMigrateValue:
+    def test_returns_canonical_choice_for_a_legacy_value(self) -> None:
+        _node, helper, _param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            deprecated_values={"Beta": "beta"},
+        )
+
+        assert helper.migrate_value("Beta") == "beta"
+
+    def test_returns_none_for_a_current_choice(self) -> None:
+        _node, helper, _param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            deprecated_values={"Beta": "beta"},
+        )
+
+        assert helper.migrate_value("beta") is None
+
+    def test_returns_none_for_an_unknown_value(self) -> None:
+        _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="alpha")
+
+        assert helper.migrate_value("never-heard-of-it") is None
+
+    def test_returns_none_for_non_string_input(self) -> None:
+        _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="alpha")
+
+        assert helper.migrate_value(None) is None
+        assert helper.migrate_value(123) is None
+
+
+class TestReinstallOptionsKeepsLegacyValues:
+    def test_reinstall_puts_legacy_values_back_into_choices(self) -> None:
+        """reinstall_options() rebuilds Options with the same choices + legacy union.
+
+        A node that strips Options when a driver connects, then reinstalls it
+        when the driver is removed, must not lose the ability to accept a legacy
+        value -- otherwise loading an old workflow after a driver round-trip
+        snaps the value to choices[0].
+        """
+        _node, helper, param = _build_probe_node_with_component(
+            model_choices=["alpha", "beta"],
+            default_model="alpha",
+            deprecated_values={"Beta": "beta"},
+        )
+        for trait in param.find_elements_by_type(Options):
+            param.remove_trait(trait_type=trait)
+
+        helper.reinstall_options()
+
+        (options_trait,) = param.find_elements_by_type(Options)
+        assert "Beta" in options_trait.choices
+        assert {row["name"] for row in param.ui_options["data"]} == {"alpha", "beta"}

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -989,3 +989,85 @@ class TestReinstallOptionsKeepsLegacyValues:
         (options_trait,) = param.find_elements_by_type(Options)
         assert "Beta" in options_trait.choices
         assert {row["name"] for row in param.ui_options["data"]} == {"alpha", "beta"}
+
+
+class TestSelectionReadingApi:
+    """The component owns the parameter, so callers never re-derive the current value."""
+
+    def test_parameter_name_and_selected_value_read_the_owned_parameter(self) -> None:
+        node, helper, param = _build_probe_node_with_component(model_choices=["alpha", "beta"], default_model="alpha")
+
+        assert helper.parameter_name == param.name
+        assert helper.selected_value == "alpha"
+
+        node.set_parameter_value(param.name, "beta")
+        assert helper.selected_value == "beta"
+
+    def test_selection_denial_gates_the_current_selection(self, griptape_nodes) -> None:  # noqa: ANN001
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_alpha":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        try:
+            node, helper, param = _build_probe_node_with_component(
+                model_choices=["alpha", "beta"], default_model="beta"
+            )
+            assert helper.selection_denial() is None
+
+            node.set_parameter_value(param.name, "alpha", initial_setup=True)
+            denial = helper.selection_denial()
+            assert denial is not None
+            assert denial.messages() == ["Alpha not enabled."]
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+
+    def test_raise_if_selection_denied_raises_for_the_current_selection(self, griptape_nodes) -> None:  # noqa: ANN001
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_alpha":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        try:
+            node, helper, param = _build_probe_node_with_component(
+                model_choices=["alpha", "beta"], default_model="beta"
+            )
+            helper.raise_if_selection_denied()  # permitted: must not raise
+
+            node.set_parameter_value(param.name, "alpha", initial_setup=True)
+            with pytest.raises(RuntimeError, match="not permitted"):
+                helper.raise_if_selection_denied()
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+
+    def test_on_value_set_ignores_other_parameters(self, griptape_nodes) -> None:  # noqa: ANN001
+        """The component filters for its own parameter so nodes can forward unconditionally."""
+        from griptape_nodes.exe_types.core_types import Parameter
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_alpha":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        try:
+            node, helper, param = _build_probe_node_with_component(
+                model_choices=["alpha", "beta"], default_model="beta"
+            )
+            other = Parameter(name="unrelated", type="str", tooltip="")
+            node.add_parameter(other)
+
+            helper.on_value_set(other, "alpha")
+            assert param.get_badge() is None
+
+            helper.on_value_set(param, "alpha")
+            assert param.get_badge() is not None
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -834,6 +834,27 @@ class TestDeprecatedValuesValidation:
                 deprecated_values={"beta": "alpha"},
             )
 
+    def test_raises_when_default_model_is_a_deprecated_key(self) -> None:
+        """A legacy key as default_model would make pick_permitted_default lie.
+
+        Denials are keyed by provider id, so a legacy key never appears in them
+        and would always look permitted -- leaving a denied model selected with
+        no badge. Caught at construction instead.
+        """
+        with pytest.raises(ValueError, match="default_model 'Alpha', which is not one of model_choices"):
+            _build_probe_node_with_component(
+                model_choices=["alpha", "beta"],
+                default_model="Alpha",
+                deprecated_values={"Alpha": "alpha"},
+            )
+
+    def test_raises_when_default_model_is_not_a_choice_at_all(self) -> None:
+        with pytest.raises(ValueError, match="default_model 'gamma', which is not one of model_choices"):
+            _build_probe_node_with_component(
+                model_choices=["alpha", "beta"],
+                default_model="gamma",
+            )
+
 
 class TestDeprecatedValuesMigration:
     """A legacy stored value is accepted wherever assigned, migrated, and never offered as a fresh selection.

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -817,7 +817,9 @@ class TestDeprecatedValuesValidation:
     """deprecated_values is validated at construction, same as the component's other preconditions."""
 
     def test_raises_when_a_value_is_not_a_current_choice(self) -> None:
-        with pytest.raises(ValueError, match="not in model_choices"):
+        # The message must name the offending canonical value ('gamma'), not the
+        # legacy key ('Alpha') -- naming the key sends the reader to the wrong fix.
+        with pytest.raises(ValueError, match="not in model_choices: 'gamma'"):
             _build_probe_node_with_component(
                 model_choices=["alpha", "beta"],
                 default_model="alpha",
@@ -825,7 +827,7 @@ class TestDeprecatedValuesValidation:
             )
 
     def test_raises_when_a_key_collides_with_a_current_choice(self) -> None:
-        with pytest.raises(ValueError, match="already a current choice"):
+        with pytest.raises(ValueError, match="already a current choice: 'beta'"):
             _build_probe_node_with_component(
                 model_choices=["alpha", "beta"],
                 default_model="alpha",

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -337,10 +337,11 @@ class TestInstall:
 class TestConstructorPreconditions:
     """The component's constructor rejects misuse rather than silently misbehaving.
 
-    Under the one-step API, ``install()`` is folded into ``__init__``. The four
-    precondition checks (parameter-not-attached, pre-existing Options trait,
-    pre-existing Button trait, second-instance-on-same-parameter) all fire
-    from the constructor.
+    Under the one-step API, ``install()`` is folded into ``__init__``. The
+    parameter-shape checks (parameter-not-attached, pre-existing Options trait,
+    pre-existing Button trait, second-instance-on-same-parameter) all fire from
+    the constructor. The checks on the declared choice list live in
+    ``TestDeprecatedValuesValidation``.
     """
 
     def test_raises_when_parameter_is_not_on_node(self) -> None:

--- a/tests/unit/exe_types/test_core_types.py
+++ b/tests/unit/exe_types/test_core_types.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import ANY
 
 import pytest  # type: ignore[reportMissingImports]
@@ -11,6 +13,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterGroup,
     ParameterList,
     ParameterType,
+    Trait,
 )
 
 # No badge by default; elements send badge: null until set_badge() is called.
@@ -457,6 +460,37 @@ class TestParameter:
         callback = lambda _p, _node_name, _param_name: None  # noqa: E731
         param.on_outgoing_connection_removed.append(callback)
         assert callback in param.on_outgoing_connection_removed
+
+    def test_add_converter_appends_in_call_order(self) -> None:
+        param = Parameter(name="test", input_types=["str"], type="str", output_type="str", tooltip="test")
+        first = lambda value: f"{value}-first"  # noqa: E731
+        second = lambda value: f"{value}-second"  # noqa: E731
+
+        param.add_converter(first)
+        param.add_converter(second)
+
+        assert param.converters == [first, second]
+
+    def test_add_converter_runs_after_trait_converters(self) -> None:
+        """A directly-attached converter observes the value after every trait has converted it."""
+
+        class _Suffixer(Trait):
+            @classmethod
+            def get_trait_keys(cls) -> list[str]:
+                return ["suffixer"]
+
+            def converters_for_trait(self) -> list[Callable[[Any], Any]]:
+                return [lambda value: f"{value}-trait"]
+
+        param = Parameter(name="test", input_types=["str"], type="str", output_type="str", tooltip="test")
+        param.add_trait(_Suffixer())
+        param.add_converter(lambda value: f"{value}-direct")
+
+        value = "seed"
+        for converter in param.converters:
+            value = converter(value)
+
+        assert value == "seed-trait-direct"
 
     def test_settable_property(self) -> None:
         """Test that settable property works correctly and is included in serialization."""


### PR DESCRIPTION
Many nodes declare their models via a human friendly name e.g. "Seedance 2.0". `ModelAccessCompoent` expects the model to be provided as a provider model id e.g. "seedance-2.0". I'm going through and migrating all nodes to use the proper form but we need a migration so existing workflows don't break. This PR adds a `deprecated_values` mapping to `ModelAccessComponent` so a node can declare the values its model dropdown used to store.