### PR TITLE
feat(libraries): generate nodes from saved workflow files

### DIFF
--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -151,7 +151,9 @@ parameters:
 - The node supplies its own Flow In and Flow Out, so the workflow's control parameters are not
     surfaced.
 - The End Flow node's built-in **Status** parameters (`was_successful`, `result_details`) are not
-    surfaced either. They report on the End Flow node's own run, not on anything you exposed.
+    surfaced either. They report on the End Flow node's own run, not on anything you exposed. A
+    parameter of your own with one of those names is only dropped if you also put it in a parameter
+    group named `Status`.
 
 A parameter name used by exactly one Start Flow or End Flow node keeps its bare name. If two Start
 Flow nodes both expose `prompt`, both parameters are qualified with their node name instead

--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -137,10 +137,11 @@ engine generates the node type for you:
 ]
 ```
 
-| Field | Meaning |
-| `node_type` | The name the node is registered under. This is what appears in saved workflows. |
-| `workflow_path` | Path to the saved workflow `.py`, relative to `griptape_nodes_library.json`. |
-| `metadata` | The same node metadata block the `nodes` array uses: category, description, display name, etc. |
+| Field           | Meaning                                                                                        |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| `node_type`     | The name the node is registered under. This is what appears in saved workflows.                |
+| `workflow_path` | Path to the saved workflow `.py`, relative to `griptape_nodes_library.json`.                   |
+| `metadata`      | The same node metadata block the `nodes` array uses: category, description, display name, etc. |
 
 **The workflow needs a Start Flow node and an End Flow node.** Those are what define the node's
 parameters:
@@ -152,7 +153,8 @@ parameters:
 
 A parameter name used by exactly one Start Flow or End Flow node keeps its bare name. If two Start
 Flow nodes both expose `prompt`, both parameters are qualified with their node name instead
-(`Start Flow.prompt`, `Start Flow_2.prompt`) so neither is lost. A name that appears on both a Start
+(`Start_Flow.prompt`, `Start_Flow_2.prompt`) so neither is lost. Spaces in the node name become
+underscores, because parameter names cannot contain whitespace. A name that appears on both a Start
 Flow node and an End Flow node becomes a single parameter that is both an input and an output.
 
 When the node runs, the engine loads the workflow as a child subflow of the node's own flow, copies
@@ -164,6 +166,10 @@ into a saved workflow, so nothing about the node's internals leaks into your use
 metadata header at the top of the workflow file, which the editor writes on save. A workflow with no
 saved shape (no Start Flow and End Flow nodes, or a hand-written file with no header) is reported as
 a library problem and its node is not registered.
+
+The workflow is also registered as a workflow in its own right, so it shows up in the editor's
+workflow picker. To keep a workflow that only exists to back a node out of that list, set
+`is_internal = true` in its metadata header.
 
 ### Library and Node Declarations
 

--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -9,7 +9,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
 ```json
 {
   "name": "Library Name",
-  "library_schema_version": "0.10.0",
+  "library_schema_version": "0.11.0",
   "settings": [
     {
       "description": "API keys required by nodes in this library",
@@ -83,6 +83,17 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
       }
     }
   ],
+  "workflow_nodes": [
+    {
+      "node_type": "UpscaleAndTag",
+      "workflow_path": "workflows/upscale_and_tag.py",
+      "metadata": {
+        "category": "image",
+        "description": "Upscales an image and tags it",
+        "display_name": "Upscale and Tag"
+      }
+    }
+  ],
   "workflows": ["workflows/example_workflow.py"],
   "is_default_library": false
 }
@@ -100,11 +111,59 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
 - **categories**: Group nodes in UI with colors and icons
 - **nodes**: List node classes, file paths, and metadata
 - **advanced_library_path**: Optional Python file declaring an `AdvancedNodeLibrary` subclass, for libraries that need to run code at load and unload, own a request type, or register node types the manifest does not list (see [Advanced Libraries](advanced_libraries.md))
+- **workflow_nodes**: Nodes generated from saved workflow files instead of Python classes. See [Nodes From Workflow Files](#nodes-from-workflow-files) below.
 - **workflows**: Template workflow files
 
 **Important:** The `secrets_to_register` array tells the system which secrets your library needs. Users will be prompted to configure these secrets through the UI or environment variables.
 
 Use flat directory structures. The engine automatically registers and loads libraries.
+
+### Nodes From Workflow Files
+
+A node does not have to be a Python class. Point a `workflow_nodes` entry at a saved workflow and the
+engine generates the node type for you:
+
+```jsonc
+"workflow_nodes": [
+  {
+    "node_type": "UpscaleAndTag",
+    "workflow_path": "workflows/upscale_and_tag.py",
+    "metadata": {
+      "category": "image",
+      "description": "Upscales an image and tags it",
+      "display_name": "Upscale and Tag"
+    }
+  }
+]
+```
+
+| Field | Meaning |
+| `node_type` | The name the node is registered under. This is what appears in saved workflows. |
+| `workflow_path` | Path to the saved workflow `.py`, relative to `griptape_nodes_library.json`. |
+| `metadata` | The same node metadata block the `nodes` array uses: category, description, display name, etc. |
+
+**The workflow needs a Start Flow node and an End Flow node.** Those are what define the node's
+parameters:
+
+- Every non-control parameter on a **Start Flow** node becomes an **input** on the node.
+- Every non-control parameter on an **End Flow** node becomes an **output** on the node.
+- The node supplies its own Flow In and Flow Out, so the workflow's control parameters are not
+    surfaced.
+
+A parameter name used by exactly one Start Flow or End Flow node keeps its bare name. If two Start
+Flow nodes both expose `prompt`, both parameters are qualified with their node name instead
+(`Start Flow.prompt`, `Start Flow_2.prompt`) so neither is lost. A name that appears on both a Start
+Flow node and an End Flow node becomes a single parameter that is both an input and an output.
+
+When the node runs, the engine loads the workflow as a child subflow of the node's own flow, copies
+the node's input values onto the Start Flow nodes, runs it, and copies the End Flow values back out
+as the node's outputs. The subflow is reused for later runs in the same session and is never written
+into a saved workflow, so nothing about the node's internals leaks into your users' files.
+
+**Save the workflow from the editor before shipping it.** The parameter shape is read out of the
+metadata header at the top of the workflow file, which the editor writes on save. A workflow with no
+saved shape (no Start Flow and End Flow nodes, or a hand-written file with no header) is reported as
+a library problem and its node is not registered.
 
 ### Library and Node Declarations
 

--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -150,6 +150,8 @@ parameters:
 - Every non-control parameter on an **End Flow** node becomes an **output** on the node.
 - The node supplies its own Flow In and Flow Out, so the workflow's control parameters are not
     surfaced.
+- The End Flow node's built-in **Status** parameters (`was_successful`, `result_details`) are not
+    surfaced either. They report on the End Flow node's own run, not on anything you exposed.
 
 A parameter name used by exactly one Start Flow or End Flow node keeps its bare name. If two Start
 Flow nodes both expose `prompt`, both parameters are qualified with their node name instead
@@ -160,7 +162,7 @@ Flow node and an End Flow node becomes a single parameter that is both an input 
 When the node runs, the engine loads the workflow as a child subflow of the node's own flow, copies
 the node's input values onto the Start Flow nodes, runs it, and copies the End Flow values back out
 as the node's outputs. The subflow is reused for later runs in the same session and is never written
-into a saved workflow, so nothing about the node's internals leaks into your users' files.
+into a saved workflow, so your users' files carry the node, not a copy of the workflow behind it.
 
 **Save the workflow from the editor before shipping it.** The parameter shape is read out of the
 metadata header at the top of the workflow file, which the editor writes on save. A workflow with no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,9 @@ pythonpath = ["libraries/griptape_nodes_library"]
 
 [tool.ruff]
 line-length = 120
-extend-exclude = ["libraries/**/templates/*.py"]
+# Engine-generated workflow files. Their formatting is whatever the workflow generator emits, so
+# reformatting them would mean the committed copy no longer matches a real save.
+extend-exclude = ["libraries/**/templates/*.py", "tests/e2e/fixtures/**/*_workflow.py"]
 
 
 [tool.ruff.lint]
@@ -201,6 +203,9 @@ venv = ".venv"
 include = ["."]
 exclude = [
   "libraries/**/templates/*",
+  # Engine-generated workflow files. The generator emits untyped request/result chains, so these are
+  # checked by running them, not by pyright.
+  "tests/e2e/fixtures/**/*_workflow.py",
   ".venv",
   "GriptapeNodes",
   "**/node_modules",

--- a/scripts/generate_shout_workflow_fixture.py
+++ b/scripts/generate_shout_workflow_fixture.py
@@ -1,0 +1,156 @@
+"""Generate tests/e2e/fixtures/workflow_node_library/shout_workflow.py.
+
+Run with `uv run python scripts/generate_shout_workflow_fixture.py` from the repo root when the
+workflow file format changes. Builds the Start -> Shout -> End graph in-process and emits it
+through the real workflow generator, so the committed fixture always matches what saving a workflow
+from the editor produces.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowShape
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    AutoLayoutFlowRequest,
+    AutoLayoutFlowResultSuccess,
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.utils.version_utils import engine_version
+
+LIBRARY_DIR = Path(__file__).resolve().parents[1] / "tests" / "e2e" / "fixtures" / "workflow_node_library"
+LIBRARY_JSON = LIBRARY_DIR / "griptape_nodes_library.json"
+NODE_FILE = LIBRARY_DIR / "workflow_node_nodes.py"
+WORKFLOW_PATH = LIBRARY_DIR / "shout_workflow.py"
+LIBRARY_NAME = "Workflow Node Library"
+WORKFLOW_NAME = "shout_workflow"
+
+
+class FixtureGenerationError(RuntimeError):
+    """Raised when a step of the fixture generation does not succeed."""
+
+
+def _expect[T](result: object, expected: type[T], attempted: str) -> T:
+    """Narrow `result` to `expected`, or fail with the engine's own failure details."""
+    if not isinstance(result, expected):
+        msg = f"Attempted to {attempted}. Failed with result: {result}"
+        raise FixtureGenerationError(msg)
+    return result
+
+
+def _create(node_type: str, node_name: str, flow_name: str) -> str:
+    result = current_engine().handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY_NAME,
+            node_name=node_name,
+            override_parent_flow_name=flow_name,
+        )
+    )
+    return _expect(result, CreateNodeResultSuccess, f"create a '{node_type}' node").node_name
+
+
+def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
+    result = current_engine().handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name=source_param,
+            target_node_name=target_node,
+            target_parameter_name=target_param,
+        )
+    )
+    if result.failed():
+        msg = f"Attempted to connect {source_node}.{source_param} to {target_node}.{target_param}. Failed: {result}"
+        raise FixtureGenerationError(msg)
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    """Copy the fixture library into `target_dir` with the running engine version.
+
+    The committed JSON pins engine_version to "0.0.0", which registration rejects. The emitted
+    workflow references its libraries by name only, so generating against a copy is equivalent.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(LIBRARY_JSON.read_text())
+    schema["metadata"]["engine_version"] = engine_version
+    # The workflow being generated is what this script writes; drop the declaration so registration
+    # does not fail on a file that does not exist yet.
+    schema.pop("workflow_nodes", None)
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    (target_dir / NODE_FILE.name).write_text(NODE_FILE.read_text())
+    return library_json
+
+
+def _generate() -> None:
+    """Build the Start -> Shout -> End graph and write it out as a saved workflow."""
+    current_engine().context_manager.push_workflow(workflow_name=WORKFLOW_NAME)
+
+    flow_result = current_engine().handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
+    )
+    flow_name = _expect(flow_result, CreateFlowResultSuccess, "create the workflow's flow").flow_name
+
+    start_node = _create("TextStartNode", "Start Flow", flow_name)
+    shout_node = _create("ShoutNode", "Shout", flow_name)
+    end_node = _create("TextEndNode", "End Flow", flow_name)
+
+    _connect(start_node, "exec_out", shout_node, "exec_in")
+    _connect(shout_node, "exec_out", end_node, "exec_in")
+    _connect(start_node, "text", shout_node, "text")
+    _connect(shout_node, "shouted", end_node, "result")
+
+    # Lay the graph out before serializing so node positions are baked into the emitted file.
+    # Without this every node serializes without a position and they stack on the same spot when
+    # the workflow is opened or previewed.
+    layout_result = current_engine().handle_request(AutoLayoutFlowRequest(flow_name=flow_name))
+    _expect(layout_result, AutoLayoutFlowResultSuccess, "lay out the workflow's nodes")
+
+    workflow_manager = current_engine().workflow_manager
+    shape = workflow_manager.extract_workflow_shape(WORKFLOW_NAME, flow_name=flow_name)
+
+    serialize_result = current_engine().handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    serialized = _expect(serialize_result, SerializeFlowToCommandsResultSuccess, "serialize the workflow's flow")
+
+    metadata = WorkflowMetadata(
+        name=WORKFLOW_NAME,
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=list(serialized.serialized_flow_commands.node_dependencies.libraries),
+        description="Uppercases the incoming text and appends an exclamation mark.",
+        workflow_shape=WorkflowShape(inputs=shape["input"], outputs=shape["output"]),
+    )
+    content = workflow_manager._generate_workflow_file_content(
+        serialized_flow_commands=serialized.serialized_flow_commands,
+        workflow_metadata=metadata,
+    )
+    WORKFLOW_PATH.write_text(content, encoding="utf-8")
+    print(f"Wrote {WORKFLOW_PATH}")  # noqa: T201
+
+
+def main() -> None:
+    """Register the fixture library against a temp copy, then regenerate the workflow file."""
+    current_engine().handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        library_json = _materialize_library(Path(temp_dir) / "library")
+        register_result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+        _expect(register_result, RegisterLibraryFromFileResultSuccess, "register the fixture library")
+        _generate()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -47,9 +47,17 @@ logger = logging.getLogger("griptape_nodes")
 # workflow expose the same parameter name.
 QUALIFIED_NAME_SEPARATOR = "."
 
-# Node-metadata key holding the name of the live imported subflow. Runtime-only: the subflow is
-# tagged transient so it never round-trips through a save, which makes any value present at load
-# time stale. The editor reads it to offer a "view the subflow" affordance during a session.
+# The parameters `ExecutionStatusComponent` puts on every End Flow node, and the group it puts them
+# in. They report on the End Flow node's own execution rather than on anything the workflow's author
+# chose to expose, so the generated node drops them the way it drops control parameters.
+STATUS_GROUP_NAME = "Status"
+STATUS_PARAMETER_NAMES = frozenset({"was_successful", "result_details"})
+
+# Node-metadata key holding the name of the live imported subflow, matching the key
+# `SubflowNodeGroup` writes so the editor's subflow preview can read either. Session-scoped: the
+# subflow itself is tagged transient and is never serialized, and `__init__` drops this key, so a
+# value a save happened to bake into a file is inert when that file is loaded. The editor reads it to
+# offer a "view the subflow" affordance during a session.
 SUBFLOW_NAME_KEY = "subflow_name"
 
 # Node-metadata flag the editor uses to recognize a node that runs a workflow. Presence of this key
@@ -129,8 +137,9 @@ def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowP
 
     A parameter name used by exactly one Start/End node keeps its bare name. A name used by more
     than one node is qualified as ``<node name>.<parameter name>`` for every node that uses it, so
-    the result never depends on iteration order. Control parameters are dropped: the generated node
-    supplies its own control flow.
+    the result never depends on iteration order. Control parameters and the End Flow node's Status
+    parameters are dropped: the generated node supplies its own control flow and reports its own
+    status.
 
     Raises:
         WorkflowNodeDefinitionError: Two workflow parameters claim the same surface name, which would
@@ -139,14 +148,14 @@ def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowP
     nodes_using_name: dict[str, list[str]] = {}
     for workflow_node_name, parameters in section.items():
         for parameter_name, definition in parameters.items():
-            if _is_control_parameter(definition):
+            if not _is_surfaced_parameter(parameter_name, definition):
                 continue
             nodes_using_name.setdefault(parameter_name, []).append(workflow_node_name)
 
     routes: dict[str, WorkflowParameterRoute] = {}
     for workflow_node_name, parameters in section.items():
         for parameter_name, definition in parameters.items():
-            if _is_control_parameter(definition):
+            if not _is_surfaced_parameter(parameter_name, definition):
                 continue
             if len(nodes_using_name[parameter_name]) == 1:
                 surface_name = parameter_name
@@ -287,9 +296,9 @@ class WorkflowNode(ControlNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
 
-        # The imported subflow is an execution-time artifact tracked through node metadata. It is
-        # never serialized, so anything present at load time is stale (or, after a copy/paste,
-        # belongs to a different node).
+        # The imported subflow is an execution-time artifact tracked through node metadata. The
+        # subflow it names is transient and never serialized, so any name that reaches us here is
+        # stale (or, after a copy/paste, belongs to a different node).
         self.metadata.pop(SUBFLOW_NAME_KEY, None)
         self.metadata[WORKFLOW_NODE_KEY] = True
         self._publish_workflow_registry_key()
@@ -520,8 +529,11 @@ def build_workflow_node_class(
     )
 
 
-def _is_control_parameter(definition: ParameterMinimalDict) -> bool:
-    return definition.get("type") == ParameterTypeBuiltin.CONTROL_TYPE.value
+def _is_surfaced_parameter(parameter_name: str, definition: ParameterMinimalDict) -> bool:
+    """Whether a parameter in the workflow's shape becomes a parameter on the generated node."""
+    is_control = definition.get("type") == ParameterTypeBuiltin.CONTROL_TYPE.value
+    is_status = parameter_name in STATUS_PARAMETER_NAMES and definition.get("parent_element_name") == STATUS_GROUP_NAME
+    return not is_control and not is_status
 
 
 def _build_surface_parameter(surface_name: str, surface_parameter: WorkflowNodeSurfaceParameter) -> Parameter:

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -1,0 +1,471 @@
+"""Node types whose behavior is defined by a saved workflow file.
+
+A library can declare a node in its ``workflow_nodes`` list instead of its ``nodes`` list,
+pointing at a saved workflow ``.py`` that contains Start Flow and End Flow nodes. The engine
+reads the workflow's saved shape and generates a node type whose inputs are the workflow's
+Start Flow parameters and whose outputs are its End Flow parameters. Running the node imports
+the workflow as a transient subflow, feeds the inputs in, runs it, and copies the End Flow
+values back out.
+
+The generated node types are ordinary ``BaseNode`` subclasses built by
+``build_workflow_node_class``, so they behave like any other library node on the canvas.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.flow import ControlFlow
+from griptape_nodes.exe_types.node_types import ControlNode, EndNode, StartNode
+from griptape_nodes.files.path_utils import derive_registry_key
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry
+from griptape_nodes.retained_mode.events.execution_events import (
+    StartLocalSubflowRequest,
+    StartLocalSubflowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import TRANSIENT_KEY, DeleteFlowRequest
+from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    ImportWorkflowAsReferencedSubFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from griptape_nodes.node_library.workflow_registry import NodeParametersMapping, ParameterMinimalDict
+
+logger = logging.getLogger("griptape_nodes")
+
+# Separator used to qualify a surface parameter with its Start/End node name when two nodes in the
+# workflow expose the same parameter name.
+QUALIFIED_NAME_SEPARATOR = "."
+
+# Node-metadata key holding the name of the live imported subflow. Runtime-only: the subflow is
+# tagged transient so it never round-trips through a save, which makes any value present at load
+# time stale. The editor reads it to offer a "view the subflow" affordance during a session.
+SUBFLOW_NAME_KEY = "subflow_name"
+
+# Node-metadata flag the editor uses to recognize a node that runs a workflow. Presence of this key
+# is what makes the editor render the node with its subflow-preview wrapper (see
+# `determineNodeType` in the editor's ConstructNode.ts), which offers a "View Subflow" button.
+WORKFLOW_NODE_KEY = "workflow_node"
+
+# Node-metadata key holding the registry key of the backing workflow. The editor's preview reads
+# this to import and display the workflow when the node has not run yet and therefore has no live
+# subflow. Shared contract with the standard library's SubflowWorkflowNode, which stores its
+# dropdown selection here.
+WORKFLOW_FILE_VALUE_KEY = "_workflow_file_value"
+
+
+class WorkflowNodeDefinitionError(Exception):
+    """Raised when a workflow file cannot back a node type."""
+
+
+class WorkflowParameterRoute(NamedTuple):
+    """Where a surface parameter reads from or writes to inside the workflow."""
+
+    workflow_node_name: str
+    parameter_name: str
+
+
+class WorkflowNodeLiveRoutes(NamedTuple):
+    """Surface parameter names mapped onto the live subflow parameters they address."""
+
+    inputs: dict[str, WorkflowParameterRoute]
+    outputs: dict[str, WorkflowParameterRoute]
+
+
+class WorkflowNodeSurfaceParameter(NamedTuple):
+    """One parameter on the generated node, plus the workflow parameters it is wired to.
+
+    A name that appears on both a Start Flow node and an End Flow node carries both routes, so a
+    single parameter serves as input and output (matching how the workflow itself passes it
+    through).
+    """
+
+    definition: ParameterMinimalDict
+    input_route: WorkflowParameterRoute | None
+    output_route: WorkflowParameterRoute | None
+
+
+def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowParameterRoute]:
+    """Flatten one half of a workflow shape into surface parameter names.
+
+    A parameter name used by exactly one Start/End node keeps its bare name. A name used by more
+    than one node is qualified as ``<node name>.<parameter name>`` for every node that uses it, so
+    the result never depends on iteration order. Control parameters are dropped: the generated node
+    supplies its own control flow.
+    """
+    nodes_using_name: dict[str, list[str]] = {}
+    for workflow_node_name, parameters in section.items():
+        for parameter_name, definition in parameters.items():
+            if _is_control_parameter(definition):
+                continue
+            nodes_using_name.setdefault(parameter_name, []).append(workflow_node_name)
+
+    routes: dict[str, WorkflowParameterRoute] = {}
+    for workflow_node_name, parameters in section.items():
+        for parameter_name, definition in parameters.items():
+            if _is_control_parameter(definition):
+                continue
+            if len(nodes_using_name[parameter_name]) == 1:
+                surface_name = parameter_name
+            else:
+                surface_name = f"{workflow_node_name}{QUALIFIED_NAME_SEPARATOR}{parameter_name}"
+            routes[surface_name] = WorkflowParameterRoute(
+                workflow_node_name=workflow_node_name, parameter_name=parameter_name
+            )
+    return routes
+
+
+def build_workflow_node_surface(workflow_metadata: WorkflowMetadata) -> dict[str, WorkflowNodeSurfaceParameter]:
+    """Derive the generated node's parameter surface from a workflow's saved shape.
+
+    Inputs come first so they render above the outputs on the canvas.
+
+    Raises:
+        WorkflowNodeDefinitionError: The workflow carries no saved shape, meaning it has no Start
+            Flow and End Flow nodes to derive a surface from.
+    """
+    workflow_shape = workflow_metadata.workflow_shape
+    if workflow_shape is None:
+        msg = (
+            f"Workflow '{workflow_metadata.name}' cannot back a node because it has no saved input and output "
+            "shape. Add a Start Flow node and an End Flow node to the workflow, then save it."
+        )
+        raise WorkflowNodeDefinitionError(msg)
+
+    input_routes = flatten_shape_section(workflow_shape.inputs)
+    output_routes = flatten_shape_section(workflow_shape.outputs)
+    if not input_routes and not output_routes:
+        msg = (
+            f"Workflow '{workflow_metadata.name}' cannot back a node because its Start Flow and End Flow nodes "
+            "expose no parameters. Add at least one parameter to a Start Flow or End Flow node, then save it."
+        )
+        raise WorkflowNodeDefinitionError(msg)
+
+    surface: dict[str, WorkflowNodeSurfaceParameter] = {}
+    for surface_name, route in input_routes.items():
+        definition = workflow_shape.inputs[route.workflow_node_name][route.parameter_name]
+        surface[surface_name] = WorkflowNodeSurfaceParameter(
+            definition=definition, input_route=route, output_route=None
+        )
+    for surface_name, route in output_routes.items():
+        definition = workflow_shape.outputs[route.workflow_node_name][route.parameter_name]
+        existing = surface.get(surface_name)
+        if existing is None:
+            surface[surface_name] = WorkflowNodeSurfaceParameter(
+                definition=definition, input_route=None, output_route=route
+            )
+        else:
+            surface[surface_name] = existing._replace(output_route=route)
+    return surface
+
+
+def match_shape_nodes(declared_names: Sequence[str], live_names: Iterable[str]) -> dict[str, str]:
+    """Pair the Start/End node names in a saved shape with their names in an imported subflow.
+
+    Importing a workflow renames any node whose name is already taken elsewhere in the session,
+    appending a ``_N`` suffix, so the saved shape's node names can be stale. An exact name match
+    wins; a declared name otherwise claims the first unclaimed live name that looks like a
+    de-duplicated spelling of it.
+    """
+    remaining = list(live_names)
+    matches: dict[str, str] = {}
+
+    for declared_name in declared_names:
+        if declared_name in remaining:
+            matches[declared_name] = declared_name
+            remaining.remove(declared_name)
+
+    for declared_name in declared_names:
+        if declared_name in matches:
+            continue
+        renamed = next((live_name for live_name in remaining if live_name.startswith(f"{declared_name}_")), None)
+        if renamed is not None:
+            matches[declared_name] = renamed
+            remaining.remove(renamed)
+
+    return matches
+
+
+def ensure_workflow_registered(workflow_file_path: Path, workflow_metadata: WorkflowMetadata) -> str:
+    """Register `workflow_file_path` in the workflow registry if it is not there already.
+
+    Returns the registry key the workflow is available under. Registration is idempotent and
+    happens lazily, at execution time, because the registry is cleared and rebuilt when the
+    workspace changes while a library's node types survive that reload.
+
+    The entry is marked internal so a workflow that exists only to back a node does not show up
+    in the editor's workflow picker. A library that also lists the file in its ``workflows`` array
+    registers it through the normal path first, and that entry wins.
+    """
+    registry_key = derive_registry_key(str(workflow_file_path))
+    if WorkflowRegistry.has_workflow_with_name(registry_key):
+        return registry_key
+
+    WorkflowRegistry.generate_new_workflow(
+        registry_key=registry_key,
+        metadata=workflow_metadata.model_copy(update={"is_internal": True}),
+        file_path=str(workflow_file_path),
+    )
+    return registry_key
+
+
+class WorkflowNode(ControlNode):
+    """Base class for node types generated from a saved workflow file.
+
+    ``build_workflow_node_class`` produces the concrete subclasses; the class attributes below are
+    filled in per workflow. Instantiating this base class directly is not useful.
+    """
+
+    # Absolute path to the workflow that backs this node type.
+    workflow_file_path: ClassVar[Path]
+    # Metadata read from that workflow's header at library load time.
+    workflow_metadata: ClassVar[WorkflowMetadata]
+    # Surface parameter name -> the workflow parameters it is wired to.
+    workflow_surface: ClassVar[dict[str, WorkflowNodeSurfaceParameter]]
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        # The imported subflow is an execution-time artifact tracked through node metadata. It is
+        # never serialized, so anything present at load time is stale (or, after a copy/paste,
+        # belongs to a different node).
+        self.metadata.pop(SUBFLOW_NAME_KEY, None)
+        self.metadata[WORKFLOW_NODE_KEY] = True
+        self._publish_workflow_registry_key()
+
+        for surface_name, surface_parameter in self.workflow_surface.items():
+            self.add_parameter(_build_surface_parameter(surface_name, surface_parameter))
+
+    def _publish_workflow_registry_key(self) -> None:
+        """Register the backing workflow and record its key so the editor can preview it.
+
+        Registration happens here, rather than only at execution time, so the workflow can be
+        previewed before the node has ever run. Failure is not fatal: the node stays usable and the
+        preview is simply unavailable until the next run re-registers the workflow.
+        """
+        try:
+            self.metadata[WORKFLOW_FILE_VALUE_KEY] = ensure_workflow_registered(
+                self.workflow_file_path, self.workflow_metadata
+            )
+        except (KeyError, ValueError):
+            logger.warning(
+                "Node '%s' could not register its workflow '%s' for preview; it will be registered on the next run.",
+                self.name,
+                self.workflow_file_path,
+            )
+
+    def after_node_deleted(self) -> None:
+        self._discard_subflow()
+
+    async def aprocess(self) -> None:
+        subflow_name = await self._load_subflow()
+        live_routes = self._resolve_live_routes(subflow_name)
+
+        self._apply_inputs(subflow_name, live_routes)
+
+        result = await GriptapeNodes.ahandle_request(StartLocalSubflowRequest(flow_name=subflow_name))
+        if not isinstance(result, StartLocalSubflowResultSuccess):
+            msg = (
+                f"Attempted to run the workflow behind node '{self.name}'. "
+                f"Failed because the workflow did not finish: {result.result_details}"
+            )
+            raise RuntimeError(msg)  # noqa: TRY004 - the workflow failed at run time; this is not a type error
+
+        self._collect_outputs(subflow_name, live_routes)
+
+    async def _load_subflow(self) -> str:
+        """Return the name of this node's live subflow, importing the workflow if needed.
+
+        The subflow is reused across runs so repeat executions do not pay for another import. It
+        is tagged transient so the engine never serializes it, which keeps the node-to-subflow
+        link out of saved workflows entirely.
+        """
+        tracked = self.metadata.get(SUBFLOW_NAME_KEY)
+        if tracked is not None:
+            if _get_flow_or_none(tracked) is not None:
+                return tracked
+            # Torn down out from under us (for example when the parent flow was deleted).
+            self.metadata.pop(SUBFLOW_NAME_KEY, None)
+
+        flow_result = GriptapeNodes.handle_request(GetFlowForNodeRequest(node_name=self.name))
+        if not isinstance(flow_result, GetFlowForNodeResultSuccess):
+            msg = (
+                f"Attempted to run the workflow behind node '{self.name}'. "
+                f"Failed because the flow containing the node could not be found: {flow_result.result_details}"
+            )
+            raise RuntimeError(msg)  # noqa: TRY004 - the lookup failed at run time; this is not a type error
+
+        registry_key = ensure_workflow_registered(self.workflow_file_path, self.workflow_metadata)
+        import_result = await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(
+                workflow_name=registry_key,
+                flow_name=flow_result.flow_name,
+                imported_flow_metadata={TRANSIENT_KEY: True},
+            )
+        )
+        if not isinstance(import_result, ImportWorkflowAsReferencedSubFlowResultSuccess):
+            msg = (
+                f"Attempted to load the workflow at '{self.workflow_file_path}' for node '{self.name}'. "
+                f"Failed because the workflow could not be loaded: {import_result.result_details}"
+            )
+            raise RuntimeError(msg)  # noqa: TRY004 - the import failed at run time; this is not a type error
+
+        self.metadata[SUBFLOW_NAME_KEY] = import_result.created_flow_name
+        return import_result.created_flow_name
+
+    def _discard_subflow(self) -> None:
+        """Delete this node's subflow if it is still live, and stop tracking it."""
+        tracked = self.metadata.pop(SUBFLOW_NAME_KEY, None)
+        if tracked is None:
+            return
+        if _get_flow_or_none(tracked) is None:
+            return
+        delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=tracked))
+        if delete_result.failed():
+            logger.warning(
+                "Node '%s' could not clean up its workflow subflow '%s': %s",
+                self.name,
+                tracked,
+                delete_result.result_details,
+            )
+
+    def _resolve_live_routes(self, subflow_name: str) -> WorkflowNodeLiveRoutes:
+        """Map each surface parameter onto the parameter it addresses in the imported subflow.
+
+        The saved shape's node names can be stale (an import renames nodes whose names are already
+        taken), so the Start/End nodes are re-read from the live subflow and paired back up with
+        the declared names.
+        """
+        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
+        live_start_nodes = [node.name for node in flow.nodes.values() if isinstance(node, StartNode)]
+        live_end_nodes = [node.name for node in flow.nodes.values() if isinstance(node, EndNode)]
+
+        declared_start_nodes = _declared_route_nodes(surface.input_route for surface in self.workflow_surface.values())
+        declared_end_nodes = _declared_route_nodes(surface.output_route for surface in self.workflow_surface.values())
+
+        start_node_names = match_shape_nodes(declared_start_nodes, live_start_nodes)
+        end_node_names = match_shape_nodes(declared_end_nodes, live_end_nodes)
+
+        live_routes = WorkflowNodeLiveRoutes(inputs={}, outputs={})
+        for surface_name, surface_parameter in self.workflow_surface.items():
+            input_route = _relocate_route(surface_parameter.input_route, start_node_names)
+            if input_route is not None:
+                live_routes.inputs[surface_name] = input_route
+            output_route = _relocate_route(surface_parameter.output_route, end_node_names)
+            if output_route is not None:
+                live_routes.outputs[surface_name] = output_route
+        return live_routes
+
+    def _apply_inputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
+        for surface_name, route in live_routes.inputs.items():
+            set_result = GriptapeNodes.handle_request(
+                SetParameterValueRequest(
+                    parameter_name=route.parameter_name,
+                    node_name=route.workflow_node_name,
+                    value=self.get_parameter_value(surface_name),
+                )
+            )
+            if set_result.failed():
+                msg = (
+                    f"Attempted to pass '{surface_name}' into the workflow behind node '{self.name}'. "
+                    f"Failed because the value could not be set on '{route.workflow_node_name}': "
+                    f"{set_result.result_details}"
+                )
+                raise RuntimeError(msg)
+        logger.debug("Node '%s' applied inputs to workflow subflow '%s'.", self.name, subflow_name)
+
+    def _collect_outputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
+        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
+        for surface_name, route in live_routes.outputs.items():
+            end_node = flow.nodes.get(route.workflow_node_name)
+            if end_node is None:
+                continue
+            # A node that ran publishes to parameter_output_values; fall back to the stored value
+            # for parameters an End Flow node only receives as input.
+            if route.parameter_name in end_node.parameter_output_values:
+                value = end_node.parameter_output_values[route.parameter_name]
+            else:
+                value = end_node.get_parameter_value(route.parameter_name)
+            self.parameter_output_values[surface_name] = value
+
+
+def build_workflow_node_class(
+    *,
+    node_type: str,
+    workflow_file_path: Path,
+    workflow_metadata: WorkflowMetadata,
+) -> type[WorkflowNode]:
+    """Generate a node type named `node_type` that runs the workflow at `workflow_file_path`.
+
+    Raises:
+        WorkflowNodeDefinitionError: The workflow has no saved input and output shape to build a
+            parameter surface from.
+    """
+    surface = build_workflow_node_surface(workflow_metadata)
+    return type(
+        node_type,
+        (WorkflowNode,),
+        {
+            "workflow_file_path": workflow_file_path,
+            "workflow_metadata": workflow_metadata,
+            "workflow_surface": surface,
+            "__doc__": workflow_metadata.description or f"Runs the '{workflow_metadata.name}' workflow.",
+        },
+    )
+
+
+def _is_control_parameter(definition: ParameterMinimalDict) -> bool:
+    return definition.get("type") == ParameterTypeBuiltin.CONTROL_TYPE.value
+
+
+def _build_surface_parameter(surface_name: str, surface_parameter: WorkflowNodeSurfaceParameter) -> Parameter:
+    definition = surface_parameter.definition
+    allowed_modes: set[ParameterMode] = set()
+    if surface_parameter.input_route is not None:
+        allowed_modes.add(ParameterMode.INPUT)
+        if definition.get("mode_allowed_property", True):
+            allowed_modes.add(ParameterMode.PROPERTY)
+    if surface_parameter.output_route is not None:
+        allowed_modes.add(ParameterMode.OUTPUT)
+
+    return Parameter(
+        name=surface_name,
+        tooltip=definition.get("tooltip", ""),
+        type=definition.get("type"),
+        input_types=definition.get("input_types"),
+        output_type=definition.get("output_type"),
+        default_value=definition.get("default_value"),
+        allowed_modes=allowed_modes,
+        ui_options=definition.get("ui_options"),
+    )
+
+
+def _declared_route_nodes(routes: Iterable[WorkflowParameterRoute | None]) -> list[str]:
+    """Return the distinct workflow node names referenced by `routes`, in first-seen order."""
+    node_names: list[str] = []
+    for route in routes:
+        if route is not None and route.workflow_node_name not in node_names:
+            node_names.append(route.workflow_node_name)
+    return node_names
+
+
+def _relocate_route(route: WorkflowParameterRoute | None, node_names: dict[str, str]) -> WorkflowParameterRoute | None:
+    if route is None:
+        return None
+    live_node_name = node_names.get(route.workflow_node_name)
+    if live_node_name is None:
+        return None
+    return route._replace(workflow_node_name=live_node_name)
+
+
+def _get_flow_or_none(flow_name: str) -> ControlFlow | None:
+    return GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -35,7 +35,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Sequence
     from pathlib import Path
 
     from griptape_nodes.node_library.workflow_registry import NodeParametersMapping, ParameterMinimalDict
@@ -98,6 +98,20 @@ class WorkflowNodeSurfaceParameter(NamedTuple):
     output_route: WorkflowParameterRoute | None
 
 
+class WorkflowNodeSurface(NamedTuple):
+    """Everything the generated node type derives from a workflow's saved shape.
+
+    `start_node_names` and `end_node_names` list every Start/End node the shape records, including
+    ones that expose no parameters of their own, because they are what the live subflow's nodes are
+    paired against by position. Deriving them from `parameters` instead would miss a Start Flow node
+    that only carries control flow.
+    """
+
+    parameters: dict[str, WorkflowNodeSurfaceParameter]
+    start_node_names: list[str]
+    end_node_names: list[str]
+
+
 def _sanitize_for_parameter_name(workflow_node_name: str) -> str:
     """Collapse whitespace in a workflow node name so it can be used inside a parameter name.
 
@@ -151,10 +165,12 @@ def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowP
     return routes
 
 
-def build_workflow_node_surface(workflow_metadata: WorkflowMetadata) -> dict[str, WorkflowNodeSurfaceParameter]:
+def build_workflow_node_surface(workflow_metadata: WorkflowMetadata) -> WorkflowNodeSurface:
     """Derive the generated node's parameter surface from a workflow's saved shape.
 
-    Inputs come first so they render above the outputs on the canvas.
+    Inputs come first so they render above the outputs on the canvas. The shape's Start/End node
+    lists are carried through as-is, so a node that exposes no parameters of its own still counts
+    toward the positional pairing done at run time.
 
     Raises:
         WorkflowNodeDefinitionError: The workflow carries no saved shape, meaning it has no Start
@@ -192,7 +208,11 @@ def build_workflow_node_surface(workflow_metadata: WorkflowMetadata) -> dict[str
             )
         else:
             surface[surface_name] = existing._replace(output_route=route)
-    return surface
+    return WorkflowNodeSurface(
+        parameters=surface,
+        start_node_names=list(workflow_shape.inputs),
+        end_node_names=list(workflow_shape.outputs),
+    )
 
 
 def pair_shape_nodes(declared_names: Sequence[str], live_names: Sequence[str], role: str) -> dict[str, str]:
@@ -259,8 +279,8 @@ class WorkflowNode(ControlNode):
     workflow_file_path: ClassVar[Path]
     # Metadata read from that workflow's header at library load time.
     workflow_metadata: ClassVar[WorkflowMetadata]
-    # Surface parameter name -> the workflow parameters it is wired to.
-    workflow_surface: ClassVar[dict[str, WorkflowNodeSurfaceParameter]]
+    # The parameter surface and Start/End node lists derived from the workflow's saved shape.
+    workflow_surface: ClassVar[WorkflowNodeSurface]
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
@@ -272,7 +292,7 @@ class WorkflowNode(ControlNode):
         self.metadata[WORKFLOW_NODE_KEY] = True
         self._publish_workflow_registry_key()
 
-        for surface_name, surface_parameter in self.workflow_surface.items():
+        for surface_name, surface_parameter in self.workflow_surface.parameters.items():
             self.add_parameter(_build_surface_parameter(surface_name, surface_parameter))
 
     def _publish_workflow_registry_key(self) -> None:
@@ -397,23 +417,21 @@ class WorkflowNode(ControlNode):
         live_start_nodes = [node.name for node in flow.nodes.values() if isinstance(node, StartNode)]
         live_end_nodes = [node.name for node in flow.nodes.values() if isinstance(node, EndNode)]
 
-        declared_start_nodes = _declared_route_nodes(surface.input_route for surface in self.workflow_surface.values())
-        declared_end_nodes = _declared_route_nodes(surface.output_route for surface in self.workflow_surface.values())
+        start_node_names = pair_shape_nodes(self.workflow_surface.start_node_names, live_start_nodes, role="Start Flow")
+        end_node_names = pair_shape_nodes(self.workflow_surface.end_node_names, live_end_nodes, role="End Flow")
 
-        start_node_names = pair_shape_nodes(declared_start_nodes, live_start_nodes, role="Start Flow")
-        end_node_names = pair_shape_nodes(declared_end_nodes, live_end_nodes, role="End Flow")
-
-        live_routes = WorkflowNodeLiveRoutes(inputs={}, outputs={})
-        for surface_name, surface_parameter in self.workflow_surface.items():
+        input_routes: dict[str, WorkflowParameterRoute] = {}
+        output_routes: dict[str, WorkflowParameterRoute] = {}
+        for surface_name, surface_parameter in self.workflow_surface.parameters.items():
             if surface_parameter.input_route is not None:
-                live_routes.inputs[surface_name] = self._relocate_route(
+                input_routes[surface_name] = self._relocate_route(
                     surface_parameter.input_route, start_node_names, flow, surface_name
                 )
             if surface_parameter.output_route is not None:
-                live_routes.outputs[surface_name] = self._relocate_route(
+                output_routes[surface_name] = self._relocate_route(
                     surface_parameter.output_route, end_node_names, flow, surface_name
                 )
-        return live_routes
+        return WorkflowNodeLiveRoutes(inputs=input_routes, outputs=output_routes)
 
     def _relocate_route(
         self,
@@ -524,15 +542,6 @@ def _build_surface_parameter(surface_name: str, surface_parameter: WorkflowNodeS
         allowed_modes=allowed_modes,
         ui_options=definition.get("ui_options"),
     )
-
-
-def _declared_route_nodes(routes: Iterable[WorkflowParameterRoute | None]) -> list[str]:
-    """Return the distinct workflow node names referenced by `routes`, in first-seen order."""
-    node_names: list[str] = []
-    for route in routes:
-        if route is not None and route.workflow_node_name not in node_names:
-            node_names.append(route.workflow_node_name)
-    return node_names
 
 
 def _get_flow_or_none(flow_name: str) -> ControlFlow | None:

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -67,6 +67,10 @@ class WorkflowNodeDefinitionError(Exception):
     """Raised when a workflow file cannot back a node type."""
 
 
+class WorkflowNodeRoutingError(RuntimeError):
+    """Raised when a node's parameters cannot be matched to the copy of the workflow it loaded."""
+
+
 class WorkflowParameterRoute(NamedTuple):
     """Where a surface parameter reads from or writes to inside the workflow."""
 
@@ -94,6 +98,16 @@ class WorkflowNodeSurfaceParameter(NamedTuple):
     output_route: WorkflowParameterRoute | None
 
 
+def _sanitize_for_parameter_name(workflow_node_name: str) -> str:
+    """Collapse whitespace in a workflow node name so it can be used inside a parameter name.
+
+    `BaseNode.add_parameter` rejects parameter names containing whitespace, and Start/End node names
+    routinely contain spaces ("Start Flow"), so a qualified name built from a raw node name would be
+    impossible to add.
+    """
+    return "_".join(workflow_node_name.split())
+
+
 def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowParameterRoute]:
     """Flatten one half of a workflow shape into surface parameter names.
 
@@ -101,6 +115,10 @@ def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowP
     than one node is qualified as ``<node name>.<parameter name>`` for every node that uses it, so
     the result never depends on iteration order. Control parameters are dropped: the generated node
     supplies its own control flow.
+
+    Raises:
+        WorkflowNodeDefinitionError: Two workflow parameters claim the same surface name, which would
+            otherwise surface as a duplicate-parameter crash when the node is created.
     """
     nodes_using_name: dict[str, list[str]] = {}
     for workflow_node_name, parameters in section.items():
@@ -117,7 +135,16 @@ def flatten_shape_section(section: NodeParametersMapping) -> dict[str, WorkflowP
             if len(nodes_using_name[parameter_name]) == 1:
                 surface_name = parameter_name
             else:
-                surface_name = f"{workflow_node_name}{QUALIFIED_NAME_SEPARATOR}{parameter_name}"
+                qualifier = _sanitize_for_parameter_name(workflow_node_name)
+                surface_name = f"{qualifier}{QUALIFIED_NAME_SEPARATOR}{parameter_name}"
+            existing = routes.get(surface_name)
+            if existing is not None:
+                msg = (
+                    f"Attempted to expose '{workflow_node_name}.{parameter_name}' on a node. Failed because it "
+                    f"collides with '{existing.workflow_node_name}.{existing.parameter_name}', which also maps to "
+                    f"'{surface_name}'. Rename one of the parameters or one of the nodes in the workflow."
+                )
+                raise WorkflowNodeDefinitionError(msg)
             routes[surface_name] = WorkflowParameterRoute(
                 workflow_node_name=workflow_node_name, parameter_name=parameter_name
             )
@@ -168,43 +195,46 @@ def build_workflow_node_surface(workflow_metadata: WorkflowMetadata) -> dict[str
     return surface
 
 
-def match_shape_nodes(declared_names: Sequence[str], live_names: Iterable[str]) -> dict[str, str]:
+def pair_shape_nodes(declared_names: Sequence[str], live_names: Sequence[str], role: str) -> dict[str, str]:
     """Pair the Start/End node names in a saved shape with their names in an imported subflow.
 
-    Importing a workflow renames any node whose name is already taken elsewhere in the session,
-    appending a ``_N`` suffix, so the saved shape's node names can be stale. An exact name match
-    wins; a declared name otherwise claims the first unclaimed live name that looks like a
-    de-duplicated spelling of it.
+    Importing a workflow renames any node whose name is already taken elsewhere in the session, so
+    declared names cannot be matched to live names by string: a renamed node can collide textually
+    with a *different* declared name ("Start Flow" becoming "Start Flow_1" in a workflow that itself
+    declares a "Start Flow_1"), which would cross-wire the two.
+
+    Both sequences are in node creation order, because the saved shape was built by walking the flow
+    and importing replays node creation in that same order. Pair them positionally instead.
+
+    Raises:
+        WorkflowNodeRoutingError: The loaded copy does not have the expected number of nodes, so
+            positions cannot be trusted.
     """
-    remaining = list(live_names)
-    matches: dict[str, str] = {}
-
-    for declared_name in declared_names:
-        if declared_name in remaining:
-            matches[declared_name] = declared_name
-            remaining.remove(declared_name)
-
-    for declared_name in declared_names:
-        if declared_name in matches:
-            continue
-        renamed = next((live_name for live_name in remaining if live_name.startswith(f"{declared_name}_")), None)
-        if renamed is not None:
-            matches[declared_name] = renamed
-            remaining.remove(renamed)
-
-    return matches
+    if len(declared_names) != len(live_names):
+        msg = (
+            f"Attempted to match the workflow's {role} nodes to the copy that was loaded. Failed because the "
+            f"workflow lists {len(declared_names)} of them but the loaded copy has {len(live_names)}. "
+            "Open the workflow in the editor and save it so its stored inputs and outputs match its nodes."
+        )
+        raise WorkflowNodeRoutingError(msg)
+    return dict(zip(declared_names, live_names, strict=True))
 
 
 def ensure_workflow_registered(workflow_file_path: Path, workflow_metadata: WorkflowMetadata) -> str:
     """Register `workflow_file_path` in the workflow registry if it is not there already.
 
-    Returns the registry key the workflow is available under. Registration is idempotent and
-    happens lazily, at execution time, because the registry is cleared and rebuilt when the
+    Returns the registry key the workflow is available under. Registration is idempotent, and is
+    also re-attempted before each run, because the registry is cleared and rebuilt when the
     workspace changes while a library's node types survive that reload.
 
-    The entry is marked internal so a workflow that exists only to back a node does not show up
-    in the editor's workflow picker. A library that also lists the file in its ``workflows`` array
-    registers it through the normal path first, and that entry wins.
+    The workflow's own `is_internal` flag is respected rather than overridden: a library author who
+    wants a node-backing workflow kept out of the editor's workflow picker sets `is_internal = true`
+    in the workflow's metadata header. Overriding it here would race the library's own `workflows`
+    registration and silently hide a workflow the author had listed deliberately.
+
+    Raises:
+        KeyError: The key was claimed concurrently.
+        ValueError: The workflow file is no longer on disk.
     """
     registry_key = derive_registry_key(str(workflow_file_path))
     if WorkflowRegistry.has_workflow_with_name(registry_key):
@@ -212,7 +242,7 @@ def ensure_workflow_registered(workflow_file_path: Path, workflow_metadata: Work
 
     WorkflowRegistry.generate_new_workflow(
         registry_key=registry_key,
-        metadata=workflow_metadata.model_copy(update={"is_internal": True}),
+        metadata=workflow_metadata,
         file_path=str(workflow_file_path),
     )
     return registry_key
@@ -304,7 +334,7 @@ class WorkflowNode(ControlNode):
             )
             raise RuntimeError(msg)  # noqa: TRY004 - the lookup failed at run time; this is not a type error
 
-        registry_key = ensure_workflow_registered(self.workflow_file_path, self.workflow_metadata)
+        registry_key = self._register_workflow()
         import_result = await GriptapeNodes.ahandle_request(
             ImportWorkflowAsReferencedSubFlowRequest(
                 workflow_name=registry_key,
@@ -321,6 +351,17 @@ class WorkflowNode(ControlNode):
 
         self.metadata[SUBFLOW_NAME_KEY] = import_result.created_flow_name
         return import_result.created_flow_name
+
+    def _register_workflow(self) -> str:
+        """Return the backing workflow's registry key, registering it if it is not registered yet."""
+        try:
+            return ensure_workflow_registered(self.workflow_file_path, self.workflow_metadata)
+        except (KeyError, ValueError) as err:
+            msg = (
+                f"Attempted to load the workflow at '{self.workflow_file_path}' for node '{self.name}'. "
+                f"Failed because the workflow could not be registered: {err}"
+            )
+            raise WorkflowNodeRoutingError(msg) from err
 
     def _discard_subflow(self) -> None:
         """Delete this node's subflow if it is still live, and stop tracking it."""
@@ -342,8 +383,15 @@ class WorkflowNode(ControlNode):
         """Map each surface parameter onto the parameter it addresses in the imported subflow.
 
         The saved shape's node names can be stale (an import renames nodes whose names are already
-        taken), so the Start/End nodes are re-read from the live subflow and paired back up with
-        the declared names.
+        taken), so the Start/End nodes are re-read from the live subflow and paired back up with the
+        declared ones by position.
+
+        Every declared route must resolve. A route that silently dropped out would let the run report
+        success while an input was never delivered or an output never collected.
+
+        Raises:
+            WorkflowNodeRoutingError: A declared parameter is not present on the node it was paired
+                with, meaning the loaded copy does not match the workflow's stored shape.
         """
         flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
         live_start_nodes = [node.name for node in flow.nodes.values() if isinstance(node, StartNode)]
@@ -352,18 +400,46 @@ class WorkflowNode(ControlNode):
         declared_start_nodes = _declared_route_nodes(surface.input_route for surface in self.workflow_surface.values())
         declared_end_nodes = _declared_route_nodes(surface.output_route for surface in self.workflow_surface.values())
 
-        start_node_names = match_shape_nodes(declared_start_nodes, live_start_nodes)
-        end_node_names = match_shape_nodes(declared_end_nodes, live_end_nodes)
+        start_node_names = pair_shape_nodes(declared_start_nodes, live_start_nodes, role="Start Flow")
+        end_node_names = pair_shape_nodes(declared_end_nodes, live_end_nodes, role="End Flow")
 
         live_routes = WorkflowNodeLiveRoutes(inputs={}, outputs={})
         for surface_name, surface_parameter in self.workflow_surface.items():
-            input_route = _relocate_route(surface_parameter.input_route, start_node_names)
-            if input_route is not None:
-                live_routes.inputs[surface_name] = input_route
-            output_route = _relocate_route(surface_parameter.output_route, end_node_names)
-            if output_route is not None:
-                live_routes.outputs[surface_name] = output_route
+            if surface_parameter.input_route is not None:
+                live_routes.inputs[surface_name] = self._relocate_route(
+                    surface_parameter.input_route, start_node_names, flow, surface_name
+                )
+            if surface_parameter.output_route is not None:
+                live_routes.outputs[surface_name] = self._relocate_route(
+                    surface_parameter.output_route, end_node_names, flow, surface_name
+                )
         return live_routes
+
+    def _relocate_route(
+        self,
+        route: WorkflowParameterRoute,
+        node_names: dict[str, str],
+        flow: ControlFlow,
+        surface_name: str,
+    ) -> WorkflowParameterRoute:
+        """Point `route` at the corresponding node in the loaded copy of the workflow."""
+        live_node_name = node_names.get(route.workflow_node_name)
+        live_node = flow.nodes.get(live_node_name) if live_node_name is not None else None
+        if live_node is None:
+            msg = (
+                f"Attempted to connect '{surface_name}' on node '{self.name}' to the workflow it runs. Failed "
+                f"because the workflow's '{route.workflow_node_name}' node is missing from the copy that was "
+                "loaded. Open the workflow in the editor and save it to refresh its stored inputs and outputs."
+            )
+            raise WorkflowNodeRoutingError(msg)
+        if live_node.get_parameter_by_name(route.parameter_name) is None:
+            msg = (
+                f"Attempted to connect '{surface_name}' on node '{self.name}' to the workflow it runs. Failed "
+                f"because '{live_node_name}' has no '{route.parameter_name}' parameter. Open the workflow in the "
+                "editor and save it to refresh its stored inputs and outputs."
+            )
+            raise WorkflowNodeRoutingError(msg)
+        return route._replace(workflow_node_name=live_node_name)
 
     def _apply_inputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
         for surface_name, route in live_routes.inputs.items():
@@ -386,15 +462,16 @@ class WorkflowNode(ControlNode):
     def _collect_outputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
         flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
         for surface_name, route in live_routes.outputs.items():
-            end_node = flow.nodes.get(route.workflow_node_name)
-            if end_node is None:
-                continue
+            end_node = flow.nodes[route.workflow_node_name]
             # A node that ran publishes to parameter_output_values; fall back to the stored value
             # for parameters an End Flow node only receives as input.
             if route.parameter_name in end_node.parameter_output_values:
                 value = end_node.parameter_output_values[route.parameter_name]
             else:
                 value = end_node.get_parameter_value(route.parameter_name)
+            # None is published rather than skipped. These parameters are a fixed part of the node
+            # type, so a downstream node is already wired to them and needs to see that this run
+            # produced nothing rather than keep reading the previous run's value.
             self.parameter_output_values[surface_name] = value
 
 
@@ -456,15 +533,6 @@ def _declared_route_nodes(routes: Iterable[WorkflowParameterRoute | None]) -> li
         if route is not None and route.workflow_node_name not in node_names:
             node_names.append(route.workflow_node_name)
     return node_names
-
-
-def _relocate_route(route: WorkflowParameterRoute | None, node_names: dict[str, str]) -> WorkflowParameterRoute | None:
-    if route is None:
-        return None
-    live_node_name = node_names.get(route.workflow_node_name)
-    if live_node_name is None:
-        return None
-    return route._replace(workflow_node_name=live_node_name)
 
 
 def _get_flow_or_none(flow_name: str) -> ControlFlow | None:

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -14,6 +14,7 @@ The generated node types are ordinary ``BaseNode`` subclasses built by
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
@@ -90,7 +91,8 @@ class WorkflowNodeSurfaceParameter(NamedTuple):
 
     A name that appears on both a Start Flow node and an End Flow node carries both routes, so a
     single parameter serves as input and output (matching how the workflow itself passes it
-    through).
+    through). Its type, tooltip, and UI options come from the Start Flow node's copy; the End Flow
+    node's copy of the same name supplies only the output route.
     """
 
     definition: ParameterMinimalDict
@@ -295,24 +297,6 @@ class WorkflowNode(ControlNode):
         for surface_name, surface_parameter in self.workflow_surface.parameters.items():
             self.add_parameter(_build_surface_parameter(surface_name, surface_parameter))
 
-    def _publish_workflow_registry_key(self) -> None:
-        """Register the backing workflow and record its key so the editor can preview it.
-
-        Registration happens here, rather than only at execution time, so the workflow can be
-        previewed before the node has ever run. Failure is not fatal: the node stays usable and the
-        preview is simply unavailable until the next run re-registers the workflow.
-        """
-        try:
-            self.metadata[WORKFLOW_FILE_VALUE_KEY] = ensure_workflow_registered(
-                self.workflow_file_path, self.workflow_metadata
-            )
-        except (KeyError, ValueError):
-            logger.warning(
-                "Node '%s' could not register its workflow '%s' for preview; it will be registered on the next run.",
-                self.name,
-                self.workflow_file_path,
-            )
-
     def after_node_deleted(self) -> None:
         self._discard_subflow()
 
@@ -331,6 +315,24 @@ class WorkflowNode(ControlNode):
             raise RuntimeError(msg)  # noqa: TRY004 - the workflow failed at run time; this is not a type error
 
         self._collect_outputs(subflow_name, live_routes)
+
+    def _publish_workflow_registry_key(self) -> None:
+        """Register the backing workflow and record its key so the editor can preview it.
+
+        Registration happens at construction, rather than only at execution time, so the workflow can
+        be previewed before the node has ever run. Failure is not fatal: the node stays usable and the
+        preview is simply unavailable until the next run re-registers the workflow.
+        """
+        try:
+            self.metadata[WORKFLOW_FILE_VALUE_KEY] = ensure_workflow_registered(
+                self.workflow_file_path, self.workflow_metadata
+            )
+        except (KeyError, ValueError):
+            logger.warning(
+                "Node '%s' could not register its workflow '%s' for preview; it will be registered on the next run.",
+                self.name,
+                self.workflow_file_path,
+            )
 
     async def _load_subflow(self) -> str:
         """Return the name of this node's live subflow, importing the workflow if needed.
@@ -523,7 +525,10 @@ def _is_control_parameter(definition: ParameterMinimalDict) -> bool:
 
 
 def _build_surface_parameter(surface_name: str, surface_parameter: WorkflowNodeSurfaceParameter) -> Parameter:
-    definition = surface_parameter.definition
+    # The definition lives on the generated node type, shared by every instance of it, while a
+    # Parameter holds onto its default value by reference. Copying keeps one node's edit to a list or
+    # dict default out of every other node of the same type.
+    definition = deepcopy(surface_parameter.definition)
     allowed_modes: set[ParameterMode] = set()
     if surface_parameter.input_route is not None:
         allowed_modes.add(ParameterMode.INPUT)

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -207,6 +207,21 @@ class NodeDefinition(BaseModel):
     metadata: NodeMetadata
 
 
+class WorkflowNodeDefinition(BaseModel):
+    """Defines a node whose behavior comes from a saved workflow file instead of a Python class.
+
+    The workflow must contain at least one Start Flow node and one End Flow node. Its Start Flow
+    parameters become the node's inputs and its End Flow parameters become the node's outputs.
+    """
+
+    # Node type name registered in the library, e.g. "ShoutText". This is what CreateNodeRequest
+    # takes; there is no Python class in the library for it, so the author names it here.
+    node_type: str
+    # Path to the saved workflow `.py`, relative to the library JSON (absolute paths also work).
+    workflow_path: str
+    metadata: NodeMetadata
+
+
 class Setting(BaseModel):
     """Defines a library-specific setting, which will automatically be injected into the user's Configuration."""
 
@@ -238,13 +253,15 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.10.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.11.0"
 
     name: str
     library_schema_version: str
     metadata: LibraryMetadata
     categories: list[dict[str, CategoryDefinition]]
     nodes: list[NodeDefinition]
+    # Nodes generated from saved workflow files rather than Python classes.
+    workflow_nodes: list[WorkflowNodeDefinition] | None = None
     workflows: list[str] | None = None
     scripts: list[str] | None = None
     settings: list[Setting] | None = None

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -160,6 +160,14 @@ def find_metadata_blocks(workflow_content: str, block_name: str) -> list[re.Matc
     return [match for match in _METADATA_BLOCK_PATTERN.finditer(workflow_content) if match.group("type") == block_name]
 
 
+def strip_metadata_comment_prefixes(metadata_block: re.Match[str]) -> str:
+    """Recover the raw TOML from a metadata block by dropping the comment marker off each line."""
+    return "".join(
+        line[2:] if line.startswith("# ") else line[1:]
+        for line in metadata_block.group("content").splitlines(keepends=True)
+    )
+
+
 def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
     """Read the metadata header out of a workflow file.
 
@@ -191,10 +199,7 @@ def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
         raise WorkflowMetadataError(msg)
 
     # Strip the leading comment marker off each line to recover the raw TOML.
-    metadata_toml = "".join(
-        line[2:] if line.startswith("# ") else line[1:]
-        for line in matches[0].group("content").splitlines(keepends=True)
-    )
+    metadata_toml = strip_metadata_comment_prefixes(matches[0])
 
     try:
         toml_document = tomllib.loads(metadata_toml)

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -27,10 +27,55 @@ _METADATA_BLOCK_PATTERN = re.compile(r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<
 
 _TOOL_TABLE = "tool"
 _GRIPTAPE_NODES_TABLE = "griptape-nodes"
+# How the required table is spelled in messages and in the editor's workflow-load report.
+METADATA_TABLE_PATH = f"[{_TOOL_TABLE}.{_GRIPTAPE_NODES_TABLE}]"
 
 
 class WorkflowMetadataError(Exception):
-    """Raised when a workflow file's metadata header cannot be read."""
+    """Raised when a workflow file's metadata header cannot be read.
+
+    Callers that only need to know it failed catch this. Callers that report per-stage detail, such
+    as the editor's workflow-load report, catch the subclasses below, which carry the values that
+    report displays.
+    """
+
+
+class WorkflowMetadataFileError(WorkflowMetadataError):
+    """The workflow file itself could not be read."""
+
+
+class WorkflowMetadataSectionCountError(WorkflowMetadataError):
+    """The file does not carry exactly one metadata header."""
+
+    def __init__(self, message: str, *, section_name: str, count: int) -> None:
+        super().__init__(message)
+        self.section_name = section_name
+        self.count = count
+
+
+class WorkflowMetadataTomlError(WorkflowMetadataError):
+    """The metadata header is not valid TOML."""
+
+    def __init__(self, message: str, *, error_message: str) -> None:
+        super().__init__(message)
+        self.error_message = error_message
+
+
+class WorkflowMetadataMissingTableError(WorkflowMetadataError):
+    """The metadata header carries no `[tool.griptape-nodes]` table."""
+
+    def __init__(self, message: str, *, section_path: str) -> None:
+        super().__init__(message)
+        self.section_path = section_path
+
+
+class WorkflowMetadataSchemaError(WorkflowMetadataError):
+    """The `[tool.griptape-nodes]` table does not match `WorkflowMetadata`."""
+
+    def __init__(self, message: str, *, section_path: str, error_message: str) -> None:
+        super().__init__(message)
+        self.section_path = section_path
+        self.error_message = error_message
 
 
 class LibraryNameAndNodeType(NamedTuple):
@@ -173,12 +218,15 @@ def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
 
     Pure file parsing: no registry lookups, no engine requests, and no waiting on library
     registration. Callers that run while libraries are still loading (the library loader itself,
-    for instance) must use this rather than `LoadWorkflowMetadata`, whose handler blocks until
-    library registration completes.
+    for instance) can use this directly; `LoadWorkflowMetadata`'s handler wraps it with the file
+    checks, dependency checks, and per-stage problem reporting the editor needs.
 
     Raises:
-        WorkflowMetadataError: The file could not be read, does not carry exactly one metadata
-            header, or that header is not TOML with a valid `[tool.griptape-nodes]` table.
+        WorkflowMetadataFileError: The file could not be read.
+        WorkflowMetadataSectionCountError: The file does not carry exactly one metadata header.
+        WorkflowMetadataTomlError: The header is not valid TOML.
+        WorkflowMetadataMissingTableError: The header has no `[tool.griptape-nodes]` table.
+        WorkflowMetadataSchemaError: That table does not match the expected schema.
     """
     try:
         workflow_content = workflow_file_path.read_text(encoding="utf-8")
@@ -187,7 +235,7 @@ def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
             f"Attempted to read workflow metadata from '{workflow_file_path}'. "
             f"Failed because the file could not be read: {err}"
         )
-        raise WorkflowMetadataError(msg) from err
+        raise WorkflowMetadataFileError(msg) from err
 
     matches = find_metadata_blocks(workflow_content, WORKFLOW_METADATA_BLOCK_NAME)
     if len(matches) != 1:
@@ -196,11 +244,13 @@ def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
             f"{len(matches)} '{WORKFLOW_METADATA_BLOCK_NAME}' metadata sections, and exactly 1 is required. "
             "Open the workflow in the editor and save it to regenerate the header."
         )
-        raise WorkflowMetadataError(msg)
+        raise WorkflowMetadataSectionCountError(msg, section_name=WORKFLOW_METADATA_BLOCK_NAME, count=len(matches))
 
-    # Strip the leading comment marker off each line to recover the raw TOML.
     metadata_toml = strip_metadata_comment_prefixes(matches[0])
 
+    # tomllib, not tomlkit: this is a read-only path, and tomlkit builds a formatting-preserving
+    # document model that costs ~20x more per header. Only the save path needs tomlkit, to keep the
+    # formatting of headers it rewrites.
     try:
         toml_document = tomllib.loads(metadata_toml)
     except tomllib.TOMLDecodeError as err:
@@ -208,25 +258,25 @@ def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
             f"Attempted to read workflow metadata from '{workflow_file_path}'. "
             f"Failed because the header is not valid TOML: {err}"
         )
-        raise WorkflowMetadataError(msg) from err
+        raise WorkflowMetadataTomlError(msg, error_message=str(err)) from err
 
     try:
         tool_section = toml_document[_TOOL_TABLE][_GRIPTAPE_NODES_TABLE]
     except (KeyError, TypeError) as err:
         msg = (
             f"Attempted to read workflow metadata from '{workflow_file_path}'. Failed because the header has no "
-            f"'[{_TOOL_TABLE}.{_GRIPTAPE_NODES_TABLE}]' table."
+            f"'{METADATA_TABLE_PATH}' table."
         )
-        raise WorkflowMetadataError(msg) from err
+        raise WorkflowMetadataMissingTableError(msg, section_path=METADATA_TABLE_PATH) from err
 
     try:
         return WorkflowMetadata.model_validate(tool_section)
     except ValidationError as err:
         msg = (
             f"Attempted to read workflow metadata from '{workflow_file_path}'. Failed because the "
-            f"'[{_TOOL_TABLE}.{_GRIPTAPE_NODES_TABLE}]' table does not match the expected schema: {err}"
+            f"'{METADATA_TABLE_PATH}' table does not match the expected schema: {err}"
         )
-        raise WorkflowMetadataError(msg) from err
+        raise WorkflowMetadataSchemaError(msg, section_path=METADATA_TABLE_PATH, error_message=str(err)) from err
 
 
 class WorkflowRegistry(metaclass=SingletonMeta):

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar, NamedTuple
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_serializer, field_validator
 
 from griptape_nodes.files.path_utils import resolve_workspace_path
 from griptape_nodes.node_library.library_registry import (
@@ -15,6 +17,20 @@ from griptape_nodes.node_library.library_registry import (
 from griptape_nodes.utils.metaclasses import SingletonMeta
 
 logger = logging.getLogger("griptape_nodes")
+
+# Name of the inline metadata block that carries a workflow's metadata header.
+WORKFLOW_METADATA_BLOCK_NAME = "script"
+
+# PEP 723-style inline metadata block: a "# /// <name>" opener, comment-prefixed body lines,
+# and a "# ///" closer.
+_METADATA_BLOCK_PATTERN = re.compile(r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$")
+
+_TOOL_TABLE = "tool"
+_GRIPTAPE_NODES_TABLE = "griptape-nodes"
+
+
+class WorkflowMetadataError(Exception):
+    """Raised when a workflow file's metadata header cannot be read."""
 
 
 class LibraryNameAndNodeType(NamedTuple):
@@ -137,6 +153,75 @@ class WorkflowMetadata(BaseModel):
                 return None
         # Unexpected type - let Pydantic's normal validation handle it
         return value
+
+
+def find_metadata_blocks(workflow_content: str, block_name: str) -> list[re.Match[str]]:
+    """Return every inline metadata block in `workflow_content` whose name is `block_name`."""
+    return [match for match in _METADATA_BLOCK_PATTERN.finditer(workflow_content) if match.group("type") == block_name]
+
+
+def read_workflow_metadata(workflow_file_path: Path) -> WorkflowMetadata:
+    """Read the metadata header out of a workflow file.
+
+    Pure file parsing: no registry lookups, no engine requests, and no waiting on library
+    registration. Callers that run while libraries are still loading (the library loader itself,
+    for instance) must use this rather than `LoadWorkflowMetadata`, whose handler blocks until
+    library registration completes.
+
+    Raises:
+        WorkflowMetadataError: The file could not be read, does not carry exactly one metadata
+            header, or that header is not TOML with a valid `[tool.griptape-nodes]` table.
+    """
+    try:
+        workflow_content = workflow_file_path.read_text(encoding="utf-8")
+    except OSError as err:
+        msg = (
+            f"Attempted to read workflow metadata from '{workflow_file_path}'. "
+            f"Failed because the file could not be read: {err}"
+        )
+        raise WorkflowMetadataError(msg) from err
+
+    matches = find_metadata_blocks(workflow_content, WORKFLOW_METADATA_BLOCK_NAME)
+    if len(matches) != 1:
+        msg = (
+            f"Attempted to read workflow metadata from '{workflow_file_path}'. Failed because the file has "
+            f"{len(matches)} '{WORKFLOW_METADATA_BLOCK_NAME}' metadata sections, and exactly 1 is required. "
+            "Open the workflow in the editor and save it to regenerate the header."
+        )
+        raise WorkflowMetadataError(msg)
+
+    # Strip the leading comment marker off each line to recover the raw TOML.
+    metadata_toml = "".join(
+        line[2:] if line.startswith("# ") else line[1:]
+        for line in matches[0].group("content").splitlines(keepends=True)
+    )
+
+    try:
+        toml_document = tomllib.loads(metadata_toml)
+    except tomllib.TOMLDecodeError as err:
+        msg = (
+            f"Attempted to read workflow metadata from '{workflow_file_path}'. "
+            f"Failed because the header is not valid TOML: {err}"
+        )
+        raise WorkflowMetadataError(msg) from err
+
+    try:
+        tool_section = toml_document[_TOOL_TABLE][_GRIPTAPE_NODES_TABLE]
+    except (KeyError, TypeError) as err:
+        msg = (
+            f"Attempted to read workflow metadata from '{workflow_file_path}'. Failed because the header has no "
+            f"'[{_TOOL_TABLE}.{_GRIPTAPE_NODES_TABLE}]' table."
+        )
+        raise WorkflowMetadataError(msg) from err
+
+    try:
+        return WorkflowMetadata.model_validate(tool_section)
+    except ValidationError as err:
+        msg = (
+            f"Attempted to read workflow metadata from '{workflow_file_path}'. Failed because the "
+            f"'[{_TOOL_TABLE}.{_GRIPTAPE_NODES_TABLE}]' table does not match the expected schema: {err}"
+        )
+        raise WorkflowMetadataError(msg) from err
 
 
 class WorkflowRegistry(metaclass=SingletonMeta):

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -41,6 +41,7 @@ from .unresolved_model_provider_usage_reference_problem import UnresolvedModelPr
 from .unresolved_model_usage_reference_problem import UnresolvedModelUsageReferenceProblem
 from .update_config_category_problem import UpdateConfigCategoryProblem
 from .venv_creation_failed_problem import VenvCreationFailedProblem
+from .workflow_node_load_problem import WorkflowNodeLoadProblem
 
 __all__ = [
     "AdvancedLibraryLoadFailureProblem",
@@ -84,4 +85,5 @@ __all__ = [
     "UnresolvedModelUsageReferenceProblem",
     "UpdateConfigCategoryProblem",
     "VenvCreationFailedProblem",
+    "WorkflowNodeLoadProblem",
 ]

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/workflow_node_load_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/workflow_node_load_problem.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkflowNodeLoadProblem(LibraryProblem):
+    """Problem indicating a node declared in `workflow_nodes` could not be generated.
+
+    This is stackable - a library can declare many workflow-backed nodes.
+    """
+
+    node_type: str
+    workflow_path: str
+    error_message: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[WorkflowNodeLoadProblem]) -> str:
+        """List each workflow-backed node that failed to load, with the reason."""
+        if len(instances) == 1:
+            problem = instances[0]
+            return f"Failed to build node '{problem.node_type}' from workflow '{problem.workflow_path}': {problem.error_message}"
+
+        sorted_instances = sorted(instances, key=lambda problem: problem.node_type)
+        output_lines = [f"Encountered {len(instances)} workflow-backed node failures:"]
+        output_lines.extend(
+            f"  - {problem.node_type} (from '{problem.workflow_path}'): {problem.error_message}"
+            for problem in sorted_instances
+        )
+        return "\n".join(output_lines)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -37,6 +37,7 @@ from griptape_nodes.common.strict_mode import (
 from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.exe_types.workflow_node import WorkflowNodeDefinitionError, build_workflow_node_class
 from griptape_nodes.files.path_utils import canonicalize_for_identity, canonicalize_for_io, resolve_workspace_path
 from griptape_nodes.node_library.library_declarations import (
     LibraryDeclaration,
@@ -57,11 +58,13 @@ from griptape_nodes.node_library.library_registry import (
     LibrarySchema,
     NodeDefinition,
     NodeMetadata,
+    WorkflowNodeDefinition,
 )
 from griptape_nodes.node_library.library_validation import (
     detect_retired_node_declarations,
     validate_library_declarations,
 )
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadataError, read_workflow_metadata
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
     AppInitializationComplete,
@@ -228,6 +231,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     RequestHandlersWorkerIncompatibleProblem,
     SandboxDirectoryMissingProblem,
     UpdateConfigCategoryProblem,
+    WorkflowNodeLoadProblem,
 )
 from griptape_nodes.retained_mode.managers.os_manager import OSManager
 from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
@@ -4642,6 +4646,53 @@ class LibraryManager(EngineScoped):
             library_info.problems.append(library_problem)
         return True
 
+    def _register_workflow_node(
+        self,
+        workflow_node_definition: WorkflowNodeDefinition,
+        base_dir: Path,
+        library: Library,
+        library_info: LibraryInfo,
+    ) -> bool:
+        """Generate and register a node type from a saved workflow file.
+
+        The workflow's metadata header supplies the saved input/output shape that becomes the node's
+        parameters. Returns False (recording a library problem) when the header cannot be read or
+        carries no shape.
+        """
+        workflow_file_path = resolve_workspace_path(Path(workflow_node_definition.workflow_path), base_dir)
+        try:
+            workflow_metadata = read_workflow_metadata(workflow_file_path)
+        except WorkflowMetadataError as err:
+            library_info.problems.append(
+                WorkflowNodeLoadProblem(
+                    node_type=workflow_node_definition.node_type,
+                    workflow_path=str(workflow_file_path),
+                    error_message=str(err),
+                )
+            )
+            return False
+
+        try:
+            node_class = build_workflow_node_class(
+                node_type=workflow_node_definition.node_type,
+                workflow_file_path=workflow_file_path,
+                workflow_metadata=workflow_metadata,
+            )
+        except WorkflowNodeDefinitionError as err:
+            library_info.problems.append(
+                WorkflowNodeLoadProblem(
+                    node_type=workflow_node_definition.node_type,
+                    workflow_path=str(workflow_file_path),
+                    error_message=str(err),
+                )
+            )
+            return False
+
+        library_problem = library.register_new_node_type(node_class, metadata=workflow_node_definition.metadata)
+        if library_problem is not None:
+            library_info.problems.append(library_problem)
+        return True
+
     def _attempt_load_nodes_from_library(  # noqa: PLR0912, PLR0915, C901
         self,
         library_data: LibrarySchema,
@@ -4721,6 +4772,12 @@ class LibraryManager(EngineScoped):
                 )
 
             if node_registered:
+                any_nodes_loaded_successfully = True
+
+        # Nodes generated from saved workflow files. These need no Python module, so they are always
+        # built now rather than lazily: reading a workflow's metadata header is cheap.
+        for workflow_node_definition in library_data.workflow_nodes or []:
+            if self._register_workflow_node(workflow_node_definition, base_dir, library, library_info):
                 any_nodes_loaded_successfully = True
 
         # Register widgets and check for duplicates

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -43,6 +43,7 @@ from griptape_nodes.node_library.workflow_registry import (
     WorkflowRegistry,
     WorkflowShape,
     find_metadata_blocks,
+    strip_metadata_comment_prefixes,
 )
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
@@ -1823,10 +1824,7 @@ class WorkflowManager(EngineScoped):
             return LoadWorkflowMetadataResultFailure(result_details=details)
 
         # Now attempt to parse out the metadata section, stripped of comment prefixes.
-        metadata_content_toml = "".join(
-            line[2:] if line.startswith("# ") else line[1:]
-            for line in matches[0].group("content").splitlines(keepends=True)
-        )
+        metadata_content_toml = strip_metadata_comment_prefixes(matches[0])
 
         # tomllib, not tomlkit: this is a read-only path, and tomlkit builds a
         # formatting-preserving document model that costs ~20x more per header. Only the

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -6,7 +6,6 @@ import logging
 import pickle
 import re
 import sys
-import tomllib
 from collections import defaultdict
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import UTC, datetime
@@ -40,10 +39,16 @@ from griptape_nodes.files.project_file import SITUATION_TO_FILE_POLICY, ProjectF
 from griptape_nodes.node_library.workflow_registry import (
     Workflow,
     WorkflowMetadata,
+    WorkflowMetadataError,
+    WorkflowMetadataFileError,
+    WorkflowMetadataMissingTableError,
+    WorkflowMetadataSchemaError,
+    WorkflowMetadataSectionCountError,
+    WorkflowMetadataTomlError,
     WorkflowRegistry,
     WorkflowShape,
     find_metadata_blocks,
-    strip_metadata_comment_prefixes,
+    read_workflow_metadata,
 )
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
@@ -1810,72 +1815,10 @@ class WorkflowManager(EngineScoped):
             return LoadWorkflowMetadataResultFailure(result_details=details)
 
         # Find the metadata block.
-        block_name = WorkflowManager.WORKFLOW_METADATA_HEADER
-        matches = self.get_workflow_metadata(complete_file_path, block_name=block_name)
-        if len(matches) != 1:
-            self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
-                status=WorkflowManager.WorkflowStatus.UNUSABLE,
-                workflow_path=str_path,
-                workflow_name=None,
-                workflow_dependencies=[],
-                problems=[InvalidMetadataSectionCountProblem(section_name=block_name, count=len(matches))],
-            )
-            details = f"Attempted to load workflow metadata for a file at '{complete_file_path}'. Failed as it had {len(matches)} sections titled '{block_name}', and we expect exactly 1 such section."
-            return LoadWorkflowMetadataResultFailure(result_details=details)
-
-        # Now attempt to parse out the metadata section, stripped of comment prefixes.
-        metadata_content_toml = strip_metadata_comment_prefixes(matches[0])
-
-        # tomllib, not tomlkit: this is a read-only path, and tomlkit builds a
-        # formatting-preserving document model that costs ~20x more per header. Only the
-        # save path (_generate_workflow_metadata_header) needs tomlkit, to keep the
-        # formatting of headers it rewrites.
-        try:
-            toml_doc = tomllib.loads(metadata_content_toml)
-        except tomllib.TOMLDecodeError as err:
-            self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
-                status=WorkflowManager.WorkflowStatus.UNUSABLE,
-                workflow_path=str_path,
-                workflow_name=None,
-                workflow_dependencies=[],
-                problems=[InvalidTomlFormatProblem(error_message=str(err))],
-            )
-            details = f"Attempted to load workflow metadata for a file at '{complete_file_path}'. Failed because the metadata was not valid TOML: {err}"
-            return LoadWorkflowMetadataResultFailure(result_details=details)
-
-        tool_header = "tool"
-        griptape_nodes_header = "griptape-nodes"
-        try:
-            griptape_nodes_tool_section = toml_doc[tool_header][griptape_nodes_header]
-        except (KeyError, TypeError) as err:
-            self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
-                status=WorkflowManager.WorkflowStatus.UNUSABLE,
-                workflow_path=str_path,
-                workflow_name=None,
-                workflow_dependencies=[],
-                problems=[MissingTomlSectionProblem(section_path=f"[{tool_header}.{griptape_nodes_header}]")],
-            )
-            details = f"Attempted to load workflow metadata for a file at '{complete_file_path}'. Failed because the '[{tool_header}.{griptape_nodes_header}]' section could not be found: {err}"
-            return LoadWorkflowMetadataResultFailure(result_details=details)
-
-        try:
-            # Is it kosher?
-            workflow_metadata = WorkflowMetadata.model_validate(griptape_nodes_tool_section)
-        except Exception as err:
-            # No, it is haram.
-            self._workflow_file_path_to_info[str(str_path)] = WorkflowManager.WorkflowInfo(
-                status=WorkflowManager.WorkflowStatus.UNUSABLE,
-                workflow_path=str_path,
-                workflow_name=None,
-                workflow_dependencies=[],
-                problems=[
-                    InvalidMetadataSchemaProblem(
-                        section_path=f"[{tool_header}.{griptape_nodes_header}]", error_message=str(err)
-                    )
-                ],
-            )
-            details = f"Attempted to load workflow metadata for a file at '{complete_file_path}'. Failed because the metadata in the '[{tool_header}.{griptape_nodes_header}]' section did not match the requisite schema with error: {err}"
-            return LoadWorkflowMetadataResultFailure(result_details=details)
+        metadata_or_failure = self._read_workflow_metadata_for_request(complete_file_path, str_path)
+        if isinstance(metadata_or_failure, LoadWorkflowMetadataResultFailure):
+            return metadata_or_failure
+        workflow_metadata = metadata_or_failure
 
         # We have valid dependencies, etc.
         # TODO: validate schema versions, engine versions: https://github.com/griptape-ai/griptape-nodes/issues/617
@@ -2066,6 +2009,71 @@ class WorkflowManager(EngineScoped):
         return LoadWorkflowMetadataResultSuccess(
             metadata=workflow_metadata, result_details="Workflow metadata loaded successfully."
         )
+
+    def _read_workflow_metadata_for_request(
+        self, workflow_file_path: Path, workflow_path: str
+    ) -> WorkflowMetadata | LoadWorkflowMetadataResultFailure:
+        """Read a workflow's metadata header, turning each way it can fail into a reportable problem.
+
+        The parsing itself lives in `read_workflow_metadata` so the library loader and this handler
+        read headers the same way. What this adds is the editor's per-stage reporting: each failure
+        becomes the specific problem the workflow-load report displays for it.
+        """
+        try:
+            return read_workflow_metadata(workflow_file_path)
+        except WorkflowMetadataFileError as err:
+            return self._record_workflow_metadata_failure(
+                workflow_path,
+                status=WorkflowManager.WorkflowStatus.MISSING,
+                problem=WorkflowNotFoundProblem(),
+                error=err,
+            )
+        except WorkflowMetadataSectionCountError as err:
+            return self._record_workflow_metadata_failure(
+                workflow_path,
+                status=WorkflowManager.WorkflowStatus.UNUSABLE,
+                problem=InvalidMetadataSectionCountProblem(section_name=err.section_name, count=err.count),
+                error=err,
+            )
+        except WorkflowMetadataTomlError as err:
+            return self._record_workflow_metadata_failure(
+                workflow_path,
+                status=WorkflowManager.WorkflowStatus.UNUSABLE,
+                problem=InvalidTomlFormatProblem(error_message=err.error_message),
+                error=err,
+            )
+        except WorkflowMetadataMissingTableError as err:
+            return self._record_workflow_metadata_failure(
+                workflow_path,
+                status=WorkflowManager.WorkflowStatus.UNUSABLE,
+                problem=MissingTomlSectionProblem(section_path=err.section_path),
+                error=err,
+            )
+        except WorkflowMetadataSchemaError as err:
+            return self._record_workflow_metadata_failure(
+                workflow_path,
+                status=WorkflowManager.WorkflowStatus.UNUSABLE,
+                problem=InvalidMetadataSchemaProblem(section_path=err.section_path, error_message=err.error_message),
+                error=err,
+            )
+
+    def _record_workflow_metadata_failure(
+        self,
+        workflow_path: str,
+        *,
+        status: WorkflowManager.WorkflowStatus,
+        problem: WorkflowProblem,
+        error: WorkflowMetadataError,
+    ) -> LoadWorkflowMetadataResultFailure:
+        """Record why a workflow's metadata header could not be read, and fail the request."""
+        self._workflow_file_path_to_info[workflow_path] = WorkflowManager.WorkflowInfo(
+            status=status,
+            workflow_path=workflow_path,
+            workflow_name=None,
+            workflow_dependencies=[],
+            problems=[problem],
+        )
+        return LoadWorkflowMetadataResultFailure(result_details=str(error))
 
     async def register_workflows_from_config(self, config_section: str) -> None:
         workflows_to_register = self.engine.config_manager.get_config_value(config_section)

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -42,6 +42,7 @@ from griptape_nodes.node_library.workflow_registry import (
     WorkflowMetadata,
     WorkflowRegistry,
     WorkflowShape,
+    find_metadata_blocks,
 )
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import (
@@ -627,16 +628,7 @@ class WorkflowManager(EngineScoped):
         with workflow_file_path.open("r", encoding="utf-8") as file:
             workflow_content = file.read()
 
-        # Find the metadata block.
-        regex = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
-        matches = list(
-            filter(
-                lambda m: m.group("type") == block_name,
-                re.finditer(regex, workflow_content),
-            )
-        )
-
-        return matches
+        return find_metadata_blocks(workflow_content, block_name)
 
     def print_workflow_load_status(self, min_status: WorkflowStatus = WorkflowStatus.FLAWED) -> None:  # noqa: PLR0915
         workflow_file_paths = self.get_workflows_attempted_to_load()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,7 +24,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Iterator, Sequence
 
 
 @pytest.fixture(autouse=True)
@@ -89,11 +89,19 @@ def materialize_library() -> Callable[..., Path]:
     Rewrites the fixture JSON's ``engine_version`` to the running engine version so
     ``IncompatibleEngineVersionCheck`` never marks the library UNUSABLE on a version bump,
     optionally overrides the library ``name`` (needed when two tests register the same
-    fixture under distinct names), copies the node file, and returns the written
+    fixture under distinct names), copies the node file plus any ``extra_files`` the library
+    references (workflow files, for instance), and returns the written
     ``griptape_nodes_library.json`` path.
     """
 
-    def _materialize(target_dir: Path, *, template: Path, node_file: Path, name: str | None = None) -> Path:
+    def _materialize(
+        target_dir: Path,
+        *,
+        template: Path,
+        node_file: Path,
+        name: str | None = None,
+        extra_files: Sequence[Path] | None = None,
+    ) -> Path:
         target_dir.mkdir(parents=True, exist_ok=True)
         schema = json.loads(template.read_text())
         if name is not None:
@@ -102,6 +110,8 @@ def materialize_library() -> Callable[..., Path]:
         library_json = target_dir / "griptape_nodes_library.json"
         library_json.write_text(json.dumps(schema, indent=2))
         (target_dir / node_file.name).write_text(node_file.read_text())
+        for extra_file in extra_files or ():
+            (target_dir / extra_file.name).write_text(extra_file.read_text())
         return library_json
 
     return _materialize

--- a/tests/e2e/fixtures/generate_shout_workflow_fixture.py
+++ b/tests/e2e/fixtures/generate_shout_workflow_fixture.py
@@ -1,9 +1,14 @@
-"""Generate tests/e2e/fixtures/workflow_node_library/shout_workflow.py.
+"""Generate `workflow_node_library/shout_workflow.py`, the saved workflow the e2e test points a node at.
 
-Run with `uv run python scripts/generate_shout_workflow_fixture.py` from the repo root when the
-workflow file format changes. Builds the Start -> Shout -> End graph in-process and emits it
-through the real workflow generator, so the committed fixture always matches what saving a workflow
-from the editor produces.
+Run with `uv run python tests/e2e/fixtures/generate_shout_workflow_fixture.py` from the repo root when
+the workflow file format changes.
+
+The fixture is committed rather than built during the test run on purpose: it pins what a *saved*
+workflow looks like on disk, so a change to the metadata header, the stored workflow shape, or the
+workflow generator shows up as a failing test instead of silently producing a file the node code can
+no longer read. This script builds the Start -> Shout -> End graph in-process and emits it through
+the real workflow generator, so the committed fixture always matches what saving from the editor
+produces.
 """
 
 from __future__ import annotations
@@ -31,7 +36,7 @@ from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, C
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.utils.version_utils import engine_version
 
-LIBRARY_DIR = Path(__file__).resolve().parents[1] / "tests" / "e2e" / "fixtures" / "workflow_node_library"
+LIBRARY_DIR = Path(__file__).resolve().parent / "workflow_node_library"
 LIBRARY_JSON = LIBRARY_DIR / "griptape_nodes_library.json"
 NODE_FILE = LIBRARY_DIR / "workflow_node_nodes.py"
 WORKFLOW_PATH = LIBRARY_DIR / "shout_workflow.py"

--- a/tests/e2e/fixtures/workflow_node_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/workflow_node_library/griptape_nodes_library.json
@@ -1,0 +1,52 @@
+{
+  "name": "Workflow Node Library",
+  "library_schema_version": "0.11.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library exercising nodes generated from workflow files",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "TextStartNode",
+      "file_path": "workflow_node_nodes.py",
+      "metadata": {"category": "test", "description": "workflow text input", "display_name": "Text Start"}
+    },
+    {
+      "class_name": "ShoutNode",
+      "file_path": "workflow_node_nodes.py",
+      "metadata": {"category": "test", "description": "uppercases text", "display_name": "Shout"}
+    },
+    {
+      "class_name": "TextEndNode",
+      "file_path": "workflow_node_nodes.py",
+      "metadata": {"category": "test", "description": "workflow text output", "display_name": "Text End"}
+    }
+  ],
+  "workflow_nodes": [
+    {
+      "node_type": "ShoutWorkflow",
+      "workflow_path": "shout_workflow.py",
+      "metadata": {
+        "category": "test",
+        "description": "Runs the shout workflow: uppercases text and appends an exclamation mark",
+        "display_name": "Shout Workflow"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/workflow_node_library/shout_workflow.py
+++ b/tests/e2e/fixtures/workflow_node_library/shout_workflow.py
@@ -1,0 +1,106 @@
+# /// script
+# dependencies = []
+# 
+# [tool.griptape-nodes]
+# name = "shout_workflow"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.0.0"
+# node_libraries_referenced = [["Workflow Node Library", "0.1.0"]]
+# node_types_used = []
+# description = "Uppercases the incoming text and appends an exclamation mark."
+# is_griptape_provided = false
+# is_template = false
+# is_internal = false
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"text\":{\"name\":\"text\",\"tooltip\":\"Text handed to the workflow\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result\":{\"name\":\"result\",\"tooltip\":\"Text produced by the workflow\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null}}}}"
+# 
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.node_library.library_registry import IconVariant, NodeDeprecationMetadata, NodeMetadata
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, AlterParameterDetailsRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from typing import Any
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(RegisterLibraryFromFileRequest(library_name='Workflow Node Library', perform_discovery_if_not_found=True))
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {'cd1932ee-7ec7-46ea-840e-6ce4d28f2977': pickle.loads(b'\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94.'), '3dec5129-d017-46f5-b814-a4d76da064ed': pickle.loads(b'\x80\x04\x89.')}
+    # Create the Flow, then do work within it as context.
+    flow0_name = (await GriptapeNodes.ahandle_request(CreateFlowRequest(parent_flow_name=None, flow_name='ControlFlow_1', set_as_new_context=False, metadata={}))).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (await GriptapeNodes.ahandle_request(CreateNodeRequest(node_type='TextStartNode', specific_library_name='Workflow Node Library', node_name='Start Flow', metadata={'library_node_metadata': {'category': 'test', 'description': 'workflow text input', 'display_name': 'Text Start', 'tags': None, 'icon': None, 'color': None, 'group': None, 'deprecation': None, 'is_node_group': None, 'declarations': []}, 'library': 'Workflow Node Library', 'node_type': 'TextStartNode', 'position': {'x': 0.0, 'y': 0.0}}, initial_setup=True))).node_name
+        node1_name = (await GriptapeNodes.ahandle_request(CreateNodeRequest(node_type='ShoutNode', specific_library_name='Workflow Node Library', node_name='Shout', metadata={'library_node_metadata': {'category': 'test', 'description': 'uppercases text', 'display_name': 'Shout', 'tags': None, 'icon': None, 'color': None, 'group': None, 'deprecation': None, 'is_node_group': None, 'declarations': []}, 'library': 'Workflow Node Library', 'node_type': 'ShoutNode', 'position': {'x': 650.0, 'y': 0.0}}, initial_setup=True))).node_name
+        node2_name = (await GriptapeNodes.ahandle_request(CreateNodeRequest(node_type='TextEndNode', specific_library_name='Workflow Node Library', node_name='End Flow', metadata={'library_node_metadata': {'category': 'test', 'description': 'workflow text output', 'display_name': 'Text End', 'tags': None, 'icon': None, 'color': None, 'group': None, 'deprecation': None, 'is_node_group': None, 'declarations': []}, 'library': 'Workflow Node Library', 'node_type': 'TextEndNode', 'position': {'x': 1300.0, 'y': 0.0}}, initial_setup=True))).node_name
+        await GriptapeNodes.ahandle_request(CreateConnectionRequest(source_node_name=node0_name, source_parameter_name='exec_out', target_node_name=node1_name, target_parameter_name='exec_in', initial_setup=True))
+        await GriptapeNodes.ahandle_request(CreateConnectionRequest(source_node_name=node1_name, source_parameter_name='exec_out', target_node_name=node2_name, target_parameter_name='exec_in', initial_setup=True))
+        await GriptapeNodes.ahandle_request(CreateConnectionRequest(source_node_name=node0_name, source_parameter_name='text', target_node_name=node1_name, target_parameter_name='text', initial_setup=True))
+        await GriptapeNodes.ahandle_request(CreateConnectionRequest(source_node_name=node1_name, source_parameter_name='shouted', target_node_name=node2_name, target_parameter_name='result', initial_setup=True))
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(SetParameterValueRequest(parameter_name='text', node_name=node0_name, value=top_level_unique_values_dict['cd1932ee-7ec7-46ea-840e-6ce4d28f2977'], initial_setup=True, is_output=False))
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(SetParameterValueRequest(parameter_name='shouted', node_name=node1_name, value=top_level_unique_values_dict['cd1932ee-7ec7-46ea-840e-6ce4d28f2977'], initial_setup=True, is_output=False))
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(SetParameterValueRequest(parameter_name='was_successful', node_name=node2_name, value=top_level_unique_values_dict['3dec5129-d017-46f5-b814-a4d76da064ed'], initial_setup=True, is_output=False))
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None=None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+async def aexecute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None=None, **kwargs: Any) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault('pickle_control_flow_result', False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument('--json-input', default=None, help='JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.')
+    parser.add_argument('--exec_out', dest='exec_out', default=None, help='Connection to the next node in the execution chain')
+    parser.add_argument('--text', dest='text', default=None, help='Text handed to the workflow')
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if 'Start Flow' not in flow_input:
+            flow_input['Start Flow'] = {}
+        if args.exec_out is not None:
+            flow_input['Start Flow']['exec_out'] = args.exec_out
+        if args.text is not None:
+            flow_input['Start Flow']['text'] = args.text
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/e2e/fixtures/workflow_node_library/workflow_node_nodes.py
+++ b/tests/e2e/fixtures/workflow_node_library/workflow_node_nodes.py
@@ -1,0 +1,77 @@
+"""Fixture nodes for the workflow-backed node e2e test.
+
+Provides the Start Flow / End Flow pair and a transform node that ``shout_workflow.py`` wires
+together. The library JSON declares that workflow in its ``workflow_nodes`` list, so registering
+this library also produces a ``ShoutWorkflow`` node type generated from the workflow file.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import ControlNode, EndNode, StartNode
+
+
+class TextStartNode(StartNode):
+    """Start Flow node exposing a single ``text`` input to the workflow."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                type="str",
+                default_value="",
+                tooltip="Text handed to the workflow",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["text"] = self.get_parameter_value("text") or ""
+
+
+class ShoutNode(ControlNode):
+    """Uppercases ``text`` and appends an exclamation mark."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                type="str",
+                default_value="",
+                tooltip="Text to shout",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="shouted",
+                type="str",
+                default_value="",
+                tooltip="The shouted text",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        text = self.get_parameter_value("text") or ""
+        self.parameter_output_values["shouted"] = f"{text.upper()}!"
+
+
+class TextEndNode(EndNode):
+    """End Flow node exposing a single ``result`` output from the workflow."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            Parameter(
+                name="result",
+                type="str",
+                default_value="",
+                tooltip="Text produced by the workflow",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )

--- a/tests/e2e/test_workflow_node_execution.py
+++ b/tests/e2e/test_workflow_node_execution.py
@@ -1,0 +1,190 @@
+"""End-to-end coverage for node types generated from workflow files.
+
+A library can declare a node in ``workflow_nodes`` instead of ``nodes``, pointing at a saved
+workflow file that has Start Flow and End Flow nodes. Registering the library must then produce a
+usable node type whose parameters mirror the workflow's saved shape, and running that node must
+execute the workflow and hand its End Flow values back as node outputs.
+
+The fixture library ships ``shout_workflow.py`` (Start -> Shout -> End), regenerate it with
+``uv run python scripts/generate_shout_workflow_fixture.py`` when the workflow file format changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.exe_types.workflow_node import WorkflowNode
+from griptape_nodes.retained_mode.events.execution_events import StartFlowRequest, StartFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    ListFlowsInFlowRequest,
+    ListFlowsInFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    ListNodeTypesInLibraryRequest,
+    ListNodeTypesInLibraryResultSuccess,
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "workflow_node_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "workflow_node_nodes.py"
+FIXTURE_WORKFLOW_FILE = FIXTURE_LIBRARY_DIR / "shout_workflow.py"
+LIBRARY_NAME = "Workflow Node Library"
+WORKFLOW_NODE_TYPE = "ShoutWorkflow"
+
+
+@pytest.fixture
+def registered_library(tmp_path: Path, materialize_library: Callable[..., Path]) -> Path:
+    """Materialize and register the fixture library, returning its JSON path."""
+    library_json = materialize_library(
+        tmp_path / "library",
+        template=FIXTURE_LIBRARY_JSON_TEMPLATE,
+        node_file=FIXTURE_NODE_FILE,
+        extra_files=[FIXTURE_WORKFLOW_FILE],
+    )
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    return library_json
+
+
+@pytest.mark.skipif(
+    not FIXTURE_WORKFLOW_FILE.exists(),
+    reason=f"Workflow Node Library fixture workflow missing at {FIXTURE_WORKFLOW_FILE}",
+)
+def test_workflow_node_registers_with_shape_derived_parameters(
+    registered_library: Path,  # noqa: ARG001
+    create_node: Callable[..., str],
+) -> None:
+    """A `workflow_nodes` entry becomes a real node type whose parameters mirror the shape."""
+    list_result = GriptapeNodes.handle_request(ListNodeTypesInLibraryRequest(library=LIBRARY_NAME))
+    assert isinstance(list_result, ListNodeTypesInLibraryResultSuccess), list_result
+    assert WORKFLOW_NODE_TYPE in list_result.node_types
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_e2e_shape")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+
+    create_node(WORKFLOW_NODE_TYPE, "Shout It", flow_result.flow_name, library_name=LIBRARY_NAME)
+    node = GriptapeNodes.NodeManager().get_node_by_name("Shout It")
+
+    assert isinstance(node, WorkflowNode), f"Expected a workflow-backed node, got {type(node).__name__}"
+    # `text` comes from the workflow's Start Flow node, `result` from its End Flow node. Control
+    # parameters in the shape are dropped in favor of the node's own control flow.
+    assert node.get_parameter_by_name("text") is not None
+    assert node.get_parameter_by_name("result") is not None
+    assert node.get_parameter_by_name("exec_out") is node.control_parameter_out
+
+
+@pytest.mark.skipif(
+    not FIXTURE_WORKFLOW_FILE.exists(),
+    reason=f"Workflow Node Library fixture workflow missing at {FIXTURE_WORKFLOW_FILE}",
+)
+@pytest.mark.asyncio
+async def test_workflow_node_runs_its_workflow_and_returns_outputs(
+    registered_library: Path,  # noqa: ARG001
+    create_node: Callable[..., str],
+) -> None:
+    """Running the generated node executes the workflow and surfaces its End Flow values."""
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_e2e")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    parent_flow = flow_result.flow_name
+
+    create_node(WORKFLOW_NODE_TYPE, "Shout It", parent_flow, library_name=LIBRARY_NAME)
+    set_result = GriptapeNodes.handle_request(
+        SetParameterValueRequest(parameter_name="text", node_name="Shout It", value="hello there")
+    )
+    assert set_result.succeeded(), set_result
+
+    run_result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=parent_flow,
+            flow_node_name="Shout It",
+            wait_for_completion=True,
+            completion_timeout_ms=60000,
+        )
+    )
+    assert isinstance(run_result, StartFlowResultSuccess), run_result
+
+    node = GriptapeNodes.NodeManager().get_node_by_name("Shout It")
+    assert node.state == NodeResolutionState.RESOLVED
+    assert node.parameter_output_values.get("result") == "HELLO THERE!"
+
+    # The workflow was imported as a child flow of the node's own flow so it can be inspected
+    # during the session, and it is tagged transient so a save never bakes it in.
+    subflows_result = GriptapeNodes.handle_request(ListFlowsInFlowRequest(parent_flow_name=parent_flow))
+    assert isinstance(subflows_result, ListFlowsInFlowResultSuccess), subflows_result
+    assert node.metadata["subflow_name"] in subflows_result.flow_names
+
+
+@pytest.mark.skipif(
+    not FIXTURE_WORKFLOW_FILE.exists(),
+    reason=f"Workflow Node Library fixture workflow missing at {FIXTURE_WORKFLOW_FILE}",
+)
+@pytest.mark.asyncio
+async def test_two_workflow_nodes_run_independently(
+    registered_library: Path,  # noqa: ARG001
+    create_node: Callable[..., str],
+    connect: Callable[..., None],
+) -> None:
+    """Two instances of the same generated node each get their own subflow.
+
+    The second import renames the workflow's Start/End nodes (their names are already taken), so
+    this covers the path where the saved shape's node names no longer match the live subflow.
+    """
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_e2e_pair")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    parent_flow = flow_result.flow_name
+
+    create_node(WORKFLOW_NODE_TYPE, "First", parent_flow, library_name=LIBRARY_NAME)
+    create_node(WORKFLOW_NODE_TYPE, "Second", parent_flow, library_name=LIBRARY_NAME)
+    connect("First", "exec_out", "Second", "exec_in")
+    connect("First", "result", "Second", "text")
+
+    set_result = GriptapeNodes.handle_request(
+        SetParameterValueRequest(parameter_name="text", node_name="First", value="hey")
+    )
+    assert set_result.succeeded(), set_result
+
+    run_result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=parent_flow,
+            flow_node_name="First",
+            wait_for_completion=True,
+            completion_timeout_ms=60000,
+        )
+    )
+    assert isinstance(run_result, StartFlowResultSuccess), run_result
+
+    node_manager = GriptapeNodes.NodeManager()
+    first = node_manager.get_node_by_name("First")
+    second = node_manager.get_node_by_name("Second")
+
+    assert first.parameter_output_values.get("result") == "HEY!"
+    assert second.parameter_output_values.get("result") == "HEY!!"
+    assert first.metadata["subflow_name"] != second.metadata["subflow_name"]

--- a/tests/e2e/test_workflow_node_execution.py
+++ b/tests/e2e/test_workflow_node_execution.py
@@ -87,9 +87,9 @@ def test_workflow_node_registers_with_shape_derived_parameters(
 
     assert isinstance(node, WorkflowNode), f"Expected a workflow-backed node, got {type(node).__name__}"
     # `text` comes from the workflow's Start Flow node, `result` from its End Flow node. Control
-    # parameters in the shape are dropped in favor of the node's own control flow.
-    assert node.get_parameter_by_name("text") is not None
-    assert node.get_parameter_by_name("result") is not None
+    # parameters in the shape are dropped in favor of the node's own control flow, and so is the End
+    # Flow node's Status group, which reports on that node's run rather than on the workflow's output.
+    assert [parameter.name for parameter in node.parameters] == ["exec_in", "exec_out", "text", "result"]
     assert node.get_parameter_by_name("exec_out") is node.control_parameter_out
 
 

--- a/tests/e2e/test_workflow_node_execution.py
+++ b/tests/e2e/test_workflow_node_execution.py
@@ -6,7 +6,8 @@ usable node type whose parameters mirror the workflow's saved shape, and running
 execute the workflow and hand its End Flow values back as node outputs.
 
 The fixture library ships ``shout_workflow.py`` (Start -> Shout -> End), regenerate it with
-``uv run python scripts/generate_shout_workflow_fixture.py`` when the workflow file format changes.
+``uv run python tests/e2e/fixtures/generate_shout_workflow_fixture.py`` when the workflow file format
+changes.
 """
 
 from __future__ import annotations

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -7,7 +7,8 @@ from typing import Any
 
 import pytest
 
-from griptape_nodes.exe_types.core_types import ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.exe_types.workflow_node import (
     WorkflowNode,
     WorkflowNodeDefinitionError,
@@ -19,6 +20,8 @@ from griptape_nodes.exe_types.workflow_node import (
     pair_shape_nodes,
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 CONTROL_TYPE = "parametercontroltype"
 
@@ -47,6 +50,37 @@ def _metadata(shape: WorkflowShape | None) -> WorkflowMetadata:
         node_libraries_referenced=[],
         workflow_shape=shape,
     )
+
+
+def _build_live_subflow() -> str:
+    """Create a flow standing in for an imported workflow, and return its name.
+
+    Mirrors what an import produces for the shape used by `TestResolveLiveRoutes`: a parameterless
+    Start Flow node, a Start Flow node exposing `text`, and an End Flow node exposing `result`, all
+    renamed because their original names were already taken on the canvas.
+    """
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_live_routes")
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="Subflow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+
+    flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_result.flow_name)
+    flow.add_node(StartNode(name="Start Flow_1"))
+
+    start_with_text = StartNode(name="Start Flow_2")
+    start_with_text.add_parameter(
+        Parameter(name="text", tooltip="text tooltip", type="str", allowed_modes={ParameterMode.OUTPUT})
+    )
+    flow.add_node(start_with_text)
+
+    end_node = EndNode(name="End Flow_1")
+    end_node.add_parameter(
+        Parameter(name="result", tooltip="result tooltip", type="str", allowed_modes={ParameterMode.INPUT})
+    )
+    flow.add_node(end_node)
+
+    return flow_result.flow_name
 
 
 class TestFlattenShapeSection:
@@ -111,11 +145,13 @@ class TestBuildWorkflowNodeSurface:
 
         surface = build_workflow_node_surface(_metadata(shape))
 
-        assert list(surface) == ["text", "result"]
-        assert surface["text"].input_route == WorkflowParameterRoute("Start Flow", "text")
-        assert surface["text"].output_route is None
-        assert surface["result"].output_route == WorkflowParameterRoute("End Flow", "result")
-        assert surface["result"].input_route is None
+        assert list(surface.parameters) == ["text", "result"]
+        assert surface.parameters["text"].input_route == WorkflowParameterRoute("Start Flow", "text")
+        assert surface.parameters["text"].output_route is None
+        assert surface.parameters["result"].output_route == WorkflowParameterRoute("End Flow", "result")
+        assert surface.parameters["result"].input_route is None
+        assert surface.start_node_names == ["Start Flow"]
+        assert surface.end_node_names == ["End Flow"]
 
     def test_name_on_both_sides_carries_both_routes(self) -> None:
         shape = WorkflowShape(
@@ -125,9 +161,29 @@ class TestBuildWorkflowNodeSurface:
 
         surface = build_workflow_node_surface(_metadata(shape))
 
-        assert list(surface) == ["value"]
-        assert surface["value"].input_route == WorkflowParameterRoute("Start Flow", "value")
-        assert surface["value"].output_route == WorkflowParameterRoute("End Flow", "value")
+        assert list(surface.parameters) == ["value"]
+        assert surface.parameters["value"].input_route == WorkflowParameterRoute("Start Flow", "value")
+        assert surface.parameters["value"].output_route == WorkflowParameterRoute("End Flow", "value")
+
+    def test_parameterless_nodes_still_count_toward_the_shape(self) -> None:
+        """A Start Flow node that only carries control flow is invisible in the parameter surface.
+
+        It is still one of the nodes the live subflow gets paired against by position, so dropping it
+        from `start_node_names` would make every run of the node fail the pairing count check.
+        """
+        shape = WorkflowShape(
+            inputs={
+                "Start Flow": {"exec_out": _param("exec_out", CONTROL_TYPE)},
+                "Start Flow_1": {"text": _param("text")},
+            },
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+
+        surface = build_workflow_node_surface(_metadata(shape))
+
+        assert list(surface.parameters) == ["text", "result"]
+        assert surface.start_node_names == ["Start Flow", "Start Flow_1"]
+        assert surface.end_node_names == ["End Flow"]
 
     def test_missing_shape_rejected(self) -> None:
         with pytest.raises(WorkflowNodeDefinitionError, match="no saved input and output shape"):
@@ -169,6 +225,37 @@ class TestPairShapeNodes:
     def test_count_mismatch_is_rejected(self) -> None:
         with pytest.raises(WorkflowNodeRoutingError, match="lists 2 of them but the loaded copy has 1"):
             pair_shape_nodes(["Start Flow", "Other"], ["Start Flow"], role="Start Flow")
+
+
+class TestResolveLiveRoutes:
+    """Routes are re-pointed at the imported copy of the workflow before every run."""
+
+    def test_parameterless_start_node_is_counted_and_skipped(self) -> None:
+        """A Start Flow node carrying only control flow contributes no route but still holds a slot.
+
+        Pairing is positional, so the parameterless node has to be counted on the declared side or
+        every run of the node fails the count check even though the saved shape is correct.
+        """
+        shape = WorkflowShape(
+            inputs={
+                "Start Flow": {"exec_out": _param("exec_out", CONTROL_TYPE)},
+                "Start Flow_1": {"text": _param("text")},
+            },
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=Path("/library/shout_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+        node = node_class(name="Shout It")
+        subflow_name = _build_live_subflow()
+
+        live_routes = node._resolve_live_routes(subflow_name)
+
+        # The import renamed every node, so each declared name resolves one position along.
+        assert live_routes.inputs == {"text": WorkflowParameterRoute("Start Flow_2", "text")}
+        assert live_routes.outputs == {"result": WorkflowParameterRoute("End Flow_1", "result")}
 
 
 class TestBuildWorkflowNodeClass:

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -1,0 +1,269 @@
+"""Tests for the pure parts of generating a node type from a workflow file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import ParameterMode
+from griptape_nodes.exe_types.workflow_node import (
+    WorkflowNode,
+    WorkflowNodeDefinitionError,
+    WorkflowParameterRoute,
+    build_workflow_node_class,
+    build_workflow_node_surface,
+    flatten_shape_section,
+    match_shape_nodes,
+)
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
+
+CONTROL_TYPE = "parametercontroltype"
+
+
+def _param(name: str, param_type: str = "str", **overrides: Any) -> dict[str, Any]:
+    definition = {
+        "name": name,
+        "type": param_type,
+        "input_types": [param_type],
+        "output_type": param_type,
+        "default_value": None,
+        "tooltip": f"{name} tooltip",
+        "mode_allowed_input": True,
+        "mode_allowed_property": True,
+        "mode_allowed_output": True,
+    }
+    definition.update(overrides)
+    return definition
+
+
+def _metadata(shape: WorkflowShape | None) -> WorkflowMetadata:
+    return WorkflowMetadata(
+        name="demo",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=[],
+        workflow_shape=shape,
+    )
+
+
+class TestFlattenShapeSection:
+    def test_bare_names_when_unique(self) -> None:
+        section = {"Start Flow": {"text": _param("text"), "count": _param("count", "int")}}
+
+        routes = flatten_shape_section(section)
+
+        assert routes == {
+            "text": WorkflowParameterRoute("Start Flow", "text"),
+            "count": WorkflowParameterRoute("Start Flow", "count"),
+        }
+
+    def test_control_parameters_dropped(self) -> None:
+        section = {"Start Flow": {"exec_out": _param("exec_out", CONTROL_TYPE), "text": _param("text")}}
+
+        assert list(flatten_shape_section(section)) == ["text"]
+
+    def test_collision_qualifies_every_side(self) -> None:
+        section = {
+            "Start A": {"text": _param("text"), "only_a": _param("only_a")},
+            "Start B": {"text": _param("text")},
+        }
+
+        routes = flatten_shape_section(section)
+
+        assert routes == {
+            "Start A.text": WorkflowParameterRoute("Start A", "text"),
+            "only_a": WorkflowParameterRoute("Start A", "only_a"),
+            "Start B.text": WorkflowParameterRoute("Start B", "text"),
+        }
+
+    def test_result_is_order_independent(self) -> None:
+        forward = {"Start A": {"text": _param("text")}, "Start B": {"text": _param("text")}}
+        reversed_order = {"Start B": {"text": _param("text")}, "Start A": {"text": _param("text")}}
+
+        assert flatten_shape_section(forward) == flatten_shape_section(reversed_order)
+
+
+class TestBuildWorkflowNodeSurface:
+    def test_inputs_precede_outputs(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+
+        surface = build_workflow_node_surface(_metadata(shape))
+
+        assert list(surface) == ["text", "result"]
+        assert surface["text"].input_route == WorkflowParameterRoute("Start Flow", "text")
+        assert surface["text"].output_route is None
+        assert surface["result"].output_route == WorkflowParameterRoute("End Flow", "result")
+        assert surface["result"].input_route is None
+
+    def test_name_on_both_sides_carries_both_routes(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"value": _param("value")}},
+            outputs={"End Flow": {"value": _param("value")}},
+        )
+
+        surface = build_workflow_node_surface(_metadata(shape))
+
+        assert list(surface) == ["value"]
+        assert surface["value"].input_route == WorkflowParameterRoute("Start Flow", "value")
+        assert surface["value"].output_route == WorkflowParameterRoute("End Flow", "value")
+
+    def test_missing_shape_rejected(self) -> None:
+        with pytest.raises(WorkflowNodeDefinitionError, match="no saved input and output shape"):
+            build_workflow_node_surface(_metadata(None))
+
+    def test_control_only_shape_rejected(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"exec_out": _param("exec_out", CONTROL_TYPE)}},
+            outputs={"End Flow": {"exec_in": _param("exec_in", CONTROL_TYPE)}},
+        )
+
+        with pytest.raises(WorkflowNodeDefinitionError, match="expose no parameters"):
+            build_workflow_node_surface(_metadata(shape))
+
+
+class TestMatchShapeNodes:
+    def test_exact_names(self) -> None:
+        assert match_shape_nodes(["Start Flow"], ["Start Flow"]) == {"Start Flow": "Start Flow"}
+
+    def test_deduplicated_rename(self) -> None:
+        assert match_shape_nodes(["Start Flow"], ["Start Flow_1"]) == {"Start Flow": "Start Flow_1"}
+
+    def test_exact_match_wins_over_rename(self) -> None:
+        matches = match_shape_nodes(["Start Flow"], ["Start Flow_1", "Start Flow"])
+
+        assert matches == {"Start Flow": "Start Flow"}
+
+    def test_each_declared_name_claims_a_distinct_live_name(self) -> None:
+        matches = match_shape_nodes(["Start A", "Start B"], ["Start A_1", "Start B_1"])
+
+        assert matches == {"Start A": "Start A_1", "Start B": "Start B_1"}
+
+    def test_unmatched_declared_name_is_absent(self) -> None:
+        assert match_shape_nodes(["Start Flow", "Other"], ["Start Flow"]) == {"Start Flow": "Start Flow"}
+
+
+class TestBuildWorkflowNodeClass:
+    def test_class_name_and_attributes(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        metadata = _metadata(shape)
+
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=Path("/library/shout_workflow.py"),
+            workflow_metadata=metadata,
+        )
+
+        assert node_class.__name__ == "ShoutWorkflow"
+        assert issubclass(node_class, WorkflowNode)
+        assert node_class.workflow_file_path == Path("/library/shout_workflow.py")
+        assert node_class.workflow_metadata is metadata
+
+    def test_instance_parameters_mirror_the_shape(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"exec_out": _param("exec_out", CONTROL_TYPE), "text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=Path("/library/shout_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+        node = node_class(name="Shout It")
+
+        text_param = node.get_parameter_by_name("text")
+        result_param = node.get_parameter_by_name("result")
+        assert text_param is not None
+        assert result_param is not None
+        assert text_param.allowed_modes == {ParameterMode.INPUT, ParameterMode.PROPERTY}
+        assert result_param.allowed_modes == {ParameterMode.OUTPUT}
+        # The node brings its own control flow rather than surfacing the workflow's.
+        assert node.get_parameter_by_name("exec_in") is node.control_parameter_in
+        assert node.get_parameter_by_name("exec_out") is node.control_parameter_out
+
+    def test_property_mode_withheld_when_shape_forbids_it(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text", mode_allowed_property=False)}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=Path("/library/shout_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+        node = node_class(name="Shout It")
+
+        text_param = node.get_parameter_by_name("text")
+        assert text_param is not None
+        assert text_param.allowed_modes == {ParameterMode.INPUT}
+
+    def test_stale_subflow_name_is_dropped_on_construction(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=Path("/library/shout_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+
+        node = node_class(name="Shout It", metadata={"subflow_name": "some_stale_flow"})
+
+        assert "subflow_name" not in node.metadata
+        assert node.metadata["workflow_node"] is True
+
+
+class TestEditorPreviewMetadata:
+    """The editor renders these nodes with its subflow-preview wrapper keyed off node metadata.
+
+    `workflow_node` selects the wrapper (which shows a "View Subflow" button) and
+    `_workflow_file_value` is the registry key its preview imports when the node has not run yet.
+    Without the second key the button opens nothing.
+    """
+
+    def test_registry_key_recorded_for_preview(self, tmp_path: Path) -> None:
+        workflow_path = tmp_path / "shout_workflow.py"
+        workflow_path.write_text("# placeholder\n", encoding="utf-8")
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=workflow_path,
+            workflow_metadata=_metadata(shape),
+        )
+
+        node = node_class(name="Shout It")
+
+        registry_key = node.metadata["_workflow_file_value"]
+        assert WorkflowRegistry.has_workflow_with_name(registry_key)
+        # Backing workflows are hidden from the editor's workflow picker.
+        assert WorkflowRegistry.get_workflow_by_name(registry_key).metadata.is_internal is True
+
+    def test_missing_workflow_file_leaves_preview_unavailable(self) -> None:
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=Path("/definitely/absent/shout_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+
+        node = node_class(name="Shout It")
+
+        # The node is still usable; only the preview is unavailable.
+        assert "_workflow_file_value" not in node.metadata
+        assert node.get_parameter_by_name("text") is not None

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -37,6 +37,7 @@ def _param(name: str, param_type: str = "str", **overrides: Any) -> dict[str, An
         "mode_allowed_input": True,
         "mode_allowed_property": True,
         "mode_allowed_output": True,
+        "parent_element_name": None,
     }
     definition.update(overrides)
     return definition
@@ -98,6 +99,24 @@ class TestFlattenShapeSection:
         section = {"Start Flow": {"exec_out": _param("exec_out", CONTROL_TYPE), "text": _param("text")}}
 
         assert list(flatten_shape_section(section)) == ["text"]
+
+    def test_end_node_status_parameters_dropped(self) -> None:
+        """Every End Flow node carries these, and they describe that node's run rather than an output."""
+        section = {
+            "End Flow": {
+                "was_successful": _param("was_successful", "bool", parent_element_name="Status"),
+                "result_details": _param("result_details", parent_element_name="Status"),
+                "result": _param("result"),
+            }
+        }
+
+        assert list(flatten_shape_section(section)) == ["result"]
+
+    def test_status_names_outside_the_status_group_are_kept(self) -> None:
+        """Only the Status group's copies are dropped, not an author's own parameter of that name."""
+        section = {"End Flow": {"was_successful": _param("was_successful", "bool")}}
+
+        assert list(flatten_shape_section(section)) == ["was_successful"]
 
     def test_collision_qualifies_every_side(self) -> None:
         section = {

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -11,11 +11,12 @@ from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.workflow_node import (
     WorkflowNode,
     WorkflowNodeDefinitionError,
+    WorkflowNodeRoutingError,
     WorkflowParameterRoute,
     build_workflow_node_class,
     build_workflow_node_surface,
     flatten_shape_section,
-    match_shape_nodes,
+    pair_shape_nodes,
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
 
@@ -73,10 +74,26 @@ class TestFlattenShapeSection:
         routes = flatten_shape_section(section)
 
         assert routes == {
-            "Start A.text": WorkflowParameterRoute("Start A", "text"),
+            "Start_A.text": WorkflowParameterRoute("Start A", "text"),
             "only_a": WorkflowParameterRoute("Start A", "only_a"),
-            "Start B.text": WorkflowParameterRoute("Start B", "text"),
+            "Start_B.text": WorkflowParameterRoute("Start B", "text"),
         }
+
+    def test_qualifier_replaces_whitespace(self) -> None:
+        """Parameter names cannot contain whitespace, and Start/End node names routinely do."""
+        section = {"Start Flow": {"text": _param("text")}, "Start Flow_1": {"text": _param("text")}}
+
+        routes = flatten_shape_section(section)
+
+        assert set(routes) == {"Start_Flow.text", "Start_Flow_1.text"}
+        assert not any(char.isspace() for name in routes for char in name)
+
+    def test_qualifier_collision_is_rejected(self) -> None:
+        """Two node names that differ only by whitespace would produce one parameter name."""
+        section = {"Start Flow": {"text": _param("text")}, "Start_Flow": {"text": _param("text")}}
+
+        with pytest.raises(WorkflowNodeDefinitionError, match="collides with"):
+            flatten_shape_section(section)
 
     def test_result_is_order_independent(self) -> None:
         forward = {"Start A": {"text": _param("text")}, "Start B": {"text": _param("text")}}
@@ -126,25 +143,32 @@ class TestBuildWorkflowNodeSurface:
             build_workflow_node_surface(_metadata(shape))
 
 
-class TestMatchShapeNodes:
+class TestPairShapeNodes:
     def test_exact_names(self) -> None:
-        assert match_shape_nodes(["Start Flow"], ["Start Flow"]) == {"Start Flow": "Start Flow"}
+        assert pair_shape_nodes(["Start Flow"], ["Start Flow"], role="Start Flow") == {"Start Flow": "Start Flow"}
 
     def test_deduplicated_rename(self) -> None:
-        assert match_shape_nodes(["Start Flow"], ["Start Flow_1"]) == {"Start Flow": "Start Flow_1"}
+        assert pair_shape_nodes(["Start Flow"], ["Start Flow_1"], role="Start Flow") == {"Start Flow": "Start Flow_1"}
 
-    def test_exact_match_wins_over_rename(self) -> None:
-        matches = match_shape_nodes(["Start Flow"], ["Start Flow_1", "Start Flow"])
+    def test_prefix_overlapping_names_are_not_cross_wired(self) -> None:
+        """A renamed node can collide textually with a different declared name.
 
-        assert matches == {"Start Flow": "Start Flow"}
+        A workflow declaring both "Start Flow" and "Start Flow_1", imported into a canvas that
+        already has a "Start Flow", gets renamed to "Start Flow_1" and "Start Flow_2". Matching by
+        name would hand "Start Flow_1" to the wrong declared node and swap the two routes.
+        """
+        paired = pair_shape_nodes(["Start Flow", "Start Flow_1"], ["Start Flow_1", "Start Flow_2"], role="Start Flow")
+
+        assert paired == {"Start Flow": "Start Flow_1", "Start Flow_1": "Start Flow_2"}
 
     def test_each_declared_name_claims_a_distinct_live_name(self) -> None:
-        matches = match_shape_nodes(["Start A", "Start B"], ["Start A_1", "Start B_1"])
+        paired = pair_shape_nodes(["Start A", "Start B"], ["Start A_1", "Start B_1"], role="Start Flow")
 
-        assert matches == {"Start A": "Start A_1", "Start B": "Start B_1"}
+        assert paired == {"Start A": "Start A_1", "Start B": "Start B_1"}
 
-    def test_unmatched_declared_name_is_absent(self) -> None:
-        assert match_shape_nodes(["Start Flow", "Other"], ["Start Flow"]) == {"Start Flow": "Start Flow"}
+    def test_count_mismatch_is_rejected(self) -> None:
+        with pytest.raises(WorkflowNodeRoutingError, match="lists 2 of them but the loaded copy has 1"):
+            pair_shape_nodes(["Start Flow", "Other"], ["Start Flow"], role="Start Flow")
 
 
 class TestBuildWorkflowNodeClass:
@@ -222,6 +246,31 @@ class TestBuildWorkflowNodeClass:
         assert "subflow_name" not in node.metadata
         assert node.metadata["workflow_node"] is True
 
+    def test_colliding_shape_produces_a_constructible_node(self) -> None:
+        """Qualified names must survive add_parameter, which rejects whitespace.
+
+        Testing the flattening in isolation is not enough: node names routinely contain spaces, so a
+        qualified name built from a raw node name makes the generated node type uncreatable.
+        """
+        shape = WorkflowShape(
+            inputs={
+                "Start Flow": {"text": _param("text")},
+                "Start Flow_1": {"text": _param("text")},
+            },
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        node_class = build_workflow_node_class(
+            node_type="ShoutTwiceWorkflow",
+            workflow_file_path=Path("/library/shout_twice_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+
+        node = node_class(name="Shout Twice")
+
+        assert node.get_parameter_by_name("Start_Flow.text") is not None
+        assert node.get_parameter_by_name("Start_Flow_1.text") is not None
+        assert node.get_parameter_by_name("result") is not None
+
 
 class TestEditorPreviewMetadata:
     """The editor renders these nodes with its subflow-preview wrapper keyed off node metadata.
@@ -248,8 +297,31 @@ class TestEditorPreviewMetadata:
 
         registry_key = node.metadata["_workflow_file_value"]
         assert WorkflowRegistry.has_workflow_with_name(registry_key)
-        # Backing workflows are hidden from the editor's workflow picker.
-        assert WorkflowRegistry.get_workflow_by_name(registry_key).metadata.is_internal is True
+
+    def test_workflow_is_internal_flag_is_respected_not_overridden(self, tmp_path: Path) -> None:
+        """The workflow's own is_internal flag wins.
+
+        Overriding it would race the library's own `workflows` registration and silently hide a
+        workflow the author had listed deliberately.
+        """
+        workflow_path = tmp_path / "shout_workflow.py"
+        workflow_path.write_text("# placeholder\n", encoding="utf-8")
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"text": _param("text")}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        metadata = _metadata(shape)
+        assert metadata.is_internal is False, "sanity: the fixture does not opt into hiding"
+        node_class = build_workflow_node_class(
+            node_type="ShoutWorkflow",
+            workflow_file_path=workflow_path,
+            workflow_metadata=metadata,
+        )
+
+        node = node_class(name="Shout It")
+
+        registry_key = node.metadata["_workflow_file_value"]
+        assert WorkflowRegistry.get_workflow_by_name(registry_key).metadata.is_internal is False
 
     def test_missing_workflow_file_leaves_preview_unavailable(self) -> None:
         shape = WorkflowShape(

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -317,6 +317,33 @@ class TestBuildWorkflowNodeClass:
         assert text_param is not None
         assert text_param.allowed_modes == {ParameterMode.INPUT}
 
+    def test_mutable_defaults_are_not_shared_between_instances(self) -> None:
+        """The shape lives on the generated type, so its defaults have to be copied per instance.
+
+        A Parameter keeps its default value by reference. Handing every instance the same list would
+        let one node's edit show up on every other node of the same type.
+        """
+        shape = WorkflowShape(
+            inputs={"Start Flow": {"items": _param("items", "list", default_value=["a"])}},
+            outputs={"End Flow": {"result": _param("result")}},
+        )
+        node_class = build_workflow_node_class(
+            node_type="ListWorkflow",
+            workflow_file_path=Path("/library/list_workflow.py"),
+            workflow_metadata=_metadata(shape),
+        )
+
+        first = node_class(name="First")
+        second = node_class(name="Second")
+
+        first_items = first.get_parameter_by_name("items")
+        second_items = second.get_parameter_by_name("items")
+        assert first_items is not None
+        assert second_items is not None
+        first_items.default_value.append("b")
+        assert second_items.default_value == ["a"]
+        assert shape.inputs["Start Flow"]["items"]["default_value"] == ["a"]
+
     def test_stale_subflow_name_is_dropped_on_construction(self) -> None:
         shape = WorkflowShape(
             inputs={"Start Flow": {"text": _param("text")}},

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -402,8 +402,8 @@ class TestRequiresWorkerProcess:
 
 
 class TestSchemaVersion:
-    def test_latest_schema_version_is_0_10_0(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.10.0"
+    def test_latest_schema_version_is_0_11_0(self) -> None:
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
 
 
 # ---------- Model catalog ----------

--- a/tests/unit/node_library/test_workflow_metadata_reader.py
+++ b/tests/unit/node_library/test_workflow_metadata_reader.py
@@ -1,0 +1,107 @@
+"""Tests for reading a workflow's metadata header straight off disk."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.workflow_registry import (
+    WorkflowMetadataError,
+    find_metadata_blocks,
+    read_workflow_metadata,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SHAPE = {
+    "inputs": {"Start Flow": {"text": {"name": "text", "type": "str", "default_value": ""}}},
+    "outputs": {"End Flow": {"result": {"name": "result", "type": "str", "default_value": ""}}},
+}
+
+
+def _header(**overrides: str) -> str:
+    fields = {
+        "name": '"demo"',
+        "schema_version": '"0.20.0"',
+        "engine_version_created_with": '"0.0.0"',
+        "node_libraries_referenced": '[["Demo Library", "0.1.0"]]',
+    }
+    fields.update(overrides)
+    lines = ["# /// script", "# [tool.griptape-nodes]"]
+    lines.extend(f"# {key} = {value}" for key, value in fields.items())
+    lines.append("# ///")
+    return "\n".join(lines) + "\n"
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    workflow_path = tmp_path / "demo_workflow.py"
+    workflow_path.write_text(content, encoding="utf-8")
+    return workflow_path
+
+
+class TestFindMetadataBlocks:
+    def test_finds_matching_block(self) -> None:
+        matches = find_metadata_blocks(_header(), "script")
+        assert len(matches) == 1
+        assert 'name = "demo"' in matches[0].group("content")
+
+    def test_ignores_other_block_names(self) -> None:
+        assert find_metadata_blocks(_header(), "other") == []
+
+    def test_no_block_at_all(self) -> None:
+        assert find_metadata_blocks("print('hello')\n", "script") == []
+
+
+class TestReadWorkflowMetadata:
+    def test_reads_header_fields(self, tmp_path: Path) -> None:
+        workflow_path = _write(tmp_path, _header(description='"A demo"') + "\nprint('body')\n")
+
+        metadata = read_workflow_metadata(workflow_path)
+
+        assert metadata.name == "demo"
+        assert metadata.schema_version == "0.20.0"
+        assert metadata.description == "A demo"
+        assert [library.library_name for library in metadata.node_libraries_referenced] == ["Demo Library"]
+
+    def test_deserializes_workflow_shape(self, tmp_path: Path) -> None:
+        shape_json = json.dumps(json.dumps(_SHAPE, separators=(",", ":")))
+        workflow_path = _write(tmp_path, _header(workflow_shape=shape_json))
+
+        metadata = read_workflow_metadata(workflow_path)
+
+        assert metadata.workflow_shape is not None
+        assert list(metadata.workflow_shape.inputs) == ["Start Flow"]
+        assert list(metadata.workflow_shape.outputs) == ["End Flow"]
+
+    def test_shape_absent_is_none(self, tmp_path: Path) -> None:
+        assert read_workflow_metadata(_write(tmp_path, _header())).workflow_shape is None
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        with pytest.raises(WorkflowMetadataError, match="could not be read"):
+            read_workflow_metadata(tmp_path / "absent.py")
+
+    def test_no_header(self, tmp_path: Path) -> None:
+        with pytest.raises(WorkflowMetadataError, match="0 'script' metadata sections"):
+            read_workflow_metadata(_write(tmp_path, "print('hello')\n"))
+
+    def test_two_headers(self, tmp_path: Path) -> None:
+        with pytest.raises(WorkflowMetadataError, match="2 'script' metadata sections"):
+            read_workflow_metadata(_write(tmp_path, _header() + "\n" + _header()))
+
+    def test_invalid_toml(self, tmp_path: Path) -> None:
+        content = "# /// script\n# [tool.griptape-nodes\n# name = broken\n# ///\n"
+        with pytest.raises(WorkflowMetadataError, match="not valid TOML"):
+            read_workflow_metadata(_write(tmp_path, content))
+
+    def test_missing_tool_table(self, tmp_path: Path) -> None:
+        content = '# /// script\n# dependencies = []\n# name = "demo"\n# ///\n'
+        with pytest.raises(WorkflowMetadataError, match=r"no '\[tool.griptape-nodes\]' table"):
+            read_workflow_metadata(_write(tmp_path, content))
+
+    def test_schema_mismatch(self, tmp_path: Path) -> None:
+        content = '# /// script\n# [tool.griptape-nodes]\n# name = "demo"\n# ///\n'
+        with pytest.raises(WorkflowMetadataError, match="does not match the expected schema"):
+            read_workflow_metadata(_write(tmp_path, content))

--- a/tests/unit/node_library/test_workflow_metadata_reader.py
+++ b/tests/unit/node_library/test_workflow_metadata_reader.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.node_library.workflow_registry import (
+    METADATA_TABLE_PATH,
     WorkflowMetadataError,
+    WorkflowMetadataFileError,
+    WorkflowMetadataMissingTableError,
+    WorkflowMetadataSchemaError,
+    WorkflowMetadataSectionCountError,
+    WorkflowMetadataTomlError,
     find_metadata_blocks,
     read_workflow_metadata,
 )
@@ -80,28 +86,46 @@ class TestReadWorkflowMetadata:
         assert read_workflow_metadata(_write(tmp_path, _header())).workflow_shape is None
 
     def test_missing_file(self, tmp_path: Path) -> None:
-        with pytest.raises(WorkflowMetadataError, match="could not be read"):
+        with pytest.raises(WorkflowMetadataFileError, match="could not be read"):
             read_workflow_metadata(tmp_path / "absent.py")
 
     def test_no_header(self, tmp_path: Path) -> None:
-        with pytest.raises(WorkflowMetadataError, match="0 'script' metadata sections"):
+        with pytest.raises(WorkflowMetadataSectionCountError, match="0 'script' metadata sections") as excinfo:
             read_workflow_metadata(_write(tmp_path, "print('hello')\n"))
 
+        assert excinfo.value.section_name == "script"
+        assert excinfo.value.count == 0
+
     def test_two_headers(self, tmp_path: Path) -> None:
-        with pytest.raises(WorkflowMetadataError, match="2 'script' metadata sections"):
-            read_workflow_metadata(_write(tmp_path, _header() + "\n" + _header()))
+        two_headers = _header() + "\n" + _header()
+        with pytest.raises(WorkflowMetadataSectionCountError, match="2 'script' metadata sections") as excinfo:
+            read_workflow_metadata(_write(tmp_path, two_headers))
+
+        assert excinfo.value.count == two_headers.count("# /// script")
 
     def test_invalid_toml(self, tmp_path: Path) -> None:
         content = "# /// script\n# [tool.griptape-nodes\n# name = broken\n# ///\n"
-        with pytest.raises(WorkflowMetadataError, match="not valid TOML"):
+        with pytest.raises(WorkflowMetadataTomlError, match="not valid TOML") as excinfo:
             read_workflow_metadata(_write(tmp_path, content))
+
+        assert excinfo.value.error_message
 
     def test_missing_tool_table(self, tmp_path: Path) -> None:
         content = '# /// script\n# dependencies = []\n# name = "demo"\n# ///\n'
-        with pytest.raises(WorkflowMetadataError, match=r"no '\[tool.griptape-nodes\]' table"):
+        with pytest.raises(WorkflowMetadataMissingTableError, match=r"no '\[tool.griptape-nodes\]' table") as excinfo:
             read_workflow_metadata(_write(tmp_path, content))
+
+        assert excinfo.value.section_path == METADATA_TABLE_PATH
 
     def test_schema_mismatch(self, tmp_path: Path) -> None:
         content = '# /// script\n# [tool.griptape-nodes]\n# name = "demo"\n# ///\n'
-        with pytest.raises(WorkflowMetadataError, match="does not match the expected schema"):
+        with pytest.raises(WorkflowMetadataSchemaError, match="does not match the expected schema") as excinfo:
             read_workflow_metadata(_write(tmp_path, content))
+
+        assert excinfo.value.section_path == METADATA_TABLE_PATH
+        assert excinfo.value.error_message
+
+    def test_every_failure_is_catchable_as_the_base_error(self, tmp_path: Path) -> None:
+        """Callers that only need "the header is unreadable" catch the base class, as the loader does."""
+        with pytest.raises(WorkflowMetadataError):
+            read_workflow_metadata(_write(tmp_path, "print('hello')\n"))

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -69,7 +69,7 @@ class TestLibraryDependencyDeclaration:
         assert not hasattr(deps, "library_dependencies")
 
     def test_schema_version_bumped(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.10.0"
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
 
 
 class TestLibraryDependencyProblem:

--- a/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
@@ -51,6 +51,7 @@ def _make_library(advanced_library: AdvancedNodeLibrary | None = None) -> Librar
     schema.is_default_library = False
     schema.name = "TestLib"
     schema.nodes = []
+    schema.workflow_nodes = []
     schema.widgets = []
     schema.config_categories = []
     return Library(library_data=schema, advanced_library=advanced_library)

--- a/tests/unit/retained_mode/managers/test_library_manager_workflow_nodes.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_workflow_nodes.py
@@ -1,0 +1,194 @@
+"""Tests for registering `workflow_nodes` entries as node types (library manager side)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from griptape_nodes.exe_types.workflow_node import WorkflowNode
+from griptape_nodes.node_library.library_registry import (
+    Library,
+    LibraryMetadata,
+    LibrarySchema,
+    NodeMetadata,
+    WorkflowNodeDefinition,
+)
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import WorkflowNodeLoadProblem
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+NODE_TYPE = "ShoutWorkflow"
+
+_SHAPE = {
+    "inputs": {"Start Flow": {"text": {"name": "text", "type": "str", "default_value": ""}}},
+    "outputs": {"End Flow": {"result": {"name": "result", "type": "str", "default_value": ""}}},
+}
+
+
+def _library_info() -> LibraryManager.LibraryInfo:
+    return LibraryManager.LibraryInfo(
+        lifecycle_state=LibraryManager.LibraryLifecycleState.EVALUATED,
+        fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
+        library_path="/fake/path",
+        is_sandbox=False,
+        library_name="TestLib",
+        library_version="1.0.0",
+    )
+
+
+def _library(workflow_nodes: list[WorkflowNodeDefinition]) -> Library:
+    schema = LibrarySchema(
+        name="TestLib",
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="Test",
+            description="Test",
+            library_version="1.0.0",
+            engine_version="0.0.0",
+            tags=[],
+        ),
+        categories=[],
+        nodes=[],
+        workflow_nodes=workflow_nodes,
+    )
+    return Library(library_data=schema)
+
+
+def _definition(workflow_path: str) -> WorkflowNodeDefinition:
+    return WorkflowNodeDefinition(
+        node_type=NODE_TYPE,
+        workflow_path=workflow_path,
+        metadata=NodeMetadata(category="test", description="Runs a workflow", display_name="Shout Workflow"),
+    )
+
+
+def _write_workflow(tmp_path: Path, *, shape: dict[str, Any] | None) -> Path:
+    lines = [
+        "# /// script",
+        "# [tool.griptape-nodes]",
+        '# name = "demo"',
+        f'# schema_version = "{WorkflowMetadata.LATEST_SCHEMA_VERSION}"',
+        '# engine_version_created_with = "0.0.0"',
+        "# node_libraries_referenced = []",
+    ]
+    if shape is not None:
+        encoded = json.dumps(json.dumps(shape, separators=(",", ":")))
+        lines.append(f"# workflow_shape = {encoded}")
+    lines.append("# ///")
+    workflow_path = tmp_path / "demo_workflow.py"
+    workflow_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return workflow_path
+
+
+class TestRegisterWorkflowNode:
+    def test_registers_generated_node_type(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+        workflow_path = _write_workflow(tmp_path, shape=_SHAPE)
+        library = _library([_definition(workflow_path.name)])
+        library_info = _library_info()
+
+        registered = griptape_nodes.library_manager._register_workflow_node(
+            library.get_library_data().workflow_nodes[0],  # type: ignore[index]
+            tmp_path,
+            library,
+            library_info,
+        )
+
+        assert registered is True
+        assert library_info.problems == []
+        assert library.has_node_type(NODE_TYPE)
+        node_class = library.get_node_class(NODE_TYPE)
+        assert issubclass(node_class, WorkflowNode)
+        assert node_class.workflow_file_path == workflow_path
+
+    def test_metadata_from_the_json_wins(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+        workflow_path = _write_workflow(tmp_path, shape=_SHAPE)
+        library = _library([_definition(workflow_path.name)])
+
+        griptape_nodes.library_manager._register_workflow_node(
+            library.get_library_data().workflow_nodes[0],  # type: ignore[index]
+            tmp_path,
+            library,
+            _library_info(),
+        )
+
+        assert library.get_node_metadata(NODE_TYPE).display_name == "Shout Workflow"
+
+    def test_missing_workflow_file_records_problem(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+        library = _library([_definition("absent_workflow.py")])
+        library_info = _library_info()
+
+        registered = griptape_nodes.library_manager._register_workflow_node(
+            library.get_library_data().workflow_nodes[0],  # type: ignore[index]
+            tmp_path,
+            library,
+            library_info,
+        )
+
+        assert registered is False
+        assert not library.has_node_type(NODE_TYPE)
+        assert [type(problem) for problem in library_info.problems] == [WorkflowNodeLoadProblem]
+
+    def test_workflow_without_shape_records_problem(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+        workflow_path = _write_workflow(tmp_path, shape=None)
+        library = _library([_definition(workflow_path.name)])
+        library_info = _library_info()
+
+        registered = griptape_nodes.library_manager._register_workflow_node(
+            library.get_library_data().workflow_nodes[0],  # type: ignore[index]
+            tmp_path,
+            library,
+            library_info,
+        )
+
+        assert registered is False
+        assert not library.has_node_type(NODE_TYPE)
+        problem = library_info.problems[0]
+        assert isinstance(problem, WorkflowNodeLoadProblem)
+        assert "no saved input and output shape" in problem.error_message
+
+
+class TestWorkflowNodeLoadProblemDisplay:
+    def test_single_problem_names_the_node_and_reason(self) -> None:
+        problem = WorkflowNodeLoadProblem(
+            node_type="ShoutWorkflow", workflow_path="/lib/shout.py", error_message="boom"
+        )
+
+        message = WorkflowNodeLoadProblem.collate_problems_for_display([problem])
+
+        assert "ShoutWorkflow" in message
+        assert "/lib/shout.py" in message
+        assert "boom" in message
+
+    def test_multiple_problems_are_listed_alphabetically(self) -> None:
+        problems = [
+            WorkflowNodeLoadProblem(node_type="Zed", workflow_path="/lib/z.py", error_message="z failed"),
+            WorkflowNodeLoadProblem(node_type="Alpha", workflow_path="/lib/a.py", error_message="a failed"),
+        ]
+
+        message = WorkflowNodeLoadProblem.collate_problems_for_display(problems)
+
+        assert message.index("Alpha") < message.index("Zed")
+        assert "Encountered 2 workflow-backed node failures" in message
+
+
+@pytest.mark.usefixtures("griptape_nodes")
+class TestSchemaDefaults:
+    def test_workflow_nodes_defaults_to_none(self) -> None:
+        schema = LibrarySchema(
+            name="TestLib",
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="Test", description="Test", library_version="1.0.0", engine_version="0.0.0", tags=[]
+            ),
+            categories=[],
+            nodes=[],
+        )
+
+        assert schema.workflow_nodes is None


### PR DESCRIPTION
This PR adds the ability to create nodes _from workflows_. Workflows with start/end flow nodes can be registered in the library json like so:

```json
  "workflow_nodes": [
    {
      "node_type": "UpscaleAndTag",
      "workflow_path": "workflows/upscale_and_tag.py",
      "metadata": {
        "category": "image",
        "description": "Upscales an image and tags it",
        "display_name": "Upscale and Tag"
      }
    }
  ],
```

And they'll show up rendered as regular ol' nodes. This opens up the ability for library authors abstract away complex workflows as re-usable nodes. When running, it spawns executes the workflow as a sub-flow.

<img width="436" height="433" alt="image" src="https://github.com/user-attachments/assets/3da38982-7c73-473d-b683-fdb916ab93ac" />
<img width="987" height="708" alt="image" src="https://github.com/user-attachments/assets/deed1061-3f84-4d38-bf2c-827b290258ce" />
<img width="1944" height="1169" alt="image" src="https://github.com/user-attachments/assets/1d6cbaea-9050-4c2e-9e9d-a4ec66b20860" />

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5275.org.readthedocs.build/en/5275/

<!-- readthedocs-preview griptape-nodes end -->