### PR TITLE
Fix library dependency init for workers

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2396,7 +2396,7 @@ class LibraryManager(EngineScoped):
                                 "orchestrator; the worker loads it in its own process.",
                                 library_data.name,
                             )
-                        if library_data.advanced_library_path and not skip_advanced_library:
+                        elif library_data.advanced_library_path:
                             try:
                                 advanced_library_instance = self._load_advanced_library_module(
                                     library_data=library_data,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2055,11 +2055,23 @@ class LibraryManager(EngineScoped):
 
                 library_name = metadata_result.library_schema.name
 
+                # Entering METADATA_LOADED directly, so the DISCOVERED-phase writer that
+                # normally resolves requires_worker never runs for this registration.
+                # Resolve it here too, or a library whose manifest suggests worker mode
+                # loads in-process when registered by file path (e.g. added to a running
+                # engine from the editor) -- its advanced module would then import in the
+                # orchestrator without the worker-managed dependency environment.
+                requires_worker = self._resolve_requires_worker(
+                    lib_info.registered_path if lib_info else None,
+                    metadata_result.library_schema.metadata.declarations,
+                )
+
                 # Update or create LibraryInfo
                 if lib_info:
                     lib_info.library_name = library_name
                     lib_info.library_version = metadata_result.library_schema.metadata.library_version
                     lib_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
+                    lib_info.requires_worker = requires_worker
                 else:
                     # Create new LibraryInfo since it doesn't exist yet
                     lib_info = LibraryManager.LibraryInfo(
@@ -2070,6 +2082,7 @@ class LibraryManager(EngineScoped):
                         library_version=metadata_result.library_schema.metadata.library_version,
                         fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
                         problems=[],
+                        requires_worker=requires_worker,
                     )
                     self._library_file_path_to_info[file_path] = lib_info
             else:
@@ -2364,9 +2377,26 @@ class LibraryManager(EngineScoped):
                         # Add library directory and venv site-packages to sys.path
                         await self._add_library_paths_to_sys_path(library_data.name, file_path, base_dir)
 
-                        # Load the advanced library module if specified
+                        # Load the advanced library module if specified. Worker-delegated
+                        # libraries skip this on the orchestrator, mirroring the venv/pip and
+                        # node-import skips above and below: the module executes in this
+                        # process, its third-party imports resolve against the library venv,
+                        # and the orchestrator deliberately never created that venv -- so any
+                        # manifest dependency it imports would raise ModuleNotFoundError and
+                        # kill the registration. Nothing on the orchestrator invokes the
+                        # advanced hooks for a worker library anyway (node loading, their only
+                        # load-time caller, is skipped), and generate_new_library accepts
+                        # advanced_library=None. The worker loads the module in its own
+                        # process with the venv populated.
                         advanced_library_instance = None
-                        if library_data.advanced_library_path:
+                        skip_advanced_library = library_info.requires_worker and not self._is_worker
+                        if skip_advanced_library and library_data.advanced_library_path:
+                            logger.debug(
+                                "Skipping Advanced Library load for worker-delegated library '%s' on the "
+                                "orchestrator; the worker loads it in its own process.",
+                                library_data.name,
+                            )
+                        if library_data.advanced_library_path and not skip_advanced_library:
                             try:
                                 advanced_library_instance = self._load_advanced_library_module(
                                     library_data=library_data,

--- a/tests/e2e/fixtures/worker_dep_library/dep_node.py
+++ b/tests/e2e/fixtures/worker_dep_library/dep_node.py
@@ -1,0 +1,23 @@
+"""Minimal node for the worker-dep fixture library. Zero pip dependencies of its own."""
+
+from __future__ import annotations
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class DepNode(DataNode):
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="Text to echo",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+
+    def process(self) -> None:
+        pass

--- a/tests/e2e/fixtures/worker_dep_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_dep_library/griptape_nodes_library.json
@@ -1,0 +1,36 @@
+{
+  "name": "Worker Dep Library",
+  "library_schema_version": "0.10.0",
+  "advanced_library_path": "worker_dep_library_advanced.py",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library whose advanced module imports a manifest pip dependency (the pygit2 pattern)",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "DepNode",
+      "file_path": "dep_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Minimal fixture node",
+        "display_name": "Dep Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/worker_dep_library/worker_dep_library_advanced.py
+++ b/tests/e2e/fixtures/worker_dep_library/worker_dep_library_advanced.py
@@ -1,0 +1,30 @@
+"""Advanced module that imports a third-party manifest dependency at module scope.
+
+Mirrors the shape of real model libraries (Depth Anything 3, diffusers, ...), which
+imported pygit2 here. The import only resolves when the engine has created the library
+venv, installed the manifest's pip_dependencies into it, and put its site-packages on
+sys.path BEFORE importing this module -- the contract pinned by
+tests/e2e/test_library_dependency_environment_init.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import fakegit  # type: ignore[reportMissingImports]  # The pygit2 stand-in: only importable from the library venv.
+
+from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+
+if TYPE_CHECKING:
+    from griptape_nodes.node_library.library_registry import Library, LibrarySchema
+
+# Appended to by the hooks so tests can assert they ran (and against which dep version).
+HOOKS_SEEN: list[str] = []
+
+
+class WorkerDepLibraryAdvanced(AdvancedNodeLibrary):
+    def before_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:  # noqa: ARG002 (hook signature)
+        HOOKS_SEEN.append(f"before:{fakegit.__version__}")
+
+    def after_library_nodes_loaded(self, library_data: LibrarySchema, library: Library) -> None:  # noqa: ARG002 (hook signature)
+        HOOKS_SEEN.append("after")

--- a/tests/e2e/test_library_dependency_environment_init.py
+++ b/tests/e2e/test_library_dependency_environment_init.py
@@ -1,0 +1,231 @@
+"""End-to-end tests for library dependency-environment initialization.
+
+The fixture library (`fixtures/worker_dep_library`) reproduces the shape that broke when
+the engine dropped pygit2 (engine PR #5265): an advanced module that imports a third-party
+package declared only in the manifest's ``pip_dependencies``. Real libraries with this
+shape include Depth Anything 3 and every diffusers-style model library.
+
+The contract these tests pin, across the ways a library arrives:
+
+- **Added to a running orchestrator, worker-delegated**: registration succeeds WITHOUT the
+  dependency being importable in the orchestrator process. The orchestrator must not
+  import the advanced module at all -- it deliberately never creates the library venv, so
+  the import could only fail (and before the skip landed, that failure hard-killed the
+  registration).
+- **Initial install on a worker**: the worker creates the library venv, installs the
+  manifest deps into it, puts its site-packages on ``sys.path``, and only then imports the
+  advanced module -- so the module-scope third-party import resolves.
+- **Cold engine boot with the venv already on disk**: a fresh engine re-registers the
+  library against the persisted venv and the advanced module loads again.
+- **In-process (non-worker) library on the orchestrator**: same install-before-import
+  ordering holds in the default mode.
+
+The third-party dependency is a hand-built wheel (``fakegit``) installed from a local
+``--find-links`` directory with ``--no-index``, so the tests are fully offline. Because
+``fakegit`` exists nowhere except that wheel, a successful import IS proof the library
+venv was populated and wired onto ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import sys
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import reset_root_engine
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "worker_dep_library"
+FIXTURE_FILES = ("worker_dep_library_advanced.py", "dep_node.py")
+DEP_NAME = "fakegit"
+DEP_VERSION = "1.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _forget_dep_module() -> Iterator[None]:
+    """Drop the fixture dependency from sys.modules around each test.
+
+    A successful import in one test would otherwise satisfy the next test's advanced
+    module from the module cache, hiding a broken venv wiring.
+    """
+    sys.modules.pop(DEP_NAME, None)
+    yield
+    sys.modules.pop(DEP_NAME, None)
+
+
+def _build_dep_wheel(wheel_dir: Path) -> None:
+    """Hand-build a minimal ``fakegit`` wheel so installs need no network or build backend."""
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = wheel_dir / f"{DEP_NAME}-{DEP_VERSION}-py3-none-any.whl"
+    dist_info = f"{DEP_NAME}-{DEP_VERSION}.dist-info"
+    files = {
+        f"{DEP_NAME}/__init__.py": f'__version__ = "{DEP_VERSION}"\n',
+        f"{dist_info}/METADATA": f"Metadata-Version: 2.1\nName: {DEP_NAME}\nVersion: {DEP_VERSION}\n",
+        f"{dist_info}/WHEEL": "Wheel-Version: 1.0\nGenerator: test-fixture\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    }
+    record_rows = []
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        for name, content in files.items():
+            data = content.encode()
+            zf.writestr(name, data)
+            digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+            record_rows.append(f"{name},sha256={digest},{len(data)}")
+        record_rows.append(f"{dist_info}/RECORD,,")
+        zf.writestr(f"{dist_info}/RECORD", "\n".join(record_rows) + "\n")
+
+
+def _materialize_dep_library(target_dir: Path, *, wheel_dir: Path, name: str, worker_mode: bool) -> Path:
+    """Write a registrable copy of the fixture library into ``target_dir``.
+
+    Injects the offline install flags and, for ``worker_mode``, the manifest declaration
+    that makes the library worker-delegated -- the same mechanism a real library uses.
+    """
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    schema["metadata"]["dependencies"] = {
+        "pip_dependencies": [DEP_NAME],
+        "pip_install_flags": ["--no-index", "--find-links", str(wheel_dir)],
+    }
+    if worker_mode:
+        schema["metadata"]["declarations"] = [{"type": "suggested_worker_mode", "mode": "WORKER"}]
+    target_dir.mkdir(parents=True, exist_ok=True)
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    for file_name in FIXTURE_FILES:
+        (target_dir / file_name).write_text((FIXTURE_DIR / file_name).read_text())
+    return library_json
+
+
+def _register(library_json: Path) -> RegisterLibraryFromFileResultSuccess:
+    result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return result
+
+
+def _library_info(library_json: Path) -> LibraryManager.LibraryInfo:
+    return GriptapeNodes.LibraryManager()._library_file_path_to_info[str(library_json)]
+
+
+def _hooks_seen(library_name: str) -> list[str]:
+    advanced = LibraryRegistry.get_library(library_name).get_advanced_library()
+    assert advanced is not None
+    return sys.modules[type(advanced).__module__].HOOKS_SEEN
+
+
+class TestWorkerDelegatedOnOrchestrator:
+    def test_adding_to_a_running_orchestrator_defers_the_dependency_environment(self, tmp_path: Path) -> None:
+        """The orchestrator registers a worker-delegated library without its deps.
+
+        Regression for the pygit2 breakage: before the advanced-module skip, this
+        registration hard-failed with ModuleNotFoundError because the orchestrator
+        imported the advanced module without ever creating the library venv.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_dep_wheel(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_dep_library(
+            library_dir, wheel_dir=wheel_dir, name="Worker Dep Library Orchestrator", worker_mode=True
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.requires_worker is True
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.WORKER_PENDING
+        # The dependency environment is the worker's job: no venv, no dep import here.
+        assert not (library_dir / ".venv").exists()
+        assert DEP_NAME not in sys.modules
+        # The library still registered (editor/workflow loading see it), with no advanced instance.
+        library = LibraryRegistry.get_library("Worker Dep Library Orchestrator")
+        assert library.get_advanced_library() is None
+
+
+class TestWorkerEnvironmentInitialization:
+    def test_initial_install_on_a_worker_populates_the_library_env(self, tmp_path: Path) -> None:
+        """The worker's first registration creates the venv, installs deps, then imports."""
+        wheel_dir = tmp_path / "wheels"
+        _build_dep_wheel(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_dep_library(
+            library_dir, wheel_dir=wheel_dir, name="Worker Dep Library Worker", worker_mode=True
+        )
+        GriptapeNodes.LibraryManager()._is_worker = True
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+        assert (library_dir / ".venv").exists()
+        # fakegit exists nowhere but the fixture wheel, so a successful import proves the
+        # venv was populated and its site-packages wired onto sys.path before the
+        # advanced module loaded.
+        assert DEP_NAME in sys.modules
+        assert _hooks_seen("Worker Dep Library Worker") == [f"before:{DEP_VERSION}", "after"]
+
+    def test_cold_engine_boot_reloads_against_the_persisted_venv(self, tmp_path: Path) -> None:
+        """A fresh engine (new process boot, simulated) re-registers with the venv on disk."""
+        wheel_dir = tmp_path / "wheels"
+        _build_dep_wheel(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_dep_library(
+            library_dir, wheel_dir=wheel_dir, name="Worker Dep Library Reboot", worker_mode=True
+        )
+        GriptapeNodes.LibraryManager()._is_worker = True
+        _register(library_json)
+        advanced = LibraryRegistry.get_library("Worker Dep Library Reboot").get_advanced_library()
+        assert advanced is not None
+        advanced_module_name = type(advanced).__module__
+
+        # Cold boot: fresh engine and registries, empty module cache, venv persisted on disk.
+        reset_root_engine()
+        LibraryRegistry._clear()
+        sys.modules.pop(DEP_NAME, None)
+        sys.modules.pop(advanced_module_name, None)
+        GriptapeNodes.LibraryManager()._is_worker = True
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+        assert DEP_NAME in sys.modules
+
+
+class TestInProcessLibraryOnOrchestrator:
+    def test_dependencies_install_before_the_advanced_module_imports(self, tmp_path: Path) -> None:
+        """Default (non-worker) mode: the same install-before-import ordering holds."""
+        wheel_dir = tmp_path / "wheels"
+        _build_dep_wheel(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_dep_library(
+            library_dir, wheel_dir=wheel_dir, name="Worker Dep Library InProcess", worker_mode=False
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.requires_worker is False
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+        assert (library_dir / ".venv").exists()
+        assert DEP_NAME in sys.modules
+        assert _hooks_seen("Worker Dep Library InProcess") == [f"before:{DEP_VERSION}", "after"]

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -711,3 +711,100 @@ class TestDownloadLibraryRequestAutoRegister:
         assert isinstance(result, DownloadLibraryResultFailure)
         assert "downloaded but failed to register" in str(result.result_details)
         assert "fake-library" in str(result.result_details)
+
+
+class TestWorkerDelegatedAdvancedLibrarySkip:
+    """The orchestrator must not import a worker-delegated library's advanced module.
+
+    The advanced module executes in the engine process and its third-party imports
+    resolve against the library venv -- which the orchestrator deliberately never
+    creates for worker-delegated libraries (the worker installs its own deps). Before
+    the skip, any manifest dependency imported by the advanced module raised
+    ModuleNotFoundError on the orchestrator and hard-failed the registration.
+    """
+
+    def _make_schema(self, *, advanced_library_path: str | None) -> MagicMock:
+        schema = MagicMock()
+        schema.name = "test_lib"
+        schema.metadata.library_version = "1.0.0"
+        schema.metadata.declarations = []
+        schema.advanced_library_path = advanced_library_path
+        schema.settings = None
+        return schema
+
+    def _make_lib_info(
+        self, *, state: LibraryManager.LibraryLifecycleState, requires_worker: bool
+    ) -> LibraryManager.LibraryInfo:
+        return LibraryManager.LibraryInfo(
+            lifecycle_state=state,
+            library_path="/mock.json",
+            is_sandbox=False,
+            library_name="test_lib",
+            library_version="1.0.0",
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            requires_worker=requires_worker,
+        )
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_skips_advanced_module_for_worker_delegated_library(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = self._make_lib_info(
+            state=LibraryManager.LibraryLifecycleState.WORKER_DELEGATED, requires_worker=True
+        )
+        schema = self._make_schema(advanced_library_path="lib_advanced.py")
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "_add_library_paths_to_sys_path", new=AsyncMock()),
+            patch.object(mgr, "_load_advanced_library_module") as mock_advanced,
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry.generate_new_library",
+                return_value=MagicMock(),
+            ) as mock_generate,
+        ):
+            result = await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        assert result is None
+        mock_advanced.assert_not_called()
+        # The library still registers -- with no advanced instance -- so the editor and
+        # workflow loading see it while the worker loads the real module in its process.
+        assert mock_generate.call_args.kwargs["advanced_library"] is None
+        assert lib_info.lifecycle_state is LibraryManager.LibraryLifecycleState.WORKER_PENDING
+
+    @pytest.mark.asyncio
+    async def test_in_process_library_still_loads_the_advanced_module(self, griptape_nodes: GriptapeNodes) -> None:
+        """Pins the non-worker path: the skip must key on worker delegation, not fire always."""
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = self._make_lib_info(
+            state=LibraryManager.LibraryLifecycleState.DEPENDENCIES_INSTALLED, requires_worker=False
+        )
+        schema = self._make_schema(advanced_library_path="lib_advanced.py")
+        advanced_instance = MagicMock()
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "_add_library_paths_to_sys_path", new=AsyncMock()),
+            patch.object(mgr, "_load_advanced_library_module", return_value=advanced_instance) as mock_advanced,
+            patch.object(mgr, "_attempt_load_nodes_from_library"),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.LibraryRegistry.generate_new_library",
+                return_value=MagicMock(),
+            ) as mock_generate,
+        ):
+            result = await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        assert result is None
+        mock_advanced.assert_called_once()
+        assert mock_generate.call_args.kwargs["advanced_library"] is advanced_instance

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from griptape_nodes.node_library.library_declarations import LibraryDependencyDeclaration
+from griptape_nodes.node_library.library_declarations import (
+    LibraryDependencyDeclaration,
+    SuggestedWorkerMode,
+    WorkerMode,
+)
 from griptape_nodes.node_library.library_registry import (
     Dependencies,
     LibraryNameAndVersion,
@@ -808,3 +812,93 @@ class TestWorkerDelegatedAdvancedLibrarySkip:
         assert result is None
         mock_advanced.assert_called_once()
         assert mock_generate.call_args.kwargs["advanced_library"] is advanced_instance
+
+
+class TestRequiresWorkerResolvedOnFilePathRegistration:
+    """A by-file-path registration must resolve requires_worker for itself.
+
+    This path enters METADATA_LOADED directly, so the DISCOVERED-phase writer that normally
+    resolves requires_worker never runs. Without resolving it here, a library whose manifest
+    suggests worker mode loads in-process when added to a running engine from the editor --
+    and its advanced module then imports manifest dependencies against a venv the
+    orchestrator deliberately never created (the pygit2 breakage).
+    """
+
+    def _worker_mode_schema(self) -> MagicMock:
+        schema = MagicMock()
+        schema.name = "worker_mode_lib"
+        schema.metadata.library_version = "1.0.0"
+        schema.metadata.declarations = [SuggestedWorkerMode(mode=WorkerMode.WORKER)]
+        return schema
+
+    def _request(self) -> RegisterLibraryFromFileRequest:
+        return RegisterLibraryFromFileRequest(file_path="/mock.json", perform_discovery_if_not_found=False)
+
+    @pytest.mark.asyncio
+    async def test_an_existing_library_info_is_updated_in_place(self, griptape_nodes: GriptapeNodes) -> None:
+        """Discovered-but-unnamed LibraryInfo: the stale requires_worker must be overwritten.
+
+        `_library_file_path_to_info` can already hold an entry from discovery that never got a
+        library_name (so it defaulted requires_worker to False). Updating every other field
+        while leaving that one stale is how a worker library ends up loading in-process.
+        """
+        mgr = griptape_nodes.LibraryManager()
+        lib_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.DISCOVERED,
+            library_path="/mock.json",
+            is_sandbox=False,
+            library_name=None,
+            fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
+            requires_worker=False,
+        )
+
+        with (
+            patch.object(
+                mgr,
+                "load_library_metadata_from_file_request",
+                return_value=_metadata_success(self._worker_mode_schema()),
+            ),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            result = await mgr._establish_register_library_prerequisites(self._request())
+
+        assert isinstance(result, LibraryManager.RegisterLibraryPrerequisites)
+        assert result.library_info is lib_info
+        assert lib_info.requires_worker is True
+        assert lib_info.library_name == "worker_mode_lib"
+        assert lib_info.lifecycle_state is LibraryManager.LibraryLifecycleState.METADATA_LOADED
+
+    @pytest.mark.asyncio
+    async def test_a_new_library_info_is_created_with_it(self, griptape_nodes: GriptapeNodes) -> None:
+        """Nothing discovered yet -- the freshly built LibraryInfo carries the resolved value."""
+        mgr = griptape_nodes.LibraryManager()
+
+        with (
+            patch.object(
+                mgr,
+                "load_library_metadata_from_file_request",
+                return_value=_metadata_success(self._worker_mode_schema()),
+            ),
+            patch.object(mgr, "_library_file_path_to_info", {}),
+        ):
+            result = await mgr._establish_register_library_prerequisites(self._request())
+
+        assert isinstance(result, LibraryManager.RegisterLibraryPrerequisites)
+        assert result.library_info.requires_worker is True
+        assert result.library_info.lifecycle_state is LibraryManager.LibraryLifecycleState.METADATA_LOADED
+
+    @pytest.mark.asyncio
+    async def test_a_library_with_no_worker_declaration_stays_in_process(self, griptape_nodes: GriptapeNodes) -> None:
+        """The resolution must read the manifest, not default to worker mode for everyone."""
+        mgr = griptape_nodes.LibraryManager()
+        schema = self._worker_mode_schema()
+        schema.metadata.declarations = []
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "_library_file_path_to_info", {}),
+        ):
+            result = await mgr._establish_register_library_prerequisites(self._request())
+
+        assert isinstance(result, LibraryManager.RegisterLibraryPrerequisites)
+        assert result.library_info.requires_worker is False


### PR DESCRIPTION
Before this change, a library w/ a dependency not in griptape-nodes-engine (ex: pygit2 in the DA3 library) would fail to load until the engine is restarted. With this change, the first time load properly initializes the dependencies prior to loading the library, meaning successful registration