### PR TITLE
docs: document AdvancedNodeLibrary hooks and add a dynamic library example

### DIFF
--- a/docs/development/custom_nodes/advanced_libraries.md
+++ b/docs/development/custom_nodes/advanced_libraries.md
@@ -1,0 +1,324 @@
+# Advanced Libraries
+
+Most libraries are fully described by their `griptape_nodes_library.json` manifest: the
+engine reads it, imports the node modules it names, and registers those classes. An
+**advanced library** is an optional Python class that lets your library run code at four
+points in its own lifecycle: before its nodes load, after they load, before it is
+unregistered, and when the engine collects request handlers.
+
+This page is the author's reference for that class. For the manifest itself (metadata,
+categories, declarations, dependency management) see
+[Authoring Libraries](authoring_libraries.md).
+
+## Should I write one?
+
+**You don't need one if** your library is a fixed set of node classes in files you can
+list in the manifest. That is the common case and it needs no Python beyond the nodes.
+
+**Write one if** you need to:
+
+- **Acquire or release process-wide resources** at library load and unload: a GPU
+    context, a Python binding to a native SDK, a background thread, a connection pool.
+- **Register node types the manifest doesn't list**, because the set is data-driven or
+    generated. See
+    [Registering node types without listing them](#registering-node-types-without-listing-them-in-the-manifest).
+- **Serve a request type** your library owns, so other libraries and nodes can call into
+    it. See [`get_request_handlers`](#get_request_handlers).
+- **Register a competing provider** for an engine request type, such as a workflow
+    publisher. See [Publishing](../../guides/publishing.md).
+
+## Wiring one up
+
+Point the manifest at a Python file with `advanced_library_path`, relative to the
+manifest:
+
+```json
+{
+  "name": "My Library",
+  "advanced_library_path": "advanced_library.py",
+  "nodes": []
+}
+```
+
+Then subclass `AdvancedNodeLibrary` in that file and override only the hooks you need.
+Every hook has a default no-op implementation:
+
+```python
+from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+
+
+class MyLibrary(AdvancedNodeLibrary):
+    def after_library_nodes_loaded(self, library_data, library) -> None:
+        print(f"Loaded {len(library.get_registered_nodes())} nodes")
+```
+
+Three rules govern how the engine finds and builds your class. All three fail the whole
+library if broken, so they are worth knowing:
+
+- **The class must be defined in that file.** The engine scans the module for an
+    `AdvancedNodeLibrary` subclass whose `__module__` matches the module it just
+    imported. A subclass *imported* into the file is skipped. If you want the
+    implementation to live in a package, subclass it in the file the manifest names.
+- **The first match wins.** The engine takes the first qualifying subclass it finds in
+    module order and stops. Define exactly one to avoid ambiguity.
+- **`__init__` must take no required arguments.** The engine instantiates your class with
+    no arguments. Derive whatever state you need in `__init__` or in the hooks.
+
+If the module fails to import, contains no qualifying subclass, or cannot be
+instantiated, the library is marked `UNUSABLE`, registration fails, and the editor shows
+an `AdvancedLibraryLoadFailureProblem` carrying the underlying error.
+
+## The load sequence
+
+Understanding where each hook sits is the difference between a hook that works and one
+that silently does nothing. Registering a library runs, in order:
+
+| Step | What the engine does                                                |
+| ---- | ------------------------------------------------------------------- |
+| 1    | Parses and validates `griptape_nodes_library.json`                  |
+| 2    | Adds the library directory and its venv site-packages to `sys.path` |
+| 3    | Imports your advanced library module and instantiates your class    |
+| 4    | Registers the `Library` in the `LibraryRegistry`                    |
+| 5    | Persists any library settings the manifest declares                 |
+| 6    | **Calls `before_library_nodes_loaded`**                             |
+| 7    | Iterates `library_data.nodes`, registering each node type           |
+| 8    | Registers the manifest's widgets                                    |
+| 9    | **Calls `after_library_nodes_loaded`**                              |
+| 10   | **Calls `get_request_handlers`** and registers what it returns      |
+| 11   | Computes library fitness and marks the library `LOADED`             |
+
+Two consequences worth internalizing:
+
+- Your class exists (step 3) before the library is registered (step 4), so
+    `__init__` cannot look itself up in the `LibraryRegistry`.
+- Step 7 reads `library_data.nodes` *after* step 6 has run, which is what makes dynamic
+    registration possible.
+
+Unregistering runs in the reverse spirit:
+
+| Step | What the engine does                                             |
+| ---- | ---------------------------------------------------------------- |
+| 1    | **Calls `before_library_unregistered`**                          |
+| 2    | Removes the library's app event listeners and pre-dispatch hooks |
+| 3    | Removes the request handlers it registered                       |
+| 4    | Unregisters the library's widgets                                |
+| 5    | Removes the library from the `LibraryRegistry`                   |
+
+## The hooks
+
+### `before_library_nodes_loaded`
+
+```python
+def before_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None: ...
+```
+
+Runs after your library is registered but before any node type is. Use it to set up
+prerequisites that node imports depend on, or to add node definitions to
+`library_data.nodes`.
+
+`library_data` is the live `LibrarySchema` the `Library` holds, not a copy. Mutating it
+here changes what the engine loads in step 7 and what it reports afterwards.
+
+If this raises, the engine records a `BeforeLibraryCallbackProblem` and **continues
+loading**. The library ends up `FLAWED` rather than failed, so a broken hook produces a
+library whose nodes work but whose setup did not run. Do not rely on it having succeeded.
+
+### `after_library_nodes_loaded`
+
+```python
+def after_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None: ...
+```
+
+Runs once every node type in the manifest is registered. At this point
+`library.get_registered_nodes()` returns the full list, so this is the place for work
+that needs to see the finished library.
+
+This is also where you register competing-provider event handlers via
+`LibraryManager.on_register_event_handler()`, which is how a library advertises itself as
+a workflow publisher.
+
+Errors are handled the same way as the before hook: an `AfterLibraryCallbackProblem` is
+recorded and loading continues.
+
+### `before_library_unregistered`
+
+```python
+def before_library_unregistered(self, library_data: LibrarySchema, library: Library) -> None: ...
+```
+
+Runs before the engine tears anything down, so your listeners and handlers are still
+registered while it executes. Use it to release what you acquired at load: native
+bindings, GPU contexts, background threads, connection pools.
+
+Errors here are **logged and swallowed**. Unregistration continues regardless, so a
+failing teardown cannot wedge the engine. The flip side is that a resource you fail to
+release is leaked silently.
+
+### `get_request_handlers`
+
+```python
+def get_request_handlers(self) -> list[tuple[type[RequestPayload], Callable]]: ...
+```
+
+Returns `(request_type, handler)` pairs the engine registers on your behalf, and
+deregisters automatically when your library unloads. Both sync and async handlers work.
+
+```python
+def get_request_handlers(self):
+    return [
+        (ConvertColorspaceRequest, self._handle_convert_colorspace),
+    ]
+```
+
+Constraints:
+
+- **Your library must own the request type.** Define the `RequestPayload` subclass in
+    your own package.
+- **One handler per request type, engine-wide.** Registering a type that already has a
+    handler raises, surfaced as a `RequestHandlerRegistrationProblem`. For request types
+    where several libraries compete and the caller picks one by name, use
+    `LibraryManager.on_register_event_handler()` in `after_library_nodes_loaded` instead.
+- **Orchestrator only.** A library running isolated in a worker subprocess registers its
+    handlers in that worker, where the orchestrator cannot reach them. Requests fail with
+    "No manager found". The engine flags this combination with a
+    `RequestHandlersWorkerIncompatibleProblem` at load. See
+    [Node Isolation with Workers](node_isolation_with_workers.md).
+
+Other code can discover what a loaded library exposes with
+`library.get_registered_request_handler_types()`, then inspect each type with
+`dataclasses.fields()` and `typing.get_type_hints()`.
+
+## Registering node types without listing them in the manifest
+
+If your node set is data-driven, generated, or simply large enough that hand-maintaining
+the manifest is a chore, you can leave `"nodes": []` in the manifest and synthesize the
+definitions in `before_library_nodes_loaded`.
+
+This works because of step 6 and step 7 in [the load sequence](#the-load-sequence): the
+hook runs first, `library_data` is the same object the engine reads next, and
+`library_data.nodes` is an ordinary list.
+
+```python
+class MyLibrary(AdvancedNodeLibrary):
+    def before_library_nodes_loaded(self, library_data, library) -> None:
+        library_data.nodes.extend(
+            NodeDefinition(
+                class_name=spec["class_name"],
+                file_path="generated_nodes.py",
+                metadata=NodeMetadata(
+                    category="dynamic",
+                    description=spec["description"],
+                    display_name=spec["display_name"],
+                ),
+            )
+            for spec in load_specs()
+        )
+```
+
+Nothing the editor reads comes from the manifest's `nodes` list. `ListNodeTypesInLibrary`
+and `GetAllInfoForLibrary` both read the in-memory `Library`, so synthesized node types
+appear in the node palette exactly like declared ones. Categories are still read from the
+manifest, so declare every category you intend to synthesize into. Nothing validates a
+node's category against the declared keys, so a mismatch fails quietly: the node type
+registers fine, but the editor has no category to file it under.
+
+Definitions added this way are indistinguishable from hand-written ones, which means they
+inherit the loader's behavior: lazy module loading, one memoized import per file even
+when many classes share it, stable-namespace aliasing so saved workflows can unpickle
+values your classes define, per-node problem reporting, and correct fitness.
+
+### Where the classes come from
+
+The engine resolves a node type by importing the file in `NodeDefinition.file_path` and
+calling `getattr(module, class_name)`. A module-level `__getattr__`
+([PEP 562](https://peps.python.org/pep-0562/)) satisfies that, so one file can back every
+node type in the library without a single `class` statement:
+
+```python
+def __getattr__(name: str) -> type[DataNode]:
+    spec = find_spec(name)
+    if spec is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    node_class = build_node_class(spec)
+    globals()[name] = node_class  # cache: next lookup skips __getattr__
+    return node_class
+```
+
+Cache the built class in module globals. Two lookups of the same node type must return
+the same object, because the engine caches the resolved class, `isinstance` checks
+compare against it, and pickles reference it.
+
+!!! warning "Set `__module__` explicitly when you build a class"
+
+    `type(name, bases, namespace)` does not give you the current module for free. With
+    no `__module__` key in the namespace, class creation reads `__name__` from the
+    calling frame's globals. Because `BaseNode` subclasses carry `ABCMeta`, that frame
+    is inside the standard library's `abc` module, and your class ends up claiming
+    `__module__ == "abc"`.
+
+    Nothing complains at load time. The failure appears later: unpickling a saved
+    workflow imports `__module__` and looks up `__qualname__` on it, so any workflow
+    carrying a value your class defines will fail to reopen. Pass both explicitly:
+
+    ```python
+    return type(
+        spec["class_name"],
+        (DataNode,),
+        {
+            "__init__": __init__,
+            "process": process,
+            "__module__": __name__,
+            "__qualname__": spec["class_name"],
+        },
+    )
+    ```
+
+### Why not register classes directly?
+
+`Library.register_new_node_type()` and `Library.register_lazy_node_type()` are public,
+and calling them from `after_library_nodes_loaded` also registers working node types.
+Prefer synthesizing definitions anyway, for two reasons:
+
+- **Fitness.** The engine decides whether a library loaded successfully from the
+    manifest-driven loop in step 7. A library with `"nodes": []` that registers
+    everything in the after hook is scored `UNUSABLE` and its registration is reported as
+    a failure, even though the node types registered fine.
+- **Stable namespaces.** The loader also registers a pending stable-module loader so
+    `griptape_nodes.node_libraries.<library>.<file>` resolves when a saved workflow
+    reopens. Registering a class directly skips that, and you own the problem.
+
+### Limitations
+
+- **Isolated (worker) libraries are not supported.** When a library runs in a worker
+    subprocess, the orchestrator rebuilds stub classes from schemas the worker sends
+    back, and it resolves each stub's metadata from the manifest's `nodes` list. Node
+    types that exist only in the worker's registry are dropped with a warning. Keep
+    dynamically registered libraries in the orchestrator, or list their nodes in the
+    manifest.
+- **Declaration validation only sees the manifest.** Validation of `model_usage` and
+    `model_provider_usage` references runs against the manifest read from disk, so those
+    declarations on synthesized nodes are never checked. A bad model reference fails at
+    runtime instead of at load.
+- **Node name collisions still apply.** Synthesized class names go through the same
+    cross-library collision check as declared ones, and generated names collide just as
+    easily. Prefix them.
+
+## Example library
+
+A complete, working library that registers four node types from a JSON file while
+declaring none in its manifest:
+
+- [`griptape_nodes_library.json`](example_dynamic_library/griptape_nodes_library.json):
+    manifest with `"nodes": []` and one declared category
+- [`node_specs.json`](example_dynamic_library/node_specs.json): the data the node set is
+    derived from
+- [`advanced_library.py`](example_dynamic_library/advanced_library.py): synthesizes one
+    `NodeDefinition` per spec in `before_library_nodes_loaded`
+- [`generated_nodes.py`](example_dynamic_library/generated_nodes.py): module
+    `__getattr__` that builds each `DataNode` subclass on demand
+
+Copy the folder into your workspace's `libraries` directory, register it through the
+editor's library settings, and restart the engine. You should see a **Dynamic** category
+with four nodes. Add an entry to `node_specs.json` reusing an existing `operator` value,
+restart, and a fifth node appears with no change to the manifest or the Python.

--- a/docs/development/custom_nodes/advanced_libraries.md
+++ b/docs/development/custom_nodes/advanced_libraries.md
@@ -162,15 +162,82 @@ def get_request_handlers(self) -> list[tuple[type[RequestPayload], Callable]]: .
 
 Returns `(request_type, handler)` pairs the engine registers on your behalf, and
 deregisters automatically when your library unloads. Both sync and async handlers work.
+This is how a library exposes a service its own nodes, other libraries, and external
+clients can all call.
+
+There are three pieces to build. See
+[the worked example](#example-a-library-that-serves-a-request-type) for all of them in
+context.
+
+**1. Define the payloads.** A request type and at least one result type, each a dataclass
+registered with `PayloadRegistry` so it can be resolved by name over the WebSocket and
+MCP surfaces:
 
 ```python
-def get_request_handlers(self):
-    return [
-        (ConvertColorspaceRequest, self._handle_convert_colorspace),
-    ]
+@dataclass
+@PayloadRegistry.register
+class ConvertColorspaceRequest(RequestPayload):
+    color: tuple[float, float, float]
+    source: str
+    target: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ConvertColorspaceResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    color: tuple[float, float, float]
+
+
+@dataclass
+@PayloadRegistry.register
+class ConvertColorspaceResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    pass
 ```
 
-Constraints:
+Put them in their own module that both your advanced library and your nodes import. The
+library directory is on `sys.path` by the time either loads, so a plain
+`import colorspace_events` resolves, and both files get the same module object and
+therefore the same payload classes. Give that module a distinctive name: every library
+directory lands on the same `sys.path`, so `events.py` risks resolving to another
+library's file.
+
+**2. Return the pair from the hook.**
+
+```python
+def get_request_handlers(self) -> list[tuple[type[RequestPayload], Callable]]:
+    return [(ConvertColorspaceRequest, self._handle_convert_colorspace)]
+```
+
+Annotate the return with a bare `Callable`. The base class declares
+`Callable[[RequestPayload], ResultPayload]`, and a handler annotated with your concrete
+request type is not assignable to that, because parameter types are contravariant.
+Keeping the handler's own annotation precise is worth more than matching the base
+signature exactly.
+
+**3. Dispatch it.** Any caller in the orchestrator process sends the request through the
+normal bus and gets your result back:
+
+```python
+result = GriptapeNodes.handle_request(ConvertColorspaceRequest(color=(1.0, 0.0, 0.0), source="rgb", target="hsv"))
+if result.failed():
+    msg = f"Attempted to convert a color in '{self.name}'. Failed because {result.result_details}"
+    raise RuntimeError(msg)
+
+success = cast("ConvertColorspaceResultSuccess", result)
+```
+
+Two rules for callers:
+
+- **Dispatch from `process`, never from `__init__`.** A node constructor that sends a
+    request trips the `reentrant-bus-in-init` strict-mode rule, and it can deadlock
+    against handlers that await engine startup. See
+    [Strict Mode Reference](strict_mode.md).
+- **Always handle failure.** The providing library might not be installed, might have
+    failed to load, or might have been unloaded. In those cases the request has no handler
+    at all, and the engine returns a generic failure result rather than your library's
+    failure type. Check `result.failed()` before narrowing to your success type.
+
+Constraints on the mechanism:
 
 - **Your library must own the request type.** Define the `RequestPayload` subclass in
     your own package.
@@ -304,10 +371,33 @@ Prefer synthesizing definitions anyway, for two reasons:
     cross-library collision check as declared ones, and generated names collide just as
     easily. Prefix them.
 
-## Example library
+## Examples
 
-A complete, working library that registers four node types from a JSON file while
-declaring none in its manifest:
+Two complete, working libraries. Copy either folder into your workspace's `libraries`
+directory, register it through the editor's library settings, and restart the engine.
+
+### Example: a library that serves a request type
+
+A library that owns `ConvertColorspaceRequest`, serves it from its advanced library, and
+consumes it from its own node:
+
+- [`griptape_nodes_library.json`](example_request_handler_library/griptape_nodes_library.json):
+    manifest declaring one node and the advanced library
+- [`colorspace_events.py`](example_request_handler_library/colorspace_events.py): the
+    request and result payloads, registered with `PayloadRegistry`
+- [`advanced_library.py`](example_request_handler_library/advanced_library.py): returns the
+    handler from `get_request_handlers` and implements it
+- [`nodes.py`](example_request_handler_library/nodes.py): a node that dispatches the
+    request from `process()` and handles failure
+
+Add a **Convert Colorspace** node, set `color` to `[0, 0.5, 1]` with `source` `rgb` and
+`target` `hsv`, and run it. Any other library in the same engine can now send
+`ConvertColorspaceRequest` and get the same answer.
+
+### Example: a library that registers node types dynamically
+
+A library that registers four node types from a JSON file while declaring none in its
+manifest:
 
 - [`griptape_nodes_library.json`](example_dynamic_library/griptape_nodes_library.json):
     manifest with `"nodes": []` and one declared category
@@ -318,7 +408,6 @@ declaring none in its manifest:
 - [`generated_nodes.py`](example_dynamic_library/generated_nodes.py): module
     `__getattr__` that builds each `DataNode` subclass on demand
 
-Copy the folder into your workspace's `libraries` directory, register it through the
-editor's library settings, and restart the engine. You should see a **Dynamic** category
-with four nodes. Add an entry to `node_specs.json` reusing an existing `operator` value,
-restart, and a fifth node appears with no change to the manifest or the Python.
+You should see a **Dynamic** category with four nodes. Add an entry to `node_specs.json`
+reusing an existing `operator` value, restart, and a fifth node appears with no change to
+the manifest or the Python.

--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -99,6 +99,7 @@ Bundle nodes into libraries for sharing. Create `griptape_nodes_library.json`:
 - **widgets**: Register custom JS widget components (see [Custom Widgets](custom_widgets.md))
 - **categories**: Group nodes in UI with colors and icons
 - **nodes**: List node classes, file paths, and metadata
+- **advanced_library_path**: Optional Python file declaring an `AdvancedNodeLibrary` subclass, for libraries that need to run code at load and unload, own a request type, or register node types the manifest does not list (see [Advanced Libraries](advanced_libraries.md))
 - **workflows**: Template workflow files
 
 **Important:** The `secrets_to_register` array tells the system which secrets your library needs. Users will be prompted to configure these secrets through the UI or environment variables.

--- a/docs/development/custom_nodes/example_dynamic_library/advanced_library.py
+++ b/docs/development/custom_nodes/example_dynamic_library/advanced_library.py
@@ -1,0 +1,68 @@
+"""Advanced library that synthesizes this library's node definitions at load time.
+
+`griptape_nodes_library.json` declares `"nodes": []`. Every node type this library
+offers is described in `node_specs.json` instead, and this module turns those
+descriptions into `NodeDefinition` objects during `before_library_nodes_loaded`.
+
+The engine calls that hook before it iterates `library_data.nodes`, and `library_data`
+is the same object the `Library` holds, so definitions appended here go through the
+engine's normal node loader. See the Advanced Libraries guide for the full explanation
+and for the limitations of this pattern.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+from griptape_nodes.node_library.library_registry import NodeDefinition, NodeMetadata
+
+if TYPE_CHECKING:
+    from griptape_nodes.node_library.library_registry import Library, LibrarySchema
+
+# Category key declared in griptape_nodes_library.json's `categories`.
+CATEGORY = "dynamic"
+
+# Every synthesized definition points at this one module. The engine resolves a node
+# class with `getattr(module, class_name)`, and that module's `__getattr__` manufactures
+# the class on demand.
+FACTORY_FILE = "generated_nodes.py"
+
+SPEC_FILE = Path(__file__).parent / "node_specs.json"
+
+
+def load_operation_specs() -> list[dict[str, Any]]:
+    """Read the node descriptions this library builds its node types from.
+
+    `generated_nodes.py` reads the same file with its own copy of this function rather
+    than importing it from here. The engine loads each library file as a standalone
+    module under a mangled name, so importing a sibling by module name would produce a
+    second module object for the same file, which breaks `isinstance` checks and pickling.
+    """
+    return json.loads(SPEC_FILE.read_text())["operations"]
+
+
+class DynamicNodesDemoLibrary(AdvancedNodeLibrary):
+    """Registers one node type per entry in `node_specs.json`.
+
+    The engine instantiates this class with no arguments, so any state it needs must be
+    derived here or in the hooks.
+    """
+
+    def before_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:  # noqa: ARG002
+        """Append one NodeDefinition per operation spec, before the engine's loader runs."""
+        library_data.nodes.extend(
+            NodeDefinition(
+                class_name=spec["class_name"],
+                file_path=FACTORY_FILE,
+                metadata=NodeMetadata(
+                    category=CATEGORY,
+                    description=spec["description"],
+                    display_name=spec["display_name"],
+                    icon="Sigma",
+                ),
+            )
+            for spec in load_operation_specs()
+        )

--- a/docs/development/custom_nodes/example_dynamic_library/generated_nodes.py
+++ b/docs/development/custom_nodes/example_dynamic_library/generated_nodes.py
@@ -1,0 +1,129 @@
+"""Manufactures this library's node classes on demand.
+
+The engine resolves a registered node type by importing the file named in its
+`NodeDefinition.file_path` and calling `getattr(module, class_name)`. A module-level
+`__getattr__` (PEP 562) is enough to satisfy that, so this one file backs every node
+type in the library without declaring any of them as a `class` statement.
+
+Classes are built on first lookup and cached in module globals, so repeated lookups
+return the same object. That identity matters: the engine caches the resolved class
+per node type, `isinstance` checks compare against it, and pickled parameter values
+in saved workflows reference it by `__module__` + `__qualname__`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+SPEC_FILE = Path(__file__).parent / "node_specs.json"
+
+
+def load_operation_specs() -> list[dict[str, Any]]:
+    """Read the node descriptions this module builds classes from.
+
+    Deliberately duplicated from `advanced_library.py` instead of imported: the engine
+    loads each library file as a standalone module under a mangled name, so importing a
+    sibling by module name would create a second module object for the same file.
+    """
+    return json.loads(SPEC_FILE.read_text())["operations"]
+
+
+def _apply_operation(operator: str, a: float, b: float, node_name: str) -> float:
+    if operator == "add":
+        return a + b
+    if operator == "subtract":
+        return a - b
+    if operator == "multiply":
+        return a * b
+    if operator == "divide":
+        if b == 0:
+            msg = f"Attempted to divide by zero in '{node_name}'. Failed because the 'b' input is 0. Set 'b' to any non-zero number."
+            raise ValueError(msg)
+        return a / b
+    msg = f"Attempted to run '{node_name}'. Failed because its operation '{operator}' is not one this library knows how to perform."
+    raise ValueError(msg)
+
+
+def _build_node_class(spec: dict[str, Any]) -> type[DataNode]:
+    """Build a DataNode subclass for one operation spec."""
+    operator = spec["operator"]
+    symbol = spec["symbol"]
+
+    def __init__(self: DataNode, name: str, metadata: dict | None = None) -> None:
+        DataNode.__init__(self, name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="a",
+                tooltip=f"Left operand of a {symbol} b",
+                type="float",
+                default_value=0.0,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="b",
+                tooltip=f"Right operand of a {symbol} b",
+                type="float",
+                default_value=0.0,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="result",
+                tooltip=f"Result of a {symbol} b",
+                type="float",
+                default_value=0.0,
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+            )
+        )
+
+    def process(self: DataNode) -> None:
+        a = float(self.get_parameter_value("a") or 0.0)
+        b = float(self.get_parameter_value("b") or 0.0)
+        self.parameter_output_values["result"] = _apply_operation(operator, a, b, self.name)
+
+    return type(
+        spec["class_name"],
+        (DataNode,),
+        {
+            "__init__": __init__,
+            "process": process,
+            "__doc__": f"{spec['description']} Synthesized from node_specs.json.",
+            # Set both explicitly. Without `__module__` in this namespace, class creation
+            # reads `__name__` from the calling frame's globals, and because DataNode carries
+            # ABCMeta that frame is inside the stdlib `abc` module -- the class would claim
+            # `__module__ == "abc"`. Pickled parameter values in saved workflows are restored
+            # by importing `__module__` and looking up `__qualname__` on it, so a wrong
+            # `__module__` breaks reopening any workflow that carries such a value. Pointing
+            # at this module routes that lookup back through `__getattr__`, and the engine
+            # registers a stable-namespace alias for this file so it resolves across sessions.
+            "__module__": __name__,
+            "__qualname__": spec["class_name"],
+        },
+    )
+
+
+def __getattr__(name: str) -> type[DataNode]:
+    """Build and cache the node class named `name`, or raise AttributeError."""
+    spec = next((s for s in load_operation_specs() if s["class_name"] == name), None)
+    if spec is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+
+    node_class = _build_node_class(spec)
+    # Cache in module globals so the next lookup bypasses __getattr__ entirely and
+    # every caller shares one class object.
+    globals()[name] = node_class
+    return node_class
+
+
+def __dir__() -> list[str]:
+    """Report the synthesized class names so `dir()` and tab-completion see them."""
+    return sorted({*globals(), *(spec["class_name"] for spec in load_operation_specs())})

--- a/docs/development/custom_nodes/example_dynamic_library/griptape_nodes_library.json
+++ b/docs/development/custom_nodes/example_dynamic_library/griptape_nodes_library.json
@@ -1,0 +1,23 @@
+{
+  "name": "Dynamic Nodes Demo",
+  "library_schema_version": "0.10.0",
+  "metadata": {
+    "author": "Griptape",
+    "description": "Demonstrates registering node types without enumerating them in this file. The 'nodes' list is empty; the advanced library synthesizes one NodeDefinition per entry in node_specs.json before the engine's loader runs.",
+    "library_version": "0.1.0",
+    "engine_version": "0.97.0",
+    "tags": ["demo", "dynamic"]
+  },
+  "categories": [
+    {
+      "dynamic": {
+        "title": "Dynamic",
+        "description": "Node types synthesized at library load time",
+        "color": "border-purple-500",
+        "icon": "Sparkles"
+      }
+    }
+  ],
+  "advanced_library_path": "advanced_library.py",
+  "nodes": []
+}

--- a/docs/development/custom_nodes/example_dynamic_library/node_specs.json
+++ b/docs/development/custom_nodes/example_dynamic_library/node_specs.json
@@ -1,0 +1,32 @@
+{
+  "operations": [
+    {
+      "class_name": "DynamicAddNode",
+      "display_name": "Dynamic Add",
+      "description": "Adds two numbers. Class synthesized at runtime.",
+      "operator": "add",
+      "symbol": "+"
+    },
+    {
+      "class_name": "DynamicSubtractNode",
+      "display_name": "Dynamic Subtract",
+      "description": "Subtracts b from a. Class synthesized at runtime.",
+      "operator": "subtract",
+      "symbol": "-"
+    },
+    {
+      "class_name": "DynamicMultiplyNode",
+      "display_name": "Dynamic Multiply",
+      "description": "Multiplies two numbers. Class synthesized at runtime.",
+      "operator": "multiply",
+      "symbol": "*"
+    },
+    {
+      "class_name": "DynamicDivideNode",
+      "display_name": "Dynamic Divide",
+      "description": "Divides a by b. Class synthesized at runtime.",
+      "operator": "divide",
+      "symbol": "/"
+    }
+  ]
+}

--- a/docs/development/custom_nodes/example_request_handler_library/advanced_library.py
+++ b/docs/development/custom_nodes/example_request_handler_library/advanced_library.py
@@ -1,0 +1,83 @@
+"""Advanced library that serves this library's `ConvertColorspaceRequest`.
+
+The engine calls `get_request_handlers()` after this library's nodes are loaded,
+registers each returned pair with the event bus, and deregisters them automatically
+when the library is unloaded. From then on any caller in the orchestrator process can
+dispatch `ConvertColorspaceRequest` and reach `_handle_convert_colorspace`.
+"""
+
+from __future__ import annotations
+
+import colorsys
+from typing import TYPE_CHECKING
+
+from colorspace_events import (
+    HSV,
+    RGB,
+    ConvertColorspaceRequest,
+    ConvertColorspaceResultFailure,
+    ConvertColorspaceResultSuccess,
+)
+
+from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+SUPPORTED = (RGB, HSV)
+
+
+class ColorspaceServiceLibrary(AdvancedNodeLibrary):
+    def get_request_handlers(self) -> list[tuple[type[RequestPayload], Callable]]:
+        """Declare the request types this library serves.
+
+        The return type uses a bare `Callable` on purpose. The base class declares
+        `Callable[[RequestPayload], ResultPayload]`, and a handler annotated with a
+        concrete request type is not assignable to that because parameter types are
+        contravariant. Keeping the handler's own annotation precise is worth more than
+        matching the base signature exactly.
+        """
+        return [(ConvertColorspaceRequest, self._handle_convert_colorspace)]
+
+    def _handle_convert_colorspace(self, request: ConvertColorspaceRequest) -> ResultPayload:
+        """Convert between RGB and HSV.
+
+        Validation first, success path last: every failure returns immediately with a
+        message an artist can act on.
+        """
+        if request.source not in SUPPORTED:
+            return ConvertColorspaceResultFailure(
+                result_details=(
+                    f"Attempted to convert a color from '{request.source}'. Failed because that "
+                    f"colorspace is not supported. Supported colorspaces: {', '.join(SUPPORTED)}."
+                )
+            )
+        if request.target not in SUPPORTED:
+            return ConvertColorspaceResultFailure(
+                result_details=(
+                    f"Attempted to convert a color to '{request.target}'. Failed because that "
+                    f"colorspace is not supported. Supported colorspaces: {', '.join(SUPPORTED)}."
+                )
+            )
+        if len(request.color) != len(("h", "s", "v")):
+            return ConvertColorspaceResultFailure(
+                result_details=(
+                    f"Attempted to convert a color with {len(request.color)} channels. Failed "
+                    f"because a color must have exactly 3 channels."
+                )
+            )
+
+        first, second, third = request.color
+        if request.source == request.target:
+            converted = (first, second, third)
+        elif request.target == HSV:
+            converted = colorsys.rgb_to_hsv(first, second, third)
+        else:
+            converted = colorsys.hsv_to_rgb(first, second, third)
+
+        return ConvertColorspaceResultSuccess(
+            color=converted,
+            result_details=f"Converted a color from {request.source} to {request.target}.",
+        )

--- a/docs/development/custom_nodes/example_request_handler_library/colorspace_events.py
+++ b/docs/development/custom_nodes/example_request_handler_library/colorspace_events.py
@@ -1,0 +1,62 @@
+"""Request and result payloads this library owns.
+
+Both `advanced_library.py` (which serves the request) and `nodes.py` (which sends it)
+import this module, so the payload classes they use are the same objects. The library
+directory is on `sys.path` by the time either file loads, which makes the plain
+`import colorspace_events` work.
+
+Give this file a distinctive name. Every library directory lands on the same `sys.path`,
+so a generic name like `events.py` risks resolving to a different library's file.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+# Colorspaces this library knows how to convert between.
+RGB = "rgb"
+HSV = "hsv"
+
+
+@dataclass
+@PayloadRegistry.register
+class ConvertColorspaceRequest(RequestPayload):
+    """Convert a color between this library's supported colorspaces.
+
+    Args:
+        color: Three channel values in 0.0-1.0.
+        source: Colorspace `color` is currently in ("rgb" or "hsv").
+        target: Colorspace to convert to ("rgb" or "hsv").
+
+    Results: ConvertColorspaceResultSuccess | ConvertColorspaceResultFailure
+    """
+
+    color: tuple[float, float, float]
+    source: str
+    target: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ConvertColorspaceResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Color converted successfully.
+
+    Args:
+        color: The converted three channel values in 0.0-1.0.
+    """
+
+    color: tuple[float, float, float]
+
+
+@dataclass
+@PayloadRegistry.register
+class ConvertColorspaceResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Conversion could not be performed."""

--- a/docs/development/custom_nodes/example_request_handler_library/griptape_nodes_library.json
+++ b/docs/development/custom_nodes/example_request_handler_library/griptape_nodes_library.json
@@ -1,0 +1,33 @@
+{
+  "name": "Colorspace Service Demo",
+  "library_schema_version": "0.10.0",
+  "metadata": {
+    "author": "Griptape",
+    "description": "Demonstrates a library that owns a request type and serves it to its own nodes and to other libraries.",
+    "library_version": "0.1.0",
+    "engine_version": "0.97.0",
+    "tags": ["demo", "request-handler"]
+  },
+  "categories": [
+    {
+      "color": {
+        "title": "Color",
+        "description": "Colorspace conversion",
+        "color": "border-teal-500",
+        "icon": "Palette"
+      }
+    }
+  ],
+  "advanced_library_path": "advanced_library.py",
+  "nodes": [
+    {
+      "class_name": "ConvertColorspaceNode",
+      "file_path": "nodes.py",
+      "metadata": {
+        "category": "color",
+        "description": "Converts a color between RGB and HSV by calling this library's own request handler.",
+        "display_name": "Convert Colorspace"
+      }
+    }
+  ]
+}

--- a/docs/development/custom_nodes/example_request_handler_library/nodes.py
+++ b/docs/development/custom_nodes/example_request_handler_library/nodes.py
@@ -1,0 +1,83 @@
+"""A node that consumes its own library's request handler.
+
+Dispatch from `process()`, never from `__init__`. A node constructor that sends a request
+trips the `reentrant-bus-in-init` strict-mode rule, and it can deadlock against handlers
+that await engine startup.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from colorspace_events import (
+    HSV,
+    RGB,
+    ConvertColorspaceRequest,
+    ConvertColorspaceResultSuccess,
+)
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.options import Options
+
+
+class ConvertColorspaceNode(DataNode):
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="color",
+                tooltip="Three channel values in 0.0-1.0",
+                type="list",
+                default_value=[1.0, 0.0, 0.0],
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="source",
+                tooltip="Colorspace the input color is in",
+                type="str",
+                default_value=RGB,
+                traits={Options(choices=[RGB, HSV])},
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="target",
+                tooltip="Colorspace to convert to",
+                type="str",
+                default_value=HSV,
+                traits={Options(choices=[RGB, HSV])},
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="converted",
+                tooltip="The converted color",
+                type="list",
+                default_value=[0.0, 0.0, 0.0],
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+            )
+        )
+
+    def process(self) -> None:
+        color = self.get_parameter_value("color")
+        request = ConvertColorspaceRequest(
+            color=tuple(color),
+            source=self.get_parameter_value("source"),
+            target=self.get_parameter_value("target"),
+        )
+        result = GriptapeNodes.handle_request(request)
+
+        # Always handle failure. The providing library may not be loaded at all, in which
+        # case the engine returns a generic failure rather than this library's own.
+        if result.failed():
+            msg = f"Attempted to convert a color in '{self.name}'. Failed because {result.result_details}"
+            raise RuntimeError(msg)
+
+        success = cast("ConvertColorspaceResultSuccess", result)
+        self.parameter_output_values["converted"] = list(success.color)

--- a/docs/development/custom_nodes/index.md
+++ b/docs/development/custom_nodes/index.md
@@ -106,6 +106,7 @@ class MyNode(DataNode):
 - **[Working with the Project System](project_system.md)** — Saving files through situations, macros, and `ProjectFileParameter`
 - **[Best Practices and Error Handling](error_handling.md)** — Secrets, imports, parameter payload size, validation, error handling, and logging
 - **[Authoring Libraries](authoring_libraries.md)** — Library manifests, declarations, dependency management, and contributing to the standard library
+- **[Advanced Libraries](advanced_libraries.md)** — `AdvancedNodeLibrary` lifecycle hooks, library-owned request handlers, and registering node types without listing them in the manifest
 - **[Custom Widgets](custom_widgets.md)** — Custom JavaScript widget components and the widget testbed
 - **[Patterns and Examples](examples.md)** — Advanced patterns from production nodes and quick-reference material
 - **[Node Isolation with Workers](node_isolation_with_workers.md)** — Running a library isolated in a worker subprocess

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ plugins:
           - development/custom_nodes/project_system.md: Saving files from nodes through the project system (situations, macros, ProjectFileParameter)
           - development/custom_nodes/error_handling.md: Best practices for secrets, imports, parameter payload size, validation, error handling, and logging
           - development/custom_nodes/authoring_libraries.md: Library manifests, declarations, dependency management, and contributing to the standard library
+          - development/custom_nodes/advanced_libraries.md: AdvancedNodeLibrary lifecycle hooks, library-owned request handlers, and registering node types without listing them in the manifest
           - development/custom_nodes/custom_widgets.md: Custom JavaScript widget components and the widget testbed
           - development/custom_nodes/examples.md: Advanced patterns from production nodes and quick-reference material
           - development/custom_nodes/node_isolation_with_workers.md: Running a library isolated in a worker subprocess for dependency isolation
@@ -545,6 +546,7 @@ nav:
           - Project System: development/custom_nodes/project_system.md
           - Best Practices and Error Handling: development/custom_nodes/error_handling.md
           - Authoring Libraries: development/custom_nodes/authoring_libraries.md
+          - Advanced Libraries: development/custom_nodes/advanced_libraries.md
           - Custom Widgets: development/custom_nodes/custom_widgets.md
           - Patterns and Examples: development/custom_nodes/examples.md
           - Node Isolation with Workers: development/custom_nodes/node_isolation_with_workers.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,12 @@ ignore = [
 "tests/*" = ["S101", "D104", "TID251"]
 "libraries/**/tests/**" = ["S101", "D104", "INP001"]
 "src/griptape_nodes/retained_mode/events/*" = ["TC001"]
+# Example library shipped with the Advanced Libraries doc. Authors copy these files
+# verbatim, so the exemptions live here rather than as noqa noise in the example.
+# INP001: a docs folder is not an importable package.
+# N807: the dunder-named locals are the point -- module-level `__getattr__` is PEP 562,
+# and the `__init__` built inside the class factory has to be named `__init__`.
+"docs/development/custom_nodes/example_dynamic_library/**" = ["INP001", "N807"]
 
 # TID251 allowlist for the GriptapeNodes facade. Two groups, and the difference matters.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,12 +135,15 @@ ignore = [
 "tests/*" = ["S101", "D104", "TID251"]
 "libraries/**/tests/**" = ["S101", "D104", "INP001"]
 "src/griptape_nodes/retained_mode/events/*" = ["TC001"]
-# Example library shipped with the Advanced Libraries doc. Authors copy these files
-# verbatim, so the exemptions live here rather than as noqa noise in the example.
+# Example libraries shipped with the Advanced Libraries doc. Authors copy these files
+# verbatim, so the exemptions live here rather than as noqa noise in the examples.
 # INP001: a docs folder is not an importable package.
 # N807: the dunder-named locals are the point -- module-level `__getattr__` is PEP 562,
 # and the `__init__` built inside the class factory has to be named `__init__`.
+# TID251: node libraries are the intended audience for the GriptapeNodes facade, as the
+# ban message itself says.
 "docs/development/custom_nodes/example_dynamic_library/**" = ["INP001", "N807"]
+"docs/development/custom_nodes/example_request_handler_library/**" = ["INP001", "TID251"]
 
 # TID251 allowlist for the GriptapeNodes facade. Two groups, and the difference matters.
 #


### PR DESCRIPTION
Document the advanced node library hooks and add a couple use-cases (runtime generated nodes, library registered request handler).

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5276.org.readthedocs.build/en/5276/

<!-- readthedocs-preview griptape-nodes end -->