### PR TITLE
unresolvable path declarations now fail the load, and the listing reports where paths land

### DIFF
--- a/docs/guides/projects/projects.md
+++ b/docs/guides/projects/projects.md
@@ -125,7 +125,7 @@ directories:
 | Relative | `../team-base/griptape-nodes-project.yml`                    | Preferred. Resolved against the directory of *this* project's YAML file, so the link survives moves between machines and OSes. |
 | Absolute | `/Users/alice/projects/team-base/griptape-nodes-project.yml` | Bakes in a per-machine path; works locally but does not travel.                                                                |
 
-No macros are expanded inside `parent_project_path`. Tokens like `{workspace_dir}`, `{project_dir}`, and `{outputs}` are not substituted here — a path containing them is treated literally. Macros belong in `path_macro` and `situations.*.macro` fields.
+No macros are expanded inside `parent_project_path`. Tokens like `{workspace_dir}`, `{project_dir}`, and `{outputs}` are not substituted here. Macros belong in `path_macro` and `situations.*.macro` fields. `~` and environment variables *are* expanded — see [Path values](#path-values-in-workspace_dir-libraries_dir-and-parent_project_path).
 
 ### Inheritance and tombstones
 
@@ -152,6 +152,51 @@ A parent that cannot be read or parsed surfaces as a validation error on the chi
 
 A workspace zipped on one machine and unpacked on another will keep parent links intact as long as the parent is referenced with a relative path and travels alongside the child inside the workspace. Absolute paths break across machines (different home directories, different drive letters); the relative form is what makes parent chains portable.
 
+## Path values in `workspace_dir`, `libraries_dir`, and `parent_project_path`
+
+These three fields all accept a path, and all three read it the same way, in this order:
+
+1. **`~` and environment variables expand first.** `~` becomes your home directory, and `${NAME}` (or `%NAME%` on Windows) is replaced with that variable's value.
+1. **A path that is still relative** after expansion resolves against the directory of the project file that declared it, so the value travels with the project.
+1. The result is normalized, so two spellings of the same folder mean the same folder.
+
+Expansion happening *first* is what makes this work: `${STUDIO_LIBS}/griptape-libraries` is an absolute path once `STUDIO_LIBS` is filled in, and is treated as one rather than being tacked onto the project folder.
+
+```yaml
+libraries_dir: "${STUDIO_LIBS}/griptape-libraries"   # absolute once STUDIO_LIBS is set
+workspace_dir: "~/Projects/marketing"                # your home directory
+```
+
+**Which variables count.** Only the environment the engine was launched with — what your shell, launcher, or studio pipeline exported before Griptape Nodes started. A project's own `environment:` block is deliberately **not** consulted here: those variables are applied when the project is *activated*, which happens after these fields have already been resolved. If a project's own environment could change what its workspace and libraries folders mean, a field's meaning would depend on which project happened to be open at the time.
+
+**`{macro}` tokens are not expanded.** `{workspace_dir}`, `{project_dir}`, `{outputs}`, and any other macro token is rejected rather than substituted — the engine reports the field as unresolvable instead of creating a folder literally named `{outputs}`. Macros belong in `path_macro` and `situations.*.macro` fields, which resolve against runtime state these fields cannot depend on.
+
+Three things worth knowing before you rely on a variable:
+
+- `%NAME%` expands **only on Windows**. For a value that has to work everywhere, use `${NAME}` or the per-platform mapping form.
+- A bare `$NAME` (no braces) is **not** a variable here. It is indistinguishable from a real folder name such as `$Recycle.Bin`, so it stays literal — always write `${NAME}`.
+- A variable only makes a path portable if every machine defines it. A relative path needs no such agreement, so prefer relative when the target travels with the project.
+
+### A path that cannot be resolved is an error
+
+Leaving one of these fields **out** is always fine — the project simply falls back to the next source (a parent's value, the config, the global default). But a field that *is* written and cannot produce a path means the project is asking for something this machine cannot give it, and the engine will not quietly substitute somewhere else. **The project fails to load**, reports [`UNUSABLE`](#validation-status), and its validation problems name the field, the line, and the reason. Any project that lists it as a parent fails too, with a problem pointing at its `parent_project_path`.
+
+Three things trip this:
+
+- `${STUDIO_LIBS}/libraries` when `STUDIO_LIBS` is not set — no literal `${STUDIO_LIBS}` folder is created.
+- `{outputs}/libraries` or any other `{macro}` token.
+- A per-platform mapping with no entry for the machine you are on and no `default`.
+
+That last one is the case worth planning for, and `default` is the fix. A mapping that names only `windows` says nothing about what a teammate on Linux should get, so the honest answer on their machine is a failed load rather than a guess:
+
+```yaml
+libraries_dir:
+  windows: "D:/shared-libraries"      # the fast local volume, Windows only
+  default: "./libraries"              # everyone else: beside the project
+```
+
+The failure is deliberately loud, because the alternative is worse: a shared project pinning `${STUDIO_LIBS}` would otherwise load for every teammate who has not set that variable and silently install a second copy of every library somewhere they never chose. Set the variable, add a `default`, or remove the field.
+
 ## Workspace directory
 
 The optional `workspace_dir` field names the directory this project uses as its [workspace](workspace.md). When set, it is the **highest-priority** workspace source — it overrides the per-user `project_workspaces` mapping, the `GTN_CONFIG_WORKSPACE_DIRECTORY` env var, the project-adjacent config, parent inheritance, and the global default.
@@ -171,9 +216,9 @@ workspace_dir:
   default: "./workspace"
 ```
 
-A relative path resolves against the directory of *this* project's YAML file — the same rule `parent_project_path` uses — so a relative value travels with the project across machines and operating systems. The raw value is stored verbatim and only resolved to an absolute path at workspace-resolution time; it is never absolutized on save. The target directory does not need to contain a `griptape_nodes_config.json`; an empty directory is valid.
+A relative path resolves against the directory of *this* project's YAML file — the same rule `parent_project_path` uses — so a relative value travels with the project across machines and operating systems. `~` and environment variables are expanded (see [Path values](#path-values-in-workspace_dir-libraries_dir-and-parent_project_path)). The raw value is stored verbatim and only resolved to an absolute path at workspace-resolution time; it is never absolutized on save. The target directory does not need to contain a `griptape_nodes_config.json`; an empty directory is valid.
 
-For the per-platform form, the engine picks the entry matching the current platform. When that platform's key is unset it falls back to `default`. If neither the platform key nor `default` is set, the field yields no value on that platform and workspace resolution falls through to the next source (see [Workspace resolution](workspace.md#workspace-resolution)).
+For the per-platform form, the engine picks the entry matching the current platform. When that platform's key is unset it falls back to `default`. If neither the platform key nor `default` is set, the project does not load on that platform — see [A path that cannot be resolved is an error](#a-path-that-cannot-be-resolved-is-an-error). Otherwise the resolved value feeds [Workspace resolution](workspace.md#workspace-resolution) as its highest-priority source.
 
 Unlike most fields, `workspace_dir` is **not inherited** from a parent project. It describes this project's own workspace and is taken from this project's overlay alone — a child does not adopt its parent's `workspace_dir`. (Cross-project workspace inheritance is handled separately by the resolution ladder's parent-chain step, not by the merge model.) Setting `workspace_dir: null` or omitting the field both leave the project with no declared workspace.
 
@@ -194,7 +239,7 @@ libraries_dir:
   default: "./libraries"
 ```
 
-A relative path resolves against the directory of *this* project's YAML file — the same rule `parent_project_path` and `workspace_dir` use — so a relative value travels with the project across machines. The raw value is stored verbatim and only resolved to an absolute path at resolution time; it is never absolutized on save. For the per-platform form, the engine picks the entry matching the current platform, falling back to `default`.
+A relative path resolves against the directory of *this* project's YAML file — the same rule `parent_project_path` and `workspace_dir` use — so a relative value travels with the project across machines. `~` and environment variables are expanded (see [Path values](#path-values-in-workspace_dir-libraries_dir-and-parent_project_path)). The raw value is stored verbatim and only resolved to an absolute path at resolution time; it is never absolutized on save. For the per-platform form, the engine picks the entry matching the current platform, falling back to `default`; with neither present the project does not load on that platform (see [A path that cannot be resolved is an error](#a-path-that-cannot-be-resolved-is-an-error)).
 
 ### Inheritance and resolution
 
@@ -207,6 +252,12 @@ A relative path resolves against the directory of *this* project's YAML file —
 This is the **key difference from `workspace_dir`**: `workspace_dir` is never inherited from a parent, but `libraries_dir` **is**. A child that declares no `libraries_dir` of its own adopts the nearest ancestor that declares one (only an *explicit* value is inheritable — a parent that leaves the field unset contributes nothing, and the walk continues past it). This is why the creation UI writes `libraries_dir: "./libraries"` into a **top-level** project (whose parent is the system defaults) but leaves it unset on a child: the top-level project declares an explicit, inheritable library root, and each child under it shares that root by default. A child can still declare its own `libraries_dir` to opt out, or set `libraries_dir: null` to tombstone an inherited value and fall back to the workspace-relative default.
 
 Like `workspace_dir`, `libraries_dir` is **not merge-inherited**: it is taken from this project's overlay alone and a child does not pick up the base's value through the [merge model](#the-merge-model). Cross-project inheritance is handled by the resolution order above (the parent-chain walk), not by merge.
+
+### Seeing where the paths ended up
+
+Because the answer can come from any of the three places above, you do not have to work it out yourself. `ListProjectTemplatesRequest` reports each project's effective `workspace_dir` and `libraries_root` as absolute paths, resolved exactly the way activating the project resolves them — including inheritance from a parent, so a parent and its children show the same libraries root.
+
+Both are reported for every project that loaded from a file, and are `null` only for an entry with no backing project file (the system defaults) or one that failed to load. They are never `null` because resolution gave up: a project whose declared paths cannot be resolved does not load at all.
 
 ## Validation status
 

--- a/src/griptape_nodes/common/project_templates/__init__.py
+++ b/src/griptape_nodes/common/project_templates/__init__.py
@@ -7,7 +7,11 @@ from griptape_nodes.common.project_templates.default_project_template import (
     default_template_for_version,
     schema_major_or_none,
 )
-from griptape_nodes.common.project_templates.directory import DirectoryDefinition, PerPlatformPathMacro
+from griptape_nodes.common.project_templates.directory import (
+    DirectoryDefinition,
+    PerPlatformPathMacro,
+    describe_active_platform,
+)
 from griptape_nodes.common.project_templates.loader import (
     ProjectOverlayData,
     YAMLLineInfo,
@@ -63,6 +67,7 @@ __all__ = [
     "YAMLLineInfo",
     "YAMLParseResult",
     "default_template_for_version",
+    "describe_active_platform",
     "load_partial_project_template",
     "load_project_template_from_yaml",
     "load_yaml_with_line_tracking",

--- a/src/griptape_nodes/common/project_templates/__init__.py
+++ b/src/griptape_nodes/common/project_templates/__init__.py
@@ -8,9 +8,10 @@ from griptape_nodes.common.project_templates.default_project_template import (
     schema_major_or_none,
 )
 from griptape_nodes.common.project_templates.directory import (
+    ActivePlatform,
     DirectoryDefinition,
     PerPlatformPathMacro,
-    describe_active_platform,
+    active_platform,
 )
 from griptape_nodes.common.project_templates.loader import (
     ProjectOverlayData,
@@ -47,6 +48,7 @@ __all__ = [
     "DEFAULT_PROJECT_TEMPLATE",
     "DEFAULT_PROJECT_TEMPLATE_V0",
     "DEFAULT_PROJECT_TEMPLATE_V1",
+    "ActivePlatform",
     "DirectoryDefinition",
     "PerPlatformPathMacro",
     "PerPlatformProjectPath",
@@ -66,8 +68,8 @@ __all__ = [
     "SituationTemplate",
     "YAMLLineInfo",
     "YAMLParseResult",
+    "active_platform",
     "default_template_for_version",
-    "describe_active_platform",
     "load_partial_project_template",
     "load_project_template_from_yaml",
     "load_yaml_with_line_tracking",

--- a/src/griptape_nodes/common/project_templates/__init__.py
+++ b/src/griptape_nodes/common/project_templates/__init__.py
@@ -17,7 +17,12 @@ from griptape_nodes.common.project_templates.loader import (
     load_yaml_with_line_tracking,
 )
 from griptape_nodes.common.project_templates.project import ProjectTemplate
-from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath, select_project_path
+from griptape_nodes.common.project_templates.project_path import (
+    PerPlatformProjectPath,
+    ResolvedProjectPath,
+    resolve_project_path_field,
+    select_project_path,
+)
 from griptape_nodes.common.project_templates.situation import (
     SituationFilePolicy,
     SituationPolicy,
@@ -51,6 +56,7 @@ __all__ = [
     "ProjectValidationProblemSeverity",
     "ProjectValidationStatus",
     "ProjectVariableDef",
+    "ResolvedProjectPath",
     "SituationFilePolicy",
     "SituationPolicy",
     "SituationTemplate",
@@ -60,6 +66,7 @@ __all__ = [
     "load_partial_project_template",
     "load_project_template_from_yaml",
     "load_yaml_with_line_tracking",
+    "resolve_project_path_field",
     "schema_major_or_none",
     "select_project_path",
 ]

--- a/src/griptape_nodes/common/project_templates/directory.py
+++ b/src/griptape_nodes/common/project_templates/directory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, NamedTuple, Self
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
@@ -41,7 +41,7 @@ class PerPlatformPathBase(BaseModel):
 
     def select(self) -> str | None:
         """Return the value for the active platform, falling back to `default`."""
-        active = _active_platform_key()
+        active = active_platform_key()
         if active == "linux" and self.linux is not None:
             return self.linux
         if active == "darwin" and self.darwin is not None:
@@ -55,8 +55,14 @@ class PerPlatformPathMacro(PerPlatformPathBase):
     """Per-platform path macro mapping for directory definitions."""
 
 
-def _active_platform_key() -> str:
-    """Map sys.platform to one of the per-platform mapping keys."""
+def active_platform_key() -> str:
+    """Map sys.platform to one of the per-platform mapping keys, or `""` if it has none.
+
+    An empty return is not an error -- it means this platform cannot be named in a per-platform
+    mapping at all, because `PerPlatformPathBase` forbids keys outside `linux`/`darwin`/`windows`.
+    `select()` reads it as "go straight to `default`", and callers phrasing an error should read it as
+    "`default` is the only remedy available here".
+    """
     if sys.platform.startswith("win"):
         return "windows"
     if sys.platform.startswith("darwin"):
@@ -66,18 +72,39 @@ def _active_platform_key() -> str:
     return ""
 
 
-def describe_active_platform() -> str:
-    """Name the active platform the way a `select()`-failed message should name it.
+class ActivePlatform(NamedTuple):
+    """The active platform as a `select()`-failed message needs to talk about it.
 
-    `sys.platform` is the wrong string to show someone who has to act on the message: it says
-    `win32`, while the key they need to add to their YAML is `windows`. Report the mapping key
-    instead, so "no path for this platform (windows)" names something that appears in the file.
+    Both fields come from one `active_platform_key()` call on purpose. A message has to name the
+    platform *and* propose a fix, and those two halves are only consistent if they agree on which
+    platform is active -- naming `windows` while suggesting the remedy for a keyless platform is
+    worse than either mistake alone.
 
-    Falls back to `sys.platform` only on a platform `_active_platform_key` has no key for, where the
-    raw name is the honest answer -- no per-platform entry can match it, so `default` is the only fix
-    and naming a key would imply one exists.
+    Attributes:
+        key: The mapping key for this platform, or `""` if it has none.
+        display: How to name this platform to a user who has to edit the YAML.
     """
-    return _active_platform_key() or sys.platform
+
+    key: str
+    display: str
+
+
+def active_platform() -> ActivePlatform:
+    """Describe the active platform for a message a user has to act on.
+
+    `sys.platform` is the wrong string to show them: it says `win32`, while the key they need to add
+    to their YAML is `windows`. Report the mapping key instead, so "no path for this platform
+    (windows)" names something that can appear in the file.
+
+    On a platform with no key, `sys.platform` would be worse than useless rather than merely
+    imprecise: `extra="forbid"` rejects any key that is not `linux`/`darwin`/`windows`, so naming
+    `freebsd13` points at a fix that fails validation. Say it is unsupported and keep the raw name
+    only as parenthetical detail, which is still what someone would quote in a bug report.
+    """
+    key = active_platform_key()
+    if key:
+        return ActivePlatform(key=key, display=key)
+    return ActivePlatform(key="", display=f"unsupported ({sys.platform})")
 
 
 class DirectoryDefinition(BaseModel):

--- a/src/griptape_nodes/common/project_templates/directory.py
+++ b/src/griptape_nodes/common/project_templates/directory.py
@@ -66,6 +66,20 @@ def _active_platform_key() -> str:
     return ""
 
 
+def describe_active_platform() -> str:
+    """Name the active platform the way a `select()`-failed message should name it.
+
+    `sys.platform` is the wrong string to show someone who has to act on the message: it says
+    `win32`, while the key they need to add to their YAML is `windows`. Report the mapping key
+    instead, so "no path for this platform (windows)" names something that appears in the file.
+
+    Falls back to `sys.platform` only on a platform `_active_platform_key` has no key for, where the
+    raw name is the honest answer -- no per-platform entry can match it, so `default` is the only fix
+    and naming a key would imply one exists.
+    """
+    return _active_platform_key() or sys.platform
+
+
 class DirectoryDefinition(BaseModel):
     """Definition of a logical directory in the project."""
 

--- a/src/griptape_nodes/common/project_templates/loader.py
+++ b/src/griptape_nodes/common/project_templates/loader.py
@@ -147,8 +147,10 @@ def load_yaml_with_line_tracking(yaml_text: str) -> YAMLParseResult:
             obj: CommentedMap or CommentedSeq from ruamel.yaml (has lc attribute)
             path: Current field path for tracking
 
-        Note: Only CommentedMap/CommentedSeq objects have line tracking.
-        Plain dicts/lists and scalars don't have lc attributes.
+        Note: Only CommentedMap/CommentedSeq objects have their own `lc`. A scalar value
+        has none, so its line comes from its KEY's position in the parent map -- without
+        that, a plain `libraries_dir: "..."` line could never be pointed at, and most
+        fields in a project file are scalars.
         """
         # Track line number for this object
         line = obj.lc.line + 1  # Convert to 1-indexed
@@ -160,6 +162,8 @@ def load_yaml_with_line_tracking(yaml_text: str) -> YAMLParseResult:
                 child_path = f"{path}.{key}" if path else key
                 if isinstance(value, CommentedMap | CommentedSeq):
                     track_lines(value, child_path)
+                else:
+                    _track_scalar_key_line(obj, key, child_path, line_info)
         elif isinstance(obj, CommentedSeq):
             for i, item in enumerate(obj):
                 child_path = f"{path}[{i}]"
@@ -171,6 +175,19 @@ def load_yaml_with_line_tracking(yaml_text: str) -> YAMLParseResult:
         track_lines(data, "")
 
     return YAMLParseResult(data=data, line_info=line_info)
+
+
+def _track_scalar_key_line(parent: CommentedMap, key: Any, field_path: str, line_info: YAMLLineInfo) -> None:
+    """Record the line of a scalar entry from its key's position in the parent mapping.
+
+    ruamel stores key positions on the parent's `lc.data`, which is populated for anything it
+    parsed but absent on a CommentedMap built in memory. An untracked key is simply left
+    unrecorded -- callers already treat a missing line as "no line to point at".
+    """
+    key_positions = parent.lc.data
+    if key_positions is None or key not in key_positions:
+        return
+    line_info.add_mapping(field_path, key_positions[key][0] + 1)
 
 
 def _inject_names_from_keys(data: dict[str, Any], section_field: str) -> None:

--- a/src/griptape_nodes/common/project_templates/project_path.py
+++ b/src/griptape_nodes/common/project_templates/project_path.py
@@ -83,14 +83,23 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
 
     The supported contract for these fields, in order of application:
 
-    1. `~` and PROCESS/SHELL environment variables (`${NAME}`, `%NAME%` on Windows) are expanded,
-       repeatedly, until the value stops changing -- a variable's value may itself contain a
-       reference (`LIBS=${ROOT}/libs`), which a single pass would leave half-expanded.
+    1. `~` and PROCESS/SHELL environment variables are expanded, repeatedly, until the value stops
+       changing -- a variable's value may itself contain a reference (`LIBS=${ROOT}/libs`), which a
+       single pass would leave half-expanded. The accepted forms are `os.path.expandvars`'s: `$NAME`
+       and `${NAME}` everywhere, plus `%NAME%` on Windows. A bare `$NAME` IS expanded like the rest;
+       what makes it different is only that an UNEXPANDED one is not reported as missing (see
+       `unexpanded_references`), because `$Recycle.Bin` cannot be told apart from a real directory.
        The environment is the one the engine was launched with -- deliberately NOT the project's own
        `environment:` block, which activation applies only AFTER these fields resolve
        (`ProjectManager._activate_project` restores the outgoing project's env, resolves workspace
        and libraries, and only then calls `_apply_project_env`). Honoring a project's own
        `environment:` here would make a field's meaning depend on which project happens to be open.
+       That guarantee covers the project being ACTIVATED, not every caller: a project validated or
+       registered while some OTHER project is active is read against that project's applied
+       `environment:`, since `_apply_project_env` mutates `os.environ` process-wide until the
+       active project is swapped out. A value that depends on a variable only that other project
+       sets can therefore pass validation and later fail to resolve -- the window is spelled out on
+       `ProjectManager._resolve_template_path_field`.
     2. A path still relative AFTER expansion is anchored to `anchor_dir` (the directory of the YAML
        that DECLARED it), so a relative value travels with the project across machines.
     3. The result is canonicalized for identity so two spellings of one directory compare equal.
@@ -106,9 +115,11 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
     the path built from it resolved perfectly well.
 
     `{NAME}` macro tokens are NOT supported here (the macro system resolves `directories:`
-    `path_macro` fields and node parameters, never these). They are reported rather than silently
-    becoming a directory named `{NAME}`. What counts as an unresolved reference at all is decided by
-    `unexpanded_references`, which also explains why a bare `$NAME` is left as a literal.
+    `path_macro` fields and node parameters, never these). The dependency runs the wrong way for it:
+    building the macro resolution bag needs `workspace_dir` and the project's directories, which are
+    among the values these fields produce. They are reported rather than silently becoming a directory
+    named `{NAME}`. What counts as an unresolved reference at all is decided by
+    `unexpanded_references`, which also explains which forms go unreported when they do not expand.
 
     Args:
         selected: The declared value, already reduced to one string via `select_project_path`.

--- a/src/griptape_nodes/common/project_templates/project_path.py
+++ b/src/griptape_nodes/common/project_templates/project_path.py
@@ -2,7 +2,21 @@
 
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING, NamedTuple
+
 from griptape_nodes.common.project_templates.directory import PerPlatformPathBase
+from griptape_nodes.files.path_utils import (
+    canonicalize_for_identity,
+    expand_path,
+    sanitize_path_string,
+    unexpanded_references,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger("griptape_nodes")
 
 
 class PerPlatformProjectPath(PerPlatformPathBase):
@@ -34,3 +48,95 @@ def select_project_path(value: str | PerPlatformProjectPath | None) -> str | Non
     if isinstance(value, str):
         return value
     return value.select()
+
+
+class ResolvedProjectPath(NamedTuple):
+    """Outcome of resolving a declared project path field to an absolute path.
+
+    Exactly one of these states holds:
+    - `path` is set and both lists are empty: the field resolved.
+    - `path` is None and at least one list is non-empty: the field declares a variable nothing
+      supplied a value for, so there IS no answer. Callers must report this rather than substitute a
+      guess -- a wrong path labelled "declared" is worse for users than an honest "unknown".
+
+    Attributes:
+        path: Canonical absolute path, or None when unresolved references remain.
+        unresolved_variables: Names from `${NAME}` / `%NAME%` references that expanded to nothing.
+        macro_tokens: Names from `{NAME}` macro tokens, which these fields do not support.
+        needs_anchor: True when the value is relative but no `anchor_dir` was available to
+            resolve it against. Distinguishes "cannot be placed" from "declares a bad variable".
+    """
+
+    path: Path | None
+    unresolved_variables: list[str]
+    macro_tokens: list[str]
+    needs_anchor: bool = False
+
+
+def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> ResolvedProjectPath:
+    """Resolve a declared project path field (`workspace_dir`, `libraries_dir`, `parent_project_path`).
+
+    The supported contract for these fields, in order of application:
+
+    1. `~` and PROCESS/SHELL environment variables (`${NAME}`, `%NAME%` on Windows) are expanded.
+       The environment is the one the engine was launched with -- deliberately NOT the project's own
+       `environment:` block, which activation applies only AFTER these fields resolve
+       (`ProjectManager._activate_project` restores the outgoing project's env, resolves workspace
+       and libraries, and only then calls `_apply_project_env`). Honoring a project's own
+       `environment:` here would make a field's meaning depend on which project happens to be open.
+    2. A path still relative AFTER expansion is anchored to `anchor_dir` (the directory of the YAML
+       that DECLARED it), so a relative value travels with the project across machines.
+    3. The result is canonicalized for identity so two spellings of one directory compare equal.
+
+    Expansion must precede the relative/absolute decision: `Path("${LIBS}/x").is_absolute()` is
+    False, so testing absoluteness first would anchor an absolute env-var value under `anchor_dir`
+    and -- when the variable is unset -- bake a literal `${LIBS}` directory into the result.
+
+    `{NAME}` macro tokens are NOT supported here (the macro system resolves `directories:`
+    `path_macro` fields and node parameters, never these). They are reported rather than silently
+    becoming a directory named `{NAME}`. What counts as an unresolved reference at all is decided by
+    `unexpanded_references`, which also explains why a bare `$NAME` is left as a literal.
+
+    Args:
+        selected: The declared value, already reduced to one string via `select_project_path`.
+        anchor_dir: Directory of the project YAML that declared the field. None when the caller has
+            no anchor available, in which case a value that is still relative after expansion
+            cannot be placed and comes back as `needs_anchor`.
+
+    Returns:
+        A `ResolvedProjectPath`; check `path is None` before using it.
+    """
+    sanitized = sanitize_path_string(selected)
+    expanded = expand_path(sanitized)
+
+    # Anything still delimited after expansion means the value has no answer yet. Macro tokens count
+    # because they are not part of this contract: reporting one lets the caller say so instead of
+    # creating a directory literally named `{outputs}`.
+    leftover = unexpanded_references(expanded)
+    if leftover.variables or leftover.macro_tokens:
+        logger.debug(
+            "Project path field %r could not be resolved: unresolved variables %s, macro tokens %s",
+            selected,
+            leftover.variables,
+            leftover.macro_tokens,
+        )
+        return ResolvedProjectPath(
+            path=None,
+            unresolved_variables=leftover.variables,
+            macro_tokens=leftover.macro_tokens,
+        )
+
+    if anchor_dir is None and not expanded.is_absolute():
+        logger.debug("Project path field %r is relative and no anchor directory was available", selected)
+        return ResolvedProjectPath(
+            path=None,
+            unresolved_variables=[],
+            macro_tokens=[],
+            needs_anchor=True,
+        )
+
+    return ResolvedProjectPath(
+        path=canonicalize_for_identity(expanded, base=anchor_dir),
+        unresolved_variables=[],
+        macro_tokens=[],
+    )

--- a/src/griptape_nodes/common/project_templates/project_path.py
+++ b/src/griptape_nodes/common/project_templates/project_path.py
@@ -10,6 +10,7 @@ from griptape_nodes.common.project_templates.directory import PerPlatformPathBas
 from griptape_nodes.files.path_utils import (
     canonicalize_expanded_for_identity,
     expand_path_fully,
+    expansion_introduced_quoting,
     sanitize_path_string,
     unexpanded_references,
 )
@@ -60,6 +61,9 @@ class ResolvedProjectPath(NamedTuple):
     - `path` is None and `reference_cycle` is set: the value's references expand into each other, so
       no amount of expansion finishes. The lists are empty because no single variable is at fault --
       every variable involved IS set, and naming one of them as missing would be a lie.
+    - `path` is None and `quoted_expansion` is set: a variable's value carried quotes that expansion
+      moved into the middle of the path. The lists are empty for the same reason as a cycle -- every
+      variable IS set, the value they produced just is not usable as a path.
 
     Attributes:
         path: Canonical absolute path, or None when the field could not be resolved.
@@ -69,6 +73,8 @@ class ResolvedProjectPath(NamedTuple):
             resolve it against. Distinguishes "cannot be placed" from "declares a bad variable".
         reference_cycle: True when expansion never reached a fixed point, i.e. the variables refer
             to each other in a cycle.
+        quoted_expansion: True when expansion introduced quote characters the author did not write,
+            per `expansion_introduced_quoting`.
     """
 
     path: Path | None
@@ -76,6 +82,7 @@ class ResolvedProjectPath(NamedTuple):
     macro_tokens: list[str]
     needs_anchor: bool = False
     reference_cycle: bool = False
+    quoted_expansion: bool = False
 
 
 def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> ResolvedProjectPath:
@@ -114,6 +121,11 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
     whose expansion yields another reference would be refused as declaring an unset variable while
     the path built from it resolved perfectly well.
 
+    Quoting that arrives WITH a variable's value is refused rather than cleaned, because by then it
+    cannot be told from a directory name; `expansion_introduced_quoting` draws that line. Quoting the
+    author wrote is still cleaned, which is why the declared text is sanitized before expansion and
+    the result sanitized again after.
+
     `{NAME}` macro tokens are NOT supported here (the macro system resolves `directories:`
     `path_macro` fields and node parameters, never these). The dependency runs the wrong way for it:
     building the macro resolution bag needs `workspace_dir` and the project's directories, which are
@@ -145,7 +157,10 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
     # Sanitized a second time because an expanded variable can carry its own quotes or a stray
     # newline, and this is the last point they can be cleaned. It happens HERE rather than inside the
     # canonicalize call so the value being validated below is the value that gets returned.
-    expanded = Path(sanitize_path_string(fully_expanded.path))
+    # Kept as a string as well: the quoting check below compares character-for-character against the
+    # declared text, and a `Path` round-trip rewrites separators before that comparison can be made.
+    sanitized_expanded = sanitize_path_string(fully_expanded.path)
+    expanded = Path(sanitized_expanded)
 
     # Anything still delimited after expansion means the value has no answer yet. Macro tokens count
     # because they are not part of this contract: reporting one lets the caller say so instead of
@@ -162,6 +177,23 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
             path=None,
             unresolved_variables=leftover.variables,
             macro_tokens=leftover.macro_tokens,
+        )
+
+    # A variable that supplied only part of the path can leave its own quotes stranded in the
+    # interior, where the sanitize above cannot see them. Refuse rather than guess: a leading quote
+    # makes the value look relative, which would anchor an absolute path under `anchor_dir` and
+    # report success while installing somewhere the project never named.
+    if expansion_introduced_quoting(sanitized, sanitized_expanded):
+        logger.debug(
+            "Project path field %r expanded to %r, which quoting made unusable as a path",
+            selected,
+            sanitized_expanded,
+        )
+        return ResolvedProjectPath(
+            path=None,
+            unresolved_variables=[],
+            macro_tokens=[],
+            quoted_expansion=True,
         )
 
     if anchor_dir is None and not expanded.is_absolute():

--- a/src/griptape_nodes/common/project_templates/project_path.py
+++ b/src/griptape_nodes/common/project_templates/project_path.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, NamedTuple
+from pathlib import Path
+from typing import NamedTuple
 
 from griptape_nodes.common.project_templates.directory import PerPlatformPathBase
 from griptape_nodes.files.path_utils import (
-    canonicalize_for_identity,
-    expand_path,
+    canonicalize_expanded_for_identity,
+    expand_path_fully,
     sanitize_path_string,
     unexpanded_references,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -54,23 +52,30 @@ class ResolvedProjectPath(NamedTuple):
     """Outcome of resolving a declared project path field to an absolute path.
 
     Exactly one of these states holds:
-    - `path` is set and both lists are empty: the field resolved.
+    - `path` is set, both lists are empty, and neither flag is set: the field resolved.
     - `path` is None and at least one list is non-empty: the field declares a variable nothing
       supplied a value for, so there IS no answer. Callers must report this rather than substitute a
       guess -- a wrong path labelled "declared" is worse for users than an honest "unknown".
+    - `path` is None and `needs_anchor` is set: the value is relative and there was nowhere to put it.
+    - `path` is None and `reference_cycle` is set: the value's references expand into each other, so
+      no amount of expansion finishes. The lists are empty because no single variable is at fault --
+      every variable involved IS set, and naming one of them as missing would be a lie.
 
     Attributes:
-        path: Canonical absolute path, or None when unresolved references remain.
+        path: Canonical absolute path, or None when the field could not be resolved.
         unresolved_variables: Names from `${NAME}` / `%NAME%` references that expanded to nothing.
         macro_tokens: Names from `{NAME}` macro tokens, which these fields do not support.
         needs_anchor: True when the value is relative but no `anchor_dir` was available to
             resolve it against. Distinguishes "cannot be placed" from "declares a bad variable".
+        reference_cycle: True when expansion never reached a fixed point, i.e. the variables refer
+            to each other in a cycle.
     """
 
     path: Path | None
     unresolved_variables: list[str]
     macro_tokens: list[str]
     needs_anchor: bool = False
+    reference_cycle: bool = False
 
 
 def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> ResolvedProjectPath:
@@ -78,7 +83,9 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
 
     The supported contract for these fields, in order of application:
 
-    1. `~` and PROCESS/SHELL environment variables (`${NAME}`, `%NAME%` on Windows) are expanded.
+    1. `~` and PROCESS/SHELL environment variables (`${NAME}`, `%NAME%` on Windows) are expanded,
+       repeatedly, until the value stops changing -- a variable's value may itself contain a
+       reference (`LIBS=${ROOT}/libs`), which a single pass would leave half-expanded.
        The environment is the one the engine was launched with -- deliberately NOT the project's own
        `environment:` block, which activation applies only AFTER these fields resolve
        (`ProjectManager._activate_project` restores the outgoing project's env, resolves workspace
@@ -91,6 +98,12 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
     Expansion must precede the relative/absolute decision: `Path("${LIBS}/x").is_absolute()` is
     False, so testing absoluteness first would anchor an absolute env-var value under `anchor_dir`
     and -- when the variable is unset -- bake a literal `${LIBS}` directory into the result.
+
+    The string this validates is the string it returns. Nothing below re-expands (hence
+    `canonicalize_expanded_for_identity` rather than `canonicalize_for_identity`), because a second
+    expansion would make the reported reason describe a value the caller never receives: a field
+    whose expansion yields another reference would be refused as declaring an unset variable while
+    the path built from it resolved perfectly well.
 
     `{NAME}` macro tokens are NOT supported here (the macro system resolves `directories:`
     `path_macro` fields and node parameters, never these). They are reported rather than silently
@@ -107,7 +120,21 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
         A `ResolvedProjectPath`; check `path is None` before using it.
     """
     sanitized = sanitize_path_string(selected)
-    expanded = expand_path(sanitized)
+    fully_expanded = expand_path_fully(sanitized)
+
+    if not fully_expanded.stabilized:
+        logger.debug("Project path field %r never stopped expanding; its references cycle", selected)
+        return ResolvedProjectPath(
+            path=None,
+            unresolved_variables=[],
+            macro_tokens=[],
+            reference_cycle=True,
+        )
+
+    # Sanitized a second time because an expanded variable can carry its own quotes or a stray
+    # newline, and this is the last point they can be cleaned. It happens HERE rather than inside the
+    # canonicalize call so the value being validated below is the value that gets returned.
+    expanded = Path(sanitize_path_string(fully_expanded.path))
 
     # Anything still delimited after expansion means the value has no answer yet. Macro tokens count
     # because they are not part of this contract: reporting one lets the caller say so instead of
@@ -136,7 +163,7 @@ def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> Resolv
         )
 
     return ResolvedProjectPath(
-        path=canonicalize_for_identity(expanded, base=anchor_dir),
+        path=canonicalize_expanded_for_identity(expanded, base=anchor_dir),
         unresolved_variables=[],
         macro_tokens=[],
     )

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -312,6 +312,9 @@ def sanitize_path_string(path: str | Path) -> str:
     return path_str
 
 
+_QUOTE_CHARACTERS = ("'", '"')
+
+
 def strip_surrounding_quotes(path: str) -> str:
     """Remove surrounding quotes from path string.
 
@@ -324,6 +327,44 @@ def strip_surrounding_quotes(path: str) -> str:
     if (path.startswith('"') and path.endswith('"')) or (path.startswith("'") and path.endswith("'")):
         return path[1:-1]
     return path
+
+
+def expansion_introduced_quoting(declared: str, expanded: str) -> bool:
+    """Report whether variable expansion put quoting into a path that the author did not write.
+
+    `strip_surrounding_quotes` only sees quotes wrapping the WHOLE string, which is the shape a
+    quoted value has before expansion. Once a variable supplies only a PREFIX, its own quotes move
+    into the interior -- `ROOT='"/mnt/studio"'` turns `${ROOT}/libs` into `"/mnt/studio"/libs`, where
+    there is nothing left to strip. The damage is not cosmetic: a leading quote makes
+    `Path.is_absolute()` False, so an absolute path silently becomes a relative one and gets anchored
+    somewhere the author never named.
+
+    Refusing beats cleaning, because an interior quote is ambiguous by then and the wrong guess is
+    silent. Two rules keep the refusal from swallowing real directory names:
+
+    - A `"` that expansion introduced is always quoting. Windows forbids it in a filename outright,
+      and it is the character shells and macOS Finder wrap paths in, so it did not come from a
+      directory called `He said "hi"`.
+    - A quote of either kind is refused only in the LEADING position, which is the one that flips
+      `is_absolute()`. An interior `'` is left alone: `/mnt/Dragon's Curse` is an ordinary directory
+      that a variable may legitimately hold, and `sanitize_path_string` documents apostrophes as a
+      supported case.
+
+    The DECLARED text is exempt from both rules. A quote someone typed into their own project.yml is
+    unambiguously theirs, and honoring it is what makes the refusal specific to expansion.
+
+    Args:
+        declared: The value as authored, after `sanitize_path_string` but BEFORE expansion.
+        expanded: The fully expanded value, after `sanitize_path_string` has run on it again. Pass
+            the settled value, not a single pass: a quote can arrive on any pass of
+            `expand_path_fully`, and a check placed before the fixed point misses the later ones.
+
+    Returns:
+        True when the caller should refuse the value rather than resolve it.
+    """
+    if expanded.count('"') > declared.count('"'):
+        return True
+    return expanded.startswith(_QUOTE_CHARACTERS) and not declared.startswith(_QUOTE_CHARACTERS)
 
 
 def normalize_path_for_platform(path: Path) -> str:

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -489,12 +489,21 @@ def unexpanded_references(path: str | Path) -> UnexpandedReferences:
     caller's rule (they are not legal in project path fields; see `resolve_project_path_field`), and
     whether an unsupplied variable is fatal depends on the caller too.
 
-    Two deliberate limits:
-    - A bare `$NAME` is NOT reported. `os.path.expandvars` accepts that form, but an unexpanded
-      `$Recycle.Bin` is indistinguishable from a real directory of that name, so it stays literal.
-      Only `${NAME}` and `%NAME%` are unambiguous enough to call out.
+    Three deliberate limits:
+    - A bare `$NAME` is NOT reported. `os.path.expandvars` accepts that form -- a set `$NAME` does
+      expand -- but an unexpanded `$Recycle.Bin` is indistinguishable from a real directory of that
+      name, so an unexpanded one stays literal. Only `${NAME}` and `%NAME%` are unambiguous enough to
+      call out.
     - `%NAME%` is only expanded by `os.path.expandvars` on Windows, so on other platforms it is
       reported even when the variable IS set. That is the honest answer: the value did not expand.
+      The cost is a POSIX path with two literal percent signs around a name-shaped run of characters
+      (`/srv/%share%/x`) being called out as unresolved. Requiring a leading letter or underscore
+      keeps the common encodings out of it -- `%20`, `%2F` and friends do not match -- which leaves
+      the false positive rare enough to prefer over silently creating a `%NAME%` directory on the one
+      platform where a cross-platform project.yml would not have expanded it.
+    - A variable that is SET BUT EMPTY cannot be reported. It expands to nothing and leaves no
+      delimiters behind, so by the time a value reaches here `${EMPTY}/libs` and `/libs` are the same
+      string. Callers that care must compare against the pre-expansion value themselves.
 
     Args:
         path: The already-expanded path (or any string) to scan.

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -40,6 +40,19 @@ _WINDOWS_UNC_PATTERN = re.compile(_WINDOWS_UNC_MATCH_PATTERN)
 _MACOS_VOLUME_PATTERN = re.compile(_MACOS_VOLUME_MATCH_PATTERN)
 _LINUX_MOUNT_PATTERN = re.compile(_LINUX_MOUNT_MATCH_PATTERN)
 
+# Brace/percent-delimited references that survive `expand_path` because nothing supplied a value.
+# Only the unambiguously DELIMITED env forms are matched: a bare `$NAME` is indistinguishable from a
+# real directory name (`$Recycle.Bin`), so it stays literal. See `unexpanded_references`.
+_UNEXPANDED_ENV_BRACED_MATCH_PATTERN = r"\$\{([^{}]+)\}"
+_UNEXPANDED_ENV_PERCENT_MATCH_PATTERN = r"%([A-Za-z_][A-Za-z0-9_]*)%"
+# A `{NAME}` macro reference, matched only when NOT preceded by `$` so that the `${NAME}` env form
+# above is not reported twice. The lookbehind is what couples these three patterns: they are one scan.
+_UNEXPANDED_MACRO_MATCH_PATTERN = r"(?<!\$)\{([^{}]+)\}"
+
+_UNEXPANDED_ENV_BRACED_PATTERN = re.compile(_UNEXPANDED_ENV_BRACED_MATCH_PATTERN)
+_UNEXPANDED_ENV_PERCENT_PATTERN = re.compile(_UNEXPANDED_ENV_PERCENT_MATCH_PATTERN)
+_UNEXPANDED_MACRO_PATTERN = re.compile(_UNEXPANDED_MACRO_MATCH_PATTERN)
+
 # Windows MAX_PATH limit. Retained for documentation/reference only: the historical
 # 260-char threshold at which the \\?\ prefix becomes strictly necessary. We no longer
 # gate on it -- _apply_windows_long_path_prefix applies the prefix unconditionally on
@@ -382,6 +395,52 @@ def path_needs_expansion(path_str: str) -> bool:
     is_absolute = Path(path_str).is_absolute()
     starts_with_tilde = path_str.startswith("~")
     return has_env_vars or is_absolute or starts_with_tilde
+
+
+class UnexpandedReferences(NamedTuple):
+    """Delimited references still present in a path after `expand_path` ran over it.
+
+    Attributes:
+        variables: Names from `${NAME}` / `%NAME%` references that expanded to nothing.
+        macro_tokens: Names from `{NAME}` tokens, which `expand_path` never touches.
+    """
+
+    variables: list[str]
+    macro_tokens: list[str]
+
+
+def unexpanded_references(path: str | Path) -> UnexpandedReferences:
+    """Report the delimited references an `expand_path` call left behind.
+
+    The counterpart to `path_needs_expansion`: that asks whether a raw value needs expanding, this
+    asks what expansion could not supply. Call it on `expand_path`'s OUTPUT. A caller that finds
+    anything here knows the path has no real answer yet and can name what is missing, instead of
+    treating `${LIBS}` or `{outputs}` as a directory name.
+
+    Reporting only, no policy: whether a `{NAME}` macro token is legal in a given field is the
+    caller's rule (they are not legal in project path fields; see `resolve_project_path_field`), and
+    whether an unsupplied variable is fatal depends on the caller too.
+
+    Two deliberate limits:
+    - A bare `$NAME` is NOT reported. `os.path.expandvars` accepts that form, but an unexpanded
+      `$Recycle.Bin` is indistinguishable from a real directory of that name, so it stays literal.
+      Only `${NAME}` and `%NAME%` are unambiguous enough to call out.
+    - `%NAME%` is only expanded by `os.path.expandvars` on Windows, so on other platforms it is
+      reported even when the variable IS set. That is the honest answer: the value did not expand.
+
+    Args:
+        path: The already-expanded path (or any string) to scan.
+
+    Returns:
+        An `UnexpandedReferences`; both lists empty means the value expanded fully.
+    """
+    path_str = str(path)
+    variables = [
+        *(match.group(1) for match in _UNEXPANDED_ENV_BRACED_PATTERN.finditer(path_str)),
+        *(match.group(1) for match in _UNEXPANDED_ENV_PERCENT_PATTERN.finditer(path_str)),
+    ]
+    macro_tokens = [match.group(1) for match in _UNEXPANDED_MACRO_PATTERN.finditer(path_str)]
+    return UnexpandedReferences(variables=variables, macro_tokens=macro_tokens)
 
 
 def resolve_path_safely(path: Path) -> Path:

--- a/src/griptape_nodes/files/path_utils.py
+++ b/src/griptape_nodes/files/path_utils.py
@@ -382,6 +382,70 @@ def expand_path(path_str: str) -> Path:
     return Path(expanded_user)
 
 
+class FullyExpandedPath(NamedTuple):
+    """Outcome of expanding a path string until it stops changing.
+
+    Attributes:
+        path: The expanded path.
+        stabilized: True when expansion reached a fixed point -- another pass would change nothing.
+            False means passes were still changing the value when the cap was reached, which in
+            practice means the references expand into each other in a cycle. Callers that report
+            WHY a value could not be resolved need this apart from "a variable is unset": for
+            `A=${B}` / `B=${A}` both variables ARE set, and naming either one as missing is wrong.
+    """
+
+    path: Path
+    stabilized: bool
+
+
+def expand_path_fully(path_str: str, *, max_passes: int = 8) -> FullyExpandedPath:
+    r"""Expand ~ and environment variables repeatedly until the value stops changing.
+
+    `expand_path` runs a single pass. That is right for a raw path, but a variable's VALUE can
+    itself contain a reference -- `LIBS=${ROOT}/libs` is an ordinary shape, and a `.env` read
+    without interpolation stores exactly that verbatim -- and one pass leaves the inner `${ROOT}`
+    behind.
+
+    Use this instead of `expand_path` whenever the expansion is going to be VALIDATED (see
+    `unexpanded_references`) and then used. Validating one pass and using another is how a
+    perfectly resolvable value gets reported as declaring an unset variable: the check sees
+    `${ROOT}`, while the path actually handed downstream has it filled in.
+
+    Expansion is looped over the string rather than a `Path` so intermediate values are not
+    renormalized (`/` to `\\` on Windows) between passes; the `Path` is built once at the end.
+
+    A self-referential value (`A=${A}`) is not a cycle here: `os.path.expandvars` leaves it alone,
+    so it stabilizes on the first pass and falls out as an ordinary unresolved reference. Only
+    mutual references exhaust `max_passes`.
+
+    Args:
+        path_str: Path string that may contain ~ or environment variables.
+        max_passes: Maximum expansion passes before giving up. The default is far above any real
+            reference chain; it exists to bound mutual references, not to limit depth.
+
+    Returns:
+        A `FullyExpandedPath`; check `stabilized` before trusting `path` to be fully expanded.
+
+    Examples:
+        # ROOT=/srv, LIBS=${ROOT}/libs
+        expand_path_fully("${LIBS}/griptape")
+        -> FullyExpandedPath(Path("/srv/libs/griptape"), stabilized=True)
+
+        # A=${B}, B=${A}
+        expand_path_fully("${A}/x")
+        -> FullyExpandedPath(..., stabilized=False)
+    """
+    current = path_str
+    stabilized = False
+    for _ in range(max_passes):
+        expanded = os.path.expanduser(os.path.expandvars(current))  # noqa: PTH111
+        if expanded == current:
+            stabilized = True
+            break
+        current = expanded
+    return FullyExpandedPath(path=Path(current), stabilized=stabilized)
+
+
 def path_needs_expansion(path_str: str) -> bool:
     """Return True if path contains env vars, is absolute, or starts with ~ (needs expand_path).
 
@@ -413,9 +477,13 @@ def unexpanded_references(path: str | Path) -> UnexpandedReferences:
     """Report the delimited references an `expand_path` call left behind.
 
     The counterpart to `path_needs_expansion`: that asks whether a raw value needs expanding, this
-    asks what expansion could not supply. Call it on `expand_path`'s OUTPUT. A caller that finds
-    anything here knows the path has no real answer yet and can name what is missing, instead of
-    treating `${LIBS}` or `{outputs}` as a directory name.
+    asks what expansion could not supply. A caller that finds anything here knows the path has no
+    real answer yet and can name what is missing, instead of treating `${LIBS}` or `{outputs}` as a
+    directory name.
+
+    Call it on `expand_path_fully`'s output, not `expand_path`'s: a single pass leaves the inner
+    reference of `LIBS=${ROOT}/libs` behind, so scanning it reports `ROOT` as unsupplied when it is
+    set and the value resolves fine.
 
     Reporting only, no policy: whether a `{NAME}` macro token is legal in a given field is the
     caller's rule (they are not legal in project path fields; see `resolve_project_path_field`), and
@@ -486,6 +554,41 @@ def resolve_path_safely(path: Path) -> Path:
     return Path(os.path.normpath(path))
 
 
+def _anchor_and_resolve(expanded: Path, base: Path | None) -> Path:
+    """Anchor a relative path to ``base`` (default CWD), then canonicalize it for identity.
+
+    The tail shared by ``canonicalize_for_identity`` and
+    ``canonicalize_expanded_for_identity``: the two differ only in whether they
+    sanitize and expand first, and must not drift in what they do afterwards.
+    """
+    if not expanded.is_absolute():
+        expanded = (base if base is not None else Path.cwd()) / expanded
+    return resolve_path_safely(expanded).resolve(strict=False)
+
+
+def canonicalize_expanded_for_identity(expanded: Path, *, base: Path | None = None) -> Path:
+    """Canonicalize an ALREADY-expanded path for identity, without expanding it again.
+
+    Identical to ``canonicalize_for_identity`` from the anchoring step onward; it
+    just does not sanitize or expand on the way in.
+
+    For callers that expanded the value themselves and must not have it expanded a
+    second time -- specifically, callers that VALIDATED their expansion. Handing a
+    validated string to ``canonicalize_for_identity`` would expand it again, so the
+    path returned is not the path that was checked: a value whose expansion yields
+    another reference gets reported as unresolvable while the path built from it
+    resolves fine. See ``resolve_project_path_field``.
+
+    Args:
+        expanded: A path whose ``~`` and environment variables are already expanded.
+        base: Base directory for relative paths. Defaults to ``Path.cwd()``.
+
+    Returns:
+        Canonical absolute Path.
+    """
+    return _anchor_and_resolve(expanded, base)
+
+
 def canonicalize_for_identity(path: str | Path, *, base: Path | None = None) -> Path:
     """Produce a stable path identity for use as a dict key, cache key, or ID.
 
@@ -506,11 +609,7 @@ def canonicalize_for_identity(path: str | Path, *, base: Path | None = None) -> 
     Returns:
         Canonical absolute Path.
     """
-    sanitized = sanitize_path_string(path)
-    expanded = expand_path(sanitized)
-    if not expanded.is_absolute():
-        expanded = (base if base is not None else Path.cwd()) / expanded
-    return resolve_path_safely(expanded).resolve(strict=False)
+    return _anchor_and_resolve(expand_path(sanitize_path_string(path)), base)
 
 
 def canonicalize_for_io(path: str | Path, *, base: Path | None = None) -> Path:

--- a/src/griptape_nodes/retained_mode/events/project_events.py
+++ b/src/griptape_nodes/retained_mode/events/project_events.py
@@ -227,6 +227,19 @@ class ProjectTemplateInfo:
         current_engine_version: The running engine version, for display.
         engine_version_reason: Human-readable detail explaining an incompatibility,
             None when compatible.
+        workspace_dir: Absolute path of the workspace this project activates with,
+            resolved through the same ladder activation uses (the project's own
+            `workspace_dir`, the `project_workspaces` mapping, an environment or
+            project-adjacent setting, inheritance from the parent chain, or the
+            global default). None ONLY when the entry is not file-backed (e.g. the
+            system defaults) or its template failed to load -- never because
+            resolution was attempted and gave up. A project whose declared path
+            fields cannot be resolved does not load at all; see `validation` for
+            the field and line at fault.
+        libraries_root: Absolute path where this project's libraries install and
+            resolve from -- its own `libraries_dir`, else the nearest ancestor that
+            declares one, else the workspace-relative `libraries_directory`
+            setting. None under the same conditions as `workspace_dir`.
     """
 
     project_id: ProjectID
@@ -238,6 +251,8 @@ class ProjectTemplateInfo:
     required_engine_version: str | None = None
     current_engine_version: str | None = None
     engine_version_reason: str | None = None
+    workspace_dir: str | None = None
+    libraries_root: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -52,7 +52,12 @@ from griptape_nodes.retained_mode.events.os_events import (
     WriteFileResultFailure,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.settings import WORKFLOWS_TO_REGISTER_KEY, Settings
+from griptape_nodes.retained_mode.managers.settings import (
+    DEFAULT_LIBRARIES_DIRECTORY,
+    LIBRARIES_DIRECTORY_KEY,
+    WORKFLOWS_TO_REGISTER_KEY,
+    Settings,
+)
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
 
 logger = logging.getLogger("griptape_nodes")
@@ -228,8 +233,38 @@ class ConfigManager(EngineScoped):
         """
         if self._libraries_root_override is not None:
             return Path(self._libraries_root_override)
-        libraries_dir = self.get_config_value("libraries_directory", default="libraries")
-        return resolve_workspace_path(Path(libraries_dir), self.configured_global_workspace_path())
+        return self.default_libraries_root(self.get_config_value(LIBRARIES_DIRECTORY_KEY))
+
+    def default_libraries_root(self, libraries_directory: str | None) -> Path:
+        """Resolve a workspace-relative libraries_directory value against the GLOBAL workspace.
+
+        The no-libraries_dir-declared fallback, factored out so every caller computes it the same
+        way: the live path above, the provisioning preview, and the offline resolver that reports
+        each project's effective libraries root on the project listing. Previously each open-coded
+        `resolve_workspace_path(Path(...), configured_global_workspace_path())`, which is exactly
+        the kind of duplication that lets a preview or a UI hint drift from what activation does.
+
+        The base is deliberately configured_global_workspace_path() -- the ENGINE's workspace,
+        excluding the runtime per-project override -- so this answer does NOT depend on which
+        project happens to be active. That is what makes it safe to compute for a project that is
+        not loaded. `libraries_directory` is the caller's business: it must come from the TARGET
+        project's config layers, not the merged view of whatever project is open.
+
+        A missing or empty value falls back to DEFAULT_LIBRARIES_DIRECTORY here rather than at each
+        call site: a caller that forgot its own default would otherwise hand us None and resolve the
+        libraries root to the workspace itself (`Path("")` is `Path(".")`), quietly installing
+        libraries on top of the user's workspace.
+
+        Args:
+            libraries_directory: The `libraries_directory` config value (absolute, or relative to
+                the global workspace). None or empty means "not configured".
+
+        Returns:
+            The absolute directory libraries install and resolve under.
+        """
+        if not isinstance(libraries_directory, str) or not libraries_directory:
+            libraries_directory = DEFAULT_LIBRARIES_DIRECTORY
+        return resolve_workspace_path(Path(libraries_directory), self.configured_global_workspace_path())
 
     def clear_project_layers(self) -> None:
         """Drop all per-activation config state so the next activation starts clean.

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -257,11 +257,18 @@ class ConfigManager(EngineScoped):
 
         Args:
             libraries_directory: The `libraries_directory` config value (absolute, or relative to
-                the global workspace). None or empty means "not configured".
+                the global workspace). Anything that is not a non-empty string means "not
+                configured" -- None and "" say so deliberately, and a non-string says it by
+                accident. The annotation names what callers SHOULD pass, not the full set of what
+                arrives: the value comes from user-editable config JSON, where nothing enforces the
+                type, so `get_config_value` can hand over an int or a list.
 
         Returns:
             The absolute directory libraries install and resolve under.
         """
+        # The isinstance half is load-bearing, not a redundant belt on the annotation: a config file
+        # with `"libraries_directory": 1` reaches here as an int, and Path(1) raises. Widening this
+        # to a string check alone would restore that crash.
         if not isinstance(libraries_directory, str) or not libraries_directory:
             libraries_directory = DEFAULT_LIBRARIES_DIRECTORY
         return resolve_workspace_path(Path(libraries_directory), self.configured_global_workspace_path())

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -231,6 +231,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
 from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 from griptape_nodes.retained_mode.managers.settings import (
+    LIBRARIES_DIRECTORY_KEY,
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
@@ -3647,10 +3648,7 @@ class LibraryManager(EngineScoped):
         if libraries_root is not None:
             libraries_path = libraries_root
         else:
-            libraries_path = resolve_workspace_path(
-                Path(get_dot_value(merged, "libraries_directory")),
-                config_mgr.configured_global_workspace_path(),
-            )
+            libraries_path = config_mgr.default_libraries_root(get_dot_value(merged, LIBRARIES_DIRECTORY_KEY))
 
         actions = await asyncio.gather(
             *(self._plan_one_library_provisioning(download, libraries_path) for download in downloads)

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -487,6 +487,24 @@ class AncestorValueLookup(NamedTuple):
     incomplete_reason: str | None
 
 
+class ParentLinkLookup(NamedTuple):
+    """Outcome of reducing a stored `parent_project_path` to a registry key.
+
+    Carries the reason alongside the miss because a `parent_project_path` can fail to resolve in
+    several distinct ways (an unset variable, a macro token, a relative value with nowhere to anchor,
+    a reference cycle) and the callers report that failure to a user. Collapsing them to a bare
+    `None` forces the caller to guess which one happened, and a guess printed as a diagnosis is worse
+    than no diagnosis.
+
+    Attributes:
+        path: Canonical path string usable as a registry key, or None when it could not be resolved.
+        reason: Artist-readable phrase describing the miss, or None when `path` is set.
+    """
+
+    path: str | None
+    reason: str | None
+
+
 class EffectiveProjectPaths(NamedTuple):
     """The two paths a project activates with, as reported on the project listing.
 
@@ -2294,12 +2312,15 @@ class ProjectManager(EngineScoped):
     def _describe_unresolved_path(resolution: ResolvedProjectPath) -> str:
         """Phrase why a declared path field could not be resolved, for logs and result_details.
 
-        Only ever called with a resolution whose `path` is None. In practice that always means an
-        unresolved variable or a macro token: every caller that could hand this a `needs_anchor`
-        resolution deals with that case before describing it, and `ResolvedProjectPath` guarantees an
-        unresolved result carries some reason. Both remaining branches are therefore defensive -- they
-        exist so a new failure mode reads as "could not resolve" instead of confidently naming the
-        wrong cause, which is exactly the class of bug this PR is about.
+        Only ever called with a resolution whose `path` is None. Every state `ResolvedProjectPath`
+        can be in gets its own phrasing, and each is reachable: callers anchored to a project's own
+        YAML see unresolved variables and macro tokens, `_resolve_parent_path_for_lookup` also
+        arrives here with `needs_anchor` (the validate handler is path-less, so a template not yet in
+        the registry has no directory of its own), and any of them can hit a reference cycle.
+
+        The empty-`reasons` fallback is the defensive one -- it exists so a state added to
+        `ResolvedProjectPath` later reads as "could not resolve" instead of confidently naming the
+        wrong cause, which is the class of bug this whole path is about.
         """
         reasons: list[str] = []
         if resolution.unresolved_variables:
@@ -2310,6 +2331,8 @@ class ProjectManager(EngineScoped):
             reasons.append(f"macro tokens are not supported in path fields: {names}")
         if resolution.needs_anchor:
             reasons.append("it is a relative path and the project's own directory was not available to place it in")
+        if resolution.reference_cycle:
+            reasons.append("its variable references expand into each other and never resolve")
         if not reasons:
             return "it could not be turned into a usable path"
         return "; ".join(reasons)
@@ -3081,10 +3104,11 @@ class ProjectManager(EngineScoped):
 
         selected_parent = select_project_path(template.parent_project_path)
         if selected_parent is not None:
-            parent_id = self._resolve_parent_path_for_lookup(selected_parent, anchor=project_path)
-            if parent_id is None:
-                msg = f"parent_project_path '{selected_parent}' is relative and no anchor could be resolved."
+            lookup = self._resolve_parent_path_for_lookup(selected_parent, anchor=project_path)
+            if lookup.path is None:
+                msg = f"parent_project_path '{selected_parent}' could not be resolved: {lookup.reason}"
                 raise ValueError(msg)
+            parent_id = lookup.path
             parent_info = self._successfully_loaded_project_templates.get(parent_id)
             if parent_info is None:
                 msg = (
@@ -3407,29 +3431,32 @@ class ProjectManager(EngineScoped):
         against `anchor` (canonicalized), and mapped to the parent's registered id;
         an unregistered legacy parent uses its canonical path string as its id
         (the legacy bridge). Returns None when there is no parent link, when a
-        per-platform path has no entry for this OS, or when a relative path has no
-        anchor to resolve against.
+        per-platform path has no entry for this OS, or when the path could not be
+        resolved -- `_resolve_parent_path_for_lookup` logs why in that last case,
+        including when `anchor` is None and the value is relative.
         """
         if template.parent_project_id is not None:
             return template.parent_project_id
         selected_parent = select_project_path(template.parent_project_path)
         if selected_parent is None:
             return None
-        resolved_path = self._resolve_parent_path_for_lookup(selected_parent, anchor)
-        if resolved_path is None:
+        lookup = self._resolve_parent_path_for_lookup(selected_parent, anchor)
+        if lookup.path is None:
             return None
-        return file_path_to_id.get(Path(resolved_path), resolved_path)
+        return file_path_to_id.get(Path(lookup.path), lookup.path)
 
-    def _resolve_parent_path_for_lookup(self, raw_parent: str, anchor: Path | str | None) -> str | None:
+    def _resolve_parent_path_for_lookup(self, raw_parent: str, anchor: Path | str | None) -> ParentLinkLookup:
         """Resolve a stored parent_project_path to a canonical registry key.
 
         Expands `~` and shell environment variables, then resolves a still-relative path against
         `anchor` (the containing template's file path), via the shared resolve_project_path_field so
-        this field agrees with workspace_dir / libraries_dir. Returns None when the path is relative
-        and no anchor was provided (we cannot form an absolute path without one), or when it declares
-        a variable nothing supplied a value for -- a link we cannot resolve is no link, and inventing
-        an anchor-relative path containing a literal `${NAME}` would silently break the parent chain
-        and every value that inherits along it.
+        this field agrees with workspace_dir / libraries_dir. A link that cannot be resolved is no
+        link: inventing an anchor-relative path containing a literal `${NAME}` would silently break
+        the parent chain and every value that inherits along it.
+
+        Every miss comes back with its reason and is logged here, including the relative-with-no-
+        anchor case -- `anchor` is legitimately None when validating a template that is not in the
+        registry yet, and a caller given a bare None cannot tell that apart from an unset variable.
 
         `anchor` is coerced to `Path` defensively because request payloads
         deserialized over the wire arrive with `project_path` as a `str`.
@@ -3440,18 +3467,19 @@ class ProjectManager(EngineScoped):
             anchor_dir = Path(anchor).parent
 
         resolution = resolve_project_path_field(raw_parent, anchor_dir)
-        if resolution.needs_anchor:
-            return None
         if resolution.path is None:
+            reason = self._describe_unresolved_path(resolution)
             logger.warning(
-                "Project '%s' declares parent_project_path as %r, which cannot be resolved (%s). "
+                "Project %s declares parent_project_path as %r, which cannot be resolved (%s). "
                 "Treating it as having no parent.",
-                anchor,
+                # A None anchor is the unregistered case, not a project literally named None: the
+                # validate handler is path-less, so a template it has never seen on disk has no file.
+                f"'{anchor}'" if anchor is not None else "being validated (it has no file of its own yet)",
                 raw_parent,
-                self._describe_unresolved_path(resolution),
+                reason,
             )
-            return None
-        return str(resolution.path)
+            return ParentLinkLookup(path=None, reason=reason)
+        return ParentLinkLookup(path=str(resolution.path), reason=None)
 
     def on_unregister_project_template_request(  # noqa: C901, PLR0912
         self, request: UnregisterProjectTemplateRequest

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -37,8 +37,8 @@ from griptape_nodes.common.project_templates import (
     ProjectVariableDef,
     ResolvedProjectPath,
     SituationTemplate,
+    active_platform,
     default_template_for_version,
-    describe_active_platform,
     load_partial_project_template,
     resolve_project_path_field,
     schema_major_or_none,
@@ -2306,11 +2306,21 @@ class ProjectManager(EngineScoped):
         has already refused such an overlay. One condition should not have two sets of user-facing
         strings: the unreachable copy is by definition untested, so it can drift from the reachable
         one without anything noticing.
+
+        The remedy depends on whether this platform can be named at all. On a platform with no
+        mapping key, "add an entry for this one" is advice that cannot be followed -- the schema
+        forbids any key outside `linux`/`darwin`/`windows`, so the suggested fix would fail
+        validation and `default` is the only way out.
         """
+        platform = active_platform()
+        remedy = (
+            "Add a 'default' entry for the platforms you did not name, or an entry for this one."
+            if platform.key
+            else "Add a 'default' entry: this platform has no key of its own, so 'default' is the only way to name it."
+        )
         return (
             f"Attempted to resolve '{field_name}' for this project. Failed because it lists no path "
-            f"for this platform ({describe_active_platform()}) and no 'default'. Add a 'default' "
-            f"entry for the platforms you did not name, or an entry for this one."
+            f"for this platform ({platform.display}) and no 'default'. {remedy}"
         )
 
     def _unresolvable_field_message(self, field_name: str, selected: str, resolution: ResolvedProjectPath) -> str:

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -2292,7 +2292,15 @@ class ProjectManager(EngineScoped):
 
     @staticmethod
     def _describe_unresolved_path(resolution: ResolvedProjectPath) -> str:
-        """Phrase why a declared path field could not be resolved, for logs and result_details."""
+        """Phrase why a declared path field could not be resolved, for logs and result_details.
+
+        Only ever called with a resolution whose `path` is None. In practice that always means an
+        unresolved variable or a macro token: every caller that could hand this a `needs_anchor`
+        resolution deals with that case before describing it, and `ResolvedProjectPath` guarantees an
+        unresolved result carries some reason. Both remaining branches are therefore defensive -- they
+        exist so a new failure mode reads as "could not resolve" instead of confidently naming the
+        wrong cause, which is exactly the class of bug this PR is about.
+        """
         reasons: list[str] = []
         if resolution.unresolved_variables:
             names = ", ".join(sorted(set(resolution.unresolved_variables)))
@@ -2300,8 +2308,10 @@ class ProjectManager(EngineScoped):
         if resolution.macro_tokens:
             names = ", ".join(sorted(set(resolution.macro_tokens)))
             reasons.append(f"macro tokens are not supported in path fields: {names}")
+        if resolution.needs_anchor:
+            reasons.append("it is a relative path and the project's own directory was not available to place it in")
         if not reasons:
-            return "no value was declared"
+            return "it could not be turned into a usable path"
         return "; ".join(reasons)
 
     def _resolve_template_workspace_dir(

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1013,12 +1013,7 @@ class ProjectManager(EngineScoped):
                 unresolvable_fields.append(field_name)
                 validation.add_error(
                     field_path=field_name,
-                    message=(
-                        f"Attempted to resolve '{field_name}' for this project. Failed because it "
-                        f"lists no path for this platform ({describe_active_platform()}) and no "
-                        f"'default'. Add a 'default' entry for the platforms you did not name, or an "
-                        f"entry for this one."
-                    ),
+                    message=self._platform_gap_message(field_name),
                     line_number=overlay.line_info.get_line(field_name),
                 )
                 continue
@@ -1028,10 +1023,7 @@ class ProjectManager(EngineScoped):
                 unresolvable_fields.append(field_name)
                 validation.add_error(
                     field_path=field_name,
-                    message=(
-                        f"Attempted to resolve '{field_name}' declared as '{selected}'. Failed "
-                        f"because {self._describe_unresolved_path(resolution)}."
-                    ),
+                    message=self._unresolvable_field_message(field_name, selected, resolution),
                     line_number=overlay.line_info.get_line(field_name),
                 )
 
@@ -1098,16 +1090,15 @@ class ProjectManager(EngineScoped):
             # A mapping with no key for this OS and no `default` names no parent we can locate; it
             # is an error, not "no parent here", because the child would otherwise load against the
             # system defaults and quietly lose everything the parent was supposed to supply.
-            # _read_overlay already refuses such an overlay, so this is defense in depth.
+            # _read_overlay already refuses such an overlay, so both failure branches below are
+            # defense in depth. They borrow their wording from the reachable copy in
+            # _validate_declared_path_fields rather than phrasing it again -- an unreachable message
+            # is an untested message, and two spellings of one condition drift.
             selected_parent = select_project_path(overlay.parent_project_path)
             if selected_parent is None:
                 validation.add_error(
                     field_path=parent_link_field,
-                    message=(
-                        f"Attempted to resolve this project's parent from parent_project_path. Failed "
-                        f"because it lists no path for this platform ({describe_active_platform()}) "
-                        f"and no 'default'."
-                    ),
+                    message=self._platform_gap_message(parent_link_field),
                     line_number=overlay.line_info.get_line(parent_link_field),
                 )
                 return None
@@ -1119,10 +1110,7 @@ class ProjectManager(EngineScoped):
             if parent_resolution.path is None:
                 validation.add_error(
                     field_path=parent_link_field,
-                    message=(
-                        f"Attempted to resolve this project's parent from parent_project_path "
-                        f"'{selected_parent}'. Failed because {self._describe_unresolved_path(parent_resolution)}."
-                    ),
+                    message=self._unresolvable_field_message(parent_link_field, selected_parent, parent_resolution),
                     line_number=overlay.line_info.get_line(parent_link_field),
                 )
                 return None
@@ -2310,6 +2298,32 @@ class ProjectManager(EngineScoped):
         return resolution
 
     @staticmethod
+    def _platform_gap_message(field_name: str) -> str:
+        """Phrase a per-platform mapping that names no path for this OS and has no `default`.
+
+        Shared by `_validate_declared_path_fields`, which is the copy users actually reach, and the
+        defense-in-depth check in `_resolve_parent_chain`, which cannot fire because `_read_overlay`
+        has already refused such an overlay. One condition should not have two sets of user-facing
+        strings: the unreachable copy is by definition untested, so it can drift from the reachable
+        one without anything noticing.
+        """
+        return (
+            f"Attempted to resolve '{field_name}' for this project. Failed because it lists no path "
+            f"for this platform ({describe_active_platform()}) and no 'default'. Add a 'default' "
+            f"entry for the platforms you did not name, or an entry for this one."
+        )
+
+    def _unresolvable_field_message(self, field_name: str, selected: str, resolution: ResolvedProjectPath) -> str:
+        """Phrase a declared path field that resolved to nothing, naming the value and the cause.
+
+        Shared with `_resolve_parent_chain` for the same reason as `_platform_gap_message`.
+        """
+        return (
+            f"Attempted to resolve '{field_name}' declared as '{selected}'. Failed because "
+            f"{self._describe_unresolved_path(resolution)}."
+        )
+
+    @staticmethod
     def _describe_unresolved_path(resolution: ResolvedProjectPath) -> str:
         """Phrase why a declared path field could not be resolved, for logs and result_details.
 
@@ -2334,6 +2348,11 @@ class ProjectManager(EngineScoped):
             reasons.append("it is a relative path and the project's own directory was not available to place it in")
         if resolution.reference_cycle:
             reasons.append("its variable references expand into each other and never resolve")
+        if resolution.quoted_expansion:
+            reasons.append(
+                "a variable it references expanded to a quoted value, which is not a usable path "
+                "(remove the quotes from the variable's value, not from this field)"
+            )
         if not reasons:
             return "it could not be turned into a usable path"
         return "; ".join(reasons)

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sys
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -39,6 +38,7 @@ from griptape_nodes.common.project_templates import (
     ResolvedProjectPath,
     SituationTemplate,
     default_template_for_version,
+    describe_active_platform,
     load_partial_project_template,
     resolve_project_path_field,
     schema_major_or_none,
@@ -1015,8 +1015,9 @@ class ProjectManager(EngineScoped):
                     field_path=field_name,
                     message=(
                         f"Attempted to resolve '{field_name}' for this project. Failed because it "
-                        f"lists no path for this platform ({sys.platform}) and no 'default'. Add a "
-                        f"'default' entry for the platforms you did not name, or an entry for this one."
+                        f"lists no path for this platform ({describe_active_platform()}) and no "
+                        f"'default'. Add a 'default' entry for the platforms you did not name, or an "
+                        f"entry for this one."
                     ),
                     line_number=overlay.line_info.get_line(field_name),
                 )
@@ -1104,7 +1105,8 @@ class ProjectManager(EngineScoped):
                     field_path=parent_link_field,
                     message=(
                         f"Attempted to resolve this project's parent from parent_project_path. Failed "
-                        f"because it lists no path for this platform ({sys.platform}) and no 'default'."
+                        f"because it lists no path for this platform ({describe_active_platform()}) "
+                        f"and no 'default'."
                     ),
                     line_number=overlay.line_info.get_line(parent_link_field),
                 )
@@ -1971,9 +1973,7 @@ class ProjectManager(EngineScoped):
             return None
         return parent_path_candidate
 
-    async def resolve_libraries_root_for_project_id(
-        self, project_id: str, id_index: dict[str, Path] | None = None
-    ) -> Path | None:
+    async def resolve_libraries_root_for_project_id(self, project_id: str) -> Path | None:
         """Resolve the EXPLICIT libraries root a project would use WITHOUT loading it, or None.
 
         Offline analogue of decide_libraries_root's declaring rungs: the project's own libraries_dir
@@ -1992,13 +1992,14 @@ class ProjectManager(EngineScoped):
         A declared value that cannot be resolved does not reach here: _read_overlay rejects an
         unresolvable path field, so such a project is UNUSABLE and never gets walked.
 
+        Builds its own id -> path index. The listing does NOT come through here (it goes through
+        _effective_paths_for_project, which wants the fully-defaulted answer), so there is no caller
+        with an index to hand over and no reason to accept one until one exists.
+
         Args:
             project_id: Registry key, or a legacy id that is itself a canonical project file path.
-            id_index: Prebuilt id -> path index to reuse when resolving many projects in one pass
-                (the project listing). Built here when omitted.
         """
-        if id_index is None:
-            id_index = await self._build_unloaded_id_index()
+        id_index = await self._build_unloaded_id_index()
         project_file_path = self._project_file_path_for_id(project_id, id_index)
         if project_file_path is None:
             return None

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -35,9 +36,11 @@ from griptape_nodes.common.project_templates import (
     ProjectValidationProblemSeverity,
     ProjectValidationStatus,
     ProjectVariableDef,
+    ResolvedProjectPath,
     SituationTemplate,
     default_template_for_version,
     load_partial_project_template,
+    resolve_project_path_field,
     schema_major_or_none,
     select_project_path,
 )
@@ -126,6 +129,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointSubjectType,
 )
 from griptape_nodes.retained_mode.managers.settings import (
+    LIBRARIES_DIRECTORY_KEY,
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
     PROJECTS_TO_REGISTER_KEY,
@@ -139,6 +143,7 @@ from griptape_nodes.retained_mode.publishing.project_packager import (
     rename_project_template,
 )
 from griptape_nodes.retained_mode.variable_types import FlowVariable, VariableLayer, VariablePermission
+from griptape_nodes.utils.dict_utils import get_dot_value
 from griptape_nodes.utils.file_utils import find_files_recursive
 from griptape_nodes.utils.version_utils import engine_version, engine_version_failure_detail
 
@@ -456,6 +461,42 @@ class WorkspaceDecision(NamedTuple):
 
     workspace_dir: Path
     apply_override: bool
+
+
+class AncestorValueLookup(NamedTuple):
+    """Outcome of walking a project's parent chain for the nearest declared value.
+
+    Three states, and keeping the last two apart is the whole point of this type:
+
+    - `value` set: an ancestor declares one, and this is it.
+    - `value` None, `incomplete_reason` None: the chain was walked to its root and nothing in it
+      declares a value. The caller may confidently fall back to its default.
+    - `value` None, `incomplete_reason` set: the walk did NOT come away with a complete picture --
+      the chain could not be seen to its root, because an ancestor's YAML is unreadable, an ancestor
+      declares a path field that cannot be resolved, a declared parent is missing, or the chain
+      cycles. A usable value may be hiding behind that break, so the caller logs the fall-through
+      rather than treating "nothing declared" as established.
+
+    Attributes:
+        value: The nearest ancestor's resolved value, or None if there was no hit.
+        incomplete_reason: Artist-readable phrase describing why the walk came away incomplete, or
+            None when the whole chain was seen and nothing in it declared a value.
+    """
+
+    value: str | None
+    incomplete_reason: str | None
+
+
+class EffectiveProjectPaths(NamedTuple):
+    """The two paths a project activates with, as reported on the project listing.
+
+    Both are absolute and both are always present: each resolution ladder bottoms out in an
+    unconditional default, and a project whose declared path fields could not be resolved fails to
+    load rather than reaching here.
+    """
+
+    workspace_dir: Path
+    libraries_root: Path
 
 
 class _ProvisioningConfigDirs(NamedTuple):
@@ -835,6 +876,11 @@ class ProjectManager(EngineScoped):
         records the failure in _registered_template_status, which ListProjectTemplatesRequest
         surfaces as failed_to_load. Read-only probes (e.g. resolve_workspace_dir_for_project_id)
         pass record_status=False so a transient lookup does not inject phantom failed-load entries.
+
+        This is also where a declared path field that cannot produce a path is refused
+        (_validate_declared_path_fields). Every consumer funnels through here -- the boot load,
+        activation, the offline ancestor walks and the read-only probes -- so one check means none of
+        them can substitute a different location behind the user's back.
         """
         read_request = ReadFileRequest(
             file_path=str(project_file_path),
@@ -844,44 +890,133 @@ class ProjectManager(EngineScoped):
         read_result = await self.engine.ahandle_request(read_request)
 
         if read_result.failed():
-            validation = ProjectValidationInfo(status=ProjectValidationStatus.MISSING)
-            if record_status:
-                self._registered_template_status[project_file_path] = validation
-            return LoadProjectTemplateResultFailure(
-                validation=validation,
-                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because file not found",
+            return self._overlay_read_failure(
+                project_file_path,
+                ProjectValidationInfo(status=ProjectValidationStatus.MISSING),
+                "file not found",
+                record_status=record_status,
             )
 
         if not isinstance(read_result, ReadFileResultSuccess):
-            validation = ProjectValidationInfo(status=ProjectValidationStatus.UNUSABLE)
-            if record_status:
-                self._registered_template_status[project_file_path] = validation
-            return LoadProjectTemplateResultFailure(
-                validation=validation,
-                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because file read returned unexpected result type",
+            return self._overlay_read_failure(
+                project_file_path,
+                ProjectValidationInfo(status=ProjectValidationStatus.UNUSABLE),
+                "file read returned unexpected result type",
+                record_status=record_status,
             )
 
         yaml_text = read_result.content
         if not isinstance(yaml_text, str):
-            validation = ProjectValidationInfo(status=ProjectValidationStatus.UNUSABLE)
-            if record_status:
-                self._registered_template_status[project_file_path] = validation
-            return LoadProjectTemplateResultFailure(
-                validation=validation,
-                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because template must be text, got binary content",
+            return self._overlay_read_failure(
+                project_file_path,
+                ProjectValidationInfo(status=ProjectValidationStatus.UNUSABLE),
+                "template must be text, got binary content",
+                record_status=record_status,
             )
 
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
         overlay = load_partial_project_template(yaml_text, validation)
         if overlay is None:
-            if record_status:
-                self._registered_template_status[project_file_path] = validation
-            return LoadProjectTemplateResultFailure(
-                validation=validation,
-                result_details=f"Attempted to load project template from '{project_file_path}'. Failed because YAML could not be parsed",
+            return self._overlay_read_failure(
+                project_file_path, validation, "YAML could not be parsed", record_status=record_status
+            )
+
+        unresolvable_fields = self._validate_declared_path_fields(overlay, project_file_path, validation)
+        if unresolvable_fields:
+            return self._overlay_read_failure(
+                project_file_path,
+                validation,
+                (
+                    f"these declared paths could not be resolved: {', '.join(unresolvable_fields)}. "
+                    f"See the project's validation problems for the reason and line number of each."
+                ),
+                record_status=record_status,
             )
 
         return validation, overlay
+
+    def _overlay_read_failure(
+        self,
+        project_file_path: Path,
+        validation: ProjectValidationInfo,
+        reason: str,
+        *,
+        record_status: bool,
+    ) -> LoadProjectTemplateResultFailure:
+        """Build the failure result for an overlay that could not be read, and record it if asked.
+
+        Recording is what makes the entry show up in ListProjectTemplatesRequest's failed_to_load, so
+        the read-only probes pass record_status=False to keep a transient lookup from inventing one.
+        """
+        if record_status:
+            self._registered_template_status[project_file_path] = validation
+        return LoadProjectTemplateResultFailure(
+            validation=validation,
+            result_details=f"Attempted to load project template from '{project_file_path}'. Failed because {reason}",
+        )
+
+    def _validate_declared_path_fields(
+        self, overlay: ProjectOverlayData, project_file_path: Path, validation: ProjectValidationInfo
+    ) -> list[str]:
+        """Record an error for every declared path field that cannot produce a path.
+
+        A field that is ABSENT is not this method's business: the resolution ladders fall through to
+        the next source, which is the documented behavior. A field that is PRESENT but cannot produce
+        a path -- an unset `${VAR}` / `%VAR%`, a `{macro}` token, or a per-platform mapping with no
+        entry for this OS and no `default` -- is an error, because the only alternative is to discard
+        what the user wrote and put their workspace or their libraries somewhere else. A project that
+        installs libraries into a directory it never named is worse than a project that refuses to
+        open and says which line is wrong.
+
+        All three fields are checked even after the first error, so one load reports every broken
+        field instead of making the user fix them one restart at a time.
+
+        Anchoring uses the DECLARING file's directory. That is correct for all three: workspace_dir
+        and libraries_dir are own-node fields (ProjectTemplate.merge takes them from the overlay and
+        never inherits them from the base), and parent_project_path is by definition relative to the
+        file that names it.
+
+        Returns the names of the fields that failed, in declaration order; empty means the overlay's
+        paths are all resolvable and the caller may proceed.
+        """
+        declarations: dict[str, str | PerPlatformProjectPath | None] = {
+            "workspace_dir": overlay.workspace_dir,
+            "libraries_dir": overlay.libraries_dir,
+            "parent_project_path": overlay.parent_project_path,
+        }
+
+        unresolvable_fields: list[str] = []
+        for field_name, declared in declarations.items():
+            if declared is None:
+                continue
+
+            selected = select_project_path(declared)
+            if selected is None:
+                unresolvable_fields.append(field_name)
+                validation.add_error(
+                    field_path=field_name,
+                    message=(
+                        f"Attempted to resolve '{field_name}' for this project. Failed because it "
+                        f"lists no path for this platform ({sys.platform}) and no 'default'. Add a "
+                        f"'default' entry for the platforms you did not name, or an entry for this one."
+                    ),
+                    line_number=overlay.line_info.get_line(field_name),
+                )
+                continue
+
+            resolution = resolve_project_path_field(selected, project_file_path.parent)
+            if resolution.path is None:
+                unresolvable_fields.append(field_name)
+                validation.add_error(
+                    field_path=field_name,
+                    message=(
+                        f"Attempted to resolve '{field_name}' declared as '{selected}'. Failed "
+                        f"because {self._describe_unresolved_path(resolution)}."
+                    ),
+                    line_number=overlay.line_info.get_line(field_name),
+                )
+
+        return unresolvable_fields
 
     async def _resolve_parent_chain(  # noqa: C901, PLR0911
         self,
@@ -904,8 +1039,8 @@ class ProjectManager(EngineScoped):
            `project_file_path` so a child can name its parent with a relative path
            (e.g. `parent_project_path: ../base/griptape-nodes-project.yml`). A
            per-platform mapping is reduced to the active OS's path first; a mapping
-           with no key for this OS and no `default` is treated as no parent on this
-           platform.
+           with no key for this OS and no `default` names no parent this engine can
+           find, which is an error like any other unresolvable path field.
         3. Neither set: the base is `DEFAULT_PROJECT_TEMPLATE`.
 
         Once the parent file path is located, the parent YAML is read, recursively
@@ -940,23 +1075,38 @@ class ProjectManager(EngineScoped):
                 return None
         elif overlay.parent_project_path is not None:
             parent_link_field = "parent_project_path"
-            # Reduce the (possibly per-platform) value to a single string for the
-            # active platform. A per-platform mapping with no key matching the
-            # active OS and no `default` returns None — treat that as "no parent
-            # on this platform" and fall back to the system default base.
+            # Reduce the (possibly per-platform) value to a single string for the active platform.
+            # A mapping with no key for this OS and no `default` names no parent we can locate; it
+            # is an error, not "no parent here", because the child would otherwise load against the
+            # system defaults and quietly lose everything the parent was supposed to supply.
+            # _read_overlay already refuses such an overlay, so this is defense in depth.
             selected_parent = select_project_path(overlay.parent_project_path)
             if selected_parent is None:
-                logger.debug(
-                    "parent_project_path %r has no entry for the active platform and no default; "
-                    "treating as no parent on this OS",
-                    overlay.parent_project_path,
+                validation.add_error(
+                    field_path=parent_link_field,
+                    message=(
+                        f"Attempted to resolve this project's parent from parent_project_path. Failed "
+                        f"because it lists no path for this platform ({sys.platform}) and no 'default'."
+                    ),
+                    line_number=overlay.line_info.get_line(parent_link_field),
                 )
-                return default_template_for_version(overlay.project_template_schema_version)
+                return None
             parent_label = selected_parent
-            parent_path_raw = Path(selected_parent)
-            if not parent_path_raw.is_absolute():
-                parent_path_raw = project_file_path.parent / parent_path_raw
-            parent_file_path = canonicalize_for_identity(parent_path_raw)
+            # Expand `~` / shell env vars BEFORE deciding relative-vs-absolute, so an absolute
+            # variable value is not anchored under this project's directory and an unset variable
+            # cannot bake a literal `${NAME}` into the parent link.
+            parent_resolution = resolve_project_path_field(selected_parent, project_file_path.parent)
+            if parent_resolution.path is None:
+                validation.add_error(
+                    field_path=parent_link_field,
+                    message=(
+                        f"Attempted to resolve this project's parent from parent_project_path "
+                        f"'{selected_parent}'. Failed because {self._describe_unresolved_path(parent_resolution)}."
+                    ),
+                    line_number=overlay.line_info.get_line(parent_link_field),
+                )
+                return None
+            parent_file_path = parent_resolution.path
         else:
             return default_template_for_version(overlay.project_template_schema_version)
 
@@ -1075,12 +1225,17 @@ class ProjectManager(EngineScoped):
             result_details=f"Resolved workspace for '{request.project_id}': {resolved}",
         )
 
-    def on_list_project_templates_request(
+    async def on_list_project_templates_request(
         self, request: ListProjectTemplatesRequest
     ) -> ListProjectTemplatesResultSuccess:
         """List all project templates that have been loaded or attempted to load.
 
         Returns separate lists for successfully loaded and failed templates.
+
+        Async because each loaded entry reports the workspace and libraries root it activates with,
+        which walks its parent chain from disk. The id -> path index that walk needs is built ONCE
+        here and shared by every entry, so a listing of N projects costs one scan of
+        projects_to_register rather than N.
         """
         successfully_loaded: list[ProjectTemplateInfo] = []
         failed_to_load: list[ProjectTemplateInfo] = []
@@ -1095,13 +1250,17 @@ class ProjectManager(EngineScoped):
             if info.project_file_path is not None
         }
 
+        id_index = await self._build_unloaded_id_index()
+
         # Gather successfully loaded templates from _successfully_loaded_project_templates
         for project_id, project_info in self._successfully_loaded_project_templates.items():
             # Skip system builtins unless requested
             if not request.include_system_builtins and project_id == SYSTEM_DEFAULTS_KEY:
                 continue
 
-            successfully_loaded.append(self._build_loaded_template_info(project_id, project_info, file_path_to_id))
+            successfully_loaded.append(
+                await self._build_loaded_template_info(project_id, project_info, file_path_to_id, id_index)
+            )
 
         # Gather failed templates from _registered_template_status.
         # These are tracked by Path, so correlate against the id-keyed registry
@@ -1127,16 +1286,18 @@ class ProjectManager(EngineScoped):
             result_details=f"Successfully listed project templates. Loaded: {len(successfully_loaded)}, Failed: {len(failed_to_load)}",
         )
 
-    def _build_loaded_template_info(
+    async def _build_loaded_template_info(
         self,
         project_id: ProjectID,
         project_info: ProjectInfo,
         file_path_to_id: dict[Path, ProjectID],
+        id_index: dict[str, Path],
     ) -> ProjectTemplateInfo:
         """Build the ProjectTemplateInfo for a successfully loaded template.
 
-        Resolves the parent's id and the project-adjacent engine-version
-        compatibility for the listing emitted to the GUI.
+        Resolves the parent's id, the project-adjacent engine-version
+        compatibility, and the workspace + libraries root this project activates
+        with, for the listing emitted to the GUI.
         """
         # Emit the parent's id so the GUI can reconstruct the hierarchy by
         # matching it against another entry's project_id. An explicit
@@ -1146,17 +1307,9 @@ class ProjectManager(EngineScoped):
         # registered, its id is its canonical path string (the legacy bridge),
         # so the canonical string is the correct fallback. Per-platform
         # mappings are reduced to the active platform's value first.
-        resolved_parent_id: str | None = None
-        if project_info.template.parent_project_id is not None:
-            resolved_parent_id = project_info.template.parent_project_id
-        else:
-            selected_parent = select_project_path(project_info.template.parent_project_path)
-            if selected_parent is not None:
-                parent_path = Path(selected_parent)
-                if not parent_path.is_absolute() and project_info.project_file_path is not None:
-                    parent_path = project_info.project_file_path.parent / parent_path
-                canonical_parent = canonicalize_for_identity(parent_path)
-                resolved_parent_id = file_path_to_id.get(canonical_parent, str(canonical_parent))
+        resolved_parent_id = self._reduce_parent_link_to_id(
+            project_info.template, project_info.project_file_path, file_path_to_id
+        )
 
         # Read the project-adjacent config's requires_engine specifier without
         # merging it into the live config, so the GUI can disable activation
@@ -1170,6 +1323,14 @@ class ProjectManager(EngineScoped):
             )
         engine_version_reason = engine_version_failure_detail(required_engine_version)
 
+        # Where this project's files and libraries actually land. Both stay None for an entry with no
+        # backing file (the system defaults), which declares nothing and is never activated.
+        effective_paths: EffectiveProjectPaths | None = None
+        if project_info.project_file_path is not None:
+            effective_paths = await self._effective_paths_for_project(
+                project_info.project_file_path, project_info.template, id_index
+            )
+
         return ProjectTemplateInfo(
             project_id=project_id,
             validation=project_info.validation,
@@ -1182,6 +1343,8 @@ class ProjectManager(EngineScoped):
             required_engine_version=required_engine_version,
             current_engine_version=engine_version,
             engine_version_reason=engine_version_reason,
+            workspace_dir=str(effective_paths.workspace_dir) if effective_paths is not None else None,
+            libraries_root=str(effective_paths.libraries_root) if effective_paths is not None else None,
         )
 
     def on_get_situation_request(
@@ -1592,12 +1755,9 @@ class ProjectManager(EngineScoped):
         replay the unpinned branch-3 config-merge re-point the live config merge would apply.
         """
         id_index = await self._build_unloaded_id_index()
-        project_file_path = id_index.get(project_id)
+        project_file_path = self._project_file_path_for_id(project_id, id_index)
         if project_file_path is None:
-            legacy_path_candidate = canonicalize_for_identity(Path(project_id))
-            if not legacy_path_candidate.is_file():
-                return None
-            project_file_path = legacy_path_candidate
+            return None
 
         project_config = self._config_manager.read_config_file(project_file_path.parent / "griptape_nodes_config.json")
         env_config = self._config_manager.read_env_config()
@@ -1644,8 +1804,15 @@ class ProjectManager(EngineScoped):
         if pre_inheritance is not None:
             return pre_inheritance
 
-        inherited = await self._inherit_workspace_from_parents_offline(project_file_path, id_index)
-        return self._decide_workspace_post_inheritance(project_file_path, inherited)
+        lookup = await self._inherit_workspace_from_parents_offline(project_file_path, id_index)
+        if lookup.incomplete_reason is not None:
+            logger.warning(
+                "Could not inherit a workspace for project '%s' from its parent chain (%s). "
+                "Falling back to the global default workspace.",
+                project_file_path,
+                lookup.incomplete_reason,
+            )
+        return self._decide_workspace_post_inheritance(project_file_path, lookup.value)
 
     async def _decide_libraries_root_from_disk(
         self, project_file_path: Path, template_libraries_dir: str | None, id_index: dict[str, Path]
@@ -1658,12 +1825,25 @@ class ProjectManager(EngineScoped):
         so a child's shared libraries/ tree is identical whether or not its parent is loaded. Returns
         None when no libraries_dir is declared anywhere in the chain (caller falls back to the
         workspace-relative default).
+
+        A chain that could not be fully walked still falls back to the workspace-relative default --
+        activation has to pick SOMETHING to run with -- but it says so in the log. That break is rare
+        by construction: a project whose parent link or path fields do not resolve fails its own load,
+        so a chain normally breaks only if an ancestor file was moved or made unreadable after the
+        descendants were registered.
         """
         if template_libraries_dir is not None:
             return Path(template_libraries_dir)
-        inherited = await self._inherit_libraries_dir_from_parents_offline(project_file_path, id_index)
-        if inherited is not None:
-            return Path(inherited)
+        lookup = await self._inherit_libraries_dir_from_parents_offline(project_file_path, id_index)
+        if lookup.incomplete_reason is not None:
+            logger.warning(
+                "Could not inherit a libraries root for project '%s' from its parent chain (%s). "
+                "Falling back to the workspace-relative libraries directory.",
+                project_file_path,
+                lookup.incomplete_reason,
+            )
+        if lookup.value is not None:
+            return Path(lookup.value)
         return None
 
     def _resolve_workspace_dir(self, workspace_dir: Path) -> Path:
@@ -1711,7 +1891,7 @@ class ProjectManager(EngineScoped):
 
     async def _inherit_workspace_from_parents_offline(
         self, project_file_path: Path, id_index: dict[str, Path]
-    ) -> str | None:
+    ) -> AncestorValueLookup:
         """Offline analogue of _inherit_workspace_from_parents: walk the parent chain from disk.
 
         Resolves an ancestor's workspace without forcing that ancestor to be loaded/enabled. The
@@ -1723,10 +1903,11 @@ class ProjectManager(EngineScoped):
         starting project's own explicit sources are handled by _decide_workspace_pre_inheritance.
 
         Because the shared walker requires each node's overlay to be readable to stay on the chain, an
-        ancestor whose project YAML is unreadable is skipped even if it declares a workspace via a
-        project_workspaces override or adjacent config. This fails closed (the walk returns None and
-        the resolver falls back to the global default), matching the live walk and the offline
-        libraries walk, which already treat an unreadable/unloadable ancestor as a broken chain link.
+        ancestor whose project YAML is unreadable ends the walk even if it declares a workspace via a
+        project_workspaces override or adjacent config. That case comes back as an
+        `incomplete_reason` rather than a bare miss, so the caller can log that it is falling back to
+        the global default without a complete picture instead of implying the default was chosen
+        because the chain genuinely declared nothing.
         """
         project_workspaces = self._config_manager.get_config_value(
             "project_workspaces",
@@ -1734,15 +1915,24 @@ class ProjectManager(EngineScoped):
             default={},
         )
 
-        def probe(node_path: Path, overlay: ProjectOverlayData) -> str | None:
+        def probe(node_path: Path, overlay: ProjectOverlayData) -> ResolvedProjectPath:
             # The ancestor's workspace_dir template field (branch 0) wins, mirroring how the ancestor
             # would resolve its own workspace as the active project; the overlay was already read by
             # the walker to follow the parent link, so the field is free to read here. Falls through
-            # to the ancestor's project_workspaces override / adjacent config when the field is unset.
-            template_workspace = self._resolve_template_workspace_dir(overlay.workspace_dir, node_path)
-            if template_workspace is not None:
-                return template_workspace
-            return self._resolve_node_explicit_workspace(node_path, project_workspaces)
+            # to the ancestor's project_workspaces override / adjacent config when the field is
+            # unset. (It cannot be set-but-unresolvable: _read_overlay would have refused the
+            # ancestor, and the walker reports that as a break in the chain.)
+            template_resolution = self._resolve_template_path_field(overlay.workspace_dir, node_path, "workspace_dir")
+            if template_resolution.path is not None:
+                return template_resolution
+            explicit_workspace = self._resolve_node_explicit_workspace(node_path, project_workspaces)
+            if explicit_workspace is not None:
+                return ResolvedProjectPath(
+                    path=Path(explicit_workspace),
+                    unresolved_variables=[],
+                    macro_tokens=[],
+                )
+            return template_resolution
 
         return await self._nearest_ancestor_value_offline(project_file_path, id_index, probe)
 
@@ -1763,39 +1953,124 @@ class ProjectManager(EngineScoped):
             return None
         return parent_path_candidate
 
-    async def resolve_libraries_root_for_project_id(self, project_id: str) -> Path | None:
-        """Resolve the libraries root a project would use WITHOUT loading it, or None for the default.
+    async def resolve_libraries_root_for_project_id(
+        self, project_id: str, id_index: dict[str, Path] | None = None
+    ) -> Path | None:
+        """Resolve the EXPLICIT libraries root a project would use WITHOUT loading it, or None.
 
-        Offline analogue of decide_libraries_root, used by the provisioning preview so the previewed
-        SKIP/INSTALL/OVERWRITE plan matches what activation reconciles. The id is resolved to a file
-        path the same way resolve_workspace_dir_for_project_id does. Branch 0 reads this project's own
-        libraries_dir from its on-disk overlay; branch 1 walks the parent chain offline. Returns None
-        when no libraries_dir is declared anywhere in the chain, so the caller falls back to the
-        workspace-relative libraries directory.
+        Offline analogue of decide_libraries_root's declaring rungs: the project's own libraries_dir
+        (branch 0, read from its on-disk overlay so an unloaded project still honors it), then the
+        nearest ancestor that declares one (branch 1, walked from disk so an unloaded parent still
+        counts). Both rungs run through _decide_libraries_root_from_disk, the same code activation
+        uses, so the two cannot state different paths.
+
+        None means "no explicit libraries_dir applies here" -- nothing in the chain declares one, or
+        the id resolves to no readable project file. Callers that need a directory to install into
+        supply the workspace-relative default themselves; the provisioning preview does exactly that
+        from the merged config it already holds, which is what keeps its SKIP/INSTALL/OVERWRITE plan
+        matching what activation reconciles. _effective_paths_for_project is the caller that wants the
+        fully-defaulted answer.
+
+        A declared value that cannot be resolved does not reach here: _read_overlay rejects an
+        unresolvable path field, so such a project is UNUSABLE and never gets walked.
+
+        Args:
+            project_id: Registry key, or a legacy id that is itself a canonical project file path.
+            id_index: Prebuilt id -> path index to reuse when resolving many projects in one pass
+                (the project listing). Built here when omitted.
         """
-        id_index = await self._build_unloaded_id_index()
-        project_file_path = id_index.get(project_id)
+        if id_index is None:
+            id_index = await self._build_unloaded_id_index()
+        project_file_path = self._project_file_path_for_id(project_id, id_index)
         if project_file_path is None:
-            legacy_path_candidate = canonicalize_for_identity(Path(project_id))
-            if not legacy_path_candidate.is_file():
-                return None
-            project_file_path = legacy_path_candidate
+            return None
 
         own_overlay_load = await self._read_overlay(project_file_path, record_status=False)
-        if not isinstance(own_overlay_load, LoadProjectTemplateResultFailure):
-            _, own_overlay = own_overlay_load
-            template_libraries_dir = self._resolve_template_libraries_dir(own_overlay.libraries_dir, project_file_path)
-            if template_libraries_dir is not None:
-                return Path(template_libraries_dir)
+        if isinstance(own_overlay_load, LoadProjectTemplateResultFailure):
+            return None
+        _, own_overlay = own_overlay_load
 
-        inherited = await self._inherit_libraries_dir_from_parents_offline(project_file_path, id_index)
-        if inherited is not None:
-            return Path(inherited)
-        return None
+        template_libraries_dir = self._resolve_template_libraries_dir(own_overlay.libraries_dir, project_file_path)
+        return await self._decide_libraries_root_from_disk(project_file_path, template_libraries_dir, id_index)
+
+    async def _effective_paths_for_project(
+        self, project_file_path: Path, template: ProjectTemplate, id_index: dict[str, Path]
+    ) -> EffectiveProjectPaths:
+        """Resolve the workspace + libraries paths a LOADED project activates with, for the listing.
+
+        Both ladders are walked from disk rather than through the live config, because that is what
+        activation itself does for any project declaring a parent
+        (_apply_workspace_and_libraries_layers) and because the live path reads the CURRENT project's
+        config layers -- which would make the answer for one project depend on which other project
+        happens to be open.
+
+        The starting project's own workspace_dir / libraries_dir come from its already-loaded
+        template, so only ancestors cost an overlay read. That is safe because both fields are
+        own-node fields: ProjectTemplate.merge takes them from the overlay alone and never inherits
+        them from the base (see merged_workspace_dir / merged_libraries_dir), so the loaded value is
+        this project's own declaration and anchoring it to this project's directory is correct.
+
+        Both values are always a real path: each ladder bottoms out in an unconditional default, and
+        a project whose declarations could not be resolved would have failed to load.
+        """
+        project_config = self._config_manager.read_config_file(project_file_path.parent / "griptape_nodes_config.json")
+        env_config = self._config_manager.read_env_config()
+        template_workspace_dir = self._resolve_template_workspace_dir(template.workspace_dir, project_file_path)
+        template_libraries_dir = self._resolve_template_libraries_dir(template.libraries_dir, project_file_path)
+
+        decision = await self._decide_workspace_from_disk(
+            project_file_path, project_config, env_config, template_workspace_dir, id_index
+        )
+        libraries_root = await self._decide_libraries_root_from_disk(
+            project_file_path, template_libraries_dir, id_index
+        )
+        if libraries_root is None:
+            libraries_root = self._workspace_relative_libraries_root(project_file_path, decision)
+
+        return EffectiveProjectPaths(
+            workspace_dir=self._resolve_workspace_dir(decision.workspace_dir), libraries_root=libraries_root
+        )
+
+    def _workspace_relative_libraries_root(self, project_file_path: Path, decision: WorkspaceDecision) -> Path:
+        """Compute the nothing-declared libraries default for a target project, offline.
+
+        Resolves `libraries_directory` against the ENGINE's global workspace via
+        ConfigManager.default_libraries_root, exactly as the live
+        ConfigManager.resolved_libraries_root fallback does. The value is read from the merged view
+        the TARGET project would activate with (compute_project_provisioning_config over its own
+        project dir and the workspace it decided) rather than the live merged config, so a layer that
+        re-points libraries_directory is honored and the answer does not change depending on which
+        project happens to be open. That is the same merged view the provisioning preview reads, so
+        the two cannot disagree about where an undeclared libraries root lands.
+
+        Takes the caller's already-computed WorkspaceDecision rather than re-deciding, so resolving
+        both paths for one project walks its parent chain once.
+        """
+        project_dir = project_file_path.parent
+        merged = self._config_manager.compute_project_provisioning_config(
+            project_dir, decision.workspace_dir, apply_override=decision.apply_override
+        )
+        return self._config_manager.default_libraries_root(get_dot_value(merged, LIBRARIES_DIRECTORY_KEY))
+
+    def _project_file_path_for_id(self, project_id: str, id_index: dict[str, Path]) -> Path | None:
+        """Map an opaque project id to its file path for the offline resolvers, or None.
+
+        The id is looked up verbatim in the index (ids must never be parsed as paths), then -- for a
+        legacy project whose id IS its canonical file path string -- accepted directly when that path
+        is a readable file. Returns None when the id resolves to no project file on disk.
+        """
+        indexed_path = id_index.get(project_id)
+        if indexed_path is not None:
+            return indexed_path
+
+        legacy_path_candidate = canonicalize_for_identity(Path(project_id))
+        if not legacy_path_candidate.is_file():
+            return None
+        return legacy_path_candidate
 
     async def _inherit_libraries_dir_from_parents_offline(
         self, project_file_path: Path, id_index: dict[str, Path]
-    ) -> str | None:
+    ) -> AncestorValueLookup:
         """Offline analogue of _inherit_libraries_dir_from_parents: walk the parent chain from disk.
 
         Resolves an ancestor's libraries_dir without forcing that ancestor to be loaded/enabled. The
@@ -1805,8 +2080,8 @@ class ProjectManager(EngineScoped):
         parent: the starting project's own libraries_dir is handled by branch 0 of the caller.
         """
 
-        def probe(node_path: Path, overlay: ProjectOverlayData) -> str | None:
-            return self._resolve_template_libraries_dir(overlay.libraries_dir, node_path)
+        def probe(node_path: Path, overlay: ProjectOverlayData) -> ResolvedProjectPath:
+            return self._resolve_template_path_field(overlay.libraries_dir, node_path, "libraries_dir")
 
         return await self._nearest_ancestor_value_offline(project_file_path, id_index, probe)
 
@@ -1814,9 +2089,9 @@ class ProjectManager(EngineScoped):
         self,
         project_file_path: Path,
         id_index: dict[str, Path],
-        probe: Callable[[Path, ProjectOverlayData], str | None],
-    ) -> str | None:
-        """Walk the explicit parent chain from disk and return the first probe hit, or None.
+        probe: Callable[[Path, ProjectOverlayData], ResolvedProjectPath],
+    ) -> AncestorValueLookup:
+        """Walk the explicit parent chain from disk for the nearest probe hit, reporting completeness.
 
         Shared skeleton for the offline workspace and libraries inheritance walks, used when a target
         project may not be loaded (e.g. the provisioning preview). Reads each node's overlay from disk
@@ -1824,12 +2099,21 @@ class ProjectManager(EngineScoped):
         shared _reduce_parent_link_to_id) and to probe that node. Each reduced id maps back to a file
         path through `id_index` for a parent_project_id (or a legacy path already indexed), else the
         reduced canonical path is followed directly from disk for an unregistered legacy
-        parent_project_path; an id with no index entry and no readable file fails closed (None).
+        parent_project_path.
 
         The start project is NOT probed: its own value is handled by the caller's branch 0 / the
-        earlier decide_workspace branches, so the walk begins at the parent. A node whose overlay
-        cannot be read returns None (fail-closed) -- an unreadable project YAML is not a valid chain
-        link. A visited id-set guards against a cyclic parent chain.
+        earlier decide_workspace branches, so the walk begins at the parent. A visited id-set guards
+        against a cyclic parent chain.
+
+        Crucially, a MISS and an INCOMPLETE PICTURE are reported differently. Both used to collapse to
+        None, which callers read as "no ancestor declares one, so use the default" -- turning an
+        unreadable ancestor into a confident wrong answer. Now only a chain walked all the way to its
+        root reports `incomplete_reason=None`; an ancestor that could not be loaded, a parent id that
+        maps to no file, and a cycle each say why they stopped.
+
+        A probe that comes back unresolved cannot occur: _read_overlay rejects an overlay whose path
+        fields do not resolve, so such an ancestor fails the read above and is reported as a break in
+        the chain rather than silently stepped past.
         """
         file_path_to_id: dict[Path, ProjectID] = {path: pid for pid, path in id_index.items()}
 
@@ -1839,29 +2123,45 @@ class ProjectManager(EngineScoped):
         start_id = file_path_to_id.get(project_file_path)
         visited: set[ProjectID] = {start_id} if start_id is not None else set()
 
-        current_path: Path | None = project_file_path
+        current_path = project_file_path
         is_start = True
-        while current_path is not None:
+        while True:
             read_load = await self._read_overlay(current_path, record_status=False)
             if isinstance(read_load, LoadProjectTemplateResultFailure):
-                return None
+                if is_start:
+                    # The starting project's own YAML is unusable; the caller's own-overlay branch
+                    # already reported that, so this is not an ancestor-chain problem.
+                    return AncestorValueLookup(value=None, incomplete_reason=None)
+                return AncestorValueLookup(
+                    value=None,
+                    incomplete_reason=f"the parent project '{current_path}' could not be loaded",
+                )
             _, overlay = read_load
 
             if not is_start:
-                node_value = probe(current_path, overlay)
-                if node_value is not None:
-                    return node_value
+                probed = probe(current_path, overlay)
+                if probed.path is not None:
+                    return AncestorValueLookup(value=str(probed.path), incomplete_reason=None)
             is_start = False
 
             parent_id = self._reduce_parent_link_to_id(overlay, current_path, file_path_to_id)
             if parent_id is None:
-                return None
+                # The chain ended at its root: nothing usable in it, and nothing hidden from us.
+                return AncestorValueLookup(value=None, incomplete_reason=None)
             if parent_id in visited:
-                return None
+                return AncestorValueLookup(
+                    value=None,
+                    incomplete_reason=f"the parent chain forms a cycle at project '{parent_id}'",
+                )
             visited.add(parent_id)
 
-            current_path = self._resolve_parent_id_to_path(parent_id, id_index)
-        return None
+            parent_path = self._resolve_parent_id_to_path(parent_id, id_index)
+            if parent_path is None:
+                return AncestorValueLookup(
+                    value=None,
+                    incomplete_reason=f"parent project '{parent_id}' is declared but could not be located on disk",
+                )
+            current_path = parent_path
 
     def decide_workspace(
         self,
@@ -1890,7 +2190,10 @@ class ProjectManager(EngineScoped):
         `template_workspace_dir` is the highest-priority source: a project that declares its own
         workspace_dir beats the per-user project_workspaces mapping and the env var. The caller
         resolves the (possibly per-platform, possibly relative) raw field to an absolute path before
-        passing it, so this method and the offline resolver share the branch verbatim.
+        passing it, so this method and the offline resolver share the branch verbatim. For a project
+        that loaded, None means the field was ABSENT and nothing more: a declared value that cannot
+        produce a path is refused by _read_overlay, so the project is UNUSABLE and never reaches this
+        ladder. Branch 0 is skipped only when the project genuinely declares no workspace of its own.
 
         Branch 4 walks the project's explicit parent chain (parent_project_id / legacy
         parent_project_path, resolved through the registry) and inherits the first ancestor that
@@ -1931,24 +2234,90 @@ class ProjectManager(EngineScoped):
         inherited = self._inherit_workspace_from_parents(project_file_path)
         return self._decide_workspace_post_inheritance(project_file_path, inherited)
 
+    def _resolve_template_path_field(
+        self, raw: str | PerPlatformProjectPath | None, project_file_path: Path, field_name: str
+    ) -> ResolvedProjectPath:
+        """Resolve a template's raw workspace_dir/libraries_dir field, reporting WHY it failed.
+
+        Reduces a per-platform mapping to the active platform's value, then hands the value to the
+        shared resolve_project_path_field, which expands `~` and shell environment variables BEFORE
+        deciding relative-vs-absolute and anchors a still-relative path to the DECLARING project's
+        directory. Mirrors how parent_project_path is resolved (_resolve_parent_chain), so all three
+        path fields treat relative paths and variables identically.
+
+        This is the single source of truth for both fields; _resolve_template_workspace_dir and
+        _resolve_template_libraries_dir are `str | None` projections of it for the resolution
+        ladders, which only need "is there a usable value?".
+
+        An unset field resolves to a None path with empty reason lists -- "nothing declared", so the
+        ladder falls through to the next source.
+
+        A field that IS declared but cannot produce a path (no entry for this platform and no
+        'default', an unset variable, a macro token) cannot reach here for a project that loaded:
+        _read_overlay validates all three path fields and refuses the overlay, so the project is
+        UNUSABLE and never gets activated or listed. The warn-and-fall-through below is therefore
+        defense in depth rather than a normal outcome, and it keeps the resolvers total for callers
+        that hand them a value from somewhere other than an overlay read.
+
+        One window where load-time and activation-time answers can differ: a project registered
+        WHILE another project's `environment:` block is applied validates against that mutated
+        os.environ, whereas activation restores the launch environment before resolving. A value that
+        depends on a variable only some other project sets can therefore pass validation and then
+        fail to resolve here.
+        """
+        if raw is None:
+            return ResolvedProjectPath(path=None, unresolved_variables=[], macro_tokens=[])
+
+        selected = select_project_path(raw)
+        if selected is None:
+            logger.warning(
+                "Project '%s' declares %s as a per-platform mapping with no entry for this platform "
+                "and no 'default'. Ignoring it and falling back to the next source.",
+                project_file_path,
+                field_name,
+            )
+            return ResolvedProjectPath(path=None, unresolved_variables=[], macro_tokens=[])
+
+        resolution = resolve_project_path_field(selected, project_file_path.parent)
+        if resolution.path is None:
+            logger.warning(
+                "Project '%s' declares %s as %r, which cannot be resolved (%s). Ignoring it and "
+                "falling back to the next source.",
+                project_file_path,
+                field_name,
+                selected,
+                self._describe_unresolved_path(resolution),
+            )
+        return resolution
+
+    @staticmethod
+    def _describe_unresolved_path(resolution: ResolvedProjectPath) -> str:
+        """Phrase why a declared path field could not be resolved, for logs and result_details."""
+        reasons: list[str] = []
+        if resolution.unresolved_variables:
+            names = ", ".join(sorted(set(resolution.unresolved_variables)))
+            reasons.append(f"no value is set for {names}")
+        if resolution.macro_tokens:
+            names = ", ".join(sorted(set(resolution.macro_tokens)))
+            reasons.append(f"macro tokens are not supported in path fields: {names}")
+        if not reasons:
+            return "no value was declared"
+        return "; ".join(reasons)
+
     def _resolve_template_workspace_dir(
         self, raw: str | PerPlatformProjectPath | None, project_file_path: Path
     ) -> str | None:
         """Resolve a template's raw workspace_dir field to an absolute path string, or None.
 
-        Reduces a per-platform mapping to the active platform's value, resolves a relative path
-        against the project YAML's directory, and canonicalizes the result. Mirrors how
-        parent_project_path is resolved (_resolve_parent_chain), so the two fields treat relative
-        paths the same way. Returns None when the field is unset or has no value for the active
-        platform.
+        Thin projection of _resolve_template_path_field for the workspace resolution ladder. Returns
+        None when the field is unset -- and, defensively, for the declared-but-unresolvable cases that
+        _read_overlay already refuses at load time. Both mean the same thing to the ladder: fall
+        through to the next workspace source.
         """
-        selected = select_project_path(raw)
-        if selected is None:
+        resolution = self._resolve_template_path_field(raw, project_file_path, "workspace_dir")
+        if resolution.path is None:
             return None
-        candidate = Path(selected)
-        if not candidate.is_absolute():
-            candidate = project_file_path.parent / candidate
-        return str(canonicalize_for_identity(candidate))
+        return str(resolution.path)
 
     def _decide_workspace_pre_inheritance(
         self,
@@ -2098,6 +2467,12 @@ class ProjectManager(EngineScoped):
         ancestor's own dir is what makes every child point at the same parent libraries/ tree, so a
         library declared on the parent is downloaded once and reused via SKIP. See
         _inherit_libraries_dir_from_parents.
+
+        For a project that loaded, `template_libraries_dir` is None only because the field was ABSENT.
+        A declared value that cannot produce a path (unset variable, macro token, no entry for this
+        platform and no 'default') is refused by _read_overlay, so such a project is UNUSABLE and
+        never reaches this ladder -- branch 2's legacy default is never a substitute for a declaration
+        the engine failed to honor.
         """
         if template_libraries_dir is not None:
             return Path(template_libraries_dir)
@@ -2111,19 +2486,16 @@ class ProjectManager(EngineScoped):
     ) -> str | None:
         """Resolve a template's raw libraries_dir field to an absolute path string, or None.
 
-        Mirrors _resolve_template_workspace_dir: reduces a per-platform mapping to the active
-        platform's value, resolves a relative path against the project YAML's directory, and
-        canonicalizes the result. Returns None when the field is unset or has no value for the active
-        platform. This doubles as the per-node leaf primitive for the parent-chain walks, so an
-        inherited value resolves against the DECLARING node's directory.
+        Thin projection of _resolve_template_path_field, mirroring _resolve_template_workspace_dir.
+        Returns None when the field is unset -- and, defensively, for the declared-but-unresolvable
+        cases _read_overlay already refuses at load time. This doubles as the per-node leaf primitive
+        for the parent-chain walks, so an inherited value resolves against the DECLARING node's
+        directory.
         """
-        selected = select_project_path(raw)
-        if selected is None:
+        resolution = self._resolve_template_path_field(raw, project_file_path, "libraries_dir")
+        if resolution.path is None:
             return None
-        candidate = Path(selected)
-        if not candidate.is_absolute():
-            candidate = project_file_path.parent / candidate
-        return str(canonicalize_for_identity(candidate))
+        return str(resolution.path)
 
     def _inherit_libraries_dir_from_parents(self, project_file_path: Path) -> str | None:
         """Walk the explicit parent-project chain for the nearest ancestor's libraries_dir.
@@ -3041,21 +3413,35 @@ class ProjectManager(EngineScoped):
     def _resolve_parent_path_for_lookup(self, raw_parent: str, anchor: Path | str | None) -> str | None:
         """Resolve a stored parent_project_path to a canonical registry key.
 
-        Resolves relative paths against `anchor` (the containing template's
-        file path). Returns None if the path is relative and no anchor was
-        provided, since we can't form an absolute path without one. Macro
-        tokens are rejected by the loader; this resolver only sees absolute
-        or anchor-relative paths.
+        Expands `~` and shell environment variables, then resolves a still-relative path against
+        `anchor` (the containing template's file path), via the shared resolve_project_path_field so
+        this field agrees with workspace_dir / libraries_dir. Returns None when the path is relative
+        and no anchor was provided (we cannot form an absolute path without one), or when it declares
+        a variable nothing supplied a value for -- a link we cannot resolve is no link, and inventing
+        an anchor-relative path containing a literal `${NAME}` would silently break the parent chain
+        and every value that inherits along it.
 
         `anchor` is coerced to `Path` defensively because request payloads
         deserialized over the wire arrive with `project_path` as a `str`.
         """
-        parent_path = Path(raw_parent)
-        if not parent_path.is_absolute():
-            if anchor is None:
-                return None
-            parent_path = Path(anchor).parent / parent_path
-        return str(canonicalize_for_identity(parent_path))
+        if anchor is None:
+            anchor_dir = None
+        else:
+            anchor_dir = Path(anchor).parent
+
+        resolution = resolve_project_path_field(raw_parent, anchor_dir)
+        if resolution.needs_anchor:
+            return None
+        if resolution.path is None:
+            logger.warning(
+                "Project '%s' declares parent_project_path as %r, which cannot be resolved (%s). "
+                "Treating it as having no parent.",
+                anchor,
+                raw_parent,
+                self._describe_unresolved_path(resolution),
+            )
+            return None
+        return str(resolution.path)
 
     def on_unregister_project_template_request(  # noqa: C901, PLR0912
         self, request: UnregisterProjectTemplateRequest

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -21,6 +21,11 @@ WORKER_HEARTBEAT_INTERVAL_KEY = "worker.heartbeat_interval_s"
 WORKER_HEARTBEAT_TIMEOUT_KEY = "worker.heartbeat_timeout_s"
 WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
+# The `Settings.libraries_directory` field below, named here so every reader of it -- the live
+# libraries root, the provisioning preview, the offline libraries-root resolver, and the packager --
+# agrees on both the key and what a missing value means.
+LIBRARIES_DIRECTORY_KEY = "libraries_directory"
+DEFAULT_LIBRARIES_DIRECTORY = "libraries"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
 LIBRARY_LAZY_NODE_LOADING_KEY = "library.lazy_node_loading"

--- a/src/griptape_nodes/retained_mode/publishing/project_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/project_packager.py
@@ -45,6 +45,8 @@ from griptape_nodes.retained_mode.events.os_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.settings import (
+    DEFAULT_LIBRARIES_DIRECTORY,
+    LIBRARIES_DIRECTORY_KEY,
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
 )
@@ -72,13 +74,11 @@ ADJACENT_CONFIG_FILENAME = "griptape_nodes_config.json"
 MANIFEST_FILENAME = "manifest.json"
 COPIED_LIBRARIES_DIRNAME = "libraries"
 
-# Top-level config key (and default) for the directory the engine clones
-# libraries_to_download into. When this sink sits inside the project base dir,
-# its downloaded (referenced) source must NOT travel in the package; the
-# importing engine re-downloads referenced libs from their pins. The default is
-# relative to the project workspace (the base dir for a self-contained project).
-LIBRARIES_DIRECTORY_KEY = "libraries_directory"
-DEFAULT_LIBRARIES_DIRECTORY = "libraries"
+# LIBRARIES_DIRECTORY_KEY / DEFAULT_LIBRARIES_DIRECTORY (imported from settings) name the directory
+# the engine clones libraries_to_download into. When this sink sits inside the project base dir, its
+# downloaded (referenced) source must NOT travel in the package; the importing engine re-downloads
+# referenced libs from their pins. The default is relative to the project workspace (the base dir for
+# a self-contained project).
 
 # Top-level config key for the project's workspace directory. The engine resolves
 # a relative libraries_directory against this (not the base dir); they coincide

--- a/tests/unit/files/test_path_utils.py
+++ b/tests/unit/files/test_path_utils.py
@@ -10,11 +10,13 @@ import pytest
 from griptape_nodes.files.path_utils import (
     FilenameParts,
     _apply_windows_long_path_prefix,
+    canonicalize_expanded_for_identity,
     canonicalize_for_identity,
     canonicalize_for_io,
     canonicalize_to_posix,
     decompose_source_path,
     expand_path,
+    expand_path_fully,
     normalize_path_for_platform,
     parse_file_uri,
     path_needs_expansion,
@@ -252,6 +254,70 @@ class TestExpandPath:
         """Test that function returns a Path object."""
         result = expand_path("~/test")
         assert isinstance(result, Path)
+
+
+class TestExpandPathFully:
+    """Tests for expand_path_fully: expansion repeated until the value stops changing."""
+
+    def test_expands_a_reference_that_expands_to_another_reference(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A variable whose VALUE contains a reference resolves all the way, which one pass cannot do."""
+        monkeypatch.setenv("GTN_TEST_INNER", "/studio")
+        monkeypatch.setenv("GTN_TEST_OUTER", "${GTN_TEST_INNER}/projects")
+
+        result = expand_path_fully("${GTN_TEST_OUTER}/libs")
+
+        assert result.path.as_posix() == "/studio/projects/libs"
+        assert result.stabilized is True
+        # The single-pass version stops one level short; that gap is the whole reason this exists.
+        assert "GTN_TEST_INNER" in str(expand_path("${GTN_TEST_OUTER}/libs"))
+
+    def test_reports_a_reference_cycle_instead_of_looping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mutually referencing variables terminate and come back as not stabilized."""
+        monkeypatch.setenv("GTN_TEST_PING", "${GTN_TEST_PONG}")
+        monkeypatch.setenv("GTN_TEST_PONG", "${GTN_TEST_PING}")
+
+        result = expand_path_fully("${GTN_TEST_PING}/libs")
+
+        assert result.stabilized is False
+
+    def test_self_reference_is_not_a_cycle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`A=${A}` is left alone by expandvars, so it stabilizes as an ordinary unresolved reference."""
+        monkeypatch.setenv("GTN_TEST_SELF", "${GTN_TEST_SELF}")
+
+        result = expand_path_fully("${GTN_TEST_SELF}/libs")
+
+        assert result.stabilized is True
+        assert unexpanded_references(result.path).variables == ["GTN_TEST_SELF"]
+
+    def test_plain_path_stabilizes_unchanged(self) -> None:
+        """A value with nothing to expand comes back untouched on the first pass."""
+        result = expand_path_fully("/studio/libraries")
+
+        assert result.path.as_posix() == "/studio/libraries"
+        assert result.stabilized is True
+
+    def test_expands_tilde(self) -> None:
+        """Tilde expansion still happens, same as expand_path."""
+        result = expand_path_fully("~/Documents")
+
+        assert str(result.path).startswith(str(Path.home()))
+        assert result.stabilized is True
+
+    def test_bare_dollar_name_stays_literal(self) -> None:
+        """`$Recycle.Bin` is a real Windows directory; looping must not start eating it."""
+        result = expand_path_fully("$Recycle.Bin/libs")
+
+        assert result.path.as_posix() == "$Recycle.Bin/libs"
+        assert result.stabilized is True
+
+    def test_unset_variable_is_left_in_place(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unset reference is not a cycle: it stops changing immediately and stays reportable."""
+        monkeypatch.delenv("GTN_TEST_MISSING", raising=False)
+
+        result = expand_path_fully("${GTN_TEST_MISSING}/libs")
+
+        assert result.stabilized is True
+        assert unexpanded_references(result.path).variables == ["GTN_TEST_MISSING"]
 
 
 class TestPathNeedsExpansion:
@@ -978,6 +1044,48 @@ class TestCanonicalizeForIdentity:
 
         result = canonicalize_for_identity(link)
         assert result == target.resolve()
+
+
+class TestCanonicalizeExpandedForIdentity:
+    """Tests for canonicalize_expanded_for_identity: the same tail, without expanding again."""
+
+    def test_does_not_expand_variables(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A reference that survived the caller's own expansion is left alone, not expanded here.
+
+        The point of the function: a caller that VALIDATED its expansion must get back a path built
+        from the string it checked. Expanding again would return a different path than was validated.
+        """
+        monkeypatch.setenv("GTN_TEST_LATE", "/somewhere/else")
+
+        result = canonicalize_expanded_for_identity(tmp_path / "${GTN_TEST_LATE}")
+
+        assert result.name == "${GTN_TEST_LATE}"
+        # canonicalize_for_identity, given the same value, would expand it -- hence the two functions.
+        assert canonicalize_for_identity(tmp_path / "${GTN_TEST_LATE}") != result
+
+    def test_anchors_relative_paths_to_base(self, tmp_path: Path) -> None:
+        """Relative values are placed under `base`, same as canonicalize_for_identity."""
+        result = canonicalize_expanded_for_identity(Path("sub/file.txt"), base=tmp_path)
+
+        assert result == (tmp_path / "sub" / "file.txt").resolve()
+
+    def test_defaults_relative_paths_to_cwd(self) -> None:
+        """With no `base`, a relative value lands under CWD."""
+        result = canonicalize_expanded_for_identity(Path("file.txt"))
+
+        assert result == (Path.cwd() / "file.txt").resolve()
+
+    def test_normalizes_dot_segments(self, tmp_path: Path) -> None:
+        """`.` and `..` are collapsed so two spellings of one path compare equal."""
+        result = canonicalize_expanded_for_identity(tmp_path / "a" / ".." / "b" / "." / "c.txt")
+
+        assert result == (tmp_path / "b" / "c.txt").resolve()
+
+    def test_matches_canonicalize_for_identity_when_nothing_needs_expanding(self, tmp_path: Path) -> None:
+        """The two agree on any value with nothing left to expand; only the leading steps differ."""
+        already_expanded = tmp_path / "sub" / "project.yml"
+
+        assert canonicalize_expanded_for_identity(already_expanded) == canonicalize_for_identity(already_expanded)
 
 
 class TestCanonicalizeForIo:

--- a/tests/unit/files/test_path_utils.py
+++ b/tests/unit/files/test_path_utils.py
@@ -17,6 +17,7 @@ from griptape_nodes.files.path_utils import (
     decompose_source_path,
     expand_path,
     expand_path_fully,
+    expansion_introduced_quoting,
     normalize_path_for_platform,
     parse_file_uri,
     path_needs_expansion,
@@ -231,6 +232,34 @@ class TestStripSurroundingQuotes:
         """Test that unmatched quotes are preserved."""
         assert strip_surrounding_quotes('"test') == '"test'
         assert strip_surrounding_quotes("test'") == "test'"
+
+
+class TestExpansionIntroducedQuoting:
+    """Tests for expansion_introduced_quoting: quoting a variable brought in, not the author."""
+
+    def test_quoted_variable_used_as_a_prefix_is_flagged(self) -> None:
+        """The case strip_surrounding_quotes cannot see: the quotes end up interior."""
+        assert expansion_introduced_quoting("${ROOT}/libs", '"/mnt/studio"/libs') is True
+
+    def test_single_quoted_variable_used_as_a_prefix_is_flagged(self) -> None:
+        """A leading `'` flips is_absolute() exactly as `"` does, so it is refused too."""
+        assert expansion_introduced_quoting("${ROOT}/libs", "'/mnt/studio'/libs") is True
+
+    def test_apostrophe_from_a_variable_value_is_not_flagged(self) -> None:
+        """`/mnt/Dragon's Curse` is a real directory, so an interior apostrophe must survive."""
+        assert expansion_introduced_quoting("${ROOT}/libs", "/mnt/Dragon's Curse/libs") is False
+
+    def test_apostrophe_the_author_declared_is_not_flagged(self) -> None:
+        """Quotes in the declared text are the author's intent, wherever they sit."""
+        assert expansion_introduced_quoting("'/mnt/studio'/libs", "'/mnt/studio'/libs") is False
+
+    def test_unquoted_expansion_is_not_flagged(self) -> None:
+        """The ordinary case stays ordinary."""
+        assert expansion_introduced_quoting("${ROOT}/libs", "/mnt/studio/libs") is False
+
+    def test_additional_double_quote_is_flagged_even_when_the_author_wrote_one(self) -> None:
+        """Counted rather than tested for presence, so an author's quote cannot mask a new one."""
+        assert expansion_introduced_quoting('/mnt/say"hi/${ROOT}', '/mnt/say"hi/"/opt"') is True
 
 
 class TestExpandPath:

--- a/tests/unit/files/test_path_utils.py
+++ b/tests/unit/files/test_path_utils.py
@@ -22,6 +22,7 @@ from griptape_nodes.files.path_utils import (
     resolve_path_safely,
     sanitize_path_string,
     strip_surrounding_quotes,
+    unexpanded_references,
 )
 
 
@@ -280,6 +281,73 @@ class TestPathNeedsExpansion:
     def test_relative_path_no_expansion(self) -> None:
         """Test that relative paths without special chars don't need expansion."""
         assert path_needs_expansion("relative/path") is False
+
+
+class TestUnexpandedReferences:
+    """Tests for unexpanded_references: what `expand_path` could not supply a value for."""
+
+    def test_fully_expanded_path_reports_nothing(self) -> None:
+        """A path with no delimited references left comes back with both lists empty."""
+        result = unexpanded_references("/studio/libraries")
+
+        assert result.variables == []
+        assert result.macro_tokens == []
+
+    def test_reports_braced_variable_left_behind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A `${NAME}` that expand_path could not resolve is reported by name."""
+        monkeypatch.delenv("GTN_TEST_MISSING", raising=False)
+
+        result = unexpanded_references(expand_path("${GTN_TEST_MISSING}/libs"))
+
+        assert result.variables == ["GTN_TEST_MISSING"]
+        assert result.macro_tokens == []
+
+    def test_reports_nothing_once_the_variable_is_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The same value expands cleanly when the variable has a value."""
+        monkeypatch.setenv("GTN_TEST_PRESENT", "/studio")
+
+        result = unexpanded_references(expand_path("${GTN_TEST_PRESENT}/libs"))
+
+        assert result.variables == []
+
+    def test_reports_macro_tokens_separately(self) -> None:
+        """A `{NAME}` token is reported as a macro token, which expand_path never touches."""
+        result = unexpanded_references("{outputs}/libs")
+
+        assert result.variables == []
+        assert result.macro_tokens == ["outputs"]
+
+    def test_braced_variable_is_not_double_reported_as_a_macro_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`${NAME}` contains `{NAME}`, so the macro scan must skip what the env scan already claimed."""
+        monkeypatch.delenv("GTN_TEST_MISSING", raising=False)
+
+        result = unexpanded_references(expand_path("${GTN_TEST_MISSING}/libs"))
+
+        assert result.variables == ["GTN_TEST_MISSING"]
+        assert result.macro_tokens == []
+
+    def test_bare_dollar_name_is_not_reported(self) -> None:
+        """A bare `$NAME` stays literal: it is indistinguishable from a real folder like `$Recycle.Bin`."""
+        result = unexpanded_references("$Recycle.Bin/libs")
+
+        assert result.variables == []
+        assert result.macro_tokens == []
+
+    def test_reports_every_reference_in_one_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A value with several problems reports all of them, so a caller can show the whole picture."""
+        monkeypatch.delenv("GTN_TEST_ONE", raising=False)
+        monkeypatch.delenv("GTN_TEST_TWO", raising=False)
+
+        result = unexpanded_references("${GTN_TEST_ONE}/{outputs}/${GTN_TEST_TWO}")
+
+        assert result.variables == ["GTN_TEST_ONE", "GTN_TEST_TWO"]
+        assert result.macro_tokens == ["outputs"]
+
+    def test_accepts_a_path_object(self) -> None:
+        """expand_path returns a Path, so the helper takes one without the caller stringifying it."""
+        result = unexpanded_references(Path("{outputs}/libs"))
+
+        assert result.macro_tokens == ["outputs"]
 
 
 class TestResolvePathSafely:

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -231,6 +231,29 @@ class TestConfigManager:
 
             assert manager.resolved_libraries_root() == (global_ws / "libraries").resolve()
 
+    def test_default_libraries_root_falls_back_when_value_is_missing_or_empty(self, isolate_user_config: Path) -> None:
+        """An absent, empty, or non-string libraries_directory resolves to `<global workspace>/libraries`.
+
+        The fallback lives inside default_libraries_root so no caller can skip it. Without it, a
+        caller that read the value with no default of its own would pass None (crash) or "" -- and
+        `Path("")` is `Path(".")`, which would resolve the libraries root to the workspace itself and
+        install libraries on top of the user's files.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir, patch.dict(os.environ, {}, clear=True):
+            workspace = Path(temp_dir) / "ws"
+            workspace.mkdir()
+            isolate_user_config.write_text(json.dumps({"workspace_directory": str(workspace)}), encoding="utf-8")
+            manager = ConfigManager()
+            expected = (workspace / "libraries").resolve()
+
+            assert manager.default_libraries_root(None) == expected
+            assert manager.default_libraries_root("") == expected
+            # A hand-edited config can put any JSON type here; it must not become a path component.
+            assert manager.default_libraries_root(5) == expected  # type: ignore[arg-type]
+
+            # A real value is still honored, relative to the global workspace.
+            assert manager.default_libraries_root("custom-libs") == (workspace / "custom-libs").resolve()
+
     def test_coerce_to_type_bool_from_string(self) -> None:
         """Test that _coerce_to_type correctly converts string values to bool."""
         manager = ConfigManager()

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -5,6 +5,7 @@ import logging
 import subprocess
 import sys
 from collections.abc import Callable, Generator
+from functools import partial
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -53,6 +54,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     UnloadLibraryFromRegistryResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager as _LibraryManager
 from griptape_nodes.retained_mode.managers.library_manager import LibraryVenvInitResult
 from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
@@ -2570,11 +2572,24 @@ class TestPreviewProjectProvisioning:
         mock_project_manager.resolve_libraries_root_for_project_id = AsyncMock(return_value=libraries_root)
         mock_config_manager = MagicMock()
         mock_config_manager.compute_project_provisioning_config.return_value = merged
+        TestPreviewProjectProvisioning._use_real_libraries_root_formula(mock_config_manager)
         with (
             patch.object(griptape_nodes, "_project_manager", mock_project_manager),
             patch.object(griptape_nodes, "_config_manager", mock_config_manager),
         ):
             yield mock_project_manager, mock_config_manager
+
+    @staticmethod
+    def _use_real_libraries_root_formula(mock_config_manager: MagicMock) -> None:
+        """Have a mocked ConfigManager compute the libraries fallback with the REAL formula.
+
+        The mock supplies the config layers (configured_global_workspace_path); production code does
+        the math. Without this, the fallback would return a MagicMock and these tests would silently
+        assert nothing about where libraries actually land.
+        """
+        mock_config_manager.default_libraries_root.side_effect = partial(
+            ConfigManager.default_libraries_root, mock_config_manager
+        )
 
     @staticmethod
     @contextlib.contextmanager
@@ -2747,6 +2762,7 @@ class TestPreviewProjectProvisioning:
         live_config = MagicMock()
         live_config.configured_global_workspace_path.return_value = global_ws
         live_config.compute_project_provisioning_config.return_value = merged
+        self._use_real_libraries_root_formula(live_config)
         mock_project_manager = MagicMock()
         mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=MagicMock())
         mock_project_manager.resolve_libraries_root_for_project_id = AsyncMock(return_value=None)

--- a/tests/unit/retained_mode/managers/test_project_effective_paths.py
+++ b/tests/unit/retained_mode/managers/test_project_effective_paths.py
@@ -259,12 +259,12 @@ class TestEffectiveProjectPathsThroughEngine:
         but is not a usable project file. Both must decline instead of falling back to the workspace
         default, or a caller asking about a project it does not have would be told a plausible path.
         """
-        unparseable = tmp_path / "junk" / PROJECT_FILE_NAME
-        unparseable.parent.mkdir(parents=True, exist_ok=True)
-        unparseable.write_text("name: [unclosed\n", encoding="utf-8")
+        unparsable = tmp_path / "junk" / PROJECT_FILE_NAME
+        unparsable.parent.mkdir(parents=True, exist_ok=True)
+        unparsable.write_text("name: [unclosed\n", encoding="utf-8")
 
         assert await engine.project_manager.resolve_libraries_root_for_project_id("no-such-project") is None
-        assert await engine.project_manager.resolve_libraries_root_for_project_id(str(unparseable)) is None
+        assert await engine.project_manager.resolve_libraries_root_for_project_id(str(unparsable)) is None
 
     def test_unresolvable_declaration_fails_the_load_with_the_field_and_its_line(
         self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/unit/retained_mode/managers/test_project_effective_paths.py
+++ b/tests/unit/retained_mode/managers/test_project_effective_paths.py
@@ -37,6 +37,13 @@ PROJECT_FILE_NAME = "griptape-nodes-project.yml"
 ADJACENT_CONFIG_NAME = "griptape_nodes_config.json"
 LIBS_ENV_VAR = "GTN_TEST_STUDIO_LIBS"
 
+# A variable whose VALUE is itself a reference. Ordinary in a `.env` read without interpolation, and
+# the shape that one expansion pass leaves half-resolved.
+CHAIN_OUTER_ENV_VAR = "GTN_TEST_CHAIN_OUTER"
+CHAIN_INNER_ENV_VAR = "GTN_TEST_CHAIN_INNER"
+CYCLE_A_ENV_VAR = "GTN_TEST_CYCLE_A"
+CYCLE_B_ENV_VAR = "GTN_TEST_CYCLE_B"
+
 # A pinned download entry proves the provisioning preview probes the SAME libraries root the listing
 # reports. The preview payload carries no path, but its installed-version probe READS one, so the
 # plan's kind is an observable proxy for the directory it looked in.
@@ -55,6 +62,14 @@ parent_project_path: "../../{PROJECT_FILE_NAME}"
 """
 DECLARES_NOTHING_YAML = """project_template_schema_version: "0.3.3"
 name: Solo
+"""
+CHAINED_LIBRARIES_YAML = f"""project_template_schema_version: "0.3.3"
+name: Studio Chained
+libraries_dir: "${{{CHAIN_OUTER_ENV_VAR}}}/shared-libraries"
+"""
+CYCLIC_LIBRARIES_YAML = f"""project_template_schema_version: "0.3.3"
+name: Studio Cyclic
+libraries_dir: "${{{CYCLE_A_ENV_VAR}}}/shared-libraries"
 """
 
 
@@ -165,6 +180,54 @@ class TestEffectiveProjectPathsThroughEngine:
         assert libraries_root == str(canonicalize_for_identity(studio_dir / "shared-libraries"))
         assert str(base_path.parent) not in libraries_root
         assert LIBS_ENV_VAR not in libraries_root
+
+    def test_a_variable_whose_value_is_itself_a_reference_resolves_all_the_way(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, studio_dir: Path
+    ) -> None:
+        """A chained variable loads and reports its final root, rather than being called unresolvable.
+
+        `libraries_dir` names OUTER, whose value names INNER. Both are set, so there is a real answer.
+        A single expansion pass leaves `${INNER}` behind, and validating THAT while returning a
+        second, further-expanded path made the project fail to load citing INNER as having no value --
+        naming a variable that is set, for a project that is correctly configured.
+        """
+        monkeypatch.setenv(CHAIN_INNER_ENV_VAR, str(studio_dir))
+        monkeypatch.setenv(CHAIN_OUTER_ENV_VAR, f"${{{CHAIN_INNER_ENV_VAR}}}/projects")
+        chained_path = write_project(tmp_path / "chained", CHAINED_LIBRARIES_YAML)
+
+        assert isinstance(self.load(engine, chained_path), LoadProjectTemplateResultSuccess)
+        info = self.loaded_by_path(self.listing(engine))[str(chained_path)]
+
+        libraries_root = self.libraries_root_of(info)
+        assert libraries_root == str(canonicalize_for_identity(studio_dir / "projects" / "shared-libraries"))
+        assert CHAIN_INNER_ENV_VAR not in libraries_root
+        assert CHAIN_OUTER_ENV_VAR not in libraries_root
+
+    def test_a_reference_cycle_fails_the_load_as_a_cycle_not_as_a_missing_value(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Mutually referencing variables refuse the load, and say so as a cycle.
+
+        Both variables ARE set, so "no value is set for A" would be false. Expansion cannot finish,
+        which is a different problem with a different fix, and the artist needs to be told which.
+        """
+        monkeypatch.setenv(CYCLE_A_ENV_VAR, f"${{{CYCLE_B_ENV_VAR}}}")
+        monkeypatch.setenv(CYCLE_B_ENV_VAR, f"${{{CYCLE_A_ENV_VAR}}}")
+        cyclic_path = write_project(tmp_path / "cyclic", CYCLIC_LIBRARIES_YAML)
+
+        assert isinstance(self.load(engine, cyclic_path), LoadProjectTemplateResultFailure)
+        listing = self.listing(engine)
+
+        assert self.loaded_by_path(listing) == {}
+        failed = [info for info in listing.failed_to_load if info.project_id == str(cyclic_path)]
+        assert len(failed) == 1
+        assert failed[0].libraries_root is None
+
+        problems = [p for p in failed[0].validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert "cycle" in problems[0].message or "each other" in problems[0].message
+        assert "no value is set" not in problems[0].message
+        assert problems[0].line_number is not None
 
     def test_child_reports_the_libraries_root_it_inherits_from_its_parent(self, engine: Engine, tmp_path: Path) -> None:
         """libraries_dir inherits down the chain, anchored to the DECLARING project's directory.

--- a/tests/unit/retained_mode/managers/test_project_effective_paths.py
+++ b/tests/unit/retained_mode/managers/test_project_effective_paths.py
@@ -1,0 +1,328 @@
+"""Effective project paths, exercised through a real Engine against real files on disk.
+
+The rest of the project-manager suite calls handlers directly with a mocked ConfigManager, which is
+the right harness for the resolution ladders but structurally cannot catch three things:
+
+- a handler that was never registered (nothing else dispatches ListProjectTemplatesRequest through
+  the event system, so a wiring mistake would not fail the suite),
+- a config layer read from the wrong file, since the layers are real here rather than stubbed,
+- the listing disagreeing with the provisioning preview about where libraries live.
+
+So these tests build an actual Engine, write actual project YAML, and go through handle_request.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.files.path_utils import canonicalize_for_identity
+from griptape_nodes.retained_mode.engine import Engine
+from griptape_nodes.retained_mode.events.library_events import (
+    LibraryProvisioningActionKind,
+    PreviewProjectProvisioningRequest,
+    PreviewProjectProvisioningResultFailure,
+    PreviewProjectProvisioningResultSuccess,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    ListProjectTemplatesRequest,
+    ListProjectTemplatesResultSuccess,
+    LoadProjectTemplateRequest,
+    LoadProjectTemplateResultFailure,
+    LoadProjectTemplateResultSuccess,
+    ProjectTemplateInfo,
+)
+
+PROJECT_FILE_NAME = "griptape-nodes-project.yml"
+ADJACENT_CONFIG_NAME = "griptape_nodes_config.json"
+LIBS_ENV_VAR = "GTN_TEST_STUDIO_LIBS"
+
+# A pinned download entry proves the provisioning preview probes the SAME libraries root the listing
+# reports. The preview payload carries no path, but its installed-version probe READS one, so the
+# plan's kind is an observable proxy for the directory it looked in.
+LIB_GIT_URL = "https://github.com/example/gtn-test-lib"
+LIB_DIR_NAME = "gtn-test-lib"  # extract_repo_name_from_url(LIB_GIT_URL); no `name` key, so the probe uses it
+VERSION_AT_DECLARED_ROOT = "1.2.3"
+VERSION_AT_WORKSPACE_DEFAULT = "9.9.9"
+
+DECLARED_LIBRARIES_YAML = f"""project_template_schema_version: "0.3.3"
+name: Studio Base
+libraries_dir: "${{{LIBS_ENV_VAR}}}/shared-libraries"
+"""
+CHILD_OF_BASE_YAML = f"""project_template_schema_version: "0.3.3"
+name: Shot sc010
+parent_project_path: "../../{PROJECT_FILE_NAME}"
+"""
+DECLARES_NOTHING_YAML = """project_template_schema_version: "0.3.3"
+name: Solo
+"""
+
+
+def write_project(project_dir: Path, yaml_text: str) -> Path:
+    """Write a project YAML at its canonical filename and return the path."""
+    project_dir.mkdir(parents=True, exist_ok=True)
+    project_path = project_dir / PROJECT_FILE_NAME
+    project_path.write_text(yaml_text, encoding="utf-8")
+    return project_path
+
+
+def write_pinned_download(project_dir: Path, version_spec: str) -> None:
+    """Pin one libraries_to_download entry in a project's adjacent config.
+
+    The key lives under the app_events tree (LIBRARIES_TO_DOWNLOAD_KEY), not at the config root.
+    """
+    (project_dir / ADJACENT_CONFIG_NAME).write_text(
+        json.dumps(
+            {
+                "app_events": {
+                    "on_app_initialization_complete": {
+                        "libraries_to_download": [{"git_url": LIB_GIT_URL, "version": version_spec}]
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def plant_installed_library(libraries_root: Path, version: str) -> None:
+    """Write the minimal installed-library manifest the provisioning version probe reads."""
+    manifest_dir = libraries_root / LIB_DIR_NAME
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "griptape_nodes_library.json").write_text(
+        json.dumps({"name": "GTN Test Lib", "metadata": {"library_version": version}}),
+        encoding="utf-8",
+    )
+
+
+class TestEffectiveProjectPathsThroughEngine:
+    """The listing reports where each project's files and libraries actually land."""
+
+    @pytest.fixture
+    def workspace(self, tmp_path: Path) -> Path:
+        """The engine's global workspace, empty of any project."""
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        return workspace_dir
+
+    @pytest.fixture
+    def studio_dir(self, tmp_path: Path) -> Path:
+        """The off-workspace volume a project points its libraries at through an env var."""
+        return tmp_path / "studio"
+
+    @pytest.fixture
+    def engine(self, monkeypatch: pytest.MonkeyPatch, workspace: Path, studio_dir: Path) -> Engine:
+        """A real Engine whose config layers see only this test's workspace and variable.
+
+        Built AFTER the env vars are set, because ConfigManager loads its layers during construction.
+        """
+        monkeypatch.setenv("GTN_CONFIG_WORKSPACE_DIRECTORY", str(workspace))
+        monkeypatch.setenv(LIBS_ENV_VAR, str(studio_dir))
+        return Engine()
+
+    @staticmethod
+    def load(engine: Engine, project_path: Path) -> LoadProjectTemplateResultSuccess | LoadProjectTemplateResultFailure:
+        """Register a project through the event system, as the boot path and the GUI both do."""
+        result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_path))
+        assert isinstance(result, LoadProjectTemplateResultSuccess | LoadProjectTemplateResultFailure)
+        return result
+
+    @staticmethod
+    def listing(engine: Engine) -> ListProjectTemplatesResultSuccess:
+        result = engine.handle_request(ListProjectTemplatesRequest(include_system_builtins=False))
+        assert isinstance(result, ListProjectTemplatesResultSuccess)
+        return result
+
+    @staticmethod
+    def loaded_by_path(listing: ListProjectTemplatesResultSuccess) -> dict[str, ProjectTemplateInfo]:
+        return {info.project_file_path: info for info in listing.successfully_loaded if info.project_file_path}
+
+    @staticmethod
+    def libraries_root_of(info: ProjectTemplateInfo) -> str:
+        """The reported libraries root of a project that loaded.
+
+        The field is optional on the payload for entries that have no project file or failed to load;
+        asserting it here is the contract every case below relies on -- a loaded, file-backed project
+        always names a root.
+        """
+        assert info.libraries_root is not None
+        return info.libraries_root
+
+    def test_declared_libraries_dir_is_reported_expanded_and_absolute(
+        self, engine: Engine, tmp_path: Path, studio_dir: Path
+    ) -> None:
+        """An env-var libraries_dir resolves against the variable, not the project directory.
+
+        Before this, `Path("${VAR}/x").is_absolute()` was False, so the unexpanded value was joined
+        onto the project dir and libraries landed at `<project_dir>/${VAR}/x`.
+        """
+        base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
+
+        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultSuccess)
+        info = self.loaded_by_path(self.listing(engine))[str(base_path)]
+
+        libraries_root = self.libraries_root_of(info)
+        assert libraries_root == str(canonicalize_for_identity(studio_dir / "shared-libraries"))
+        assert str(base_path.parent) not in libraries_root
+        assert LIBS_ENV_VAR not in libraries_root
+
+    def test_child_reports_the_libraries_root_it_inherits_from_its_parent(self, engine: Engine, tmp_path: Path) -> None:
+        """libraries_dir inherits down the chain, anchored to the DECLARING project's directory.
+
+        This is the case the GUI cannot work out for itself, and the reason #5204 was filed: the child
+        declares nothing, so its root is only knowable by walking to the ancestor that does.
+        """
+        base_dir = tmp_path / "base"
+        base_path = write_project(base_dir, DECLARED_LIBRARIES_YAML)
+        child_path = write_project(base_dir / "shots" / "sc010", CHILD_OF_BASE_YAML)
+
+        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultSuccess)
+        assert isinstance(self.load(engine, child_path), LoadProjectTemplateResultSuccess)
+        by_path = self.loaded_by_path(self.listing(engine))
+
+        child_libraries_root = self.libraries_root_of(by_path[str(child_path)])
+        assert child_libraries_root == self.libraries_root_of(by_path[str(base_path)])
+        assert str(child_path.parent) not in child_libraries_root
+
+    def test_nothing_declared_falls_back_to_the_workspace_default(
+        self, engine: Engine, tmp_path: Path, workspace: Path
+    ) -> None:
+        """A project declaring no paths at all lands on the global workspace and its libraries dir."""
+        solo_path = write_project(tmp_path / "solo", DECLARES_NOTHING_YAML)
+
+        assert isinstance(self.load(engine, solo_path), LoadProjectTemplateResultSuccess)
+        info = self.loaded_by_path(self.listing(engine))[str(solo_path)]
+
+        assert info.workspace_dir == str(canonicalize_for_identity(workspace))
+        assert info.libraries_root == str(canonicalize_for_identity(workspace / "libraries"))
+
+    def test_provisioning_probes_the_roots_the_listing_reported(self, engine: Engine, tmp_path: Path) -> None:
+        """The reported root is the one provisioning actually installs into, on BOTH rungs.
+
+        PreviewProjectProvisioningResultSuccess carries no path, but its installed-version probe reads
+        one, so `kind` is an observable proxy for the directory it looked in. The two projects are
+        mutually discriminating: each pins the version planted at ITS OWN root, so both must answer
+        SKIP. Swap the roots and both would answer OVERWRITE -- the child would find 9.9.9 against a
+        ==1.2.3 pin, the solo project 1.2.3 against a ==9.9.9 pin.
+        """
+        base_dir = tmp_path / "base"
+        base_path = write_project(base_dir, DECLARED_LIBRARIES_YAML)
+        child_dir = base_dir / "shots" / "sc010"
+        child_path = write_project(child_dir, CHILD_OF_BASE_YAML)
+        solo_dir = tmp_path / "solo"
+        solo_path = write_project(solo_dir, DECLARES_NOTHING_YAML)
+        write_pinned_download(child_dir, f"=={VERSION_AT_DECLARED_ROOT}")
+        write_pinned_download(solo_dir, f"=={VERSION_AT_WORKSPACE_DEFAULT}")
+
+        for project_path in (base_path, child_path, solo_path):
+            assert isinstance(self.load(engine, project_path), LoadProjectTemplateResultSuccess)
+        by_path = self.loaded_by_path(self.listing(engine))
+        child_info = by_path[str(child_path)]
+        solo_info = by_path[str(solo_path)]
+
+        # Inherited-declaration rung for the child, workspace-default rung for the solo project.
+        child_libraries_root = self.libraries_root_of(child_info)
+        solo_libraries_root = self.libraries_root_of(solo_info)
+        assert child_libraries_root != solo_libraries_root
+        plant_installed_library(Path(child_libraries_root), VERSION_AT_DECLARED_ROOT)
+        plant_installed_library(Path(solo_libraries_root), VERSION_AT_WORKSPACE_DEFAULT)
+
+        for info, expected_version in (
+            (child_info, VERSION_AT_DECLARED_ROOT),
+            (solo_info, VERSION_AT_WORKSPACE_DEFAULT),
+        ):
+            preview = engine.handle_request(PreviewProjectProvisioningRequest(project_id=info.project_id))
+            assert isinstance(preview, PreviewProjectProvisioningResultSuccess), preview.result_details
+            assert len(preview.actions) == 1, preview.actions
+            action = preview.actions[0]
+            assert action.installed_version == expected_version
+            assert action.kind is LibraryProvisioningActionKind.SKIP
+
+    def test_provisioning_declines_to_preview_a_project_that_is_not_loaded(self, engine: Engine) -> None:
+        """The preview refuses rather than previewing against the current project's config layers.
+
+        Its dirs come from the loaded-template registry, so an id that is not there has no project dir
+        and no workspace to merge -- answering anyway would describe some other project's libraries.
+        """
+        preview = engine.handle_request(PreviewProjectProvisioningRequest(project_id="no-such-project"))
+
+        assert isinstance(preview, PreviewProjectProvisioningResultFailure)
+        assert "not loaded" in str(preview.result_details)
+
+    @pytest.mark.asyncio
+    async def test_resolver_answers_nothing_for_an_id_that_is_not_a_loadable_project(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
+        """The public resolver returns None rather than guessing a root for an id it cannot read.
+
+        Covers the two ways an id fails to produce a template: no such project, and a path that exists
+        but is not a usable project file. Both must decline instead of falling back to the workspace
+        default, or a caller asking about a project it does not have would be told a plausible path.
+        """
+        unparseable = tmp_path / "junk" / PROJECT_FILE_NAME
+        unparseable.parent.mkdir(parents=True, exist_ok=True)
+        unparseable.write_text("name: [unclosed\n", encoding="utf-8")
+
+        assert await engine.project_manager.resolve_libraries_root_for_project_id("no-such-project") is None
+        assert await engine.project_manager.resolve_libraries_root_for_project_id(str(unparseable)) is None
+
+    def test_unresolvable_declaration_fails_the_load_with_the_field_and_its_line(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """With the variable unset the project refuses to load instead of substituting a path.
+
+        The listing reports it under failed_to_load with no paths at all, so the GUI can tell "here is
+        where the libraries live" apart from "this project is broken."
+        """
+        monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
+        base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
+
+        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultFailure)
+        listing = self.listing(engine)
+
+        assert self.loaded_by_path(listing) == {}
+        failed = [info for info in listing.failed_to_load if info.project_id == str(base_path)]
+        assert len(failed) == 1
+        assert failed[0].workspace_dir is None
+        assert failed[0].libraries_root is None
+
+        problems = [p for p in failed[0].validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert LIBS_ENV_VAR in problems[0].message
+        # The scalar's line is tracked from its key's position in the parent mapping; before that,
+        # every scalar field in a project file reported no line at all.
+        assert problems[0].line_number is not None
+        cited_line = base_path.read_text(encoding="utf-8").splitlines()[problems[0].line_number - 1]
+        assert "libraries_dir" in cited_line
+
+    def test_a_broken_parent_takes_its_child_down_but_not_an_unrelated_project(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, workspace: Path
+    ) -> None:
+        """Failing closed cascades along the parent chain and stops there.
+
+        A shared base pinning an unset variable stops loading for everything derived from it -- the
+        accepted cost, since the alternative is each child quietly installing libraries elsewhere. A
+        project that never referenced the variable is untouched and still reports its paths.
+        """
+        monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
+        base_dir = tmp_path / "base"
+        base_path = write_project(base_dir, DECLARED_LIBRARIES_YAML)
+        child_path = write_project(base_dir / "shots" / "sc010", CHILD_OF_BASE_YAML)
+        solo_path = write_project(tmp_path / "solo", DECLARES_NOTHING_YAML)
+
+        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultFailure)
+        assert isinstance(self.load(engine, child_path), LoadProjectTemplateResultFailure)
+        assert isinstance(self.load(engine, solo_path), LoadProjectTemplateResultSuccess)
+        listing = self.listing(engine)
+
+        failed_ids = {info.project_id for info in listing.failed_to_load}
+        assert {str(base_path), str(child_path)} <= failed_ids
+        assert all(info.libraries_root is None for info in listing.failed_to_load)
+
+        child_problems = [
+            p for info in listing.failed_to_load if info.project_id == str(child_path) for p in info.validation.problems
+        ]
+        assert any(p.field_path == "parent_project_path" for p in child_problems)
+
+        solo_info = self.loaded_by_path(listing)[str(solo_path)]
+        assert solo_info.libraries_root == str(canonicalize_for_identity(workspace / "libraries"))

--- a/tests/unit/retained_mode/managers/test_project_effective_paths.py
+++ b/tests/unit/retained_mode/managers/test_project_effective_paths.py
@@ -168,8 +168,8 @@ class TestEffectiveProjectPathsThroughEngine:
     ) -> None:
         """An env-var libraries_dir resolves against the variable, not the project directory.
 
-        Before this, `Path("${VAR}/x").is_absolute()` was False, so the unexpanded value was joined
-        onto the project dir and libraries landed at `<project_dir>/${VAR}/x`.
+        Expansion happens before the relative-vs-absolute decision, so a variable holding an absolute
+        path is reported as that path and never joined onto the project directory.
         """
         base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
 
@@ -187,9 +187,9 @@ class TestEffectiveProjectPathsThroughEngine:
         """A chained variable loads and reports its final root, rather than being called unresolvable.
 
         `libraries_dir` names OUTER, whose value names INNER. Both are set, so there is a real answer.
-        A single expansion pass leaves `${INNER}` behind, and validating THAT while returning a
-        second, further-expanded path made the project fail to load citing INNER as having no value --
-        naming a variable that is set, for a project that is correctly configured.
+        Expansion runs to a fixed point and the string that gets validated is the string that gets
+        returned, so a reference that only surfaces partway through expansion is never reported as an
+        unset variable for a project that is correctly configured.
         """
         monkeypatch.setenv(CHAIN_INNER_ENV_VAR, str(studio_dir))
         monkeypatch.setenv(CHAIN_OUTER_ENV_VAR, f"${{{CHAIN_INNER_ENV_VAR}}}/projects")

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -7043,6 +7043,61 @@ directories:
         return AsyncMock(side_effect=route)
 
     @pytest.mark.asyncio
+    async def test_binary_content_is_unusable_rather_than_a_crash(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A project file read back as bytes fails the load with an explanation.
+
+        The YAML parser would raise on bytes, so _read_overlay checks the content type itself. Worth
+        pinning because the read result's `content` is typed loosely enough for this to happen.
+        """
+        from griptape_nodes.common.project_templates.validation import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.os_events import ReadFileResultSuccess
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultFailure,
+        )
+
+        project_path = (tmp_path / "binary.yml").resolve()
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(
+                return_value=ReadFileResultSuccess(
+                    content=b"\x00\x01",
+                    file_size=2,
+                    mime_type="application/octet-stream",
+                    encoding=None,
+                    result_details="ok",
+                )
+            )
+            result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert "binary content" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_read_result_type_is_unusable(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A read that answers with neither success nor a recognized failure is still reported clearly."""
+        from griptape_nodes.common.project_templates.validation import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultFailure,
+        )
+
+        project_path = (tmp_path / "odd.yml").resolve()
+        unexpected = Mock()
+        unexpected.failed.return_value = False
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = AsyncMock(return_value=unexpected)
+            result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert "unexpected result type" in str(result.result_details)
+
+    @pytest.mark.asyncio
     async def test_no_parent_still_merges_with_defaults(self, pm: ProjectManager, tmp_path: Path) -> None:
         """A project without parent_project_path still merges on top of system defaults."""
         from griptape_nodes.retained_mode.events.project_events import (

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -7706,6 +7706,42 @@ directories:
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=parent_path))
         assert isinstance(result, LoadProjectTemplateResultSuccess)
 
+    def test_save_refusal_names_the_real_reason_the_parent_could_not_be_resolved(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unset variable in parent_project_path is reported as an unset variable.
+
+        The refusal is correct -- diffing against system defaults would bake the parent's inherited
+        values into the child's overlay. What was wrong was the explanation: every unresolvable parent
+        was reported as "is relative and no anchor could be resolved", which here is doubly false.
+        There is an anchor (the file being saved) and the value is not relative; the variable is
+        simply unset, and that is the only sentence an artist can act on.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            SaveProjectTemplateRequest,
+            SaveProjectTemplateResultFailure,
+        )
+
+        monkeypatch.delenv("GTN_TEST_SAVE_MISSING", raising=False)
+        child_path = tmp_path / "child.yml"
+        template_data = {
+            "project_template_schema_version": "0.3.2",
+            "name": "child",
+            "parent_project_path": "${GTN_TEST_SAVE_MISSING}/parent.yml",
+            "situations": {},
+            "directories": {},
+        }
+
+        result = pm.on_save_project_template_request(
+            SaveProjectTemplateRequest(project_path=child_path, template_data=template_data)
+        )
+
+        assert isinstance(result, SaveProjectTemplateResultFailure)
+        details = str(result.result_details)
+        assert "GTN_TEST_SAVE_MISSING" in details
+        assert "no anchor" not in details
+        assert not child_path.exists()
+
     def test_save_without_parent_diffs_against_system_defaults(self, pm: ProjectManager, tmp_path: Path) -> None:
         """Regression: with no parent, diff base remains DEFAULT_PROJECT_TEMPLATE."""
         from griptape_nodes.retained_mode.events.project_events import (
@@ -8296,6 +8332,43 @@ class TestValidateProjectTemplateParentChain:
         )
         assert isinstance(result, ValidateProjectTemplateResultSuccess)
         assert any(p.field_path == "parent_project_path" and "Cycle" in p.message for p in result.validation.problems)
+
+    def test_relative_parent_with_no_anchor_says_so_instead_of_going_quiet(
+        self, pm: ProjectManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A brand-new template's relative parent_project_path cannot be placed, and that is logged.
+
+        Validation is path-less: an unregistered template has no file of its own, so there is no
+        directory to resolve `../base.yml` against. The chain walk correctly stops (load-time
+        detection still applies), but it used to stop with no record at all -- the one route that can
+        reach this case skipped the reason and returned, while every sibling failure logged one. A
+        chain that silently ends looks identical to a project with no parent.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            ValidateProjectTemplateRequest,
+            ValidateProjectTemplateResultSuccess,
+        )
+
+        template_data = {
+            "project_template_schema_version": "0.3.2",
+            "name": "brand new child",
+            "parent_project_path": "../base.yml",
+            "situations": {},
+            "directories": {},
+        }
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = pm.on_validate_project_template_request(
+                ValidateProjectTemplateRequest(template_data=template_data)
+            )
+
+        assert isinstance(result, ValidateProjectTemplateResultSuccess)
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        matching = [m for m in warnings if "../base.yml" in m]
+        assert len(matching) == 1, warnings
+        assert "relative path" in matching[0]
+        # The reason must be the anchor, not a variable: there is no variable in this value at all.
+        assert "no value is set" not in matching[0]
 
 
 class TestPerPlatformProjectsToRegister:

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -8959,6 +8959,44 @@ class TestProjectPathFieldValidation:
         assert problems[0].line_number == _line_of(project_yaml, "darwin:")
 
     @pytest.mark.asyncio
+    async def test_platform_gap_message_names_the_yaml_key_not_sys_platform(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The message names the key the user must add (`windows`), not `sys.platform` (`win32`).
+
+        The two strings are the same on Linux and macOS, so every other platform-gap test passes
+        either way. Windows is the one platform where they differ, and telling someone their mapping
+        has "no path for this platform (win32)" points them at a key that does not exist in the
+        schema.
+
+        Patches the selector rather than `sys.platform` so the assertion holds on any host: a real
+        `sys.platform` of `win32` OR `linux` must be absent from the message, and neither is the
+        value being reported.
+        """
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.setattr(
+            "griptape_nodes.common.project_templates.directory._active_platform_key",
+            lambda: "windows",
+        )
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            "libraries_dir:\n"
+            '  darwin: "/Volumes/fast/libs"\n'
+            '  linux: "/mnt/fast/libs"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert "no path for this platform (windows) and no 'default'" in problems[0].message
+        assert sys.platform not in problems[0].message
+
+    @pytest.mark.asyncio
     async def test_every_broken_field_is_reported_in_one_load(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -8849,8 +8849,8 @@ class TestProjectPathFieldValidation:
     ) -> None:
         """`${GTN_TEST_LIBS}/libraries` with the variable unset is an error, not a fallback.
 
-        The old behavior logged a warning, discarded the declaration, and installed libraries under
-        `<workspace>/libraries` instead -- a location the project never asked for.
+        An unresolvable declaration is never quietly replaced with `<workspace>/libraries`:
+        installing libraries somewhere the project never named is worse than refusing to open.
         """
         from griptape_nodes.common.project_templates import ProjectValidationStatus
         from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
@@ -8957,6 +8957,64 @@ class TestProjectPathFieldValidation:
         # A nested block anchors at its first child key (`darwin:`), which is close enough for an
         # editor to jump to the offending field.
         assert problems[0].line_number == _line_of(project_yaml, "darwin:")
+
+    @pytest.mark.asyncio
+    async def test_quoted_variable_value_fails_the_load_instead_of_anchoring_under_the_project(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A variable whose value carries quotes is refused, not quietly relocated.
+
+        Quotes wrapping a whole value are cleaned, but a variable supplying only a PREFIX moves its
+        own quotes into the interior, where there is nothing left to strip. The leading quote then
+        makes an absolute path look relative, so it would be anchored under the project directory --
+        libraries installing somewhere the project never named, reported as a clean resolve.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.setenv("GTN_TEST_QUOTED_ROOT", '"/mnt/studio"')
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'libraries_dir: "${GTN_TEST_QUOTED_ROOT}/libs"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert "expanded to a quoted value" in problems[0].message
+        # The actionable half: the quotes are in the variable, so telling the user to edit this field
+        # would send them to the wrong file.
+        assert "remove the quotes from the variable's value" in problems[0].message
+        assert problems[0].line_number == _line_of(project_yaml, "libraries_dir:")
+
+    @pytest.mark.asyncio
+    async def test_quoted_variable_supplying_the_whole_value_still_resolves(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The shape sanitizing was written for keeps working: quotes around the entire value.
+
+        Guards the boundary of the refusal above. A shell-exported `ROOT='"/mnt/studio"'` used on its
+        own is unambiguous -- the quotes surround everything, so they can be stripped -- and turning
+        that into a failed load would break the case `sanitize_path_string` exists to absorb.
+        """
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
+
+        monkeypatch.setenv("GTN_TEST_QUOTED_WHOLE", f'"{tmp_path.as_posix()}/studio-libs"')
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'libraries_dir: "${GTN_TEST_QUOTED_WHOLE}"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
 
     @pytest.mark.asyncio
     async def test_platform_gap_message_names_the_yaml_key_not_sys_platform(

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from griptape_nodes.common.project_templates import ProjectValidationInfo
     from griptape_nodes.common.project_templates.directory import PerPlatformPathMacro
     from griptape_nodes.common.project_templates.loader import ProjectOverlayData
-    from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath
+    from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath, ResolvedProjectPath
     from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
 
 from griptape_nodes.common.macro_parser import MacroMatchFailureReason
@@ -39,7 +40,53 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetStateForMacroResultSuccess,
     PathResolutionFailureReason,
 )
-from griptape_nodes.retained_mode.managers.project_manager import ProjectManager
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+from griptape_nodes.retained_mode.managers.project_manager import PROJECTS_TO_REGISTER_KEY, ProjectManager
+
+
+def _stub_config_for_listing(mock_config: Mock, *, global_workspace: str = "/global/ws") -> None:
+    """Give a Mock ConfigManager the minimum behavior ListProjectTemplatesRequest needs.
+
+    The listing reports each entry's effective workspace_dir and libraries_root, which runs the real
+    workspace and libraries ladders. These stubs stand in for a machine with nothing configured: no
+    registered projects, no project_workspaces overrides, no adjacent project configs -- so every
+    project lands on the global workspace and its libraries directly under it. Tests that care about
+    those inputs model them instead (see TestResolveWorkspaceDirForProjectId._build_pm).
+
+    `default_libraries_root` runs the REAL ConfigManager formula so a test asserting where libraries
+    land is not asserting against a re-implementation of the math.
+    """
+    stubbed_values = {
+        PROJECTS_TO_REGISTER_KEY: [],
+        "project_workspaces": {},
+        "workspace_directory": global_workspace,
+    }
+
+    def fake_get(key: str, **kwargs: Any) -> Any:
+        if key in stubbed_values:
+            return stubbed_values[key]
+        return kwargs.get("default")
+
+    mock_config.get_config_value.side_effect = fake_get
+    mock_config.read_env_config.return_value = {}
+    mock_config.read_config_file.return_value = {}
+    mock_config.compute_project_provisioning_config.return_value = {}
+    mock_config.configured_global_workspace_path.return_value = Path(global_workspace).expanduser().resolve()
+    mock_config.default_libraries_root.side_effect = partial(ConfigManager.default_libraries_root, mock_config)
+
+
+def _line_of(yaml_text: str, needle: str) -> int:
+    """Return the 1-indexed line of the first line containing `needle`.
+
+    Validation problems carry the line an editor should jump to. Searching the fixture for the
+    offending text keeps that assertion meaningful when a fixture gains or loses a line, instead of
+    pinning a bare number that has to be recounted by hand.
+    """
+    for line_number, line in enumerate(yaml_text.splitlines(), start=1):
+        if needle in line:
+            return line_number
+    msg = f"'{needle}' does not appear in the fixture YAML"
+    raise AssertionError(msg)
 
 
 class TestProjectManagerMacroHandlers:
@@ -1311,7 +1358,8 @@ class TestProjectManagerGetCurrentProject:
 class TestProjectManagerListProjectTemplates:
     """Test ProjectManager ListProjectTemplates request handler."""
 
-    def test_list_project_templates_empty(self) -> None:
+    @pytest.mark.asyncio
+    async def test_list_project_templates_empty(self) -> None:
         """Test ListProjectTemplates with no projects loaded."""
         from griptape_nodes.retained_mode.events.project_events import (
             ListProjectTemplatesRequest,
@@ -1321,16 +1369,18 @@ class TestProjectManagerListProjectTemplates:
         mock_config = Mock()
         mock_secrets = Mock()
         mock_event_manager = Mock()
+        _stub_config_for_listing(mock_config)
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         request = ListProjectTemplatesRequest(include_system_builtins=False)
-        result = pm.on_list_project_templates_request(request)
+        result = await pm.on_list_project_templates_request(request)
 
         assert isinstance(result, ListProjectTemplatesResultSuccess)
         assert result.successfully_loaded == []
         assert result.failed_to_load == []
 
-    def test_list_project_templates_successfully_loaded(self) -> None:
+    @pytest.mark.asyncio
+    async def test_list_project_templates_successfully_loaded(self) -> None:
         """Test ListProjectTemplates returns successfully loaded projects."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
@@ -1345,6 +1395,7 @@ class TestProjectManagerListProjectTemplates:
         mock_config.read_config_file_value.return_value = None
         mock_secrets = Mock()
         mock_event_manager = Mock()
+        _stub_config_for_listing(mock_config)
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         # Add two successfully loaded projects
@@ -1384,7 +1435,7 @@ class TestProjectManagerListProjectTemplates:
         pm._successfully_loaded_project_templates[project2_id] = project_info2
 
         request = ListProjectTemplatesRequest(include_system_builtins=False)
-        result = pm.on_list_project_templates_request(request)
+        result = await pm.on_list_project_templates_request(request)
 
         assert isinstance(result, ListProjectTemplatesResultSuccess)
         assert result.failed_to_load == []
@@ -1393,7 +1444,8 @@ class TestProjectManagerListProjectTemplates:
         project_ids = {info.project_id for info in result.successfully_loaded}
         assert project_ids == {project1_id, project2_id}
 
-    def test_list_project_templates_with_failures(self) -> None:
+    @pytest.mark.asyncio
+    async def test_list_project_templates_with_failures(self) -> None:
         """Test ListProjectTemplates returns failed projects."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.retained_mode.events.project_events import (
@@ -1404,6 +1456,7 @@ class TestProjectManagerListProjectTemplates:
         mock_config = Mock()
         mock_secrets = Mock()
         mock_event_manager = Mock()
+        _stub_config_for_listing(mock_config)
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         # Add a failed project to registered_template_status
@@ -1414,7 +1467,7 @@ class TestProjectManagerListProjectTemplates:
         pm._registered_template_status[failed_path] = failed_validation
 
         request = ListProjectTemplatesRequest(include_system_builtins=False)
-        result = pm.on_list_project_templates_request(request)
+        result = await pm.on_list_project_templates_request(request)
 
         assert isinstance(result, ListProjectTemplatesResultSuccess)
         assert result.successfully_loaded == []
@@ -1422,7 +1475,8 @@ class TestProjectManagerListProjectTemplates:
         assert result.failed_to_load[0].project_id == str(failed_path)
         assert result.failed_to_load[0].validation.status == ProjectValidationStatus.UNUSABLE
 
-    def test_list_project_templates_filters_system_builtins(self) -> None:
+    @pytest.mark.asyncio
+    async def test_list_project_templates_filters_system_builtins(self) -> None:
         """Test ListProjectTemplates filters system builtins when requested."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
@@ -1435,6 +1489,7 @@ class TestProjectManagerListProjectTemplates:
         mock_config = Mock()
         mock_secrets = Mock()
         mock_event_manager = Mock()
+        _stub_config_for_listing(mock_config)
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         # Add system defaults
@@ -1456,20 +1511,21 @@ class TestProjectManagerListProjectTemplates:
 
         # Test with include_system_builtins=False (default)
         request_no_builtins = ListProjectTemplatesRequest(include_system_builtins=False)
-        result_no_builtins = pm.on_list_project_templates_request(request_no_builtins)
+        result_no_builtins = await pm.on_list_project_templates_request(request_no_builtins)
 
         assert isinstance(result_no_builtins, ListProjectTemplatesResultSuccess)
         assert result_no_builtins.successfully_loaded == []
 
         # Test with include_system_builtins=True
         request_with_builtins = ListProjectTemplatesRequest(include_system_builtins=True)
-        result_with_builtins = pm.on_list_project_templates_request(request_with_builtins)
+        result_with_builtins = await pm.on_list_project_templates_request(request_with_builtins)
 
         assert isinstance(result_with_builtins, ListProjectTemplatesResultSuccess)
         assert len(result_with_builtins.successfully_loaded) == 1
         assert result_with_builtins.successfully_loaded[0].project_id == SYSTEM_DEFAULTS_KEY
 
-    def test_list_project_templates_mixed_state(self) -> None:
+    @pytest.mark.asyncio
+    async def test_list_project_templates_mixed_state(self) -> None:
         """Test ListProjectTemplates with mix of successful and failed projects."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
@@ -1484,6 +1540,7 @@ class TestProjectManagerListProjectTemplates:
         mock_config.read_config_file_value.return_value = None
         mock_secrets = Mock()
         mock_event_manager = Mock()
+        _stub_config_for_listing(mock_config)
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         # Add successful project
@@ -1514,7 +1571,7 @@ class TestProjectManagerListProjectTemplates:
         pm._registered_template_status[failed_path] = failed_validation
 
         request = ListProjectTemplatesRequest(include_system_builtins=False)
-        result = pm.on_list_project_templates_request(request)
+        result = await pm.on_list_project_templates_request(request)
 
         assert isinstance(result, ListProjectTemplatesResultSuccess)
         assert len(result.successfully_loaded) == 1
@@ -1522,7 +1579,8 @@ class TestProjectManagerListProjectTemplates:
         assert result.successfully_loaded[0].project_id == success_id
         assert result.failed_to_load[0].project_id == str(failed_path)
 
-    def test_list_marks_incompatible_engine_version(self) -> None:
+    @pytest.mark.asyncio
+    async def test_list_marks_incompatible_engine_version(self) -> None:
         """A project whose adjacent config pins an unsatisfiable engine_version is flagged incompatible."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
@@ -1538,6 +1596,7 @@ class TestProjectManagerListProjectTemplates:
         mock_config.read_config_file_value.return_value = ">=99"
         mock_secrets = Mock()
         mock_event_manager = Mock()
+        _stub_config_for_listing(mock_config)
         pm = ProjectManager(mock_event_manager, mock_config, mock_secrets)
 
         project_path = Path("/test/pinned.yml")
@@ -1556,7 +1615,7 @@ class TestProjectManagerListProjectTemplates:
             parsed_directory_schemas=directory_schemas,
         )
 
-        result = pm.on_list_project_templates_request(ListProjectTemplatesRequest(include_system_builtins=False))
+        result = await pm.on_list_project_templates_request(ListProjectTemplatesRequest(include_system_builtins=False))
 
         assert isinstance(result, ListProjectTemplatesResultSuccess)
         info = result.successfully_loaded[0]
@@ -3690,6 +3749,18 @@ class TestResolveWorkspaceDirForProjectId:
 
         mock_config.read_config_file.side_effect = fake_read_config_file
 
+        # The nothing-declared libraries fallback runs the REAL ConfigManager formula over these
+        # stubbed layers, so tests assert where libraries actually land instead of re-implementing
+        # the math. compute_project_provisioning_config stands in for the merged view with the
+        # target's adjacent config, which is the layer these tests vary.
+        mock_config.configured_global_workspace_path.return_value = cls._resolved(
+            env_workspace or configured_root or default_root or "/global/ws"
+        )
+        mock_config.default_libraries_root.side_effect = partial(ConfigManager.default_libraries_root, mock_config)
+        mock_config.compute_project_provisioning_config.side_effect = lambda project_dir, _workspace_dir, **_kwargs: (
+            dir_to_config.get(Path(project_dir), {})
+        )
+
         path_to_overlay = {
             canonicalize_for_identity(Path(spec["file"])): cls._make_overlay(
                 project_id=spec["id"],
@@ -4132,6 +4203,118 @@ class TestResolveWorkspaceDirForProjectId:
         assert isinstance(probe, LoadProjectTemplateResultFailure)
         assert isinstance(recorded, LoadProjectTemplateResultFailure)
 
+    @pytest.mark.asyncio
+    async def test_unloaded_workspace_dir_expands_env_var_before_anchoring(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An env var in workspace_dir expands BEFORE the relative/absolute decision, so it is not mis-anchored.
+
+        `Path("${VAR}/ws").is_absolute()` is False, so deciding absoluteness first would join the
+        whole thing onto the project directory and hand back a path with a literal `${VAR}` component
+        in it. Expansion has to come first.
+        """
+        project_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        project_file.parent.mkdir(parents=True)
+        project_file.touch()
+        env_root = tmp_path / "env-root"
+        monkeypatch.setenv("GTN_TEST_WS", str(env_root))
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "workspace_dir": "${GTN_TEST_WS}/ws"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_workspace_dir_for_project_id("C")
+
+        assert result == self._resolved(str(env_root / "ws"))
+        assert "GTN_TEST_WS" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_unloaded_workspace_dir_with_unset_env_var_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unset env var in workspace_dir falls through to the next ladder source, not a literal path.
+
+        The value cannot be resolved, so the ladder behaves as if the project declared nothing --
+        which is what activation does -- rather than creating a directory named `${GTN_TEST_WS}`
+        under the project.
+        """
+        project_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        project_file.parent.mkdir(parents=True)
+        project_file.touch()
+        monkeypatch.delenv("GTN_TEST_WS", raising=False)
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "workspace_dir": "${GTN_TEST_WS}/ws"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_workspace_dir_for_project_id("C")
+
+        assert result == self._resolved("/global/ws")
+
+    @pytest.mark.asyncio
+    async def test_unloaded_parent_link_expands_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A legacy parent_project_path holding an env var resolves, so inheritance follows the link."""
+        parent_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        child_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        for f in (parent_file, child_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
+        parent_ws = tmp_path / "parent-ws"
+        monkeypatch.setenv("GTN_TEST_PARENT", str(parent_file.parent))
+
+        pm = self._build_pm(
+            [
+                {"id": "A", "file": parent_file, "config": {}, "workspace_dir": str(parent_ws)},
+                {
+                    "id": "C",
+                    "file": child_file,
+                    "parent_path": "${GTN_TEST_PARENT}/griptape-nodes-project.yml",
+                    "config": {},
+                },
+            ],
+            registered=[str(parent_file), str(child_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_workspace_dir_for_project_id("C")
+
+        assert result == self._resolved(str(parent_ws))
+
+    @pytest.mark.asyncio
+    async def test_unloaded_parent_link_with_unset_env_var_reports_no_parent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unresolvable parent_project_path is no link at all, not a bogus child-relative path.
+
+        Anchoring the unexpanded value would produce `<child_dir>/${GTN_TEST_PARENT}/...`, which
+        matches no project on disk -- the same dead end, but reached by inventing a path. The child
+        therefore falls back to the global default instead of inheriting anything.
+        """
+        parent_file = tmp_path / "a" / "griptape-nodes-project.yml"
+        child_file = tmp_path / "c" / "griptape-nodes-project.yml"
+        for f in (parent_file, child_file):
+            f.parent.mkdir(parents=True)
+            f.touch()
+        monkeypatch.delenv("GTN_TEST_PARENT", raising=False)
+
+        pm = self._build_pm(
+            [
+                {"id": "A", "file": parent_file, "config": {}, "workspace_dir": str(tmp_path / "parent-ws")},
+                {
+                    "id": "C",
+                    "file": child_file,
+                    "parent_path": "${GTN_TEST_PARENT}/griptape-nodes-project.yml",
+                    "config": {},
+                },
+            ],
+            registered=[str(parent_file), str(child_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_workspace_dir_for_project_id("C")
+
+        assert result == self._resolved("/global/ws")
+
 
 class TestResolveLibrariesRootForProjectId(TestResolveWorkspaceDirForProjectId):
     """`resolve_libraries_root_for_project_id` resolves an UNLOADED project's libraries root.
@@ -4330,12 +4513,14 @@ class TestResolveLibrariesRootForProjectId(TestResolveWorkspaceDirForProjectId):
 
         pm._read_overlay = counting_read_overlay  # type: ignore[method-assign]
 
-        def probe(node_path: Path, overlay: "ProjectOverlayData") -> str | None:
-            return pm._resolve_template_libraries_dir(overlay.libraries_dir, node_path)
+        def probe(node_path: Path, overlay: "ProjectOverlayData") -> "ResolvedProjectPath":
+            return pm._resolve_template_path_field(overlay.libraries_dir, node_path, "libraries_dir")
 
         result = await pm._nearest_ancestor_value_offline(child_canonical, id_index, probe)
 
-        assert result == str(self._canonical(grand_file.parent / "shared-libs"))
+        # Only G declares a libraries_dir, so reaching its value proves the walk ran the full chain.
+        assert result.value == str(self._canonical(grand_file.parent / "shared-libs"))
+        assert result.incomplete_reason is None
         # The walk visits C (start), A, G -- each overlay read exactly once, none twice.
         assert read_counts, "expected the walk to read at least one overlay"
         assert max(read_counts.values()) == 1, f"a node overlay was read more than once: {read_counts}"
@@ -4412,6 +4597,195 @@ class TestResolveLibrariesRootForProjectId(TestResolveWorkspaceDirForProjectId):
         result = await pm.resolve_libraries_root_for_project_id("C")
 
         assert result == self._canonical(b_file.parent / "b-libs")
+
+
+class TestLibrariesRootPathResolution(TestResolveLibrariesRootForProjectId):
+    """How the VALUE in a libraries_dir field becomes a path.
+
+    Same offline resolver as the class above, but exercising the shared path primitives rather than
+    the inheritance ladder: `~` and `${VAR}` expansion, the deliberate bare-`$NAME` carve-out, and
+    the per-platform `default` key.
+
+    A declared value that cannot produce a path is refused at LOAD time, so a project carrying one
+    never reaches these resolvers -- see TestProjectPathFieldValidation. This harness stubs
+    `_read_overlay`, which is exactly where that refusal lives, so the fall-through assertions below
+    document the resolvers' defense-in-depth behavior rather than a reachable user-facing outcome.
+    """
+
+    @staticmethod
+    def _write_project(project_file: Path) -> Path:
+        """Create a project YAML on disk (its content is supplied via specs, not read from the file)."""
+        project_file.parent.mkdir(parents=True, exist_ok=True)
+        project_file.touch()
+        return project_file
+
+    @pytest.mark.asyncio
+    async def test_libraries_dir_expands_env_var_before_anchoring(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An env var in libraries_dir expands BEFORE the relative/absolute decision.
+
+        `Path("${VAR}/libs").is_absolute()` is False, so deciding absoluteness first would anchor the
+        whole thing under the project directory -- the bug that made the previous attempt report
+        confident wrong paths.
+        """
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+        env_root = tmp_path / "env-libs-root"
+        monkeypatch.setenv("GTN_TEST_LIBS", str(env_root))
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": "${GTN_TEST_LIBS}/libs"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result == self._canonical(env_root / "libs")
+        assert "GTN_TEST_LIBS" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_libraries_dir_expands_home(self, tmp_path: Path) -> None:
+        """`~` in libraries_dir expands to the user's home directory, not a literal `~` component."""
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": "~/shared-libs"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result == self._canonical(Path.home() / "shared-libs")
+
+    @pytest.mark.asyncio
+    async def test_bare_dollar_name_stays_literal(self, tmp_path: Path) -> None:
+        """A bare `$NAME` that expands to nothing stays a literal path component.
+
+        Regression guard for the deliberate carve-out: `$Recycle.Bin` is a real directory on Windows,
+        and only the unambiguously delimited `${NAME}` / `%NAME%` forms are treated as variables.
+        """
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": "$Recycle.Bin/libs"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result == self._canonical(project_file.parent / "$Recycle.Bin" / "libs")
+
+    @pytest.mark.asyncio
+    async def test_per_platform_default_key_resolves_on_every_platform(self, tmp_path: Path) -> None:
+        """A per-platform mapping carrying `default` resolves wherever the OS key is absent.
+
+        This is the portable escape hatch: `%VAR%` only expands on Windows and drive letters mean
+        nothing elsewhere, so a mapping that names one OS explicitly should also say what the others
+        get. Omitting `default` is what makes a platform gap a load error.
+        """
+        from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath
+
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+        other_os = tmp_path / "other-os-libs"
+        shared = tmp_path / "default-libs"
+        # Name a platform we are NOT on, plus a default -- the default is what must be selected.
+        if sys.platform.startswith("win"):
+            per_platform = PerPlatformProjectPath(linux=str(other_os), default=str(shared))
+        else:
+            per_platform = PerPlatformProjectPath(windows=str(other_os), default=str(shared))
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": per_platform}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result == self._canonical(shared)
+
+    @pytest.mark.asyncio
+    async def test_unset_env_var_yields_no_explicit_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unresolvable declaration never becomes a guessed path: the resolver reports None.
+
+        Defense in depth. A project declaring this does not load (see
+        TestProjectPathFieldValidation), so the only way to reach the resolver with such a value is
+        to bypass the overlay read -- and even then it must not invent `<project_dir>/${GTN_TEST_LIBS}/libs`.
+        """
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+        monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": "${GTN_TEST_LIBS}/libs"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_macro_token_yields_no_explicit_root(self, tmp_path: Path) -> None:
+        """A `{macro}` token never becomes a literal directory name (defense in depth).
+
+        These fields resolve before the project's runtime state exists, so the macro system does not
+        apply to them -- and a directory literally named `{outputs}` is nobody's intent.
+        """
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": "{outputs}/libs"}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_value_for_this_platform_yields_no_explicit_root(self, tmp_path: Path) -> None:
+        """A per-platform mapping with no entry for this OS and no `default` yields None (defense in depth)."""
+        from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath
+
+        project_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+        other_os = tmp_path / "other-os-libs"
+        # Set only a platform we are NOT running on, so select_project_path finds nothing.
+        if sys.platform.startswith("win"):
+            per_platform = PerPlatformProjectPath(linux=str(other_os))
+        else:
+            per_platform = PerPlatformProjectPath(windows=str(other_os))
+
+        pm = self._build_pm(
+            [{"id": "C", "file": project_file, "config": {}, "libraries_dir": per_platform}],
+            registered=[str(project_file)],
+            configured_root="/global/ws",
+        )
+        result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_inherited_value_anchors_to_the_declaring_ancestor(self, tmp_path: Path) -> None:
+        """A relative value inherited from a parent anchors to the PARENT's directory, not the child's.
+
+        This is what makes parent and child report the SAME libraries root, which is the whole point
+        of inheriting the field: one shared libraries/ tree instead of one download per child.
+        """
+        parent_file = self._write_project(tmp_path / "a" / "griptape-nodes-project.yml")
+        child_file = self._write_project(tmp_path / "c" / "griptape-nodes-project.yml")
+
+        pm = self._build_pm(
+            [
+                {"id": "A", "file": parent_file, "config": {}, "libraries_dir": "./shared-libs"},
+                {"id": "C", "file": child_file, "parent_id": "A", "config": {}},
+            ],
+            registered=[str(parent_file), str(child_file)],
+            configured_root="/global/ws",
+        )
+        parent_result = await pm.resolve_libraries_root_for_project_id("A")
+        child_result = await pm.resolve_libraries_root_for_project_id("C")
+
+        assert child_result == self._canonical(parent_file.parent / "shared-libs")
+        assert child_result == parent_result
 
 
 class TestOnResolveProjectWorkspaceRequest(TestResolveWorkspaceDirForProjectId):
@@ -6633,7 +7007,7 @@ directories:
         mock_config_manager.project_config = {}
         mock_config_manager.env_config = {}
         mock_config_manager.merged_config = {}
-        mock_config_manager.get_config_value.return_value = []
+        _stub_config_for_listing(mock_config_manager, global_workspace=str(tmp_path))
         mock_config_manager.read_config_file_value.return_value = None
         mock_config_manager.workspace_path = tmp_path
         return ProjectManager(mock_event_manager, mock_config_manager, Mock())
@@ -6921,7 +7295,9 @@ directories:
         assert isinstance(base_load, LoadProjectTemplateResultSuccess)
         assert isinstance(child_load, LoadProjectTemplateResultSuccess)
 
-        list_result = pm.on_list_project_templates_request(ListProjectTemplatesRequest(include_system_builtins=False))
+        list_result = await pm.on_list_project_templates_request(
+            ListProjectTemplatesRequest(include_system_builtins=False)
+        )
         by_id = {info.project_id: info for info in list_result.successfully_loaded}
 
         # Child's parent_project_id from the list must match the base's project_id
@@ -8161,13 +8537,21 @@ directories:
         assert "child_outputs" in result.template.directories
 
     @pytest.mark.asyncio
-    async def test_load_child_with_per_platform_parent_no_match_treats_as_no_parent(
+    async def test_load_child_with_per_platform_parent_no_match_is_an_error(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When no platform key matches and no default, the child loads against system defaults instead."""
+        """No platform key matching and no `default` is a load error, not a silent reparent.
+
+        Loading such a child against the system defaults would drop everything the parent was
+        supposed to supply -- its directories, situations and libraries root -- while still reporting
+        success, so the artist would see a project that opens and behaves like a different project.
+        The `default` key exists to say what other platforms should use; omitting it expresses no
+        intent to honor.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
         from griptape_nodes.retained_mode.events.project_events import (
             LoadProjectTemplateRequest,
-            LoadProjectTemplateResultSuccess,
+            LoadProjectTemplateResultFailure,
         )
 
         monkeypatch.setattr("sys.platform", "linux")
@@ -8190,11 +8574,14 @@ directories:
             mock_engine.ahandle_request = self._file_router(files)
             result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=child_path))
 
-        assert isinstance(result, LoadProjectTemplateResultSuccess)
-        # Child's own directory survives.
-        assert "child_outputs" in result.template.directories
-        # System default directories present (default fallback applied).
-        assert "outputs" in result.template.directories
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "parent_project_path"]
+        assert len(problems) == 1
+        assert "no path for this platform" in problems[0].message
+        # A nested block anchors at its first child key (`darwin:`), which is where the line tracker
+        # points -- close enough for an editor to jump to the offending field.
+        assert problems[0].line_number == _line_of(child_yaml, "darwin:")
 
     @pytest.mark.asyncio
     async def test_load_child_with_per_platform_parent_falls_back_to_default(
@@ -8263,6 +8650,550 @@ directories:
         assert isinstance(result.template.parent_project_path, PerPlatformProjectPath)
         assert result.template.parent_project_path.darwin == base_path.as_posix()
         assert result.template.parent_project_path.linux == "/mnt/base.yml"
+
+
+class TestProjectPathFieldValidation:
+    """A declared path field that cannot produce a path fails the load, naming field, line and cause.
+
+    The rule, uniform across `workspace_dir`, `libraries_dir` and `parent_project_path`: ABSENT means
+    "fall through to the next source", PRESENT-but-unresolvable means the project is broken. The only
+    alternative is to discard what the user wrote and put their workspace or their libraries somewhere
+    they never named, which is how a shared project ends up silently installing a second copy of every
+    library on a teammate's machine.
+
+    These tests drive the REAL `_read_overlay` through `on_load_project_template_request` with YAML on
+    disk, because `_read_overlay` is where the check lives -- the `_build_pm` harness used by the
+    resolver tests stubs exactly that method out.
+    """
+
+    @pytest.fixture
+    def pm(self, tmp_path: Path) -> ProjectManager:
+        mock_event_manager = Mock()
+        mock_config_manager = Mock()
+        mock_config_manager.project_config = {}
+        mock_config_manager.env_config = {}
+        mock_config_manager.merged_config = {}
+        mock_config_manager.read_config_file_value.return_value = None
+        mock_config_manager.workspace_path = tmp_path
+        _stub_config_for_listing(mock_config_manager, global_workspace=str(tmp_path / "global-ws"))
+        return ProjectManager(mock_event_manager, mock_config_manager, Mock())
+
+    @staticmethod
+    def _file_router(files: dict[Path, str]) -> AsyncMock:
+        """Build an `ahandle_request` mock that returns YAML content based on file path."""
+        from griptape_nodes.retained_mode.events.os_events import (
+            FileIOFailureReason,
+            ReadFileResultFailure,
+            ReadFileResultSuccess,
+        )
+
+        async def route(request: object) -> object:
+            file_path = Path(getattr(request, "file_path", ""))
+            content = files.get(file_path)
+            if content is None:
+                return ReadFileResultFailure(
+                    failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
+                    result_details=f"missing: {file_path}",
+                )
+            return ReadFileResultSuccess(
+                content=content,
+                file_size=len(content),
+                mime_type="text/plain",
+                encoding="utf-8",
+                result_details="ok",
+            )
+
+        return AsyncMock(side_effect=route)
+
+    async def _load(self, pm: ProjectManager, files: dict[Path, str], project_path: Path) -> Any:
+        """Load one project through the real handler, with the other files readable as ancestors."""
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateRequest
+
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
+            return await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
+
+    @pytest.mark.asyncio
+    async def test_unset_variable_in_libraries_dir_fails_the_load(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`${GTN_TEST_LIBS}/libraries` with the variable unset is an error, not a fallback.
+
+        The old behavior logged a warning, discarded the declaration, and installed libraries under
+        `<workspace>/libraries` instead -- a location the project never asked for.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'libraries_dir: "${GTN_TEST_LIBS}/libraries"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert "no value is set for GTN_TEST_LIBS" in problems[0].message
+        assert problems[0].line_number == _line_of(project_yaml, "libraries_dir:")
+
+    @pytest.mark.asyncio
+    async def test_macro_token_in_workspace_dir_fails_the_load(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A `{macro}` token in a path field is refused rather than becoming a folder of that name.
+
+        Macros resolve against runtime state that does not exist yet when these fields are read, so
+        `{outputs}` here can only ever mean a directory literally called `{outputs}`.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\nname: Studio Project\nworkspace_dir: "{outputs}/work"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "workspace_dir"]
+        assert len(problems) == 1
+        assert "macro tokens are not supported" in problems[0].message
+        assert "outputs" in problems[0].message
+        assert problems[0].line_number == _line_of(project_yaml, "workspace_dir:")
+
+    @pytest.mark.asyncio
+    async def test_percent_reference_in_libraries_dir_fails_the_load(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `%NAME%` reference that expands to nothing fails the load on every platform.
+
+        `%NAME%` expands only on Windows, so elsewhere it never resolves at all. Either way the value
+        has no answer, and a real directory whose name happens to contain `%SHOT_CODE%` is now refused
+        rather than used literally -- the deliberate cost of treating the form as a variable.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.delenv("SHOT_CODE", raising=False)
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\nname: Studio Project\nlibraries_dir: "%SHOT_CODE%/libs"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert "no value is set for SHOT_CODE" in problems[0].message
+
+    @pytest.mark.asyncio
+    async def test_platform_gap_in_libraries_dir_fails_the_load(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A per-platform mapping with no entry for this OS and no `default` fails the load.
+
+        `default` exists precisely to say what the platforms you did not name should get. A mapping
+        that names only Windows says nothing about a Linux teammate, so there is nothing to honor and
+        nothing to guess.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.setattr("sys.platform", "linux")
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            "libraries_dir:\n"
+            '  darwin: "/Volumes/fast/libs"\n'
+            '  windows: "D:/libs"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert "no path for this platform (linux) and no 'default'" in problems[0].message
+        # A nested block anchors at its first child key (`darwin:`), which is close enough for an
+        # editor to jump to the offending field.
+        assert problems[0].line_number == _line_of(project_yaml, "darwin:")
+
+    @pytest.mark.asyncio
+    async def test_every_broken_field_is_reported_in_one_load(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All three fields are checked, so the user fixes everything in one pass, not one per restart."""
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.delenv("GTN_TEST_WS", raising=False)
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'workspace_dir: "${GTN_TEST_WS}/work"\n'
+            'libraries_dir: "{outputs}/libs"\n'
+            'parent_project_path: "{project_dir}/base.yml"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        broken_fields = {p.field_path for p in result.validation.problems}
+        assert broken_fields == {"workspace_dir", "libraries_dir", "parent_project_path"}
+        for field_name in broken_fields:
+            assert field_name in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_absent_path_fields_load_normally(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """Declaring none of the three fields is not an error -- absence still means "next source"."""
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
+
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = 'project_template_schema_version: "0.3.3"\nname: Studio Project\ndirectories: {}\n'
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+
+    @pytest.mark.asyncio
+    async def test_resolvable_variable_loads_and_keeps_the_raw_value(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A variable that IS set loads, and the template keeps the unexpanded value verbatim.
+
+        Validation must not rewrite the field: the raw form is what makes the project portable to the
+        next machine, where the variable points somewhere else.
+        """
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
+
+        monkeypatch.setenv("GTN_TEST_LIBS", str(tmp_path / "studio"))
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'libraries_dir: "${GTN_TEST_LIBS}/libraries"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.template.libraries_dir == "${GTN_TEST_LIBS}/libraries"
+
+    @pytest.mark.asyncio
+    async def test_child_of_project_with_unresolvable_libraries_dir_also_fails(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A broken parent brings its descendants down, with the error on the child's parent link.
+
+        This is the accepted cost of failing closed: a shared base project pinning an unset variable
+        stops loading for every project derived from it. The alternative is each of those children
+        quietly installing libraries somewhere the base never named.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
+        base_path = (tmp_path / "base.yml").resolve()
+        child_path = (tmp_path / "child.yml").resolve()
+        base_yaml = (
+            'project_template_schema_version: "0.3.3"\nname: Base\nlibraries_dir: "${GTN_TEST_LIBS}/libraries"\n'
+        )
+        child_yaml = (
+            f'project_template_schema_version: "0.3.3"\nname: Child\nparent_project_path: "{base_path.as_posix()}"\n'
+        )
+
+        result = await self._load(pm, {base_path: base_yaml, child_path: child_yaml}, child_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        problems = [p for p in result.validation.problems if p.field_path == "parent_project_path"]
+        assert len(problems) == 1
+        assert "could not be loaded" in problems[0].message
+        assert problems[0].line_number == _line_of(child_yaml, "parent_project_path:")
+
+    @pytest.mark.asyncio
+    async def test_failed_project_is_listed_as_failed_with_no_paths(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused project surfaces in failed_to_load, and reports no paths at all.
+
+        The GUI needs to distinguish "here is where this project's libraries live" from "this project
+        is broken" -- so a failed entry carries its validation problems and nothing that looks like an
+        answer.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            ListProjectTemplatesRequest,
+            ListProjectTemplatesResultSuccess,
+        )
+
+        monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\nname: Broken\nlibraries_dir: "${GTN_TEST_LIBS}/libraries"\n'
+        )
+        files = {project_path: project_yaml}
+        await self._load(pm, files, project_path)
+
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            mock_engine.ahandle_request = self._file_router(files)
+            listing = await pm.on_list_project_templates_request(
+                ListProjectTemplatesRequest(include_system_builtins=False)
+            )
+
+        assert isinstance(listing, ListProjectTemplatesResultSuccess)
+        assert listing.successfully_loaded == []
+        assert len(listing.failed_to_load) == 1
+        failed = listing.failed_to_load[0]
+        assert failed.project_id == str(project_path)
+        assert failed.workspace_dir is None
+        assert failed.libraries_root is None
+        assert any(p.field_path == "libraries_dir" for p in failed.validation.problems)
+
+
+class TestListProjectTemplatesEffectivePaths:
+    """The listing reports where each project's files and libraries actually land.
+
+    This is what #5204 asked for: `libraries_dir` is decoupled from the workspace and inherits down
+    the parent chain, so the GUI cannot derive the location from anything it already holds.
+
+    Both paths are resolved from DISK, the way activation resolves them for any project declaring a
+    parent -- never through the live merged config, whose layers belong to whichever project happens
+    to be open. `test_answers_do_not_depend_on_which_project_is_open` is the guard on that.
+    """
+
+    @pytest.fixture
+    def global_workspace(self, tmp_path: Path) -> Path:
+        return (tmp_path / "global-ws").resolve()
+
+    @pytest.fixture
+    def mock_config(self, global_workspace: Path) -> Mock:
+        mock_config_manager = Mock()
+        mock_config_manager.project_config = {}
+        mock_config_manager.env_config = {}
+        mock_config_manager.merged_config = {}
+        mock_config_manager.read_config_file_value.return_value = None
+        mock_config_manager.workspace_path = global_workspace
+        _stub_config_for_listing(mock_config_manager, global_workspace=str(global_workspace))
+        return mock_config_manager
+
+    @pytest.fixture
+    def pm(self, mock_config: Mock) -> ProjectManager:
+        return ProjectManager(Mock(), mock_config, Mock())
+
+    @staticmethod
+    def _file_router(files: dict[Path, str]) -> AsyncMock:
+        """Build an `ahandle_request` mock that returns YAML content based on file path."""
+        from griptape_nodes.retained_mode.events.os_events import (
+            FileIOFailureReason,
+            ReadFileResultFailure,
+            ReadFileResultSuccess,
+        )
+
+        async def route(request: object) -> object:
+            file_path = Path(getattr(request, "file_path", ""))
+            content = files.get(file_path)
+            if content is None:
+                return ReadFileResultFailure(
+                    failure_reason=FileIOFailureReason.FILE_NOT_FOUND,
+                    result_details=f"missing: {file_path}",
+                )
+            return ReadFileResultSuccess(
+                content=content,
+                file_size=len(content),
+                mime_type="text/plain",
+                encoding="utf-8",
+                result_details="ok",
+            )
+
+        return AsyncMock(side_effect=route)
+
+    async def _load_then_list(
+        self, pm: ProjectManager, files: dict[Path, str], load_order: list[Path]
+    ) -> dict[str, Any]:
+        """Load each project through the real handler, then list, keyed by project file path.
+
+        Both halves run against one router so the listing's own disk walks read the same YAML the
+        loads did.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            ListProjectTemplatesRequest,
+            ListProjectTemplatesResultSuccess,
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+        )
+
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            cast("Mock", pm._event_manager).evaluate_authorization_checkpoint.return_value = None
+            mock_engine.ahandle_request = self._file_router(files)
+            for project_path in load_order:
+                load_result = await pm.on_load_project_template_request(
+                    LoadProjectTemplateRequest(project_path=project_path)
+                )
+                assert isinstance(load_result, LoadProjectTemplateResultSuccess), load_result.result_details
+            listing = await pm.on_list_project_templates_request(
+                ListProjectTemplatesRequest(include_system_builtins=False)
+            )
+
+        assert isinstance(listing, ListProjectTemplatesResultSuccess)
+        # Builtins are excluded from the request, so every entry here is file-backed; the None guard is
+        # only to key the dict by a real path.
+        return {
+            info.project_file_path: info for info in listing.successfully_loaded if info.project_file_path is not None
+        }
+
+    @pytest.mark.asyncio
+    async def test_declared_libraries_dir_is_reported_absolute(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A project's own relative `libraries_dir` is reported as an absolute path under its own dir."""
+        project_path = (tmp_path / "solo" / "griptape-nodes-project.yml").resolve()
+        files = {
+            project_path: (
+                'project_template_schema_version: "0.3.3"\nname: Solo\nlibraries_dir: "./shared-libraries"\n'
+            )
+        }
+
+        by_path = await self._load_then_list(pm, files, [project_path])
+
+        info = by_path[str(project_path)]
+        assert info.libraries_root == str(canonicalize_for_identity(project_path.parent / "shared-libraries"))
+
+    @pytest.mark.asyncio
+    async def test_child_and_parent_report_the_same_libraries_root(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """An inherited `libraries_dir` anchors to the DECLARING ancestor, so the whole tree agrees.
+
+        This is the point of inheriting the field: one shared libraries tree that is downloaded once,
+        not one copy per child. A child anchoring the parent's `./libraries` to its OWN directory would
+        silently give every child a private tree.
+        """
+        base_path = (tmp_path / "base" / "griptape-nodes-project.yml").resolve()
+        child_path = (tmp_path / "base" / "shots" / "griptape-nodes-project.yml").resolve()
+        files = {
+            base_path: 'project_template_schema_version: "0.3.3"\nname: Base\nlibraries_dir: "./libraries"\n',
+            child_path: (
+                'project_template_schema_version: "0.3.3"\n'
+                "name: Child\n"
+                f'parent_project_path: "{base_path.as_posix()}"\n'
+            ),
+        }
+
+        by_path = await self._load_then_list(pm, files, [base_path, child_path])
+
+        expected = str(canonicalize_for_identity(base_path.parent / "libraries"))
+        assert by_path[str(base_path)].libraries_root == expected
+        assert by_path[str(child_path)].libraries_root == expected
+
+    @pytest.mark.asyncio
+    async def test_nothing_declared_falls_back_to_the_global_workspace_default(
+        self, pm: ProjectManager, tmp_path: Path, global_workspace: Path
+    ) -> None:
+        """With no declaration anywhere, both paths come from the engine's global workspace."""
+        project_path = (tmp_path / "plain" / "griptape-nodes-project.yml").resolve()
+        files = {project_path: 'project_template_schema_version: "0.3.3"\nname: Plain\ndirectories: {}\n'}
+
+        by_path = await self._load_then_list(pm, files, [project_path])
+
+        info = by_path[str(project_path)]
+        assert info.workspace_dir == str(global_workspace)
+        assert info.libraries_root == str(global_workspace / "libraries")
+
+    @pytest.mark.asyncio
+    async def test_libraries_directory_config_value_is_honored(
+        self, pm: ProjectManager, mock_config: Mock, tmp_path: Path, global_workspace: Path
+    ) -> None:
+        """The nothing-declared default reads `libraries_directory` from the TARGET's own config view.
+
+        A config layer that re-points `libraries_directory` has to be honored, and it has to be read
+        from the layers the target project would activate with -- which is what
+        `compute_project_provisioning_config` computes -- rather than the currently merged view.
+        """
+        mock_config.compute_project_provisioning_config.return_value = {"libraries_directory": "custom-libs"}
+        project_path = (tmp_path / "plain" / "griptape-nodes-project.yml").resolve()
+        files = {project_path: 'project_template_schema_version: "0.3.3"\nname: Plain\ndirectories: {}\n'}
+
+        by_path = await self._load_then_list(pm, files, [project_path])
+
+        assert by_path[str(project_path)].libraries_root == str(global_workspace / "custom-libs")
+
+    @pytest.mark.asyncio
+    async def test_declared_workspace_dir_wins_and_is_reported(self, pm: ProjectManager, tmp_path: Path) -> None:
+        """A project's own `workspace_dir` is the highest-priority source and is what gets reported."""
+        project_path = (tmp_path / "selfcontained" / "griptape-nodes-project.yml").resolve()
+        files = {project_path: 'project_template_schema_version: "0.3.3"\nname: Self Contained\nworkspace_dir: "./"\n'}
+
+        by_path = await self._load_then_list(pm, files, [project_path])
+
+        info = by_path[str(project_path)]
+        assert info.workspace_dir == str(project_path.parent.resolve())
+        # Nothing declares libraries_dir, so they land under the GLOBAL workspace, not this project's
+        # own workspace -- the libraries default is deliberately engine-global.
+        assert info.libraries_root is not None
+
+    @pytest.mark.asyncio
+    async def test_system_defaults_entry_reports_no_paths(self, pm: ProjectManager) -> None:
+        """The built-in defaults have no backing file, declare nothing, and are never activated."""
+        from griptape_nodes.retained_mode.events.project_events import (
+            ListProjectTemplatesRequest,
+            ListProjectTemplatesResultSuccess,
+        )
+
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            mock_engine.ahandle_request = self._file_router({})
+            pm._load_system_defaults()
+            listing = await pm.on_list_project_templates_request(
+                ListProjectTemplatesRequest(include_system_builtins=True)
+            )
+
+        assert isinstance(listing, ListProjectTemplatesResultSuccess)
+        file_backed = [info for info in listing.successfully_loaded if info.project_file_path is None]
+        assert len(file_backed) == 1
+        assert file_backed[0].workspace_dir is None
+        assert file_backed[0].libraries_root is None
+
+    @pytest.mark.asyncio
+    async def test_answers_do_not_depend_on_which_project_is_open(self, mock_config: Mock, tmp_path: Path) -> None:
+        """Contamination guard: one project's reported paths never move because another one is active.
+
+        The live workspace/libraries ladders read the CURRENT project's config layers. Reporting from
+        those would make the answer for project B depend on A being open -- the defect that got the
+        first attempt at this rejected. So the live layers are stubbed here to point somewhere
+        obviously wrong, and the listing is taken with each project active in turn.
+        """
+        first_path = (tmp_path / "first" / "griptape-nodes-project.yml").resolve()
+        second_path = (tmp_path / "second" / "griptape-nodes-project.yml").resolve()
+        files = {
+            first_path: 'project_template_schema_version: "0.3.3"\nname: First\nlibraries_dir: "./first-libs"\n',
+            second_path: 'project_template_schema_version: "0.3.3"\nname: Second\nlibraries_dir: "./second-libs"\n',
+        }
+        # If the listing read the live layers instead of the target's own, these would leak in.
+        mock_config.project_config = {"workspace_directory": str(tmp_path / "hijacked-workspace")}
+        mock_config.env_config = {"workspace_directory": str(tmp_path / "hijacked-workspace")}
+
+        answers = []
+        for active_project_id in [None, str(first_path), str(second_path)]:
+            fresh_pm = ProjectManager(Mock(), mock_config, Mock())
+            by_path = await self._load_then_list(fresh_pm, files, [first_path, second_path])
+            if active_project_id is not None:
+                fresh_pm._current_project_id = active_project_id
+                by_path = await self._load_then_list(fresh_pm, files, [])
+            answers.append({path: (info.workspace_dir, info.libraries_root) for path, info in by_path.items()})
+
+        assert answers[0] == answers[1] == answers[2]
+        assert answers[0][str(first_path)][1] == str(canonicalize_for_identity(first_path.parent / "first-libs"))
+        assert answers[0][str(second_path)][1] == str(canonicalize_for_identity(second_path.parent / "second-libs"))
 
 
 class TestSnapshotLibraryConfig:

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -8492,7 +8492,7 @@ situations:
         # OS-specific resources, and falls into `os.uname()` on Linux/Mac branches.
         # On a Windows CI host with `sys.platform` faked to "linux", that crashes.
         monkeypatch.setattr(
-            "griptape_nodes.common.project_templates.directory._active_platform_key",
+            "griptape_nodes.common.project_templates.directory.active_platform_key",
             lambda: "linux",
         )
         entry = {
@@ -9034,7 +9034,7 @@ class TestProjectPathFieldValidation:
         from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
 
         monkeypatch.setattr(
-            "griptape_nodes.common.project_templates.directory._active_platform_key",
+            "griptape_nodes.common.project_templates.directory.active_platform_key",
             lambda: "windows",
         )
         project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
@@ -9053,6 +9053,42 @@ class TestProjectPathFieldValidation:
         assert len(problems) == 1
         assert "no path for this platform (windows) and no 'default'" in problems[0].message
         assert sys.platform not in problems[0].message
+
+    @pytest.mark.asyncio
+    async def test_platform_with_no_key_is_told_default_is_the_only_remedy(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On a platform the schema cannot name, the message must not suggest naming it.
+
+        `PerPlatformProjectPath` sets `extra="forbid"`, so on FreeBSD there is no key to add -- a
+        message reading "no path for this platform (freebsd13) ... or an entry for this one" describes
+        a fix that fails validation, which is the same confidently-wrong-cause failure this whole
+        field-resolution path exists to avoid. `default` is the only way out, and the message says so.
+        """
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+
+        monkeypatch.setattr(
+            "griptape_nodes.common.project_templates.directory.active_platform_key",
+            lambda: "",
+        )
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            "libraries_dir:\n"
+            '  darwin: "/Volumes/fast/libs"\n'
+            '  linux: "/mnt/fast/libs"\n'
+            '  windows: "Z:\\\\fast\\\\libs"\n'
+        )
+
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+
+        assert isinstance(result, LoadProjectTemplateResultFailure)
+        problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
+        assert len(problems) == 1
+        assert f"no path for this platform (unsupported ({sys.platform})) and no 'default'" in problems[0].message
+        assert "or an entry for this one" not in problems[0].message
+        assert "'default' is the only way to name it" in problems[0].message
 
     @pytest.mark.asyncio
     async def test_every_broken_field_is_reported_in_one_load(

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -4207,7 +4207,7 @@ class TestResolveWorkspaceDirForProjectId:
     async def test_unloaded_workspace_dir_expands_env_var_before_anchoring(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An env var in workspace_dir expands BEFORE the relative/absolute decision, so it is not mis-anchored.
+        """An env var in workspace_dir expands BEFORE the relative/absolute decision, so it lands where declared.
 
         `Path("${VAR}/ws").is_absolute()` is False, so deciding absoluteness first would join the
         whole thing onto the project directory and hand back a path with a literal `${VAR}` component


### PR DESCRIPTION
Closes #5204. Supersedes #5205.

## The problem behind the problem

#5204 asks for the effective libraries root on the frontend. `libraries_dir` is decoupled from the workspace and inherits down the parent chain, so the GUI cannot derive it from anything it already holds. #5205 added a dedicated event for it and was rejected for returning confidently **wrong** paths.

Investigating that turned up the real defect: **the engine silently substituted a different path when a declaration could not be resolved.** `libraries_dir: "${LIBS}/libs"` with `LIBS` unset logged a warning, discarded the declaration, and loaded the project against `<workspace>/libraries`. Libraries then installed somewhere the project never named. A per-platform mapping with no entry for the current OS behaved the same way — even though `PerPlatformProjectPath` has a first-class `default` key for exactly that case, so omitting both keys expresses no intent to honor.

There was no point exposing a path the engine itself was guessing at, so this PR fixes the resolution first and then reports the result.

## The rule

> A project path field (`workspace_dir`, `libraries_dir`, `parent_project_path`) that is **absent** falls through to the next source, as before. A field that is **present but cannot produce a path** — an unset `${VAR}` / `%VAR%`, a `{macro}` token, or a per-platform mapping with no entry for this OS and no `default` — is a validation **error**: the project reports `UNUSABLE`, lands in `failed_to_load` with the offending field and line number, and nothing is substituted.

`parent_project_path` already worked this way; the other two shrugged. Now all three are uniform.

That uniformity shrinks everything downstream: a project that **loaded** has, by construction, resolvable declarations. "Declared but dropped" ceases to exist, so the reported paths need no `source` / `unknown_reason` vocabulary — they are non-null for every loaded file-backed project and `None` only where they do not apply.

## What ships

- **Load-time validation in `_read_overlay`** — the single funnel every consumer goes through (boot load, activation, the offline ancestor walks, the read-only probes). One check means none of them can disagree, which is the drift #5205 was rejected for. All three fields are checked in one pass, so the user fixes everything in one edit rather than one per restart.
- **`resolve_project_path_field`** expands `~` and env vars **first**, then decides relative-vs-absolute, then anchors to the **declaring** project's directory. Previously `Path("${LIBS}/x").is_absolute()` was `False`, so the value was joined onto the project dir before expansion.
- **`unexpanded_references`** in `path_utils.py` — policy-free detection of `${NAME}` / `%NAME%` / `{NAME}` surviving expansion. Deliberately never reports a bare `$NAME`, which is indistinguishable from a real directory (`$Recycle.Bin`).
- **`ConfigManager.default_libraries_root`** — one workspace-relative-libraries formula shared by the live root, the provisioning preview, the offline resolver and the packager, with the missing/empty fallback inside it (an empty value made `Path("")` → `Path(".")` and installed libraries on top of the workspace).
- **`ProjectTemplateInfo.workspace_dir` / `.libraries_root`** — absolute paths on the existing `ListProjectTemplatesRequest` payload, resolved through the same ladders activation uses, including inheritance, so a parent and its children report the same libraries root. Chosen over a new request because this payload already carries derived-not-declared values and the GUI already fetches it.
- The listing resolves from **disk**, not the live merged config, whose layers belong to whichever project happens to be open — otherwise the answer for project B would depend on A being active (defect #3 of the #5205 review). It builds the id-index once for the whole listing rather than once per project.
- **Scalar fields now get line numbers.** `load_yaml_with_line_tracking` only recorded lines for containers, so `libraries_dir: "..."` had no line to point at. ~15 pre-existing `get_line(...)` call sites across the loader, project, situation and directory validators were silently getting `None`; they all work now.
- Deletes the never-merged, never-consumed `ResolveProjectLibrariesRootRequest` apparatus (`LibrariesRootSource`, `LibrariesRootUnknownReason`, the detail resolver, the "found a hit but it was unresolvable" provenance fields the new rule makes unreachable). The shipped `ResolveProjectWorkspaceRequest` is untouched.

Two scope boundaries: the rule covers the three project-template path fields only, **not** `projects_to_register` in engine config, where a per-platform gap legitimately means "that project is not on this machine." And it does tighten `parent_project_path`'s platform-gap case, which was previously documented as "no parent on this platform" — that docstring and its tests are updated. Uniform was the deliberate call.

## Behavior changes

**1. Unresolvable declarations now fail the load.** A project relying on the old silent fallback stops loading until the variable is set, a `default:` key is added, or the field is removed. Descendants fail too, with the error on their `parent_project_path`.

This is loud on purpose. A shared base project pinning `${STUDIO_LIBS}` used to have every teammate without that variable quietly install a second copy of every library somewhere else; now it says which line is wrong. The portable escape hatch is explicit:

```yaml
libraries_dir:
  windows: "D:/shared-libraries"      # the fast local volume, Windows only
  default: "./libraries"              # everyone else: beside the project
```

**2. Paths move for values that did resolve.** `libraries_dir: "${LIBS}/libs"` with `LIBS=/studio` previously produced `<project_dir>/studio/libs` and now produces `/studio/libs`. `~/shared` previously created a literal `~` directory under the project. Libraries at the old location will be re-provisioned at the new one.

**3. A real directory whose name contains `%IDENT%` or `{braces}`** is now an unresolved reference and fails the load instead of being used literally.

## Documented contract

`projects.md` now states what was true but undocumented: process/shell env vars and `~` work in all three fields; a project's own `environment:` block does **not** participate (it is applied after these fields are read, so they only ever see the launch environment); `{NAME}` macro tokens are unsupported because they resolve against runtime state that can change while the project is loaded; `%NAME%` expands only on Windows, and the per-platform mapping is the portable answer. Plus the new fail-closed rule and the `default:` key.

## Verification

`make fix` and `make check` clean (except 2 pre-existing `os.uname` pyright errors in `os_manager.py`). `make test/unit`: **3952 passed, 82 skipped**, with 3 pre-existing `WinError 1314` symlink-privilege failures in `test_file_utils.py` unrelated to this change.

New tests drive the real code through the disk/config harness — never a stand-in for the code under test, which was the fatal flaw in #5205's tests:

- **Load failures**, one per field: unset `${GTN_TEST_LIBS}`, `{outputs}` macro, `%SHOT_CODE%`, and a per-platform mapping naming only the other OS. Each asserts `UNUSABLE`, the `field_path`, the YAML line, and a message naming the cause. Plus every-broken-field-in-one-load, and the parent cascade.
- **Resolution guards** retargeted from the deleted detail tests: the same variable **set** resolves to the expanded absolute path, `~` expands rather than creating a literal `~` component, `$Recycle.Bin` stays literal, a `default:` mapping loads everywhere.
- **Listing cases**: declared value; inherited from a parent, anchored to the declaring ancestor's dir so parent and child report the same root; nothing declared → `<global workspace>/libraries`; a target whose own adjacent config sets `libraries_directory: "custom-libs"`; failed and non-file-backed entries reporting `None` for both.
- **Contamination guard**: the listing is taken with each project active in turn and with none active, against deliberately hijacked live config layers — all three report identical values.

End to end, a throwaway script builds a real `Engine`, registers a parent/child pair with `libraries_dir: "${GTN_5204_LIBS}/shared-libraries"` on the parent, and confirms both report the same expanded absolute root, that nothing is anchored under the project dir, and that `PreviewProjectProvisioningRequest` runs against the same project. Then it unsets the variable and confirms both come back in `failed_to_load` with the field, the reason and the line number rather than a substituted path. This also closes a coverage gap: nothing in the unit suite dispatches `ListProjectTemplatesRequest` through the event system, so a wiring mistake would not have failed it.


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5271.org.readthedocs.build/en/5271/

<!-- readthedocs-preview griptape-nodes end -->