### PR TITLE
Remove strict-mode violation for HuggingFaceModelParameter

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -13,6 +13,7 @@ from griptape_nodes.exe_types.param_components.model_policy import (
 )
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.model_events import ListModelDownloadsRequest, ListModelDownloadsResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
@@ -88,6 +89,10 @@ class HuggingFaceModelParameter(ABC):
         # `_refresh_policy()`. Whether enforcement is active is DERIVED from these two on read
         # (see `_gated`) rather than stored, so it cannot fall out of step with the verdicts it
         # was computed from.
+        #
+        # When this runs inside a node __init__ (the common case), the query is deferred and
+        # `_policy` holds DEFERRED_SNAPSHOT — no denials, no bus request — until the first
+        # post-construction refresh_parameters() re-queries and replaces it.
         self._gate_mode = gated
         self._policy = ModelPolicySnapshot()
         if gated is not False:
@@ -403,6 +408,15 @@ class HuggingFaceModelParameter(ABC):
     def _refresh_downloading_model_ids(self) -> None:
         # Only called from refresh_parameters() — never from inside a button
         # callback — to avoid nested handle_request() calls that cause recursion.
+        #
+        # Deferred during node __init__: a bus request issued there trips the
+        # reentrant-bus-in-init strict-mode rule and can deadlock the worker's
+        # schema probe. An empty set is benign — rows lose only their
+        # "Downloading…" subtitle until the first refresh_parameters() after
+        # construction (validate_before_node_run or the refresh button).
+        if LibraryRegistry.is_constructing_node():
+            self._downloading_model_ids = set()
+            return
         result = GriptapeNodes.handle_request(ListModelDownloadsRequest())
         if not isinstance(result, ListModelDownloadsResultSuccess):
             self._downloading_model_ids = set()

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -13,10 +13,10 @@ from griptape_nodes.exe_types.param_components.model_policy import (
 )
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.model_events import ListModelDownloadsRequest, ListModelDownloadsResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+from griptape_nodes.retained_mode.managers.event_manager import reentrant_bus_in_init_would_report
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload, OnClickMessageResultPayload
 from griptape_nodes.traits.options import Options
 
@@ -90,9 +90,12 @@ class HuggingFaceModelParameter(ABC):
         # (see `_gated`) rather than stored, so it cannot fall out of step with the verdicts it
         # was computed from.
         #
-        # When this runs inside a node __init__ (the common case), the query is deferred and
-        # `_policy` holds DEFERRED_SNAPSHOT — no denials, no bus request — until the first
-        # post-construction refresh_parameters() re-queries and replaces it.
+        # This runs inside a node __init__, so the query is deferred — `_policy` holds
+        # DEFERRED_SNAPSHOT, no denials and no bus request — in the one case where issuing it
+        # would trip reentrant-bus-in-init: a strict-mode scope is open, meaning the worker's
+        # schema probe or node execution. Everywhere else (editor drop, workflow load,
+        # single-process engine) it queries here, so denial rows and the badge are right
+        # immediately instead of waiting for a refresh.
         self._gate_mode = gated
         self._policy = ModelPolicySnapshot()
         if gated is not False:
@@ -409,12 +412,15 @@ class HuggingFaceModelParameter(ABC):
         # Only called from refresh_parameters() — never from inside a button
         # callback — to avoid nested handle_request() calls that cause recursion.
         #
-        # Deferred during node __init__: a bus request issued there trips the
-        # reentrant-bus-in-init strict-mode rule and can deadlock the worker's
-        # schema probe. An empty set is benign — rows lose only their
-        # "Downloading…" subtitle until the first refresh_parameters() after
-        # construction (validate_before_node_run or the refresh button).
-        if LibraryRegistry.is_constructing_node():
+        # Deferred only when the request would trip reentrant-bus-in-init: a node
+        # __init__ on the stack inside a strict-mode scope, i.e. the worker's schema
+        # probe (which would drop the class from the worker schema) or node execution.
+        # An editor drop or workflow load opens no scope, so the query runs and the
+        # rows carry their "Downloading…"/"Downloaded" subtitles from the moment the
+        # node appears. When it IS deferred, an empty set is benign — rows lose only
+        # the subtitle until the first refresh_parameters() after construction
+        # (validate_before_node_run or the refresh button).
+        if reentrant_bus_in_init_would_report():
             self._downloading_model_ids = set()
             return
         result = GriptapeNodes.handle_request(ListModelDownloadsRequest())

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -51,12 +51,15 @@ different value is currently permitted — resets the parameter's stored value
 to a permitted alternative via ``set_parameter_value(..., initial_setup=True)``.
 The parameter's declarative ``default_value`` is untouched.
 
-When the constructor runs inside a node ``__init__`` (the common case), the
-snapshot fetch is deferred — issuing a bus request during construction trips
-the reentrant-bus-in-init strict-mode rule and can deadlock the worker's
-schema probe. The deferred snapshot denies nothing, so the caller's default
-is kept and no denial rows or badge appear until the first ``refresh()``
-(the inline refresh button). Run-time enforcement is unaffected:
+The snapshot fetch is deferred in the one case where issuing it would trip the
+reentrant-bus-in-init strict-mode rule: a node ``__init__`` on the stack inside
+a strict-mode scope, meaning the worker's schema probe (where the violation
+drops the class from the worker schema) or node execution. Everywhere else --
+an editor drop, a workflow load, any single-process engine -- the constructor
+queries, so denial rows and the badge are right from the moment the node
+appears. When it IS deferred, the deferred snapshot denies nothing, so the
+caller's default is kept and decoration waits for the first ``refresh()`` (the
+inline refresh button). Run-time enforcement is unaffected either way:
 ``query_for_denial`` re-fetches a deferred snapshot before answering.
 
 Nodes then forward ``after_value_set`` to ``self._model_access.on_value_set(
@@ -358,9 +361,12 @@ class ModelAccessComponent:
             return None
         # A snapshot deferred at construction has never asked policy anything, so it cannot gate
         # this run -- without a re-fetch, `catalog_ids_for` below returns () for every value and
-        # enforcement is silently bypassed until the artist clicks refresh. Re-fetch now: this
-        # path runs outside node __init__ (and if it somehow doesn't, query_model_policy defers
-        # again harmlessly). Deliberately no UI rebuild here -- this can run inside aprocess,
+        # enforcement is silently bypassed until the artist clicks refresh. Deferral is now narrow
+        # (a node __init__ inside a strict-mode scope), but it still happens: the worker constructs
+        # transient nodes under RUNTIME_EXECUTE, and those reach here with a deferred snapshot.
+        # Re-fetch now: this path runs outside node __init__ (and if it somehow doesn't,
+        # query_model_policy defers again harmlessly). Deliberately no UI rebuild here -- this
+        # can run inside aprocess,
         # where mutating ui_options is a strict-mode concern; decoration heals on `refresh()`.
         if self._snapshot.deferred:
             self._snapshot = self._fetch_snapshot()
@@ -564,9 +570,10 @@ class ModelAccessComponent:
         denials known" as "no denials". A node that simply declares no models
         is a valid empty snapshot, not a failure.
 
-        During node construction the query is skipped and ``DEFERRED_SNAPSHOT``
-        comes back instead (see ``query_model_policy``); ``query_for_denial``
-        re-fetches it before its first real verdict.
+        When a node ``__init__`` is on the stack inside a strict-mode scope --
+        the worker's schema probe, or node execution -- the query is skipped and
+        ``DEFERRED_SNAPSHOT`` comes back instead (see ``query_model_policy``);
+        ``query_for_denial`` re-fetches it before its first real verdict.
         """
         return query_model_policy(type(self._node).__name__)
 

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -51,6 +51,14 @@ different value is currently permitted — resets the parameter's stored value
 to a permitted alternative via ``set_parameter_value(..., initial_setup=True)``.
 The parameter's declarative ``default_value`` is untouched.
 
+When the constructor runs inside a node ``__init__`` (the common case), the
+snapshot fetch is deferred — issuing a bus request during construction trips
+the reentrant-bus-in-init strict-mode rule and can deadlock the worker's
+schema probe. The deferred snapshot denies nothing, so the caller's default
+is kept and no denial rows or badge appear until the first ``refresh()``
+(the inline refresh button). Run-time enforcement is unaffected:
+``query_for_denial`` re-fetches a deferred snapshot before answering.
+
 Nodes then forward ``after_value_set`` to ``self._model_access.on_value_set(
 parameter, value)`` -- the component filters for its own parameter -- and pick a
 failure-routing idiom that matches their base class:
@@ -348,6 +356,14 @@ class ModelAccessComponent:
         # source of truth for the model in this state; bypass the gate.
         if not isinstance(value, str):
             return None
+        # A snapshot deferred at construction has never asked policy anything, so it cannot gate
+        # this run -- without a re-fetch, `catalog_ids_for` below returns () for every value and
+        # enforcement is silently bypassed until the artist clicks refresh. Re-fetch now: this
+        # path runs outside node __init__ (and if it somehow doesn't, query_model_policy defers
+        # again harmlessly). Deliberately no UI rebuild here -- this can run inside aprocess,
+        # where mutating ui_options is a strict-mode concern; decoration heals on `refresh()`.
+        if self._snapshot.deferred:
+            self._snapshot = self._fetch_snapshot()
         # Snapshot-level refusals first: an unresolvable node (a developer setup bug must not
         # silently open the gate) and a denial policy handed us that no row can carry. Both are
         # decisions about the whole parameter, so the live per-id re-query below cannot answer
@@ -547,6 +563,10 @@ class ModelAccessComponent:
         ``failure_detail``, so runtime checks deny rather than reading "no
         denials known" as "no denials". A node that simply declares no models
         is a valid empty snapshot, not a failure.
+
+        During node construction the query is skipped and ``DEFERRED_SNAPSHOT``
+        comes back instead (see ``query_model_policy``); ``query_for_denial``
+        re-fetches it before its first real verdict.
         """
         return query_model_policy(type(self._node).__name__)
 

--- a/src/griptape_nodes/exe_types/param_components/model_policy.py
+++ b/src/griptape_nodes/exe_types/param_components/model_policy.py
@@ -20,6 +20,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeRequest,
     QueryModelAccessForNodeResultSuccess,
@@ -73,6 +74,13 @@ class ModelPolicySnapshot:
     ``provider_model_id`` to match a dropdown value against. Those denials cannot be honored
     per-row, so they are honored for the whole parameter instead -- see ``denial_for``. Dropping
     them would let an explicitly forbidden model run.
+
+    ``deferred`` is True when the query was skipped entirely because a node ``__init__`` was on
+    the stack (issuing a bus request there trips the reentrant-bus-in-init strict-mode rule and
+    can deadlock the worker's schema probe). Both tables are empty and every lookup answers "no
+    denial" -- a deferred snapshot must not read as fail-closed, because no query has failed; one
+    was never made. It is replaced wholesale by the first post-construction
+    ``query_model_policy()``.
     """
 
     denial_by_provider_id: dict[str, CheckpointDenial] = field(default_factory=dict)
@@ -81,6 +89,7 @@ class ModelPolicySnapshot:
     failure_detail: str | None = None
     has_unmatchable_entries: bool = False
     unmatchable_denials: tuple[str, ...] = ()
+    deferred: bool = False
 
     def catalog_ids_for(self, provider_model_id: str) -> tuple[str, ...]:
         """Every catalog id declared against ``provider_model_id``, in declaration order."""
@@ -96,7 +105,7 @@ class ModelPolicySnapshot:
         """
         return bool(self.catalog_ids_by_provider_id) or self.has_unmatchable_entries
 
-    def denial_for(
+    def denial_for(  # noqa: PLR0911 -- a chain of early-exit verdicts, one per snapshot state
         self, provider_model_id: str | None, *, refuse_unrecognized: bool = False
     ) -> CheckpointDenial | None:
         """Return the denial for a resolved dropdown value, or ``None`` when permitted.
@@ -116,6 +125,11 @@ class ModelPolicySnapshot:
         # placeholder row badged "Model Not Permitted" would report a library-registration problem
         # as a licensing one, and hide the "download this model" message that says what to do.
         if provider_model_id is None:
+            return None
+        # A deferred snapshot has asked policy nothing, so it can deny nothing. Without this,
+        # the `refuse_unrecognized` path below would refuse every choice against the empty
+        # catalog -- badging a freshly constructed gated dropdown entirely "not permitted".
+        if self.deferred:
             return None
         if self.failure_detail is not None:
             return CheckpointDenial(failures=(CheckpointFailure(detail=self.failure_detail),))
@@ -157,8 +171,18 @@ class ModelPolicySnapshot:
         return None
 
 
+# Shared "policy not yet queried" snapshot. Frozen, so one instance serves every deferral.
+DEFERRED_SNAPSHOT = ModelPolicySnapshot(deferred=True)
+
+
 def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPolicySnapshot:
     """Ask the engine which of ``node_type``'s declared models are permitted.
+
+    Returns ``DEFERRED_SNAPSHOT`` without querying when a node ``__init__`` is on the stack:
+    a bus request issued during construction trips the reentrant-bus-in-init strict-mode rule
+    and can deadlock the worker's schema probe (which gets the class dropped from the worker
+    schema). Callers hold the deferred snapshot until their first post-construction refresh
+    replaces it with a real query result.
 
     Args:
         node_type: The node class name the manifest declares ``model_usage`` against.
@@ -168,6 +192,9 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
             has not adopted declarations", which is the pre-adoption status quo rather than an
             error, and the snapshot is empty.
     """
+    if LibraryRegistry.is_constructing_node():
+        logger.debug("Deferring model-policy query for node type '%s': node __init__ in progress.", node_type)
+        return DEFERRED_SNAPSHOT
     result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type=node_type))
     if not isinstance(result, QueryModelAccessForNodeResultSuccess):
         details = getattr(result, "result_details", None) or type(result).__name__

--- a/src/griptape_nodes/exe_types/param_components/model_policy.py
+++ b/src/griptape_nodes/exe_types/param_components/model_policy.py
@@ -20,13 +20,13 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeRequest,
     QueryModelAccessForNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+from griptape_nodes.retained_mode.managers.event_manager import reentrant_bus_in_init_would_report
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
@@ -75,12 +75,14 @@ class ModelPolicySnapshot:
     per-row, so they are honored for the whole parameter instead -- see ``denial_for``. Dropping
     them would let an explicitly forbidden model run.
 
-    ``deferred`` is True when the query was skipped entirely because a node ``__init__`` was on
-    the stack (issuing a bus request there trips the reentrant-bus-in-init strict-mode rule and
-    can deadlock the worker's schema probe). Both tables are empty and every lookup answers "no
-    denial" -- a deferred snapshot must not read as fail-closed, because no query has failed; one
-    was never made. It is replaced wholesale by the first post-construction
-    ``query_model_policy()``.
+    ``deferred`` is True when the query was skipped entirely because issuing it would have
+    tripped the reentrant-bus-in-init strict-mode rule -- a node ``__init__`` on the stack
+    *inside* a strict-mode scope, which in practice means the worker's schema probe or node
+    execution (see ``reentrant_bus_in_init_would_report``). Both tables are empty and every
+    lookup answers "no denial" -- a deferred snapshot must not read as fail-closed, because no
+    query has failed; one was never made. It is replaced wholesale by the next
+    ``query_model_policy()``, which for a probed node type is the first refresh after
+    construction.
     """
 
     denial_by_provider_id: dict[str, CheckpointDenial] = field(default_factory=dict)
@@ -178,11 +180,16 @@ DEFERRED_SNAPSHOT = ModelPolicySnapshot(deferred=True)
 def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPolicySnapshot:
     """Ask the engine which of ``node_type``'s declared models are permitted.
 
-    Returns ``DEFERRED_SNAPSHOT`` without querying when a node ``__init__`` is on the stack:
-    a bus request issued during construction trips the reentrant-bus-in-init strict-mode rule
-    and can deadlock the worker's schema probe (which gets the class dropped from the worker
-    schema). Callers hold the deferred snapshot until their first post-construction refresh
-    replaces it with a real query result.
+    Returns ``DEFERRED_SNAPSHOT`` without querying when the request would trip
+    reentrant-bus-in-init: a node ``__init__`` on the stack inside a strict-mode scope, which
+    is the worker's schema probe (where the violation drops the class from the worker schema)
+    or node execution. Those callers hold the deferred snapshot until their first
+    post-construction refresh replaces it with a real query result.
+
+    Construction OUTSIDE such a scope -- an editor drop, a workflow load, any single-process
+    engine, where nothing observes the violation and no probe exists -- queries normally, so
+    the dropdown's denial rows and badge are correct as soon as the node appears rather than
+    only after it runs.
 
     Args:
         node_type: The node class name the manifest declares ``model_usage`` against.
@@ -192,8 +199,11 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
             has not adopted declarations", which is the pre-adoption status quo rather than an
             error, and the snapshot is empty.
     """
-    if LibraryRegistry.is_constructing_node():
-        logger.debug("Deferring model-policy query for node type '%s': node __init__ in progress.", node_type)
+    if reentrant_bus_in_init_would_report():
+        logger.debug(
+            "Deferring model-policy query for node type '%s': node __init__ in progress under a strict-mode scope.",
+            node_type,
+        )
         return DEFERRED_SNAPSHOT
     result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type=node_type))
     if not isinstance(result, QueryModelAccessForNodeResultSuccess):

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -71,6 +71,38 @@ def current_request_type() -> type[RequestPayload] | None:
     return _active_request_type.get()
 
 
+def reentrant_bus_in_init_would_report() -> bool:
+    """Whether a bus request issued right now would fire ``reentrant-bus-in-init``.
+
+    Both halves of the detector's condition (see
+    ``EventManager._report_reentrant_bus_in_init``), exposed so code that runs
+    inside a node ``__init__`` can ask BEFORE issuing a request and skip it
+    rather than commit the violation. The detector and every such caller read
+    this one predicate, so "we deferred" and "it would have been reported"
+    cannot drift apart as the scopes change.
+
+    Being inside a node ``__init__`` is not sufficient on its own. ``STRICT_MODE.report``
+    no-ops when no scope is active, and scopes open in exactly two places: around the
+    worker's schema probe (LOAD_PROBE, where a violation drops the class from the worker
+    schema) and around node execution (RUNTIME_EXECUTE, where a worker violation promotes
+    the result to a failure). An ordinary ``CreateNodeRequest`` -- an editor drop, a
+    workflow load, any single-process engine, where no probe runs at all -- opens neither,
+    so a read from ``__init__`` there is free and callers should just do it. Keying a
+    deferral off ``is_constructing_node()`` alone instead makes every node in every
+    deployment pay for a hazard only the worker's probe has.
+
+    When strict mode is disabled the scope is detached (``open_scope`` keeps it off the
+    stack), so this cannot tell a probe from an editor drop. It answers True while
+    constructing in that case: with the checker off, the conservative answer is the
+    safe one.
+    """
+    if not LibraryRegistry.is_constructing_node():
+        return False
+    if not STRICT_MODE.enabled:
+        return True
+    return STRICT_MODE.current_scope() is not None
+
+
 # Result types that should NOT trigger a flush request.
 #
 # Add result types to this set if they should never trigger a flush (typically because they ARE
@@ -520,8 +552,13 @@ class EventManager(EngineScoped):
         the worker thread during library load. LibraryRegistry sets a
         ContextVar around create_node so every __init__ body in the
         hierarchy is covered.
+
+        The condition lives in ``reentrant_bus_in_init_would_report`` rather
+        than inline, because engine components that legitimately read state
+        from a node ``__init__`` consult the same predicate to decide whether
+        to defer. One owner, so the two answers cannot disagree.
         """
-        if not LibraryRegistry.is_constructing_node():
+        if not reentrant_bus_in_init_would_report():
             return
         rule = RULES["reentrant-bus-in-init"]
         # Subject attribution lives on the violation's ``subject`` field,

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
@@ -33,6 +33,7 @@ from griptape_nodes.retained_mode.events.access_events import (
 from griptape_nodes.retained_mode.events.model_events import ListModelDownloadsRequest
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 from tests.unit.exe_types.mocks import MockNode
+from tests.unit.exe_types.param_components.probe_scope import constructing_under_probe
 
 DENIED_REPO = "black-forest-labs/FLUX.1-dev"
 ALLOWED_REPO = "black-forest-labs/FLUX.1-schnell"
@@ -309,16 +310,19 @@ class TestRunPathGate:
 
 
 class TestConstructionDefersBusRequests:
-    """No bus request may be issued while a node __init__ is on the stack.
+    """No bus request may be issued from a node __init__ that a strict-mode scope is watching.
 
-    The worker's schema probe constructs every node class during library load; a bus request
-    from inside that construction fires reentrant-bus-in-init and drops the class from the
-    worker schema. In production this component always runs inside a node __init__, so its
-    policy and download queries defer until the first post-construction refresh.
+    The worker's schema probe constructs every node class during library load, inside a
+    LOAD_PROBE scope; a bus request from inside that construction fires reentrant-bus-in-init
+    and drops the class from the worker schema. So under a scope this component's policy and
+    download queries defer until the first post-construction refresh.
+
+    Construction with no scope open is the ordinary case and must still query -- see
+    ``TestConstructionWithoutAScopeStillQueries``.
     """
 
     def _construct_deferred(self, *, gated: bool | None) -> HuggingFaceRepoParameter:
-        with LibraryRegistry.constructing_node():
+        with constructing_under_probe():
             param = _param(gated=gated)
             param.add_input_parameters()
         return param
@@ -369,3 +373,46 @@ class TestConstructionDefersBusRequests:
         errors = param.validate_before_node_run()
         assert errors is not None
         assert "not permitted" in str(errors[0])
+
+
+class TestConstructionWithoutAScopeStillQueries:
+    """An editor drop or workflow load queries from __init__, so decoration is right immediately.
+
+    Outside a strict-mode scope nothing records a reentrant-bus-in-init violation and there is no
+    probe to drop the class, so deferring there bought nothing -- and cost the shield rows and the
+    download subtitles until the node was run or refreshed by hand. These pin that the deferral
+    keys off the scope and not off being in ``__init__`` at all.
+    """
+
+    def _construct_in_init(self, *, gated: bool | None = True) -> HuggingFaceRepoParameter:
+        with LibraryRegistry.constructing_node():
+            param = _param(gated=gated)
+            param.add_input_parameters()
+        return param
+
+    def test_policy_is_queried_during_construction(self) -> None:
+        param = self._construct_in_init()
+        assert param._policy.deferred is False
+        assert param.query_for_denial(DENIED_REPO) is not None
+        assert param.query_for_denial(ALLOWED_REPO) is None
+
+    def test_denial_decoration_lands_without_a_refresh(self) -> None:
+        param = self._construct_in_init()
+        by_name = {row["name"]: row for row in param._build_data_choices([ALLOWED_REPO, DENIED_REPO])}
+        assert by_name[DENIED_REPO]["icon"] == "shield-off"
+        assert by_name[DENIED_REPO]["subtitle"] == "Not permitted by your license"
+
+    def test_the_download_status_query_is_issued_too(self) -> None:
+        """The other half of the decoration: without this the rows lose their download subtitle."""
+        seen: list[type] = []
+
+        def handle_request(request: object) -> object:
+            seen.append(type(request))
+            if isinstance(request, QueryModelAccessForNodeRequest):
+                return QueryModelAccessForNodeResultSuccess(verdicts=_verdicts(), result_details="ok")
+            return object()  # not a ResultSuccess -> "nothing downloading", as in _stub_engine
+
+        module = "griptape_nodes.exe_types.param_components.huggingface"
+        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request):
+            self._construct_in_init()
+        assert ListModelDownloadsRequest in seen

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
@@ -23,6 +23,7 @@ import pytest
 
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_model_parameter import NO_MODELS_PLACEHOLDER
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_repo_parameter import HuggingFaceRepoParameter
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.access_events import (
     ModelAccessVerdict,
     QueryModelAccessForNodeRequest,
@@ -301,6 +302,69 @@ class TestRunPathGate:
     def test_validate_before_node_run_blocks_a_denied_selection(self) -> None:
         param = _param(gated=True)
         param.add_input_parameters()
+        param._node.set_parameter_value("model", DENIED_REPO)
+        errors = param.validate_before_node_run()
+        assert errors is not None
+        assert "not permitted" in str(errors[0])
+
+
+class TestConstructionDefersBusRequests:
+    """No bus request may be issued while a node __init__ is on the stack.
+
+    The worker's schema probe constructs every node class during library load; a bus request
+    from inside that construction fires reentrant-bus-in-init and drops the class from the
+    worker schema. In production this component always runs inside a node __init__, so its
+    policy and download queries defer until the first post-construction refresh.
+    """
+
+    def _construct_deferred(self, *, gated: bool | None) -> HuggingFaceRepoParameter:
+        with LibraryRegistry.constructing_node():
+            param = _param(gated=gated)
+            param.add_input_parameters()
+        return param
+
+    def test_construction_issues_no_bus_requests(self) -> None:
+        module = "griptape_nodes.exe_types.param_components.huggingface"
+        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request") as handle:
+            self._construct_deferred(gated=True)
+        handle.assert_not_called()
+
+    def test_a_deferred_gated_param_denies_nothing(self) -> None:
+        """No denials while deferred -- including the refuse-unrecognized backstop.
+
+        A naive skip that left a plain empty snapshot would refuse EVERY choice as
+        unrecognized and badge the whole dropdown "not permitted" at construction.
+        """
+        param = self._construct_deferred(gated=True)
+        assert param._policy.deferred is True
+        assert param.query_for_denial(DENIED_REPO) is None
+        assert param.query_for_denial(UNDECLARED_REPO) is None
+
+    def test_no_denial_decoration_lands_while_deferred(self) -> None:
+        param = self._construct_deferred(gated=True)
+        data = param._build_data_choices([ALLOWED_REPO, DENIED_REPO])
+        assert all(row.get("icon") != "shield-off" for row in data)
+        parameter = param._node.get_parameter_by_name("model")
+        assert parameter is not None
+        assert parameter.get_badge() is None
+
+    def test_refresh_parameters_heals_after_construction(self) -> None:
+        param = self._construct_deferred(gated=True)
+        param.refresh_parameters()
+        assert param._policy.deferred is False
+        assert param.query_for_denial(DENIED_REPO) is not None
+        assert param.query_for_denial(ALLOWED_REPO) is None
+
+    def test_auto_detect_heals_too(self) -> None:
+        """Pins the `_gate_mode is not False` refresh guard: auto-detect must re-query as well."""
+        param = self._construct_deferred(gated=None)
+        param.refresh_parameters()
+        assert param._policy.deferred is False
+        assert param.query_for_denial(DENIED_REPO) is not None
+
+    def test_the_run_path_still_blocks_a_denied_selection(self) -> None:
+        """validate_before_node_run refreshes first, so deferral cannot weaken run gating."""
+        param = self._construct_deferred(gated=True)
         param._node.set_parameter_value("model", DENIED_REPO)
         errors = param.validate_before_node_run()
         assert errors is not None

--- a/tests/unit/exe_types/param_components/probe_scope.py
+++ b/tests/unit/exe_types/param_components/probe_scope.py
@@ -1,0 +1,41 @@
+"""Helper for reproducing the one condition under which construction defers a bus request.
+
+The model-dropdown components skip their policy / download-status queries exactly when
+``reentrant_bus_in_init_would_report()`` is True: a node ``__init__`` on the stack AND a
+strict-mode scope open, which in production is the worker's schema probe or node execution.
+Both halves are required, so a test that wants the deferral has to set up both -- and a test
+that wants the ordinary path (an editor drop, a workflow load) sets up only the first.
+
+Lives in one module so the three component test files pin the same condition. Setting the
+constructing flag alone here would silently stop exercising deferral the moment the shared
+predicate changes.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from griptape_nodes.common.strict_mode import STRICT_MODE, StrictModeScopeKind
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextmanager
+def constructing_under_probe(subject: str = "SomeNode") -> Iterator[None]:
+    """Construct as the worker's schema probe does: LOAD_PROBE scope + constructing flag.
+
+    ``is_worker=True`` matches the probe, which only ever runs on a worker.
+    """
+    with (
+        STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject=subject,
+            library_name="test_library",
+            is_worker=True,
+        ),
+        LibraryRegistry.constructing_node(),
+    ):
+        yield

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -32,6 +32,7 @@ from griptape_nodes.retained_mode.events.access_events import QueryModelAccessFo
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
+from tests.unit.exe_types.param_components.probe_scope import constructing_under_probe
 
 _LIBRARY_NAME = "model-access-param-test-library"
 
@@ -1135,19 +1136,19 @@ class TestSelectionReadingApi:
 
 
 class TestConstructionDeferral:
-    """The snapshot fetch is skipped while a node __init__ is on the stack.
+    """The snapshot fetch is skipped when a node __init__ runs inside a strict-mode scope.
 
-    In production the component is always constructed inside a node __init__, where a bus
-    request fires the reentrant-bus-in-init strict-mode rule and can deadlock the worker's
-    schema probe (dropping the class from the worker schema). The deferred snapshot denies
-    nothing, so the caller's default survives and no denial decoration lands; enforcement is
-    restored by the re-fetch in query_for_denial before the first real verdict.
+    That is the worker's schema probe or node execution: there a bus request from __init__ is
+    recorded as a reentrant-bus-in-init violation, which for the probe drops the class from the
+    worker schema. The deferred snapshot denies nothing, so the caller's default survives and no
+    denial decoration lands; enforcement is restored by the re-fetch in query_for_denial before
+    the first real verdict. Construction with no scope open queries instead -- see
+    ``TestConstructionWithoutAScopeStillQueries``.
     """
 
     def test_construction_defers_the_query_and_keeps_the_default(self, griptape_nodes) -> None:  # noqa: ANN001
         from unittest.mock import MagicMock
 
-        from griptape_nodes.node_library.library_registry import LibraryRegistry
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_all(_checkpoint: object) -> CheckpointDenial:
@@ -1161,7 +1162,7 @@ class TestConstructionDeferral:
                     "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request",
                     handle,
                 ),
-                LibraryRegistry.constructing_node(),
+                constructing_under_probe(),
             ):
                 node, helper, param = _build_probe_node_with_component(
                     model_choices=["alpha", "beta"], default_model="alpha"
@@ -1180,9 +1181,9 @@ class TestConstructionDeferral:
         """The enforcement-gap regression: run-time gating must not stay bypassed until a refresh.
 
         This component has no validate_before_node_run equivalent, so if query_for_denial
-        answered from the deferred snapshot it would return None for everything, forever.
+        answered from the deferred snapshot it would return None for everything, forever. The
+        worker still constructs transient nodes under RUNTIME_EXECUTE, so this path is live.
         """
-        from griptape_nodes.node_library.library_registry import LibraryRegistry
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1192,7 +1193,7 @@ class TestConstructionDeferral:
 
         griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
         try:
-            with LibraryRegistry.constructing_node():
+            with constructing_under_probe():
                 _node, helper, _param = _build_probe_node_with_component(
                     model_choices=["alpha", "beta"], default_model="beta"
                 )
@@ -1204,6 +1205,39 @@ class TestConstructionDeferral:
             griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
 
     def test_refresh_heals_decoration(self, griptape_nodes) -> None:  # noqa: ANN001
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_alpha":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        try:
+            with constructing_under_probe():
+                _node, helper, param = _build_probe_node_with_component(
+                    model_choices=["alpha", "beta"], default_model="beta"
+                )
+            assert all(row.get("icon") != "shield-off" for row in param.ui_options["data"])
+
+            helper.refresh()
+
+            data_by_name = {row["name"]: row for row in param.ui_options["data"]}
+            assert data_by_name["alpha"]["icon"] == "shield-off"
+            assert helper._snapshot.deferred is False
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+
+
+class TestConstructionWithoutAScopeStillQueries:
+    """An editor drop or workflow load queries from __init__, so decoration is right immediately.
+
+    No strict-mode scope is open there, so no violation is recorded and no probe exists to drop
+    the class -- the deferral buys nothing and costs the shield rows and the badge until the
+    artist clicks refresh.
+    """
+
+    def test_denial_decoration_and_default_relocation_happen_at_construction(self, griptape_nodes) -> None:  # noqa: ANN001
         from griptape_nodes.node_library.library_registry import LibraryRegistry
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -1215,15 +1249,15 @@ class TestConstructionDeferral:
         griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
         try:
             with LibraryRegistry.constructing_node():
-                _node, helper, param = _build_probe_node_with_component(
-                    model_choices=["alpha", "beta"], default_model="beta"
+                node, helper, param = _build_probe_node_with_component(
+                    model_choices=["alpha", "beta"], default_model="alpha"
                 )
-            assert all(row.get("icon") != "shield-off" for row in param.ui_options["data"])
-
-            helper.refresh()
-
+            assert helper._snapshot.deferred is False
             data_by_name = {row["name"]: row for row in param.ui_options["data"]}
             assert data_by_name["alpha"]["icon"] == "shield-off"
-            assert helper._snapshot.deferred is False
+            assert data_by_name["beta"].get("icon") != "shield-off"
+            # The denied default is relocated to the permitted choice, as it would be outside
+            # __init__ -- construction-time deferral is what suppressed this.
+            assert node.get_parameter_value(param.name) == "beta"
         finally:
             griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -1132,3 +1132,98 @@ class TestSelectionReadingApi:
             assert param.get_badge() is not None
         finally:
             griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+
+
+class TestConstructionDeferral:
+    """The snapshot fetch is skipped while a node __init__ is on the stack.
+
+    In production the component is always constructed inside a node __init__, where a bus
+    request fires the reentrant-bus-in-init strict-mode rule and can deadlock the worker's
+    schema probe (dropping the class from the worker schema). The deferred snapshot denies
+    nothing, so the caller's default survives and no denial decoration lands; enforcement is
+    restored by the re-fetch in query_for_denial before the first real verdict.
+    """
+
+    def test_construction_defers_the_query_and_keeps_the_default(self, griptape_nodes) -> None:  # noqa: ANN001
+        from unittest.mock import MagicMock
+
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_all(_checkpoint: object) -> CheckpointDenial:
+            return CheckpointDenial(failures=(CheckpointFailure(detail="Nothing enabled."),))
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_all)
+        handle = MagicMock()
+        try:
+            with (
+                patch(
+                    "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request",
+                    handle,
+                ),
+                LibraryRegistry.constructing_node(),
+            ):
+                node, helper, param = _build_probe_node_with_component(
+                    model_choices=["alpha", "beta"], default_model="alpha"
+                )
+            handle.assert_not_called()
+            assert helper._snapshot.deferred is True
+            # Despite the deny-all policy, the default is NOT relocated -- policy was never asked.
+            assert node.get_parameter_value(param.name) == "alpha"
+            # And no denial decoration lands.
+            assert all(row.get("icon") != "shield-off" for row in param.ui_options["data"])
+            assert param.get_badge() is None
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_all)
+
+    def test_query_for_denial_heals_a_deferred_snapshot(self, griptape_nodes) -> None:  # noqa: ANN001
+        """The enforcement-gap regression: run-time gating must not stay bypassed until a refresh.
+
+        This component has no validate_before_node_run equivalent, so if query_for_denial
+        answered from the deferred snapshot it would return None for everything, forever.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_alpha":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        try:
+            with LibraryRegistry.constructing_node():
+                _node, helper, _param = _build_probe_node_with_component(
+                    model_choices=["alpha", "beta"], default_model="beta"
+                )
+            assert helper._snapshot.deferred is True
+            assert helper.query_for_denial("alpha") is not None
+            assert helper._snapshot.deferred is False
+            assert helper.query_for_denial("beta") is None
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+
+    def test_refresh_heals_decoration(self, griptape_nodes) -> None:  # noqa: ANN001
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_alpha":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
+            return None
+
+        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        try:
+            with LibraryRegistry.constructing_node():
+                _node, helper, param = _build_probe_node_with_component(
+                    model_choices=["alpha", "beta"], default_model="beta"
+                )
+            assert all(row.get("icon") != "shield-off" for row in param.ui_options["data"])
+
+            helper.refresh()
+
+            data_by_name = {row["name"]: row for row in param.ui_options["data"]}
+            assert data_by_name["alpha"]["icon"] == "shield-off"
+            assert helper._snapshot.deferred is False
+        finally:
+            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)

--- a/tests/unit/exe_types/param_components/test_model_policy.py
+++ b/tests/unit/exe_types/param_components/test_model_policy.py
@@ -24,6 +24,7 @@ from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+from tests.unit.exe_types.param_components.probe_scope import constructing_under_probe
 
 _HANDLE = "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request"
 
@@ -275,20 +276,38 @@ class TestBothComponentsAgreeOnAnUnattributableDenial:
 
 
 class TestConstructionDeferral:
-    """During node __init__ the query is skipped entirely -- see reentrant-bus-in-init.
+    """The query is skipped only where issuing it would trip reentrant-bus-in-init.
 
-    A bus request issued while a node __init__ is on the stack deadlocks the worker's schema
-    probe and gets the class dropped from the worker schema, so `query_model_policy` must not
-    touch the bus there. The deferred snapshot it returns instead must deny nothing: no query
-    was made, so there is no verdict (and no failure) to enforce.
+    That rule fires for a bus request made while a node __init__ is on the stack AND a
+    strict-mode scope is open -- the worker's schema probe (where the violation drops the
+    class from the worker schema) or node execution. `query_model_policy` must not touch the
+    bus there, and the deferred snapshot it returns instead must deny nothing: no query was
+    made, so there is no verdict (and no failure) to enforce.
+
+    Construction with no scope open -- an editor drop, a workflow load, any single-process
+    engine -- must still query, because that is where the dropdown's denial rows and badge
+    come from. Deferring there is what made decoration wait for the first run.
     """
 
-    def test_no_bus_request_while_constructing(self) -> None:
+    def test_no_bus_request_while_constructing_under_a_probe_scope(self) -> None:
         handle = MagicMock()
-        with patch(_HANDLE, handle), LibraryRegistry.constructing_node():
+        with patch(_HANDLE, handle), constructing_under_probe():
             snapshot = query_model_policy("SomeNode")
         handle.assert_not_called()
         assert snapshot.deferred is True
+
+    def test_construction_outside_a_strict_mode_scope_queries_normally(self) -> None:
+        """The regression that motivated narrowing the condition.
+
+        An editor drop constructs the node with no scope open, so nothing would observe the
+        violation and no probe exists to deadlock. Skipping the query there stripped denial
+        rows and the badge until the node ran.
+        """
+        verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
+        with patch(_HANDLE, return_value=_success(verdicts)), LibraryRegistry.constructing_node():
+            snapshot = query_model_policy("SomeNode")
+        assert snapshot.deferred is False
+        assert snapshot.denial_for(DENIED) is _DENIAL
 
     def test_a_deferred_snapshot_denies_nothing_even_when_asked_to_refuse_unrecognized(self) -> None:
         """The regression this exists for: a naive empty snapshot DOES refuse unrecognized ids.
@@ -308,7 +327,7 @@ class TestConstructionDeferral:
     def test_the_query_goes_through_once_construction_ends(self) -> None:
         verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
         with patch(_HANDLE, return_value=_success(verdicts)):
-            with LibraryRegistry.constructing_node():
+            with constructing_under_probe():
                 assert query_model_policy("SomeNode").deferred is True
             snapshot = query_model_policy("SomeNode")
         assert snapshot.deferred is False

--- a/tests/unit/exe_types/param_components/test_model_policy.py
+++ b/tests/unit/exe_types/param_components/test_model_policy.py
@@ -8,14 +8,16 @@ in particular the one axis on which the two are ALLOWED to differ: `refuse_unrec
 
 import logging
 from dataclasses import FrozenInstanceError
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from griptape_nodes.exe_types.param_components.model_policy import (
+    DEFERRED_SNAPSHOT,
     ModelPolicySnapshot,
     query_model_policy,
 )
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.events.access_events import (
     ModelAccessVerdict,
     QueryModelAccessForNodeResultFailure,
@@ -270,6 +272,47 @@ class TestBothComponentsAgreeOnAnUnattributableDenial:
             assert component.query_for_denial("alpha") is not None
             with pytest.raises(RuntimeError):
                 component.raise_if_denied("alpha")
+
+
+class TestConstructionDeferral:
+    """During node __init__ the query is skipped entirely -- see reentrant-bus-in-init.
+
+    A bus request issued while a node __init__ is on the stack deadlocks the worker's schema
+    probe and gets the class dropped from the worker schema, so `query_model_policy` must not
+    touch the bus there. The deferred snapshot it returns instead must deny nothing: no query
+    was made, so there is no verdict (and no failure) to enforce.
+    """
+
+    def test_no_bus_request_while_constructing(self) -> None:
+        handle = MagicMock()
+        with patch(_HANDLE, handle), LibraryRegistry.constructing_node():
+            snapshot = query_model_policy("SomeNode")
+        handle.assert_not_called()
+        assert snapshot.deferred is True
+
+    def test_a_deferred_snapshot_denies_nothing_even_when_asked_to_refuse_unrecognized(self) -> None:
+        """The regression this exists for: a naive empty snapshot DOES refuse unrecognized ids.
+
+        Skipping the query without the `deferred` marker would badge every choice on a gated
+        dropdown "not permitted" at construction. Pin the contrast explicitly.
+        """
+        assert ModelPolicySnapshot().denial_for(UNKNOWN, refuse_unrecognized=True) is not None
+        assert DEFERRED_SNAPSHOT.denial_for(UNKNOWN, refuse_unrecognized=True) is None
+        assert DEFERRED_SNAPSHOT.denial_for(UNKNOWN) is None
+
+    def test_a_deferred_snapshot_is_not_fail_closed(self) -> None:
+        """Deferral is "not yet asked", not "could not answer" -- it must not read as a failure."""
+        assert DEFERRED_SNAPSHOT.failure_detail is None
+        assert DEFERRED_SNAPSHOT.declares_models is False
+
+    def test_the_query_goes_through_once_construction_ends(self) -> None:
+        verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
+        with patch(_HANDLE, return_value=_success(verdicts)):
+            with LibraryRegistry.constructing_node():
+                assert query_model_policy("SomeNode").deferred is True
+            snapshot = query_model_policy("SomeNode")
+        assert snapshot.deferred is False
+        assert snapshot.denial_for(DENIED) is _DENIAL
 
 
 class TestSnapshotIsImmutable:

--- a/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
@@ -13,6 +13,11 @@ during library load via ``drops_class_from_schema``.
 Outside of node construction, dispatch must not record a violation.
 Outside of any strict-mode scope, ``STRICT_MODE.report`` is a no-op so
 the reentrant call still goes through without crashing.
+
+``reentrant_bus_in_init_would_report`` exposes that same condition for
+callers that legitimately read engine state from a node ``__init__`` and
+want to skip the request rather than commit the violation. It has its own
+class below, including a test that it and the detector cannot disagree.
 """
 
 from __future__ import annotations
@@ -38,7 +43,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadSuccess,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager
+from griptape_nodes.retained_mode.managers.event_manager import EventManager, reentrant_bus_in_init_would_report
 
 
 @dataclass(kw_only=True)
@@ -174,3 +179,84 @@ class TestReentrantBusInInit:
             _constructing_node.reset(token)
 
         assert scope.violations[0].severity is StrictModeSeverity.ERROR
+
+
+class TestReentrantBusInInitWouldReport:
+    """The predicate components consult before issuing a request from a node __init__.
+
+    Being inside ``__init__`` is not enough: with no scope open the detector's report is a
+    no-op, so the request is free and the caller should just make it. Components keyed their
+    deferral off ``is_constructing_node()`` alone once, which made every node in every
+    deployment pay for a hazard only the worker's probe and node execution have -- model
+    dropdowns lost their denial rows and download subtitles until the node was run.
+    """
+
+    def test_false_outside_node_init_even_inside_a_scope(self) -> None:
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.LOAD_PROBE,
+            subject="MyNodeClass",
+            library_name="libA",
+            is_worker=True,
+        ):
+            assert reentrant_bus_in_init_would_report() is False
+
+    def test_false_during_node_init_with_no_scope_open(self) -> None:
+        """The restored case: an editor drop, a workflow load, any single-process engine."""
+        token = _constructing_node.set(True)
+        try:
+            assert reentrant_bus_in_init_would_report() is False
+        finally:
+            _constructing_node.reset(token)
+
+    @pytest.mark.parametrize("kind", [StrictModeScopeKind.LOAD_PROBE, StrictModeScopeKind.RUNTIME_EXECUTE])
+    def test_true_during_node_init_inside_a_scope(self, kind: StrictModeScopeKind) -> None:
+        token = _constructing_node.set(True)
+        try:
+            with STRICT_MODE.open_scope(kind=kind, subject="s", library_name="libA", is_worker=True):
+                assert reentrant_bus_in_init_would_report() is True
+        finally:
+            _constructing_node.reset(token)
+
+    def test_true_during_node_init_when_strict_mode_is_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A disabled reporter detaches its scopes, so a probe is indistinguishable from a drop.
+
+        Reaches for the private ``_enabled`` because ``enabled`` is a read-only property and the
+        env var is read once at construction; the reporter is a module singleton, so re-creating
+        it would not be the object the predicate consults.
+        """
+        monkeypatch.setattr(STRICT_MODE, "_enabled", False)
+        token = _constructing_node.set(True)
+        try:
+            assert reentrant_bus_in_init_would_report() is True
+        finally:
+            _constructing_node.reset(token)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("constructing", [True, False])
+    @pytest.mark.parametrize("open_a_scope", [True, False])
+    async def test_it_agrees_with_the_detector(self, *, constructing: bool, open_a_scope: bool) -> None:
+        """The drift guard: "we deferred" and "it would have been reported" are one condition.
+
+        A caller that skips a request the detector would have ignored loses functionality for
+        nothing; one that issues a request the detector reports gets its class dropped from the
+        worker schema. Both halves live in the predicate so neither can happen.
+        """
+        event_manager = _make_event_manager_with_probe_handler()
+        scope_kind = StrictModeScopeKind.LOAD_PROBE
+
+        token = _constructing_node.set(constructing)
+        try:
+            if not open_a_scope:
+                predicted = reentrant_bus_in_init_would_report()
+                await event_manager.ahandle_request(_ProbeRequest(marker="m7"))
+                assert predicted is False  # nothing to compare against; report() no-ops
+                return
+            with STRICT_MODE.open_scope(
+                kind=scope_kind, subject="MyNodeClass", library_name="libA", is_worker=True
+            ) as scope:
+                predicted = reentrant_bus_in_init_would_report()
+                await event_manager.ahandle_request(_ProbeRequest(marker="m7"))
+        finally:
+            _constructing_node.reset(token)
+
+        assert predicted is (len(scope.violations) == 1)

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -16,7 +16,10 @@ import pytest
 
 from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
+from griptape_nodes.exe_types.param_components.huggingface.huggingface_repo_parameter import HuggingFaceRepoParameter
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from tests.unit.exe_types.mocks import MockNode
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -40,7 +43,11 @@ def patched_registry() -> Callable[[dict[str, type]], AbstractContextManager[Non
         lib.get_node_class.side_effect = lambda name: nodes[name]
 
         def _create_node(*, node_type: str, name: str, specific_library_name: str | None = None) -> Any:  # noqa: ARG001
-            return nodes[node_type](name)
+            # The real create_node sets the constructing-node flag; the probe's
+            # detectors (and the construction-time deferrals they motivated) key
+            # off it, so the mock must set it too to reproduce probe conditions.
+            with LibraryRegistry.constructing_node():
+                return nodes[node_type](name)
 
         with patch.multiple(
             "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry",
@@ -107,6 +114,44 @@ class TestSerializeSchemasStrictMode:
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("fixture probe violation" in r.getMessage() for r in warnings)
         assert any("class=Violator" in r.getMessage() for r in warnings)
+
+
+class _ProbeWithHuggingFaceRepoParam(MockNode):
+    """Node whose __init__ builds the engine's HF repo dropdown — the DA3/diffusers pattern.
+
+    Regression for the reentrant-bus-in-init violations the component itself used to commit:
+    its policy and download queries fired from inside node __init__, so every library using it
+    (Depth Anything 3, diffusers, …) had its classes dropped from the worker schema.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name)
+        repo_param = HuggingFaceRepoParameter(self, repo_ids=["owner/model-a"])
+        repo_param.add_input_parameters()
+
+
+class TestHuggingFaceRepoParameterSurvivesTheProbe:
+    @pytest.mark.asyncio
+    async def test_hf_param_node_is_included_and_issues_no_bus_requests(
+        self, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        module = "griptape_nodes.exe_types.param_components.huggingface"
+
+        def _refuse_bus(request: object) -> object:
+            msg = f"bus request issued during probe construction: {type(request).__name__}"
+            raise AssertionError(msg)
+
+        manager = GriptapeNodes.LibraryManager()
+        with (
+            patch(f"{module}.huggingface_repo_parameter.list_repo_revisions_in_cache", return_value=[]),
+            patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=_refuse_bus),
+            patched_registry({"HFNode": _ProbeWithHuggingFaceRepoParam}),
+        ):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        # Before the construction-time deferral, the component's bus requests fired
+        # reentrant-bus-in-init here and the class was dropped from the schemas.
+        assert [s.class_name for s in schemas] == ["HFNode"]
 
 
 class _DummyTrait(Trait):


### PR DESCRIPTION
The model policy application to HF model param led to a strict-mode violation, preventing nodes using the param from working in worker mode. We need these libraries to support isolated execution so libraries will not get load-time model-state info in the node params until it has run. That sucks but the nodes outright not working in worker mode sucks more