### PR TITLE
Fix Locked Node Runs 

### DIFF
--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1902,6 +1902,11 @@ class SuccessFailureNode(BaseNode):
 
     def get_next_control_output(self) -> Parameter | None:
         """Determine which control output to follow based on execution result."""
+        if self._execution_succeeded is None and self.lock:
+            # A locked node never executes, so it has no result to branch on. Follow the success
+            # path so locking a node to freeze its outputs doesn't dead-end the control flow.
+            return self.control_parameter_out
+
         if self._execution_succeeded is None:
             # Execution hasn't completed yet
             self.stop_flow = True

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1902,9 +1902,12 @@ class SuccessFailureNode(BaseNode):
 
     def get_next_control_output(self) -> Parameter | None:
         """Determine which control output to follow based on execution result."""
-        if self._execution_succeeded is None and self.lock:
-            # A locked node never executes, so it has no result to branch on. Follow the success
-            # path so locking a node to freeze its outputs doesn't dead-end the control flow.
+        # A locked node never executes, so it has no result to branch on this run. Whatever
+        # _execution_succeeded holds is left over from a previous run (it is only ever written by
+        # _set_status_results and reset by _clear_execution_status, both reached via process()).
+        # Follow the success path so locking a node to freeze its outputs doesn't route down
+        # Failed or dead-end the control flow.
+        if self.lock:
             return self.control_parameter_out
 
         if self._execution_succeeded is None:

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -354,6 +354,14 @@ class ExecuteDagState(State):
 
         dag_node = context.node_to_reference[node_name]
 
+        # A locked node is frozen: it never executes and keeps its existing output values.
+        # Mark it DONE here rather than queueing it, so pop_done_states propagates those frozen
+        # outputs and advances control flow. Gating at queue time (rather than at dispatch) is
+        # what keeps it out of the priority queue entirely.
+        if dag_node.node_reference.lock:
+            dag_node.node_state = NodeState.DONE
+            return
+
         # Only check nodes that are currently waiting
         if dag_node.node_state == NodeState.WAITING:
             can_queue = context.dag_builder.can_queue_control_node(dag_node)
@@ -426,12 +434,7 @@ class ExecuteDagState(State):
         canceled_nodes = set()
         for node in leaf_nodes:
             node_reference = context.node_to_reference[node]
-            # If the node is locked, mark it as done so it skips execution
-            if node_reference.node_reference.lock:
-                node_reference.node_state = NodeState.DONE
-                continue
-            node_state = node_reference.node_state
-            if node_state == NodeState.CANCELED:
+            if node_reference.node_state == NodeState.CANCELED:
                 canceled_nodes.add(node)
         return NodeStatesResult(canceled_nodes=canceled_nodes, leaf_nodes=leaf_nodes)
 

--- a/tests/unit/exe_types/test_node_types.py
+++ b/tests/unit/exe_types/test_node_types.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import AsyncResult, TrackedParameterOutputValues
+from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode, TrackedParameterOutputValues
 
 from .mocks import MockNode
 
@@ -226,3 +226,49 @@ class TestErrorProxyNode:
         assert message.markdown is True
         assert "**Permission denied**" in message.value
         assert "Ask your admin to enable Labs nodes." in message.value
+
+
+class TestLockedSuccessFailureNodeRouting:
+    """A locked SuccessFailureNode must route down Succeeded, not Failed or nowhere.
+
+    A locked node never executes, so ``_execution_succeeded`` is never written for the current
+    run. It is only assigned by ``_set_status_results`` and reset by ``_clear_execution_status``,
+    both reached through ``process()``. So the attribute holds whatever the *previous* run left:
+    ``None`` if the node never ran (which used to set ``stop_flow`` and dead-end the branch), or a
+    stale ``False`` if the node failed before being locked (which used to route down Failed).
+    """
+
+    @staticmethod
+    def _locked_node() -> SuccessFailureNode:
+        node = SuccessFailureNode(name="locked_branch")
+        node.lock = True
+        return node
+
+    def test_locked_node_that_never_ran_follows_success_path(self) -> None:
+        """``_execution_succeeded is None`` must not set stop_flow when the node is locked."""
+        node = self._locked_node()
+        assert node._execution_succeeded is None
+
+        assert node.get_next_control_output() is node.control_parameter_out
+        assert node.stop_flow is False
+
+    def test_locked_node_with_stale_failure_follows_success_path(self) -> None:
+        """A stale ``False`` from a run before the lock must not route down Failed."""
+        node = self._locked_node()
+        node._execution_succeeded = False
+
+        assert node.get_next_control_output() is node.control_parameter_out
+
+    def test_unlocked_node_still_routes_on_its_result(self) -> None:
+        """Unlocked nodes keep their normal success/failure/not-yet-run routing."""
+        node = SuccessFailureNode(name="unlocked_branch")
+
+        node._execution_succeeded = False
+        assert node.get_next_control_output() is node.failure_output
+
+        node._execution_succeeded = True
+        assert node.get_next_control_output() is node.control_parameter_out
+
+        node._execution_succeeded = None
+        assert node.get_next_control_output() is None
+        assert node.stop_flow is True

--- a/tests/unit/machines/test_parallel_flow_execution.py
+++ b/tests/unit/machines/test_parallel_flow_execution.py
@@ -576,3 +576,66 @@ class TestParallelResolutionNodeDoneWhenTaskCompletes:
         assert dag_node.node_state == NodeState.ERRORED
         assert context.workflow_state == WorkflowState.ERRORED
         assert context.error_message is not None
+
+
+class TestLockedNodeIsNeverQueuedOrExecuted:
+    """A locked node is frozen: it must never be dispatched, and its outputs must survive.
+
+    The lock used to be checked only in ``build_node_states`` (which marked the node DONE without
+    removing its *name* from the priority queue) and in ``pop_done_states`` (which runs at the end
+    of ``on_update``, after the execute loop). So ``get_next_node`` popped a name that should never
+    have been queued and ran the node anyway -- after ``silent_clear()`` had already wiped the
+    frozen outputs it was supposed to preserve. The gate now lives in ``_try_queue_waiting_node``.
+    """
+
+    @staticmethod
+    def _context_with_locked_leaf() -> ParallelResolutionContext:
+        """A context with one locked WAITING leaf node, eligible for queueing but for the lock."""
+        node = MagicMock(spec=BaseNode)
+        node.name = "locked"
+        node.lock = True
+        node.state = NodeResolutionState.RESOLVED
+
+        graph = DirectedGraph()
+        graph.add_node("locked")
+
+        dag_builder = DagBuilder()
+        dag_builder.graphs["locked"] = graph
+        dag_builder.node_to_reference["locked"] = DagNode(node_reference=node, node_state=NodeState.WAITING)
+
+        return ParallelResolutionContext("flow", max_nodes_in_parallel=5, dag_builder=dag_builder)
+
+    def test_locked_node_is_marked_done_and_not_queued(self) -> None:
+        """The queueing gate must divert a locked node to DONE instead of into the priority queue."""
+        context = self._context_with_locked_leaf()
+
+        ExecuteDagState._try_queue_waiting_node(context, "locked")
+
+        assert context.node_to_reference["locked"].node_state == NodeState.DONE
+        assert "locked" not in context.node_priority_queue._queued_nodes
+        assert "locked" not in context.node_priority_queue._blocked_nodes
+
+    @pytest.mark.asyncio
+    async def test_locked_node_is_never_executed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``on_update`` must not create an execution task for a locked node."""
+        context = self._context_with_locked_leaf()
+
+        execute_node = AsyncMock()
+        monkeypatch.setattr(ExecuteDagState, "execute_node", execute_node)
+        # handle_done_nodes touches the full engine (events, connections, library registry); stub it
+        # so this stays a focused scheduler unit test.
+        monkeypatch.setattr(ExecuteDagState, "handle_done_nodes", AsyncMock())
+
+        await ExecuteDagState.on_update(context)
+
+        execute_node.assert_not_awaited()
+        assert not context.task_to_node, "a task was created for a locked node"
+
+    def test_build_node_states_does_not_mutate_node_state(self) -> None:
+        """``build_node_states`` is a query: it reports leaves without mutating execution state."""
+        context = self._context_with_locked_leaf()
+
+        result = ExecuteDagState.build_node_states(context)
+
+        assert result.leaf_nodes == {"locked"}
+        assert context.node_to_reference["locked"].node_state == NodeState.WAITING


### PR DESCRIPTION
Nodes that were locked had two big issues: 
1. They were still getting queued despite their locked state, because there was no `lock` check before queueing nodes, even though there were locked checks in other places. 
2. There were extraneous lock checks, that were never actually getting hit. 
3. A locked node would sometimes end the flow on their run, because it had no `execution_succeeded` parameter if it was a failure/success node. 

closes #5118 