### PR TITLE
feat(traits): free-text and typeahead options for parameters

### DIFF
--- a/docs/development/custom_nodes/parameter_ui_reference.md
+++ b/docs/development/custom_nodes/parameter_ui_reference.md
@@ -119,17 +119,33 @@ For a bounded slider, use the `Slider` trait rather than writing `ui_options["sl
 
 Traits live in `griptape_nodes.traits` and are attached with `add_trait()` or `traits={...}` on the parameter. Each row lists what the trait renders and, where relevant, the `ui_options` keys it manages — set the trait rather than the keys.
 
-| Trait                | Typical types             | What it does                                                                                          | `ui_options` it writes                                   |
-| -------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `Options`            | `str`, any                | Dropdown constrained to fixed choices, with optional search.                                          | `simple_dropdown`, `show_search`, `search_filter`        |
-| `MultiOptions`       | `list`                    | Multi-select dropdown.                                                                                | `multi_options`                                          |
-| `Slider`             | `int`, `float`            | Slider between `min_val` and `max_val`; out-of-range values fail validation.                          | `slider`                                                 |
-| `Clamp`              | `int`, `float`, sequences | Clamps the value into range on assignment. No UI of its own.                                          | —                                                        |
-| `Button`             | `button`                  | Configures a button's label, variant, size, and click behavior.                                       | `button_label`, `variant`, `size`, `state`, `full_width` |
-| `ColorPicker`        | `str`                     | Color swatch that opens a color picker; validates the format (`"hex"`, etc.).                         | `color_picker`                                           |
-| `FileSystemPicker`   | `str`                     | Browse button that opens a file/directory picker with filtering options.                              | `fileSystemPicker`                                       |
-| `NumbersSelector`    | `dict`                    | Min/max/step numeric range selector.                                                                  | `numbers_selector`                                       |
-| `CompareImagesTrait` | `dict`                    | Validates the two-image dict shape used by the comparison slider (pair with `ui_options["compare"]`). | —                                                        |
-| `Widget`             | any                       | Replaces the built-in widget with a custom widget shipped by a library.                               | `widget`, `library`                                      |
+| Trait                | Typical types             | What it does                                                                                          | `ui_options` it writes                                                          |
+| -------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `Options`            | `str`, any                | Dropdown of fixed choices, with optional search. Can also accept free text (see below).               | `simple_dropdown`, `show_search`, `search_filter`, `allow_user_created_options` |
+| `MultiOptions`       | `list`                    | Multi-select dropdown.                                                                                | `multi_options`                                                                 |
+| `Slider`             | `int`, `float`            | Slider between `min_val` and `max_val`; out-of-range values fail validation.                          | `slider`                                                                        |
+| `Clamp`              | `int`, `float`, sequences | Clamps the value into range on assignment. No UI of its own.                                          | —                                                                               |
+| `Button`             | `button`                  | Configures a button's label, variant, size, and click behavior.                                       | `button_label`, `variant`, `size`, `state`, `full_width`                        |
+| `ColorPicker`        | `str`                     | Color swatch that opens a color picker; validates the format (`"hex"`, etc.).                         | `color_picker`                                                                  |
+| `FileSystemPicker`   | `str`                     | Browse button that opens a file/directory picker with filtering options.                              | `fileSystemPicker`                                                              |
+| `NumbersSelector`    | `dict`                    | Min/max/step numeric range selector.                                                                  | `numbers_selector`                                                              |
+| `CompareImagesTrait` | `dict`                    | Validates the two-image dict shape used by the comparison slider (pair with `ui_options["compare"]`). | —                                                                               |
+| `Widget`             | any                       | Replaces the built-in widget with a custom widget shipped by a library.                               | `widget`, `library`                                                             |
 
 See the [Traits section of the Parameters reference](parameters.md#traits) for constructor signatures and examples.
+
+### Dropdowns that accept free text
+
+By default `Options` constrains the value to `choices`: anything else is snapped back to the first choice, and assigning it directly fails validation. Pass `allow_user_created_options=True` to turn the choices into suggestions instead:
+
+```python
+Parameter(
+    name="model",
+    type="str",
+    tooltip="Pick a suggested model or type your own id",
+    traits={Options(choices=SUGGESTED_MODELS, allow_user_created_options=True)},
+    default_value=SUGGESTED_MODELS[0],
+)
+```
+
+The dropdown still filters `choices` as the user types, but text matching no choice is offered as a `Use "..."` row and stored verbatim. Reach for this when the list is a convenience rather than the full set of valid values — a model id the provider added after the node shipped, a user's own fine-tune. Leave it off when an unrecognized value would fail at run time; a dropdown that rejects bad input up front beats a node that errors mid-flow.

--- a/docs/development/custom_nodes/parameter_ui_reference.md
+++ b/docs/development/custom_nodes/parameter_ui_reference.md
@@ -122,6 +122,7 @@ Traits live in `griptape_nodes.traits` and are attached with `add_trait()` or `t
 | Trait                | Typical types             | What it does                                                                                          | `ui_options` it writes                                                          |
 | -------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `Options`            | `str`, any                | Dropdown of fixed choices, with optional search. Can also accept free text (see below).               | `simple_dropdown`, `show_search`, `search_filter`, `allow_user_created_options` |
+| `Suggestions`        | `str`                     | Text field with typeahead; the choices are hints and the value is never constrained (see below).      | `suggestions`                                                                   |
 | `MultiOptions`       | `list`                    | Multi-select dropdown.                                                                                | `multi_options`                                                                 |
 | `Slider`             | `int`, `float`            | Slider between `min_val` and `max_val`; out-of-range values fail validation.                          | `slider`                                                                        |
 | `Clamp`              | `int`, `float`, sequences | Clamps the value into range on assignment. No UI of its own.                                          | —                                                                               |
@@ -134,7 +135,15 @@ Traits live in `griptape_nodes.traits` and are attached with `add_trait()` or `t
 
 See the [Traits section of the Parameters reference](parameters.md#traits) for constructor signatures and examples.
 
-### Dropdowns that accept free text
+### Choosing between a dropdown, a loose dropdown, and a typeahead
+
+Three widgets offer a list of values. They differ in who is in charge, the list or the user.
+
+| You want the user to                                     | Use                                             | Renders as                                      |
+| -------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------- |
+| pick one of N values, and nothing else                   | `Options(choices=...)`                          | Dropdown; unlisted values are rejected          |
+| mostly pick, but occasionally paste a value of their own | `Options(..., allow_user_created_options=True)` | Dropdown, plus a `Use "..."` row for typed text |
+| mostly type, with the list as a hint                     | `Suggestions(choices=...)`                      | Text field; matches appear as they type         |
 
 By default `Options` constrains the value to `choices`: anything else is snapped back to the first choice, and assigning it directly fails validation. Pass `allow_user_created_options=True` to turn the choices into suggestions instead:
 
@@ -148,4 +157,32 @@ Parameter(
 )
 ```
 
-The dropdown still filters `choices` as the user types, but text matching no choice is offered as a `Use "..."` row and stored verbatim. Reach for this when the list is a convenience rather than the full set of valid values — a model id the provider added after the node shipped, a user's own fine-tune. Leave it off when an unrecognized value would fail at run time; a dropdown that rejects bad input up front beats a node that errors mid-flow.
+The dropdown still filters `choices` as the user types, but text matching no choice is offered as a `Use "..."` row and stored verbatim.
+
+`Suggestions` is the other way round. The parameter is an ordinary text field, and the choices only surface once there is something to match:
+
+```python
+from griptape_nodes.traits.suggestions import Suggestion, Suggestions
+
+Parameter(
+    name="model",
+    type="str",
+    tooltip="Pick a suggested model or type your own id",
+    traits={
+        Suggestions(
+            choices=[
+                Suggestion("gpt-4.1", label="GPT-4.1", subtitle="OpenAI"),
+                "claude-sonnet-4-5",
+            ]
+        )
+    },
+)
+```
+
+Choices are plain strings, or `Suggestion` rows when a row needs a friendly `label`, a `subtitle`, or an `icon`. Only `name` is ever stored: the decoration dresses up the row in the list, and picking a row fills the field with `name`. Because the value is never constrained, `Suggestions` adds no converter and no validator, so updating its `choices` at run time cannot invalidate a value the node already holds.
+
+Rule of thumb: reach for a loose dropdown or a typeahead when the list is a convenience rather than the full set of valid values, such as a model id the provider added after the node shipped, or a user's own fine-tune. Stay with a plain `Options` when an unrecognized value would fail at run time; a dropdown that rejects bad input up front beats a node that errors mid-flow.
+
+!!! warning "Do not put `Options` and `Suggestions` on the same parameter"
+
+    Both write the key the editor uses to pick a widget. The dropdown wins and the suggestions are silently ignored.

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -32,6 +32,7 @@ All Parameter attributes:
 Add functionality via `add_trait()`:
 
 - **Options**: `Options(choices=list[str] | list[tuple[str, Any]], show_search: bool = True, search_filter: str = "", allow_user_created_options: bool = False)`
+- **Suggestions**: `Suggestions(choices=list[str | Suggestion])` (text field with typeahead; never constrains the value)
 - **Slider**: `Slider(min_val: float, max_val: float)`
 - **Button**: `Button(label: str = "", variant=..., size=..., button_link=... | on_click=..., get_button_state=...)`
 - **ColorPicker**: `ColorPicker(format="hex")`

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -31,7 +31,7 @@ All Parameter attributes:
 
 Add functionality via `add_trait()`:
 
-- **Options**: `Options(choices=list[str] | list[tuple[str, Any]], show_search: bool = True, search_filter: str = "")`
+- **Options**: `Options(choices=list[str] | list[tuple[str, Any]], show_search: bool = True, search_filter: str = "", allow_user_created_options: bool = False)`
 - **Slider**: `Slider(min_val: float, max_val: float)`
 - **Button**: `Button(label: str = "", variant=..., size=..., button_link=... | on_click=..., get_button_state=...)`
 - **ColorPicker**: `ColorPicker(format="hex")`

--- a/src/griptape_nodes/traits/options.py
+++ b/src/griptape_nodes/traits/options.py
@@ -28,14 +28,23 @@ class Options(Trait):
     element_id: str = field(default_factory=lambda: "Options")
     show_search: bool = field(default=True)
     search_filter: str = field(default="")
+    _allow_user_created_options: bool = field(default=False)
 
-    def __init__(self, *, choices: list | None = None, show_search: bool = True, search_filter: str = "") -> None:
+    def __init__(
+        self,
+        *,
+        choices: list | None = None,
+        show_search: bool = True,
+        search_filter: str = "",
+        allow_user_created_options: bool = False,
+    ) -> None:
         super().__init__()
         # Set choices through property to ensure dual sync from the start
         if choices is not None:
             self.choices = choices
         self.show_search = show_search
         self.search_filter = search_filter
+        self._allow_user_created_options = allow_user_created_options
 
     @property
     def choices(self) -> list:
@@ -85,6 +94,25 @@ class Options(Trait):
             # Write choices to ui_options (this gets serialized and survives reload)
             self._parent.ui_options["simple_dropdown"] = value  # type: ignore[attr-defined]
 
+    @property
+    def allow_user_created_options(self) -> bool:
+        """Whether a value outside ``choices`` is kept, with ui_options as primary source of truth.
+
+        Read priority matches the choices property, for the same reason plus one more:
+        Parameter.ui_options lets a manually-set entry override what a trait publishes, so
+        ui_options is what the editor actually renders from. Reading it here keeps the engine
+        from snapping back a value the widget just offered.
+
+        1. FIRST: ui_options["allow_user_created_options"] (what the editor sees)
+        2. FALLBACK: the constructor argument (used before trait attachment)
+        """
+        if self._parent and hasattr(self._parent, "ui_options"):
+            ui_options = getattr(self._parent, "ui_options", None)
+            if isinstance(ui_options, dict) and "allow_user_created_options" in ui_options:
+                return bool(ui_options["allow_user_created_options"])
+
+        return self._allow_user_created_options
+
     @classmethod
     def get_trait_keys(cls) -> list[str]:
         return ["options", "models"]
@@ -95,6 +123,12 @@ class Options(Trait):
             # The property reads from ui_options first, ensuring we use post-deserialization
             # choices data instead of stale trait field data. This prevents the bug where
             # selected values revert to first choice after save/reload.
+
+            # In user-created mode the choices are suggestions, so a value the user typed
+            # is kept as-is instead of being snapped back to the first choice.
+            if self.allow_user_created_options:
+                return value
+
             if value not in self.choices:
                 return self.choices[0]
             return value
@@ -105,6 +139,11 @@ class Options(Trait):
         def validator(param: Parameter, value: Any) -> None:  # noqa: ARG001
             # CRITICAL: This validator uses self.choices property (not _choices field)
             # Same reasoning as converter - use live ui_options data after deserialization
+
+            # In user-created mode any value is allowed, so there is nothing to check.
+            if self.allow_user_created_options:
+                return
+
             if value not in self.choices:
                 msg = "Choice not allowed"
                 raise ValueError(msg)
@@ -125,9 +164,11 @@ class Options(Trait):
 
         Using _choices directly breaks this cycle while still providing the correct
         initial choices for UI rendering. The property-based sync handles runtime updates.
+        _allow_user_created_options is read directly for the same reason.
         """
         return {
             "simple_dropdown": self._choices,
             "show_search": self.show_search,
             "search_filter": self.search_filter,
+            "allow_user_created_options": self._allow_user_created_options,
         }

--- a/src/griptape_nodes/traits/suggestions.py
+++ b/src/griptape_nodes/traits/suggestions.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Trait
+
+
+@dataclass
+class Suggestion:
+    """One row offered by a :class:`Suggestions` list.
+
+    ``name`` is the text filled into the field when the row is picked, so it is the
+    value the node receives. ``label`` is display-only: use it when the stored value
+    is an id a person would not recognize. ``subtitle`` and ``icon`` decorate the row
+    in the list and are never stored.
+    """
+
+    name: str
+    label: str | None = None
+    subtitle: str | None = None
+    icon: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        row: dict[str, Any] = {"name": self.name}
+        if self.label is not None:
+            row["label"] = self.label
+        if self.subtitle is not None:
+            row["subtitle"] = self.subtitle
+        if self.icon is not None:
+            row["icon"] = self.icon
+        return row
+
+
+@dataclass(eq=False)
+class Suggestions(Trait):
+    """Turns a text parameter into a typeahead: the user types, the editor suggests.
+
+    This is the free-text counterpart to ``Options``, and the two are different
+    widgets rather than two settings of one widget:
+
+    - ``Options`` is a dropdown. The value must be one of ``choices``; anything else
+      is rejected. Reach for it when an unlisted value would fail at run time.
+    - ``Options(allow_user_created_options=True)`` is still a dropdown, but tolerates
+      a value the user typed. Reach for it when picking is the normal path and typing
+      is the exception.
+    - ``Suggestions`` is a plain text field that offers matching rows once the user
+      starts typing. The value is always whatever they typed. Reach for it when the
+      list is a convenience and the full set of valid values is open-ended.
+
+    Because the value is never constrained, this trait adds no converter and no
+    validator. It is presentation only, which is why ``choices`` can be updated at
+    run time without any risk of invalidating a value the node already holds.
+
+    Choices are plain strings, or ``Suggestion`` rows when a row needs a friendly
+    label, a subtitle, or an icon:
+
+        Parameter(
+            name="model",
+            type="str",
+            tooltip="Pick a suggested model or type your own id",
+            traits={
+                Suggestions(
+                    choices=[
+                        Suggestion("gpt-4.1", label="GPT-4.1", subtitle="OpenAI"),
+                        "claude-sonnet-4-5",
+                    ]
+                )
+            },
+        )
+
+    Do not combine this with ``Options`` on the same parameter. Both write the key
+    the editor keys off, the dropdown wins, and the suggestions are silently ignored.
+    """
+
+    _choices: list[Suggestion] = field(default_factory=list)
+    element_id: str = field(default_factory=lambda: "Suggestions")
+
+    def __init__(self, *, choices: list[str | Suggestion] | None = None) -> None:
+        super().__init__()
+        if choices is None:
+            self.choices = []
+        else:
+            self.choices = choices
+
+    @property
+    def choices(self) -> list[Suggestion]:
+        """The rows offered as the user types.
+
+        Unlike ``Options.choices``, this reads the trait's own field rather than
+        ui_options. Nothing in the engine consults these rows -- there is no converter
+        or validator to go stale against a saved workflow -- so the round trip through
+        ui_options that ``Options`` needs would buy nothing here.
+        """
+        return self._choices
+
+    @choices.setter
+    def choices(self, value: list[str | Suggestion]) -> None:
+        """Replace the rows, publishing them to the editor.
+
+        Writing to ui_options is what makes a run-time update visible, and what makes
+        it survive a save/reload, since ui_options is serialized and trait fields are not.
+        """
+        rows = [self._coerce_row(index, entry) for index, entry in enumerate(value)]
+
+        self._choices = rows
+
+        if self._parent and hasattr(self._parent, "ui_options"):
+            ui_options = getattr(self._parent, "ui_options", None)
+            if not isinstance(ui_options, dict):
+                self._parent.ui_options = {}  # type: ignore[attr-defined]
+            self._parent.ui_options["suggestions"] = [row.to_dict() for row in rows]  # type: ignore[attr-defined]
+
+    @classmethod
+    def get_trait_keys(cls) -> list[str]:
+        return ["suggestions"]
+
+    def ui_options_for_trait(self) -> dict:
+        return {"suggestions": [row.to_dict() for row in self._choices]}
+
+    @staticmethod
+    def _coerce_row(index: int, entry: str | Suggestion) -> Suggestion:
+        if isinstance(entry, Suggestion):
+            if not entry.name.strip():
+                msg = (
+                    f"Attempted to build a suggestion list. Failed because suggestion {index + 1} has a blank name. "
+                    f"A suggestion's name is the text filled into the field when it is picked, so it cannot be empty."
+                )
+                raise ValueError(msg)
+            return entry
+
+        if isinstance(entry, str):
+            if not entry.strip():
+                msg = (
+                    f"Attempted to build a suggestion list. Failed because suggestion {index + 1} is blank. "
+                    f"Every suggestion needs text to offer the user."
+                )
+                raise ValueError(msg)
+            return Suggestion(name=entry)
+
+        msg = (
+            f"Attempted to build a suggestion list. Failed because suggestion {index + 1} is a "
+            f"{type(entry).__name__}. Suggestions must be text, or a Suggestion when the row needs a "
+            f"label, subtitle, or icon."
+        )
+        raise TypeError(msg)

--- a/tests/unit/traits/test_options.py
+++ b/tests/unit/traits/test_options.py
@@ -1,0 +1,106 @@
+import pytest  # type: ignore[reportMissingImports]
+
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.traits.options import Options
+
+CHOICES = ["red", "green", "blue"]
+
+
+def _parameter_with(trait: Options) -> Parameter:
+    param = Parameter(name="color", input_types=["str"], type="str", output_type="str", tooltip="test")
+    param.add_trait(trait)
+    return param
+
+
+def _convert(param: Parameter, value: object) -> object:
+    for converter in param.converters:
+        value = converter(value)
+    return value
+
+
+def _validate(param: Parameter, value: object) -> None:
+    for validator in param.validators:
+        validator(param, value)
+
+
+class TestOptionsConstrained:
+    def test_snaps_unknown_value_to_first_choice(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES))
+
+        assert _convert(param, "chartreuse") == "red"
+
+    def test_keeps_known_value(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES))
+
+        assert _convert(param, "green") == "green"
+
+    def test_rejects_unknown_value(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES))
+
+        with pytest.raises(ValueError, match="Choice not allowed"):
+            _validate(param, "chartreuse")
+
+
+class TestOptionsUserCreated:
+    def test_keeps_unknown_value(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES, allow_user_created_options=True))
+
+        assert _convert(param, "chartreuse") == "chartreuse"
+
+    def test_keeps_known_value(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES, allow_user_created_options=True))
+
+        assert _convert(param, "green") == "green"
+
+    def test_accepts_unknown_value(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES, allow_user_created_options=True))
+
+        _validate(param, "chartreuse")
+
+    def test_keeps_unknown_value_when_choices_are_empty(self) -> None:
+        """Constrained mode has no first choice to fall back on; user-created mode never needs one."""
+        param = _parameter_with(Options(choices=[], allow_user_created_options=True))
+
+        assert _convert(param, "chartreuse") == "chartreuse"
+        _validate(param, "chartreuse")
+
+    def test_survives_a_choices_update(self) -> None:
+        """Updating choices at runtime rewrites ui_options, which must not drop the flag."""
+        trait = Options(choices=CHOICES, allow_user_created_options=True)
+        param = _parameter_with(trait)
+
+        trait.choices = ["cyan", "magenta"]
+
+        assert param.ui_options["allow_user_created_options"] is True
+        assert _convert(param, "chartreuse") == "chartreuse"
+
+
+class TestOptionsUiOptions:
+    def test_defaults_to_constrained(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES))
+
+        assert param.ui_options["allow_user_created_options"] is False
+
+    def test_publishes_the_flag(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES, allow_user_created_options=True))
+
+        assert param.ui_options["allow_user_created_options"] is True
+
+    def test_a_manual_ui_option_wins_over_the_constructor(self) -> None:
+        """Parameter.ui_options lets a manual entry override a trait's, and that is what the editor renders.
+
+        The converter has to follow it, otherwise the engine snaps back a value the widget offered.
+        """
+        param = _parameter_with(Options(choices=CHOICES))
+        param.ui_options = {"allow_user_created_options": True}
+
+        assert _convert(param, "chartreuse") == "chartreuse"
+        _validate(param, "chartreuse")
+
+    def test_a_manual_ui_option_can_re_constrain_the_parameter(self) -> None:
+        param = _parameter_with(Options(choices=CHOICES, allow_user_created_options=True))
+        param.ui_options = {"allow_user_created_options": False}
+
+        assert _convert(param, "chartreuse") == "red"
+        with pytest.raises(ValueError, match="Choice not allowed"):
+            _validate(param, "chartreuse")

--- a/tests/unit/traits/test_suggestions.py
+++ b/tests/unit/traits/test_suggestions.py
@@ -1,0 +1,72 @@
+import pytest  # type: ignore[reportMissingImports]
+
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.traits.suggestions import Suggestion, Suggestions
+
+
+def _parameter_with(trait: Suggestions) -> Parameter:
+    param = Parameter(name="model", input_types=["str"], type="str", output_type="str", tooltip="test")
+    param.add_trait(trait)
+    return param
+
+
+class TestSuggestionsUiOptions:
+    def test_publishes_plain_strings_as_rows(self) -> None:
+        param = _parameter_with(Suggestions(choices=["gpt-4.1", "claude-sonnet-4-5"]))
+
+        assert param.ui_options["suggestions"] == [{"name": "gpt-4.1"}, {"name": "claude-sonnet-4-5"}]
+
+    def test_publishes_row_decoration_only_when_set(self) -> None:
+        param = _parameter_with(
+            Suggestions(choices=[Suggestion("gpt-4.1", label="GPT-4.1", subtitle="OpenAI"), "claude-sonnet-4-5"])
+        )
+
+        assert param.ui_options["suggestions"] == [
+            {"name": "gpt-4.1", "label": "GPT-4.1", "subtitle": "OpenAI"},
+            {"name": "claude-sonnet-4-5"},
+        ]
+
+    def test_publishes_an_empty_list_when_there_are_no_choices(self) -> None:
+        param = _parameter_with(Suggestions())
+
+        assert param.ui_options["suggestions"] == []
+
+    def test_a_runtime_update_reaches_the_editor(self) -> None:
+        trait = Suggestions(choices=["gpt-4.1"])
+        param = _parameter_with(trait)
+
+        trait.choices = ["gemini-2.5-pro"]
+
+        assert param.ui_options["suggestions"] == [{"name": "gemini-2.5-pro"}]
+
+    def test_does_not_claim_the_dropdown_key(self) -> None:
+        """The editor renders a dropdown when simple_dropdown is present, which is the wrong widget here."""
+        param = _parameter_with(Suggestions(choices=["gpt-4.1"]))
+
+        assert "simple_dropdown" not in param.ui_options
+
+
+class TestSuggestionsDoesNotConstrain:
+    def test_adds_no_converter(self) -> None:
+        param = _parameter_with(Suggestions(choices=["gpt-4.1"]))
+
+        assert param.converters == []
+
+    def test_adds_no_validator(self) -> None:
+        param = _parameter_with(Suggestions(choices=["gpt-4.1"]))
+
+        assert param.validators == []
+
+
+class TestSuggestionsRejectsBadRows:
+    def test_rejects_a_blank_string(self) -> None:
+        with pytest.raises(ValueError, match="suggestion 2 is blank"):
+            Suggestions(choices=["gpt-4.1", "   "])
+
+    def test_rejects_a_row_with_a_blank_name(self) -> None:
+        with pytest.raises(ValueError, match="suggestion 1 has a blank name"):
+            Suggestions(choices=[Suggestion("", label="GPT-4.1")])
+
+    def test_rejects_a_row_that_is_neither_text_nor_a_suggestion(self) -> None:
+        with pytest.raises(TypeError, match="suggestion 1 is a dict"):
+            Suggestions(choices=[{"name": "gpt-4.1"}])  # type: ignore[list-item]


### PR DESCRIPTION


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5268.org.readthedocs.build/en/5268/

<!-- readthedocs-preview griptape-nodes end -->