### PR TITLE
feat(static-server): let a host process provide the workspace static server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,9 +200,9 @@ Griptape Nodes uses a variety of environment variables for influencing its low-l
 - **`GT_CLOUD_API_KEY`**: The API key for authenticating with the Griptape Cloud API. This is required for the engine to function properly.
 - **`STATIC_SERVER_HOST`**: The host for the static server (default `localhost`). This is used to serve static files from the engine.
 - **`STATIC_SERVER_PORT`**: The port for the static server (default `8124`). This is used to serve static files from the engine.
-- **`STATIC_SERVER_URL`**: The URL path for the static server (default `/static`). This is used to serve static files from the engine.
-- **`STATIC_SERVER_LOG_LEVEL`**: The log level for the static server (default `info`). This is used to control the verbosity of the static server logs.
-- **`STATIC_SERVER_ENABLED`**: Whether the static server is enabled (default `true`. This is used to control whether the static server is started or not.
+- **`STATIC_SERVER_URL`**: The URL path the workspace is served under (default `/workspace`). This is used to serve static files from the engine.
+- **`STATIC_SERVER_LOG_LEVEL`**: The log level for the static server (default `error`). This is used to control the verbosity of the static server logs.
+- **`STATIC_SERVER_ENABLED`**: Whether the static server is enabled (default `true`). This is used to control whether the static server is started or not.
 
 ## Contributing to Documentation
 

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -119,6 +119,12 @@ class AppInitializationComplete(AppPayload):
     # taken from the first entry in libraries_to_register. Multiple workers can run
     # simultaneously for different libraries.
     is_worker: bool = False
+    # URL of a static file server the host process already runs for this workspace. When set,
+    # the engine points its storage drivers at that server instead of starting one of its own,
+    # so asset URLs outlive this engine. Leave unset when the host serves nothing: the engine
+    # then serves the workspace itself, which is the path that goes away once every shipped
+    # host provides a server (see the fallback in StaticFilesManager).
+    static_server_base_url: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -99,17 +99,16 @@ class StaticFilesManager(EngineScoped):
         self.storage_backend = config_manager.get_config_value("storage_backend", default=StorageBackend.LOCAL)
         workspace_directory = config_manager.workspace_path
 
-        # Capture any explicit base URL override now; leave the underlying field None otherwise
-        # so on_app_initialization_complete can derive the URL from the OS-assigned port. A set
-        # value here (including one that equals the server defaults) is the signal for "user
-        # override" and short-circuits the port refresh.
-        configured_base_url = config_manager.get_config_value("static_server_base_url")
-        self._static_server_base_url: str | None = (
-            configured_base_url.rstrip("/") if configured_base_url is not None else None
-        )
-        base_url = (
-            f"{self._static_server_base_url}{STATIC_SERVER_URL}" if self._static_server_base_url is not None else None
-        )
+        # Where the workspace is served, resolved in on_app_initialization_complete. Staying None
+        # until then is also what tells that handler it has not settled this yet, so a second
+        # initialization pass in the same process doesn't start a second server.
+        self._static_server_base_url: str | None = None
+
+        # Seed the driver with any configured override so URLs built before initialization
+        # completes still point at the tunnel or proxy fronting the server. The handler re-reads
+        # it, so an override from a project activated after this manager was constructed counts.
+        configured_base_url = self._configured_base_url()
+        base_url = f"{configured_base_url}{STATIC_SERVER_URL}" if configured_base_url is not None else None
 
         match self.storage_backend:
             case StorageBackend.GTC:
@@ -169,10 +168,11 @@ class StaticFilesManager(EngineScoped):
 
     @property
     def static_server_base_url(self) -> str:
-        """Base URL for the static server.
+        """Base URL of the static server serving this workspace.
 
-        Resolved during ``on_app_initialization_complete`` once the server has bound to a
-        port. Reading this before that event fires indicates a startup-ordering bug.
+        Resolved during ``on_app_initialization_complete``, either from the server the host
+        process provided or from the one this engine started. Reading it before that event
+        fires is a startup-ordering bug.
         """
         if self._static_server_base_url is None:
             msg = "static_server_base_url accessed before on_app_initialization_complete resolved it."
@@ -416,23 +416,58 @@ class StaticFilesManager(EngineScoped):
             result_details="Successfully created static file download URL",
         )
 
-    def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
-        # Start static server in daemon thread if enabled
-        if isinstance(self.storage_driver, LocalStorageDriver):
+    def on_app_initialization_complete(self, payload: AppInitializationComplete) -> None:
+        if not isinstance(self.storage_driver, LocalStorageDriver):
+            return
+
+        if payload.static_server_base_url is not None:
+            # The host process serves this workspace and told us where. Pointing at its server
+            # keeps asset URLs valid for as long as the host runs, rather than only as long as
+            # this engine does.
+            self._static_server_base_url = payload.static_server_base_url.rstrip("/")
+            logger.debug("Using host-provided static server at %s", self._static_server_base_url)
+        elif self._static_server_base_url is not None:
+            # Initialization can complete more than once per process: a workflow executor
+            # broadcasts it for its own run. Where the workspace is served is already settled.
+            logger.debug("Static server already settled at %s", self._static_server_base_url)
+        else:
+            # No host-provided server, so serve the workspace here.
+            #
+            # This is the path that disappears once every shipped host serves the workspace
+            # itself and sets static_server_base_url on the initialization payload. At that
+            # point this branch and servers/static.py both go away, and a workspace with no
+            # host-provided server simply has no server.
+            #
             # Pre-bind to port 0 (or the configured port) so the OS assigns a free port before
             # the server thread starts. This lets us know the actual port immediately with no
             # race condition between discovering the port and uvicorn binding to it.
             sock = bind_free_socket(STATIC_SERVER_HOST, STATIC_SERVER_PORT)
             actual_port = sock.getsockname()[1]
 
-            # When there's no explicit override, derive the base URL from the bind host and
-            # the OS-assigned port. An override set in __init__ (e.g. an ngrok tunnel, reverse
-            # proxy, or `ssh -L` tunnel on a different port) is taken verbatim.
-            if self._static_server_base_url is None:
+            # An override (e.g. an ngrok tunnel, reverse proxy, or `ssh -L` tunnel on a
+            # different port) fronts the server we just bound, so it is advertised verbatim.
+            # Otherwise the URL follows the bind host and the OS-assigned port.
+            configured_base_url = self._configured_base_url()
+            if configured_base_url is None:
                 self._static_server_base_url = f"http://{STATIC_SERVER_HOST}:{actual_port}"
-            self.storage_driver.base_url = f"{self._static_server_base_url}{STATIC_SERVER_URL}"
+            else:
+                self._static_server_base_url = configured_base_url
 
             threading.Thread(target=start_static_server, args=(sock,), daemon=True, name="static-server").start()
+            logger.info("Serving workspace static files at %s", self._static_server_base_url)
+
+        self.storage_driver.base_url = f"{self._static_server_base_url}{STATIC_SERVER_URL}"
+
+    def _configured_base_url(self) -> str | None:
+        """Return the configured static server base URL, normalized, or None when unset.
+
+        A configured value means a tunnel or reverse proxy fronts the server, so it is what
+        gets advertised rather than the address the server binds to.
+        """
+        configured_base_url = self.config_manager.get_config_value("static_server_base_url")
+        if configured_base_url is None:
+            return None
+        return configured_base_url.rstrip("/")
 
     def save_static_file(
         self,

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -912,7 +912,12 @@ class TestStaticFilesManagerCreateUploadUrl:
 
 
 class TestStaticFilesManagerBaseUrlTrailingSlash:
-    """Test that static_server_base_url trailing slashes are stripped."""
+    """Test that static_server_base_url trailing slashes are stripped.
+
+    Normalizing at construction keeps a configured override from reaching the storage driver as
+    `https://host//workspace`. The resolved URL is only settled once initialization completes,
+    so that is asserted in TestStaticFilesManagerOnAppInitializationComplete.
+    """
 
     @pytest.fixture
     def mock_secrets_manager(self) -> Mock:
@@ -931,7 +936,7 @@ class TestStaticFilesManagerBaseUrlTrailingSlash:
     def test_init_strips_trailing_slashes(
         self, mock_secrets_manager: Mock, configured_url: str, expected_url: str
     ) -> None:
-        """Trailing slashes on static_server_base_url are stripped during init."""
+        """Trailing slashes on static_server_base_url are stripped before the driver sees it."""
         mock_config = Mock()
         mock_config.get_config_value.side_effect = lambda key, default=None: {
             "storage_backend": "local",
@@ -939,21 +944,21 @@ class TestStaticFilesManagerBaseUrlTrailingSlash:
         }.get(key, default)
         mock_config.workspace_path = Path("/mock/workspace")
 
-        with patch("griptape_nodes.retained_mode.managers.static_files_manager.LocalStorageDriver"):
-            manager = StaticFilesManager(
-                config_manager=mock_config, secrets_manager=mock_secrets_manager, event_manager=None
-            )
+        with patch("griptape_nodes.retained_mode.managers.static_files_manager.LocalStorageDriver") as driver_cls:
+            StaticFilesManager(config_manager=mock_config, secrets_manager=mock_secrets_manager, event_manager=None)
 
-        assert manager.static_server_base_url == expected_url
+        assert driver_cls.call_args.kwargs["base_url"] == f"{expected_url}/workspace"
 
 
 class TestStaticFilesManagerOnAppInitializationComplete:
-    """Test port handling in on_app_initialization_complete.
+    """Test static server ownership and port handling in on_app_initialization_complete.
 
-    The engine binds a free port at startup and may rewrite `static_server_base_url`
-    to reflect the OS-assigned port. That rewrite must only happen when the user has
-    not provided an explicit override, otherwise it clobbers tunnel configurations
-    (e.g. `ssh -L 8888:localhost:8124`, ngrok, reverse proxies).
+    A host process that serves the workspace itself sets `static_server_base_url` on the
+    initialization payload, and the engine must then point at that server rather than starting
+    one of its own. With no host-provided server the engine serves the workspace itself, binding
+    a free port and rewriting `static_server_base_url` to reflect the OS-assigned port. That
+    rewrite must only happen when the user has not provided an explicit override, otherwise it
+    clobbers tunnel configurations (e.g. `ssh -L 8888:localhost:8124`, ngrok, reverse proxies).
     """
 
     @pytest.fixture
@@ -977,7 +982,9 @@ class TestStaticFilesManagerOnAppInitializationComplete:
             )
         return manager
 
-    def _invoke_initialization(self, manager: StaticFilesManager, actual_port: int) -> None:
+    def _invoke_initialization(
+        self, manager: StaticFilesManager, actual_port: int, host_base_url: str | None = None
+    ) -> tuple[Mock, Mock]:
         from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 
         mock_sock = Mock()
@@ -987,10 +994,11 @@ class TestStaticFilesManagerOnAppInitializationComplete:
             patch(
                 "griptape_nodes.retained_mode.managers.static_files_manager.bind_free_socket",
                 return_value=mock_sock,
-            ),
-            patch("griptape_nodes.retained_mode.managers.static_files_manager.threading.Thread"),
+            ) as bind,
+            patch("griptape_nodes.retained_mode.managers.static_files_manager.threading.Thread") as thread_cls,
         ):
-            manager.on_app_initialization_complete(AppInitializationComplete())
+            manager.on_app_initialization_complete(AppInitializationComplete(static_server_base_url=host_base_url))
+        return bind, thread_cls
 
     def test_unset_base_url_rewritten_to_actual_port(self, mock_secrets_manager: Mock) -> None:
         """When no override is configured, the OS-assigned port replaces the server's default port."""
@@ -1034,6 +1042,96 @@ class TestStaticFilesManagerOnAppInitializationComplete:
 
         with pytest.raises(RuntimeError, match="static_server_base_url accessed before"):
             _ = manager.static_server_base_url
+
+    def test_access_before_initialization_raises_even_with_an_override(self, mock_secrets_manager: Mock) -> None:
+        """A configured override does not count as resolved: no server is known to exist yet.
+
+        This is also what lets the resolved URL stand in for "already settled" once
+        initialization completes, with no extra state to track.
+        """
+        manager = self._build_manager(mock_secrets_manager, "https://my-tunnel.ngrok.io")
+
+        with pytest.raises(RuntimeError, match="static_server_base_url accessed before"):
+            _ = manager.static_server_base_url
+
+    @pytest.mark.parametrize(
+        ("configured_url", "expected_url"),
+        [
+            ("http://localhost:8124/", "http://localhost:8124"),
+            ("http://localhost:8124///", "http://localhost:8124"),
+            ("https://my-tunnel.ngrok.io/", "https://my-tunnel.ngrok.io"),
+        ],
+    )
+    def test_configured_url_trailing_slashes_are_stripped(
+        self, mock_secrets_manager: Mock, configured_url: str, expected_url: str
+    ) -> None:
+        """A trailing slash must not survive into the resolved URL or the workspace path."""
+        manager = self._build_manager(mock_secrets_manager, configured_url)
+
+        self._invoke_initialization(manager, actual_port=54321)
+
+        assert manager.static_server_base_url == expected_url
+        assert manager.storage_driver.base_url == f"{expected_url}/workspace"
+
+    def test_override_configured_after_construction_is_honored(self, mock_secrets_manager: Mock) -> None:
+        """Project activation can set the override after this manager is built, before app init."""
+        manager = self._build_manager(mock_secrets_manager, None)
+        manager.config_manager.get_config_value.side_effect = lambda key, default=None: {
+            "storage_backend": "local",
+            "static_server_base_url": "https://from-project.ngrok.io",
+        }.get(key, default)
+
+        self._invoke_initialization(manager, actual_port=54321)
+
+        assert manager.static_server_base_url == "https://from-project.ngrok.io"
+        assert manager.storage_driver.base_url == "https://from-project.ngrok.io/workspace"
+
+    def test_host_provided_server_is_adopted(self, mock_secrets_manager: Mock) -> None:
+        """When the host serves the workspace, the engine points at it and starts nothing."""
+        manager = self._build_manager(mock_secrets_manager, None)
+
+        bind, thread_cls = self._invoke_initialization(
+            manager, actual_port=54321, host_base_url="http://localhost:8124/"
+        )
+
+        assert manager.static_server_base_url == "http://localhost:8124"
+        assert manager.storage_driver.base_url == "http://localhost:8124/workspace"
+        bind.assert_not_called()
+        thread_cls.assert_not_called()
+
+    def test_host_provided_server_wins_over_a_configured_override(self, mock_secrets_manager: Mock) -> None:
+        """The host resolves its own URL, including any override, so its answer is final."""
+        manager = self._build_manager(mock_secrets_manager, "https://my-tunnel.ngrok.io")
+
+        _, thread_cls = self._invoke_initialization(manager, actual_port=54321, host_base_url="http://localhost:8124")
+
+        assert manager.static_server_base_url == "http://localhost:8124"
+        thread_cls.assert_not_called()
+
+    def test_serves_workspace_when_no_host_provides_one(self, mock_secrets_manager: Mock) -> None:
+        """Legacy path: with no host-provided server the engine serves the workspace itself.
+
+        Removed once every shipped host provides one.
+        """
+        manager = self._build_manager(mock_secrets_manager, None)
+
+        bind, thread_cls = self._invoke_initialization(manager, actual_port=54321)
+
+        bind.assert_called_once_with("localhost", 8124)
+        assert thread_cls.call_args.kwargs["name"] == "static-server"
+        assert thread_cls.call_args.kwargs["daemon"] is True
+        thread_cls.return_value.start.assert_called_once_with()
+
+    def test_repeat_initialization_does_not_start_a_second_server(self, mock_secrets_manager: Mock) -> None:
+        """Initialization completes again per workflow-executor run; one server is enough."""
+        manager = self._build_manager(mock_secrets_manager, None)
+
+        self._invoke_initialization(manager, actual_port=54321)
+        bind, thread_cls = self._invoke_initialization(manager, actual_port=54322)
+
+        assert manager.static_server_base_url == "http://localhost:54321"
+        bind.assert_not_called()
+        thread_cls.assert_not_called()
 
 
 class TestStaticFilesManagerCloudCredential:


### PR DESCRIPTION
Near term we'd like to move the static file serving out of the engine and into the host app. Removing it right now would break engine users using an older version of the app (e.g. via `make run`). This PR adds the ability for the app to disable the engine's static server hosting by providing a URL. Eventually, we can remove the other path.