### PR TITLE
refactor: clone and update libraries with the git CLI instead of pygit2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
   "ruamel.yaml>=0.18.15",
   "asyncio-thread-runner>=1.0",
   "portalocker>=2.10.0",
-  "pygit2>=1.19.0",
   "send2trash>=2.1.0",
   "tenacity>=9.0.0",
   "truststore>=0.10.1",

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -246,12 +246,7 @@ from griptape_nodes.utils.async_utils import subprocess_run
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, normalize_secrets_to_register
 from griptape_nodes.utils.file_utils import find_file_in_directory, find_files_recursive
 from griptape_nodes.utils.git_utils import (
-    GitCloneError,
     GitError,
-    GitPullError,
-    GitRefError,
-    GitRemoteError,
-    GitRepositoryError,
     clone_repository,
     extract_repo_name_from_url,
     get_current_ref,
@@ -5798,13 +5793,13 @@ class LibraryManager(EngineScoped):
             if git_remote is None:
                 details = f"Library '{library_name}' is not a git repository or has no remote configured."
                 return CheckLibraryUpdateResultFailure(result_details=details)
-        except GitRemoteError as e:
+        except GitError as e:
             details = f"Failed to get git remote for Library '{library_name}': {e}"
             return CheckLibraryUpdateResultFailure(result_details=details)
 
         try:
             git_ref = await asyncio.to_thread(get_current_ref, library_dir)
-        except GitRefError as e:
+        except GitError as e:
             details = f"Failed to get current git reference for Library '{library_name}': {e}"
             return CheckLibraryUpdateResultFailure(result_details=details)
 
@@ -5823,7 +5818,7 @@ class LibraryManager(EngineScoped):
         if git_ref is not None:
             try:
                 ref_on_remote = await asyncio.to_thread(remote_ref_exists, git_remote, git_ref)
-            except GitRemoteError as e:
+            except GitError as e:
                 details = f"Failed to query git remote for Library '{library_name}': {e}"
                 return CheckLibraryUpdateResultFailure(result_details=details)
 
@@ -5850,7 +5845,7 @@ class LibraryManager(EngineScoped):
             version_info = await asyncio.to_thread(clone_and_get_library_version, git_remote, ref_to_check)
             latest_version = version_info.library_version
             remote_commit = version_info.commit_sha
-        except GitCloneError as e:
+        except GitError as e:
             details = f"Failed to retrieve latest version from git remote for Library '{library_name}': {e}"
             return CheckLibraryUpdateResultFailure(result_details=details)
 
@@ -6115,7 +6110,7 @@ class LibraryManager(EngineScoped):
                 library_dir,
                 overwrite_existing=request.overwrite_existing,
             )
-        except (GitPullError, GitRepositoryError) as e:
+        except GitError as e:
             error_msg = str(e).lower()
 
             # Check if error is retryable (uncommitted changes)
@@ -6195,14 +6190,14 @@ class LibraryManager(EngineScoped):
             if old_ref is None:
                 details = f"Library '{library_name}' is not on a branch/tag or is not a git repository."
                 return SwitchLibraryRefResultFailure(result_details=details)
-        except GitRefError as e:
+        except GitError as e:
             details = f"Failed to get current branch/tag for Library '{library_name}': {e}"
             return SwitchLibraryRefResultFailure(result_details=details)
 
         # Perform git ref switch (branch or tag)
         try:
             await asyncio.to_thread(switch_branch_or_tag, library_dir, ref_name)
-        except (GitRefError, GitRepositoryError) as e:
+        except GitError as e:
             details = f"Failed to switch to '{ref_name}' for Library '{library_name}': {e}"
             return SwitchLibraryRefResultFailure(result_details=details)
 
@@ -6222,7 +6217,7 @@ class LibraryManager(EngineScoped):
             new_ref = await asyncio.to_thread(get_current_ref, library_dir)
             if new_ref is None:
                 new_ref = "unknown"
-        except GitRefError:
+        except GitError:
             new_ref = "unknown"
 
         details = f"Successfully switched Library '{library_name}' from '{old_ref}' (version {old_version}) to '{new_ref}' (version {new_version})."
@@ -6301,7 +6296,7 @@ class LibraryManager(EngineScoped):
         else:
             try:
                 await asyncio.to_thread(clone_repository, git_url, target_path, branch_tag_commit)
-            except GitCloneError as e:
+            except GitError as e:
                 details = f"Failed to clone repository from {git_url} to {target_path}: {e}"
                 return DownloadLibraryResultFailure(result_details=details)
 
@@ -6789,7 +6784,7 @@ class LibraryManager(EngineScoped):
         # Perform sparse checkout to get library JSON
         try:
             checkout = sparse_checkout_library_json(normalized_url, ref)
-        except GitCloneError as e:
+        except GitError as e:
             details = f"Failed to inspect library from {normalized_url}: {e}"
             logger.error(details)
             return InspectLibraryRepoResultFailure(result_details=details)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5767,14 +5767,20 @@ class LibraryManager(EngineScoped):
         library_dir = Path(library_file_path).parent.absolute()
 
         # Check if library is in a monorepo (multiple libraries in same git repository)
-        if await asyncio.to_thread(is_monorepo, library_dir):
+        try:
+            in_monorepo = await asyncio.to_thread(is_monorepo, library_dir)
+        except GitError as e:
+            details = f"Attempted to check for updates for Library '{library_name}'. Failed because the repository layout could not be determined: {e}"
+            return CheckLibraryUpdateResultFailure(result_details=details)
+
+        if in_monorepo:
             details = (
                 f"Library '{library_name}' is in a monorepo with multiple libraries. Updates must be managed manually."
             )
             logger.info(details)
-            # Get git info for the response
-            git_remote = await asyncio.to_thread(get_git_remote, library_dir)
-            git_ref = await asyncio.to_thread(get_current_ref, library_dir)
+            # Get git info for the response. Informational only here, so a git failure must not
+            # turn the successful "monorepo, update manually" answer into a failure.
+            git_remote, git_ref = await asyncio.to_thread(get_git_info, library_dir)
             current_version = library.get_metadata().library_version
             return CheckLibraryUpdateResultSuccess(
                 has_update=False,
@@ -5810,7 +5816,11 @@ class LibraryManager(EngineScoped):
             return CheckLibraryUpdateResultFailure(result_details=details)
 
         # Get local commit SHA
-        local_commit = await asyncio.to_thread(get_local_commit_sha, library_dir)
+        try:
+            local_commit = await asyncio.to_thread(get_local_commit_sha, library_dir)
+        except GitError as e:
+            details = f"Failed to read the local commit for Library '{library_name}': {e}"
+            return CheckLibraryUpdateResultFailure(result_details=details)
 
         # If the current ref does not exist on the remote (e.g. a local-only branch that has
         # not been pushed, or a detached HEAD on a bare commit), there is nothing on the remote
@@ -6061,7 +6071,7 @@ class LibraryManager(EngineScoped):
 
         return new_version
 
-    async def update_library_request(self, request: UpdateLibraryRequest) -> ResultPayload:  # noqa: C901
+    async def update_library_request(self, request: UpdateLibraryRequest) -> ResultPayload:  # noqa: C901, PLR0911
         """Update a library to the latest version using the appropriate git strategy.
 
         Automatically detects whether the library uses branch-based or tag-based workflow:
@@ -6084,7 +6094,13 @@ class LibraryManager(EngineScoped):
         library_dir = validation_result.library_dir
 
         # Check if library is in a monorepo (multiple libraries in same git repository)
-        if await asyncio.to_thread(is_monorepo, library_dir):
+        try:
+            in_monorepo = await asyncio.to_thread(is_monorepo, library_dir)
+        except GitError as e:
+            details = f"Cannot update Library '{library_name}'. Failed because the repository layout could not be determined: {e}"
+            return UpdateLibraryResultFailure(result_details=details)
+
+        if in_monorepo:
             details = f"Cannot update Library '{library_name}'. Repository contains multiple libraries and must be updated manually."
             return UpdateLibraryResultFailure(result_details=details)
 

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import tempfile
 from datetime import UTC, datetime
+from functools import cache
 from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import urlparse
@@ -296,6 +297,22 @@ _GIT_MISSING_MESSAGE = (
 _GIT_ALLOWED_PROTOCOLS = "file:git:http:https:ssh"
 
 
+@cache
+def _log_git_env_override(name: str, inherited: str, default: str) -> None:
+    """Report that an inherited environment variable displaced a git hardening default.
+
+    Cached so a launcher that sets one of these permanently produces one line per distinct
+    value rather than one line per git invocation.
+    """
+    logger.warning(
+        "Inherited %s=%r from the environment, overriding the Griptape Nodes default of %r. "
+        "Library installs and updates will use the inherited setting.",
+        name,
+        inherited,
+        default,
+    )
+
+
 def _git_env() -> dict[str, str]:
     """Build the environment for a git subprocess.
 
@@ -308,13 +325,20 @@ def _git_env() -> dict[str, str]:
     by default, but leaves unrecognized ones permitted for a directly invoked command.
 
     An inherited value wins for both, letting a launcher opt back into prompting or admit
-    a transport this list omits.
+    a transport this list omits. Because that also lets a launcher turn off the transport
+    restriction, an override is logged so it is visible rather than silent.
     """
-    return {
+    defaults = {
         "GIT_TERMINAL_PROMPT": "0",
         "GIT_ALLOW_PROTOCOL": _GIT_ALLOWED_PROTOCOLS,
-        **os.environ,
     }
+
+    for name, default in defaults.items():
+        inherited = os.environ.get(name)
+        if inherited is not None and inherited != default:
+            _log_git_env_override(name, inherited, default)
+
+    return {**defaults, **os.environ}
 
 
 def _reject_option_like(value: str, description: str, error_cls: type[GitError]) -> None:
@@ -345,7 +369,12 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
             env=_git_env(),
             stdin=subprocess.DEVNULL,
             capture_output=True,
-            text=True,
+            # git writes paths, refs, and messages as UTF-8 regardless of the process locale,
+            # so decode as UTF-8 rather than letting the platform's preferred encoding decide.
+            # errors="replace" keeps an undecodable byte from turning into a UnicodeDecodeError
+            # that escapes as something other than a GitError.
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
     except FileNotFoundError as e:
@@ -477,13 +506,21 @@ def get_git_info(library_path: Path) -> tuple[str | None, str | None]:
     values are needed: those functions each re-run is_git_repository(), and each raises
     where this one degrades to None.
 
+    This runs for every library on every metadata load, where git details are informational
+    and a library must still load without them. A missing git installation therefore reports
+    "unavailable" here instead of raising the way the single-value accessors do.
+
     Returns:
         tuple[str | None, str | None]: (git_remote, git_ref), each None if unavailable.
     """
     if not is_git_repository(library_path):
         return None, None
 
-    return _remote_url(library_path), _describe_head(library_path)
+    try:
+        return _remote_url(library_path), _describe_head(library_path)
+    except GitNotFoundError:
+        logger.debug("Reporting no git details for %s: git is not installed", library_path)
+        return None, None
 
 
 def get_git_remote(library_path: Path) -> str | None:
@@ -636,6 +673,7 @@ def _resolve_update_upstream(library_path: Path) -> str:
     Raises:
         GitRepositoryError: If validation fails.
         GitPullError: If repository state is invalid for update.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         msg = f"Cannot update: {library_path} is not a git repository"
@@ -674,6 +712,7 @@ def git_update_from_remote(library_path: Path, *, overwrite_existing: bool = Fal
         GitRepositoryError: If the path is not a valid git repository.
         GitPullError: If the update operation fails or uncommitted changes exist
             when overwrite_existing=False.
+        GitNotFoundError: If git is not installed.
     """
     upstream = _resolve_update_upstream(library_path)
 
@@ -707,6 +746,7 @@ def update_to_moving_tag(library_path: Path, tag_name: str, *, overwrite_existin
         GitRepositoryError: If the path is not a valid git repository.
         GitPullError: If the tag update operation fails or uncommitted changes exist
             when overwrite_existing=False.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         msg = f"Cannot update tag: {library_path} is not a git repository"
@@ -761,6 +801,7 @@ def update_library_git(library_path: Path, *, overwrite_existing: bool = False) 
         GitRepositoryError: If the path is not a valid git repository.
         GitPullError: If the update operation fails or uncommitted changes exist
             when overwrite_existing=False.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         msg = f"Cannot update: {library_path} is not a git repository"
@@ -793,6 +834,7 @@ def switch_branch(library_path: Path, branch_name: str) -> None:
     Raises:
         GitRepositoryError: If the path is not a valid git repository.
         GitRefError: If the branch switch operation fails.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         msg = f"Cannot switch branch: {library_path} is not a git repository"
@@ -841,6 +883,7 @@ def switch_branch_or_tag(library_path: Path, ref_name: str) -> None:
     Raises:
         GitRepositoryError: If the path is not a valid git repository.
         GitRefError: If the switch operation fails.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         msg = f"Cannot switch ref: {library_path} is not a git repository"
@@ -889,6 +932,7 @@ def clone_repository(git_url: str, target_path: Path, branch_tag_commit: str | N
 
     Raises:
         GitCloneError: If cloning fails or target path already exists.
+        GitNotFoundError: If git is not installed.
     """
     # The clone runs in a throwaway directory (see _run_git_detached), so git would resolve a
     # relative target against that directory and the clone would be discarded with it. Anchor to
@@ -970,6 +1014,7 @@ def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> LibraryJ
 
     Raises:
         GitCloneError: If the checkout fails or library metadata is invalid.
+        GitNotFoundError: If git is not installed.
     """
     _reject_option_like(remote_url, "git URL", GitCloneError)
     _reject_option_like(ref, "ref", GitCloneError)
@@ -1044,6 +1089,7 @@ def remote_ref_exists(remote_url: str, ref: str) -> bool:
 
     Raises:
         GitRemoteError: If the remote cannot be queried.
+        GitNotFoundError: If git is not installed.
     """
     _reject_option_like(remote_url, "git URL", GitRemoteError)
     _reject_option_like(ref, "ref", GitRemoteError)

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -290,16 +290,31 @@ _GIT_MISSING_MESSAGE = (
     "git was not found on PATH. Griptape Nodes requires a git installation to install and update libraries."
 )
 
+# Transports a library URL is allowed to use. Anything outside this list, notably a
+# "<helper>::<url>" spelling that makes git exec a git-remote-<helper> binary, is refused
+# before a connection is attempted.
+_GIT_ALLOWED_PROTOCOLS = "file:git:http:https:ssh"
+
 
 def _git_env() -> dict[str, str]:
     """Build the environment for a git subprocess.
 
     The engine runs headless, so git must never block on an interactive credential
-    prompt nobody can answer. An inherited value wins, letting a launcher opt back
-    into prompting. This covers git's own prompts; `_git` closes stdin to stop the
-    transports git shells out to (ssh, in particular) from prompting either.
+    prompt nobody can answer. This covers git's own prompts; `_git` closes stdin to stop
+    the transports git shells out to (ssh, in particular) from prompting either.
+
+    Library URLs reach git from workflow and request payloads, so the transports git will
+    speak are pinned to `_GIT_ALLOWED_PROTOCOLS`. git already refuses the `ext` transport
+    by default, but leaves unrecognized ones permitted for a directly invoked command.
+
+    An inherited value wins for both, letting a launcher opt back into prompting or admit
+    a transport this list omits.
     """
-    return {"GIT_TERMINAL_PROMPT": "0", **os.environ}
+    return {
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ALLOW_PROTOCOL": _GIT_ALLOWED_PROTOCOLS,
+        **os.environ,
+    }
 
 
 def _reject_option_like(value: str, description: str, error_cls: type[GitError]) -> None:
@@ -868,12 +883,19 @@ def clone_repository(git_url: str, target_path: Path, branch_tag_commit: str | N
 
     Args:
         git_url: The git repository URL to clone (HTTPS or SSH).
-        target_path: The target directory path to clone into.
+        target_path: The target directory path to clone into. A relative path is anchored to the
+            current working directory.
         branch_tag_commit: Optional branch, tag, or commit to checkout after cloning.
 
     Raises:
         GitCloneError: If cloning fails or target path already exists.
     """
+    # The clone runs in a throwaway directory (see _run_git_detached), so git would resolve a
+    # relative target against that directory and the clone would be discarded with it. Anchor to
+    # the caller's working directory instead, before anything else reads the path. Deliberately
+    # not canonicalize_for_io: it applies the Windows \\?\ long-path prefix, which git rejects.
+    target_path = target_path.absolute()
+
     if target_path.exists():
         msg = f"Cannot clone: target path {target_path} already exists"
         raise GitCloneError(msg)

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -977,7 +977,13 @@ def clone_repository(git_url: str, target_path: Path, branch_tag_commit: str | N
     # relative target against that directory and the clone would be discarded with it. Anchor to
     # the caller's working directory instead, before anything else reads the path. Deliberately
     # not canonicalize_for_io: it applies the Windows \\?\ long-path prefix, which git rejects.
-    target_path = target_path.absolute()
+    try:
+        target_path = target_path.absolute()
+    except OSError as e:
+        # Anchoring a relative path reads the working directory, which fails if that directory
+        # has been deleted from under the process.
+        msg = f"Attempted to clone {git_url} to {target_path}. Failed due to: {e}"
+        raise GitCloneError(msg) from e
 
     if target_path.exists():
         msg = f"Cannot clone: target path {target_path} already exists"

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -357,13 +357,17 @@ def _reject_option_like(value: str, description: str, error_cls: type[GitError])
         raise error_cls(msg)
 
 
-def _spawn_failure_error(cwd: Path | None, error: OSError) -> GitError:
-    """Explain why a git subprocess could not be started.
+def _git_os_error(cwd: Path | None, error: OSError) -> GitError:
+    """Explain an OS-level failure to run git.
 
     subprocess reports a missing git, a git that cannot be run, and an unusable working directory
     with different sibling OSError types, so the cause has to be established afterwards from what
-    is actually missing. Every outcome is a GitError: callers guard on that, and a raw OS error
-    escaping here would reach a request handler unhandled.
+    is actually missing. Anything left over kept the exact OS error for the log: it covers both a
+    git that never started and one that started and then hit something like fd exhaustion mid-run,
+    which are indistinguishable from here.
+
+    Every outcome is a GitError: callers guard on that, and a raw OS error escaping here would
+    reach a request handler unhandled.
     """
     # which() also rejects a git that is present but not executable, which is the same problem
     # from the caller's point of view: there is no git this process can run.
@@ -374,7 +378,7 @@ def _spawn_failure_error(cwd: Path | None, error: OSError) -> GitError:
         msg = f"Cannot run git in {cwd}: no folder exists at that path."
         return GitRepositoryError(msg)
 
-    msg = f"Could not start git in {cwd}: {error}"
+    msg = f"Attempted to run git in {cwd}. Failed due to: {error}"
     return GitError(msg)
 
 
@@ -384,7 +388,7 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
     Raises:
         GitNotFoundError: If no runnable git is on PATH.
         GitRepositoryError: If cwd is not a directory.
-        GitError: If git cannot be started for any other reason.
+        GitError: If git cannot be run for any other reason.
     """
     try:
         return subprocess.run(  # noqa: S603
@@ -402,7 +406,7 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
             check=False,
         )
     except OSError as e:
-        raise _spawn_failure_error(cwd, e) from e
+        raise _git_os_error(cwd, e) from e
 
 
 def _run_git(
@@ -427,6 +431,7 @@ def _run_git(
         error_cls: If the command exits non-zero.
         GitNotFoundError: If no runnable git is on PATH.
         GitRepositoryError: If cwd is not a directory.
+        GitError: If git cannot be run for any other reason.
     """
     result = _git(args, cwd)
     if result.returncode != 0:
@@ -445,6 +450,7 @@ def _try_git(args: list[str], cwd: Path | None = None) -> str | None:
 
     Raises:
         GitNotFoundError: If no runnable git is on PATH.
+        GitError: If git cannot be run for any other reason.
     """
     try:
         result = _git(args, cwd)
@@ -468,7 +474,8 @@ def _run_git_detached(args: list[str], *, error_msg: str, error_cls: type[GitErr
 
     Raises:
         error_cls: If the command exits non-zero.
-        GitNotFoundError: If git is not installed.
+        GitNotFoundError: If no runnable git is on PATH.
+        GitError: If git cannot be run for any other reason.
     """
     with tempfile.TemporaryDirectory() as neutral_dir:
         return _run_git(args, error_msg=error_msg, cwd=Path(neutral_dir), error_cls=error_cls)
@@ -539,8 +546,8 @@ def get_git_info(library_path: Path) -> tuple[str | None, str | None]:
     where this one degrades to None.
 
     This runs for every library on every metadata load, where git details are informational
-    and a library must still load without them. A missing git installation therefore reports
-    "unavailable" here instead of raising the way the single-value accessors do.
+    and a library must still load without them. Every git failure therefore reports
+    "unavailable" here, rather than raising the way the single-value accessors do.
 
     Returns:
         tuple[str | None, str | None]: (git_remote, git_ref), each None if unavailable.
@@ -550,8 +557,8 @@ def get_git_info(library_path: Path) -> tuple[str | None, str | None]:
 
     try:
         return _remote_url(library_path), _describe_head(library_path)
-    except GitNotFoundError:
-        logger.debug("Reporting no git details for %s: git is not installed", library_path)
+    except GitError as e:
+        logger.debug("Reporting no git details for %s: %s", library_path, e)
         return None, None
 
 

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
 from datetime import UTC, datetime
@@ -361,6 +362,7 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
 
     Raises:
         GitNotFoundError: If git is not installed.
+        GitRepositoryError: If cwd no longer exists.
     """
     try:
         return subprocess.run(  # noqa: S603
@@ -378,7 +380,14 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
             check=False,
         )
     except FileNotFoundError as e:
-        raise GitNotFoundError(_GIT_MISSING_MESSAGE) from e
+        # subprocess reports a missing executable and a missing cwd with the same exception, so
+        # ask which one is actually absent rather than blaming git for a directory that was
+        # deleted between the caller's is_git_repository() check and this call.
+        if shutil.which("git") is None:
+            raise GitNotFoundError(_GIT_MISSING_MESSAGE) from e
+
+        msg = f"Cannot run git in {cwd}: that folder is no longer there."
+        raise GitRepositoryError(msg) from e
 
 
 def _run_git(
@@ -402,6 +411,7 @@ def _run_git(
     Raises:
         error_cls: If the command exits non-zero.
         GitNotFoundError: If git is not installed.
+        GitRepositoryError: If cwd no longer exists.
     """
     result = _git(args, cwd)
     if result.returncode != 0:
@@ -414,12 +424,19 @@ def _try_git(args: list[str], cwd: Path | None = None) -> str | None:
     """Run a git command and return its stripped stdout, or None if it failed.
 
     For queries where a non-zero exit is an answer rather than a fault: no upstream is
-    configured, HEAD is detached, the ref doesn't exist.
+    configured, HEAD is detached, the ref doesn't exist. A repository that was deleted
+    while the query ran belongs in that group too, so it reads as "no answer" rather than
+    propagating out of the accessors built on this.
 
     Raises:
         GitNotFoundError: If git is not installed.
     """
-    result = _git(args, cwd)
+    try:
+        result = _git(args, cwd)
+    except GitRepositoryError:
+        logger.debug("git %s found no repository in %s", " ".join(args), cwd)
+        return None
+
     if result.returncode != 0:
         logger.debug("git %s failed in %s: %s", " ".join(args), cwd, result.stderr.strip())
         return None

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 from datetime import UTC, datetime
-from functools import cache
 from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import urlparse
@@ -292,26 +292,20 @@ _GIT_MISSING_MESSAGE = (
     "git was not found on PATH. Griptape Nodes requires a git installation to install and update libraries."
 )
 
+# Ceiling on any single git command. Generous enough for a large library clone over a slow
+# connection, but bounded so a stalled transport fails the request instead of holding a worker
+# thread until the engine is restarted.
+_GIT_TIMEOUT_SECONDS = 600
+
 # Transports a library URL is allowed to use. Anything outside this list, notably a
 # "<helper>::<url>" spelling that makes git exec a git-remote-<helper> binary, is refused
 # before a connection is attempted.
 _GIT_ALLOWED_PROTOCOLS = "file:git:http:https:ssh"
 
-
-@cache
-def _log_git_env_override(name: str, inherited: str, default: str) -> None:
-    """Report that an inherited environment variable displaced a git hardening default.
-
-    Cached so a launcher that sets one of these permanently produces one line per distinct
-    value rather than one line per git invocation.
-    """
-    logger.warning(
-        "Inherited %s=%r from the environment, overriding the Griptape Nodes default of %r. "
-        "Library installs and updates will use the inherited setting.",
-        name,
-        inherited,
-        default,
-    )
+# git reads "<helper>::<address>" as a request to exec git-remote-<helper>, and the built-in
+# `ext` helper hands its address to a shell. The prefix is anchored and excludes "/", ":" and
+# "[" so a normal URL ("https://host/x") and an IPv6 literal ("https://[::1]/x") don't match.
+_REMOTE_HELPER_URL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9+.-]*::")
 
 
 def _git_env() -> dict[str, str]:
@@ -322,24 +316,15 @@ def _git_env() -> dict[str, str]:
     the transports git shells out to (ssh, in particular) from prompting either.
 
     Library URLs reach git from workflow and request payloads, so the transports git will
-    speak are pinned to `_GIT_ALLOWED_PROTOCOLS`. git already refuses the `ext` transport
-    by default, but leaves unrecognized ones permitted for a directly invoked command.
-
-    An inherited value wins for both, letting a launcher opt back into prompting or admit
-    a transport this list omits. Because that also lets a launcher turn off the transport
-    restriction, an override is logged so it is visible rather than silent.
+    speak are pinned to `_GIT_ALLOWED_PROTOCOLS`. Both settings override anything inherited:
+    a `GIT_ALLOW_PROTOCOL` from the surrounding environment that re-admitted `ext` would turn
+    a library URL into arbitrary command execution, so the environment does not get a vote.
     """
-    defaults = {
+    return {
+        **os.environ,
         "GIT_TERMINAL_PROMPT": "0",
         "GIT_ALLOW_PROTOCOL": _GIT_ALLOWED_PROTOCOLS,
     }
-
-    for name, default in defaults.items():
-        inherited = os.environ.get(name)
-        if inherited is not None and inherited != default:
-            _log_git_env_override(name, inherited, default)
-
-    return {**defaults, **os.environ}
 
 
 def _reject_option_like(value: str, description: str, error_cls: type[GitError]) -> None:
@@ -354,6 +339,22 @@ def _reject_option_like(value: str, description: str, error_cls: type[GitError])
     """
     if value.startswith("-"):
         msg = f"Invalid {description}: {value!r} must not start with '-'"
+        raise error_cls(msg)
+
+
+def _reject_unsafe_url(url: str, error_cls: type[GitError]) -> None:
+    """Reject a library URL git would treat as something other than a repository address.
+
+    Checked here rather than left to `GIT_ALLOW_PROTOCOL` alone so the refusal does not depend
+    on git honoring an environment variable.
+
+    Raises:
+        error_cls: If the URL would be read as an option or as a remote helper invocation.
+    """
+    _reject_option_like(url, "git URL", error_cls)
+
+    if _REMOTE_HELPER_URL.match(url):
+        msg = f"Invalid git URL: {url!r} names a transport helper. Use an http, https, ssh, git, or file URL."
         raise error_cls(msg)
 
 
@@ -388,7 +389,7 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
     Raises:
         GitNotFoundError: If no runnable git is on PATH.
         GitRepositoryError: If cwd is not a directory.
-        GitError: If git cannot be run for any other reason.
+        GitError: If git times out or cannot be run for any other reason.
     """
     try:
         return subprocess.run(  # noqa: S603
@@ -403,8 +404,15 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
             # that escapes as something other than a GitError.
             encoding="utf-8",
             errors="replace",
+            timeout=_GIT_TIMEOUT_SECONDS,
             check=False,
         )
+    except subprocess.TimeoutExpired as e:
+        msg = (
+            f"git {args[0]} did not finish within {_GIT_TIMEOUT_SECONDS} seconds and was stopped. "
+            f"The remote may be unreachable."
+        )
+        raise GitError(msg) from e
     except OSError as e:
         raise _git_os_error(cwd, e) from e
 
@@ -431,7 +439,7 @@ def _run_git(
         error_cls: If the command exits non-zero.
         GitNotFoundError: If no runnable git is on PATH.
         GitRepositoryError: If cwd is not a directory.
-        GitError: If git cannot be run for any other reason.
+        GitError: If git times out or cannot be run for any other reason.
     """
     result = _git(args, cwd)
     if result.returncode != 0:
@@ -450,7 +458,7 @@ def _try_git(args: list[str], cwd: Path | None = None) -> str | None:
 
     Raises:
         GitNotFoundError: If no runnable git is on PATH.
-        GitError: If git cannot be run for any other reason.
+        GitError: If git times out or cannot be run for any other reason.
     """
     try:
         result = _git(args, cwd)
@@ -475,7 +483,7 @@ def _run_git_detached(args: list[str], *, error_msg: str, error_cls: type[GitErr
     Raises:
         error_cls: If the command exits non-zero.
         GitNotFoundError: If no runnable git is on PATH.
-        GitError: If git cannot be run for any other reason.
+        GitError: If git times out or cannot be run for any other reason.
     """
     with tempfile.TemporaryDirectory() as neutral_dir:
         return _run_git(args, error_msg=error_msg, cwd=Path(neutral_dir), error_cls=error_cls)
@@ -989,7 +997,7 @@ def clone_repository(git_url: str, target_path: Path, branch_tag_commit: str | N
         msg = f"Cannot clone: target path {target_path} already exists"
         raise GitCloneError(msg)
 
-    _reject_option_like(git_url, "git URL", GitCloneError)
+    _reject_unsafe_url(git_url, GitCloneError)
     if branch_tag_commit:
         _reject_option_like(branch_tag_commit, "ref", GitCloneError)
 
@@ -1061,7 +1069,7 @@ def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> LibraryJ
         GitCloneError: If the checkout fails or library metadata is invalid.
         GitNotFoundError: If git is not installed.
     """
-    _reject_option_like(remote_url, "git URL", GitCloneError)
+    _reject_unsafe_url(remote_url, GitCloneError)
     _reject_option_like(ref, "ref", GitCloneError)
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -1136,12 +1144,18 @@ def remote_ref_exists(remote_url: str, ref: str) -> bool:
         GitRemoteError: If the remote cannot be queried.
         GitNotFoundError: If git is not installed.
     """
-    _reject_option_like(remote_url, "git URL", GitRemoteError)
+    _reject_unsafe_url(remote_url, GitRemoteError)
     _reject_option_like(ref, "ref", GitRemoteError)
 
+    # ls-remote's trailing arguments are glob patterns matched against the tail of each ref
+    # name, so a bare "main" also matches refs/heads/feature/main. Ask for the two fully
+    # qualified spellings and compare what comes back exactly.
+    wanted = [f"refs/heads/{ref}", f"refs/tags/{ref}"]
     refs = _run_git_detached(
-        ["ls-remote", "--heads", "--tags", remote_url, ref],
+        ["ls-remote", "--heads", "--tags", remote_url, *wanted],
         error_msg=f"Failed to query remote refs from {remote_url}",
         error_cls=GitRemoteError,
     )
-    return bool(refs)
+    # Each line is "<sha>\t<refname>".
+    found = {line.partition("\t")[2].strip() for line in refs.splitlines()}
+    return bool(found & set(wanted))

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -357,12 +357,34 @@ def _reject_option_like(value: str, description: str, error_cls: type[GitError])
         raise error_cls(msg)
 
 
+def _spawn_failure_error(cwd: Path | None, error: OSError) -> GitError:
+    """Explain why a git subprocess could not be started.
+
+    subprocess reports a missing git, a git that cannot be run, and an unusable working directory
+    with different sibling OSError types, so the cause has to be established afterwards from what
+    is actually missing. Every outcome is a GitError: callers guard on that, and a raw OS error
+    escaping here would reach a request handler unhandled.
+    """
+    # which() also rejects a git that is present but not executable, which is the same problem
+    # from the caller's point of view: there is no git this process can run.
+    if shutil.which("git") is None:
+        return GitNotFoundError(_GIT_MISSING_MESSAGE)
+
+    if cwd is not None and not cwd.is_dir():
+        msg = f"Cannot run git in {cwd}: no folder exists at that path."
+        return GitRepositoryError(msg)
+
+    msg = f"Could not start git in {cwd}: {error}"
+    return GitError(msg)
+
+
 def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
     """Run a git command to completion without inspecting its exit code.
 
     Raises:
-        GitNotFoundError: If git is not installed.
-        GitRepositoryError: If cwd no longer exists.
+        GitNotFoundError: If no runnable git is on PATH.
+        GitRepositoryError: If cwd is not a directory.
+        GitError: If git cannot be started for any other reason.
     """
     try:
         return subprocess.run(  # noqa: S603
@@ -379,15 +401,8 @@ def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
             errors="replace",
             check=False,
         )
-    except FileNotFoundError as e:
-        # subprocess reports a missing executable and a missing cwd with the same exception, so
-        # ask which one is actually absent rather than blaming git for a directory that was
-        # deleted between the caller's is_git_repository() check and this call.
-        if shutil.which("git") is None:
-            raise GitNotFoundError(_GIT_MISSING_MESSAGE) from e
-
-        msg = f"Cannot run git in {cwd}: that folder is no longer there."
-        raise GitRepositoryError(msg) from e
+    except OSError as e:
+        raise _spawn_failure_error(cwd, e) from e
 
 
 def _run_git(
@@ -410,8 +425,8 @@ def _run_git(
 
     Raises:
         error_cls: If the command exits non-zero.
-        GitNotFoundError: If git is not installed.
-        GitRepositoryError: If cwd no longer exists.
+        GitNotFoundError: If no runnable git is on PATH.
+        GitRepositoryError: If cwd is not a directory.
     """
     result = _git(args, cwd)
     if result.returncode != 0:
@@ -429,7 +444,7 @@ def _try_git(args: list[str], cwd: Path | None = None) -> str | None:
     propagating out of the accessors built on this.
 
     Raises:
-        GitNotFoundError: If git is not installed.
+        GitNotFoundError: If no runnable git is on PATH.
     """
     try:
         result = _git(args, cwd)

--- a/src/griptape_nodes/utils/git_utils.py
+++ b/src/griptape_nodes/utils/git_utils.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import NamedTuple, cast
+from typing import NamedTuple
 from urllib.parse import urlparse
 
-import pygit2
-
 from griptape_nodes.utils.file_utils import find_file_in_directory
-
-# Common SSH key paths to try when SSH agent doesn't have keys loaded
-_SSH_KEY_PATHS = [
-    Path.home() / ".ssh" / "id_ed25519",
-    Path.home() / ".ssh" / "id_rsa",
-    Path.home() / ".ssh" / "id_ecdsa",
-]
 
 logger = logging.getLogger("griptape_nodes")
 
 
 class GitError(Exception):
     """Base exception for git operations."""
+
+
+class GitNotFoundError(GitError):
+    """Raised when the git executable is not available on PATH.
+
+    Subclasses GitError rather than any of the operation-specific errors below: a
+    missing git is a fault of the environment, not of the repository, remote, or
+    ref the caller happened to be working with.
+    """
 
 
 class GitRepositoryError(GitError):
@@ -285,44 +286,181 @@ def is_git_repository(path: Path) -> bool:
     return False
 
 
-def _find_tag_for_commit(repo: pygit2.Repository, head_commit: object) -> str | None:
-    for tag_name in repo.references:
-        if not tag_name.startswith("refs/tags/"):
-            continue
-        tag_ref = repo.references[tag_name]
-        if hasattr(tag_ref, "peel"):
-            tag_target = tag_ref.peel(pygit2.Commit).id
-        else:
-            tag_target = tag_ref.target
-        if tag_target == head_commit:
-            return tag_name.replace("refs/tags/", "")
-    return None
+_GIT_MISSING_MESSAGE = (
+    "git was not found on PATH. Griptape Nodes requires a git installation to install and update libraries."
+)
 
 
-def _get_ref_from_repo(repo: pygit2.Repository, library_path: Path) -> str | None:
-    # Called from get_git_info to reuse an already-open repo — do not open a new one here.
+def _git_env() -> dict[str, str]:
+    """Build the environment for a git subprocess.
+
+    The engine runs headless, so git must never block on an interactive credential
+    prompt nobody can answer. An inherited value wins, letting a launcher opt back
+    into prompting. This covers git's own prompts; `_git` closes stdin to stop the
+    transports git shells out to (ssh, in particular) from prompting either.
+    """
+    return {"GIT_TERMINAL_PROMPT": "0", **os.environ}
+
+
+def _reject_option_like(value: str, description: str, error_cls: type[GitError]) -> None:
+    """Reject a value git's argument parser would read as an option rather than data.
+
+    git refnames cannot begin with "-" and no git URL scheme does either, so a leading
+    "-" is always malformed input. Rejecting it keeps a caller-supplied URL or ref from
+    reaching git as a flag, where `--upload-pack=<cmd>` would run an arbitrary command.
+
+    Raises:
+        error_cls: If the value would be parsed as an option.
+    """
+    if value.startswith("-"):
+        msg = f"Invalid {description}: {value!r} must not start with '-'"
+        raise error_cls(msg)
+
+
+def _git(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str]:
+    """Run a git command to completion without inspecting its exit code.
+
+    Raises:
+        GitNotFoundError: If git is not installed.
+    """
     try:
-        if repo.head_is_unborn:
-            return None
-        if repo.head_is_detached:
-            tag = _find_tag_for_commit(repo, repo.head.target)
-            if tag is not None:
-                return tag
-            return str(repo.head.target)
-        shorthand = repo.head.shorthand
-    except pygit2.GitError as e:
-        logger.debug("Failed to get current git reference for %s: %s", library_path, e)
+        return subprocess.run(  # noqa: S603
+            ["git", *args],  # noqa: S607
+            cwd=cwd,
+            env=_git_env(),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise GitNotFoundError(_GIT_MISSING_MESSAGE) from e
+
+
+def _run_git(
+    args: list[str],
+    *,
+    error_msg: str,
+    cwd: Path | None = None,
+    error_cls: type[GitError] = GitError,
+) -> str:
+    """Run a git command and return its stripped stdout.
+
+    Args:
+        args: Arguments to pass to git, without the leading "git".
+        error_msg: Prefix for the raised exception's message. git's stderr is appended to it.
+        cwd: Directory to run the command in.
+        error_cls: Exception type to raise when the command fails.
+
+    Returns:
+        str: The command's stdout, stripped.
+
+    Raises:
+        error_cls: If the command exits non-zero.
+        GitNotFoundError: If git is not installed.
+    """
+    result = _git(args, cwd)
+    if result.returncode != 0:
+        msg = f"{error_msg}: {result.stderr.strip()}"
+        raise error_cls(msg)
+    return result.stdout.strip()
+
+
+def _try_git(args: list[str], cwd: Path | None = None) -> str | None:
+    """Run a git command and return its stripped stdout, or None if it failed.
+
+    For queries where a non-zero exit is an answer rather than a fault: no upstream is
+    configured, HEAD is detached, the ref doesn't exist.
+
+    Raises:
+        GitNotFoundError: If git is not installed.
+    """
+    result = _git(args, cwd)
+    if result.returncode != 0:
+        logger.debug("git %s failed in %s: %s", " ".join(args), cwd, result.stderr.strip())
         return None
-    else:
-        return shorthand
+    return result.stdout.strip()
+
+
+def _run_git_detached(args: list[str], *, error_msg: str, error_cls: type[GitError] = GitError) -> str:
+    """Run a git command that operates on a remote rather than a local repository.
+
+    Runs in an empty directory so the command can't inherit the repository the engine's
+    working directory happens to sit inside. git inspects that repository even for work
+    that has nothing to do with it, and refuses to run at all when it is broken or owned
+    by another user.
+
+    Raises:
+        error_cls: If the command exits non-zero.
+        GitNotFoundError: If git is not installed.
+    """
+    with tempfile.TemporaryDirectory() as neutral_dir:
+        return _run_git(args, error_msg=error_msg, cwd=Path(neutral_dir), error_cls=error_cls)
+
+
+def _head_commit_sha(library_path: Path) -> str | None:
+    """Full SHA of the commit HEAD points at, or None when HEAD is unborn."""
+    return _try_git(["rev-parse", "--verify", "-q", "HEAD"], library_path)
+
+
+def _current_branch(library_path: Path) -> str | None:
+    """Name of the checked-out branch, or None when HEAD is detached.
+
+    Reports a branch name for an unborn HEAD too, since the branch is only
+    unresolvable, not absent. Callers that need a commit check
+    ``_head_commit_sha`` first.
+    """
+    return _try_git(["symbolic-ref", "--short", "HEAD"], library_path)
+
+
+def _tag_at_head(library_path: Path) -> str | None:
+    """Name of a tag pointing at HEAD, or None when HEAD isn't tagged.
+
+    Reports the first name git lists when several tags share the commit.
+    """
+    tags = _try_git(["tag", "--points-at", "HEAD"], library_path)
+    if not tags:
+        return None
+    return tags.splitlines()[0].strip()
+
+
+def _ref_exists(library_path: Path, ref: str) -> bool:
+    """Whether a fully-qualified ref (e.g. "refs/tags/v1") exists in the repository."""
+    return _try_git(["rev-parse", "--verify", "-q", ref], library_path) is not None
+
+
+def _remote_url(library_path: Path) -> str | None:
+    """URL of the origin remote, or None when no origin is configured."""
+    return _try_git(["remote", "get-url", "origin"], library_path)
+
+
+def _upstream_ref(library_path: Path) -> str | None:
+    """Upstream of the current branch as "origin/main", or None when unset."""
+    return _try_git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], library_path)
+
+
+def _describe_head(library_path: Path) -> str | None:
+    """Describe what HEAD points at: branch name, else tag name, else commit SHA.
+
+    Returns None when HEAD is unborn, which is the only state with nothing to name.
+    """
+    head_sha = _head_commit_sha(library_path)
+    if head_sha is None:
+        return None
+
+    branch = _current_branch(library_path)
+    if branch is not None:
+        return branch
+
+    return _tag_at_head(library_path) or head_sha
 
 
 def get_git_info(library_path: Path) -> tuple[str | None, str | None]:
-    """Get both the git remote URL and current ref for a library in a single repo open.
+    """Get both the git remote URL and current ref for a library.
 
     Prefer this over calling get_git_remote() + get_current_ref() separately when both
-    values are needed: those functions each call is_git_repository(), discover_repository(),
-    and Repository() independently, which triples the I/O cost per library.
+    values are needed: those functions each re-run is_git_repository(), and each raises
+    where this one degrades to None.
 
     Returns:
         tuple[str | None, str | None]: (git_remote, git_ref), each None if unavailable.
@@ -330,22 +468,7 @@ def get_git_info(library_path: Path) -> tuple[str | None, str | None]:
     if not is_git_repository(library_path):
         return None, None
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            return None, None
-        repo = pygit2.Repository(repo_path)
-    except pygit2.GitError as e:
-        logger.debug("Failed to open git repository at %s: %s", library_path, e)
-        return None, None
-
-    git_remote: str | None = None
-    try:
-        git_remote = repo.remotes["origin"].url
-    except (KeyError, IndexError, pygit2.GitError) as e:
-        logger.debug("Failed to get git remote for %s: %s", library_path, e)
-
-    return git_remote, _get_ref_from_repo(repo, library_path)
+    return _remote_url(library_path), _describe_head(library_path)
 
 
 def get_git_remote(library_path: Path) -> str | None:
@@ -358,29 +481,12 @@ def get_git_remote(library_path: Path) -> str | None:
         str | None: The remote URL if found, None if not a git repository or no remote configured.
 
     Raises:
-        GitRemoteError: If an error occurs while accessing the git remote.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         return None
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            return None
-
-        repo = pygit2.Repository(repo_path)
-
-        # Access remote by indexing (raises KeyError if not found)
-        try:
-            remote = repo.remotes["origin"]
-        except (KeyError, IndexError):
-            return None
-        else:
-            return remote.url
-
-    except pygit2.GitError as e:
-        msg = f"Error getting git remote for {library_path}: {e}"
-        raise GitRemoteError(msg) from e
+    return _remote_url(library_path)
 
 
 def get_current_ref(library_path: Path) -> str | None:
@@ -393,44 +499,16 @@ def get_current_ref(library_path: Path) -> str | None:
         str | None: The current git reference (branch name, tag name, or commit SHA) if found, None if not a git repository.
 
     Raises:
-        GitRefError: If an error occurs while getting the current git reference.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         logger.debug("Path %s is not a git repository", library_path)
         return None
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            logger.debug("Could not discover git repository at %s", library_path)
-            return None
-
-        repo = pygit2.Repository(repo_path)
-
-        # Check if HEAD is unborn (no commits yet)
-        if repo.head_is_unborn:
-            logger.debug("Repository at %s has unborn HEAD (no commits)", library_path)
-            return None
-
-        # Check if HEAD is detached
-        if repo.head_is_detached:
-            # HEAD is detached - check if it's pointing to a tag
-            tag_name = get_current_tag(library_path)
-            if tag_name:
-                logger.debug("Repository at %s has detached HEAD on tag %s", library_path, tag_name)
-                return tag_name
-
-            # No tag found, return the commit SHA as fallback
-            head_commit = repo.head.target
-            logger.debug("Repository at %s has detached HEAD at commit %s", library_path, head_commit)
-            return str(head_commit)
-
-    except pygit2.GitError as e:
-        msg = f"Error getting current git reference for {library_path}: {e}"
-        raise GitRefError(msg) from e
-    else:
-        # Get the current git reference name (branch)
-        return repo.head.shorthand
+    ref = _describe_head(library_path)
+    if ref is None:
+        logger.debug("Repository at %s has unborn HEAD (no commits)", library_path)
+    return ref
 
 
 def get_current_tag(library_path: Path) -> str | None:
@@ -443,44 +521,15 @@ def get_current_tag(library_path: Path) -> str | None:
         str | None: The current tag name if found, None if not on a tag or not a git repository.
 
     Raises:
-        GitError: If an error occurs while getting the current tag.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         return None
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            return None
-
-        repo = pygit2.Repository(repo_path)
-
-        # Get the current HEAD commit
-        if repo.head_is_unborn:
-            return None
-
-        head_commit = repo.head.target
-
-        # Check all tags to see if any point to HEAD
-        for tag_name in repo.references:
-            if not tag_name.startswith("refs/tags/"):
-                continue
-
-            tag_ref = repo.references[tag_name]
-            # Handle both lightweight and annotated tags
-            if hasattr(tag_ref, "peel"):
-                tag_target = tag_ref.peel(pygit2.Commit).id
-            else:
-                tag_target = tag_ref.target
-
-            if tag_target == head_commit:
-                # Return tag name without refs/tags/ prefix
-                return tag_name.replace("refs/tags/", "")
-    except pygit2.GitError as e:
-        msg = f"Error getting current tag for {library_path}: {e}"
-        raise GitError(msg) from e
-    else:
+    if _head_commit_sha(library_path) is None:
         return None
+
+    return _tag_at_head(library_path)
 
 
 def is_on_tag(library_path: Path) -> bool:
@@ -502,29 +551,15 @@ def get_local_commit_sha(library_path: Path) -> str | None:
         library_path: The path to the library directory.
 
     Returns:
-        str | None: The full commit SHA if found, None if not a git repository or error occurs.
+        str | None: The full commit SHA if found, None if not a git repository or HEAD is unborn.
 
     Raises:
-        GitError: If an error occurs while getting the commit SHA.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         return None
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            return None
-
-        repo = pygit2.Repository(repo_path)
-
-        if repo.head_is_unborn:
-            return None
-
-        return str(repo.head.target)
-
-    except pygit2.GitError as e:
-        msg = f"Error getting commit SHA for {library_path}: {e}"
-        raise GitError(msg) from e
+    return _head_commit_sha(library_path)
 
 
 def get_git_repository_root(library_path: Path) -> Path | None:
@@ -535,35 +570,20 @@ def get_git_repository_root(library_path: Path) -> Path | None:
 
     Returns:
         Path | None: The root directory of the git repository, or None if not in a git repository.
+            A bare repository is not recognized, matching is_git_repository().
 
     Raises:
-        GitRepositoryError: If an error occurs while accessing the git repository.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         return None
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            return None
-
-        # discover_repository returns path to .git directory
-        # For a normal repo: /path/to/repo/.git
-        # For a bare repo: /path/to/repo.git
-        git_dir = Path(repo_path)
-
-        # Check if it's a bare repository
-        if git_dir.name.endswith(".git") and git_dir.is_dir():
-            repo = pygit2.Repository(repo_path)
-            if repo.is_bare:
-                return git_dir
-
-    except pygit2.GitError as e:
-        msg = f"Error getting git repository root for {library_path}: {e}"
-        raise GitRepositoryError(msg) from e
-    else:
-        # Normal repository - return parent of .git directory
-        return git_dir.parent
+    # --show-cdup is relative to library_path, so the root comes back in the caller's
+    # own path vocabulary. --show-toplevel would resolve symlinks along the way.
+    cdup = _try_git(["rev-parse", "--show-cdup"], library_path)
+    if cdup is None:
+        return None
+    return Path(os.path.normpath(library_path / cdup))
 
 
 def has_uncommitted_changes(library_path: Path) -> bool:
@@ -577,28 +597,26 @@ def has_uncommitted_changes(library_path: Path) -> bool:
 
     Raises:
         GitRepositoryError: If the path is not a valid git repository.
+        GitNotFoundError: If git is not installed.
     """
     if not is_git_repository(library_path):
         msg = f"Cannot check status: {library_path} is not a git repository"
         raise GitRepositoryError(msg)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot check status: {library_path} is not a git repository"
-            raise GitRepositoryError(msg)
-
-        repo = pygit2.Repository(repo_path)
-        status = repo.status()
-        return len(status) > 0
-
-    except pygit2.GitError as e:
-        msg = f"Failed to check git status at {library_path}: {e}"
-        raise GitRepositoryError(msg) from e
+    status = _run_git(
+        ["status", "--porcelain"],
+        error_msg=f"Failed to check git status at {library_path}",
+        cwd=library_path,
+        error_cls=GitRepositoryError,
+    )
+    return bool(status)
 
 
-def _validate_branch_update_preconditions(library_path: Path) -> None:
-    """Validate preconditions for branch-based update.
+def _resolve_update_upstream(library_path: Path) -> str:
+    """Validate that a branch-based update is possible and return the upstream ref name.
+
+    Returns:
+        str: The upstream of the current branch, e.g. "origin/main".
 
     Raises:
         GitRepositoryError: If validation fails.
@@ -608,36 +626,21 @@ def _validate_branch_update_preconditions(library_path: Path) -> None:
         msg = f"Cannot update: {library_path} is not a git repository"
         raise GitRepositoryError(msg)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot discover repository at {library_path}"
-            raise GitRepositoryError(msg)
+    branch = _current_branch(library_path)
+    if branch is None:
+        msg = f"Repository at {library_path} has detached HEAD"
+        raise GitPullError(msg)
 
-        repo = pygit2.Repository(repo_path)
+    upstream = _upstream_ref(library_path)
+    if upstream is None:
+        msg = f"No upstream branch set for {branch} at {library_path}"
+        raise GitPullError(msg)
 
-        if repo.head_is_detached:
-            msg = f"Repository at {library_path} has detached HEAD"
-            raise GitPullError(msg)
+    if _remote_url(library_path) is None:
+        msg = f"No origin remote found for repository at {library_path}"
+        raise GitPullError(msg)
 
-        current_branch = repo.branches.get(repo.head.shorthand)
-        if current_branch is None:
-            msg = f"Cannot get current branch for repository at {library_path}"
-            raise GitPullError(msg)
-
-        if current_branch.upstream is None:
-            msg = f"No upstream branch set for {current_branch.branch_name} at {library_path}"
-            raise GitPullError(msg)
-
-        try:
-            _ = repo.remotes["origin"]
-        except (KeyError, IndexError) as e:
-            msg = f"No origin remote found for repository at {library_path}"
-            raise GitPullError(msg) from e
-
-    except pygit2.GitError as e:
-        msg = f"Git error during update at {library_path}: {e}"
-        raise GitPullError(msg) from e
+    return upstream
 
 
 def git_update_from_remote(library_path: Path, *, overwrite_existing: bool = False) -> None:
@@ -657,7 +660,7 @@ def git_update_from_remote(library_path: Path, *, overwrite_existing: bool = Fal
         GitPullError: If the update operation fails or uncommitted changes exist
             when overwrite_existing=False.
     """
-    _validate_branch_update_preconditions(library_path)
+    upstream = _resolve_update_upstream(library_path)
 
     if has_uncommitted_changes(library_path):
         if not overwrite_existing:
@@ -666,38 +669,11 @@ def git_update_from_remote(library_path: Path, *, overwrite_existing: bool = Fal
 
         logger.warning("Discarding uncommitted changes at %s", library_path)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot update: {library_path} is not a git repository"
-            raise GitPullError(msg)
+    error_msg = f"Git error during update at {library_path}"
+    _run_git(["fetch", "origin"], error_msg=error_msg, cwd=library_path, error_cls=GitPullError)
+    _run_git(["reset", "--hard", upstream], error_msg=error_msg, cwd=library_path, error_cls=GitPullError)
 
-        repo = pygit2.Repository(repo_path)
-
-        # Get remote and fetch
-        remote = repo.remotes["origin"]
-        remote.fetch()
-
-        # Get upstream branch reference
-        try:
-            upstream_name = repo.branches.get(repo.head.shorthand).upstream.branch_name
-            upstream_ref = repo.references.get(f"refs/remotes/{upstream_name}")
-            if upstream_ref is None:
-                msg = f"Failed to find upstream reference {upstream_name} at {library_path}"
-                raise GitPullError(msg)
-            upstream_oid = upstream_ref.target
-        except (pygit2.GitError, AttributeError) as e:
-            msg = f"Failed to determine upstream branch at {library_path}: {e}"
-            raise GitPullError(msg) from e
-
-        # Hard reset to upstream
-        repo.reset(upstream_oid, pygit2.enums.ResetMode.HARD)
-
-        logger.debug("Successfully updated library at %s to match remote %s", library_path, upstream_name)
-
-    except pygit2.GitError as e:
-        msg = f"Git error during update at {library_path}: {e}"
-        raise GitPullError(msg) from e
+    logger.debug("Successfully updated library at %s to match remote %s", library_path, upstream)
 
 
 def update_to_moving_tag(library_path: Path, tag_name: str, *, overwrite_existing: bool = False) -> None:
@@ -721,26 +697,12 @@ def update_to_moving_tag(library_path: Path, tag_name: str, *, overwrite_existin
         msg = f"Cannot update tag: {library_path} is not a git repository"
         raise GitRepositoryError(msg)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot discover repository at {library_path}"
-            raise GitRepositoryError(msg)
+    _reject_option_like(tag_name, "tag name", GitPullError)
 
-        repo = pygit2.Repository(repo_path)
+    if _remote_url(library_path) is None:
+        msg = f"No origin remote found for repository at {library_path}"
+        raise GitPullError(msg)
 
-        # Check for origin remote
-        try:
-            _ = repo.remotes["origin"]
-        except (KeyError, IndexError) as e:
-            msg = f"No origin remote found for repository at {library_path}"
-            raise GitPullError(msg) from e
-
-    except pygit2.GitError as e:
-        msg = f"Git error during tag update at {library_path}: {e}"
-        raise GitPullError(msg) from e
-
-    # Check for uncommitted changes
     if has_uncommitted_changes(library_path):
         if not overwrite_existing:
             msg = f"Cannot update library at {library_path}: You have uncommitted changes. Use overwrite_existing=True to discard them."
@@ -748,31 +710,23 @@ def update_to_moving_tag(library_path: Path, tag_name: str, *, overwrite_existin
 
         logger.warning("Discarding uncommitted changes at %s", library_path)
 
-    # Use pygit2 to fetch tags and checkout
-    try:
-        # Step 1: Delete local tag to allow fetch to update it (pygit2 doesn't honor +force)
-        tag_ref = f"refs/tags/{tag_name}"
-        if tag_ref in repo.references:
-            repo.references.delete(tag_ref)
-            logger.debug("Deleted local tag %s to allow force-update", tag_name)
+    error_msg = f"Git error during tag update at {library_path}"
 
-        # Step 2: Fetch all tags (will create the deleted tag with new commit)
-        remote = repo.remotes["origin"]
-        remote.fetch(refspecs=["+refs/tags/*:refs/tags/*"])
+    # --force is what makes this work for a moving tag: without it git refuses to
+    # replace a local tag whose remote counterpart now points at a new commit.
+    _run_git(["fetch", "--tags", "--force", "origin"], error_msg=error_msg, cwd=library_path, error_cls=GitPullError)
 
-        # Step 3: Checkout the tag with force to discard local changes
-        if tag_ref not in repo.references:
-            msg = f"Tag {tag_name} not found at {library_path}"
-            raise GitPullError(msg)
+    tag_ref = f"refs/tags/{tag_name}"
+    if not _ref_exists(library_path, tag_ref):
+        msg = f"Tag {tag_name} not found at {library_path}"
+        raise GitPullError(msg)
 
-        strategy = pygit2.enums.CheckoutStrategy.FORCE if overwrite_existing else pygit2.enums.CheckoutStrategy.SAFE
-        repo.checkout(tag_ref, strategy=strategy)
+    checkout = ["checkout", "--detach", tag_ref]
+    if overwrite_existing:
+        checkout.insert(1, "--force")
+    _run_git(checkout, error_msg=error_msg, cwd=library_path, error_cls=GitPullError)
 
-        logger.debug("Successfully updated library at %s to tag %s", library_path, tag_name)
-
-    except pygit2.GitError as e:
-        msg = f"Git error during tag update at {library_path}: {e}"
-        raise GitPullError(msg) from e
+    logger.debug("Successfully updated library at %s to tag %s", library_path, tag_name)
 
 
 def update_library_git(library_path: Path, *, overwrite_existing: bool = False) -> None:
@@ -797,32 +751,18 @@ def update_library_git(library_path: Path, *, overwrite_existing: bool = False) 
         msg = f"Cannot update: {library_path} is not a git repository"
         raise GitRepositoryError(msg)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot discover repository at {library_path}"
-            raise GitRepositoryError(msg)
+    if _current_branch(library_path) is None:
+        # Detached HEAD - likely on a tag
+        tag_name = get_current_tag(library_path)
+        if tag_name is None:
+            msg = f"Repository at {library_path} is in detached HEAD state but not on a known tag. Cannot auto-update."
+            raise GitPullError(msg)
 
-        repo = pygit2.Repository(repo_path)
-
-        # Detect workflow type
-        if repo.head_is_detached:
-            # Detached HEAD - likely on a tag
-            tag_name = get_current_tag(library_path)
-            if tag_name is None:
-                msg = f"Repository at {library_path} is in detached HEAD state but not on a known tag. Cannot auto-update."
-                raise GitPullError(msg)
-
-            logger.debug("Detected tag-based workflow for %s (tag: %s)", library_path, tag_name)
-            update_to_moving_tag(library_path, tag_name, overwrite_existing=overwrite_existing)
-        else:
-            # On a branch - use fetch + reset to match remote
-            logger.debug("Detected branch-based workflow for %s", library_path)
-            git_update_from_remote(library_path, overwrite_existing=overwrite_existing)
-
-    except pygit2.GitError as e:
-        msg = f"Git error during library update at {library_path}: {e}"
-        raise GitPullError(msg) from e
+        logger.debug("Detected tag-based workflow for %s (tag: %s)", library_path, tag_name)
+        update_to_moving_tag(library_path, tag_name, overwrite_existing=overwrite_existing)
+    else:
+        logger.debug("Detected branch-based workflow for %s", library_path)
+        git_update_from_remote(library_path, overwrite_existing=overwrite_existing)
 
 
 def switch_branch(library_path: Path, branch_name: str) -> None:
@@ -843,59 +783,34 @@ def switch_branch(library_path: Path, branch_name: str) -> None:
         msg = f"Cannot switch branch: {library_path} is not a git repository"
         raise GitRepositoryError(msg)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot discover repository at {library_path}"
-            raise GitRepositoryError(msg)
+    _reject_option_like(branch_name, "branch name", GitRefError)
 
-        repo = pygit2.Repository(repo_path)
+    if _remote_url(library_path) is None:
+        msg = f"No origin remote found for repository at {library_path}"
+        raise GitRefError(msg)
 
-        # Get origin remote
-        try:
-            remote = repo.remotes["origin"]
-        except (KeyError, IndexError) as e:
-            msg = f"No origin remote found for repository at {library_path}"
-            raise GitRefError(msg) from e
+    error_msg = f"Git error during branch switch at {library_path}"
+    _run_git(["fetch", "origin"], error_msg=error_msg, cwd=library_path, error_cls=GitRefError)
 
-        # Fetch from remote first
-        remote.fetch()
+    if _ref_exists(library_path, f"refs/heads/{branch_name}"):
+        _run_git(["checkout", branch_name], error_msg=error_msg, cwd=library_path, error_cls=GitRefError)
+        logger.debug("Checked out existing local branch %s at %s", branch_name, library_path)
+        return
 
-        # Try to find the branch locally first
-        local_branch = repo.branches.get(branch_name)
+    remote_branch_name = f"origin/{branch_name}"
+    if not _ref_exists(library_path, f"refs/remotes/{remote_branch_name}"):
+        msg = f"Branch {branch_name} not found locally or on remote at {library_path}"
+        raise GitRefError(msg)
 
-        if local_branch is not None:
-            # Branch exists locally, just check it out
-            repo.checkout(local_branch)
-            logger.debug("Checked out existing local branch %s at %s", branch_name, library_path)
-            return
-
-        # Branch doesn't exist locally, try to find it on remote
-        remote_branch_name = f"origin/{branch_name}"
-        remote_branch = repo.branches.get(remote_branch_name)
-
-        if remote_branch is None:
-            msg = f"Branch {branch_name} not found locally or on remote at {library_path}"
-            raise GitRefError(msg)
-
-        # Create local tracking branch from remote
-        commit = repo.get(remote_branch.target)
-        if commit is None:
-            msg = f"Failed to get commit for remote branch {remote_branch_name} at {library_path}"
-            raise GitRefError(msg)
-
-        new_branch = repo.branches.local.create(branch_name, commit)  # type: ignore[arg-type]
-        new_branch.upstream = remote_branch
-
-        # Checkout the new branch
-        repo.checkout(new_branch)
-        logger.debug(
-            "Created and checked out tracking branch %s from %s at %s", branch_name, remote_branch_name, library_path
-        )
-
-    except pygit2.GitError as e:
-        msg = f"Git error during branch switch at {library_path}: {e}"
-        raise GitRefError(msg) from e
+    _run_git(
+        ["checkout", "-b", branch_name, "--track", remote_branch_name],
+        error_msg=error_msg,
+        cwd=library_path,
+        error_cls=GitRefError,
+    )
+    logger.debug(
+        "Created and checked out tracking branch %s from %s at %s", branch_name, remote_branch_name, library_path
+    )
 
 
 def switch_branch_or_tag(library_path: Path, ref_name: str) -> None:
@@ -916,191 +831,36 @@ def switch_branch_or_tag(library_path: Path, ref_name: str) -> None:
         msg = f"Cannot switch ref: {library_path} is not a git repository"
         raise GitRepositoryError(msg)
 
-    try:
-        repo_path = pygit2.discover_repository(str(library_path))
-        if repo_path is None:
-            msg = f"Cannot switch ref: {library_path} is not a git repository"
-            raise GitRefError(msg)
+    _reject_option_like(ref_name, "ref name", GitRefError)
 
-        repo = pygit2.Repository(repo_path)
+    error_msg = f"Git error during ref switch at {library_path}"
+    # --tags fetches tags on top of the configured refspec, so one call updates
+    # remote-tracking branches and force-updates moved tags.
+    _run_git(["fetch", "--tags", "--force", "origin"], error_msg=error_msg, cwd=library_path, error_cls=GitRefError)
 
-        # Fetch both branches and tags from remote
-        remote = repo.remotes["origin"]
-        remote.fetch(refspecs=["+refs/tags/*:refs/tags/*"])
-        remote.fetch()
-
-        # Try to checkout the ref (works for both branches and tags)
-        # First check if it's a tag
-        tag_ref = f"refs/tags/{ref_name}"
-        branch_ref = f"refs/remotes/origin/{ref_name}"
-
-        if tag_ref in repo.references:
-            repo.checkout(tag_ref)
-        elif branch_ref in repo.references:
-            # For remote branches, create/update local tracking branch and checkout
-            remote_branch_name = f"origin/{ref_name}"
-            remote_branch = repo.branches.get(remote_branch_name)
-
-            if remote_branch is None:
-                msg = f"Remote branch {remote_branch_name} not found at {library_path}"
-                raise GitRefError(msg)
-
-            commit = repo.get(remote_branch.target)
-            if commit is None:
-                msg = f"Failed to get commit for remote branch {remote_branch_name} at {library_path}"
-                raise GitRefError(msg)
-
-            # Create or update local branch
-            if ref_name in repo.branches.local:
-                local_branch = repo.branches.local[ref_name]
-                local_branch.set_target(commit.id)
-            else:
-                local_branch = repo.branches.local.create(ref_name, commit)  # type: ignore[arg-type]
-
-            local_branch.upstream = remote_branch
-            repo.checkout(local_branch)
-        elif ref_name in repo.branches:
-            # Local branch
-            repo.checkout(repo.branches[ref_name])
-        else:
-            msg = f"Ref {ref_name} not found at {library_path}"
-            raise GitRefError(msg)
-
-        logger.debug("Checked out %s at %s", ref_name, library_path)
-
-    except pygit2.GitError as e:
-        msg = f"Git error during ref switch at {library_path}: {e}"
-        raise GitRefError(msg) from e
-
-
-class _CredentialCallbacks(pygit2.RemoteCallbacks):
-    """RemoteCallbacks that handle both SSH and public HTTPS authentication.
-
-    When libgit2 requests SSH credentials (either for SSH URLs or HTTPS URLs
-    rewritten via url.insteadOf git config), tries SSH key files then falls
-    back to the SSH agent. For HTTPS, returns empty credentials (sufficient
-    for public repos).
-    """
-
-    def credentials(self, url: str, username_from_url: str | None, allowed_types: int) -> object:  # type: ignore[override]
-        ssh_types = (
-            pygit2.enums.CredentialType.SSH_KEY
-            | pygit2.enums.CredentialType.SSH_CUSTOM
-            | pygit2.enums.CredentialType.SSH_MEMORY
+    remote_branch_name = f"origin/{ref_name}"
+    if _ref_exists(library_path, f"refs/tags/{ref_name}"):
+        _run_git(
+            ["checkout", "--detach", f"refs/tags/{ref_name}"],
+            error_msg=error_msg,
+            cwd=library_path,
+            error_cls=GitRefError,
         )
-        if allowed_types & ssh_types:
-            # libgit2 rewrote the HTTPS URL to SSH via a url.insteadOf git config rule,
-            # or this is an SSH URL directly. Try key files first, then agent.
-            for key_path in _SSH_KEY_PATHS:
-                pub_key_path = key_path.with_suffix(key_path.suffix + ".pub")
-                if key_path.exists() and pub_key_path.exists():
-                    logger.debug("Using SSH key from %s for %s", key_path, url)
-                    return pygit2.Keypair(username_from_url or "git", str(pub_key_path), str(key_path), "")
-            logger.debug("No SSH key files found, falling back to SSH agent for %s", url)
-            return pygit2.KeypairFromAgent(username_from_url or "git")
-
-        return pygit2.UserPass("", "")
-
-
-def _is_git_available() -> bool:
-    """Check if git CLI is available on PATH.
-
-    Returns:
-        bool: True if git CLI is available, False otherwise.
-    """
-    try:
-        subprocess.run(
-            ["git", "--version"],  # noqa: S607
-            capture_output=True,
-            check=True,
+    elif _ref_exists(library_path, f"refs/remotes/{remote_branch_name}"):
+        # -B resets an existing local branch onto the freshly fetched remote tip.
+        _run_git(
+            ["checkout", "-B", ref_name, "--track", remote_branch_name],
+            error_msg=error_msg,
+            cwd=library_path,
+            error_cls=GitRefError,
         )
-    except (subprocess.SubprocessError, FileNotFoundError):
-        return False
+    elif _ref_exists(library_path, f"refs/heads/{ref_name}"):
+        _run_git(["checkout", ref_name], error_msg=error_msg, cwd=library_path, error_cls=GitRefError)
     else:
-        return True
+        msg = f"Ref {ref_name} not found at {library_path}"
+        raise GitRefError(msg)
 
-
-def _run_git_command(args: list[str], cwd: str, error_msg: str) -> subprocess.CompletedProcess[str]:
-    """Run a git command and raise GitCloneError on failure.
-
-    Args:
-        args: Git command arguments (e.g., ["git", "init"]).
-        cwd: Working directory for the command.
-        error_msg: Error message prefix to use if command fails.
-
-    Returns:
-        subprocess.CompletedProcess: The result of the command.
-
-    Raises:
-        GitCloneError: If the command returns a non-zero exit code.
-    """
-    result = subprocess.run(  # noqa: S603
-        args,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        msg = f"{error_msg}: {result.stderr}"
-        raise GitCloneError(msg)
-
-    return result
-
-
-def _checkout_branch_tag_or_commit(repo: pygit2.Repository, ref: str) -> None:
-    """Check out a branch, tag, or commit in a repository.
-
-    For branches, creates a local tracking branch from the remote.
-    For tags and commits, checks out in detached HEAD state.
-
-    Args:
-        repo: The pygit2 Repository object.
-        ref: The branch, tag, or commit reference to checkout.
-
-    Raises:
-        GitCloneError: If checkout fails.
-    """
-    # Try to resolve as a local branch first
-    try:
-        branch = repo.branches[ref]
-        repo.checkout(branch)
-    except (pygit2.GitError, KeyError, IndexError):
-        pass
-    else:
-        logger.debug("Checked out local branch %s", ref)
-        return
-
-    # Try to resolve as a remote branch and create local tracking branch
-    remote_ref = f"refs/remotes/origin/{ref}"
-    remote_branch_exists = remote_ref in repo.references
-
-    if remote_branch_exists:
-        remote_branch_name = f"origin/{ref}"
-        remote_branch = repo.branches.get(remote_branch_name)
-
-        if remote_branch is not None:
-            commit = repo.get(remote_branch.target)
-            if commit is None:
-                msg = f"Failed to get commit for remote branch {remote_branch_name}"
-                raise GitCloneError(msg)
-
-            # Create local tracking branch
-            local_branch = repo.branches.local.create(ref, commit)  # type: ignore[arg-type]
-            local_branch.upstream = remote_branch
-            repo.checkout(local_branch)
-            logger.debug("Checked out remote branch %s as local tracking branch", ref)
-            return
-
-    # Not a local or remote branch, try as tag or commit
-    try:
-        commit_obj = repo.revparse_single(ref)
-        repo.checkout_tree(commit_obj)
-        repo.set_head(commit_obj.id)
-        logger.debug("Checked out %s as tag or commit", ref)
-    except pygit2.GitError as e:
-        msg = f"Failed to checkout {ref}: {e}"
-        raise GitCloneError(msg) from e
+    logger.debug("Checked out %s at %s", ref_name, library_path)
 
 
 def clone_repository(git_url: str, target_path: Path, branch_tag_commit: str | None = None) -> None:
@@ -1118,20 +878,26 @@ def clone_repository(git_url: str, target_path: Path, branch_tag_commit: str | N
         msg = f"Cannot clone: target path {target_path} already exists"
         raise GitCloneError(msg)
 
-    try:
-        # Clone the repository
-        repo = pygit2.clone_repository(git_url, str(target_path), callbacks=_CredentialCallbacks())
-        if repo is None:
-            msg = f"Failed to clone repository from {git_url}"
-            raise GitCloneError(msg)
+    _reject_option_like(git_url, "git URL", GitCloneError)
+    if branch_tag_commit:
+        _reject_option_like(branch_tag_commit, "ref", GitCloneError)
 
-        # Checkout specific branch/tag/commit if provided
-        if branch_tag_commit:
-            _checkout_branch_tag_or_commit(repo, branch_tag_commit)
+    _run_git_detached(
+        ["clone", git_url, str(target_path)],
+        error_msg=f"Git error while cloning {git_url} to {target_path}",
+        error_cls=GitCloneError,
+    )
 
-    except pygit2.GitError as e:
-        msg = f"Git error while cloning {git_url} to {target_path}: {e}"
-        raise GitCloneError(msg) from e
+    if branch_tag_commit:
+        # A single checkout covers all three: a remote branch name becomes a local
+        # tracking branch, a tag or commit lands on a detached HEAD.
+        _run_git(
+            ["checkout", branch_tag_commit],
+            error_msg=f"Failed to checkout {branch_tag_commit} in {target_path}",
+            cwd=target_path,
+            error_cls=GitCloneError,
+        )
+        logger.debug("Checked out %s in %s", branch_tag_commit, target_path)
 
 
 def _extract_library_version_from_json(json_path: Path, remote_url: str) -> str:
@@ -1167,223 +933,11 @@ def _extract_library_version_from_json(json_path: Path, remote_url: str) -> str:
     return library_data["metadata"]["library_version"]
 
 
-def _sparse_checkout_with_git_cli(remote_url: str, ref: str) -> LibraryJsonCheckout:
-    """Perform sparse checkout using git CLI to fetch only library JSON file.
-
-    This is the most efficient method as it only downloads files matching the sparse
-    checkout patterns, not the entire repository.
-
-    Args:
-        remote_url: The git repository URL (HTTPS or SSH).
-        ref: The git reference (branch, tag, or commit) to checkout.
-
-    Returns:
-        LibraryJsonCheckout: The library version, commit SHA, commit datetime, and library data.
-
-    Raises:
-        GitCloneError: If sparse checkout fails or library metadata is invalid.
-    """
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-
-        try:
-            # Initialize empty git repository
-            _run_git_command(["git", "init"], temp_dir, "Git init failed")
-
-            # Add remote
-            _run_git_command(
-                ["git", "remote", "add", "origin", remote_url],
-                temp_dir,
-                "Git remote add failed",
-            )
-
-            # Enable sparse checkout
-            _run_git_command(
-                ["git", "config", "core.sparseCheckout", "true"],
-                temp_dir,
-                "Git sparse checkout config failed",
-            )
-
-            # Configure sparse-checkout patterns
-            sparse_checkout_file = temp_path / ".git" / "info" / "sparse-checkout"
-            sparse_checkout_file.parent.mkdir(parents=True, exist_ok=True)
-            patterns = [
-                "griptape_nodes_library.json",
-                "*/griptape_nodes_library.json",
-                "*/*/griptape_nodes_library.json",
-                "griptape-nodes-library.json",
-                "*/griptape-nodes-library.json",
-                "*/*/griptape-nodes-library.json",
-            ]
-            sparse_checkout_file.write_text("\n".join(patterns), encoding="utf-8")
-
-            # Fetch with depth 1 (shallow clone)
-            _run_git_command(
-                ["git", "fetch", "--depth=1", "origin", ref],
-                temp_dir,
-                f"Git fetch failed for {ref}",
-            )
-
-            # Checkout the ref
-            _run_git_command(["git", "checkout", "FETCH_HEAD"], temp_dir, "Git checkout failed")
-
-            # Find the library JSON file
-            library_json_path = find_file_in_directory(temp_path, "griptape[-_]nodes[-_]library.json")
-            if library_json_path is None:
-                msg = f"No library JSON file found in sparse checkout from {remote_url}"
-                raise GitCloneError(msg)
-
-            # Extract version from JSON
-            library_version = _extract_library_version_from_json(library_json_path, remote_url)
-
-            # Get commit SHA
-            rev_parse_result = _run_git_command(
-                ["git", "rev-parse", "HEAD"],
-                temp_dir,
-                "Git rev-parse failed",
-            )
-            commit_sha = rev_parse_result.stdout.strip()
-
-            # Get the committer date of the checked-out commit (strict ISO 8601). This is a
-            # best-effort field for the update age gate; a failure here must not fail the whole
-            # checkout, which backs the core version-check path, so degrade to None on error
-            # (mirroring the pygit2 path below).
-            commit_datetime = None
-            try:
-                commit_date_result = _run_git_command(
-                    ["git", "log", "-1", "--format=%cI", "HEAD"],
-                    temp_dir,
-                    "Git log failed",
-                )
-                commit_datetime = parse_commit_datetime(commit_date_result.stdout.strip())
-            except GitCloneError as e:
-                logger.debug("Failed to read commit datetime from sparse checkout of %s: %s", remote_url, e)
-
-            # Read the JSON data before temp directory is deleted
-            try:
-                with library_json_path.open(encoding="utf-8") as f:
-                    library_data = json.load(f)
-            except (OSError, json.JSONDecodeError) as e:
-                msg = f"Failed to read library file from {remote_url}: {e}"
-                raise GitCloneError(msg) from e
-
-        except subprocess.SubprocessError as e:
-            msg = f"Subprocess error during sparse checkout from {remote_url}: {e}"
-            raise GitCloneError(msg) from e
-
-        return LibraryJsonCheckout(
-            library_version=library_version,
-            commit_sha=commit_sha,
-            commit_datetime=commit_datetime,
-            library_data=library_data,
-        )
-
-
-def _shallow_clone_with_pygit2(remote_url: str, ref: str) -> LibraryJsonCheckout:
-    """Perform shallow clone using pygit2 to fetch library JSON file.
-
-    This is a fallback method when git CLI is not available. It downloads all files
-    but with limited history (depth=1).
-
-    Args:
-        remote_url: The git repository URL (HTTPS or SSH).
-        ref: The git reference (branch, tag, or commit) to checkout.
-
-    Returns:
-        LibraryJsonCheckout: The library version, commit SHA, commit datetime, and library data.
-
-    Raises:
-        GitCloneError: If clone fails or library metadata is invalid.
-    """
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-        repo = None  # Initialize for finally block
-
-        try:
-            callbacks = _CredentialCallbacks()
-
-            # Shallow clone with depth=1
-            # Note: We don't use checkout_branch here because it only works with branches,
-            # not tags or commit SHAs. Instead, we'll fetch and checkout the ref manually.
-            repo = pygit2.clone_repository(
-                remote_url,
-                str(temp_path),
-                callbacks=callbacks,
-                depth=1,
-            )
-
-            if repo is None:
-                msg = f"Failed to clone repository from {remote_url}"
-                raise GitCloneError(msg)
-
-            # If a specific ref was requested (not HEAD), fetch and checkout that ref
-            if ref != "HEAD":
-                try:
-                    # Fetch the specific ref (works for branches, tags, and commits)
-                    remote = repo.remotes["origin"]
-                    remote.fetch([ref], callbacks=callbacks, depth=1)
-
-                    # Now resolve and checkout the ref
-                    resolved_ref = repo.revparse_single(ref)
-                    repo.checkout_tree(resolved_ref)
-                    repo.set_head(resolved_ref.id)
-                except (KeyError, pygit2.GitError) as e:
-                    msg = f"Failed to fetch and checkout ref '{ref}' in clone from {remote_url}: {e}"
-                    raise GitCloneError(msg) from e
-
-            # Find the library JSON file
-            library_json_path = find_file_in_directory(temp_path, "griptape[-_]nodes[-_]library.json")
-            if library_json_path is None:
-                msg = f"No library JSON file found in clone from {remote_url}"
-                raise GitCloneError(msg)
-
-            # Extract version from JSON
-            library_version = _extract_library_version_from_json(library_json_path, remote_url)
-
-            # Get commit SHA
-            commit_sha = str(repo.head.target)
-
-            # Get the committer date of the checked-out commit. Peel to a commit first: for an
-            # annotated tag repo.head.target is the tag OID, and indexing it yields a pygit2.Tag
-            # (no commit_time). This is a best-effort field, so any failure degrades to None.
-            commit_datetime = None
-            try:
-                commit_obj = cast("pygit2.Commit", repo[repo.head.target].peel(pygit2.Commit))
-                commit_datetime = datetime.fromtimestamp(commit_obj.commit_time, tz=UTC)
-            except (pygit2.GitError, KeyError, AttributeError, ValueError, OverflowError, OSError) as e:
-                logger.debug("Failed to read commit datetime from clone of %s: %s", remote_url, e)
-
-            # Read the JSON data before temp directory is deleted
-            try:
-                with library_json_path.open(encoding="utf-8") as f:
-                    library_data = json.load(f)
-            except (OSError, json.JSONDecodeError) as e:
-                msg = f"Failed to read library file from {remote_url}: {e}"
-                raise GitCloneError(msg) from e
-
-        except pygit2.GitError as e:
-            msg = f"Git error during clone from {remote_url}: {e}"
-            raise GitCloneError(msg) from e
-        finally:
-            # Release repository file handles before temp directory cleanup
-            # Critical on Windows where open handles prevent directory deletion
-            if repo is not None:
-                repo.free()
-
-        return LibraryJsonCheckout(
-            library_version=library_version,
-            commit_sha=commit_sha,
-            commit_datetime=commit_datetime,
-            library_data=library_data,
-        )
-
-
 def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> LibraryJsonCheckout:
-    """Fetch library JSON file from a git repository.
+    """Fetch a library's JSON metadata from a git remote without a full clone.
 
-    This function uses the most efficient method available:
-    - If git CLI is available: uses sparse checkout (only downloads needed files)
-    - Otherwise: falls back to pygit2 shallow clone (downloads all files with depth=1)
+    Uses a sparse checkout so only files matching the library JSON patterns are
+    downloaded, rather than the whole repository.
 
     Args:
         remote_url: The git repository URL (HTTPS or SSH).
@@ -1393,76 +947,71 @@ def sparse_checkout_library_json(remote_url: str, ref: str = "HEAD") -> LibraryJ
         LibraryJsonCheckout: The library version, commit SHA, commit datetime, and library data.
 
     Raises:
-        GitCloneError: If the operation fails or library metadata is invalid.
+        GitCloneError: If the checkout fails or library metadata is invalid.
     """
-    if _is_git_available():
-        logger.debug("Using git CLI for sparse checkout from %s", remote_url)
-        return _sparse_checkout_with_git_cli(remote_url, ref)
+    _reject_option_like(remote_url, "git URL", GitCloneError)
+    _reject_option_like(ref, "ref", GitCloneError)
 
-    logger.debug("Git CLI not available, using pygit2 shallow clone from %s", remote_url)
-    return _shallow_clone_with_pygit2(remote_url, ref)
-
-
-def _remote_ref_exists_with_git_cli(remote_url: str, ref: str) -> bool:
-    """Check whether a branch or tag ref exists on a remote using the git CLI.
-
-    Args:
-        remote_url: The git repository URL (HTTPS or SSH).
-        ref: The branch or tag name to look for on the remote.
-
-    Returns:
-        bool: True if a matching branch or tag ref exists on the remote, False otherwise.
-
-    Raises:
-        GitRemoteError: If the remote cannot be queried.
-    """
-    result = subprocess.run(  # noqa: S603
-        ["git", "ls-remote", "--heads", "--tags", remote_url, ref],  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        msg = f"Failed to query remote refs from {remote_url}: {result.stderr.strip()}"
-        raise GitRemoteError(msg)
-
-    return bool(result.stdout.strip())
-
-
-def _remote_ref_exists_with_pygit2(remote_url: str, ref: str) -> bool:
-    """Check whether a branch or tag ref exists on a remote using pygit2.
-
-    Args:
-        remote_url: The git repository URL (HTTPS or SSH).
-        ref: The branch or tag name to look for on the remote.
-
-    Returns:
-        bool: True if a matching branch or tag ref exists on the remote, False otherwise.
-
-    Raises:
-        GitRemoteError: If the remote cannot be queried.
-    """
-    candidate_names = {f"refs/heads/{ref}", f"refs/tags/{ref}"}
     with tempfile.TemporaryDirectory() as temp_dir:
-        repo = pygit2.init_repository(temp_dir, bare=True)
-        try:
-            remote = repo.remotes.create("origin", remote_url)
-            remote_refs = remote.ls_remotes(callbacks=_CredentialCallbacks())
-        except pygit2.GitError as e:
-            msg = f"Failed to query remote refs from {remote_url}: {e}"
-            raise GitRemoteError(msg) from e
-        finally:
-            repo.free()
+        temp_path = Path(temp_dir)
 
-    return any(remote_ref.get("name") in candidate_names for remote_ref in remote_refs)
+        def run(args: list[str], error_msg: str) -> str:
+            return _run_git(args, error_msg=error_msg, cwd=temp_path, error_cls=GitCloneError)
+
+        run(["init"], "Git init failed")
+        run(["remote", "add", "origin", remote_url], "Git remote add failed")
+        run(["config", "core.sparseCheckout", "true"], "Git sparse checkout config failed")
+
+        # Configure sparse-checkout patterns
+        sparse_checkout_file = temp_path / ".git" / "info" / "sparse-checkout"
+        sparse_checkout_file.parent.mkdir(parents=True, exist_ok=True)
+        patterns = [
+            "griptape_nodes_library.json",
+            "*/griptape_nodes_library.json",
+            "*/*/griptape_nodes_library.json",
+            "griptape-nodes-library.json",
+            "*/griptape-nodes-library.json",
+            "*/*/griptape-nodes-library.json",
+        ]
+        sparse_checkout_file.write_text("\n".join(patterns), encoding="utf-8")
+
+        run(["fetch", "--depth=1", "origin", ref], f"Git fetch failed for {ref}")
+        run(["checkout", "FETCH_HEAD"], "Git checkout failed")
+
+        library_json_path = find_file_in_directory(temp_path, "griptape[-_]nodes[-_]library.json")
+        if library_json_path is None:
+            msg = f"No library JSON file found in sparse checkout from {remote_url}"
+            raise GitCloneError(msg)
+
+        library_version = _extract_library_version_from_json(library_json_path, remote_url)
+        commit_sha = run(["rev-parse", "HEAD"], "Git rev-parse failed")
+
+        # Committer date of the checked-out commit (strict ISO 8601). This is a best-effort
+        # field for the update age gate; a failure here must not fail the whole checkout,
+        # which backs the core version-check path, so degrade to None on error.
+        commit_datetime = parse_commit_datetime(_try_git(["log", "-1", "--format=%cI", "HEAD"], temp_path) or "")
+
+        # Read the JSON data before temp directory is deleted
+        try:
+            with library_json_path.open(encoding="utf-8") as f:
+                library_data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            msg = f"Failed to read library file from {remote_url}: {e}"
+            raise GitCloneError(msg) from e
+
+        return LibraryJsonCheckout(
+            library_version=library_version,
+            commit_sha=commit_sha,
+            commit_datetime=commit_datetime,
+            library_data=library_data,
+        )
 
 
 def remote_ref_exists(remote_url: str, ref: str) -> bool:
     """Check whether a branch or tag named ``ref`` exists on a git remote.
 
-    Uses the git CLI when available and falls back to pygit2 otherwise, mirroring
-    sparse_checkout_library_json. Commit SHAs are not advertised as named refs, so a
-    detached HEAD pointing at a bare commit reports False.
+    Commit SHAs are not advertised as named refs, so a detached HEAD pointing at a
+    bare commit reports False.
 
     Args:
         remote_url: The git repository URL (HTTPS or SSH).
@@ -1474,9 +1023,12 @@ def remote_ref_exists(remote_url: str, ref: str) -> bool:
     Raises:
         GitRemoteError: If the remote cannot be queried.
     """
-    if _is_git_available():
-        logger.debug("Using git CLI to check remote ref '%s' on %s", ref, remote_url)
-        return _remote_ref_exists_with_git_cli(remote_url, ref)
+    _reject_option_like(remote_url, "git URL", GitRemoteError)
+    _reject_option_like(ref, "ref", GitRemoteError)
 
-    logger.debug("Git CLI not available, using pygit2 to check remote ref '%s' on %s", ref, remote_url)
-    return _remote_ref_exists_with_pygit2(remote_url, ref)
+    refs = _run_git_detached(
+        ["ls-remote", "--heads", "--tags", remote_url, ref],
+        error_msg=f"Failed to query remote refs from {remote_url}",
+        error_cls=GitRemoteError,
+    )
+    return bool(refs)

--- a/tests/unit/retained_mode/managers/test_library_manager_git_failures.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_git_failures.py
@@ -1,0 +1,147 @@
+"""Tests for how LibraryManager's git-backed request handlers report git failures.
+
+Every git call these handlers make can fail for reasons outside the repository, most notably a
+machine with no git installed. These tests pin down that such a failure comes back as a result
+failure the editor can display, rather than escaping the handler.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.retained_mode.events.library_events import (
+    CheckLibraryUpdateRequest,
+    CheckLibraryUpdateResultFailure,
+    CheckLibraryUpdateResultSuccess,
+    UpdateLibraryRequest,
+    UpdateLibraryResultFailure,
+)
+from griptape_nodes.retained_mode.managers.library_manager import (
+    LibraryGitOperationContext,
+)
+from griptape_nodes.utils.git_utils import GitError, GitNotFoundError
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
+LIBRARY_DIR = Path("/var/lib/test_lib")
+
+
+def _library_info() -> MagicMock:
+    """Build the registry lookup result the handlers use to find a library on disk."""
+    library_info = MagicMock()
+    library_info.library_path = str(LIBRARY_DIR / "griptape_nodes_library.json")
+    return library_info
+
+
+def _library(*, version: str = "1.0.0") -> MagicMock:
+    """Build a registered library that reports a version."""
+    library = MagicMock()
+    library.get_metadata.return_value = MagicMock(library_version=version)
+    return library
+
+
+def _validation_context() -> LibraryGitOperationContext:
+    """Build the pre-flight result update_library_request works from."""
+    return LibraryGitOperationContext(
+        library=MagicMock(),
+        old_version="1.0.0",
+        library_file_path=str(LIBRARY_DIR / "griptape_nodes_library.json"),
+        library_dir=LIBRARY_DIR,
+    )
+
+
+class TestCheckLibraryUpdateRequestGitFailures:
+    """Test check_library_update_request when a git call fails."""
+
+    @pytest.mark.asyncio
+    async def test_monorepo_check_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """A git failure while reading the repository layout fails the check instead of escaping."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=_library()),
+            patch.object(library_manager, "get_library_info_by_library_name", return_value=_library_info()),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", side_effect=GitNotFoundError("git was not found on PATH")),
+        ):
+            result = await library_manager.check_library_update_request(
+                CheckLibraryUpdateRequest(library_name="test_lib")
+            )
+
+        assert isinstance(result, CheckLibraryUpdateResultFailure)
+        assert "test_lib" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_local_commit_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """A git failure while reading the local commit fails the check instead of escaping."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=_library()),
+            patch.object(library_manager, "get_library_info_by_library_name", return_value=_library_info()),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value="https://example.com/repo.git"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_current_ref", return_value="main"),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_local_commit_sha", side_effect=GitError("boom")),
+        ):
+            result = await library_manager.check_library_update_request(
+                CheckLibraryUpdateRequest(library_name="test_lib")
+            )
+
+        assert isinstance(result, CheckLibraryUpdateResultFailure)
+        assert "test_lib" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_monorepo_reports_no_update_without_git_details(self, griptape_nodes: GriptapeNodes) -> None:
+        """A monorepo library still reports "no update, manage manually" when git details are unavailable.
+
+        The remote and ref in that response are informational, so their absence must not turn a
+        successful answer into a failure.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=_library()),
+            patch.object(library_manager, "get_library_info_by_library_name", return_value=_library_info()),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=True),
+            patch(f"{LIBRARY_MANAGER_MODULE}.get_git_info", return_value=(None, None)),
+        ):
+            result = await library_manager.check_library_update_request(
+                CheckLibraryUpdateRequest(library_name="test_lib")
+            )
+
+        assert isinstance(result, CheckLibraryUpdateResultSuccess)
+        assert result.has_update is False
+        assert result.git_remote is None
+        assert result.git_ref is None
+
+
+class TestUpdateLibraryRequestGitFailures:
+    """Test update_library_request when a git call fails."""
+
+    @pytest.mark.asyncio
+    async def test_monorepo_check_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+        """A git failure while reading the repository layout fails the update before the working tree is touched."""
+        library_manager = griptape_nodes.LibraryManager()
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=_validation_context()),
+            ),
+            patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", side_effect=GitNotFoundError("git was not found on PATH")),
+            patch(f"{LIBRARY_MANAGER_MODULE}.update_library_git") as mock_update_git,
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultFailure)
+        assert "test_lib" in str(result.result_details)
+        mock_update_git.assert_not_called()

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -2,40 +2,87 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import pygit2
 import pytest
 
 from griptape_nodes.utils.git_utils import (
     GitCloneError,
+    GitError,
+    GitNotFoundError,
     GitPullError,
     GitRefError,
     GitRemoteError,
     GitRepositoryError,
-    _CredentialCallbacks,
     clone_repository,
     extract_repo_name_from_url,
     get_current_ref,
+    get_current_tag,
     get_git_info,
     get_git_remote,
     get_git_repository_root,
+    get_local_commit_sha,
     git_update_from_remote,
+    has_uncommitted_changes,
     is_git_repository,
     is_git_url,
+    is_on_tag,
     normalize_github_url,
     parse_commit_datetime,
     parse_git_url_with_ref,
     remote_ref_exists,
+    sparse_checkout_library_json,
     switch_branch,
+    switch_branch_or_tag,
+    update_library_git,
+    update_to_moving_tag,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+
+def run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command with a throwaway identity so commits succeed without machine git config."""
+    return subprocess.run(  # noqa: S603
+        ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def make_origin_repo(origin_path: Path, *, library_version: str = "1.2.3") -> Path:
+    """Create a git repository at origin_path with a committed griptape_nodes_library.json.
+
+    Pins the initial branch to "main" instead of relying on the local machine's
+    init.defaultBranch configuration.
+    """
+    origin_path.mkdir(parents=True, exist_ok=True)
+    run_git(origin_path, "init", "-b", "main")
+    library_json = origin_path / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps({"metadata": {"library_version": library_version}}), encoding="utf-8")
+    run_git(origin_path, "add", ".")
+    run_git(origin_path, "commit", "-m", "initial commit")
+    return origin_path
+
+
+def clone_repo(origin_path: Path, clone_path: Path) -> Path:
+    """Clone origin_path into clone_path with the git CLI directly, bypassing the code under test."""
+    run_git(clone_path.parent, "clone", str(origin_path), str(clone_path))
+    return clone_path
+
+
+def head_sha(repo_path: Path) -> str:
+    """Return the full commit SHA that HEAD points to in repo_path."""
+    return run_git(repo_path, "rev-parse", "HEAD").stdout.strip()
 
 
 class TestParseGitUrlWithRef:
@@ -196,7 +243,7 @@ class TestIsGitUrl:
         assert result is False
 
     def test_is_git_url_returns_false_for_local_path(self) -> None:
-        """Test that local paths are not recognized as git URLs."""
+        """Test that local paths are not recognized as a git URL."""
         result = is_git_url("/home/user/repo")
 
         assert result is False
@@ -299,12 +346,7 @@ class TestIsGitRepository:
 
     def test_is_git_repository_returns_false_when_not_git_repo(self) -> None:
         """Test that False is returned when directory is not a git repository."""
-        with (
-            tempfile.TemporaryDirectory() as tmpdir,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_discover.side_effect = pygit2.GitError("not a git repository")
-
+        with tempfile.TemporaryDirectory() as tmpdir:
             result = is_git_repository(Path(tmpdir))
 
             assert result is False
@@ -347,82 +389,30 @@ class TestGetGitRemote:
 
     def test_get_git_remote_returns_none_when_not_git_repository(self, temp_dir: Path) -> None:
         """Test that None is returned when path is not a git repository."""
-        with patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git:
-            mock_is_git.return_value = False
+        result = get_git_remote(temp_dir)
 
-            result = get_git_remote(temp_dir)
-
-            assert result is None
-
-    def test_get_git_remote_returns_none_when_repository_not_discovered(self, temp_dir: Path) -> None:
-        """Test that None is returned when repository cannot be discovered."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = None
-
-            result = get_git_remote(temp_dir)
-
-            assert result is None
+        assert result is None
 
     def test_get_git_remote_returns_none_when_no_origin_remote(self, temp_dir: Path) -> None:
         """Test that None is returned when no origin remote exists."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        repo = make_origin_repo(temp_dir / "repo")
 
-            mock_repo = Mock()
-            mock_repo.remotes = {}
-            mock_repo_class.return_value = mock_repo
+        result = get_git_remote(repo)
 
-            result = get_git_remote(temp_dir)
-
-            assert result is None
+        assert result is None
 
     def test_get_git_remote_returns_url_when_origin_exists(self, temp_dir: Path) -> None:
         """Test that remote URL is returned when origin exists."""
+        repo = make_origin_repo(temp_dir / "repo")
         expected_url = "https://github.com/user/repo.git"
+        run_git(repo, "remote", "add", "origin", expected_url)
 
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        result = get_git_remote(repo)
 
-            mock_remote = Mock()
-            mock_remote.url = expected_url
-            mock_repo = Mock()
-            mock_repo.remotes = {"origin": mock_remote}
-            mock_repo_class.return_value = mock_repo
-
-            result = get_git_remote(temp_dir)
-
-            assert result == expected_url
-
-    def test_get_git_remote_raises_error_on_git_error(self, temp_dir: Path) -> None:
-        """Test that GitRemoteError is raised on pygit2.GitError."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.side_effect = pygit2.GitError("error")
-
-            with pytest.raises(GitRemoteError) as exc_info:
-                get_git_remote(temp_dir)
-
-            assert "Error getting git remote" in str(exc_info.value)
+        assert result == expected_url
 
 
-class TestGetCurrentBranch:
+class TestGetCurrentRef:
     """Test get_current_ref function."""
 
     @pytest.fixture
@@ -433,89 +423,159 @@ class TestGetCurrentBranch:
 
     def test_get_current_ref_returns_none_when_not_git_repository(self, temp_dir: Path) -> None:
         """Test that None is returned when path is not a git repository."""
-        with patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git:
-            mock_is_git.return_value = False
+        result = get_current_ref(temp_dir)
 
-            result = get_current_ref(temp_dir)
-
-            assert result is None
-
-    def test_get_current_ref_returns_none_when_repository_not_discovered(self, temp_dir: Path) -> None:
-        """Test that None is returned when repository cannot be discovered."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = None
-
-            result = get_current_ref(temp_dir)
-
-            assert result is None
-
-    def test_get_current_ref_returns_none_when_head_detached(self, temp_dir: Path) -> None:
-        """Test that commit SHA is returned when HEAD is detached."""
-        expected_commit_sha = "abc123def456"
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-            patch("griptape_nodes.utils.git_utils.get_current_tag") as mock_get_current_tag,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
-            mock_get_current_tag.return_value = None
-
-            mock_head = Mock()
-            mock_head.target = expected_commit_sha
-            mock_repo = Mock()
-            mock_repo.head_is_unborn = False
-            mock_repo.head_is_detached = True
-            mock_repo.head = mock_head
-            mock_repo_class.return_value = mock_repo
-
-            result = get_current_ref(temp_dir)
-
-            assert result == expected_commit_sha
+        assert result is None
 
     def test_get_current_ref_returns_branch_name_when_on_branch(self, temp_dir: Path) -> None:
         """Test that branch name is returned when on a branch."""
-        expected_branch = "main"
+        repo = make_origin_repo(temp_dir / "repo")
 
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        result = get_current_ref(repo)
 
-            mock_head = Mock()
-            mock_head.shorthand = expected_branch
-            mock_repo = Mock()
-            mock_repo.head_is_unborn = False
-            mock_repo.head_is_detached = False
-            mock_repo.head = mock_head
-            mock_repo_class.return_value = mock_repo
+        assert result == "main"
 
-            result = get_current_ref(temp_dir)
+    def test_get_current_ref_returns_tag_name_when_head_detached_and_tagged(self, temp_dir: Path) -> None:
+        """Test that tag name is returned when HEAD is detached on a tagged commit."""
+        repo = make_origin_repo(temp_dir / "repo")
+        run_git(repo, "tag", "v1.0.0")
+        run_git(repo, "checkout", "--detach", "v1.0.0")
 
-            assert result == expected_branch
+        result = get_current_ref(repo)
 
-    def test_get_current_ref_raises_error_on_git_error(self, temp_dir: Path) -> None:
-        """Test that GitRefError is raised on pygit2.GitError."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.side_effect = pygit2.GitError("error")
+        assert result == "v1.0.0"
 
-            with pytest.raises(GitRefError) as exc_info:
-                get_current_ref(temp_dir)
+    def test_get_current_ref_returns_commit_sha_when_head_detached_and_not_tagged(self, temp_dir: Path) -> None:
+        """Test that commit SHA is returned when HEAD is detached and not tagged."""
+        repo = make_origin_repo(temp_dir / "repo")
+        sha = head_sha(repo)
+        run_git(repo, "checkout", "--detach", sha)
 
-            assert "Error getting current git reference" in str(exc_info.value)
+        result = get_current_ref(repo)
+
+        assert result == sha
+
+    def test_get_current_ref_returns_none_when_head_is_unborn(self, temp_dir: Path) -> None:
+        """Test that None is returned for a freshly initialized repository with no commits."""
+        repo = temp_dir / "unborn"
+        repo.mkdir()
+        run_git(repo, "init", "-b", "main")
+
+        result = get_current_ref(repo)
+
+        assert result is None
+
+
+class TestGetCurrentTag:
+    """Test get_current_tag function."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_get_current_tag_returns_none_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that None is returned when path is not a git repository."""
+        result = get_current_tag(temp_dir)
+
+        assert result is None
+
+    def test_get_current_tag_returns_none_when_head_is_unborn(self, temp_dir: Path) -> None:
+        """Test that None is returned for a freshly initialized repository with no commits."""
+        repo = temp_dir / "unborn"
+        repo.mkdir()
+        run_git(repo, "init", "-b", "main")
+
+        result = get_current_tag(repo)
+
+        assert result is None
+
+    def test_get_current_tag_returns_none_when_head_not_tagged(self, temp_dir: Path) -> None:
+        """Test that None is returned when HEAD has no tag pointing at it."""
+        repo = make_origin_repo(temp_dir / "repo")
+
+        result = get_current_tag(repo)
+
+        assert result is None
+
+    def test_get_current_tag_returns_tag_name_when_head_is_tagged(self, temp_dir: Path) -> None:
+        """Test that the tag name is returned when a tag points at HEAD, even on a branch."""
+        repo = make_origin_repo(temp_dir / "repo")
+        run_git(repo, "tag", "v1.0.0")
+
+        result = get_current_tag(repo)
+
+        assert result == "v1.0.0"
+
+
+class TestIsOnTag:
+    """Test is_on_tag function."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_is_on_tag_returns_false_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that False is returned when path is not a git repository."""
+        result = is_on_tag(temp_dir)
+
+        assert result is False
+
+    def test_is_on_tag_returns_false_when_head_not_tagged(self, temp_dir: Path) -> None:
+        """Test that False is returned when HEAD has no tag pointing at it."""
+        repo = make_origin_repo(temp_dir / "repo")
+
+        result = is_on_tag(repo)
+
+        assert result is False
+
+    def test_is_on_tag_returns_true_when_head_is_tagged(self, temp_dir: Path) -> None:
+        """Test that True is returned when a tag points at HEAD."""
+        repo = make_origin_repo(temp_dir / "repo")
+        run_git(repo, "tag", "v1.0.0")
+
+        result = is_on_tag(repo)
+
+        assert result is True
+
+
+class TestGetLocalCommitSha:
+    """Test get_local_commit_sha function."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_get_local_commit_sha_returns_none_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that None is returned when path is not a git repository."""
+        result = get_local_commit_sha(temp_dir)
+
+        assert result is None
+
+    def test_get_local_commit_sha_returns_none_when_head_is_unborn(self, temp_dir: Path) -> None:
+        """Test that None is returned for a freshly initialized repository with no commits."""
+        repo = temp_dir / "unborn"
+        repo.mkdir()
+        run_git(repo, "init", "-b", "main")
+
+        result = get_local_commit_sha(repo)
+
+        assert result is None
+
+    def test_get_local_commit_sha_returns_full_commit_sha_when_head_has_commits(self, temp_dir: Path) -> None:
+        """Test that the full HEAD commit SHA is returned."""
+        repo = make_origin_repo(temp_dir / "repo")
+
+        result = get_local_commit_sha(repo)
+
+        assert result == head_sha(repo)
+        assert result is not None
+        assert len(result) == 40  # noqa: PLR2004
 
 
 class TestGetGitRepositoryRoot:
@@ -529,75 +589,164 @@ class TestGetGitRepositoryRoot:
 
     def test_get_git_repository_root_returns_none_when_not_git_repository(self, temp_dir: Path) -> None:
         """Test that None is returned when path is not a git repository."""
-        with patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git:
-            mock_is_git.return_value = False
+        result = get_git_repository_root(temp_dir)
 
-            result = get_git_repository_root(temp_dir)
+        assert result is None
 
-            assert result is None
+    def test_get_git_repository_root_returns_root_when_called_on_root(self, temp_dir: Path) -> None:
+        """Test that the repository root is returned when called on the root itself."""
+        repo = make_origin_repo(temp_dir / "repo")
 
-    def test_get_git_repository_root_returns_none_when_repository_not_discovered(self, temp_dir: Path) -> None:
-        """Test that None is returned when repository cannot be discovered."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = None
+        result = get_git_repository_root(repo)
 
-            result = get_git_repository_root(temp_dir)
+        assert result == repo
 
-            assert result is None
+    def test_get_git_repository_root_returns_root_when_called_on_subdirectory(self, temp_dir: Path) -> None:
+        """Test that the repository root is returned when called on a subdirectory."""
+        repo = make_origin_repo(temp_dir / "repo")
+        subdir = repo / "subdir"
+        subdir.mkdir()
 
-    def test_get_git_repository_root_returns_parent_for_normal_repository(self, temp_dir: Path) -> None:
-        """Test that parent of .git directory is returned for normal repository."""
-        git_dir = temp_dir / ".git"
+        result = get_git_repository_root(subdir)
 
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(git_dir)
+        assert result == repo
 
-            result = get_git_repository_root(temp_dir)
 
-            assert result == temp_dir
+class TestCloneRepositoryWorkingDirectory:
+    """Test clone_repository's independence from the working directory."""
 
-    def test_get_git_repository_root_returns_bare_repo_path_for_bare_repository(self, temp_dir: Path) -> None:
-        """Test that bare repository path is returned for bare repositories."""
-        bare_repo_path = temp_dir / "repo.git"
-        bare_repo_path.mkdir()
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
 
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(bare_repo_path)
+    def test_clone_repository_ignores_a_broken_repository_in_the_working_directory(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that a broken repository at the working directory doesn't fail the clone."""
+        origin = make_origin_repo(temp_dir / "origin")
+        broken = temp_dir / "broken"
+        broken.mkdir()
+        (broken / ".git").write_text("gitdir: /nonexistent/worktrees/gone\n")
+        monkeypatch.chdir(broken)
 
-            mock_repo = Mock()
-            mock_repo.is_bare = True
-            mock_repo_class.return_value = mock_repo
+        clone_repository(str(origin), temp_dir / "clone")
 
-            result = get_git_repository_root(temp_dir)
+        assert (temp_dir / "clone" / "griptape_nodes_library.json").exists()
 
-            assert result == bare_repo_path
 
-    def test_get_git_repository_root_raises_error_on_git_error(self, temp_dir: Path) -> None:
-        """Test that GitRepositoryError is raised on pygit2.GitError."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.side_effect = pygit2.GitError("error")
+class TestGetGitInfo:
+    """Test get_git_info function.
 
-            with pytest.raises(GitRepositoryError) as exc_info:
-                get_git_repository_root(temp_dir)
+    get_git_info degrades to (None, None) where get_git_remote() and get_current_ref() would
+    each raise or independently re-check is_git_repository().
+    """
 
-            assert "Error getting git repository root" in str(exc_info.value)
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_get_git_info_returns_none_none_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that (None, None) is returned when path is not a git repository."""
+        git_remote, git_ref = get_git_info(temp_dir)
+
+        assert git_remote is None
+        assert git_ref is None
+
+    def test_get_git_info_returns_remote_and_branch_when_on_branch(self, temp_dir: Path) -> None:
+        """Test that both remote URL and branch name are returned when on a branch."""
+        repo = make_origin_repo(temp_dir / "repo")
+        expected_url = "https://github.com/user/repo.git"
+        run_git(repo, "remote", "add", "origin", expected_url)
+
+        git_remote, git_ref = get_git_info(repo)
+
+        assert git_remote == expected_url
+        assert git_ref == "main"
+
+    def test_get_git_info_returns_none_remote_when_no_origin(self, temp_dir: Path) -> None:
+        """Test that remote is None when no origin is configured."""
+        repo = make_origin_repo(temp_dir / "repo")
+
+        git_remote, git_ref = get_git_info(repo)
+
+        assert git_remote is None
+        assert git_ref == "main"
+
+    def test_get_git_info_returns_commit_sha_when_head_detached_and_no_tag(self, temp_dir: Path) -> None:
+        """Test that the commit SHA is returned as the ref for a detached, untagged HEAD."""
+        repo = make_origin_repo(temp_dir / "repo")
+        sha = head_sha(repo)
+        run_git(repo, "checkout", "--detach", sha)
+
+        _git_remote, git_ref = get_git_info(repo)
+
+        assert git_ref == sha
+
+    def test_get_git_info_returns_tag_name_when_head_on_tag(self, temp_dir: Path) -> None:
+        """Test that the tag name is returned as the ref for a detached, tagged HEAD."""
+        repo = make_origin_repo(temp_dir / "repo")
+        run_git(repo, "tag", "v1.0.0")
+        run_git(repo, "checkout", "--detach", "v1.0.0")
+
+        _git_remote, git_ref = get_git_info(repo)
+
+        assert git_ref == "v1.0.0"
+
+    def test_get_git_info_returns_none_ref_when_head_unborn(self, temp_dir: Path) -> None:
+        """Test that ref is None for a freshly initialized repository with no commits."""
+        repo = temp_dir / "unborn"
+        repo.mkdir()
+        run_git(repo, "init", "-b", "main")
+
+        git_remote, git_ref = get_git_info(repo)
+
+        assert git_remote is None
+        assert git_ref is None
+
+
+class TestHasUncommittedChanges:
+    """Test has_uncommitted_changes function."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_has_uncommitted_changes_raises_error_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that GitRepositoryError is raised when not a git repository."""
+        with pytest.raises(GitRepositoryError, match="is not a git repository"):
+            has_uncommitted_changes(temp_dir)
+
+    def test_has_uncommitted_changes_returns_false_when_clean(self, temp_dir: Path) -> None:
+        """Test that False is returned when the working tree is clean."""
+        repo = make_origin_repo(temp_dir / "repo")
+
+        result = has_uncommitted_changes(repo)
+
+        assert result is False
+
+    def test_has_uncommitted_changes_returns_true_when_tracked_file_modified(self, temp_dir: Path) -> None:
+        """Test that True is returned when a tracked file has local modifications."""
+        repo = make_origin_repo(temp_dir / "repo")
+        (repo / "griptape_nodes_library.json").write_text("changed", encoding="utf-8")
+
+        result = has_uncommitted_changes(repo)
+
+        assert result is True
+
+    def test_has_uncommitted_changes_returns_true_when_untracked_file_present(self, temp_dir: Path) -> None:
+        """Test that True is returned when an untracked file is present."""
+        repo = make_origin_repo(temp_dir / "repo")
+        (repo / "untracked.txt").write_text("new", encoding="utf-8")
+
+        result = has_uncommitted_changes(repo)
+
+        assert result is True
 
 
 class TestGitUpdateFromRemote:
@@ -611,187 +760,204 @@ class TestGitUpdateFromRemote:
 
     def test_git_update_from_remote_raises_error_when_not_git_repository(self, temp_dir: Path) -> None:
         """Test that GitRepositoryError is raised when not a git repository."""
-        with patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git:
-            mock_is_git.return_value = False
-
-            with pytest.raises(GitRepositoryError) as exc_info:
-                git_update_from_remote(temp_dir)
-
-            assert "not a git repository" in str(exc_info.value)
-
-    def test_git_update_from_remote_raises_error_when_repository_not_discovered(self, temp_dir: Path) -> None:
-        """Test that GitRepositoryError is raised when repository cannot be discovered."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = None
-
-            with pytest.raises(GitRepositoryError) as exc_info:
-                git_update_from_remote(temp_dir)
-
-            assert "Cannot discover repository" in str(exc_info.value)
+        with pytest.raises(GitRepositoryError, match="is not a git repository"):
+            git_update_from_remote(temp_dir)
 
     def test_git_update_from_remote_raises_error_when_head_detached(self, temp_dir: Path) -> None:
         """Test that GitPullError is raised when HEAD is detached."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "checkout", "--detach", head_sha(clone))
 
-            mock_repo = Mock()
-            mock_repo.head_is_detached = True
-            mock_repo_class.return_value = mock_repo
-
-            with pytest.raises(GitPullError) as exc_info:
-                git_update_from_remote(temp_dir)
-
-            assert "detached HEAD" in str(exc_info.value)
+        with pytest.raises(GitPullError, match="detached HEAD"):
+            git_update_from_remote(clone)
 
     def test_git_update_from_remote_raises_error_when_no_upstream_branch(self, temp_dir: Path) -> None:
         """Test that GitPullError is raised when no upstream branch is set."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "checkout", "-b", "untracked")
 
-            mock_branch = Mock()
-            mock_branch.upstream = None
-            mock_branch.branch_name = "main"
-
-            mock_head = Mock()
-            mock_head.shorthand = "main"
-
-            mock_branches = Mock()
-            mock_branches.get.return_value = mock_branch
-
-            mock_repo = Mock()
-            mock_repo.head_is_detached = False
-            mock_repo.head = mock_head
-            mock_repo.branches = mock_branches
-            mock_repo_class.return_value = mock_repo
-
-            with pytest.raises(GitPullError) as exc_info:
-                git_update_from_remote(temp_dir)
-
-            assert "No upstream branch" in str(exc_info.value)
+        with pytest.raises(GitPullError, match="No upstream branch"):
+            git_update_from_remote(clone)
 
     def test_git_update_from_remote_raises_error_when_no_origin_remote(self, temp_dir: Path) -> None:
         """Test that GitPullError is raised when no origin remote exists."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        # Renaming keeps the branch's upstream tracking resolvable while origin disappears,
+        # isolating the "no origin remote" check from the "no upstream" check.
+        run_git(clone, "remote", "rename", "origin", "other")
 
-            mock_branch = Mock()
-            mock_branch.upstream = Mock()
-            mock_branch.branch_name = "main"
+        with pytest.raises(GitPullError, match="No origin remote"):
+            git_update_from_remote(clone)
 
-            mock_head = Mock()
-            mock_head.shorthand = "main"
+    def test_git_update_from_remote_raises_error_when_uncommitted_changes_and_not_overwriting(
+        self, temp_dir: Path
+    ) -> None:
+        """Test that GitPullError is raised when uncommitted changes exist and overwrite_existing is False."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        (clone / "griptape_nodes_library.json").write_text("dirty", encoding="utf-8")
 
-            mock_branches = Mock()
-            mock_branches.get.return_value = mock_branch
+        with pytest.raises(GitPullError, match="uncommitted changes"):
+            git_update_from_remote(clone)
 
-            mock_repo = Mock()
-            mock_repo.head_is_detached = False
-            mock_repo.head = mock_head
-            mock_repo.branches = mock_branches
-            mock_repo.remotes = {}
-            mock_repo_class.return_value = mock_repo
+    def test_git_update_from_remote_discards_uncommitted_changes_when_overwrite_existing_true(
+        self, temp_dir: Path
+    ) -> None:
+        """Test that uncommitted changes are discarded when overwrite_existing is True."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        (clone / "griptape_nodes_library.json").write_text("dirty", encoding="utf-8")
 
-            with pytest.raises(GitPullError) as exc_info:
-                git_update_from_remote(temp_dir)
+        git_update_from_remote(clone, overwrite_existing=True)
 
-            assert "No origin remote" in str(exc_info.value)
+        assert has_uncommitted_changes(clone) is False
 
-    def test_git_update_from_remote_succeeds_with_pygit2(self, temp_dir: Path) -> None:
-        """Test that function succeeds when pygit2 operations succeed."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-            patch("griptape_nodes.utils.git_utils.has_uncommitted_changes") as mock_has_changes,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
-            mock_has_changes.return_value = False
+    def test_git_update_from_remote_resets_to_upstream_tip_after_origin_moves_forward(self, temp_dir: Path) -> None:
+        """Test that the local branch is reset to match the remote after origin advances."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        (origin / "extra.txt").write_text("extra", encoding="utf-8")
+        run_git(origin, "add", ".")
+        run_git(origin, "commit", "-m", "advance origin")
 
-            mock_upstream_ref = Mock()
-            mock_upstream_ref.target = "abc123"
+        git_update_from_remote(clone)
 
-            mock_references = Mock()
-            mock_references.get.return_value = mock_upstream_ref
+        assert get_local_commit_sha(clone) == head_sha(origin)
+        assert (clone / "extra.txt").exists()
 
-            mock_branch = Mock()
-            mock_branch.upstream = Mock()
-            mock_branch.upstream.branch_name = "origin/main"
 
-            mock_head = Mock()
-            mock_head.shorthand = "main"
+class TestUpdateToMovingTag:
+    """Test update_to_moving_tag function."""
 
-            mock_branches = Mock()
-            mock_branches.get.return_value = mock_branch
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
 
-            mock_remote = Mock()
-            mock_repo = Mock()
-            mock_repo.head_is_detached = False
-            mock_repo.head = mock_head
-            mock_repo.branches = mock_branches
-            mock_repo.remotes = {"origin": mock_remote}
-            mock_repo.references = mock_references
-            mock_repo_class.return_value = mock_repo
+    def test_update_to_moving_tag_raises_error_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that GitRepositoryError is raised when not a git repository."""
+        with pytest.raises(GitRepositoryError, match="is not a git repository"):
+            update_to_moving_tag(temp_dir, "latest")
 
-            git_update_from_remote(temp_dir)
+    def test_update_to_moving_tag_raises_error_when_no_origin_remote(self, temp_dir: Path) -> None:
+        """Test that GitPullError is raised when no origin remote exists."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "latest")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "remote", "rename", "origin", "other")
 
-            mock_remote.fetch.assert_called_once()
-            mock_repo.reset.assert_called_once()
+        with pytest.raises(GitPullError, match="No origin remote"):
+            update_to_moving_tag(clone, "latest")
 
-    def test_git_update_from_remote_raises_error_when_fetch_fails(self, temp_dir: Path) -> None:
-        """Test that GitPullError is raised when fetch fails."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-            patch("griptape_nodes.utils.git_utils.has_uncommitted_changes") as mock_has_changes,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
-            mock_has_changes.return_value = False
+    def test_update_to_moving_tag_raises_error_when_tag_not_found_on_remote(self, temp_dir: Path) -> None:
+        """Test that GitPullError is raised when the tag does not exist on the remote."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
 
-            mock_branch = Mock()
-            mock_branch.upstream = Mock()
-            mock_branch.upstream.branch_name = "origin/main"
+        with pytest.raises(GitPullError, match="not found"):
+            update_to_moving_tag(clone, "latest")
 
-            mock_head = Mock()
-            mock_head.shorthand = "main"
+    def test_update_to_moving_tag_follows_tag_when_origin_force_moves_it(self, temp_dir: Path) -> None:
+        """Test that the tag is followed to a new commit after origin force-moves it."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "latest")
+        clone = clone_repo(origin, temp_dir / "clone")
 
-            mock_branches = Mock()
-            mock_branches.get.return_value = mock_branch
+        update_to_moving_tag(clone, "latest")
 
-            mock_remote = Mock()
-            mock_remote.fetch.side_effect = pygit2.GitError("fetch failed")
-            mock_repo = Mock()
-            mock_repo.head_is_detached = False
-            mock_repo.head = mock_head
-            mock_repo.branches = mock_branches
-            mock_repo.remotes = {"origin": mock_remote}
-            mock_repo_class.return_value = mock_repo
+        assert get_local_commit_sha(clone) == head_sha(origin)
 
-            with pytest.raises(GitPullError) as exc_info:
-                git_update_from_remote(temp_dir)
+        (origin / "extra.txt").write_text("extra", encoding="utf-8")
+        run_git(origin, "add", ".")
+        run_git(origin, "commit", "-m", "advance origin")
+        run_git(origin, "tag", "-f", "latest")
+        moved_sha = head_sha(origin)
 
-            assert "Git error during update" in str(exc_info.value)
+        update_to_moving_tag(clone, "latest")
+
+        assert get_local_commit_sha(clone) == moved_sha
+
+    def test_update_to_moving_tag_raises_error_when_uncommitted_changes_and_not_overwriting(
+        self, temp_dir: Path
+    ) -> None:
+        """Test that GitPullError is raised when uncommitted changes exist and overwrite_existing is False."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "latest")
+        clone = clone_repo(origin, temp_dir / "clone")
+        (clone / "griptape_nodes_library.json").write_text("dirty", encoding="utf-8")
+
+        with pytest.raises(GitPullError, match="uncommitted changes"):
+            update_to_moving_tag(clone, "latest")
+
+    def test_update_to_moving_tag_discards_uncommitted_changes_when_overwrite_existing_true(
+        self, temp_dir: Path
+    ) -> None:
+        """Test that uncommitted changes are discarded when overwrite_existing is True."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "latest")
+        clone = clone_repo(origin, temp_dir / "clone")
+        (clone / "griptape_nodes_library.json").write_text("dirty", encoding="utf-8")
+
+        update_to_moving_tag(clone, "latest", overwrite_existing=True)
+
+        assert has_uncommitted_changes(clone) is False
+
+
+class TestUpdateLibraryGit:
+    """Test update_library_git function."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_update_library_git_raises_error_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that GitRepositoryError is raised when not a git repository."""
+        with pytest.raises(GitRepositoryError, match="is not a git repository"):
+            update_library_git(temp_dir)
+
+    def test_update_library_git_dispatches_to_branch_update_when_on_branch(self, temp_dir: Path) -> None:
+        """Test that update_library_git resets to the remote tip for a branch-based checkout."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        (origin / "extra.txt").write_text("extra", encoding="utf-8")
+        run_git(origin, "add", ".")
+        run_git(origin, "commit", "-m", "advance origin")
+
+        update_library_git(clone)
+
+        assert get_local_commit_sha(clone) == head_sha(origin)
+
+    def test_update_library_git_dispatches_to_tag_update_when_detached_head_on_tag(self, temp_dir: Path) -> None:
+        """Test that update_library_git follows a moving tag for a tag-based checkout."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "stable")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "checkout", "--detach", "stable")
+
+        (origin / "extra.txt").write_text("extra", encoding="utf-8")
+        run_git(origin, "add", ".")
+        run_git(origin, "commit", "-m", "advance origin")
+        run_git(origin, "tag", "-f", "stable")
+        moved_sha = head_sha(origin)
+
+        update_library_git(clone)
+
+        assert get_local_commit_sha(clone) == moved_sha
+
+    def test_update_library_git_raises_error_when_detached_head_without_known_tag(self, temp_dir: Path) -> None:
+        """Test that GitPullError is raised for a detached HEAD that isn't on a known tag."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "checkout", "--detach", head_sha(clone))
+
+        with pytest.raises(GitPullError, match="not on a known tag"):
+            update_library_git(clone)
 
 
 class TestSwitchBranch:
@@ -805,118 +971,98 @@ class TestSwitchBranch:
 
     def test_switch_branch_raises_error_when_not_git_repository(self, temp_dir: Path) -> None:
         """Test that GitRepositoryError is raised when not a git repository."""
-        with patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git:
-            mock_is_git.return_value = False
-
-            with pytest.raises(GitRepositoryError) as exc_info:
-                switch_branch(temp_dir, "main")
-
-            assert "not a git repository" in str(exc_info.value)
+        with pytest.raises(GitRepositoryError, match="is not a git repository"):
+            switch_branch(temp_dir, "main")
 
     def test_switch_branch_raises_error_when_no_origin_remote(self, temp_dir: Path) -> None:
         """Test that GitRefError is raised when no origin remote exists."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "remote", "rename", "origin", "other")
 
-            mock_repo = Mock()
-            mock_repo.remotes = {}
-            mock_repo_class.return_value = mock_repo
-
-            with pytest.raises(GitRefError) as exc_info:
-                switch_branch(temp_dir, "main")
-
-            assert "No origin remote" in str(exc_info.value)
+        with pytest.raises(GitRefError, match="No origin remote"):
+            switch_branch(clone, "main")
 
     def test_switch_branch_checks_out_existing_local_branch(self, temp_dir: Path) -> None:
-        """Test that existing local branch is checked out."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        """Test that an existing local branch is checked out."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "branch", "feature")
 
-            mock_branch = Mock()
-            mock_branches = Mock()
-            mock_branches.get.return_value = mock_branch
+        switch_branch(clone, "feature")
 
-            mock_remote = Mock()
-            mock_repo = Mock()
-            mock_repo.remotes = {"origin": mock_remote}
-            mock_repo.branches = mock_branches
-            mock_repo_class.return_value = mock_repo
+        assert get_current_ref(clone) == "feature"
 
-            switch_branch(temp_dir, "main")
+    def test_switch_branch_creates_tracking_branch_from_remote_when_only_remote_has_it(self, temp_dir: Path) -> None:
+        """Test that a tracking branch is created from the remote when only origin has it."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(origin, "branch", "feature")
 
-            mock_remote.fetch.assert_called_once()
-            mock_repo.checkout.assert_called_once_with(mock_branch)
+        switch_branch(clone, "feature")
 
-    def test_switch_branch_creates_tracking_branch_from_remote(self, temp_dir: Path) -> None:
-        """Test that tracking branch is created from remote when local doesn't exist."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
-
-            mock_remote_branch = Mock()
-            mock_remote_branch.target = "abc123"
-            mock_commit = Mock()
-            mock_new_branch = Mock()
-
-            mock_local_branches = Mock()
-            mock_local_branches.create.return_value = mock_new_branch
-
-            mock_branches = Mock()
-            # First call for local branch returns None, second for remote returns mock
-            mock_branches.get.side_effect = [None, mock_remote_branch]
-            mock_branches.local = mock_local_branches
-
-            mock_remote = Mock()
-            mock_repo = Mock()
-            mock_repo.remotes = {"origin": mock_remote}
-            mock_repo.branches = mock_branches
-            mock_repo.get.return_value = mock_commit
-            mock_repo_class.return_value = mock_repo
-
-            switch_branch(temp_dir, "feature")
-
-            mock_remote.fetch.assert_called_once()
-            mock_local_branches.create.assert_called_once_with("feature", mock_commit)
-            assert mock_new_branch.upstream == mock_remote_branch
-            mock_repo.checkout.assert_called_once_with(mock_new_branch)
+        assert get_current_ref(clone) == "feature"
 
     def test_switch_branch_raises_error_when_branch_not_found(self, temp_dir: Path) -> None:
-        """Test that GitRefError is raised when branch doesn't exist locally or remotely."""
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository") as mock_is_git,
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository") as mock_discover,
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository") as mock_repo_class,
-        ):
-            mock_is_git.return_value = True
-            mock_discover.return_value = str(temp_dir / ".git")
+        """Test that GitRefError is raised when the branch doesn't exist locally or remotely."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
 
-            mock_branches = Mock()
-            mock_branches.get.return_value = None
+        with pytest.raises(GitRefError, match="not found"):
+            switch_branch(clone, "nonexistent")
 
-            mock_remote = Mock()
-            mock_repo = Mock()
-            mock_repo.remotes = {"origin": mock_remote}
-            mock_repo.branches = mock_branches
-            mock_repo_class.return_value = mock_repo
 
-            with pytest.raises(GitRefError) as exc_info:
-                switch_branch(temp_dir, "nonexistent")
+class TestSwitchBranchOrTag:
+    """Test switch_branch_or_tag function."""
 
-            assert "not found" in str(exc_info.value)
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_switch_branch_or_tag_raises_error_when_not_git_repository(self, temp_dir: Path) -> None:
+        """Test that GitRepositoryError is raised when not a git repository."""
+        with pytest.raises(GitRepositoryError, match="is not a git repository"):
+            switch_branch_or_tag(temp_dir, "main")
+
+    def test_switch_branch_or_tag_checks_out_tag(self, temp_dir: Path) -> None:
+        """Test that a tag is checked out as a detached HEAD."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "v1.0.0")
+        clone = clone_repo(origin, temp_dir / "clone")
+
+        switch_branch_or_tag(clone, "v1.0.0")
+
+        assert get_current_tag(clone) == "v1.0.0"
+
+    def test_switch_branch_or_tag_checks_out_remote_only_branch(self, temp_dir: Path) -> None:
+        """Test that a branch only present on the remote is checked out as a tracking branch."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(origin, "branch", "feature")
+
+        switch_branch_or_tag(clone, "feature")
+
+        assert get_current_ref(clone) == "feature"
+
+    def test_switch_branch_or_tag_checks_out_local_branch(self, temp_dir: Path) -> None:
+        """Test that a local-only branch is checked out."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        run_git(clone, "branch", "localonly")
+
+        switch_branch_or_tag(clone, "localonly")
+
+        assert get_current_ref(clone) == "localonly"
+
+    def test_switch_branch_or_tag_raises_error_for_unknown_ref(self, temp_dir: Path) -> None:
+        """Test that GitRefError is raised when the ref doesn't exist anywhere."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+
+        with pytest.raises(GitRefError, match="not found"):
+            switch_branch_or_tag(clone, "nonexistent")
 
 
 class TestCloneRepository:
@@ -933,293 +1079,254 @@ class TestCloneRepository:
         existing_path = temp_dir / "existing"
         existing_path.mkdir()
 
-        with pytest.raises(GitCloneError) as exc_info:
+        with pytest.raises(GitCloneError, match="already exists"):
             clone_repository("https://github.com/user/repo.git", existing_path)
 
-        assert "already exists" in str(exc_info.value)
+    def test_clone_repository_clones_repository(self, temp_dir: Path) -> None:
+        """Test that a repository is cloned successfully."""
+        origin = make_origin_repo(temp_dir / "origin")
+        target = temp_dir / "clone"
 
-    def test_clone_repository_clones_https_url(self, temp_dir: Path) -> None:
-        """Test that HTTPS URLs are cloned successfully."""
-        target_path = temp_dir / "repo"
+        clone_repository(str(origin), target)
 
-        with patch("griptape_nodes.utils.git_utils.pygit2.clone_repository") as mock_clone:
-            mock_clone.return_value = Mock()
-
-            clone_repository("https://github.com/user/repo.git", target_path)
-
-            args, kwargs = mock_clone.call_args
-            assert args == ("https://github.com/user/repo.git", str(target_path))
-            assert isinstance(kwargs["callbacks"], _CredentialCallbacks)
-
-    def test_clone_repository_raises_error_when_clone_returns_none(self, temp_dir: Path) -> None:
-        """Test that GitCloneError is raised when clone returns None."""
-        target_path = temp_dir / "repo"
-
-        with patch("griptape_nodes.utils.git_utils.pygit2.clone_repository") as mock_clone:
-            mock_clone.return_value = None
-
-            with pytest.raises(GitCloneError) as exc_info:
-                clone_repository("https://github.com/user/repo.git", target_path)
-
-            assert "Failed to clone" in str(exc_info.value)
+        assert (target / ".git").exists()
+        assert (target / "griptape_nodes_library.json").exists()
+        assert get_current_ref(target) == "main"
 
     def test_clone_repository_checks_out_specified_branch(self, temp_dir: Path) -> None:
-        """Test that specified branch is checked out after cloning."""
-        target_path = temp_dir / "repo"
+        """Test that the specified branch is checked out after cloning."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "branch", "feature")
+        target = temp_dir / "clone"
 
-        with patch("griptape_nodes.utils.git_utils.pygit2.clone_repository") as mock_clone:
-            mock_branch = Mock()
-            mock_repo = Mock()
-            mock_repo.branches = {"feature": mock_branch}
-            mock_clone.return_value = mock_repo
+        clone_repository(str(origin), target, "feature")
 
-            clone_repository("https://github.com/user/repo.git", target_path, "feature")
+        assert get_current_ref(target) == "feature"
 
-            mock_repo.checkout.assert_called_once_with(mock_branch)
+    def test_clone_repository_checks_out_specified_tag(self, temp_dir: Path) -> None:
+        """Test that the specified tag is checked out as a detached HEAD after cloning."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "v1.0.0")
+        target = temp_dir / "clone"
 
-    def test_clone_repository_checks_out_commit_when_branch_not_found(self, temp_dir: Path) -> None:
-        """Test that commit is checked out when branch doesn't exist."""
-        target_path = temp_dir / "repo"
+        clone_repository(str(origin), target, "v1.0.0")
 
-        with patch("griptape_nodes.utils.git_utils.pygit2.clone_repository") as mock_clone:
-            mock_commit = Mock()
-            mock_commit.id = "abc123"
-            mock_repo = Mock()
-            mock_repo.branches = {}
-            mock_repo.references = []
-            mock_repo.revparse_single.return_value = mock_commit
-            mock_clone.return_value = mock_repo
+        assert get_current_tag(target) == "v1.0.0"
 
-            clone_repository("https://github.com/user/repo.git", target_path, "abc123")
+    def test_clone_repository_checks_out_specified_commit(self, temp_dir: Path) -> None:
+        """Test that a full commit SHA is checked out as a detached HEAD after cloning."""
+        origin = make_origin_repo(temp_dir / "origin")
+        sha = head_sha(origin)
+        target = temp_dir / "clone"
 
-            mock_repo.checkout_tree.assert_called_once_with(mock_commit)
-            mock_repo.set_head.assert_called_once_with(mock_commit.id)
+        clone_repository(str(origin), target, sha)
 
-    def test_clone_repository_raises_error_on_git_error(self, temp_dir: Path) -> None:
-        """Test that GitCloneError is raised on pygit2.GitError."""
-        target_path = temp_dir / "repo"
+        assert get_local_commit_sha(target) == sha
+        assert get_current_ref(target) == sha
 
-        with patch("griptape_nodes.utils.git_utils.pygit2.clone_repository") as mock_clone:
-            mock_clone.side_effect = pygit2.GitError("clone failed")
+    def test_clone_repository_raises_error_on_bogus_source_url(self, temp_dir: Path) -> None:
+        """Test that GitCloneError is raised when the source URL doesn't resolve to a repository."""
+        target = temp_dir / "clone"
 
-            with pytest.raises(GitCloneError) as exc_info:
-                clone_repository("https://github.com/user/repo.git", target_path)
-
-            assert "Git error while cloning" in str(exc_info.value)
+        with pytest.raises(GitCloneError, match="Git error while cloning"):
+            clone_repository(str(temp_dir / "does-not-exist"), target)
 
 
-class TestGetGitInfo:
-    """Test get_git_info function.
-
-    get_git_info opens the pygit2 repo once and returns both (git_remote, git_ref),
-    replacing the previous pattern of calling get_git_remote + get_current_ref
-    separately (which opened the repo 2-3x per library).
-    """
+class TestSparseCheckoutLibraryJson:
+    """Test sparse_checkout_library_json function."""
 
     @pytest.fixture
     def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
-    def _make_repo_mock(  # noqa: PLR0913
-        self,
-        *,
-        remote_url: str | None = "https://github.com/user/repo.git",
-        head_is_unborn: bool = False,
-        head_is_detached: bool = False,
-        branch_shorthand: str = "main",
-        head_target: object = "abc123",
-        references: dict | None = None,
-    ) -> Mock:
-        mock_repo = Mock()
-        mock_repo.remotes = {"origin": Mock(url=remote_url)} if remote_url else {}
-        mock_repo.head_is_unborn = head_is_unborn
-        mock_repo.head_is_detached = head_is_detached
-        mock_repo.head = Mock(shorthand=branch_shorthand, target=head_target)
-        mock_repo.references = references if references is not None else {}
-        return mock_repo
+    def test_sparse_checkout_library_json_returns_metadata_for_default_ref(self, temp_dir: Path) -> None:
+        """Test that library version, commit SHA, commit datetime, and library data are returned for HEAD."""
+        origin = make_origin_repo(temp_dir / "origin", library_version="1.2.3")
 
-    def test_returns_none_none_when_not_git_repository(self, temp_dir: Path) -> None:
-        with patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=False):
-            git_remote, git_ref = get_git_info(temp_dir)
+        result = sparse_checkout_library_json(str(origin))
 
-        assert git_remote is None
-        assert git_ref is None
+        assert result.library_version == "1.2.3"
+        assert len(result.commit_sha) == 40  # noqa: PLR2004
+        assert result.commit_sha == head_sha(origin)
+        assert result.commit_datetime is not None
+        assert result.commit_datetime.tzinfo is not None
+        assert result.library_data == {"metadata": {"library_version": "1.2.3"}}
 
-    def test_returns_none_none_when_repository_not_discovered(self, temp_dir: Path) -> None:
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=None),
-        ):
-            git_remote, git_ref = get_git_info(temp_dir)
+    def test_sparse_checkout_library_json_uses_specified_ref(self, temp_dir: Path) -> None:
+        """Test that an older tagged commit is fetched when a ref is specified."""
+        origin = make_origin_repo(temp_dir / "origin", library_version="1.0.0")
+        run_git(origin, "tag", "v1")
+        library_json = origin / "griptape_nodes_library.json"
+        library_json.write_text(json.dumps({"metadata": {"library_version": "2.0.0"}}), encoding="utf-8")
+        run_git(origin, "add", ".")
+        run_git(origin, "commit", "-m", "bump version")
 
-        assert git_remote is None
-        assert git_ref is None
+        head_result = sparse_checkout_library_json(str(origin))
+        tagged_result = sparse_checkout_library_json(str(origin), ref="v1")
 
-    def test_returns_none_none_on_git_error_opening_repo(self, temp_dir: Path) -> None:
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch(
-                "griptape_nodes.utils.git_utils.pygit2.discover_repository",
-                side_effect=pygit2.GitError("error"),
-            ),
-        ):
-            git_remote, git_ref = get_git_info(temp_dir)
+        assert head_result.library_version == "2.0.0"
+        assert tagged_result.library_version == "1.0.0"
 
-        assert git_remote is None
-        assert git_ref is None
+    def test_sparse_checkout_library_json_raises_error_when_no_library_json_present(self, temp_dir: Path) -> None:
+        """Test that GitCloneError is raised when the repository has no library JSON file."""
+        origin = temp_dir / "origin"
+        origin.mkdir()
+        run_git(origin, "init", "-b", "main")
+        (origin / "README.md").write_text("no library here", encoding="utf-8")
+        run_git(origin, "add", ".")
+        run_git(origin, "commit", "-m", "initial commit")
 
-    def test_returns_remote_and_branch_when_on_branch(self, temp_dir: Path) -> None:
-        mock_repo = self._make_repo_mock(remote_url="https://github.com/user/repo.git", branch_shorthand="main")
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=str(temp_dir / ".git")),
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository", return_value=mock_repo),
-        ):
-            git_remote, git_ref = get_git_info(temp_dir)
-
-        assert git_remote == "https://github.com/user/repo.git"
-        assert git_ref == "main"
-
-    def test_returns_none_remote_when_no_origin(self, temp_dir: Path) -> None:
-        mock_repo = self._make_repo_mock(remote_url=None, branch_shorthand="main")
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=str(temp_dir / ".git")),
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository", return_value=mock_repo),
-        ):
-            git_remote, git_ref = get_git_info(temp_dir)
-
-        assert git_remote is None
-        assert git_ref == "main"
-
-    def test_returns_commit_sha_when_head_detached_and_no_tag(self, temp_dir: Path) -> None:
-        expected_sha = "deadbeef1234"
-        mock_repo = self._make_repo_mock(
-            remote_url=None, head_is_detached=True, head_target=expected_sha, references={}
-        )
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=str(temp_dir / ".git")),
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository", return_value=mock_repo),
-        ):
-            _git_remote, git_ref = get_git_info(temp_dir)
-
-        assert git_ref == expected_sha
-
-    def test_returns_tag_name_when_head_on_tag(self, temp_dir: Path) -> None:
-        expected_sha = "deadbeef1234"
-        expected_tag = "v1.0.0"
-
-        mock_tag_ref = Mock()
-        mock_tag_ref.peel.return_value.id = expected_sha
-
-        mock_repo = self._make_repo_mock(
-            remote_url=None,
-            head_is_detached=True,
-            head_target=expected_sha,
-            references={f"refs/tags/{expected_tag}": mock_tag_ref},
-        )
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=str(temp_dir / ".git")),
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository", return_value=mock_repo),
-        ):
-            _git_remote, git_ref = get_git_info(temp_dir)
-
-        assert git_ref == expected_tag
-
-    def test_returns_none_ref_when_head_unborn(self, temp_dir: Path) -> None:
-        mock_repo = self._make_repo_mock(remote_url=None, head_is_unborn=True)
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=str(temp_dir / ".git")),
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository", return_value=mock_repo),
-        ):
-            _git_remote, git_ref = get_git_info(temp_dir)
-
-        assert git_ref is None
-
-    def test_opens_repo_exactly_once(self, temp_dir: Path) -> None:
-        mock_repo = self._make_repo_mock()
-
-        with (
-            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
-            patch("griptape_nodes.utils.git_utils.pygit2.discover_repository", return_value=str(temp_dir / ".git")),
-            patch("griptape_nodes.utils.git_utils.pygit2.Repository", return_value=mock_repo) as mock_repo_class,
-        ):
-            get_git_info(temp_dir)
-
-        mock_repo_class.assert_called_once()
+        with pytest.raises(GitCloneError, match="No library JSON file found"):
+            sparse_checkout_library_json(str(origin))
 
 
 class TestRemoteRefExists:
-    """Tests for remote_ref_exists."""
+    """Test remote_ref_exists function."""
 
-    def test_returns_true_when_git_cli_lists_matching_ref(self) -> None:
-        completed = Mock(returncode=0, stdout="abc123\trefs/heads/main\n", stderr="")
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_remote_ref_exists_returns_true_for_existing_branch(self, temp_dir: Path) -> None:
+        """Test that True is returned for a branch that exists on the remote."""
+        origin = make_origin_repo(temp_dir / "origin")
+
+        assert remote_ref_exists(str(origin), "main") is True
+
+    def test_remote_ref_exists_returns_true_for_existing_tag(self, temp_dir: Path) -> None:
+        """Test that True is returned for a tag that exists on the remote."""
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "tag", "v1.0.0")
+
+        assert remote_ref_exists(str(origin), "v1.0.0") is True
+
+    def test_remote_ref_exists_returns_false_for_unknown_ref(self, temp_dir: Path) -> None:
+        """Test that False is returned for a ref that doesn't exist on the remote."""
+        origin = make_origin_repo(temp_dir / "origin")
+
+        assert remote_ref_exists(str(origin), "no-such-ref") is False
+
+    def test_remote_ref_exists_returns_false_for_commit_sha(self, temp_dir: Path) -> None:
+        """Test that False is returned for a commit SHA, since SHAs aren't advertised as named refs."""
+        origin = make_origin_repo(temp_dir / "origin")
+        sha = head_sha(origin)
+
+        assert remote_ref_exists(str(origin), sha) is False
+
+    def test_remote_ref_exists_raises_error_when_remote_cannot_be_queried(self, temp_dir: Path) -> None:
+        """Test that GitRemoteError is raised when the remote cannot be queried."""
+        with pytest.raises(GitRemoteError, match="Failed to query remote refs"):
+            remote_ref_exists(str(temp_dir / "not-a-repo"), "main")
+
+    def test_remote_ref_exists_ignores_a_broken_repository_in_the_working_directory(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that a broken repository at the working directory doesn't fail the query."""
+        origin = make_origin_repo(temp_dir / "origin")
+        broken = temp_dir / "broken"
+        broken.mkdir()
+        (broken / ".git").write_text("gitdir: /nonexistent/worktrees/gone\n")
+        monkeypatch.chdir(broken)
+
+        assert remote_ref_exists(str(origin), "main") is True
+
+
+class TestOptionLikeArguments:
+    """Test that caller-supplied values git would read as options are rejected."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_clone_repository_rejects_option_like_url(self, temp_dir: Path) -> None:
+        """Test that GitCloneError is raised for a URL that git would parse as an option."""
+        with pytest.raises(GitCloneError, match="must not start with"):
+            clone_repository("--upload-pack=touch /tmp/pwned", temp_dir / "clone")
+
+    def test_clone_repository_rejects_option_like_ref(self, temp_dir: Path) -> None:
+        """Test that GitCloneError is raised for a ref that git would parse as an option."""
+        origin = make_origin_repo(temp_dir / "origin")
+
+        with pytest.raises(GitCloneError, match="must not start with"):
+            clone_repository(str(origin), temp_dir / "clone", "--orphan")
+
+    def test_remote_ref_exists_rejects_option_like_url(self) -> None:
+        """Test that GitRemoteError is raised for a URL that git would parse as an option."""
+        with pytest.raises(GitRemoteError, match="must not start with"):
+            remote_ref_exists("--upload-pack=touch /tmp/pwned", "main")
+
+    def test_sparse_checkout_library_json_rejects_option_like_url(self) -> None:
+        """Test that GitCloneError is raised for a URL that git would parse as an option."""
+        with pytest.raises(GitCloneError, match="must not start with"):
+            sparse_checkout_library_json("--upload-pack=touch /tmp/pwned")
+
+    def test_switch_branch_rejects_option_like_branch(self, temp_dir: Path) -> None:
+        """Test that GitRefError is raised for a branch name that git would parse as an option."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+
+        with pytest.raises(GitRefError, match="must not start with"):
+            switch_branch(clone, "--track")
+
+    def test_switch_branch_or_tag_rejects_option_like_ref(self, temp_dir: Path) -> None:
+        """Test that GitRefError is raised for a ref name that git would parse as an option."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+
+        with pytest.raises(GitRefError, match="must not start with"):
+            switch_branch_or_tag(clone, "--detach")
+
+    def test_update_to_moving_tag_rejects_option_like_tag(self, temp_dir: Path) -> None:
+        """Test that GitPullError is raised for a tag name that git would parse as an option."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+
+        with pytest.raises(GitPullError, match="must not start with"):
+            update_to_moving_tag(clone, "--force")
+
+
+class TestGitNotInstalled:
+    """Test the documented contract for functions when git isn't found on PATH."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_reader_raises_git_not_found_error_naming_git_as_a_requirement(self, temp_dir: Path) -> None:
+        """Test that get_current_tag raises GitNotFoundError naming git as a requirement when git is missing."""
+        # A bare ".git" marker is enough for is_git_repository's filesystem check; no real
+        # git invocation happens before the patched subprocess.run call.
+        (temp_dir / ".git").mkdir()
+
         with (
-            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=True),
-            patch("griptape_nodes.utils.git_utils.subprocess.run", return_value=completed) as mock_run,
+            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
+            pytest.raises(GitNotFoundError, match="git was not found on PATH"),
         ):
-            assert remote_ref_exists("git@github.com:owner/repo.git", "main") is True
+            get_current_tag(temp_dir)
 
-        args = mock_run.call_args.args[0]
-        assert args == ["git", "ls-remote", "--heads", "--tags", "git@github.com:owner/repo.git", "main"]
-
-    def test_returns_false_when_git_cli_lists_no_matching_ref(self) -> None:
-        completed = Mock(returncode=0, stdout="\n", stderr="")
+    def test_mutator_raises_git_not_found_error_naming_git_as_a_requirement(self) -> None:
+        """Test that remote_ref_exists raises GitNotFoundError naming git as a requirement when git is missing."""
         with (
-            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=True),
-            patch("griptape_nodes.utils.git_utils.subprocess.run", return_value=completed),
+            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
+            pytest.raises(GitNotFoundError, match="git was not found on PATH"),
         ):
-            assert remote_ref_exists("git@github.com:owner/repo.git", "local-only-branch") is False
+            remote_ref_exists("https://example.com/user/repo.git", "main")
 
-    def test_raises_git_remote_error_when_git_cli_fails(self) -> None:
-        completed = Mock(returncode=128, stdout="", stderr="fatal: could not read from remote\n")
+    def test_git_not_found_error_is_catchable_as_git_error(self) -> None:
+        """Test that callers handling the base GitError also handle a missing git."""
         with (
-            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=True),
-            patch("griptape_nodes.utils.git_utils.subprocess.run", return_value=completed),
-            pytest.raises(GitRemoteError, match="Failed to query remote refs"),
+            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
+            pytest.raises(GitError),
         ):
-            remote_ref_exists("git@github.com:owner/repo.git", "main")
-
-    def test_returns_true_when_pygit2_lists_matching_ref(self) -> None:
-        mock_remote = Mock()
-        mock_remote.ls_remotes.return_value = [{"name": "refs/heads/feature/foo"}, {"name": "refs/heads/main"}]
-        mock_repo = Mock()
-        mock_repo.remotes.create.return_value = mock_remote
-        with (
-            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=False),
-            patch("griptape_nodes.utils.git_utils.pygit2.init_repository", return_value=mock_repo),
-        ):
-            assert remote_ref_exists("https://github.com/owner/repo.git", "feature/foo") is True
-
-    def test_returns_false_when_pygit2_lists_no_matching_ref(self) -> None:
-        mock_remote = Mock()
-        mock_remote.ls_remotes.return_value = [{"name": "refs/heads/main"}]
-        mock_repo = Mock()
-        mock_repo.remotes.create.return_value = mock_remote
-        with (
-            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=False),
-            patch("griptape_nodes.utils.git_utils.pygit2.init_repository", return_value=mock_repo),
-        ):
-            assert remote_ref_exists("https://github.com/owner/repo.git", "local-only-branch") is False
-
-    def test_raises_git_remote_error_when_pygit2_fails(self) -> None:
-        mock_repo = Mock()
-        mock_repo.remotes.create.side_effect = pygit2.GitError("auth failed")
-        with (
-            patch("griptape_nodes.utils.git_utils._is_git_available", return_value=False),
-            patch("griptape_nodes.utils.git_utils.pygit2.init_repository", return_value=mock_repo),
-            pytest.raises(GitRemoteError, match="Failed to query remote refs"),
-        ):
-            remote_ref_exists("https://github.com/owner/repo.git", "main")
+            remote_ref_exists("https://example.com/user/repo.git", "main")
 
 
 class TestParseCommitDatetime:

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 from datetime import UTC, datetime
@@ -1396,34 +1397,42 @@ class TestGitNotInstalled:
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
+    @pytest.fixture
+    def git_uninstalled(self) -> Generator[None, None, None]:
+        """Simulate a machine with no git.
+
+        Both patches are needed: the FileNotFoundError is what subprocess raises for a missing
+        executable, and the empty which() is how git_utils tells that apart from a missing cwd.
+        """
+        with (
+            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
+            patch("griptape_nodes.utils.git_utils.shutil.which", return_value=None),
+        ):
+            yield
+
+    @pytest.mark.usefixtures("git_uninstalled")
     def test_reader_raises_git_not_found_error_naming_git_as_a_requirement(self, temp_dir: Path) -> None:
         """Test that get_current_tag raises GitNotFoundError naming git as a requirement when git is missing."""
         # A bare ".git" marker is enough for is_git_repository's filesystem check; no real
         # git invocation happens before the patched subprocess.run call.
         (temp_dir / ".git").mkdir()
 
-        with (
-            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
-            pytest.raises(GitNotFoundError, match="git was not found on PATH"),
-        ):
+        with pytest.raises(GitNotFoundError, match="git was not found on PATH"):
             get_current_tag(temp_dir)
 
+    @pytest.mark.usefixtures("git_uninstalled")
     def test_mutator_raises_git_not_found_error_naming_git_as_a_requirement(self) -> None:
         """Test that remote_ref_exists raises GitNotFoundError naming git as a requirement when git is missing."""
-        with (
-            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
-            pytest.raises(GitNotFoundError, match="git was not found on PATH"),
-        ):
+        with pytest.raises(GitNotFoundError, match="git was not found on PATH"):
             remote_ref_exists("https://example.com/user/repo.git", "main")
 
+    @pytest.mark.usefixtures("git_uninstalled")
     def test_git_not_found_error_is_catchable_as_git_error(self) -> None:
         """Test that callers handling the base GitError also handle a missing git."""
-        with (
-            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError),
-            pytest.raises(GitError),
-        ):
+        with pytest.raises(GitError):
             remote_ref_exists("https://example.com/user/repo.git", "main")
 
+    @pytest.mark.usefixtures("git_uninstalled")
     def test_get_git_info_reports_no_details_when_git_is_missing(self, temp_dir: Path) -> None:
         """Test that get_git_info degrades instead of raising, so a library still loads without git.
 
@@ -1431,11 +1440,47 @@ class TestGitNotInstalled:
         """
         (temp_dir / ".git").mkdir()
 
-        with patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError):
-            git_remote, git_ref = get_git_info(temp_dir)
+        git_remote, git_ref = get_git_info(temp_dir)
 
         assert git_remote is None
         assert git_ref is None
+
+
+class TestVanishedRepository:
+    """Test behavior when a repository directory is deleted out from under a git call.
+
+    subprocess reports a missing executable and a missing working directory with the same
+    exception, so these pin down that a deleted folder is never misreported as a missing git.
+    """
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_mutator_names_the_missing_folder_rather_than_blaming_git(self, temp_dir: Path) -> None:
+        """Test that a mutator reports the deleted folder, not a missing git installation."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+        # Pass is_git_repository's filesystem check, then delete the directory so the git call
+        # itself is the thing that finds it gone.
+        with patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True):
+            shutil.rmtree(clone)
+
+            with pytest.raises(GitRepositoryError, match="no longer there"):
+                has_uncommitted_changes(clone)
+
+    def test_accessor_reports_no_answer_rather_than_raising(self, temp_dir: Path) -> None:
+        """Test that a query accessor treats a deleted folder as "no answer", as it does a detached HEAD."""
+        origin = make_origin_repo(temp_dir / "origin")
+        clone = clone_repo(origin, temp_dir / "clone")
+
+        with patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True):
+            shutil.rmtree(clone)
+
+            assert get_git_remote(clone) is None
+            assert get_git_info(clone) == (None, None)
 
 
 class TestParseCommitDatetime:

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -1410,6 +1410,38 @@ class TestGitNotInstalled:
         ):
             yield
 
+    def test_a_git_that_cannot_be_run_is_reported_as_a_missing_git(self, temp_dir: Path) -> None:
+        """Test that a non-executable git on PATH reads as a missing git rather than an OS error.
+
+        subprocess raises PermissionError rather than FileNotFoundError for this, and which()
+        skips it for the same reason, so there is no runnable git either way.
+        """
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "git").write_text("#!/bin/sh\nexit 0\n")
+        (bin_dir / "git").chmod(0o644)
+        (temp_dir / ".git").mkdir()
+
+        with (
+            patch.dict(os.environ, {"PATH": str(bin_dir)}, clear=False),
+            pytest.raises(GitNotFoundError, match="git was not found on PATH"),
+        ):
+            get_current_tag(temp_dir)
+
+    def test_an_unexplained_start_failure_is_still_a_git_error(self, temp_dir: Path) -> None:
+        """Test that an OS error with no specific diagnosis still reaches callers as a GitError.
+
+        Callers guard on GitError, so a raw OS error escaping here would surface as an unhandled
+        crash rather than a failed request.
+        """
+        (temp_dir / ".git").mkdir()
+
+        with (
+            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=OSError("too many open files")),
+            pytest.raises(GitError, match="Could not start git"),
+        ):
+            get_current_tag(temp_dir)
+
     @pytest.mark.usefixtures("git_uninstalled")
     def test_reader_raises_git_not_found_error_naming_git_as_a_requirement(self, temp_dir: Path) -> None:
         """Test that get_current_tag raises GitNotFoundError naming git as a requirement when git is missing."""
@@ -1468,8 +1500,23 @@ class TestVanishedRepository:
         with patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True):
             shutil.rmtree(clone)
 
-            with pytest.raises(GitRepositoryError, match="no longer there"):
+            with pytest.raises(GitRepositoryError, match="no folder exists"):
                 has_uncommitted_changes(clone)
+
+    def test_mutator_names_a_path_that_is_a_file_rather_than_a_folder(self, temp_dir: Path) -> None:
+        """Test that a file where a repository should be is reported as such.
+
+        subprocess raises a different error for this than for a missing directory, so it needs
+        its own path to a GitError.
+        """
+        not_a_folder = temp_dir / "library"
+        not_a_folder.write_text("")
+
+        with (
+            patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True),
+            pytest.raises(GitRepositoryError, match="no folder exists"),
+        ):
+            has_uncommitted_changes(not_a_folder)
 
     def test_accessor_reports_no_answer_rather_than_raising(self, temp_dir: Path) -> None:
         """Test that a query accessor treats a deleted folder as "no answer", as it does a detached HEAD."""

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -1435,10 +1435,9 @@ class TestGitNotInstalled:
         crash rather than a failed request.
         """
         (temp_dir / ".git").mkdir()
-
         with (
             patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=OSError("too many open files")),
-            pytest.raises(GitError, match="Could not start git"),
+            pytest.raises(GitError, match="Failed due to: too many open files"),
         ):
             get_current_tag(temp_dir)
 
@@ -1473,6 +1472,20 @@ class TestGitNotInstalled:
         (temp_dir / ".git").mkdir()
 
         git_remote, git_ref = get_git_info(temp_dir)
+
+        assert git_remote is None
+        assert git_ref is None
+
+    def test_get_git_info_reports_no_details_on_any_git_failure(self, temp_dir: Path) -> None:
+        """Test that get_git_info degrades for a git failure it has no specific diagnosis for.
+
+        Its callers on the metadata-load path have no guard, so the "never raises" contract has to
+        hold for every failure, not only for a git that is missing outright.
+        """
+        (temp_dir / ".git").mkdir()
+
+        with patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=OSError("too many open files")):
+            git_remote, git_ref = get_git_info(temp_dir)
 
         assert git_remote is None
         assert git_ref is None

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import pytest
 
 from griptape_nodes.utils.git_utils import (
+    _GIT_ALLOWED_PROTOCOLS,
     GitCloneError,
     GitError,
     GitNotFoundError,
@@ -21,6 +22,7 @@ from griptape_nodes.utils.git_utils import (
     GitRefError,
     GitRemoteError,
     GitRepositoryError,
+    _git_env,
     clone_repository,
     extract_repo_name_from_url,
     get_current_ref,
@@ -668,6 +670,66 @@ class TestCloneRepositoryWorkingDirectory:
             clone_repository("weirdhelper::whatever", temp_dir / "clone")
 
         assert not marker.exists()
+
+    def test_clone_repository_rejects_ext_transport_url(self, temp_dir: Path) -> None:
+        """Test that an 'ext::<command>' URL cannot make git run an arbitrary shell command.
+
+        The ext transport hands its argument to a shell, so a URL reaching it is remote code
+        execution. The marker file proves the command never ran, rather than only that the
+        clone reported failure.
+        """
+        marker = temp_dir / "ext-ran"
+
+        with pytest.raises(GitCloneError):
+            clone_repository(f'ext::sh -c "touch {marker}"', temp_dir / "clone")
+
+        assert not marker.exists()
+
+
+class TestGitEnvironment:
+    """Test the environment git subprocesses are given."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_git_env_pins_the_transport_allowlist_and_disables_prompting(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that the hardening defaults are present when nothing is inherited."""
+        monkeypatch.delenv("GIT_ALLOW_PROTOCOL", raising=False)
+        monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
+
+        env = _git_env()
+
+        assert env["GIT_ALLOW_PROTOCOL"] == _GIT_ALLOWED_PROTOCOLS
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+
+    def test_git_env_lets_an_inherited_value_override_a_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that a launcher can admit a transport the allowlist omits."""
+        monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "https")
+        monkeypatch.setenv("GIT_TERMINAL_PROMPT", "1")
+
+        env = _git_env()
+
+        assert env["GIT_ALLOW_PROTOCOL"] == "https"
+        assert env["GIT_TERMINAL_PROMPT"] == "1"
+
+    def test_git_env_reaches_the_subprocess(self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that the built environment is what git actually runs with.
+
+        Without this, the allowlist could be computed correctly and never passed along.
+        """
+        monkeypatch.delenv("GIT_ALLOW_PROTOCOL", raising=False)
+        origin = make_origin_repo(temp_dir / "origin")
+
+        with patch("griptape_nodes.utils.git_utils.subprocess.run", wraps=subprocess.run) as mock_run:
+            clone_repository(str(origin), temp_dir / "clone")
+
+        assert mock_run.call_args_list
+        for call in mock_run.call_args_list:
+            assert call.kwargs["env"]["GIT_ALLOW_PROTOCOL"] == _GIT_ALLOWED_PROTOCOLS
+            assert call.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
 
 
 class TestGetGitInfo:
@@ -1361,6 +1423,19 @@ class TestGitNotInstalled:
             pytest.raises(GitError),
         ):
             remote_ref_exists("https://example.com/user/repo.git", "main")
+
+    def test_get_git_info_reports_no_details_when_git_is_missing(self, temp_dir: Path) -> None:
+        """Test that get_git_info degrades instead of raising, so a library still loads without git.
+
+        This runs on every metadata load, where git details are informational.
+        """
+        (temp_dir / ".git").mkdir()
+
+        with patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=FileNotFoundError):
+            git_remote, git_ref = get_git_info(temp_dir)
+
+        assert git_remote is None
+        assert git_ref is None
 
 
 class TestParseCommitDatetime:

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
 from datetime import UTC, datetime
@@ -634,6 +635,39 @@ class TestCloneRepositoryWorkingDirectory:
         clone_repository(str(origin), temp_dir / "clone")
 
         assert (temp_dir / "clone" / "griptape_nodes_library.json").exists()
+
+    def test_clone_repository_clones_relative_target_into_the_working_directory(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that a relative target lands in the caller's cwd, not the internal scratch dir."""
+        origin = make_origin_repo(temp_dir / "origin")
+        workdir = temp_dir / "workdir"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+
+        clone_repository(str(origin), Path("nested/clone"))
+
+        assert (workdir / "nested" / "clone" / "griptape_nodes_library.json").exists()
+
+    def test_clone_repository_rejects_remote_helper_url(self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that a '<helper>::<url>' URL cannot make git exec a transport binary from PATH.
+
+        git resolves an unrecognized URL prefix to a git-remote-<prefix> executable and runs it.
+        A planted helper stands in for that binary: it must never be executed, so the URL has to
+        be refused on the transport policy rather than on the helper's own exit code.
+        """
+        marker = temp_dir / "helper-ran"
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        helper = bin_dir / "git-remote-weirdhelper"
+        helper.write_text(f'#!/bin/sh\ntouch "{marker}"\nexit 1\n')
+        helper.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+        with pytest.raises(GitCloneError):
+            clone_repository("weirdhelper::whatever", temp_dir / "clone")
+
+        assert not marker.exists()
 
 
 class TestGetGitInfo:

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -18,6 +18,7 @@ import pytest
 
 from griptape_nodes.utils.git_utils import (
     _GIT_ALLOWED_PROTOCOLS,
+    _GIT_TIMEOUT_SECONDS,
     GitCloneError,
     GitError,
     GitNotFoundError,
@@ -703,6 +704,33 @@ class TestCloneRepositoryWorkingDirectory:
 
         assert not marker.exists()
 
+    def test_clone_repository_rejects_a_helper_url_even_when_the_environment_allows_ext(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that a GIT_ALLOW_PROTOCOL admitting `ext` cannot be used to reach the ext transport.
+
+        git executes the address of an `ext::` URL directly, so an inherited allowlist plus a
+        library URL from a request payload would otherwise be arbitrary command execution.
+        """
+        monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "ext:file:https")
+        marker = temp_dir / "ext-env-ran"
+
+        with pytest.raises(GitCloneError, match="transport helper"):
+            clone_repository(f"ext::/usr/bin/touch {marker}", temp_dir / "clone")
+
+        assert not marker.exists()
+
+    def test_clone_repository_accepts_an_ipv6_url(self, temp_dir: Path) -> None:
+        """Test that the helper-URL check doesn't mistake an IPv6 literal's '::' for a helper name.
+
+        The clone still fails because nothing is listening, but it must fail on the connection
+        rather than be refused as a transport helper.
+        """
+        with pytest.raises(GitCloneError) as excinfo:
+            clone_repository("https://[::1]:9/user/repo.git", temp_dir / "clone")
+
+        assert "transport helper" not in str(excinfo.value)
+
     @pytest.mark.skipif(
         sys.platform.startswith("win"),
         reason="Windows holds a handle on the process's working directory, so it cannot be deleted.",
@@ -743,15 +771,25 @@ class TestGitEnvironment:
         assert env["GIT_ALLOW_PROTOCOL"] == _GIT_ALLOWED_PROTOCOLS
         assert env["GIT_TERMINAL_PROMPT"] == "0"
 
-    def test_git_env_lets_an_inherited_value_override_a_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that a launcher can admit a transport the allowlist omits."""
-        monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "https")
+    def test_git_env_overrides_an_inherited_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that the surrounding environment cannot loosen the transport allowlist.
+
+        An inherited GIT_ALLOW_PROTOCOL that re-admitted `ext` would turn a library URL into
+        arbitrary command execution, so the engine's list has to win.
+        """
+        monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "ext:https")
         monkeypatch.setenv("GIT_TERMINAL_PROMPT", "1")
 
         env = _git_env()
 
-        assert env["GIT_ALLOW_PROTOCOL"] == "https"
-        assert env["GIT_TERMINAL_PROMPT"] == "1"
+        assert env["GIT_ALLOW_PROTOCOL"] == _GIT_ALLOWED_PROTOCOLS
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+
+    def test_git_env_keeps_the_rest_of_the_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that unrelated variables still reach git, which needs HOME, SSH_AUTH_SOCK and proxies."""
+        monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -v")
+
+        assert _git_env()["GIT_SSH_COMMAND"] == "ssh -v"
 
     def test_git_env_reaches_the_subprocess(self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that the built environment is what git actually runs with.
@@ -768,6 +806,44 @@ class TestGitEnvironment:
         for call in mock_run.call_args_list:
             assert call.kwargs["env"]["GIT_ALLOW_PROTOCOL"] == _GIT_ALLOWED_PROTOCOLS
             assert call.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+class TestGitTimeout:
+    """Test the ceiling on how long a single git command may run."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def test_every_git_call_carries_a_timeout(self, temp_dir: Path) -> None:
+        """Test that no git command is started without a deadline.
+
+        A stalled transport would otherwise hold a worker thread until the engine restarts.
+        """
+        origin = make_origin_repo(temp_dir / "origin")
+
+        with patch("griptape_nodes.utils.git_utils.subprocess.run", wraps=subprocess.run) as mock_run:
+            clone_repository(str(origin), temp_dir / "clone")
+
+        assert mock_run.call_args_list
+        for call in mock_run.call_args_list:
+            assert call.kwargs["timeout"] == _GIT_TIMEOUT_SECONDS
+
+    def test_a_timeout_is_reported_as_a_git_error(self, temp_dir: Path) -> None:
+        """Test that a command that overruns its deadline reaches callers as a GitError.
+
+        Callers guard on GitError, so a bare TimeoutExpired would surface as an unhandled crash.
+        """
+        (temp_dir / ".git").mkdir()
+        timeout = subprocess.TimeoutExpired(cmd=["git", "tag"], timeout=_GIT_TIMEOUT_SECONDS)
+
+        with (
+            patch("griptape_nodes.utils.git_utils.subprocess.run", side_effect=timeout),
+            pytest.raises(GitError, match="did not finish within"),
+        ):
+            get_current_tag(temp_dir)
 
 
 class TestGetGitInfo:
@@ -1343,6 +1419,26 @@ class TestRemoteRefExists:
         origin = make_origin_repo(temp_dir / "origin")
 
         assert remote_ref_exists(str(origin), "no-such-ref") is False
+
+    def test_remote_ref_exists_does_not_match_a_ref_that_only_ends_with_the_name(self, temp_dir: Path) -> None:
+        """Test that a similarly-named branch elsewhere in the hierarchy is not counted as a hit.
+
+        ls-remote matches its trailing pattern against the tail of each ref name, so asking for
+        "main" would otherwise be answered by refs/heads/feature/main.
+        """
+        origin = make_origin_repo(temp_dir / "origin")
+        run_git(origin, "branch", "feature/main")
+        run_git(origin, "branch", "-m", "main", "trunk")
+
+        assert remote_ref_exists(str(origin), "main") is False
+        assert remote_ref_exists(str(origin), "feature/main") is True
+        assert remote_ref_exists(str(origin), "trunk") is True
+
+    def test_remote_ref_exists_does_not_match_a_glob(self, temp_dir: Path) -> None:
+        """Test that a wildcard in the requested name doesn't match a real ref."""
+        origin = make_origin_repo(temp_dir / "origin")
+
+        assert remote_ref_exists(str(origin), "ma*") is False
 
     def test_remote_ref_exists_returns_false_for_commit_sha(self, temp_dir: Path) -> None:
         """Test that False is returned for a commit SHA, since SHAs aren't advertised as named refs."""

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import stat
 import subprocess
+import sys
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
@@ -49,7 +51,22 @@ from griptape_nodes.utils.git_utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
+
+
+def remove_repo(path: Path) -> None:
+    """Delete a git working tree.
+
+    git marks the files under .git/objects read-only, and Windows refuses to unlink a read-only
+    file until that bit is cleared.
+    """
+
+    def clear_readonly(func: Callable[[str], None], target: str, _exc: BaseException) -> None:
+        target_path = Path(target)
+        target_path.chmod(target_path.stat().st_mode | stat.S_IWRITE)
+        func(target)
+
+    shutil.rmtree(path, onexc=clear_readonly)
 
 
 def run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -686,6 +703,10 @@ class TestCloneRepositoryWorkingDirectory:
 
         assert not marker.exists()
 
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Windows holds a handle on the process's working directory, so it cannot be deleted.",
+    )
     def test_clone_repository_reports_a_deleted_working_directory_as_a_clone_failure(
         self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1527,7 +1548,7 @@ class TestVanishedRepository:
         # Pass is_git_repository's filesystem check, then delete the directory so the git call
         # itself is the thing that finds it gone.
         with patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True):
-            shutil.rmtree(clone)
+            remove_repo(clone)
 
             with pytest.raises(GitRepositoryError, match="no folder exists"):
                 has_uncommitted_changes(clone)
@@ -1553,7 +1574,7 @@ class TestVanishedRepository:
         clone = clone_repo(origin, temp_dir / "clone")
 
         with patch("griptape_nodes.utils.git_utils.is_git_repository", return_value=True):
-            shutil.rmtree(clone)
+            remove_repo(clone)
 
             assert get_git_remote(clone) is None
             assert get_git_info(clone) == (None, None)

--- a/tests/unit/utils/test_git_utils.py
+++ b/tests/unit/utils/test_git_utils.py
@@ -686,6 +686,22 @@ class TestCloneRepositoryWorkingDirectory:
 
         assert not marker.exists()
 
+    def test_clone_repository_reports_a_deleted_working_directory_as_a_clone_failure(
+        self, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that anchoring a relative target fails cleanly when the working directory is gone.
+
+        Anchoring reads the working directory, so a directory deleted from under the process has
+        to surface as a clone failure rather than a raw OS error the caller has no guard for.
+        """
+        workdir = temp_dir / "workdir"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+        workdir.rmdir()
+
+        with pytest.raises(GitCloneError):
+            clone_repository("https://example.com/user/repo.git", Path("clone"))
+
 
 class TestGitEnvironment:
     """Test the environment git subprocesses are given."""

--- a/uv.lock
+++ b/uv.lock
@@ -608,7 +608,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai-skills" },
     { name = "pydantic-ai-slim", extra = ["mcp", "openai"] },
-    { name = "pygit2" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "rich" },
@@ -682,7 +681,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-ai-skills", specifier = ">=0.11.0" },
     { name = "pydantic-ai-slim", extras = ["mcp", "openai"], specifier = ">=1.95.1" },
-    { name = "pygit2", specifier = ">=1.19.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "rich", specifier = ">=14.1.0" },
@@ -1854,37 +1852,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/d6/887a1ff844e64aa823fb4905978d882a633cfe295c32eacad582b78a7d8b/pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c", size = 48608, upload-time = "2025-09-24T14:19:10.015Z" },
-]
-
-[[package]]
-name = "pygit2"
-version = "1.19.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/44/415aa93422b4bfc21a6448acb7e16280d5f33a9a3fae38a384e37b046ae4/pygit2-1.19.3.tar.gz", hash = "sha256:a543e6d4ebb43825564935758dc234e770016fed673b84370d46ae9580558831", size = 810489, upload-time = "2026-06-13T08:06:04.982Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/9c/9bc9a8d727b2ae8ae77306ecfb77a5dcf836da4997d4f7053c893f8e0d11/pygit2-1.19.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d696ee240cc8b84e747b04443d85768c859ef0b88abe4a3505dc0b8e2a953ca0", size = 5708797, upload-time = "2026-06-13T08:05:00.097Z" },
-    { url = "https://files.pythonhosted.org/packages/63/7e/9099ea2f90791549185f8ac737a8b448e05cf3882cc79928a380be9bf38c/pygit2-1.19.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86318a704bef836067fa9ac06c56591738d548dcdf2ea24ec227257e3f8115f8", size = 5700295, upload-time = "2026-06-13T08:05:01.676Z" },
-    { url = "https://files.pythonhosted.org/packages/39/84/e9610f041dc43699fca8af55050f9bf9fe0d340ab9902ab8e3fa67bece23/pygit2-1.19.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc3ddb3e5d16cf662d2d0faeb53259e31ae584cc990cd76df909beeb4a36736a", size = 6036822, upload-time = "2026-06-13T08:05:03.473Z" },
-    { url = "https://files.pythonhosted.org/packages/64/bd/419ec17df3f1f1182de8c8fe800b698ff2a489cc50ec2d34990092bf3d61/pygit2-1.19.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73820fb34339fe3c52731d1c46c298a3239ee75b61bc3a2d9b45f8b8873acc47", size = 4638181, upload-time = "2026-06-13T08:05:05.145Z" },
-    { url = "https://files.pythonhosted.org/packages/90/5f/aecca9c7f4ffdc1facc4b2402ea40073848e67c8c607a5f0698e1e8a61e4/pygit2-1.19.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20f6ad50608f51b053bf6c321ae2c31cc57f15e4131a4609261c44e29bdae7cb", size = 5799910, upload-time = "2026-06-13T08:05:06.48Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2a/e131af7752f75f70e04f7f3ae724481d0e2db9c6c688a2081ffb5948657e/pygit2-1.19.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b2c63c7a371dbd5825e5fb7069b759c79aa5dec97806d49cb2c9f9a8a373209d", size = 6042766, upload-time = "2026-06-13T08:05:08.052Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a5/978ee5233379b2aa725c290a7cc3baca9b141f4fc37d55d9a473631b529b/pygit2-1.19.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:977eb52cd4134ff60d3faa168327a03f8724278c38bfcd347d8e3a11041ee9cd", size = 5771434, upload-time = "2026-06-13T08:05:09.398Z" },
-    { url = "https://files.pythonhosted.org/packages/26/33/7c506492fffe3e92d9e911fae43a4b4a3dee43682b71b7793d586c25acfc/pygit2-1.19.3-cp312-cp312-win32.whl", hash = "sha256:14a2734d793d2d937d3bfc9d35b280ec83fc97a91b1934b1013554d41e6d3d70", size = 945030, upload-time = "2026-06-13T08:05:11.187Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ff/57ad08d1e87ae6e4208f80923ce1a6ea8a03ea776376e39d64816637b168/pygit2-1.19.3-cp312-cp312-win_amd64.whl", hash = "sha256:a7caeaf46aaa8e51c512af9ac1377f388e4836c9d042e134bbc5e22519fbd1bf", size = 1254825, upload-time = "2026-06-13T08:05:12.315Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/476c217a4ab3c9b4abf2506fb1135e54b19d205ce7ddecb1d961bf93a9dc/pygit2-1.19.3-cp312-cp312-win_arm64.whl", hash = "sha256:2aafa010e3ac227913f398c8a680bce419e396dfe651685fffb779ed1c109a00", size = 969650, upload-time = "2026-06-13T08:05:13.438Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/12/1e0f0fc54a24ddfdabb0da0bafb3237c82b5628a8c5258ba66fb8d39b5b2/pygit2-1.19.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9238bf7a8a953f4faedcbe90eb097b760a2709c7e7ab38edcf18dc2d0ce9dcff", size = 5708790, upload-time = "2026-06-13T08:05:14.755Z" },
-    { url = "https://files.pythonhosted.org/packages/82/12/9093b7b81de7fe869f6ae51319a05b9f0a8b2567674e0d61fd54aacb833f/pygit2-1.19.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f999a4995504a6c14443de9481b7c6c54802663fe80c7504e1b946348f43786", size = 5700256, upload-time = "2026-06-13T08:05:16.363Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/07/a5133f79cf86e8a0cadf9f424cdd5b912ba47410c7254c0237b6e5290ddb/pygit2-1.19.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0918bc9b7597f243aa4b9c785912ae853e9aee4f572bcd5c9c591fcb703542f7", size = 6037556, upload-time = "2026-06-13T08:05:17.823Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/fc/3aa049d88eaa51f14f1fbfc0b70ac4c2362d3306dbeb8d1e5e3ca301e1dc/pygit2-1.19.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:18403fee0171867be5fc1c1415bcd5d5a7fab51299bdd44bcf467c22a868fd22", size = 4638864, upload-time = "2026-06-13T08:05:19.325Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/b7/5e772367db14f800048fa2a0981abd45baae6dcd8b83453da6ac0f92cead/pygit2-1.19.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cacece712337029092a98cf1af8d244e92fa8b36e5a64d7e14212ff73ea821e8", size = 5801146, upload-time = "2026-06-13T08:05:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/07/79/075b37b9a971cc7df9721add0e03cded83cab9e7d9736a80820357b2a972/pygit2-1.19.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:49d7c494bdaa5a8da366e4c4b7c822e52bd33bb6f22c67f8585b5396e91f8ac7", size = 6043951, upload-time = "2026-06-13T08:05:22.232Z" },
-    { url = "https://files.pythonhosted.org/packages/94/76/72e13c487d013f21f97690f0662cb03533d91aad39e0c7c4c8cd3e4453d0/pygit2-1.19.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2bbe74fbe553c6f991512391822c27c9321e3a0b45cab872f45c8d458393eee3", size = 5772767, upload-time = "2026-06-13T08:05:23.487Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/24/5ba37f80fcb303bcf1a3813631e5b5dddfbac771cce7efc0b03428f4fa2e/pygit2-1.19.3-cp313-cp313-win32.whl", hash = "sha256:3ab184751ca7a92007dbd8ae4ae4ac3b7228ef60ae2d2e18129b44bbe5c0aa4c", size = 945026, upload-time = "2026-06-13T08:05:25.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/48/4ae19f2e4dc8ff2ddc2fd64de7fd1d26aeb2b453069d6c9ee251dd567983/pygit2-1.19.3-cp313-cp313-win_amd64.whl", hash = "sha256:522d9c6ab9206880dceaae5516720c0f0df706859d2ba97f49adcaeea2d661bd", size = 1254793, upload-time = "2026-06-13T08:05:26.174Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/7b/473ca9e35dfd82c758b700a6cf4ecc107b849674e91ab219383063ebb12f/pygit2-1.19.3-cp313-cp313-win_arm64.whl", hash = "sha256:c77d5a1334ca3f1432c83457e03be8759d8e9040e0d25c59c738f2318545654a", size = 969666, upload-time = "2026-06-13T08:05:27.351Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #5231
Closes #4250
